### PR TITLE
[DataViewsPicker]: `DataViewsPicker.BulkActionToolbar` now renders only the bulk-selection info and action buttons

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `DataViewsPicker`: `DataViewsPicker.BulkActionToolbar` now renders only the bulk-selection info and action buttons, without pagination, matching `DataViews.BulkActionToolbar`. The full footer it previously rendered (including pagination) is now exposed as `DataViewsPicker.Footer`, matching `DataViews.Footer`. [#79180](https://github.com/WordPress/gutenberg/pull/79180)
+
 ## 16.0.0 (2026-06-10)
 
 ### Breaking Changes

--- a/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker-footer/index.tsx
@@ -22,7 +22,10 @@ export function useIsMultiselectPicker< Item >(
 	actions: Action< Item >[] | undefined
 ) {
 	return useMemo( () => {
-		return actions?.every( ( action ) => action.supportsBulk );
+		return (
+			!! actions?.length &&
+			actions?.every( ( action ) => action.supportsBulk )
+		);
 	}, [ actions ] );
 }
 
@@ -145,7 +148,7 @@ function ActionButtons< Item >( {
 	);
 }
 
-export function DataViewsPickerFooter() {
+function PickerBulkSelectionInfo() {
 	const {
 		data,
 		selection,
@@ -158,6 +161,17 @@ export function DataViewsPickerFooter() {
 
 	const isMultiselect = useIsMultiselectPicker( actions );
 
+	const selectedItems = useMemo(
+		() =>
+			data.filter( ( item ) => selection.includes( getItemId( item ) ) ),
+		[ selection, getItemId, data ]
+	);
+
+	// The count and the selection checkbox belong with the actions, mirroring `DataViews`.
+	if ( ! actions.length ) {
+		return null;
+	}
+
 	const message = getFooterMessage(
 		selection.length,
 		data.length,
@@ -165,11 +179,87 @@ export function DataViewsPickerFooter() {
 		!! view.infiniteScrollEnabled
 	);
 
+	return (
+		<Stack
+			direction="row"
+			className="dataviews-picker-footer__bulk-selection"
+			gap="md"
+			align="center"
+		>
+			{ isMultiselect && (
+				<BulkSelectionCheckbox
+					selection={ selection }
+					selectedItems={ selectedItems }
+					onChangeSelection={ onChangeSelection }
+					data={ data }
+					getItemId={ getItemId }
+					disableSelectAll={ !! view.infiniteScrollEnabled }
+				/>
+			) }
+			<span className="dataviews-bulk-actions-footer__item-count">
+				{ message }
+			</span>
+		</Stack>
+	);
+}
+
+function PickerActions() {
+	const {
+		data,
+		selection,
+		getItemId,
+		actions = EMPTY_ARRAY,
+	} = useContext( DataViewsContext );
+
 	const selectedItems = useMemo(
 		() =>
 			data.filter( ( item ) => selection.includes( getItemId( item ) ) ),
 		[ selection, getItemId, data ]
 	);
+
+	if ( ! actions.length ) {
+		return null;
+	}
+
+	return (
+		<div className="dataviews-picker-footer__actions">
+			<ActionButtons
+				actions={ actions }
+				items={ selectedItems }
+				selection={ selection }
+			/>
+		</div>
+	);
+}
+
+// The bulk-selection info and action buttons without pagination — the picker
+// counterpart to `DataViews.BulkActionToolbar`, for free composition.
+export function DataViewsPickerBulkActionToolbar() {
+	return (
+		<Stack direction="row" gap="md" align="center">
+			<PickerBulkSelectionInfo />
+			<PickerActions />
+		</Stack>
+	);
+}
+
+// The full picker footer: bulk-selection info, pagination, and actions — the
+// picker counterpart to `DataViews.Footer`.
+export function DataViewsPickerFooter() {
+	const {
+		actions = EMPTY_ARRAY,
+		paginationInfo,
+		view,
+	} = useContext( DataViewsContext );
+
+	const hasPagination =
+		! view.infiniteScrollEnabled &&
+		!! paginationInfo.totalItems &&
+		paginationInfo.totalPages > 1;
+
+	if ( ! actions.length && ! hasPagination ) {
+		return null;
+	}
 
 	return (
 		<Stack
@@ -179,36 +269,9 @@ export function DataViewsPickerFooter() {
 			className="dataviews-footer"
 			gap="sm"
 		>
-			<Stack
-				direction="row"
-				className="dataviews-picker-footer__bulk-selection"
-				gap="md"
-				align="center"
-			>
-				{ isMultiselect && (
-					<BulkSelectionCheckbox
-						selection={ selection }
-						selectedItems={ selectedItems }
-						onChangeSelection={ onChangeSelection }
-						data={ data }
-						getItemId={ getItemId }
-						disableSelectAll={ !! view.infiniteScrollEnabled }
-					/>
-				) }
-				<span className="dataviews-bulk-actions-footer__item-count">
-					{ message }
-				</span>
-			</Stack>
+			<PickerBulkSelectionInfo />
 			<DataViewsPagination />
-			{ Boolean( actions?.length ) && (
-				<div className="dataviews-picker-footer__actions">
-					<ActionButtons
-						actions={ actions }
-						items={ selectedItems }
-						selection={ selection }
-					/>
-				</div>
-			) }
+			<PickerActions />
 		</Stack>
 	);
 }

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -29,7 +29,10 @@ import {
 	FiltersToggle,
 } from '../components/dataviews-filters';
 import DataViewsLayout from '../components/dataviews-layout';
-import { DataViewsPickerFooter } from '../components/dataviews-picker-footer';
+import {
+	DataViewsPickerFooter,
+	DataViewsPickerBulkActionToolbar,
+} from '../components/dataviews-picker-footer';
 import DataViewsSearch from '../components/dataviews-search';
 import { DataViewsPagination } from '../components/dataviews-pagination';
 import DataViewsViewConfig, {
@@ -269,7 +272,8 @@ function DataViewsPicker< Item >( {
 // Populate the DataViews sub components
 const DataViewsPickerSubComponents =
 	DataViewsPicker as typeof DataViewsPicker & {
-		BulkActionToolbar: typeof DataViewsPickerFooter;
+		BulkActionToolbar: typeof DataViewsPickerBulkActionToolbar;
+		Footer: typeof DataViewsPickerFooter;
 		Filters: typeof Filters;
 		FiltersToggled: typeof FiltersToggled;
 		FiltersToggle: typeof FiltersToggle;
@@ -280,7 +284,9 @@ const DataViewsPickerSubComponents =
 		ViewConfig: typeof DataviewsViewConfigDropdown;
 	};
 
-DataViewsPickerSubComponents.BulkActionToolbar = DataViewsPickerFooter;
+DataViewsPickerSubComponents.BulkActionToolbar =
+	DataViewsPickerBulkActionToolbar;
+DataViewsPickerSubComponents.Footer = DataViewsPickerFooter;
 DataViewsPickerSubComponents.Filters = Filters;
 DataViewsPickerSubComponents.FiltersToggled = FiltersToggled;
 DataViewsPickerSubComponents.FiltersToggle = FiltersToggle;

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -655,7 +655,7 @@ export function MediaUploadModal( {
 						onDismissError={ dismissError }
 						onOpenChange={ handlePopoverOpenChange }
 					/>
-					<DataViewsPicker.BulkActionToolbar />
+					<DataViewsPicker.Footer />
 				</div>
 			</DataViewsPicker>
 			{ createPortal(


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Extracted from https://github.com/WordPress/gutenberg/pull/77333#discussion_r3397904264

While working in updating the revisions screens to use the picker-activity layout I noticed a few things we could improve around the exports and organization of the footer components.

These changes will help more use cases and enable better composition and some more will be explored separately when we'll try to integrate this layout in GS revisions.

This PR extracts:

1. In trunk `DataViewsPicker.BulkActionToolbar` exports the footer, which is not correct. So I followed a similar approach to DataViews and created (and exported) BulkActionToolbar which holds the selection checkbox, the message, and the actions. It doesn't contain the pagination and is more flexible for free composition.
2. Fixed a logic bug in `useIsMultiselectPicker` where we wouldn't check the existence of actions, which also could lead to wrong aria props.
3. Exported the footer. This component is the one that is going to be used by the revisions (other PR).

## Testing Instructions
1. No visible changes anywhere. Everything should work as before
2. You can confirm in storybook (`npm run storybook:dev`) or existing picker usages like the media picker
