### PR TITLE
[codex] Add Identity route to site editor v2

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -25,6 +25,7 @@ add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
  */
 function gutenberg_site_editor_register_default_menu_items() {
 	gutenberg_register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
+	gutenberg_register_site_editor_v2_menu_item( 'identity', _x( 'Identity', 'site identity', 'gutenberg' ), '/identity', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15602,6 +15602,10 @@
 			"resolved": "packages/icons",
 			"link": true
 		},
+		"node_modules/@wordpress/identity-route": {
+			"resolved": "routes/identity",
+			"link": true
+		},
 		"node_modules/@wordpress/image-cropper": {
 			"resolved": "packages/image-cropper",
 			"link": true
@@ -54084,6 +54088,18 @@
 			"name": "@wordpress/home-route",
 			"version": "1.0.0",
 			"dependencies": {
+				"@wordpress/i18n": "file:../../packages/i18n"
+			}
+		},
+		"routes/identity": {
+			"name": "@wordpress/identity-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/fields": "file:../../packages/fields",
 				"@wordpress/i18n": "file:../../packages/i18n"
 			}
 		},

--- a/routes/identity/package.json
+++ b/routes/identity/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@wordpress/identity-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/identity",
+		"page": "site-editor-v2"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/fields": "file:../../packages/fields",
+		"@wordpress/i18n": "file:../../packages/i18n"
+	}
+}

--- a/routes/identity/route.js
+++ b/routes/identity/route.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+export const route = {
+	title: () => _x( 'Identity', 'site identity' ),
+	async canvas() {
+		return {
+			isPreview: true,
+		};
+	},
+};

--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -1,0 +1,106 @@
+/**
+ * WordPress dependencies
+ */
+import { Page } from '@wordpress/admin-ui';
+import { __, _x } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataForm } from '@wordpress/dataviews';
+import { MediaEdit } from '@wordpress/fields';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+type SiteIdentity = {
+	title?: string;
+	description?: string;
+	site_logo?: number;
+	site_icon?: number;
+};
+
+const fields = [
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Site Title' ),
+		description: __(
+			"Displays in your site's layout via the Site Title block."
+		),
+	},
+	{
+		id: 'description',
+		type: 'text',
+		label: __( 'Site Tagline' ),
+		description: __(
+			"In a few words, explain what this site is about. Displays in your site's layout via the Site Tagline block."
+		),
+	},
+	{
+		id: 'site_logo',
+		type: 'media',
+		label: __( 'Site Logo' ),
+		description: __(
+			"Displays in your site's layout via the Site Logo block."
+		),
+		placeholder: __( 'Choose logo' ),
+		Edit: MediaEdit,
+		setValue: ( { value }: { value?: number } ) => ( {
+			site_logo: value ?? 0,
+		} ),
+	},
+	{
+		id: 'site_icon',
+		type: 'media',
+		label: __( 'Site Icon' ),
+		description: __(
+			'Shown in browser tabs, bookmarks, and mobile apps. It should be square and at least 512 by 512 pixels.'
+		),
+		placeholder: __( 'Choose icon' ),
+		Edit: MediaEdit,
+		setValue: ( { value }: { value?: number } ) => ( {
+			site_icon: value ?? 0,
+		} ),
+	},
+];
+
+const form = {
+	layout: {
+		type: 'regular',
+		labelPosition: 'top',
+	},
+	fields: [ 'title', 'description', 'site_logo', 'site_icon' ],
+};
+
+function Identity() {
+	const data = useSelect(
+		( select ) =>
+			select( coreStore ).getEditedEntityRecord( 'root', 'site' ) as
+				| SiteIdentity
+				| undefined,
+		[]
+	);
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const onChange = ( edits: Partial< SiteIdentity > ) => {
+		editEntityRecord( 'root', 'site', undefined, edits );
+	};
+
+	return (
+		<Page
+			title={ _x( 'Identity', 'site identity' ) }
+			headingLevel={ 2 }
+			hasPadding
+		>
+			<DataForm
+				data={ data }
+				fields={ fields }
+				form={ form }
+				onChange={ onChange }
+			/>
+		</Page>
+	);
+}
+
+export const stage = Identity;

--- a/routes/identity/style.scss
+++ b/routes/identity/style.scss
@@ -1,0 +1,2 @@
+@use "@wordpress/dataviews/build-style/style.css" as dataviews;
+@use "@wordpress/fields/build-style/style.css" as fields;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1706,6 +1706,11 @@
 			"count": 1
 		}
 	},
+	"routes/identity/stage.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
 	"routes/media-editor/stage.tsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
No linked issue.

Adds a v2 Site Editor Identity route for editing the site title, site tagline, site logo, and site icon, and registers it in the default v2 menu.

## Why?
This restores a user-facing v1 Site Editor surface that was missing from the v2 route set.

## How?
The route uses `DataForm` with `core-data` site entity edits, loads the DataViews and Fields styles, and includes route workspace metadata plus the same route stylesheet lint suppression pattern used by existing v2 routes.

## Testing Instructions
1. Run `npm run lint:js -- routes/identity/route.js routes/identity/stage.tsx`.
2. Run `npm run lint:css -- routes/identity/style.scss`.
3. Run `npm run lint:pkg-json -- routes/identity/package.json`.
4. Run `./node_modules/.bin/esbuild routes/identity/route.js routes/identity/stage.tsx --bundle --format=esm '--external:@wordpress/*' --loader:.scss=empty --outdir=/tmp/gutenberg-identity-route-build`.
5. In the v2 Site Editor, open the Identity menu item and verify the form edits Site Title, Site Tagline, Site Logo, and Site Icon.

### Testing Instructions for Keyboard
1. Use the keyboard to navigate to the Identity menu item.
2. Tab through each field and media control, update values, and confirm focus remains visible and controls are reachable.

## Screenshots or screencast

N/A

## Use of AI Tools

OpenAI Codex helped port the v1 Identity surface to the v2 route structure and prepare this pull request; the resulting code and commands were reviewed before submission.
