### PR TITLE
Spacer Block: Default to last used size on insertion

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -86,6 +86,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 export default function SpacerControls( {
 	setAttributes,
+	onSizeChange,
 	orientation,
 	height,
 	width,
@@ -98,6 +99,7 @@ export default function SpacerControls( {
 			<ToolsPanel
 				label={ __( 'Settings' ) }
 				resetAll={ () => {
+					onSizeChange?.( '100px' );
 					setAttributes( {
 						width: undefined,
 						height: '100px',
@@ -117,9 +119,10 @@ export default function SpacerControls( {
 						<DimensionInput
 							label={ __( 'Width' ) }
 							value={ width }
-							onChange={ ( nextWidth ) =>
-								setAttributes( { width: nextWidth } )
-							}
+							onChange={ ( nextWidth ) => {
+								onSizeChange?.( nextWidth );
+								setAttributes( { width: nextWidth } );
+							} }
 							isResizing={ isResizing }
 						/>
 					</ToolsPanelItem>
@@ -129,16 +132,18 @@ export default function SpacerControls( {
 						label={ __( 'Height' ) }
 						isShownByDefault
 						hasValue={ () => height !== '100px' }
-						onDeselect={ () =>
-							setAttributes( { height: '100px' } )
-						}
+						onDeselect={ () => {
+							onSizeChange?.( '100px' );
+							setAttributes( { height: '100px' } );
+						} }
 					>
 						<DimensionInput
 							label={ __( 'Height' ) }
 							value={ height }
-							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight } )
-							}
+							onChange={ ( nextHeight ) => {
+								onSizeChange?.( nextHeight );
+								setAttributes( { height: nextHeight } );
+							} }
 							isResizing={ isResizing }
 						/>
 					</ToolsPanelItem>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -27,6 +27,10 @@ import SpacerControls from './controls';
 import { MIN_SPACER_SIZE } from './constants';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
+const PREFERENCES_STORE = 'core/preferences';
+
+const PREFERENCE_SCOPE = 'core/block-editor';
+const PREFERENCE_KEY = 'spacerLastUsedSize';
 
 const ResizableSpacer = ( {
 	orientation,
@@ -89,13 +93,31 @@ const SpacerEdit = ( {
 	setAttributes,
 	toggleSelection,
 	context,
+	clientId,
 	__unstableParentLayout: parentLayout,
 	className,
 } ) => {
-	const disableCustomSpacingSizes = useSelect( ( select ) => {
-		const editorSettings = select( blockEditorStore ).getSettings();
-		return editorSettings?.disableCustomSpacingSizes;
-	} );
+	const { disableCustomSpacingSizes, wasJustInserted, lastUsedSize } =
+		useSelect(
+			( select ) => {
+				const editorSettings = select( blockEditorStore ).getSettings();
+				const prefsStore = select( PREFERENCES_STORE );
+
+				return {
+					disableCustomSpacingSizes:
+						editorSettings?.disableCustomSpacingSizes,
+					wasJustInserted:
+						select( blockEditorStore ).wasBlockJustInserted(
+							clientId
+						),
+					lastUsedSize: prefsStore?.get(
+						PREFERENCE_SCOPE,
+						PREFERENCE_KEY
+					),
+				};
+			},
+			[ clientId ]
+		);
 	const { orientation } = context;
 	const {
 		orientation: parentOrientation,
@@ -127,6 +149,13 @@ const SpacerEdit = ( {
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
+	const { set: setPreference } = useDispatch( PREFERENCES_STORE );
+
+	const setRememberedSize = ( nextSize ) => {
+		if ( nextSize && setPreference ) {
+			setPreference( PREFERENCE_SCOPE, PREFERENCE_KEY, nextSize );
+		}
+	};
 
 	const handleOnVerticalResizeStop = ( newHeight ) => {
 		onResizeStop();
@@ -145,6 +174,7 @@ const SpacerEdit = ( {
 		}
 
 		setAttributes( { height: newHeight } );
+		setRememberedSize( newHeight );
 		setTemporaryHeight( null );
 	};
 
@@ -165,8 +195,29 @@ const SpacerEdit = ( {
 		}
 
 		setAttributes( { width: newWidth } );
+		setRememberedSize( newWidth );
 		setTemporaryWidth( null );
 	};
+
+	useEffect( () => {
+		if ( ! wasJustInserted || ! lastUsedSize ) {
+			return;
+		}
+
+		// Apply remembered size only for newly inserted spacers.
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes(
+			inheritedOrientation === 'horizontal'
+				? { width: lastUsedSize }
+				: { height: lastUsedSize }
+		);
+	}, [
+		__unstableMarkNextChangeAsNotPersistent,
+		inheritedOrientation,
+		lastUsedSize,
+		setAttributes,
+		wasJustInserted,
+	] );
 
 	const getHeightForVerticalBlocks = () => {
 		if ( isFlexLayout ) {
@@ -365,6 +416,7 @@ const SpacerEdit = ( {
 			{ ! isFlexLayout && (
 				<SpacerControls
 					setAttributes={ setAttributes }
+					onSizeChange={ setRememberedSize }
 					height={ temporaryHeight || height }
 					width={ temporaryWidth || width }
 					orientation={ inheritedOrientation }


### PR DESCRIPTION
Closes #45429

## What?
When inserting a new Spacer block, default its size to the last size the user set, rather than always defaulting to 100px.

## Why?
It's common to use many Spacer blocks of the same size throughout a post. Previously, every new Spacer inserted at 100px (or the theme default), forcing users to manually resize each one or duplicate and reposition existing spacers. This PR removes that friction by remembering the last size the user set and applying it to each new insertion.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a Spacer block, note the default height is 100px.
3. Resize the Spacer to a different size (e.g. 200px) using the drag handle.
4. Insert a second Spacer block, it should default to 200px.
5. Change the height via the sidebar input to 50px.
6. Insert a third Spacer, it should default to 50px.
7. Click "Reset" in the sidebar, the height returns to 100px.
8. Insert a fourth Spacer, it should default to 100px.
9. Reload the editor and insert a new Spacer, the last used size should still be applied.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/be321ee0-55a3-4982-8d15-b157e49c7c32

