### PR TITLE
Template Part: Remove restriction on tabs / inspector fills

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -79,7 +79,7 @@ const StylesTab = ( {
 					contentClientIds={ contentClientIds }
 				/>
 			) }
-			{ ! isSectionBlock && (
+			{ ( ! isSectionBlock || blockName === 'core/template-part' ) && (
 				<>
 					<InspectorControls.Slot
 						group="color"

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -79,6 +79,10 @@ const StylesTab = ( {
 					contentClientIds={ contentClientIds }
 				/>
 			) }
+			{
+				// Extenders have in the past always been allowed to add controls to group
+				// the restrictions are lessended for that block.
+			 }
 			{ ( ! isSectionBlock || blockName === 'core/template-part' ) && (
 				<>
 					<InspectorControls.Slot

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -81,7 +81,7 @@ const StylesTab = ( {
 			) }
 			{
 				// Extenders have in the past always been allowed to add controls to group
-				// the restrictions are lessended for that block.
+				// the restrictions are lessened for that block.
 			 }
 			{ ( ! isSectionBlock || blockName === 'core/template-part' ) && (
 				<>

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -55,7 +55,7 @@ export default function InspectorControlsFill( {
 
 	// During pattern editing:
 	// - All blocks can show pattern editing groups (content, list).
-	// - Template parts can show a settings tab (default, settings, advanced groups).
+	// - Template parts can show any inspector group.
 	// - Other blocks cannot show a settings tab.
 	if ( context[ mayDisplayPatternEditingControlsKey ] ) {
 		// Template parts have also historically supported

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -58,12 +58,12 @@ export default function InspectorControlsFill( {
 	// - Template parts can show a settings tab (default, settings, advanced groups).
 	// - Other blocks cannot show a settings tab.
 	if ( context[ mayDisplayPatternEditingControlsKey ] ) {
-		// Template parts are allowed to show a settings tab to allow access to the
-		// 'Design' and 'Advanced' panels. Template parts have also historically supported
-		// any controls, so unlike regular patterns they continue to do so.
+		// Template parts have also historically supported
+		// any block inspector groups for extenders. The settings
+		// tab is also used by core for the 'Design' panel. Specifically
+		// for that block the restrictions on allowed groups are lessened.
 		const isTemplatePart = context.name === 'core/template-part';
 		const isPatternEditingGroup = PATTERN_EDITING_GROUPS.includes( group );
-
 		const canShowGroup = isTemplatePart || isPatternEditingGroup;
 
 		if ( ! canShowGroup ) {

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -26,7 +26,6 @@ import {
 import { ListViewContentFill } from './list-view-content-popover';
 
 const PATTERN_EDITING_GROUPS = [ 'content', 'list' ];
-const TEMPLATE_PART_GROUPS = [ 'default', 'settings', 'advanced' ];
 
 export default function InspectorControlsFill( {
 	children,
@@ -60,13 +59,12 @@ export default function InspectorControlsFill( {
 	// - Other blocks cannot show a settings tab.
 	if ( context[ mayDisplayPatternEditingControlsKey ] ) {
 		// Template parts are allowed to show a settings tab to allow access to the
-		// 'Design' and 'Advanced' panels.
+		// 'Design' and 'Advanced' panels. Template parts have also historically supported
+		// any controls, so unlike regular patterns they continue to do so.
 		const isTemplatePart = context.name === 'core/template-part';
-		const isTemplatePartGroup = TEMPLATE_PART_GROUPS.includes( group );
 		const isPatternEditingGroup = PATTERN_EDITING_GROUPS.includes( group );
 
-		const canShowGroup =
-			( isTemplatePart && isTemplatePartGroup ) || isPatternEditingGroup;
+		const canShowGroup = isTemplatePart || isPatternEditingGroup;
 
 		if ( ! canShowGroup ) {
 			return null;


### PR DESCRIPTION
## What?
Fixes #79152

As mentioned in that issue, extenders (in this case plugins or site owners that add extra features to core blocks) in the past have been able to enable style block supports for Template Parts. Similarly they would have been able to add any custom controls to the inspector controls groups.

PRs #71714 and #74793 inadvertently restricted the groups that can be rendered for template parts. In reviewing the changes, I don't think it's necessary, we can relax the restrictions again to allow extenders to do what they want and support the same tools they had before 7.0.

## How?
- Simplifies `InspectorControlsFill` - I don't think there's any need to restrict what groups template parts can render. Core only uses 'content', 'list', 'default', 'settings' and 'advanced' for the default experience. Extenders can use others and go beyond the default after this PR.
- Similarly in `StylesTab` - render all the styles fills for Template Parts. If extenders want to add styles to the block they can, but it's not what core ships by default.

## Testing Instructions
1. Add some config like this to the template part's block.json to mimic what an extender might do:
```
"position": {
	"sticky": true
},
"spacing": {
	"margin": [
		"top",
		"bottom"
	],
	"padding": true
}
```
2. Load the site editor, select a template part, and open the block inspector

In this PR: The styles tab now shows
In trunk: No styles tools are shown

## Screenshots

### Before

<img width="279" height="450" alt="Screenshot 2026-06-15 at 4 42 05 pm" src="https://github.com/user-attachments/assets/7a200f24-f99b-4783-ad3d-67e2adf8facd" />

### After

<img width="284" height="628" alt="Screenshot 2026-06-15 at 4 41 13 pm" src="https://github.com/user-attachments/assets/b8b09d75-2788-4d47-9464-042dae0aeb03" />

Note, with 'Button Text Labels' the tabs do scroll, so are still usable. It may not be the best, but this won't be the default experience:
<img width="286" height="445" alt="Screenshot 2026-06-15 at 4 44 10 pm" src="https://github.com/user-attachments/assets/006d9904-6102-456d-a9c0-dc265ea6bed9" />


## Use of AI Tools
None