### PR TITLE
Media editor modal: Fix keyboard resizing for locked aspect-ratio crops

### DIFF
--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -6,6 +6,7 @@ import type { HandlePosition, NormalizedRect, Size } from './types';
 
 export type { HandlePosition };
 
+/** Axis whose resize distance controls the locked-ratio size projection. */
 export type ResizeDriverAxis = 'width' | 'height';
 
 /**

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -200,15 +200,18 @@ export function computeLockedResizeRect(
 	distH = Math.max( distH, minDistH );
 
 	// Determine which axis "drives" — whichever the user moved more
-	// (in pixel space) determines the size, the other follows. The
-	// `normalizedRatio` is w/h in normalized space; the equivalent
-	// pixel-space ratio is `normalizedRatio * imageW / imageH`. We
-	// compare the pixel motion ratio against that pixel-space ratio
-	// so the units line up (was a unit mismatch on non-square images).
-	const pixelDistW = distW * imageSize.width;
-	const pixelDistH = distH * imageSize.height;
+	// (in pixel space) determines the size, the other follows. Use
+	// actual pointer/keyboard movement instead of the resulting crop
+	// dimensions; otherwise a single-axis keyboard shrink can leave the
+	// unchanged axis larger and cancel the resize.
+	const pixelDeltaX = Math.abs( clientX - drag.startX );
+	const pixelDeltaY = Math.abs( clientY - drag.startY );
 	const pixelRatio = ( normalizedRatio * imageSize.width ) / imageSize.height;
-	if ( pixelDistW / pixelDistH > pixelRatio ) {
+	const isWidthDriver =
+		pixelDeltaY === 0 ||
+		( pixelDeltaX > 0 && pixelDeltaX / pixelDeltaY > pixelRatio );
+
+	if ( isWidthDriver ) {
 		// Width is the driver — compute height from ratio.
 		distH = distW / normalizedRatio;
 	} else {

--- a/packages/media-editor/src/image-editor/core/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/stencil-math.ts
@@ -6,6 +6,8 @@ import type { HandlePosition, NormalizedRect, Size } from './types';
 
 export type { HandlePosition };
 
+export type ResizeDriverAxis = 'width' | 'height';
+
 /**
  * Resolve the minimum crop dimension, in source-image pixels, for the current
  * display scale.
@@ -142,6 +144,8 @@ export function computeFreeResizeRect(
  * @param bounds          The allowed crop area bounds.
  * @param normalizedRatio The locked aspect ratio (width / height in normalized space).
  * @param minCropSize     Minimum crop rect dimension in normalized space, per axis.
+ * @param driverAxis      Optional explicit driver axis. Used for keyboard
+ *                        resize, where one arrow axis should determine the step.
  * @return The new crop rect in normalized coordinates.
  */
 export function computeLockedResizeRect(
@@ -151,7 +155,8 @@ export function computeLockedResizeRect(
 	imageSize: Size,
 	bounds: CropBounds,
 	normalizedRatio: number,
-	minCropSize: Size = DEFAULT_MIN_CROP_SIZE
+	minCropSize: Size = DEFAULT_MIN_CROP_SIZE,
+	driverAxis?: ResizeDriverAxis
 ): NormalizedRect {
 	// The math below divides by `normalizedRatio` and `imageSize`, so
 	// bail out with the start rect when any of them is zero. This can
@@ -199,17 +204,16 @@ export function computeLockedResizeRect(
 	distW = Math.max( distW, minDistW );
 	distH = Math.max( distH, minDistH );
 
-	// Determine which axis "drives" — whichever the user moved more
-	// (in pixel space) determines the size, the other follows. Use
-	// actual pointer/keyboard movement instead of the resulting crop
-	// dimensions; otherwise a single-axis keyboard shrink can leave the
-	// unchanged axis larger and cancel the resize.
-	const pixelDeltaX = Math.abs( clientX - drag.startX );
-	const pixelDeltaY = Math.abs( clientY - drag.startY );
+	// Determine which axis "drives". Pointer drags use the dragged-corner
+	// geometry so the projected crop changes continuously as the pointer moves.
+	// Keyboard resize passes an explicit axis because a single-axis arrow step
+	// should drive that axis instead of being cancelled by the unchanged axis.
 	const pixelRatio = ( normalizedRatio * imageSize.width ) / imageSize.height;
 	const isWidthDriver =
-		pixelDeltaY === 0 ||
-		( pixelDeltaX > 0 && pixelDeltaX / pixelDeltaY > pixelRatio );
+		driverAxis === 'width' ||
+		( ! driverAxis &&
+			( distW * imageSize.width ) / ( distH * imageSize.height ) >
+				pixelRatio );
 
 	if ( isWidthDriver ) {
 		// Width is the driver — compute height from ratio.

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -9,7 +9,11 @@ import {
 	type CropBounds,
 	type ResizeDragState,
 } from '../stencil-math';
-import { MIN_CROP_PIXELS, MIN_CROP_SCREEN_PX } from '../constants';
+import {
+	DEFAULT_KEYBOARD_STEP,
+	MIN_CROP_PIXELS,
+	MIN_CROP_SCREEN_PX,
+} from '../constants';
 import type { Size } from '../types';
 
 describe( 'getMinCropPixels — operable on-screen floor', () => {
@@ -148,6 +152,78 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		expect( pixelW / pixelH ).toBeCloseTo( 1, 5 );
 		expect( pixelW ).toBeCloseTo( 200, 5 );
 		expect( pixelH ).toBeCloseTo( 200, 5 );
+	} );
+
+	it( 'shrinks a locked-ratio crop from horizontal keyboard movement', () => {
+		const squareImageSize: Size = { width: 500, height: 500 };
+		const lockedStartRect = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
+		const drag: ResizeDragState = {
+			handle: 'nw',
+			startX: 0,
+			startY: 0,
+			startRect: lockedStartRect,
+		};
+		const rect = computeLockedResizeRect(
+			drag,
+			DEFAULT_KEYBOARD_STEP * squareImageSize.width,
+			0,
+			squareImageSize,
+			FULL_BOUNDS,
+			1
+		);
+
+		expect( rect.x ).toBeCloseTo(
+			lockedStartRect.x + DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.y ).toBeCloseTo(
+			lockedStartRect.y + DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.width ).toBeCloseTo(
+			lockedStartRect.width - DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.height ).toBeCloseTo(
+			lockedStartRect.height - DEFAULT_KEYBOARD_STEP,
+			5
+		);
+	} );
+
+	it( 'shrinks a locked-ratio crop from vertical keyboard movement', () => {
+		const squareImageSize: Size = { width: 500, height: 500 };
+		const lockedStartRect = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
+		const drag: ResizeDragState = {
+			handle: 'nw',
+			startX: 0,
+			startY: 0,
+			startRect: lockedStartRect,
+		};
+		const rect = computeLockedResizeRect(
+			drag,
+			0,
+			DEFAULT_KEYBOARD_STEP * squareImageSize.height,
+			squareImageSize,
+			FULL_BOUNDS,
+			1
+		);
+
+		expect( rect.x ).toBeCloseTo(
+			lockedStartRect.x + DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.y ).toBeCloseTo(
+			lockedStartRect.y + DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.width ).toBeCloseTo(
+			lockedStartRect.width - DEFAULT_KEYBOARD_STEP,
+			5
+		);
+		expect( rect.height ).toBeCloseTo(
+			lockedStartRect.height - DEFAULT_KEYBOARD_STEP,
+			5
+		);
 	} );
 } );
 

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -154,6 +154,41 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 		expect( pixelH ).toBeCloseTo( 200, 5 );
 	} );
 
