### PR TITLE
Block Editor: Fix potential crash from 'useBlockToolbarPopoverProps'

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -157,7 +157,13 @@ export default function useBlockToolbarPopoverProps( {
 					isSticky
 				)
 			),
-		[ contentElement, selectedBlockElement, scrollContainer, toolbarHeight ]
+		[
+			contentElement,
+			selectedBlockElement,
+			scrollContainer,
+			toolbarHeight,
+			isSticky,
+		]
 	);
 
 	// Update props when the block is moved. This also ensures the props are
@@ -173,18 +179,18 @@ export default function useBlockToolbarPopoverProps( {
 
 		// Update the toolbar props on viewport resize.
 		const contentView = contentElement?.ownerDocument?.defaultView;
-		contentView?.addEventHandler?.( 'resize', updateProps );
+		contentView?.addEventListener?.( 'resize', updateProps );
 
 		// Update the toolbar props on block resize.
 		let resizeObserver;
 		const blockView = selectedBlockElement?.ownerDocument?.defaultView;
-		if ( blockView.ResizeObserver ) {
+		if ( blockView?.ResizeObserver ) {
 			resizeObserver = new blockView.ResizeObserver( updateProps );
 			resizeObserver.observe( selectedBlockElement );
 		}
 
 		return () => {
-			contentView?.removeEventHandler?.( 'resize', updateProps );
+			contentView?.removeEventListener?.( 'resize', updateProps );
 
 			if ( resizeObserver ) {
 				resizeObserver.disconnect();


### PR DESCRIPTION
## What?
Closes #79118.

PR tries to fix the potential error when `blockView` is undefined in `useBlockToolbarPopoverProps`. I've also fixed a typo when registering `resize` event listeners. There's no `addEventHandler` method.

Bonus point: fixes ESLint warnings for missing `isSticky` dependency.

P.S. I wasn't able to reproduce the error myself, but `blockView` can be undefined, so it's better to guard for it.

## Testing Instructions
Try reproduction steps from #42887.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
