### PR TITLE
Media editor modal: add a fallback to recover unreachable image crops

### DIFF
--- a/packages/media-editor/src/image-editor/react/components/crop-reachability.ts
+++ b/packages/media-editor/src/image-editor/react/components/crop-reachability.ts
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import type { NormalizedRect, Size } from '../../core/types';
+
+/**
+ * Minimum visible crop edge before the crop is considered recoverable. This is
+ * intentionally much smaller than the handle touch target: the recovery should
+ * only catch rogue states where the crop is effectively unreachable, not valid
+ * crops sitting near the canvas edge.
+ */
+const MIN_RECOVERABLE_VISIBLE_CROP_EDGE = 16;
+/**
+ * A crop edge also has to be mostly clipped before recovery runs. This keeps a
+ * tiny but fully visible crop from being treated as invalid just because its
+ * rendered size is below MIN_RECOVERABLE_VISIBLE_CROP_EDGE.
+ */
+const MIN_RECOVERABLE_VISIBLE_CROP_RATIO = 0.25;
+
+/**
+ * Detect whether a crop has become visually unreachable in the rendered
+ * canvas. This is a UI reachability check, not a source-image containment
+ * check: it includes view-scale and transient viewport pan in CSS pixels.
+ *
+ * @param cropRect      Crop rectangle in normalized image-footprint space.
+ * @param canvasSize    Visible cropper canvas size in CSS pixels.
+ * @param imageSize     Rendered image footprint size in CSS pixels.
+ * @param viewportPan   Temporary cropper viewport pan in CSS pixels.
+ * @param viewportPan.x Temporary horizontal viewport pan in CSS pixels.
+ * @param viewportPan.y Temporary vertical viewport pan in CSS pixels.
+ *
+ * @return True when the crop is effectively unreachable in the visible canvas.
+ */
+export function isCropVisuallyUnreachable(
+	cropRect: NormalizedRect,
+	canvasSize: Size,
+	imageSize: Size,
+	viewportPan: { x: number; y: number }
+): boolean {
+	if (
+		canvasSize.width <= 0 ||
+		canvasSize.height <= 0 ||
+		imageSize.width <= 0 ||
+		imageSize.height <= 0 ||
+		cropRect.width <= 0 ||
+		cropRect.height <= 0
+	) {
+		return false;
+	}
+
+	const offsetX = ( canvasSize.width - imageSize.width ) / 2;
+	const offsetY = ( canvasSize.height - imageSize.height ) / 2;
+	const left = offsetX + viewportPan.x + cropRect.x * imageSize.width;
+	const top = offsetY + viewportPan.y + cropRect.y * imageSize.height;
+	const width = cropRect.width * imageSize.width;
+	const height = cropRect.height * imageSize.height;
+	const right = left + width;
+	const bottom = top + height;
+	const visibleWidth = Math.max(
+		0,
+		Math.min( canvasSize.width, right ) - Math.max( 0, left )
+	);
+	const visibleHeight = Math.max(
+		0,
+		Math.min( canvasSize.height, bottom ) - Math.max( 0, top )
+	);
+
+	const minimumVisibleWidth = Math.min(
+		MIN_RECOVERABLE_VISIBLE_CROP_EDGE,
+		width * MIN_RECOVERABLE_VISIBLE_CROP_RATIO
+	);
+	const minimumVisibleHeight = Math.min(
+		MIN_RECOVERABLE_VISIBLE_CROP_EDGE,
+		height * MIN_RECOVERABLE_VISIBLE_CROP_RATIO
+	);
+
+	return (
+		visibleWidth < minimumVisibleWidth ||
+		visibleHeight < minimumVisibleHeight
+	);
+}

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -807,11 +807,13 @@ function CropperInner(
 			return;
 		}
 
+		// Dedupe by stable geometry only. Viewport pan is part of the
+		// reachability check above, but resetViewport() changes it during
+		// recovery and should not allow a second settle for the same crop.
 		const recoveryKey = JSON.stringify( {
 			cropRect: state.cropRect,
 			canvasSize,
 			scaledVisualSize,
-			viewportPan: viewportState.pan,
 		} );
 		if ( recoveryKeyRef.current === recoveryKey ) {
 			return;

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../core/source-region';
 import { ViewportProvider, useViewport } from './viewport-provider';
 import { VISUALLY_HIDDEN_STYLE } from '../visually-hidden-style';
+import { isCropVisuallyUnreachable } from './crop-reachability';
 
 /** Threshold for comparing normalized crop rect values. */
 const CROP_RECT_EPSILON = 1e-6;
@@ -775,6 +776,64 @@ function CropperInner(
 			clearTimeout( settleTimerRef.current );
 		};
 	}, [] );
