### PR TITLE
Refactor to rename '@wordpress/lock-unlock' to '@wordpress/routes-lock-unlock'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15737,10 +15737,6 @@
 			"resolved": "packages/list-reusable-blocks",
 			"link": true
 		},
-		"node_modules/@wordpress/lock-unlock": {
-			"resolved": "routes/lock-unlock",
-			"link": true
-		},
 		"node_modules/@wordpress/media-editor": {
 			"resolved": "packages/media-editor",
 			"link": true
@@ -15907,6 +15903,10 @@
 		},
 		"node_modules/@wordpress/router": {
 			"resolved": "packages/router",
+			"link": true
+		},
+		"node_modules/@wordpress/routes-lock-unlock": {
+			"resolved": "routes/lock-unlock",
 			"link": true
 		},
 		"node_modules/@wordpress/scripts": {
@@ -53797,8 +53797,8 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/ui": "file:../../packages/ui",
 				"@wordpress/url": "file:../../packages/url"
 			},
@@ -54048,8 +54048,8 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/ui": "file:../../packages/ui"
 			}
 		},
@@ -54061,7 +54061,7 @@
 			}
 		},
 		"routes/lock-unlock": {
-			"name": "@wordpress/lock-unlock",
+			"name": "@wordpress/routes-lock-unlock",
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/private-apis": "file:../../packages/private-apis"
@@ -54078,9 +54078,9 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/media-editor": "file:../../packages/media-editor",
-				"@wordpress/route": "file:../../packages/route"
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock"
 			}
 		},
 		"routes/navigation": {
@@ -54105,8 +54105,8 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
-				"@wordpress/route": "file:../../packages/route"
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock"
 			}
 		},
 		"routes/navigation-list": {
@@ -54124,9 +54124,9 @@
 				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/views": "file:../../packages/views"
 			}
 		},
@@ -54153,9 +54153,9 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/patterns": "file:../../packages/patterns",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/views": "file:../../packages/views"
 			}
 		},
@@ -54196,9 +54196,9 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/keycodes": "file:../../packages/keycodes",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/views": "file:../../packages/views",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"
@@ -54249,8 +54249,8 @@
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/url": "file:../../packages/url"
 			}
 		},
@@ -54304,9 +54304,9 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/keycodes": "file:../../packages/keycodes",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/url": "file:../../packages/url",
 				"@wordpress/views": "file:../../packages/views",
 				"change-case": "^4.1.2",
@@ -54341,9 +54341,9 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/keycodes": "file:../../packages/keycodes",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/lock-unlock": "file:../lock-unlock",
 				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/views": "file:../../packages/views",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -14,7 +14,7 @@ import {
 import { select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -20,7 +20,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/url": "file:../../packages/url"
 	},

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { Notice } from '@wordpress/ui';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/guidelines/components/block-guideline-modal.tsx
+++ b/routes/guidelines/components/block-guideline-modal.tsx
@@ -20,7 +20,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/guidelines/package.json
+++ b/routes/guidelines/package.json
@@ -19,7 +19,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/block-library": "file:../../packages/block-library",

--- a/routes/lock-unlock/package.json
+++ b/routes/lock-unlock/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@wordpress/lock-unlock",
+	"name": "@wordpress/routes-lock-unlock",
 	"version": "1.0.0",
 	"private": true,
 	"exports": {

--- a/routes/media-editor/package.json
+++ b/routes/media-editor/package.json
@@ -17,7 +17,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/i18n": "file:../../packages/i18n",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/media-editor": "file:../../packages/media-editor",
 		"@wordpress/route": "file:../../packages/route"
 	}

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -12,7 +12,7 @@ import {
 	type Media,
 } from '@wordpress/media-editor';
 import { useNavigate, useParams } from '@wordpress/route';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/navigation-edit/editor/content.tsx
+++ b/routes/navigation-edit/editor/content.tsx
@@ -12,7 +12,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/navigation-edit/package.json
+++ b/routes/navigation-edit/package.json
@@ -18,7 +18,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/route": "file:../../packages/route"
 	}
 }

--- a/routes/navigation-list/package.json
+++ b/routes/navigation-list/package.json
@@ -18,7 +18,7 @@
 		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/views": "file:../../packages/views"

