### PR TITLE
Breadcrumbs: Fix editor preview to display real trail when post conte…

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -38,53 +38,40 @@ export default function BreadcrumbEdit( {
 		prefersTaxonomy,
 		showOnHomePage,
 	} = attributes;
-	const {
-		post,
-		isPostTypeHierarchical,
-		postTypeHasTaxonomies,
-		hasTermsAssigned,
-		isLoading,
-	} = useSelect(
-		( select ) => {
-			if ( ! postType ) {
-				return {};
-			}
-			const _post = select( coreStore ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			const postTypeObject = select( coreStore ).getPostType( postType );
-			const _postTypeHasTaxonomies =
-				postTypeObject && postTypeObject.taxonomies.length;
-			let taxonomies;
-			if ( _postTypeHasTaxonomies ) {
-				taxonomies = select( coreStore ).getTaxonomies( {
-					type: postType,
-					per_page: -1,
-				} );
-			}
-			return {
-				post: _post,
-				isPostTypeHierarchical: postTypeObject?.hierarchical,
-				postTypeHasTaxonomies: _postTypeHasTaxonomies,
-				hasTermsAssigned:
-					_post &&
-					( taxonomies || [] )
-						.filter(
-							( { visibility } ) => visibility?.publicly_queryable
-						)
-						.some( ( taxonomy ) => {
-							return !! _post[ taxonomy.rest_base ]?.length;
-						} ),
-				isLoading:
-					( postId && ! _post ) ||
-					! postTypeObject ||
-					( _postTypeHasTaxonomies && ! taxonomies ),
-			};
-		},
-		[ postType, postId ]
-	);
+	const { post, isPostTypeHierarchical, postTypeHasTaxonomies, isLoading } =
+		useSelect(
+			( select ) => {
+				if ( ! postType ) {
+					return {};
+				}
+				const _post = select( coreStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				const postTypeObject =
+					select( coreStore ).getPostType( postType );
+				const _postTypeHasTaxonomies =
+					postTypeObject && postTypeObject.taxonomies.length;
+				let taxonomies;
+				if ( _postTypeHasTaxonomies ) {
+					taxonomies = select( coreStore ).getTaxonomies( {
+						type: postType,
+						per_page: -1,
+					} );
+				}
+				return {
+					post: _post,
+					isPostTypeHierarchical: postTypeObject?.hierarchical,
+					postTypeHasTaxonomies: _postTypeHasTaxonomies,
+					isLoading:
+						( postId && ! _post ) ||
+						! postTypeObject ||
+						( _postTypeHasTaxonomies && ! taxonomies ),
+				};
+			},
+			[ postType, postId ]
+		);
 
 	/**
 	 * Counter used to cache-bust `useServerSideRender`.
@@ -161,9 +148,7 @@ export default function BreadcrumbEdit( {
 		// When `templateSlug` is set only show placeholder if the post type is not.
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.
-		( templateSlug && ! postType ) ||
-		( ! _showTerms && ! isPostTypeHierarchical ) ||
-		( _showTerms && ! hasTermsAssigned );
+		( templateSlug && ! postType );
 	if ( showPlaceholder ) {
 		const placeholderItems = [];
 		if ( showHomeItem ) {


### PR DESCRIPTION
# Breadcrumbs: Fix editor preview to display real trail when post context is present

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: #79165

This PR fixes the Breadcrumbs block editor preview by rendering the actual server-rendered breadcrumb trail when editing a specific post (post context is available), instead of falling back to a hardcoded generic placeholder.

## Why?
Currently, if a post type is non-hierarchical and does not have any taxonomy terms assigned (e.g. a newly created post, or a custom post type that does not support default categories), the editor forces the block preview to fall back to a hardcoded `Home / Category / Current` placeholder.

This causes two issues:
1. **Misleading placeholders:** For custom post types that do not support the default `Category` taxonomy, displaying "Category" in the editor is incorrect and confusing.
2. **Editor-Frontend discrepancy:** The frontend correctly renders the resolved trail (e.g. `Home / All Articles / [Post Title]`), whereas the editor shows the generic placeholder.

By letting the server-side renderer display the actual breadcrumbs when post context is available, the block preview matches the frontend exactly.

## How?
1. Updated the `showPlaceholder` logic in `packages/block-library/src/breadcrumbs/edit.js` to only evaluate to `true` when there is no active post context (e.g., when editing templates directly in the Site Editor without a post context).
2. Cleaned up the unused `hasTermsAssigned` select variable from `useSelect` and its selector return object to satisfy ESLint.

## Testing Instructions
1. Add a temporary Custom Post Type and Taxonomy registration 
2. Create a new post
3. Insert the **Breadcrumbs** block.
4. Verify that the editor preview correctly resolves to:
   `Home / All Posts / [Post Title]` (eg for Article CPT `Home / All Articles / My Article` )
   instead of displaying the generic `Home / Category / Current` placeholder.
5. Verify that it matches the frontend output exactly.

### Testing Instructions for Keyboard
No changes have been made to keyboard navigation or interaction. The rendered markup of the breadcrumbs block remains the same.

## Screenshots or screencast

### Before

#### Editor
<img width="418" height="231" alt="breadcrumb-editor" src="https://github.com/user-attachments/assets/5f71affb-d246-4464-ad64-02d09d6b456b" />

#### Frontend
<img width="1204" height="338" alt="breadcrumb-frontend" src="https://github.com/user-attachments/assets/7f7fa16a-e270-4047-9cfa-400224d7f9a2" />

### After

#### Editor
<img width="511" height="254" alt="breadcrumb-editor-after" src="https://github.com/user-attachments/assets/c06ec48a-539d-441b-9452-915498975315" />


#### Frontend
<img width="1204" height="338" alt="breadcrumb-frontend" src="https://github.com/user-attachments/assets/7f7fa16a-e270-4047-9cfa-400224d7f9a2" />

## Use of AI Tools
IDE: Antigravity IDE
Model: Gemini 3.5 Flash