+	it( 'keeps pointer resize continuous near the pixel-motion threshold', () => {
+		const originalImageSize: Size = { width: 600, height: 400 };
+		const fullImageCrop = { x: 0, y: 0, width: 1, height: 1 };
+		const drag: ResizeDragState = {
+			handle: 'nw',
+			startX: 0,
+			startY: 0,
+			startRect: fullImageCrop,
+		};
+
+		const beforeThreshold = computeLockedResizeRect(
+			drag,
+			60,
+			-39.6,
+			originalImageSize,
+			FULL_BOUNDS,
+			1
+		);
+		const afterThreshold = computeLockedResizeRect(
+			drag,
+			60,
+			-40.4,
+			originalImageSize,
+			FULL_BOUNDS,
+			1
+		);
+
+		expect(
+			Math.abs( beforeThreshold.width - afterThreshold.width )
+		).toBeLessThan( 0.01 );
+		expect(
+			Math.abs( beforeThreshold.height - afterThreshold.height )
+		).toBeLessThan( 0.01 );
+	} );
+
 	it( 'shrinks a locked-ratio crop from horizontal keyboard movement', () => {
 		const squareImageSize: Size = { width: 500, height: 500 };
 		const lockedStartRect = { x: 0.1, y: 0.1, width: 0.8, height: 0.8 };
@@ -169,7 +204,9 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 			0,
 			squareImageSize,
 			FULL_BOUNDS,
-			1
+			1,
+			undefined,
+			'width'
 		);
 
 		expect( rect.x ).toBeCloseTo(
@@ -205,7 +242,9 @@ describe( 'computeLockedResizeRect — driver-axis selection', () => {
 			DEFAULT_KEYBOARD_STEP * squareImageSize.height,
 			squareImageSize,
 			FULL_BOUNDS,
-			1
+			1,
+			undefined,
+			'height'
 		);
 
 		expect( rect.x ).toBeCloseTo(

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -25,6 +25,7 @@ import {
 	type HandlePosition,
 	type CropBounds,
 	type ResizeDragState,
+	type ResizeDriverAxis,
 } from '../../../core/stencil-math';
 import { VISUALLY_HIDDEN_STYLE } from '../../visually-hidden-style';
 
@@ -163,7 +164,8 @@ export function RectangleStencil( {
 		computeLockedRect: (
 			drag: ResizeDragState,
 			clientX: number,
-			clientY: number
+			clientY: number,
+			driverAxis?: ResizeDriverAxis
 		) => NormalizedRect;
 		computeFreeRect: (
 			drag: ResizeDragState,
@@ -339,7 +341,8 @@ export function RectangleStencil( {
 		(
 			drag: ResizeDragState,
 			clientX: number,
-			clientY: number
+			clientY: number,
+			driverAxis?: ResizeDriverAxis
 		): NormalizedRect =>
 			computeLockedResizeRect(
 				drag,
@@ -348,7 +351,8 @@ export function RectangleStencil( {
 				imageSize,
 				bounds,
 				normalizedRatio,
-				minCropSize
+				minCropSize,
+				driverAxis
 			),
 		[ imageSize, bounds, normalizedRatio, minCropSize ]
 	);
@@ -448,6 +452,8 @@ export function RectangleStencil( {
 			if ( key === 'ArrowDown' ) {
 				dy = adjustedStepY;
 			}
+			const keyboardDriverAxis: ResizeDriverAxis =
+				dx !== 0 ? 'width' : 'height';
 
 			if ( hasLockedRatio ) {
 				// For locked aspect ratio, synthesize a drag from the
@@ -461,7 +467,12 @@ export function RectangleStencil( {
 				const clientX = dx * imageSize.width;
 				const clientY = dy * imageSize.height;
 				onCropChange(
-					computeLockedRect( syntheticDrag, clientX, clientY )
+					computeLockedRect(
+						syntheticDrag,
+						clientX,
+						clientY,
+						keyboardDriverAxis
+					)
 				);
 				scheduleKeyboardResizeEnd();
 			} else {

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -8,6 +8,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
  */
 import { RectangleStencil } from '../rectangle-stencil';
 import type { NormalizedRect, Size } from '../../../../core/types';
+import { DEFAULT_KEYBOARD_STEP } from '../../../../core/constants';
 
 const DEFAULT_CROP_RECT: NormalizedRect = {
 	x: 0.1,
@@ -234,6 +235,41 @@ describe( 'RectangleStencil', () => {
 			expect( snapCropRect.mock.calls[ 0 ][ 1 ] ).toBe( 'e' );
 			expect( onCropChange.mock.calls[ 0 ][ 0 ].width ).toBeCloseTo(
 				0.82,
+				5
+			);
+		} );
+
+		it( 'shrinks a locked-ratio crop from a corner handle', () => {
+			const { onCropChange } = renderStencil( {
+				aspectRatio: 1,
+				containerSize: { width: 500, height: 500 },
+				imageSize: { width: 500, height: 500 },
+			} );
+			const nwHandle = screen.getByRole( 'button', {
+				name: 'Resize top-left corner',
+			} );
+
+			fireEvent.keyDown( nwHandle, {
+				key: 'ArrowRight',
+				shiftKey: false,
+			} );
+
+			expect( onCropChange ).toHaveBeenCalledTimes( 1 );
+			const newRect: NormalizedRect = onCropChange.mock.calls[ 0 ][ 0 ];
+			expect( newRect.x ).toBeCloseTo(
+				DEFAULT_CROP_RECT.x + DEFAULT_KEYBOARD_STEP,
+				5
+			);
+			expect( newRect.y ).toBeCloseTo(
+				DEFAULT_CROP_RECT.y + DEFAULT_KEYBOARD_STEP,
+				5
+			);
+			expect( newRect.width ).toBeCloseTo(
+				DEFAULT_CROP_RECT.width - DEFAULT_KEYBOARD_STEP,
+				5
+			);
+			expect( newRect.height ).toBeCloseTo(
+				DEFAULT_CROP_RECT.height - DEFAULT_KEYBOARD_STEP,
 				5
 			);
 		} );


### PR DESCRIPTION

## What

Fixes an issue where crop handles could not resize the crop area with the keyboard when an aspect ratio was selected.

The locked-ratio resize logic now chooses the resize driver from the actual keyboard or pointer movement, instead of the resulting crop dimensions. This prevents single-axis keyboard movement from being cancelled by the unchanged axis.

Props to @fcoveram for spotting it.

## Why

When using a fixed aspect ratio, pressing an arrow key on a focused corner handle should shrink or expand the crop area while preserving the selected ratio. Previously, some keyboard resize actions appeared to do nothing.

## Testing

1. Open an image in the cropper.
2. Select an aspect ratio, such as square.
3. Focus a corner crop handle.
4. Use the arrow keys to resize the crop area.
5. Confirm the crop area resizes smoothly and keeps the selected aspect ratio.
6. Confirm freeform crop resizing still works with keyboard controls.


https://github.com/user-attachments/assets/bcb42118-68cb-427d-9c45-903030e043f6

