### PR TITLE
Scripts: Avoid tests getting published to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52228,7 +52228,6 @@
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^0.4.0",
-				"rimraf": "^5.0.10",
 				"rtlcss": "^4.3.0",
 				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
@@ -52244,6 +52243,9 @@
 			},
 			"bin": {
 				"wp-scripts": "bin/wp-scripts.js"
+			},
+			"devDependencies": {
+				"rimraf": "^5.0.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -27,8 +27,8 @@
 		"config",
 		"plugins",
 		"scripts",
-		"!scripts/test",
-		"utils"
+		"utils",
+		"!**/test"
 	],
 	"bin": {
 		"wp-scripts": "./bin/wp-scripts.js"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -27,6 +27,7 @@
 		"config",
 		"plugins",
 		"scripts",
+		"!scripts/test",
 		"utils"
 	],
 	"bin": {
@@ -80,7 +81,6 @@
 		"react-refresh": "^0.14.0",
 		"read-pkg-up": "^7.0.1",
 		"resolve-bin": "^0.4.0",
-		"rimraf": "^5.0.10",
 		"rtlcss": "^4.3.0",
 		"sass": "^1.54.0",
 		"sass-loader": "^16.0.3",
@@ -93,6 +93,9 @@
 		"webpack-bundle-analyzer": "^4.9.1",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^4.15.1"
+	},
+	"devDependencies": {
+		"rimraf": "^5.0.10"
 	},
 	"peerDependencies": {
 		"@playwright/test": "^1.58.2",


### PR DESCRIPTION
Follow up of https://github.com/WordPress/gutenberg/pull/79095#discussion_r3415246260

## What?

Currently, the script package publishes test files to npm, which it ideally shouldn't.

## Why?

The test files are not meant for npm.

## How?

- Add a negation for test directory to skip it for publishing
- Move `rimraf` to dev deps

## Testing Instructions

- `cd packages/scripts && npm pack`
- Unpack the tarbal
- Verify that the test directory is not included.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
