### PR TITLE
Components: Render PanelColorSettings children when no colors are available

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `PanelColorSettings`: Render `children` even when there are no colors or gradients available, instead of hiding the whole panel ([#12583](https://github.com/WordPress/gutenberg/issues/12583)).
+
 ## 15.21.0 (2026-06-10)
 
 ### Code Quality

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -42,6 +42,7 @@ export const PanelColorGradientSettingsInner = ( {
 	const panelId = useInstanceId( PanelColorGradientSettingsInner );
 	const { batch } = useRegistry();
 	if (
+		! children &&
 		( ! colors || colors.length === 0 ) &&
 		( ! gradients || gradients.length === 0 ) &&
 		disableCustomColors &&

--- a/packages/block-editor/src/components/panel-color-settings/test/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -32,6 +32,20 @@ describe( 'PanelColorSettings', () => {
 			/>
 		);
 		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render children even if there are no colors to choose', async () => {
+		render(
+			<PanelColorSettings
+				title="Test Title"
+				colors={ [] }
+				disableCustomColors
+				colorSettings={ [] }
+			>
+				<p>Additional setting</p>
+			</PanelColorSettings>
+		);
+		expect( screen.getByText( 'Additional setting' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render a color panel if at least one setting supports custom colors', async () => {


### PR DESCRIPTION
## What?

Fixes #12583. `PanelColorSettings` now renders its `children` even when there are no colors or gradients available, instead of hiding the entire panel (and its children).

## Why?

`PanelColorSettings` is sometimes used to group extra controls (e.g. a toggle or select) alongside its color settings. When the available palette is empty and custom colors/gradients are disabled, the panel is hidden entirely — and any `children` passed to it disappear too. That makes the component unusable as a container in themes/contexts without a palette, which is what #12583 reports.

## How?

In `PanelColorGradientSettingsInner` (`packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js`), there is an early `return null` when there are no colors/gradients to choose and custom colors/gradients are disabled. That early return runs **before** the `children` are rendered (the children are rendered near the bottom of the component, after the color dropdowns).

The fix adds `! children` to that guard, so the panel only returns `null` when there is genuinely nothing to show. When children are present, the panel renders them as before.

```diff
 if (
+	! children &&
 	( ! colors || colors.length === 0 ) &&
 	( ! gradients || gradients.length === 0 ) &&
 	disableCustomColors &&
 	disableCustomGradients &&
 	settings?.every( /* … no colors/gradients … */ )
 ) {
 	return null;
 }
```

The existing "render nothing when truly empty" behavior is preserved for the no-children case (covered by the existing tests).

## Testing Instructions

1. `npm run test:unit packages/block-editor/src/components/panel-color-settings` — all tests pass, including the new `should render children even if there are no colors to choose`.
2. Programmatic check in the editor (no stock block passes children to this panel, so reproduce via the component directly): render `wp.blockEditor.PanelColorSettings` with `colors={[]} disableCustomColors colorSettings={[]}` and a child element. Before this change the child does not render at all; after it, the child renders inside the panel.

## Screenshots or screencast

| Before | After |
| --- | --- |
| Panel with no colors + a child renders nothing (child dropped). | Panel renders the child control. |
