### PR TITLE
Automated Testing: Use static value for IS_GUTENBERG_PLUGIN env setup

### DIFF
--- a/test/unit/config/gutenberg-env.js
+++ b/test/unit/config/gutenberg-env.js
@@ -9,5 +9,4 @@ globalThis.IS_WORDPRESS_CORE = true;
 
 // Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 // eslint-disable-next-line @wordpress/wp-global-usage
-globalThis.IS_GUTENBERG_PLUGIN =
-	String( process.env.npm_package_config_IS_GUTENBERG_PLUGIN ) === 'true';
+globalThis.IS_GUTENBERG_PLUGIN = true;


### PR DESCRIPTION
## What?

Updates Gutenberg test setup to hard-code `globalThis.IS_GUTENBERG_PLUGIN` to `true` rather than reading from the npm config value.

## Why?

- Accuracy: Reading from an environment variable risks misleading someone to think that the value would be anything other than `true`
- Code cleanup: This is part of a series of pull requests (including #79162) which looks to consolidate this `IS_GUTENBERG_PLUGIN` value, which is initialized both as an environment variable and an npm config value ([example](https://github.com/WordPress/gutenberg/blob/240812bd94367178367c002510993779ae20b293/packages/wp-build/lib/build.mjs#L134-L138)), adding complexity and risk for errors. These first pull requests are aimed at removing unnecessary existing usage, before moving to adapting remaining usage to a single approach.

## How?

Assigns `globalThis.IS_GUTENBERG_PLUGIN = true;` as hard-coded value.

Looking through git history to understand context, my best guess is that prior to #38202, it was important that the actual Gutenberg phase number was initialized accurately from `package.json` configuration for how the phase value was used in runtime code. The changes in #38202 did a simple migration to change from `GUTENBERG_PHASE: number` to `IS_GUTENBERG_PLUGIN: boolean`. But in practice, with how this applies to tests run within Gutenberg, the boolean will never be anything other than `true`, so it's overkill to initialize this from `package.json`.

## Testing Instructions

Verify unit tests pass:

1. Run `npm run test:unit`

## Use of AI Tools

This is an isolated subset of changes applied through Cursor + Claude Opus 4.8 as part of a larger effort to understand and consolidate usage of `package.json` `config.IS_GUTENBERG_PLUGIN`.