### PR TITLE
Revisions: Ignore empty `[]/{}` meta values in the Meta diff panel

### DIFF
--- a/packages/editor/src/components/revision-fields-diff/index.js
+++ b/packages/editor/src/components/revision-fields-diff/index.js
@@ -39,6 +39,16 @@ function stringifyValue( value ) {
 }
 
 /**
+ * Determines whether a meta value should be treated as empty.
+ *
+ * @param {string} str The stringified value.
+ * @return {boolean} Whether the value is effectively empty.
+ */
+function isEmptyMeta( str ) {
+	return ! str || str === '[]' || str === '{}';
+}
+
+/**
  * Panel that shows meta field diffs between the current revision and
  * the previous revision in the document sidebar during revision mode.
  */
@@ -72,7 +82,7 @@ export default function RevisionFieldsDiffPanel() {
 			const revStr = stringifyValue( revisionMeta[ key ] );
 			const prevStr = stringifyValue( previousMeta[ key ] );
 
-			if ( ! revStr && ! prevStr ) {
+			if ( isEmptyMeta( revStr ) && isEmptyMeta( prevStr ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

It was [noticed in this PR](https://github.com/WordPress/gutenberg/pull/77333#pullrequestreview-4496086562) that in `meta panel` in revisions screen we can end up showing an empty array to many revisions. 

This can happen when a revision had a post meta change (e.g. footnotes) and then that post meta were removed. Every subsequent revision would still show an empty array. This PR updates the checks to ignore `[]/{}` as empty values.

## Testing Instructions
1. Create a post and add footnotes in a paragraph. Save
2. Remove the footnotes. Save
3. Make another random change to create a revision and save.
4. View the revisions of the post and observe that for the last revision we don't show an empty array. 


### Before

https://github.com/user-attachments/assets/b9cc7fc1-2e43-4b92-b816-e92546b72311




### After

https://github.com/user-attachments/assets/524ab70c-9970-43f0-92ed-3572571ac029


