### PR TITLE
Core Data: RTC cleanup edits matching persisted record on undo/redo

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies
@@ -205,6 +206,35 @@ export const getEntityRecord =
 						editRecord: ( edits, options = {} ) => {
 							if ( ! Object.keys( edits ).length ) {
 								return;
+							}
+
+							// Clear edits that match the persisted record
+							// so the entity is no longer dirty after undo.
+							const persistedRecord = select.getEntityRecord(
+								kind,
+								name,
+								key
+							);
+							if ( persistedRecord ) {
+								edits = Object.fromEntries(
+									Object.entries( edits ).map(
+										( [ editKey, editValue ] ) => {
+											const persisted =
+												persistedRecord[ editKey ]
+													?.raw ??
+												persistedRecord[ editKey ];
+											return [
+												editKey,
+												fastDeepEqual(
+													editValue,
+													persisted
+												)
+													? undefined
+													: editValue,
+											];
+										}
+									)
+								);
 							}
 
 							dispatch( {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
-import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 
 /**
  * WordPress dependencies
@@ -27,6 +26,7 @@ import {
 	isNumericID,
 	normalizeQueryForResolution,
 	saveCRDTDoc,
+	clearUnchangedEdits,
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
@@ -208,41 +208,23 @@ export const getEntityRecord =
 								return;
 							}
 
-							// Clear edits that match the persisted record
-							// so the entity is no longer dirty after undo.
 							const persistedRecord = select.getEntityRecord(
 								kind,
 								name,
 								key
 							);
-							if ( persistedRecord ) {
-								edits = Object.fromEntries(
-									Object.entries( edits ).map(
-										( [ editKey, editValue ] ) => {
-											const persisted =
-												persistedRecord[ editKey ]
-													?.raw ??
-												persistedRecord[ editKey ];
-											return [
-												editKey,
-												fastDeepEqual(
-													editValue,
-													persisted
-												)
-													? undefined
-													: editValue,
-											];
-										}
-									)
-								);
-							}
 
 							dispatch( {
 								type: 'EDIT_ENTITY_RECORD',
 								kind,
 								name,
 								recordId: key,
-								edits,
+								// Clear edits that match the persisted record
+								// so the entity is no longer dirty after undo.
+								edits: clearUnchangedEdits(
+									edits,
+									persistedRecord
+								),
 								meta: {
 									undo: undefined,
 								},

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -550,25 +550,11 @@ test.describe( 'undo', () => {
 		// Undo new block and content addition.
 		await pageUtils.pressKeys( 'primary+z', { times: 2 } );
 
-		// This cleanup runs through `withMultiEntityRecordEdits`, which
-		// real-time collaboration bypasses in favor of its own undo manager.
-		const isCollaborationEnabled = await page.evaluate(
-			() => window._wpCollaborationEnabled === true
-		);
-
-		// The entity is no longer dirty, so the "Save" button is disabled.
-		// Under real-time collaboration the undo runs through the RTC undo
-		// manager, which doesn't yet clear the dirty state, so the button
-		// stays enabled for now. That path is fixed separately.
-		// See: https://github.com/WordPress/gutenberg/pull/77100.
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Save' } )
-		).toHaveAttribute(
-			'aria-disabled',
-			isCollaborationEnabled ? 'false' : 'true'
-		);
+		).toBeDisabled();
 	} );
 } );
 


### PR DESCRIPTION
## What?
Fixes the same bug as in #77100, but when RTC is enabled.

### Current problem

1. Block move → `editEntityRecord({ blocks, content: serializeBlocksFn })`. `content` is a **lazy function**.
2. `applyPostChangesToCRDTDoc` skips function values, so CRDT's `blocks` updates but `content` stays as the **original, pre-move HTML**.
3. Peer update arrives. `getChangesFromCRDTDoc` emits `content = <stale original HTML>` (since `getRawValue(fn)` is `undefined`, diff sees a change).
4. Fix sees incoming `content` matches `persistedRecord.content.raw` → clears the edit.
5. Only `blocks` remains, which is transient → post not dirty → "Save draft" hidden.

Pre-fix this was masked: the stale value still got stored in edits, keeping the post dirty.

### Suggested fixes (by Claude)

1. Evaluate the `content` function in `applyPostChangesToCRDTDoc` so CRDT stores fresh content.
2. Don't sync `content` when `blocks` is synced — let each peer serialize locally.

## Testing Instructions

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

## Use of AI Tools

Assisted by Claude.
