### PR TITLE
Add block bindings support: core/post-date:isLink

### DIFF
--- a/lib/compat/wordpress-7.1/block-bindings.php
+++ b/lib/compat/wordpress-7.1/block-bindings.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Block Bindings API additions for WordPress 7.1.
+ *
+ * @since 7.1.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $attributes, $block_type ) {
+		if ( 'core/post-date' === $block_type && ! in_array( 'isLink', $attributes, true ) ) {
+			$attributes[] = 'isLink';
+		}
+		return $attributes;
+	},
+	10,
+	2
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -77,6 +77,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.0/global-styles.php';
 
 	// WordPress 7.1 compat.
+	require __DIR__ . '/compat/wordpress-7.1/block-bindings.php';
 	require __DIR__ . '/compat/wordpress-7.1/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -24,6 +24,17 @@ import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
 import { store as blockEditorStore } from '../store';
 
+/*
+ * Per-block list of bindable attributes hidden from the Attributes panel.
+ * Binding these attributes to incompatible sources through the generic UI
+ * could break the block (e.g. binding the Date block's `datetime` attribute
+ * to a non-date value). They remain bindable programmatically and through
+ * dedicated UI, like the Date block's variations.
+ */
+const HIDDEN_BLOCK_BINDINGS_PANEL_ATTRIBUTES = {
+	'core/post-date': [ 'datetime' ],
+};
+
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile
@@ -39,7 +50,8 @@ const useToolsPanelDropdownMenuProps = () => {
 
 export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	const blockContext = useContext( BlockContext );
-	const { removeAllBlockBindings } = useBlockBindingsUtils();
+	const { removeAllBlockBindings, updateBlockBindings } =
+		useBlockBindingsUtils();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const { bindableAttributes, hasCompatibleFields } = useSelect(
@@ -68,14 +80,25 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		[ blockName, blockContext ]
 	);
 
-	// Return early if there are no bindable attributes.
-	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
+	const hiddenAttributes =
+		HIDDEN_BLOCK_BINDINGS_PANEL_ATTRIBUTES[ blockName ];
+	const visibleAttributes = hiddenAttributes
+		? bindableAttributes?.filter(
+				( attribute ) => ! hiddenAttributes.includes( attribute )
+		  )
+		: bindableAttributes;
+
+	// Return early if there are no bindable attributes to show.
+	if ( ! visibleAttributes || visibleAttributes.length === 0 ) {
 		return null;
 	}
 
 	const { bindings } = metadata || {};
+	const hasVisibleBindings = visibleAttributes.some(
+		( attribute ) => bindings?.[ attribute ] !== undefined
+	);
 
-	if ( bindings === undefined && ! hasCompatibleFields ) {
+	if ( ! hasVisibleBindings && ! hasCompatibleFields ) {
 		return null;
 	}
 
@@ -84,13 +107,25 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			<ToolsPanel
 				label={ __( 'Attributes' ) }
 				resetAll={ () => {
-					removeAllBlockBindings();
+					if ( hiddenAttributes?.length ) {
+						// Only remove the bindings shown in the panel, leaving the hidden ones untouched.
+						updateBlockBindings(
+							Object.fromEntries(
+								visibleAttributes.map( ( attribute ) => [
+									attribute,
+									undefined,
+								] )
+							)
+						);
+					} else {
+						removeAllBlockBindings();
+					}
 				} }
 				dropdownMenuProps={ dropdownMenuProps }
 				className="block-editor-bindings__panel"
 			>
 				<ItemGroup isBordered isSeparated>
-					{ bindableAttributes.map( ( attribute ) => (
+					{ visibleAttributes.map( ( attribute ) => (
 						<BlockBindingsAttributeControl
 							key={ attribute }
 							attribute={ attribute }
@@ -119,10 +154,8 @@ export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],
 	hasSupport( name ) {
-		return ! [
-			'core/post-date',
-			'core/navigation-link',
-			'core/navigation-submenu',
-		].includes( name );
+		return ! [ 'core/navigation-link', 'core/navigation-submenu' ].includes(
+			name
+		);
 	},
 };

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -352,6 +352,120 @@ HTML;
 	}
 
 	/**
+	 * Tests that the Post Date block's `isLink` attribute can be set through
+	 * a block bindings source.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_block
+	 */
+	public function test_post_date_is_link_binding() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => function ( $source_args ) {
+					return $source_args['value'];
+				},
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:post-date {"datetime":"2024-01-15T10:30:00","format":"Y-m-d","metadata":{"bindings":{"isLink":{"source":"test/source","args":{"value":true}}}}} /-->
+HTML;
+
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0], array( 'postId' => $post_id ) );
+		$result        = $block->render();
+
+		$this->assertTrue(
+			$block->attributes['isLink'],
+			"The 'isLink' attribute should be updated with the value returned by the source."
+		);
+		$this->assertStringContainsString(
+			'<a href="' . esc_url( get_the_permalink( $post_id ) ) . '">',
+			$result,
+			'The block content should wrap the date in a link to the post when the bound value is true.'
+		);
+		$this->assertStringContainsString(
+			'<time datetime="2024-01-15T10:30:00">2024-01-15</time>',
+			$result,
+			'The block content should keep rendering the date from the `datetime` attribute.'
+		);
+
+		$block_content = <<<HTML
+<!-- wp:post-date {"datetime":"2024-01-15T10:30:00","format":"Y-m-d","isLink":true,"metadata":{"bindings":{"isLink":{"source":"test/source","args":{"value":false}}}}} /-->
+HTML;
+
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0], array( 'postId' => $post_id ) );
+		$result        = $block->render();
+
+		$this->assertFalse(
+			$block->attributes['isLink'],
+			"The 'isLink' attribute fallback value should be overridden by the value returned by the source."
+		);
+		$this->assertStringNotContainsString(
+			'<a href=',
+			$result,
+			'The block content should not wrap the date in a link when the bound value is false.'
+		);
+	}
+
+	/**
+	 * Tests that the Post Date block's `isLink` attribute supports the default
+	 * binding for pattern overrides.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_block
+	 */
+	public function test_default_binding_for_pattern_overrides_post_date_is_link() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:post-date {"datetime":"2024-01-15T10:30:00","format":"Y-m-d","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test date"}} /-->
+HTML;
+
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId'            => $post_id,
+				'pattern/overrides' => array(
+					'Test date' => array(
+						'isLink' => true,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertStringContainsString(
+			'<a href="' . esc_url( get_the_permalink( $post_id ) ) . '">',
+			$result,
+			'The block content should wrap the date in a link when the pattern override sets `isLink` to true.'
+		);
+		$this->assertStringContainsString(
+			'<time datetime="2024-01-15T10:30:00">2024-01-15</time>',
+			$result,
+			'The block content should keep rendering the date from the `datetime` attribute.'
+		);
+		$this->assertSame(
+			array( 'source' => 'core/pattern-overrides' ),
+			$block->attributes['metadata']['bindings']['isLink'],
+			'The __default binding should be expanded to include the `isLink` binding in the block metadata.'
+		);
+	}
+
+	/**
 	 * Tests that filter `block_bindings_source_value` is applied.
 	 */
 	public function test_filter_block_bindings_source_value() {

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -883,6 +883,26 @@ test.describe( 'Registered sources', () => {
 			await expect( contentAttribute ).toBeVisible();
 		} );
 
+		test( 'should be possible to connect the post date isLink attribute, but not datetime', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/post-date',
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			const isLinkAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show isLink',
+			} );
+			await expect( isLinkAttribute ).toBeVisible();
+			// The `datetime` attribute is managed through the block variations,
+			// so it should be hidden from the Attributes panel.
+			const datetimeAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show datetime',
+			} );
+			await expect( datetimeAttribute ).toBeHidden();
+		} );
+
 		test( 'should be possible to connect the button supported attributes', async ( {
 			editor,
 			page,


### PR DESCRIPTION
Enable block bindings for the `core/post-date` block's `isLink` attribute

Editor-side, the Attributes panel was previously hidden entirely for `core/post-date` to prevent the `datetime` attribute from being bound to incompatible sources (#72712). Replaced that all-or-nothing block-level hiding with a per-attribute map so the panel can expose `isLink` while keeping `datetime` hidden (the latter remains managed through the block's variations). Resetting the panel now only clears the visible bindings, leaving the variation-managed `datetime` binding intact.

Server-side, register `isLink` as a supported attribute through the `block_bindings_supported_attributes` filter. The
block's existing render callback already wraps the date in a link based on `isLink`, so no render changes are needed.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #78851 (See for the `core/post-date` block)

Enables block bindings for the `core/post-date` block's `isLink` attribute. This block already supported binding its `datetime` attribute; this PR adds `isLink` and unhides the bindings "Attributes" panel for the block, while keeping `datetime` out of that panel.

## Why?
For `core/post-date`, `datetime` was already supported; `isLink` is the remaining attribute on the audit list.

The Attributes panel was previously hidden entirely for `core/post-date` (#72712) to prevent its `datetime` attribute from being bound to incompatible (non-date) sources, which would break the block. That all-or-nothing approach also prevented exposing any *other* attribute, like `isLink`. This PR replaces it with a finer-grained mechanism so `isLink` can be exposed safely while `datetime` stays hidden.


## How?
**Editor-side**:
- Removed `core/post-date` from the panel's `hasSupport` blocklist so the Attributes panel renders for the block again.
- Introduced a per-attribute `HIDDEN_BLOCK_BINDINGS_PANEL_ATTRIBUTES` map that keeps `datetime` hidden from the panel (it remains managed through the block's variations, where it's safely bound to `core/post-data`), while exposing `isLink`.
- Scoped `resetAll` so it only clears the *visible* bindings, leaving the variation-managed `datetime` binding intact.

**Server-side**:
- Registered `isLink` as a supported attribute via the `block_bindings_supported_attributes` filter. The block's existing render callback already wraps the date in a link based on `isLink`, so no render changes are needed.


## Testing Instructions
A binding source exposing a **boolean** field is needed to connect `isLink` (it's a boolean attribute). The quickest way is to register a boolean post-meta field:

```php
add_action( 'init', function () {
    register_post_meta( 'post', 'is_link_field', array(
        'type'         => 'boolean',
        'single'       => true,
        'show_in_rest' => true,
        'default'      => true,
    ) );
} );
```

1. Create or edit a Post.
2. Insert a Post Date block and select it.
3. Open the Settings sidebar and confirm the Attributes panel is now shown.
4. Confirm the panel lists `isLink` but does not list datetime.
5. Connect isLink to the `is_link_field` custom field.
6. View the post on the frontend: with the meta value true, the date is wrapped in a link to the post; set it to false and the date renders as plain text.
    - The meta values, for testing purposes, can be changed using the CLI:
    - `npm run wp-env run cli wp post meta update <POST_ID> is_link_field 1`
    - `npm run wp-env run cli wp post meta update <POST_ID> is_link_field 0`


### Testing Instructions for Keyboard
1. Insert a Post Date block and move focus to it.
2. Open the Settings sidebar (Ctrl/Cmd + Shift + ,).
3. Tab to the Attributes panel and confirm isLink is reachable and operable via keyboard (Enter/Space to open the menu, arrow keys to navigate sources/fields).
4. Confirm datetime is not present in the panel.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1710" height="956" alt="image" src="https://github.com/user-attachments/assets/67920e1b-0682-4999-a6c7-1e03fc061b32" />|<img width="1710" height="952" alt="image" src="https://github.com/user-attachments/assets/022845c0-e87e-43d1-95b0-83187d91bb88" /> |
|<img width="1100" height="445" alt="image" src="https://github.com/user-attachments/assets/b1e490a1-c9c6-46fc-b37d-f759b3ffd578" />|<img width="1136" height="615" alt="image" src="https://github.com/user-attachments/assets/4448c82a-30ba-493d-9ddf-26c9ed2b9213" />|

## Use of AI Tools

- AI tooling (Claude Opus4.8, Gemini 3.1 Pro) was used to investigate the existing block bindings architecture, code completions and improve test coverage.
- All changes are reviewed and tested by me.