### PR TITLE
Cover: Allow video backgrounds to be Fixed (parallax)

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Cover: Allow video backgrounds to use the "Fixed background" (parallax) option, matching image backgrounds ([#52585](https://github.com/WordPress/gutenberg/issues/52585)).
+
 ## 9.48.0 (2026-06-10)
 
 ### Code Quality

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -694,7 +694,9 @@ function CoverEdit( {
 				{ url && isVideoBackground && (
 					<video
 						ref={ mediaElement }
-						className="wp-block-cover__video-background"
+						className={ clsx( 'wp-block-cover__video-background', {
+							'has-parallax': hasParallax,
+						} ) }
 						autoPlay
 						muted
 						loop

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -303,43 +303,42 @@ export default function CoverInspectorControls( {
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ isImageBackground && (
-							<>
-								<ToolsPanelItem
+						{ ( isImageBackground || isVideoBackground ) && (
+							<ToolsPanelItem
+								label={ __( 'Fixed background' ) }
+								isShownByDefault
+								hasValue={ () => !! hasParallax }
+								onDeselect={ () =>
+									setAttributes( {
+										hasParallax: false,
+										focalPoint: undefined,
+									} )
+								}
+							>
+								<ToggleControl
 									label={ __( 'Fixed background' ) }
-									isShownByDefault
-									hasValue={ () => !! hasParallax }
-									onDeselect={ () =>
-										setAttributes( {
-											hasParallax: false,
-											focalPoint: undefined,
-										} )
-									}
-								>
-									<ToggleControl
-										label={ __( 'Fixed background' ) }
-										checked={ !! hasParallax }
-										onChange={ toggleParallax }
-									/>
-								</ToolsPanelItem>
-
-								<ToolsPanelItem
+									checked={ !! hasParallax }
+									onChange={ toggleParallax }
+								/>
+							</ToolsPanelItem>
+						) }
+						{ isImageBackground && (
+							<ToolsPanelItem
+								label={ __( 'Repeated background' ) }
+								isShownByDefault
+								hasValue={ () => isRepeated }
+								onDeselect={ () =>
+									setAttributes( {
+										isRepeated: false,
+									} )
+								}
+							>
+								<ToggleControl
 									label={ __( 'Repeated background' ) }
-									isShownByDefault
-									hasValue={ () => isRepeated }
-									onDeselect={ () =>
-										setAttributes( {
-											isRepeated: false,
-										} )
-									}
-								>
-									<ToggleControl
-										label={ __( 'Repeated background' ) }
-										checked={ isRepeated }
-										onChange={ toggleIsRepeated }
-									/>
-								</ToolsPanelItem>
-							</>
+									checked={ isRepeated }
+									onChange={ toggleIsRepeated }
+								/>
+							</ToolsPanelItem>
 						) }
 						{ showFocalPointPicker && (
 							<ToolsPanelItem

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -134,7 +134,10 @@ export default function save( { attributes } ) {
 				<video
 					className={ clsx(
 						'wp-block-cover__video-background',
-						'intrinsic-ignore'
+						'intrinsic-ignore',
+						{
+							'has-parallax': hasParallax,
+						}
 					) }
 					autoPlay
 					muted

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -73,9 +73,6 @@ export function attributesFromMedia( media ) {
 		id: media.id,
 		alt: media?.alt,
 		backgroundType: mediaType,
-		...( mediaType === VIDEO_BACKGROUND_TYPE
-			? { hasParallax: undefined }
-			: {} ),
 	};
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -228,8 +228,7 @@
 
 .wp-block-cover-image,
 .wp-block-cover,
-.wp-block-cover__image-background,
-video.wp-block-cover__video-background {
+.wp-block-cover__image-background {
 	&.has-parallax {
 		background-attachment: fixed;
 		background-size: cover;
@@ -251,6 +250,40 @@ video.wp-block-cover__video-background {
 	&.is-repeated {
 		background-repeat: repeat;
 		background-size: auto;
+	}
+}
+
+// Fixed ("parallax") background effect for video. Unlike images, a <video>
+// element cannot use `background-attachment: fixed`, so it is pinned to the
+// viewport with `position: fixed` and clipped to the cover block's bounds.
+.wp-block-cover.has-parallax {
+	// Establish a clipping context so the fixed video stays within the block.
+	clip-path: inset(0);
+
+	video.wp-block-cover__video-background {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100vw;
+		height: 100vh;
+		pointer-events: none;
+		object-fit: cover;
+
+		// Mobile Safari handles fixed positioning poorly; fall back to a
+		// contained, non-fixed video that fills the cover block.
+		@supports (-webkit-touch-callout: inherit) {
+			position: absolute;
+			width: 100%;
+			height: 100%;
+		}
+
+		// Respect OS-level reduced-motion preference: disable the parallax
+		// effect by containing the video to the cover block.
+		@media (prefers-reduced-motion: reduce) {
+			position: absolute;
+			width: 100%;
+			height: 100%;
+		}
 	}
 }
 


### PR DESCRIPTION
## What?

Adds the **"Fixed background"** (parallax) option to **video** backgrounds in the Cover block, bringing them to parity with image backgrounds. Closes #52585.

## Why?

Image backgrounds in Cover have long supported a "Fixed background" toggle, but video backgrounds did not — the toggle was hidden for videos, and selecting a video actively cleared any existing `hasParallax` value. The feature has had repeated user requests on #52585.

> Note: This overlaps with the existing PR #74289. The key difference here is the addition of **`prefers-reduced-motion` and iOS Safari fallbacks** for the fixed video (see below). I'm happy to fold this into #74289 instead if maintainers prefer — opening this to surface the accessibility/mobile handling.

## How?

The CSS trick used for images — `background-attachment: fixed` — has **no effect on a real `<video>` element** (it only applies to CSS `background-image`). So a fixed video is achieved differently:

- The `<video>` is pinned to the viewport with `position: fixed` and clipped to the cover block's bounds via `clip-path: inset(0)` on `.wp-block-cover.has-parallax`.
- The `has-parallax` class is applied to the video element in both the editor (`edit/index.js`) and saved markup (`save.js`).
- The "Fixed background" toggle in the inspector is now shown for `isImageBackground || isVideoBackground`. "Repeated background" remains image-only.
- `attributesFromMedia()` no longer clears `hasParallax` when a video is selected.

**Accessibility / mobile fallbacks** (the addition vs. #74289): under `@media (prefers-reduced-motion: reduce)` and `@supports (-webkit-touch-callout: inherit)` (iOS Safari), the video reverts to a contained, non-fixed layout (`position: absolute`, filling the cover box) — mirroring the existing image parallax fallbacks. A permanently fixed, full-viewport video is exactly the kind of motion reduced-motion users opt out of, and fixed positioning is unreliable on iOS Safari.

No new block attribute (reuses `hasParallax`) and no deprecation is required: existing serialized video covers never had `hasParallax` set, so the new class is only ever added to new content.

## Testing Instructions

1. Add a **Cover** block and select a **video** background.
2. In the block sidebar (Settings → Media), confirm a **"Fixed background"** toggle now appears; enable it. Confirm **"Repeated background"** does **not** appear for video.
3. Add inner content, increase the cover height, and add content below so the page scrolls.
4. View the post on the **front end** and scroll — the video stays pinned (parallax) and stays clipped to the cover block (it does not bleed across the page).
5. Toggle off → the video returns to its normal contained layout.
6. Regression: confirm image "Fixed background" and "Repeated background" still work.
7. Edge cases: with OS "Reduce motion" enabled (and on iOS Safari), the video should fall back to a contained, non-fixed background. Re-open an existing post containing a video cover and confirm there is no block validation error.

## Screenshots or screencast

_Editor: the "Fixed background" toggle now appears for a video Cover; front end: the video remains fixed while content scrolls over it._
