### PR TITLE
E2E: Support WordPress installs served from a subdirectory

### DIFF
--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Resolve root-relative `page.goto()` URLs against the full `baseURL`, including any subdirectory path, so tests work against WordPress installs served from a subdirectory.
+
 ## 1.48.1 (2026-06-16)
 
 ## 1.48.0 (2026-06-10)

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -143,8 +143,27 @@ const test = base.extend<
 	editor: async ( { page }, use ) => {
 		await use( new Editor( { page } ) );
 	},
-	page: async ( { page }, use ) => {
+	page: async ( { page, baseURL }, use ) => {
 		page.on( 'console', observeConsoleLogging );
+
+		// Playwright resolves root-relative URLs against the origin only,
+		// dropping any subdirectory from `baseURL`. Resolve them against the
+		// full `baseURL` instead so tests work on subdirectory installs.
+		const originalGoto = page.goto.bind( page );
+		page.goto = ( url, options ) => {
+			if (
+				baseURL &&
+				typeof url === 'string' &&
+				url.startsWith( '/' ) &&
+				! url.startsWith( '//' )
+			) {
+				const normalizedBaseURL = baseURL.endsWith( '/' )
+					? baseURL
+					: `${ baseURL }/`;
+				url = new URL( url.slice( 1 ), normalizedBaseURL ).href;
+			}
+			return originalGoto( url, options );
+		};
 
 		await use( page );
 

--- a/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts
@@ -644,8 +644,10 @@ export async function setCollaboration(
 	requestUtils: RequestUtils,
 	enabled: boolean
 ): Promise< void > {
+	// Relative path: a leading slash would resolve against the origin and
+	// break on subdirectory installs.
 	const response = await requestUtils.request.get(
-		'/wp-admin/options-writing.php'
+		'wp-admin/options-writing.php'
 	);
 	const html = await response.text();
 	const nonce = html.match( /name="_wpnonce" value="([^"]+)"/ )![ 1 ];
@@ -665,7 +667,7 @@ export async function setCollaboration(
 
 	formData[ optionName ] = optionValue;
 
-	await requestUtils.request.post( '/wp-admin/options.php', {
+	await requestUtils.request.post( 'wp-admin/options.php', {
 		form: formData,
 		failOnStatusCode: true,
 	} );

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -425,7 +425,7 @@ test.describe( 'Change detection', () => {
 			.getByRole( 'button', { name: 'Trash' } )
 			.click();
 
-		await expect( page ).toHaveURL( '/wp-admin/edit.php?post_type=post' );
+		await expect( page ).toHaveURL( 'wp-admin/edit.php?post_type=post' );
 	} );
 
 	test( 'consecutive edits to the same attribute should mark the post as dirty after a save', async ( {

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -15,7 +15,7 @@ test.describe( 'Site editor browser history', () => {
 	test( 'Back button works properly', async ( { admin, page } ) => {
 		await admin.visitAdminPage( 'index.php' );
 		await admin.visitSiteEditor();
-		await expect( page ).toHaveURL( '/wp-admin/site-editor.php' );
+		await expect( page ).toHaveURL( 'wp-admin/site-editor.php' );
 
 		// Navigate to a single template
 		await page.click( 'role=button[name="Templates"]' );
@@ -23,18 +23,18 @@ test.describe( 'Site editor browser history', () => {
 			.locator( '.fields-field__title', { hasText: 'Index' } )
 			.click();
 		await expect( page ).toHaveURL(
-			'/wp-admin/site-editor.php?p=%2Fwp_template%2Femptytheme%2F%2Findex&canvas=edit'
+			'wp-admin/site-editor.php?p=%2Fwp_template%2Femptytheme%2F%2Findex&canvas=edit'
 		);
 
 		// Navigate back to the template list
 		await page.goBack();
 		await expect( page ).toHaveURL(
-			'/wp-admin/site-editor.php?p=%2Ftemplate'
+			'wp-admin/site-editor.php?p=%2Ftemplate'
 		);
 
 		// Navigate back to the dashboard
 		await page.goBack();
 		await page.goBack();
-		await expect( page ).toHaveURL( '/wp-admin/index.php' );
+		await expect( page ).toHaveURL( 'wp-admin/index.php' );
 	} );
 } );


### PR DESCRIPTION
## What?

Makes the Playwright e2e harness and a handful of specs work when `WP_BASE_URL` points to a WordPress install served from a subdirectory (e.g. `http://localhost:8888/wp/`).

## Why?

Playwright resolves root-relative URLs (`/wp-admin/...`) against the **origin** only — `new URL( '/x', 'http://host/sub/' )` yields `http://host/x`, silently dropping the subdirectory. The suite currently assumes a root install (which wp-env always provides), so running it against a subdirectory install fails in three distinct ways:

1. `page.goto( '/...' )` calls (79 call sites across the specs) navigate to the wrong host path — e.g. the font-library spec's front-end check lands on the server's root page instead of the post.
2. `expect( page ).toHaveURL( '/wp-admin/...' )` assertions build the expected URL without the subdirectory and never match.
3. `requestUtils.request.get( '/wp-admin/options-writing.php' )` in the collaboration fixtures fetches the wrong path, the `_wpnonce` scrape returns `null`, and every collaboration spec fails in `beforeEach` with `TypeError: Cannot read properties of null (reading '1')`.

## How?

- **Harness** (`e2e-test-utils-playwright`): the `page` fixture now rewrites root-relative `goto()` URLs against the full `baseURL` (including its path). This fixes all existing `goto( '/...' )` call sites in one place, with no change needed in specs.
- **Specs**: `toHaveURL` strings in `browser-history` and `change-detection` specs and the two `requestUtils.request` paths in the collaboration fixtures are now relative (no leading slash), which Playwright resolves against `baseURL` — the same style `visitAdminPage` already uses.

No behavior change for root installs: with `baseURL` ending in `/`, relative and root-relative forms resolve identically.

## Testing Instructions

1. Set up a WordPress install served from a subdirectory (e.g. symlink a wordpress-develop build into an Apache docroot at `/wp/`) with the Gutenberg plugin and e2e test plugins mapped as in `.wp-env.test.json`.
2. `WP_BASE_URL=http://localhost:<port>/<subdir>/ npm run test:e2e -- test/e2e/specs/admin/font-library.spec.js test/e2e/specs/site-editor/browser-history.spec.js`
3. Without this change, the font-library front-end assertions and the browser-history URL assertions fail; with it they pass.
4. Against a regular wp-env (`npm run test:e2e`), behavior is unchanged.

## Testing done

Ran the full suite against a subdirectory MAMP install (`WP_BASE_URL=http://localhost:6888/test/test-2/`): the previously failing font-library, browser-history, change-detection, and all collaboration specs pass with these changes. Spot-checked specs against the default wp-env root URL to confirm no regressions.