### PR TITLE
Image block: remove duplicate data-wp-bind--srcset in the lightbox overlay

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -390,7 +390,6 @@ function block_core_image_print_lightbox_overlay() {
 							data-wp-bind--style="state.imgStyles"
 							data-wp-bind--src="state.enlargedSrc"
 							data-wp-bind--srcset="state.enlargedSrcset"
-							data-wp-bind--srcset="state.enlargedSrcset"
 							sizes="100vw"
 						>
 					</figure>


### PR DESCRIPTION
## What?

Closes #79200

Removes a duplicate `data-wp-bind--srcset="state.enlargedSrcset"` attribute declaration from the enlarged `<img>` element in `block_core_image_print_lightbox_overlay()`.

## Why?

The enlarged `<img>` in `block_core_image_print_lightbox_overlay()` declares `data-wp-bind--srcset="state.enlargedSrcset"` twice. While this does not affect functionality, the duplicate attribute is redundant and can be removed to improve code clarity and maintainability.

## How?

Removes the duplicate `data-wp-bind--srcset` attribute from the enlarged `<img>` element, leaving a single declaration in place. No functional changes are introduced.


## Screenshots or screencast

Not applicable. This is a code cleanup with no visual changes.

## Use of AI Tools

ChatGPT was used to help draft the PR description. All code changes were reviewed and validated by the author.