### PR TITLE
Media Insert Tab: Try exposing an inline panel UI for viewing attached images

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Modal,
-	Panel,
-	PanelBody,
-	Spinner,
-} from '@wordpress/components';
+import { Button, Modal, Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -227,71 +221,71 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 	);
 
 	return (
-		<Panel className="block-editor-inserter__attached-media-panel">
-			<PanelBody title={ category.labels.name } initialOpen>
-				{ isLoading && (
-					<div className="block-editor-inserter__attached-media-panel-spinner">
-						<Spinner />
-					</div>
-				) }
-				{ ! isLoading && hasError && (
-					<p className="block-editor-inserter__attached-media-panel-message">
-						{ __( 'Could not load attached images.' ) }
-					</p>
-				) }
-				{ ! isLoading && ! hasError && ! mediaList.length && (
-					<p className="block-editor-inserter__attached-media-panel-message">
-						{ __( 'No images attached to this post.' ) }
-					</p>
-				) }
-				{ ! isLoading && ! hasError && !! mediaList.length && (
-					<>
-						<div className="block-editor-inserter__attached-media-panel-grid">
-							<MediaList
-								category={ category }
-								isItemBusy={ ( media ) =>
-									updatingMediaIds.includes( media.id )
-								}
-								label={ __( 'Attached images' ) }
-								mediaList={ mediaList }
-								onClick={ onInsert }
-								onDetach={ setMediaPendingDetach }
-								variant="compact"
-							/>
-							{ remainingMediaCount > 0 && (
-								<MediaLibraryButton
-									className="block-editor-inserter__attached-media-panel-more"
-									label={ sprintf(
-										/* translators: %d: Number of additional attached images. */
-										__( 'View %d more attached images' ),
-										remainingMediaCount
-									) }
-									onSelect={ handleAttach }
-									title={ __( 'Attached images' ) }
-									value={ mediaIds }
-									variant="tertiary"
-								>
-									{ sprintf(
-										/* translators: %d: Number of additional attached images. */
-										__( '+%d' ),
-										remainingMediaCount
-									) }
-								</MediaLibraryButton>
-							) }
-						</div>
-					</>
-				) }
-				<div className="block-editor-inserter__attached-media-panel-actions">
-					<MediaLibraryButton
-						disabled={ isAttaching }
-						icon={ plus }
-						onSelect={ handleAttach }
-						title={ __( 'Attach images' ) }
-					>
-						{ __( 'Add' ) }
-					</MediaLibraryButton>
+		<div className="block-editor-inserter__attached-media-panel">
+			<h3 className="block-editor-inserter__attached-media-panel-heading">
+				{ __( 'Attached images' ) }
+			</h3>
+			{ isLoading && (
+				<div className="block-editor-inserter__attached-media-panel-spinner">
+					<Spinner />
 				</div>
-			</PanelBody>
+			) }
+			{ ! isLoading && hasError && (
+				<p className="block-editor-inserter__attached-media-panel-message">
+					{ __( 'Could not load attached images.' ) }
+				</p>
+			) }
+			{ ! isLoading && ! hasError && ! mediaList.length && (
+				<p className="block-editor-inserter__attached-media-panel-message">
+					{ __( 'No images attached to this post.' ) }
+				</p>
+			) }
+			{ ! isLoading && ! hasError && !! mediaList.length && (
+				<>
+					<div className="block-editor-inserter__attached-media-panel-grid">
+						<MediaList
+							category={ category }
+							isItemBusy={ ( media ) =>
+								updatingMediaIds.includes( media.id )
+							}
+							label={ __( 'Attached images' ) }
+							mediaList={ mediaList }
+							onClick={ onInsert }
+							onDetach={ setMediaPendingDetach }
+							variant="compact"
+						/>
+						{ remainingMediaCount > 0 && (
+							<MediaLibraryButton
+								className="block-editor-inserter__attached-media-panel-more"
+								label={ sprintf(
+									/* translators: %d: Number of additional attached images. */
+									__( 'View %d more attached images' ),
+									remainingMediaCount
+								) }
+								onSelect={ handleAttach }
+								title={ __( 'Attached images' ) }
+								value={ mediaIds }
+								variant="tertiary"
+							>
+								{ sprintf(
+									/* translators: %d: Number of additional attached images. */
+									__( '+%d' ),
+									remainingMediaCount
+								) }
+							</MediaLibraryButton>
+						) }
+					</div>
+				</>
+			) }
+			<div className="block-editor-inserter__attached-media-panel-actions">
+				<MediaLibraryButton
+					disabled={ isAttaching }
+					icon={ plus }
+					onSelect={ handleAttach }
+				>
+					{ __( 'Attach images' ) }
+				</MediaLibraryButton>
+			</div>
 			{ mediaPendingDetach && (
 				<Modal
 					title={ __( 'Detach image' ) }
@@ -321,6 +315,6 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 					</div>
 				</Modal>
 			) }
-		</Panel>
+		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
@@ -1,0 +1,326 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Modal,
+	Panel,
+	PanelBody,
+	Spinner,
+} from '@wordpress/components';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import MediaList from './media-list';
+import MediaUploadCheck from '../../media-upload/check';
+import MediaUpload from '../../media-upload';
+
+const ATTACHED_MEDIA_ITEMS_PER_PAGE = 20;
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+function useAttachedMedia( category, query ) {
+	const [ mediaList, setMediaList ] = useState( [] );
+	const [ totalItems, setTotalItems ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+	const [ refreshCount, setRefreshCount ] = useState( 0 );
+	const refresh = useCallback(
+		() => setRefreshCount( ( count ) => count + 1 ),
+		[]
+	);
+
+	useEffect( () => {
+		let isMounted = true;
+
+		( async () => {
+			setIsLoading( true );
+			setHasError( false );
+
+			try {
+				const items = await category.fetch( query );
+
+				if ( ! isMounted ) {
+					return;
+				}
+
+				setMediaList( items );
+				setTotalItems(
+					category.getTotalItems?.( query ) ?? items.length
+				);
+			} catch {
+				if ( ! isMounted ) {
+					return;
+				}
+
+				setMediaList( [] );
+				setTotalItems( null );
+				setHasError( true );
+			} finally {
+				if ( isMounted ) {
+					setIsLoading( false );
+				}
+			}
+		} )();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ category, query, refreshCount ] );
+
+	return {
+		mediaList,
+		totalItems,
+		isLoading,
+		hasError,
+		refresh,
+	};
+}
+
+function MediaLibraryButton( {
+	children,
+	className,
+	disabled,
+	icon,
+	label,
+	onSelect,
+	title,
+	value,
+	variant = 'secondary',
+} ) {
+	return (
+		<MediaUploadCheck>
+			<MediaUpload
+				multiple="add"
+				onSelect={ onSelect }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				title={ title }
+				value={ value }
+				render={ ( { open } ) => (
+					<Button
+						__next40pxDefaultSize
+						accessibleWhenDisabled
+						className={ className }
+						data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
+						disabled={ disabled }
+						icon={ icon }
+						label={ label }
+						onClick={ ( event ) => {
+							event.target.focus();
+							open();
+						} }
+						variant={ variant }
+					>
+						{ children }
+					</Button>
+				) }
+			/>
+		</MediaUploadCheck>
+	);
+}
+
+export default function AttachedMediaPanel( { onInsert, category } ) {
+	const query = useMemo(
+		() => ( { per_page: ATTACHED_MEDIA_ITEMS_PER_PAGE } ),
+		[]
+	);
+	const { mediaList, totalItems, isLoading, hasError, refresh } =
+		useAttachedMedia( category, query );
+	const [ isAttaching, setIsAttaching ] = useState( false );
+	const [ updatingMediaIds, setUpdatingMediaIds ] = useState( [] );
+	const [ mediaPendingDetach, setMediaPendingDetach ] = useState();
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+	const remainingMediaCount = Math.max(
+		0,
+		( totalItems ?? mediaList.length ) - mediaList.length
+	);
+
+	const refreshAttachedMedia = useCallback( () => {
+		category.invalidate?.( query );
+		refresh();
+	}, [ category, query, refresh ] );
+
+	const handleAttach = useCallback(
+		async ( selectedMedia ) => {
+			setIsAttaching( true );
+
+			try {
+				const attachedCount = await category.attach( selectedMedia );
+				refreshAttachedMedia();
+
+				if ( attachedCount ) {
+					createSuccessNotice(
+						sprintf(
+							/* translators: %d: Number of images attached to the post. */
+							_n(
+								'%d image attached to post.',
+								'%d images attached to post.',
+								attachedCount
+							),
+							attachedCount
+						),
+						{ type: 'snackbar', id: 'inserter-notice' }
+					);
+				}
+			} catch {
+				createErrorNotice( __( 'Could not attach images.' ), {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
+			} finally {
+				setIsAttaching( false );
+			}
+		},
+		[
+			category,
+			createErrorNotice,
+			createSuccessNotice,
+			refreshAttachedMedia,
+		]
+	);
+
+	const handleDetach = useCallback(
+		async ( media ) => {
+			setUpdatingMediaIds( ( ids ) => [ ...ids, media.id ] );
+
+			try {
+				await category.detach( media );
+				refreshAttachedMedia();
+				createSuccessNotice( __( 'Image detached from post.' ), {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
+			} catch {
+				createErrorNotice( __( 'Could not detach image.' ), {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
+			} finally {
+				setUpdatingMediaIds( ( ids ) =>
+					ids.filter( ( id ) => id !== media.id )
+				);
+			}
+		},
+		[
+			category,
+			createErrorNotice,
+			createSuccessNotice,
+			refreshAttachedMedia,
+		]
+	);
+
+	const confirmDetach = useCallback( () => {
+		const media = mediaPendingDetach;
+		setMediaPendingDetach( undefined );
+		handleDetach( media );
+	}, [ handleDetach, mediaPendingDetach ] );
+
+	const mediaIds = useMemo(
+		() => mediaList.map( ( media ) => media.id ).filter( Boolean ),
+		[ mediaList ]
+	);
+
+	return (
+		<Panel className="block-editor-inserter__attached-media-panel">
+			<PanelBody title={ category.labels.name } initialOpen>
+				{ isLoading && (
+					<div className="block-editor-inserter__attached-media-panel-spinner">
+						<Spinner />
+					</div>
+				) }
+				{ ! isLoading && hasError && (
+					<p className="block-editor-inserter__attached-media-panel-message">
+						{ __( 'Could not load attached images.' ) }
+					</p>
+				) }
+				{ ! isLoading && ! hasError && ! mediaList.length && (
+					<p className="block-editor-inserter__attached-media-panel-message">
+						{ __( 'No images attached to this post.' ) }
+					</p>
+				) }
+				{ ! isLoading && ! hasError && !! mediaList.length && (
+					<>
+						<div className="block-editor-inserter__attached-media-panel-grid">
+							<MediaList
+								category={ category }
+								isItemBusy={ ( media ) =>
+									updatingMediaIds.includes( media.id )
+								}
+								label={ __( 'Attached images' ) }
+								mediaList={ mediaList }
+								onClick={ onInsert }
+								onDetach={ setMediaPendingDetach }
+								variant="compact"
+							/>
+							{ remainingMediaCount > 0 && (
+								<MediaLibraryButton
+									className="block-editor-inserter__attached-media-panel-more"
+									label={ sprintf(
+										/* translators: %d: Number of additional attached images. */
+										__( 'View %d more attached images' ),
+										remainingMediaCount
+									) }
+									onSelect={ handleAttach }
+									title={ __( 'Attached images' ) }
+									value={ mediaIds }
+									variant="tertiary"
+								>
+									{ sprintf(
+										/* translators: %d: Number of additional attached images. */
+										__( '+%d' ),
+										remainingMediaCount
+									) }
+								</MediaLibraryButton>
+							) }
+						</div>
+					</>
+				) }
+				<div className="block-editor-inserter__attached-media-panel-actions">
+					<MediaLibraryButton
+						disabled={ isAttaching }
+						icon={ plus }
+						onSelect={ handleAttach }
+						title={ __( 'Attach images' ) }
+					>
+						{ __( 'Add' ) }
+					</MediaLibraryButton>
+				</div>
+			</PanelBody>
+			{ mediaPendingDetach && (
+				<Modal
+					title={ __( 'Detach image' ) }
+					onRequestClose={ () => setMediaPendingDetach( undefined ) }
+					className="block-editor-inserter__attached-media-panel-detach-modal"
+				>
+					<p>
+						{ __(
+							'Detach this image from the current post? The image will remain in the Media Library.'
+						) }
+					</p>
+					<div className="block-editor-inserter__attached-media-panel-detach-actions">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => setMediaPendingDetach( undefined ) }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ confirmDetach }
+						>
+							{ __( 'Detach' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</Panel>
+	);
+}

--- a/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { Button, Modal, Spinner } from '@wordpress/components';
@@ -24,10 +29,14 @@ function useAttachedMedia( category, query ) {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ hasError, setHasError ] = useState( false );
 	const [ refreshCount, setRefreshCount ] = useState( 0 );
-	const refresh = useCallback(
-		() => setRefreshCount( ( count ) => count + 1 ),
-		[]
-	);
+	const refresh = useCallback( () => {
+		// Enter the loading state synchronously so it stays continuous with the
+		// caller's other updates (e.g. clearing per-item busy state). Otherwise
+		// there's a one-render gap before the effect below sets it, which
+		// unmounts and remounts the loading spinner.
+		setIsLoading( true );
+		setRefreshCount( ( count ) => count + 1 );
+	}, [] );
 
 	useEffect( () => {
 		let isMounted = true;
@@ -134,6 +143,10 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 		0,
 		( totalItems ?? mediaList.length ) - mediaList.length
 	);
+	// A single busy flag covering the whole attach/detach/refetch lifecycle, so
+	// the grid shows one consistent loading state rather than a per-item spinner
+	// followed by a separate area-wide one.
+	const isBusy = isLoading || isAttaching || updatingMediaIds.length > 0;
 
 	const refreshAttachedMedia = useCallback( () => {
 		category.invalidate?.( query );
@@ -225,7 +238,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 			<h3 className="block-editor-inserter__attached-media-panel-heading">
 				{ __( 'Attached images' ) }
 			</h3>
-			{ isLoading && (
+			{ isLoading && ! mediaList.length && (
 				<div className="block-editor-inserter__attached-media-panel-spinner">
 					<Spinner />
 				</div>
@@ -240,14 +253,18 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 					{ __( 'No images attached to this post.' ) }
 				</p>
 			) }
-			{ ! isLoading && ! hasError && !! mediaList.length && (
-				<>
-					<div className="block-editor-inserter__attached-media-panel-grid">
+			{ !! mediaList.length && (
+				<div className="block-editor-inserter__attached-media-panel-results">
+					{ /* Keep the existing items visible (dimmed) while busy attaching,
+					     detaching or refetching, so the area doesn't flicker. */ }
+					<div
+						className={ clsx(
+							'block-editor-inserter__attached-media-panel-grid',
+							{ 'is-loading': isBusy }
+						) }
+					>
 						<MediaList
 							category={ category }
-							isItemBusy={ ( media ) =>
-								updatingMediaIds.includes( media.id )
-							}
 							label={ __( 'Attached images' ) }
 							mediaList={ mediaList }
 							onClick={ onInsert }
@@ -275,7 +292,12 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 							</MediaLibraryButton>
 						) }
 					</div>
-				</>
+					{ isBusy && (
+						<div className="block-editor-inserter__attached-media-panel-overlay">
+							<Spinner />
+						</div>
+					) }
+				</div>
 			) }
 			<div className="block-editor-inserter__attached-media-panel-actions">
 				<MediaLibraryButton

--- a/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/attached-media-panel.js
@@ -21,7 +21,6 @@ import MediaUploadCheck from '../../media-upload/check';
 import MediaUpload from '../../media-upload';
 
 const ATTACHED_MEDIA_ITEMS_PER_PAGE = 20;
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function useAttachedMedia( category, query ) {
 	const [ mediaList, setMediaList ] = useState( [] );
@@ -86,6 +85,7 @@ function useAttachedMedia( category, query ) {
 }
 
 function MediaLibraryButton( {
+	allowedTypes,
 	children,
 	className,
 	disabled,
@@ -101,7 +101,7 @@ function MediaLibraryButton( {
 			<MediaUpload
 				multiple="add"
 				onSelect={ onSelect }
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				allowedTypes={ allowedTypes }
 				title={ title }
 				value={ value }
 				render={ ( { open } ) => (
@@ -127,10 +127,35 @@ function MediaLibraryButton( {
 	);
 }
 
+/**
+ * Generic host panel for a "current post media" category — one that opts in via
+ * `isCurrentPostMedia` and supplies its own behaviour (`attach`, `detach`,
+ * `invalidate`, `getTotalItems`) alongside the usual `fetch`. See
+ * `getAttachedImagesCategory` in the `editor` package for the WordPress
+ * attachments implementation.
+ *
+ * The category owns all of the source-specific concerns — what the collection
+ * is called (`labels.name`), its media type (`mediaType`), and how items are
+ * attached/detached — so this component stays media-source-agnostic, mirroring
+ * the way `getReportUrl` drives the Openverse "Report" affordance without
+ * `block-editor` knowing anything about Openverse.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onInsert Called with a block to insert when an item is clicked.
+ * @param {Object}   props.category The current-post media category to render.
+ */
 export default function AttachedMediaPanel( { onInsert, category } ) {
 	const query = useMemo(
 		() => ( { per_page: ATTACHED_MEDIA_ITEMS_PER_PAGE } ),
 		[]
+	);
+	const categoryLabel = category.labels?.name;
+	// The upload frame's `allowedTypes` is conventionally an array. Default to the
+	// category's single `mediaType`, but let a category opt into a broader set by
+	// supplying its own `allowedTypes` array.
+	const allowedTypes = useMemo(
+		() => category.allowedTypes ?? [ category.mediaType ],
+		[ category.allowedTypes, category.mediaType ]
 	);
 	const { mediaList, totalItems, isLoading, hasError, refresh } =
 		useAttachedMedia( category, query );
@@ -236,7 +261,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 	return (
 		<div className="block-editor-inserter__attached-media-panel">
 			<h3 className="block-editor-inserter__attached-media-panel-heading">
-				{ __( 'Attached images' ) }
+				{ categoryLabel }
 			</h3>
 			{ isLoading && ! mediaList.length && (
 				<div className="block-editor-inserter__attached-media-panel-spinner">
@@ -265,7 +290,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 					>
 						<MediaList
 							category={ category }
-							label={ __( 'Attached images' ) }
+							label={ categoryLabel }
 							mediaList={ mediaList }
 							onClick={ onInsert }
 							onDetach={ setMediaPendingDetach }
@@ -273,6 +298,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 						/>
 						{ remainingMediaCount > 0 && (
 							<MediaLibraryButton
+								allowedTypes={ allowedTypes }
 								className="block-editor-inserter__attached-media-panel-more"
 								label={ sprintf(
 									/* translators: %d: Number of additional attached images. */
@@ -280,7 +306,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 									remainingMediaCount
 								) }
 								onSelect={ handleAttach }
-								title={ __( 'Attached images' ) }
+								title={ categoryLabel }
 								value={ mediaIds }
 								variant="tertiary"
 							>
@@ -301,6 +327,7 @@ export default function AttachedMediaPanel( { onInsert, category } ) {
 			) }
 			<div className="block-editor-inserter__attached-media-panel-actions">
 				<MediaLibraryButton
+					allowedTypes={ allowedTypes }
 					disabled={ isAttaching }
 					icon={ plus }
 					onSelect={ handleAttach }

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -119,7 +119,8 @@ export function useMediaCategories( rootClientId ) {
 			inserterMediaCategories.forEach( ( category ) => {
 				if (
 					canInsertMediaType[ category.mediaType ] &&
-					categoriesHaveMedia.get( category.name )
+					( categoriesHaveMedia.get( category.name ) ||
+						category.showIfEmpty )
 				) {
 					_categories.push( category );
 				}

--- a/packages/block-editor/src/components/inserter/media-tab/media-list.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-list.js
@@ -13,7 +13,10 @@ function MediaList( {
 	mediaList,
 	category,
 	onClick,
+	onDetach,
+	isItemBusy,
 	label = __( 'Media List' ),
+	variant,
 } ) {
 	return (
 		<Composite
@@ -27,6 +30,9 @@ function MediaList( {
 					media={ media }
 					category={ category }
 					onClick={ onClick }
+					onDetach={ onDetach }
+					isBusy={ isItemBusy?.( media ) }
+					variant={ variant }
 				/>
 			) ) }
 		</Composite>

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -99,7 +99,7 @@ function MediaPreviewDetachButton( { media, onDetach, title } ) {
 				event.stopPropagation();
 				onDetach( media );
 			} }
-			size="compact"
+			size="small"
 			variant="tertiary"
 		/>
 	);

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -21,7 +21,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useCallback, useState } from '@wordpress/element';
 import { cloneBlock } from '@wordpress/blocks';
-import { moreVertical, external } from '@wordpress/icons';
+import { moreVertical, external, linkOff, closeSmall } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { isBlobURL } from '@wordpress/blob';
@@ -43,11 +43,11 @@ const MEDIA_OPTIONS_POPOVER_PROPS = {
 		'block-editor-inserter__media-list__item-preview-options__popover',
 };
 
-function MediaPreviewOptions( { category, media } ) {
-	if ( ! category.getReportUrl ) {
+function MediaPreviewOptions( { category, media, onDetach } ) {
+	if ( ! category.getReportUrl && ! onDetach ) {
 		return null;
 	}
-	const reportUrl = category.getReportUrl( media );
+	const reportUrl = category.getReportUrl?.( media );
 	return (
 		<DropdownMenu
 			className="block-editor-inserter__media-list__item-preview-options"
@@ -57,21 +57,51 @@ function MediaPreviewOptions( { category, media } ) {
 		>
 			{ () => (
 				<MenuGroup>
-					<MenuItem
-						onClick={ () =>
-							window.open( reportUrl, '_blank' ).focus()
-						}
-						icon={ external }
-					>
-						{ sprintf(
-							/* translators: %s: The media type to report e.g: "image", "video", "audio" */
-							__( 'Report %s' ),
-							category.mediaType
-						) }
-					</MenuItem>
+					{ reportUrl && (
+						<MenuItem
+							onClick={ () =>
+								window.open( reportUrl, '_blank' ).focus()
+							}
+							icon={ external }
+						>
+							{ sprintf(
+								/* translators: %s: The media type to report e.g: "image", "video", "audio" */
+								__( 'Report %s' ),
+								category.mediaType
+							) }
+						</MenuItem>
+					) }
+					{ onDetach && (
+						<MenuItem
+							onClick={ () => onDetach( media ) }
+							icon={ linkOff }
+						>
+							{ __( 'Detach from post' ) }
+						</MenuItem>
+					) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>
+	);
+}
+
+function MediaPreviewDetachButton( { media, onDetach, title } ) {
+	return (
+		<Button
+			className="block-editor-inserter__media-list__item-detach-button"
+			icon={ closeSmall }
+			label={ sprintf(
+				/* translators: %s: The title of the media item. */
+				__( 'Detach %s from post' ),
+				title
+			) }
+			onClick={ ( event ) => {
+				event.stopPropagation();
+				onDetach( media );
+			} }
+			size="compact"
+			variant="tertiary"
+		/>
 	);
 }
 
@@ -122,7 +152,14 @@ function InsertExternalImageModal( { onClose, onSubmit } ) {
 	);
 }
 
-export function MediaPreview( { media, onClick, category } ) {
+export function MediaPreview( {
+	media,
+	onClick,
+	onDetach,
+	category,
+	isBusy,
+	variant,
+} ) {
 	const [ showExternalUploadModal, setShowExternalUploadModal ] =
 		useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -139,7 +176,7 @@ export function MediaPreview( { media, onClick, category } ) {
 	const onMediaInsert = useCallback(
 		( previewBlock ) => {
 			// Prevent multiple uploads when we're in the process of inserting.
-			if ( isInserting ) {
+			if ( isInserting || isBusy ) {
 				return;
 			}
 
@@ -225,6 +262,7 @@ export function MediaPreview( { media, onClick, category } ) {
 		},
 		[
 			isInserting,
+			isBusy,
 			getSettings,
 			onClick,
 			createSuccessNotice,
@@ -241,15 +279,20 @@ export function MediaPreview( { media, onClick, category } ) {
 
 	const onMouseEnter = useCallback( () => setIsHovered( true ), [] );
 	const onMouseLeave = useCallback( () => setIsHovered( false ), [] );
+	const shouldShowCompactDetachButton = variant === 'compact' && onDetach;
 	return (
 		<>
-			<InserterDraggableBlocks isEnabled blocks={ [ block ] }>
+			<InserterDraggableBlocks
+				isEnabled={ ! isBusy }
+				blocks={ [ block ] }
+			>
 				{ ( { draggable, onDragStart, onDragEnd } ) => (
 					<div
 						className={ clsx(
 							'block-editor-inserter__media-list__list-item',
 							{
 								'is-hovered': isHovered,
+								'is-compact': variant === 'compact',
 							}
 						) }
 						draggable={ draggable }
@@ -279,7 +322,7 @@ export function MediaPreview( { media, onClick, category } ) {
 										>
 											<div className="block-editor-inserter__media-list__item-preview">
 												{ preview }
-												{ isInserting && (
+												{ ( isInserting || isBusy ) && (
 													<div className="block-editor-inserter__media-list__item-preview-spinner">
 														<Spinner />
 													</div>
@@ -290,11 +333,23 @@ export function MediaPreview( { media, onClick, category } ) {
 								/>
 								<Tooltip.Popup>{ title }</Tooltip.Popup>
 							</Tooltip.Root>
-							{ ! isInserting && (
-								<MediaPreviewOptions
-									category={ category }
-									media={ media }
-								/>
+							{ ! isInserting && ! isBusy && (
+								<>
+									{ shouldShowCompactDetachButton && (
+										<MediaPreviewDetachButton
+											media={ media }
+											onDetach={ onDetach }
+											title={ title }
+										/>
+									) }
+									{ ! shouldShowCompactDetachButton && (
+										<MediaPreviewOptions
+											category={ category }
+											media={ media }
+											onDetach={ onDetach }
+										/>
+									) }
+								</>
 							) }
 						</div>
 					</div>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -10,6 +10,7 @@ import { useCallback, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { MediaCategoryPanel } from './media-panel';
+import AttachedMediaPanel from './attached-media-panel';
 import MediaUploadCheck from '../../media-upload/check';
 import MediaUpload from '../../media-upload';
 import { useMediaCategories } from './hooks';
@@ -54,6 +55,21 @@ function MediaTab( {
 			} ) ),
 		[ mediaCategories ]
 	);
+	const attachedMediaCategory = categories.find(
+		( category ) => category.isCurrentPostMedia
+	);
+	const regularCategories = categories.filter(
+		( category ) => ! category.isCurrentPostMedia
+	);
+	const mobileCategories = [
+		...regularCategories,
+		...( attachedMediaCategory ? [ attachedMediaCategory ] : [] ),
+	];
+	const selectedRegularCategory = regularCategories.includes(
+		selectedCategory
+	)
+		? selectedCategory
+		: null;
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;
@@ -63,13 +79,23 @@ function MediaTab( {
 		<>
 			{ ! isMobile && (
 				<div className={ `${ baseCssClass }-container` }>
-					<CategoryTabs
-						categories={ categories }
-						selectedCategory={ selectedCategory }
-						onSelectCategory={ onSelectCategory }
-					>
-						{ children }
-					</CategoryTabs>
+					<div className={ `${ baseCssClass }-content` }>
+						{ !! regularCategories.length && (
+							<CategoryTabs
+								categories={ regularCategories }
+								selectedCategory={ selectedRegularCategory }
+								onSelectCategory={ onSelectCategory }
+							>
+								{ children }
+							</CategoryTabs>
+						) }
+						{ attachedMediaCategory && (
+							<AttachedMediaPanel
+								onInsert={ onInsert }
+								category={ attachedMediaCategory }
+							/>
+						) }
+					</div>
 					<MediaUploadCheck>
 						<MediaUpload
 							multiple={ false }
@@ -100,14 +126,21 @@ function MediaTab( {
 				</div>
 			) }
 			{ isMobile && (
-				<MobileTabNavigation categories={ categories }>
-					{ ( category ) => (
-						<MediaCategoryPanel
-							onInsert={ onInsert }
-							rootClientId={ rootClientId }
-							category={ category }
-						/>
-					) }
+				<MobileTabNavigation categories={ mobileCategories }>
+					{ ( category ) =>
+						category.isCurrentPostMedia ? (
+							<AttachedMediaPanel
+								onInsert={ onInsert }
+								category={ category }
+							/>
+						) : (
+							<MediaCategoryPanel
+								onInsert={ onInsert }
+								rootClientId={ rootClientId }
+								category={ category }
+							/>
+						)
+					}
 				</MobileTabNavigation>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -502,7 +502,16 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__attached-media-panel {
 	flex-shrink: 0;
+	// Bleed to the sidebar edges so the divider spans the full width (matching
+	// the List View outline separator), marking this as its own section; the
+	// horizontal padding keeps the content aligned with the category buttons.
 	margin-top: $grid-unit-20;
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+	padding-top: $grid-unit-20;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
+	border-top: $border-width solid $gray-300;
 }
 
 // Matches the small uppercase label style used for `&__panel-title`.

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -546,10 +546,32 @@ $block-inserter-tabs-height: 44px;
 	margin: 0;
 }
 
+.block-editor-inserter__attached-media-panel-results {
+	position: relative;
+}
+
 .block-editor-inserter__attached-media-panel-grid {
 	display: grid;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: $grid-unit-10;
+
+	// While refetching, dim the existing items and float a spinner over them
+	// (see `&-overlay`) instead of clearing the grid, to avoid flicker.
+	&.is-loading {
+		opacity: 0.5;
+		pointer-events: none;
+
+		// Keep the per-item detach buttons hidden in this state; they would
+		// otherwise reappear over the dimmed grid via their focus/touch reveal.
+		.block-editor-inserter__media-list__item-detach-button.components-button.has-icon {
+			opacity: 0;
+			pointer-events: none;
+		}
+	}
+
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s linear;
+	}
 
 	.block-editor-inserter__media-list {
 		display: grid;
@@ -560,6 +582,14 @@ $block-inserter-tabs-height: 44px;
 		overflow: visible;
 		width: 100%;
 	}
+}
+
+.block-editor-inserter__attached-media-panel-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .block-editor-inserter__attached-media-panel-more.components-button {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -246,6 +246,10 @@ $block-inserter-tabs-height: 44px;
 	padding-top: $grid-unit-20;
 }
 
+.block-editor-inserter__media-tabs-content {
+	min-height: 0;
+}
+
 .block-editor-inserter__category-tablist {
 	margin-bottom: $grid-unit-10;
 }
@@ -496,10 +500,126 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__attached-media-panel.components-panel {
+	border: 0;
+	flex-shrink: 0;
+	margin-left: -$grid-unit-20;
+	margin-top: $grid-unit-20;
+	margin-right: -$grid-unit-20;
+}
+
+.block-editor-inserter__attached-media-panel-actions {
+	display: flex;
+	justify-content: flex-start;
+	margin-top: $grid-unit-10;
+
+	.components-button {
+		flex-shrink: 0;
+	}
+}
+
+.block-editor-inserter__attached-media-panel-spinner {
+	min-height: $grid-unit-60;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.block-editor-inserter__attached-media-panel-message {
+	color: $gray-700;
+	margin: 0;
+}
+
+.block-editor-inserter__attached-media-panel-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: $grid-unit-10;
+
+	.block-editor-inserter__media-list {
+		display: grid;
+		grid-column: 1 / -1;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: $grid-unit-10;
+		height: auto;
+		overflow: visible;
+		width: 100%;
+	}
+}
+
+.block-editor-inserter__attached-media-panel-more.components-button {
+	width: 100%;
+	min-width: 0;
+	height: auto;
+	aspect-ratio: 1;
+	padding: 0;
+	justify-content: center;
+	font-size: 11px;
+}
+
+.block-editor-inserter__attached-media-panel-detach-modal {
+	p {
+		margin-top: 0;
+	}
+}
+
+.block-editor-inserter__attached-media-panel-detach-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: $grid-unit-10;
+	margin-top: $grid-unit-20;
+}
+
 .block-editor-inserter__media-list__list-item {
 	position: relative;
 	cursor: var(--wpds-cursor-control);
 	margin-bottom: $grid-unit-30;
+
+	&.is-compact {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 1;
+		margin-bottom: 0;
+
+		> div,
+		.block-editor-inserter__media-list__item,
+		.block-editor-inserter__media-list__item-preview {
+			box-sizing: border-box;
+			width: 100%;
+			height: 100%;
+			min-width: 0;
+			min-height: 0;
+		}
+
+		.block-editor-inserter__media-list__item-preview {
+			align-items: center;
+			background: $gray-100;
+			border-radius: $radius-small;
+			justify-content: center;
+			overflow: hidden;
+		}
+
+		.block-editor-inserter__media-list__item-preview > img,
+		.block-editor-inserter__media-list__item-preview > video,
+		.block-editor-inserter__media-list__item-preview > audio {
+			display: block;
+			width: 100%;
+			height: 100%;
+			min-width: 0;
+			min-height: 0;
+			max-width: 100%;
+			max-height: 100%;
+			object-fit: cover;
+			border-radius: $radius-small;
+		}
+
+		&.is-hovered,
+		&:focus-within {
+			.block-editor-inserter__media-list__item-detach-button {
+				opacity: 1;
+				pointer-events: auto;
+			}
+		}
+	}
 
 	&.is-placeholder {
 		min-height: 100px;
@@ -542,6 +662,48 @@ $block-inserter-tabs-height: 44px;
 				outline: 2px solid transparent;
 			}
 		}
+	}
+}
+
+.block-editor-inserter__media-list__item-detach-button.components-button.has-icon {
+	position: absolute;
+	top: $grid-unit-05;
+	right: $grid-unit-05;
+	z-index: 1;
+	width: $grid-unit-30;
+	min-width: $grid-unit-30;
+	max-width: $grid-unit-30;
+	height: $grid-unit-30;
+	min-height: $grid-unit-30;
+	max-height: $grid-unit-30;
+	padding: 0;
+	align-items: center;
+	justify-content: center;
+	color: $gray-900;
+	background: $white;
+	box-shadow: 0 0 0 $border-width rgba($black, 0.12), 0 1px 2px rgba($black, 0.12);
+	opacity: 0;
+	pointer-events: none;
+
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s linear;
+	}
+
+	&:focus {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	&:focus,
+	&:hover,
+	&:active {
+		background: $white;
+		color: $gray-900;
+	}
+
+	@media ( hover: none ) {
+		opacity: 1;
+		pointer-events: auto;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -500,21 +500,28 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__attached-media-panel.components-panel {
-	border: 0;
+.block-editor-inserter__attached-media-panel {
 	flex-shrink: 0;
-	margin-left: -$grid-unit-20;
 	margin-top: $grid-unit-20;
-	margin-right: -$grid-unit-20;
+}
+
+// Matches the small uppercase label style used for `&__panel-title`.
+.block-editor-inserter__attached-media-panel-heading {
+	margin: 0 0 $grid-unit-10;
+	font-size: 11px;
+	font-weight: $font-weight-medium;
+	text-transform: uppercase;
+	color: $gray-700;
 }
 
 .block-editor-inserter__attached-media-panel-actions {
-	display: flex;
-	justify-content: flex-start;
-	margin-top: $grid-unit-10;
+	margin-top: $grid-unit-20;
 
+	// Full-width treatment, matching the "Open Media Library" button.
 	.components-button {
-		flex-shrink: 0;
+		justify-content: center;
+		width: 100%;
+		padding: $grid-unit-20;
 	}
 }
 
@@ -532,13 +539,13 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__attached-media-panel-grid {
 	display: grid;
-	grid-template-columns: repeat(4, minmax(0, 1fr));
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: $grid-unit-10;
 
 	.block-editor-inserter__media-list {
 		display: grid;
 		grid-column: 1 / -1;
-		grid-template-columns: repeat(4, minmax(0, 1fr));
+		grid-template-columns: repeat(3, minmax(0, 1fr));
 		gap: $grid-unit-10;
 		height: auto;
 		overflow: visible;
@@ -665,20 +672,14 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+// The button's square 24px sizing comes from its `size="small"` variant; this
+// rule only handles the floating overlay treatment (position, chrome, reveal).
 .block-editor-inserter__media-list__item-detach-button.components-button.has-icon {
 	position: absolute;
 	top: $grid-unit-05;
 	right: $grid-unit-05;
 	z-index: 1;
-	width: $grid-unit-30;
-	min-width: $grid-unit-30;
-	max-width: $grid-unit-30;
-	height: $grid-unit-30;
-	min-height: $grid-unit-30;
-	max-height: $grid-unit-30;
-	padding: 0;
-	align-items: center;
-	justify-content: center;
+	border-radius: $radius-small;
 	color: $gray-900;
 	background: $white;
 	box-shadow: 0 0 0 $border-width rgba($black, 0.12), 0 1px 2px rgba($black, 0.12);

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -193,6 +193,21 @@ const invalidateAttachedImagesQueries = ( postId, query = {} ) => {
 	}
 };
 
+/**
+ * Builds the "attached images" inserter media category for the current post.
+ *
+ * Beyond the standard category shape (`name`, `labels`, `mediaType`, `fetch`),
+ * this returns a self-contained behaviour bundle: `attach`, `detach`,
+ * `invalidate`, and `getTotalItems`, plus the `isCurrentPostMedia` flag that
+ * routes it to the dedicated panel in `block-editor`. All of the
+ * WordPress-attachment-specific logic (querying by `parent`, saving the `post`
+ * field) is encapsulated here so `block-editor` can host the panel without
+ * knowing anything about attachments. The capability is opt-in: categories that
+ * don't set `isCurrentPostMedia` (e.g. Images, Openverse) are unaffected.
+ *
+ * @param {number} postId The current post ID.
+ * @return {Object} The attached-images inserter media category.
+ */
 const getAttachedImagesCategory = ( postId ) => ( {
 	name: 'attached-images',
 	labels: {

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -10,7 +10,7 @@
  * WordPress dependencies
  */
 import { __, sprintf, _x } from '@wordpress/i18n';
-import { resolveSelect } from '@wordpress/data';
+import { dispatch, resolveSelect, select } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -21,6 +21,8 @@ import { store as coreStore } from '@wordpress/core-data';
 /** @typedef {import('@wordpress/block-editor').InserterMediaRequest} InserterMediaRequest */
 /** @typedef {import('@wordpress/block-editor').InserterMediaItem} InserterMediaItem */
 /** @typedef {import('@wordpress/block-editor').InserterMediaCategory} InserterMediaCategory */
+
+const ATTACHED_IMAGES_PANEL_ITEM_COUNT = 20;
 
 const getExternalLink = ( url, text ) =>
 	`<a ${ getExternalLinkAttributes( url ) }>${ text }</a>`;
@@ -124,16 +126,18 @@ const getOpenverseCaption = ( item ) => {
 	return _caption.replace( /\s{2}/g, ' ' );
 };
 
+const getCoreMediaQuery = ( query = {} ) => ( {
+	...query,
+	orderBy: !! query?.search ? 'relevance' : 'date',
+} );
+
 const coreMediaFetch = async ( query = {} ) => {
 	const mediaItems = await resolveSelect( coreStore ).getEntityRecords(
 		'postType',
 		'attachment',
-		{
-			...query,
-			orderBy: !! query?.search ? 'relevance' : 'date',
-		}
+		getCoreMediaQuery( query )
 	);
-	return mediaItems.map( ( mediaItem ) => ( {
+	return ( mediaItems || [] ).map( ( mediaItem ) => ( {
 		...mediaItem,
 		alt: mediaItem.alt_text,
 		url: mediaItem.source_url,
@@ -142,8 +146,93 @@ const coreMediaFetch = async ( query = {} ) => {
 	} ) );
 };
 
+const getAttachedImagesQuery = ( postId, query = {} ) => ( {
+	...query,
+	media_type: 'image',
+	parent: postId,
+} );
+
+const normalizePostId = ( postId ) => {
+	const parsedPostId = typeof postId === 'number' ? postId : Number( postId );
+
+	return Number.isInteger( parsedPostId ) && parsedPostId > 0
+		? parsedPostId
+		: undefined;
+};
+
+const saveAttachmentParent = ( attachmentId, postId ) =>
+	dispatch( coreStore ).saveEntityRecord( 'postType', 'attachment', {
+		id: attachmentId,
+		post: postId,
+	} );
+
+const getAttachmentIds = ( mediaItems ) => [
+	...new Set(
+		( Array.isArray( mediaItems ) ? mediaItems : [ mediaItems ] )
+			.map( ( mediaItem ) => mediaItem?.id )
+			.filter( Boolean )
+	),
+];
+
+const invalidateAttachedImagesQueries = ( postId, query = {} ) => {
+	const { invalidateResolution } = dispatch( coreStore );
+	const queries = [
+		query,
+		{ per_page: 1 },
+		{ per_page: ATTACHED_IMAGES_PANEL_ITEM_COUNT },
+	];
+
+	for ( const attachedImagesQuery of queries ) {
+		invalidateResolution( 'getEntityRecords', [
+			'postType',
+			'attachment',
+			getCoreMediaQuery(
+				getAttachedImagesQuery( postId, attachedImagesQuery )
+			),
+		] );
+	}
+};
+
+const getAttachedImagesCategory = ( postId ) => ( {
+	name: 'attached-images',
+	labels: {
+		name: __( 'Attached images' ),
+		search_items: __( 'Search attached images' ),
+	},
+	mediaType: 'image',
+	isCurrentPostMedia: true,
+	showIfEmpty: true,
+	async fetch( query = {} ) {
+		return coreMediaFetch( getAttachedImagesQuery( postId, query ) );
+	},
+	getTotalItems( query = {} ) {
+		return select( coreStore ).getEntityRecordsTotalItems(
+			'postType',
+			'attachment',
+			getCoreMediaQuery( getAttachedImagesQuery( postId, query ) )
+		);
+	},
+	async attach( mediaItems ) {
+		const attachmentIds = getAttachmentIds( mediaItems );
+
+		await Promise.all(
+			attachmentIds.map( ( attachmentId ) =>
+				saveAttachmentParent( attachmentId, postId )
+			)
+		);
+
+		return attachmentIds.length;
+	},
+	async detach( mediaItem ) {
+		await saveAttachmentParent( mediaItem.id, 0 );
+	},
+	invalidate( query = {} ) {
+		invalidateAttachedImagesQueries( postId, query );
+	},
+} );
+
 /** @type {InserterMediaCategory[]} */
-const inserterMediaCategories = [
+const coreInserterMediaCategories = [
 	{
 		name: 'images',
 		labels: {
@@ -226,4 +315,15 @@ const inserterMediaCategories = [
 	},
 ];
 
-export default inserterMediaCategories;
+export default function getInserterMediaCategories( postId ) {
+	const currentPostId = normalizePostId( postId );
+
+	if ( ! currentPostId ) {
+		return coreInserterMediaCategories;
+	}
+
+	return [
+		getAttachedImagesCategory( currentPostId ),
+		...coreInserterMediaCategories,
+	];
+}

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -1,0 +1,122 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch, resolveSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import getInserterMediaCategories from '..';
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+	resolveSelect: jest.fn(),
+	select: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+describe( 'getInserterMediaCategories', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not include attached images for non-numeric post IDs', () => {
+		const categories = getInserterMediaCategories(
+			'wp_template//theme//home'
+		);
+
+		expect(
+			categories.some(
+				( category ) => category.name === 'attached-images'
+			)
+		).toBe( false );
+	} );
+
+	it( 'fetches images attached to the current post', async () => {
+		const getEntityRecords = jest.fn().mockResolvedValue( [
+			{
+				id: 10,
+				source_url: 'https://example.com/image.jpg',
+				alt_text: 'Alt text',
+				media_details: {
+					sizes: {
+						medium: {
+							source_url: 'https://example.com/image-medium.jpg',
+						},
+					},
+				},
+				caption: {
+					raw: 'Caption',
+				},
+			},
+		] );
+		resolveSelect.mockReturnValue( { getEntityRecords } );
+
+		const [ attachedImagesCategory ] = getInserterMediaCategories( 42 );
+		const results = await attachedImagesCategory.fetch( { per_page: 20 } );
+
+		expect( getEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{
+				per_page: 20,
+				media_type: 'image',
+				parent: 42,
+				orderBy: 'date',
+			}
+		);
+		expect( results ).toEqual( [
+			expect.objectContaining( {
+				id: 10,
+				url: 'https://example.com/image.jpg',
+				previewUrl: 'https://example.com/image-medium.jpg',
+				alt: 'Alt text',
+				caption: 'Caption',
+			} ),
+		] );
+	} );
+
+	it( 'attaches and detaches attachment records', async () => {
+		const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+		dispatch.mockReturnValue( { saveEntityRecord } );
+
+		const [ attachedImagesCategory ] = getInserterMediaCategories( 42 );
+		const attachedCount = await attachedImagesCategory.attach( [
+			{ id: 10 },
+			{ id: 11 },
+			{ id: 10 },
+			{},
+		] );
+		await attachedImagesCategory.detach( { id: 11 } );
+
+		expect( attachedCount ).toBe( 2 );
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{
+				id: 10,
+				post: 42,
+			}
+		);
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{
+				id: 11,
+				post: 42,
+			}
+		);
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{
+				id: 11,
+				post: 0,
+			}
+		);
+		expect( saveEntityRecord ).toHaveBeenCalledTimes( 3 );
+	} );
+} );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -22,7 +22,7 @@ import { privateApis as mediaEditorPrivateApis } from '@wordpress/media-editor';
 /**
  * Internal dependencies
  */
-import inserterMediaCategories from '../media-categories';
+import getInserterMediaCategories from '../media-categories';
 import { mediaUpload } from '../../utils';
 import mediaUploadOnSuccess from '../../utils/media-upload/on-success';
 import { default as mediaSideload } from '../../utils/media-sideload';
@@ -324,6 +324,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	}, [ settings.allowedBlockTypes, hiddenBlockTypes, blockTypes ] );
 
 	const forceDisableFocusMode = settings.focusMode === false;
+	const inserterMediaCategories = useMemo(
+		() => getInserterMediaCategories( postId ),
+		[ postId ]
+	);
 
 	return useMemo( () => {
 		const blockEditorSettings = {
@@ -440,6 +444,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		hasUploadPermissions,
 		blockPatterns,
 		blockPatternCategories,
+		inserterMediaCategories,
 		canUseUnfilteredHTML,
 		undo,
 		createPageEntity,


### PR DESCRIPTION
## What?

Part of:

* #76955 
* #77117

> [!NOTE]
> This is a prototype and I'm sharing early to get an overall sense of the idea, all ideas welcome

Add a simple UI for viewing (and adding and removing) images attached to a post or page, to the Media inserter tab.

Note! This is currently an early draft / experimental prototype. I'm keen for feedback on the overall idea, UX, UI, and so on, but it's highly likely to change. I'm not wedded to any particular approach so happy to try out ideas!

## Why?

Described in #76955 — currently the Media tab is underutilised, and the block editor also lacks a way for users to see at a glance which images are attached to the current post or page, or a way to curate the attached images.

This PR explores a proof of concept for we might add such an interface, that is hopefully simple and easy to use without over complicating things. It can be hard for users to understand attachment relationships for media, so the goal here is to see if we can create something intuitive.

## How?

This PR currently hacks the UI into the block editor inserter via categories — injecting a bunch of additional methods in order for this to be available. That was the first idea I had off the top of my head, but if it doesn't feel viable, we could also potentially look at using a Slot/Fill approach instead.

But in principle, we show a grid of images currently attached to the post or page and allow the user to attach additional images via the "Add" button, and remove via an action icon on each image.

Ideally, this sort of behaviour will bridge the gap between curating "attached to" relationships in the core media library, and working with an individual post or page in the block editor.

## Testing Instructions

Open a post or page, and go to the media inserter. You should be able to add images to your post or page right from the inserter.

Once you've played around with the UI (attaching and detaching), try going out to the core media library and use it to attach / detach images for a particular post. Then, reload the post editor and check that the list of attached images has updated in the inserter UI.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/758914c3-fc0d-41a3-9ca8-43bc305f3140

### Empty state

<img width="1409" height="708" alt="image" src="https://github.com/user-attachments/assets/ba57031b-3d55-4574-bc1e-84a8ac9fee2c" />

### Some images are attached, and a user hovers over the detach button

<img width="1409" height="706" alt="image" src="https://github.com/user-attachments/assets/5c823991-4437-48f6-9764-ce3ce7966580" />

### Warning modal before detaching

<img width="1407" height="702" alt="image" src="https://github.com/user-attachments/assets/b8113f84-d5f9-4656-82f0-b568e85e4a9c" />

## Use of AI Tools

GPT 5.5 + a little Claude Code