### PR TITLE
Media Editor: small tweak to gutters

### DIFF
--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -146,7 +146,7 @@
 		margin-right: $grid-unit-30;
 		margin-right: 0;
 
-		// When the sidebar is a column in, the margin-right is not needed.
+		// When the sidebar is not a full page column, we offset the header to match the overall gutter.
 		@include break-small() {
 			margin-right: $grid-unit-30;
 		}

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -62,11 +62,6 @@
 		margin: 0 $grid-unit-30;
 		border-radius: $radius-large;
 		overflow: hidden;
-		@include break-small() {
-			// Compensate for the left gutter in the sidebar panel
-			// so the modal padding is uniform (24px).
-			margin-right: $grid-unit-30 - $grid-unit-10;
-		}
 	}
 
 	.media-editor__canvas-toolbar {
@@ -109,11 +104,9 @@
 		@include reset;
 
 		// Small left gutter so the tabs and panel content (and the zoom
-		// slider's thumb at its minimum) sit off the sidebar edge. Only in the
-		// column layout; below `small` the sidebar is a full-width overlay and
-		// uses the panel's own gutter instead.
+		// slider's thumb at its minimum) sit off the sidebar edge.
 		@include break-small() {
-			padding-left: $grid-unit-10;
+			padding-left: 1px;
 		}
 	}
 
@@ -151,7 +144,12 @@
 		padding-left: 0;
 		padding-right: $grid-unit-10;
 		margin-right: $grid-unit-30;
+		margin-right: 0;
 
+		// When the sidebar is a column in, the margin-right is not needed.
+		@include break-small() {
+			margin-right: $grid-unit-30;
+		}
 		.components-button.has-icon {
 			padding: 0;
 


### PR DESCRIPTION

## What?


- Removed unnecessary margin adjustments for small breakpoints in the media editor component.
- Updated padding and margin properties to ensure uniformity in the layout when the sidebar is in column mode.



## Why?

Left gutter with sidebar was too narrow.


## Testing Instructions

Eyeball the gutters. They should look passable.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1108" height="184" alt="Screenshot 2026-06-13 at 7 05 15 pm" src="https://github.com/user-attachments/assets/e4f14480-f17e-478f-a2bf-0c68babb4ec8" />|<img width="1009" height="196" alt="Screenshot 2026-06-13 at 7 03 34 pm" src="https://github.com/user-attachments/assets/df475b9a-a7cd-4ca1-939a-03e4a55a24a5" />|





## Use of AI Tools

None