### PR TITLE
wp-build: Resolve @wordpress/build from __dirname in resolve-miss test

### DIFF
--- a/packages/wp-build/lib/test/package-utils.js
+++ b/packages/wp-build/lib/test/package-utils.js
@@ -23,7 +23,7 @@ describe( 'getPackageInfo() resolve-miss contract', () => {
 	} );
 
 	it( 'still resolves an installed package that exposes its package.json', () => {
-		const info = getPackageInfo( '@wordpress/build' );
+		const info = getPackageInfo( '@wordpress/build', __dirname );
 
 		expect( info ).toMatchObject( { name: '@wordpress/build' } );
 	} );


### PR DESCRIPTION
## What?

Follow-up to #78715. Updates the `getPackageInfo()` resolve-miss test so that the "installed package" assertion resolves `@wordpress/build` from `__dirname` instead of the default (`process.cwd()`) context.

Addresses https://github.com/WordPress/gutenberg/pull/78715#discussion_r3411718721.

## Why?

The test asserted that `getPackageInfo( '@wordpress/build' )` resolves an installed package that exposes its `package.json`. With no `resolveDir` argument, `getPackageInfo()` resolves from `process.cwd()`, which silently assumes `@wordpress/build` is installed somewhere reachable from there as a dependency of some workspace. That's a fragile assumption.

## How?

Pass `__dirname` as the resolve context:

```js
const info = getPackageInfo( '@wordpress/build', __dirname );
```

`getPackageInfo()` walks up from `__dirname` to the wp-build package root and resolves `@wordpress/build/package.json` from there. Because wp-build's `package.json` `exports` field exposes `"./package.json": "./package.json"`, Node resolves it via **self-referencing** — robust regardless of how the package is hoisted in the workspace.

## Testing Instructions

```
npm run test:unit -- packages/wp-build/lib/test/package-utils.js
```

All three tests pass.