+
+	const recoveryKeyRef = useRef< string | null >( null );
+	useEffect( () => {
+		// Last-resort recovery for rogue idle states where the crop has ended up
+		// outside the visible canvas and the user cannot reach the handles. This
+		// deliberately does not run during any active interaction or settle.
+		if (
+			! state.image ||
+			isResizing ||
+			settling ||
+			isDragging ||
+			isZooming ||
+			isPlacementActive ||
+			isInteractionPlacementActive
+		) {
+			recoveryKeyRef.current = null;
+			return;
+		}
+
+		if (
+			! isCropVisuallyUnreachable(
+				state.cropRect,
+				canvasSize,
+				scaledVisualSize,
+				viewportState.pan
+			)
+		) {
+			recoveryKeyRef.current = null;
+			return;
+		}
+
+		const recoveryKey = JSON.stringify( {
+			cropRect: state.cropRect,
+			canvasSize,
+			scaledVisualSize,
+			viewportPan: viewportState.pan,
+		} );
+		if ( recoveryKeyRef.current === recoveryKey ) {
+			return;
+		}
+		recoveryKeyRef.current = recoveryKey;
+		resetViewport();
+		settleCrop();
+	}, [
+		state.image,
+		state.cropRect,
+		canvasSize,
+		scaledVisualSize,
+		viewportState.pan,
+		isResizing,
+		settling,
+		isDragging,
+		isZooming,
+		isPlacementActive,
+		isInteractionPlacementActive,
+		resetViewport,
+		settleCrop,
+	] );
 
 	const isInteractiveGrid = showGrid === 'interactive';
 	const showInteractiveGrid =

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -312,6 +312,7 @@ export function RectangleStencil( {
 				}
 				el.removeEventListener( 'pointermove', onMove );
 				el.removeEventListener( 'pointerup', onEnd );
+				el.removeEventListener( 'pointercancel', onEnd );
 				el.removeEventListener( 'lostpointercapture', onEnd );
 				activePointerResizeRef.current = null;
 				if ( notifyResizeEnd ) {
@@ -331,6 +332,7 @@ export function RectangleStencil( {
 
 			el.addEventListener( 'pointermove', onMove );
 			el.addEventListener( 'pointerup', onEnd );
+			el.addEventListener( 'pointercancel', onEnd );
 			el.addEventListener( 'lostpointercapture', onEnd );
 			activePointerResizeRef.current = { cancel: cancelResize };
 

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -353,6 +353,26 @@ describe( 'RectangleStencil', () => {
 			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
 		} );
 
+		it( 'settles the resize on pointercancel', () => {
+			const { onResizeStart, onResizeEnd } = renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.pointerDown( firstHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+			} );
+
+			expect( onResizeStart ).toHaveBeenCalledTimes( 1 );
+			expect( onResizeEnd ).not.toHaveBeenCalled();
+
+			fireEvent.pointerCancel( firstHandle, { pointerId: 1 } );
+			fireEvent.pointerUp( firstHandle, { pointerId: 1 } );
+
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'focuses the handle button after a pointer drag ends', () => {
 			renderStencil();
 			const [ firstHandle ] = screen.getAllByRole( 'button' );

--- a/packages/media-editor/src/image-editor/react/components/test/crop-reachability.ts
+++ b/packages/media-editor/src/image-editor/react/components/test/crop-reachability.ts
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import { isCropVisuallyUnreachable } from '../crop-reachability';
+import type { Size } from '../../../core/types';
+
+const CANVAS_SIZE: Size = { width: 600, height: 400 };
+const IMAGE_SIZE: Size = { width: 600, height: 400 };
+const ZERO_PAN = { x: 0, y: 0 };
+
+describe( 'isCropVisuallyUnreachable', () => {
+	it( 'returns true when the crop is fully outside the visible canvas', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: 2, y: 0.25, width: 0.5, height: 0.5 },
+				CANVAS_SIZE,
+				IMAGE_SIZE,
+				ZERO_PAN
+			)
+		).toBe( true );
+	} );
+
+	it( 'returns true when only a sliver of a large crop is visible', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: -0.48, y: 0.25, width: 0.5, height: 0.5 },
+				CANVAS_SIZE,
+				IMAGE_SIZE,
+				ZERO_PAN
+			)
+		).toBe( true );
+	} );
+
+	it( 'returns false for visible crops near the canvas edge', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: -0.02, y: 0.25, width: 0.5, height: 0.5 },
+				CANVAS_SIZE,
+				IMAGE_SIZE,
+				ZERO_PAN
+			)
+		).toBe( false );
+	} );
+
+	it( 'returns false for tiny but fully visible crops', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: 0.5, y: 0.5, width: 0.01, height: 0.01 },
+				CANVAS_SIZE,
+				IMAGE_SIZE,
+				ZERO_PAN
+			)
+		).toBe( false );
+	} );
+
+	it( 'includes transient viewport pan when checking visibility', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+				CANVAS_SIZE,
+				IMAGE_SIZE,
+				{ x: -1000, y: 0 }
+			)
+		).toBe( true );
+	} );
+
+	it( 'returns false until the canvas and image have measurable dimensions', () => {
+		expect(
+			isCropVisuallyUnreachable(
+				{ x: 2, y: 0.25, width: 0.5, height: 0.5 },
+				{ width: 0, height: 400 },
+				IMAGE_SIZE,
+				ZERO_PAN
+			)
+		).toBe( false );
+	} );
+} );

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -13,6 +13,7 @@ import {
  * Internal dependencies
  */
 import { Cropper } from '../cropper';
+import * as viewportProvider from '../viewport-provider';
 import type { CropperController } from '../../hooks/use-cropper-reducer';
 import { DEFAULT_STATE } from '../../../core/constants';
 import { getSourceRegion } from '../../../core/source-region';
@@ -589,6 +590,53 @@ describe( 'Cropper', () => {
 		await waitFor( () =>
 			expect( controller.settleCrop ).toHaveBeenCalledTimes( 1 )
 		);
+	} );
+
+	it( 'does not settle the same unreachable crop twice after viewport pan resets', async () => {
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			cropRect: { x: 2, y: 0.25, width: 0.5, height: 0.5 },
+		};
+		const resetViewport = jest.fn();
+		const setViewportPan = jest.fn();
+		const setViewportZoom = jest.fn();
+		const useViewportSpy = jest.spyOn( viewportProvider, 'useViewport' );
+		useViewportSpy.mockReturnValue( {
+			viewport: { zoom: 1, pan: { x: 24, y: 0 } },
+			setViewportZoom,
+			setViewportPan,
+			resetViewport,
+		} );
+
+		try {
+			const renderCropper = () => (
+				<Cropper
+					src="test.jpg"
+					controller={ controller }
+					showDimming={ false }
+					freeformCrop
+				/>
+			);
+			const { rerender } = render( renderCropper() );
+
+			await waitFor( () =>
+				expect( controller.settleCrop ).toHaveBeenCalledTimes( 1 )
+			);
+			expect( resetViewport ).toHaveBeenCalledTimes( 1 );
+
+			useViewportSpy.mockReturnValue( {
+				viewport: { zoom: 1, pan: { x: 0, y: 0 } },
+				setViewportZoom,
+				setViewportPan,
+				resetViewport,
+			} );
+			rerender( renderCropper() );
+
+			expect( controller.settleCrop ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			useViewportSpy.mockRestore();
+		}
 	} );
 
 	it( 'does not settle visible crops near the canvas edge', async () => {

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -570,6 +570,48 @@ describe( 'Cropper', () => {
 		jest.useRealTimers();
 	} );
 
+	it( 'settles an idle crop that is no longer visible in the canvas', async () => {
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			cropRect: { x: 2, y: 0.25, width: 0.5, height: 0.5 },
+		};
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		await waitFor( () =>
+			expect( controller.settleCrop ).toHaveBeenCalledTimes( 1 )
+		);
+	} );
+
+	it( 'does not settle visible crops near the canvas edge', async () => {
+		const controller = createController();
+		controller.state = {
+			...controller.state,
+			cropRect: { x: -0.02, y: 0.25, width: 0.5, height: 0.5 },
+		};
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		await screen.findByTestId( 'cropper-stencil' );
+
+		expect( controller.settleCrop ).not.toHaveBeenCalled();
+	} );
+
 	it( 'ignores wheel zoom while a crop resize is active', async () => {
 		const controller = createController();
 		render(


### PR DESCRIPTION

## What?

Adds a narrow recovery path for rare image cropper states where the crop area can end up outside the visible canvas and the resize handles are no longer reachable.

This also handles `pointercancel` during crop resize so interrupted pointer gestures still run the same cleanup and settle behavior as normal pointer release.

## Why?

The cropper already keeps the selected image content valid, but that does not always guarantee the crop UI remains reachable if a resize interaction is interrupted or the rendered crop gets into a rogue visual state.

This fallback is intentionally conservative: it only runs while the cropper is idle, and only when the crop is effectively unreachable in the visible canvas. It should not interfere with normal edge crops or active editing.

## Testing

Open the image editor and start cropping an image.

- Resize the crop area normally, including near the canvas edges.
- Confirm the crop handles remain usable and normal crop states are not recentred unexpectedly.
- Try interrupting a resize gesture, for example by starting a resize and moving focus away from the browser or otherwise canceling the pointer interaction.
- Confirm the cropper settles cleanly and does not get stuck with inaccessible handles.