### PR TITLE
fix: Add missing root devDependencies for WordPress packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,14 @@
 				"widgets/*"
 			],
 			"devDependencies": {
+				"@playwright/test": "^1.58.2",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
 				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+				"@wordpress/env": "file:./packages/env",
 				"@wordpress/eslint-tools": "file:./tools/eslint",
 				"@wordpress/release-tools": "file:./tools/release",
+				"@wordpress/scripts": "file:./packages/scripts",
 				"@wordpress/vips": "file:./packages/vips",
 				"concurrently": "^3.5.0",
 				"cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -62,11 +62,14 @@
 		"IS_GUTENBERG_PLUGIN": true
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.58.2",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
 		"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+		"@wordpress/env": "file:./packages/env",
 		"@wordpress/eslint-tools": "file:./tools/eslint",
 		"@wordpress/release-tools": "file:./tools/release",
+		"@wordpress/scripts": "file:./packages/scripts",
 		"@wordpress/vips": "file:./packages/vips",
 		"concurrently": "^3.5.0",
 		"cross-env": "^7.0.3",


### PR DESCRIPTION
## What?
Part of #75041

Adds `@playwright/test`, `@wordpress/env`, and `@wordpress/scripts` as explicit `devDependencies` in the root `package.json`, since they are used directly by root scripts.

## Use of AI Tools
This PR was authored with the assistance of Claude Code (Claude Opus). All changes were reviewed and verified by me.