### PR TITLE
Icon block: Move flip controls to toolbar group.

### DIFF
--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -113,37 +113,35 @@ export function Edit( { attributes, setAttributes } ) {
 			</BlockControls>
 			{ icon && (
 				<BlockControls group="block">
-					<ToolbarGroup>
-						<ToolbarButton
-							icon={ flipHorizontalIcon }
-							label={ __( 'Flip horizontal' ) }
-							isPressed={ flipHorizontal }
-							onClick={ () =>
-								setAttributes( {
-									flipHorizontal: ! flipHorizontal,
-								} )
-							}
-						/>
-						<ToolbarButton
-							icon={ flipVerticalIcon }
-							label={ __( 'Flip vertical' ) }
-							isPressed={ flipVertical }
-							onClick={ () =>
-								setAttributes( {
-									flipVertical: ! flipVertical,
-								} )
-							}
-						/>
-						<ToolbarButton
-							icon={ rotateRight }
-							label={ __( 'Rotate' ) }
-							onClick={ () =>
-								setAttributes( {
-									rotation: ( ( rotation || 0 ) + 90 ) % 360,
-								} )
-							}
-						/>
-					</ToolbarGroup>
+					<ToolbarButton
+						icon={ flipHorizontalIcon }
+						label={ __( 'Flip horizontal' ) }
+						isPressed={ flipHorizontal }
+						onClick={ () =>
+							setAttributes( {
+								flipHorizontal: ! flipHorizontal,
+							} )
+						}
+					/>
+					<ToolbarButton
+						icon={ flipVerticalIcon }
+						label={ __( 'Flip vertical' ) }
+						isPressed={ flipVertical }
+						onClick={ () =>
+							setAttributes( {
+								flipVertical: ! flipVertical,
+							} )
+						}
+					/>
+					<ToolbarButton
+						icon={ rotateRight }
+						label={ __( 'Rotate' ) }
+						onClick={ () =>
+							setAttributes( {
+								rotation: ( ( rotation || 0 ) + 90 ) % 360,
+							} )
+						}
+					/>
 				</BlockControls>
 			) }
 			{ isContentOnlyMode && icon && (

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -11,7 +11,6 @@ import {
 	DropdownMenu,
 	TextControl,
 	ToolbarButton,
-	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -102,15 +101,6 @@ export function Edit( { attributes, setAttributes } ) {
 
 	const blockControls = (
 		<>
-			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
-				<ToolbarButton
-					onClick={ () => {
-						setInserterOpen( true );
-					} }
-				>
-					{ icon ? __( 'Replace' ) : __( 'Choose icon' ) }
-				</ToolbarButton>
-			</BlockControls>
 			{ icon && (
 				<BlockControls group="block">
 					<ToolbarButton
@@ -144,37 +134,47 @@ export function Edit( { attributes, setAttributes } ) {
 					/>
 				</BlockControls>
 			) }
-			{ isContentOnlyMode && icon && (
-				// Add some extra controls for content attributes when content only mode is active.
-				// With content only mode active, the inspector is hidden, so users need another way
-				// to edit these attributes.
-				<BlockControls group="other">
-					<ToolbarGroup>
-						<DropdownMenu
-							icon=""
-							popoverProps={ {
-								className: 'is-alternate',
-							} }
-							text={ __( 'Label' ) }
-						>
-							{ () => (
-								<TextControl
-									className="wp-block-icon__toolbar-content"
-									label={ __( 'Label' ) }
-									value={ ariaLabel || '' }
-									onChange={ ( value ) =>
-										setAttributes( { ariaLabel: value } )
-									}
-									help={ __(
-										'Briefly describe the icon to help screen reader users. Leave blank for decorative icons.'
-									) }
-									__next40pxDefaultSize
-								/>
-							) }
-						</DropdownMenu>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
+			<BlockControls group="other">
+				<ToolbarButton
+					onClick={ () => {
+						setInserterOpen( true );
+					} }
+				>
+					{ icon ? __( 'Replace' ) : __( 'Choose icon' ) }
+				</ToolbarButton>
+				{ isContentOnlyMode && icon && (
+					// Add some extra controls for content attributes when content only mode is active.
+					// With content only mode active, the inspector is hidden, so users need another way
+					// to edit these attributes.
+					<DropdownMenu
+						icon=""
+						toggleProps={ {
+							as: ToolbarButton,
+						} }
+						popoverProps={ {
+							className: 'is-alternate',
+						} }
+						text={ __( 'Label' ) }
+					>
+						{ () => (
+							<TextControl
+								className="wp-block-icon__toolbar-content"
+								label={ __( 'Label' ) }
+								value={ ariaLabel || '' }
+								onChange={ ( value ) =>
+									setAttributes( {
+										ariaLabel: value,
+									} )
+								}
+								help={ __(
+									'Briefly describe the icon to help screen reader users. Leave blank for decorative icons.'
+								) }
+								__next40pxDefaultSize
+							/>
+						) }
+					</DropdownMenu>
+				) }
+			</BlockControls>
 		</>
 	);
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -103,18 +103,16 @@ export function Edit( { attributes, setAttributes } ) {
 	const blockControls = (
 		<>
 			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
-				<ToolbarGroup>
-					<ToolbarButton
-						onClick={ () => {
-							setInserterOpen( true );
-						} }
-					>
-						{ icon ? __( 'Replace' ) : __( 'Choose icon' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
+				<ToolbarButton
+					onClick={ () => {
+						setInserterOpen( true );
+					} }
+				>
+					{ icon ? __( 'Replace' ) : __( 'Choose icon' ) }
+				</ToolbarButton>
 			</BlockControls>
 			{ icon && (
-				<BlockControls group="other">
+				<BlockControls group="block">
 					<ToolbarGroup>
 						<ToolbarButton
 							icon={ flipHorizontalIcon }


### PR DESCRIPTION
## What?

Followup to #77017. Moves the flip/rotate buttons into a toolbar group. 

Before:

<img width="452" height="172" alt="Skærmbillede 2026-06-15 kl  14 57 01" src="https://github.com/user-attachments/assets/37f67459-567b-4a01-be5d-87ab977f93fd" />

After:

<img width="475" height="102" alt="Skærmbillede 2026-06-15 kl  15 08 31" src="https://github.com/user-attachments/assets/7eb7a78e-b3a1-4a85-b08d-099cfc5684e6" />

<img width="385" height="111" alt="Skærmbillede 2026-06-15 kl  15 08 36" src="https://github.com/user-attachments/assets/d36b300b-a601-469a-ac67-eb147d029f26" />

## Why?

This matches the markup and structure of the Image block, same toolbar category and the replace action on the end:

<img width="771" height="369" alt="Skærmbillede 2026-06-15 kl  14 58 26" src="https://github.com/user-attachments/assets/dad50abe-1d5c-4772-8e59-5b20743478b9" />

## Testing Instructions

Insert the Icon block and observe the Replace button being at the end of the list of toolbar items, like the Image block. 