### PR TITLE
e2e: Retry transient theme activation failures in pages spec

### DIFF
--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -3,6 +3,32 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+/**
+ * Activates a theme, retrying on the transient "socket hang up"
+ * (ECONNRESET) connection error that intermittently occurs in CI.
+ *
+ * See https://github.com/WordPress/gutenberg/issues/74483.
+ *
+ * @param {Object} requestUtils Playwright request utils.
+ * @param {string} themeSlug    Theme slug to activate.
+ */
+async function activateThemeWithRetry( requestUtils, themeSlug ) {
+	const maxAttempts = 3;
+	for ( let attempt = 1; attempt <= maxAttempts; attempt++ ) {
+		try {
+			await requestUtils.activateTheme( themeSlug );
+			return;
+		} catch ( error ) {
+			const isTransient = /socket hang up|ECONNRESET/i.test(
+				error?.message ?? ''
+			);
+			if ( ! isTransient || attempt === maxAttempts ) {
+				throw error;
+			}
+		}
+	}
+}
+
 async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
 	await page.getByRole( 'button', { name: 'Add page' } ).click();
@@ -69,7 +95,7 @@ async function addPageContent( editor, page ) {
 
 test.describe( 'Pages', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
+		await activateThemeWithRetry( requestUtils, 'emptytheme' );
 		await Promise.all( [
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllPages(),
@@ -85,7 +111,7 @@ test.describe( 'Pages', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
+		await activateThemeWithRetry( requestUtils, 'twentytwentyone' );
 		await Promise.all( [
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllPages(),


### PR DESCRIPTION
## What?

Fixes the flaky `pages` site-editor e2e test reported in #74483.

## Why?

The test itself isn't the problem — it intermittently fails in its `beforeAll`/`afterAll` hooks while activating a theme:

```
Error: apiRequestContext.get: socket hang up
  - → GET http://localhost:8889/wp-admin/themes.php
  at RequestUtils.activateTheme (.../request-utils/themes.ts:13:36)
  at .../pages.spec.js:88:22
```

`socket hang up` is a Node `ECONNRESET` — the server occasionally drops the connection under CI load. `activateTheme` issues raw `request.get()` calls with no retry, so a single dropped connection fails the whole `describe`.

## How?

Wrap the `activateTheme()` calls in the spec's hooks with a small local retry helper. It retries **only** on the transient `socket hang up` / `ECONNRESET` error (up to 3 attempts) and rethrows any other error immediately, so genuine failures (e.g. a missing theme) still surface right away.

The fix is intentionally scoped to this spec rather than the shared `themes.ts` util.

## Testing Instructions

- Run `npm run test:e2e -- test/e2e/specs/site-editor/pages.spec.js` and confirm it passes.
- The transient failure is load-dependent and won't reliably reproduce locally; the change adds the retry path around the call that fails in CI.

Fixes #74483