### PR TITLE
Refactor Prettier configuration and update dependencies

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,7 @@
 // Import the default config file and expose it in the project root.
 // Useful for editor integrations.
 module.exports = {
-	...require( '@wordpress/prettier-config' ),
+	...require( './packages/prettier-config' ),
 	overrides: [
 		{
 			files: [ 'changelog.txt' ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
 				"lint-staged": "^16.4.0",
 				"npm-run-all": "^4.1.5",
 				"patch-package": "^8.0.0",
-				"prettier": "npm:wp-prettier@^3.0.3",
 				"rimraf": "^5.0.10",
 				"stylelint-plugin-logical-css": "^1.2.3",
 				"syncpack": "^15.3.1",
@@ -53217,6 +53216,7 @@
 				"@types/node": "^20.19.39",
 				"esbuild": "^0.27.2",
 				"esbuild-esm-loader": "^0.3.3",
+				"prettier": "npm:wp-prettier@^3.0.3",
 				"storybook": "^10.2.8",
 				"stylelint": "^16.8.2"
 			},

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"lint-staged": "^16.4.0",
 		"npm-run-all": "^4.1.5",
 		"patch-package": "^8.0.0",
-		"prettier": "npm:wp-prettier@^3.0.3",
 		"rimraf": "^5.0.10",
 		"stylelint-plugin-logical-css": "^1.2.3",
 		"syncpack": "^15.3.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -97,6 +97,7 @@
 		"@types/node": "^20.19.39",
 		"esbuild": "^0.27.2",
 		"esbuild-esm-loader": "^0.3.3",
+		"prettier": "npm:wp-prettier@^3.0.3",
 		"storybook": "^10.2.8",
 		"stylelint": "^16.8.2"
 	},


### PR DESCRIPTION
## What?
Part of #75041

Moves `prettier` (`wp-prettier`) out of the root `package.json` and into the workspaces that actually use it.

## Why?
With npm, all dependencies are hoisted to the root `node_modules`, so any workspace can resolve `prettier` even without declaring it ("phantom dependency"). Keeping `prettier` in the root masks which packages truly depend on it.

## How?
- Removed `"prettier": "npm:wp-prettier@^3.0.3"` from the root `package.json` `devDependencies`.
- Updated the root `.prettierrc.js` to import the shared config via a relative path (`require( './packages/prettier-config' )`) instead of the bare `@wordpress/prettier-config` specifier.

## Use of AI Tools
Used Claude for code exploration and PR description. All changes were reviewed and verified by me.