--- a/routes/navigation-list/stage.tsx
+++ b/routes/navigation-list/stage.tsx
@@ -12,7 +12,7 @@ import { useView } from '@wordpress/views';
 import { DataViews } from '@wordpress/dataviews';
 import { Button } from '@wordpress/components';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/pattern-list/fields/sync-status.tsx
+++ b/routes/pattern-list/fields/sync-status.tsx
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/pattern-list/package.json
+++ b/routes/pattern-list/package.json
@@ -19,7 +19,7 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/patterns": "file:../../packages/patterns",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/views": "file:../../packages/views"

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -22,7 +22,7 @@ import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
 import { __ } from '@wordpress/i18n';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/pattern-list/use-patterns.ts
+++ b/routes/pattern-list/use-patterns.ts
@@ -6,7 +6,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/post-list/package.json
+++ b/routes/post-list/package.json
@@ -22,7 +22,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/keycodes": "file:../../packages/keycodes",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/views": "file:../../packages/views",

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
 

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -26,7 +26,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { drawerRight } from '@wordpress/icons';
 import type { Post } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/styles/canvas.tsx
+++ b/routes/styles/canvas.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useSearch } from '@wordpress/route';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useEditorAssets } from '@wordpress/lazy-editor';
 import { Spinner } from '@wordpress/components';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { StyleBookPreview } = unlock( editorPrivateApis );
 

--- a/routes/styles/package.json
+++ b/routes/styles/package.json
@@ -18,7 +18,7 @@
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/url": "file:../../packages/url"
 	}

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -12,7 +12,7 @@ import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { seen } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useEditorSettings } from '@wordpress/lazy-editor';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/template-list/fields/active.tsx
+++ b/routes/template-list/fields/active.tsx
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 

--- a/routes/template-list/fields/description.tsx
+++ b/routes/template-list/fields/description.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { privateApis as corePrivateApis } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 

--- a/routes/template-list/fields/slug.tsx
+++ b/routes/template-list/fields/slug.tsx
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { privateApis as corePrivateApis } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 

--- a/routes/template-list/package.json
+++ b/routes/template-list/package.json
@@ -24,7 +24,7 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/keycodes": "file:../../packages/keycodes",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/url": "file:../../packages/url",

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -21,7 +21,7 @@ import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { published, commentAuthorAvatar } from '@wordpress/icons';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -18,7 +18,7 @@ import { useMemo, useCallback } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/template-list/use-templates-legacy.ts
+++ b/routes/template-list/use-templates-legacy.ts
@@ -6,7 +6,7 @@ import {
 	privateApis as corePrivateApis,
 	type WpTemplate,
 } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/template-list/use-templates.ts
+++ b/routes/template-list/use-templates.ts
@@ -8,7 +8,7 @@ import {
 	privateApis as corePrivateApis,
 	type WpTemplate,
 } from '@wordpress/core-data';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies

--- a/routes/template-part-list/package.json
+++ b/routes/template-part-list/package.json
@@ -23,7 +23,7 @@
 		"@wordpress/icons": "file:../../packages/icons",
 		"@wordpress/keycodes": "file:../../packages/keycodes",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/lock-unlock": "file:../lock-unlock",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/views": "file:../../packages/views",

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -25,7 +25,7 @@ import { useMemo, useCallback, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import type { WpTemplatePart } from '@wordpress/core-data';
 import { CreateTemplatePartModal } from '@wordpress/fields';
-import { unlock } from '@wordpress/lock-unlock';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?

Renames the `@wordpress/routes-lock-unlock` package (previously `@wordpress/lock-unlock`) across the codebase.

Related: https://github.com/WordPress/gutenberg/pull/79138#issuecomment-4693895147 (supersedes the previous PR and updates the naming)

## Why?

The name `@wordpress/lock-unlock` is easily confused with the `lock-unlock.js` private-API pattern that already exists in most packages. Renaming it to `@wordpress/routes-lock-unlock` makes its purpose (locking/unlocking route private APIs) explicit.

## How?

- Renames the package from `@wordpress/lock-unlock` to `@wordpress/routes-lock-unlock`.
- Updates the package directory, `package.json`, and all imports/references across the codebase.

## Testing Instructions

1. Run `npm install` and confirm the workspace resolves.
2. Run `npm run build` and confirm it passes.

## Use of AI Tools

This pull request was authored with the help of Claude.