### PR TITLE
Pullquote: Migrate to text-align block support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -807,8 +807,8 @@ Give special visual emphasis to a quote from your text.
 
 -	**Name:** [core/pullquote](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-pullquote/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** citation, textAlign, value
+-	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
+-	**Attributes:** citation, value
 
 ## Query Loop
 

--- a/packages/block-library/src/pullquote/README.md
+++ b/packages/block-library/src/pullquote/README.md
@@ -16,7 +16,6 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 |-----------|------|---------|-------------|
 | `value` | `rich-text` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `rich-text`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `p`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `citation` | `rich-text` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `rich-text`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `cite`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
-| `textAlign` | `string` | — | — |
 
 ## Supports
 
@@ -39,6 +38,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`typography`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography):
   - [`fontSize`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-fontsize): `true`
   - [`lineHeight`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-lineheight): `true`
+  - [`textAlign`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-textalign): `true`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -18,9 +18,6 @@
 			"source": "rich-text",
 			"selector": "cite",
 			"role": "content"
-		},
-		"textAlign": {
-			"type": "string"
 		}
 	},
 	"supports": {
@@ -52,6 +49,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"textAlign": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -19,6 +19,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { SOLID_COLOR_CLASS } from './shared';
+import migrateTextAlignAttributeToBlockSupport from '../utils/migrate-text-align';
 
 const blockAttributes = {
 	value: {
@@ -67,6 +68,112 @@ function multilineToInline( value ) {
 
 	return values.join( '<br>' );
 }
+
+const v6 = {
+	attributes: {
+		value: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'p',
+			role: 'content',
+		},
+		citation: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'cite',
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+	supports: {
+		anchor: true,
+		align: [ 'left', 'right', 'wide', 'full' ],
+		background: {
+			backgroundImage: true,
+			backgroundSize: true,
+			__experimentalDefaultControls: {
+				backgroundImage: true,
+			},
+		},
+		color: {
+			gradients: true,
+			background: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		dimensions: {
+			minHeight: true,
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+		__experimentalStyle: {
+			typography: {
+				fontSize: '1.5em',
+				lineHeight: '1.6',
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	save( { attributes } ) {
+		const { textAlign, citation, value } = attributes;
+		const shouldShowCitation = ! RichText.isEmpty( citation );
+
+		return (
+			<figure
+				{ ...useBlockProps.save( {
+					className: clsx( {
+						[ `has-text-align-${ textAlign }` ]: textAlign,
+					} ),
+				} ) }
+			>
+				<blockquote>
+					<RichText.Content tagName="p" value={ value } />
+					{ shouldShowCitation && (
+						<RichText.Content tagName="cite" value={ citation } />
+					) }
+				</blockquote>
+			</figure>
+		);
+	},
+	isEligible( attributes ) {
+		return !! attributes.textAlign;
+	},
+	migrate: migrateTextAlignAttributeToBlockSupport,
+};
 
 // Version 5 created in #43210 / c4b2ca7f3f. Supports match block.json at the time.
 const v5 = {
@@ -156,10 +263,10 @@ const v5 = {
 		);
 	},
 	migrate( { value, ...attributes } ) {
-		return {
+		return migrateTextAlignAttributeToBlockSupport( {
 			value: multilineToInline( value ),
 			...attributes,
-		};
+		} );
 	},
 };
 
@@ -291,7 +398,7 @@ const v4 = {
 			};
 		}
 
-		return {
+		return migrateTextAlignAttributeToBlockSupport( {
 			value: multilineToInline( value ),
 			className,
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
@@ -299,7 +406,7 @@ const v4 = {
 			textAlign: isSolidColorStyle ? 'left' : undefined,
 			...attributes,
 			style,
-		};
+		} );
 	},
 };
 
@@ -448,7 +555,7 @@ const v3 = {
 				};
 			}
 		}
-		return {
+		return migrateTextAlignAttributeToBlockSupport( {
 			value: multilineToInline( value ),
 			className,
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
@@ -456,7 +563,7 @@ const v3 = {
 			textAlign: isSolidColorStyle ? 'left' : undefined,
 			...attributes,
 			style,
-		};
+		} );
 	},
 };
 
@@ -566,7 +673,7 @@ const v2 = {
 			};
 		}
 
-		return {
+		return migrateTextAlignAttributeToBlockSupport( {
 			value: multilineToInline( value ),
 			className,
 			backgroundColor: isSolidColorStyle ? mainColor : undefined,
@@ -574,7 +681,7 @@ const v2 = {
 			textAlign: isSolidColorStyle ? 'left' : undefined,
 			...attributes,
 			style,
-		};
+		} );
 	},
 };
 
@@ -643,4 +750,4 @@ const v0 = {
  *
  * See block-deprecation.md
  */
-export default [ v5, v4, v3, v2, v1, v0 ];
+export default [ v6, v5, v4, v3, v2, v1, v0 ];

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -170,7 +170,12 @@ const v6 = {
 		);
 	},
 	isEligible( attributes ) {
-		return !! attributes.textAlign;
+		return (
+			!! attributes.textAlign ||
+			!! attributes.className?.match(
+				/\bhas-text-align-(left|center|right)\b/
+			)
+		);
 	},
 	migrate: migrateTextAlignAttributeToBlockSupport,
 };

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -1,18 +1,8 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	AlignmentControl,
-	BlockControls,
-	RichText,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 /**
@@ -20,31 +10,17 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
  */
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
+import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
-function PullQuoteEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	insertBlocksAfter,
-} ) {
-	const { textAlign, citation, value } = attributes;
-	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
-	} );
+function PullQuoteEdit( props ) {
+	const { attributes, setAttributes, isSelected, insertBlocksAfter } = props;
+	useDeprecatedTextAlign( props );
+	const { citation, value } = attributes;
+	const blockProps = useBlockProps();
 	const shouldShowCitation = ! RichText.isEmpty( citation ) || isSelected;
 
 	return (
 		<>
-			<BlockControls group="block">
-				<AlignmentControl
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-			</BlockControls>
 			<Figure { ...blockProps }>
 				<BlockQuote>
 					<RichText

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -1,25 +1,14 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { textAlign, citation, value } = attributes;
+	const { citation, value } = attributes;
 	const shouldShowCitation = ! RichText.isEmpty( citation );
 
 	return (
-		<figure
-			{ ...useBlockProps.save( {
-				className: clsx( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ),
-			} ) }
-		>
+		<figure { ...useBlockProps.save() }>
 			<blockquote>
 				<RichText.Content tagName="p" value={ value } />
 				{ shouldShowCitation && (

--- a/test/integration/fixtures/blocks/core__pullquote__custom-colors.json
+++ b/test/integration/fixtures/blocks/core__pullquote__custom-colors.json
@@ -5,7 +5,6 @@
 		"attributes": {
 			"value": "pullquote",
 			"citation": "citation",
-			"textAlign": "right",
 			"className": "is-style-default",
 			"style": {
 				"color": {
@@ -14,6 +13,9 @@
 				},
 				"border": {
 					"color": "#045679"
+				},
+				"typography": {
+					"textAlign": "right"
 				}
 			}
 		},

--- a/test/integration/fixtures/blocks/core__pullquote__custom-colors.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__custom-colors.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"textAlign":"right","className":"is-style-default","style":{"color":{"background":"#3486aa","text":"#ffefef"},"border":{"color":"#045679"}}} -->
+<!-- wp:pullquote {"className":"is-style-default","style":{"color":{"background":"#3486aa","text":"#ffefef"},"border":{"color":"#045679"},"typography":{"textAlign":"right"}}} -->
 <figure class="wp-block-pullquote has-text-align-right is-style-default has-border-color has-text-color has-background" style="border-color:#045679;color:#ffefef;background-color:#3486aa"><blockquote><p>pullquote</p><cite>citation</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-4.json
@@ -6,9 +6,13 @@
 			"value": "pullquote",
 			"className": "is-style-solid-color",
 			"backgroundColor": "black",
-			"textAlign": "left",
 			"citation": "before block supports",
-			"textColor": "white"
+			"textColor": "white",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-4.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"textAlign":"left","backgroundColor":"black","textColor":"white","className":"is-style-solid-color"} -->
+<!-- wp:pullquote {"backgroundColor":"black","textColor":"white","className":"is-style-solid-color","style":{"typography":{"textAlign":"left"}}} -->
 <figure class="wp-block-pullquote has-text-align-left is-style-solid-color has-white-color has-black-background-color has-text-color has-background"><blockquote><p>pullquote</p><cite>before block supports</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-5__with-anchor.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-5__with-anchor.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:pullquote {"anchor":"test-anchor"} -->
-<figure class="wp-block-pullquote" id="test-anchor"><blockquote><p>One<br>Two</p><cite>...with a caption</cite></blockquote></figure>
+<figure id="test-anchor" class="wp-block-pullquote"><blockquote><p>One<br>Two</p><cite>...with a caption</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-6.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-6.html
@@ -1,0 +1,23 @@
+<!-- wp:pullquote {"textAlign":"left"} -->
+<figure class="wp-block-pullquote has-text-align-left">
+    <blockquote>
+    <p>Testing pullquote block...</p><cite>...with a caption</cite>
+    </blockquote>
+</figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:pullquote {"textAlign":"center"} -->
+<figure class="wp-block-pullquote has-text-align-center">
+    <blockquote>
+    <p>Testing pullquote block...</p><cite>...with a caption</cite>
+    </blockquote>
+</figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:pullquote {"textAlign":"right"} -->
+<figure class="wp-block-pullquote has-text-align-right">
+    <blockquote>
+    <p>Testing pullquote block...</p><cite>...with a caption</cite>
+    </blockquote>
+</figure>
+<!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-6.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-6.json
@@ -1,0 +1,44 @@
+[
+	{
+		"name": "core/pullquote",
+		"isValid": true,
+		"attributes": {
+			"value": "Testing pullquote block...",
+			"citation": "...with a caption",
+			"style": {
+				"typography": {
+					"textAlign": "left"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/pullquote",
+		"isValid": true,
+		"attributes": {
+			"value": "Testing pullquote block...",
+			"citation": "...with a caption",
+			"style": {
+				"typography": {
+					"textAlign": "center"
+				}
+			}
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/pullquote",
+		"isValid": true,
+		"attributes": {
+			"value": "Testing pullquote block...",
+			"citation": "...with a caption",
+			"style": {
+				"typography": {
+					"textAlign": "right"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-6.parsed.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-6.parsed.json
@@ -1,0 +1,49 @@
+[
+	{
+		"blockName": "core/pullquote",
+		"attrs": {
+			"textAlign": "left"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-pullquote has-text-align-left\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-pullquote has-text-align-left\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/pullquote",
+		"attrs": {
+			"textAlign": "center"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-pullquote has-text-align-center\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-pullquote has-text-align-center\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/pullquote",
+		"attrs": {
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-pullquote has-text-align-right\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-pullquote has-text-align-right\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-6.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-6.serialized.html
@@ -1,0 +1,11 @@
+<!-- wp:pullquote {"style":{"typography":{"textAlign":"left"}}} -->
+<figure class="wp-block-pullquote has-text-align-left"><blockquote><p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:pullquote {"style":{"typography":{"textAlign":"center"}}} -->
+<figure class="wp-block-pullquote has-text-align-center"><blockquote><p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:pullquote {"style":{"typography":{"textAlign":"right"}}} -->
+<figure class="wp-block-pullquote has-text-align-right"><blockquote><p>Testing pullquote block...</p><cite>...with a caption</cite></blockquote></figure>
+<!-- /wp:pullquote -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #60763

<!-- In a few words, what is the PR actually doing? -->
Migrates the `Pullquote` block to use the textAlign block support instead of a custom `textAlign` attribute. As a consequence it also enables global styles support for `textAlign` for the `Pullquote`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `Pullquote` block currently implements its own text alignment logic with a custom align attribute, duplicating code that should be handled by the centralized `Pullquote` block support. This migration reduces code duplication and consolidates alignment handling across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaces the custom logic with the block supports, adds deprecation and fixes transforms.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `Pullquote` block and test text alignment (left, center, right)
2. Verify alignment works correctly in the editor and frontend
3. Open a post with existing `Pullquote` blocks that have alignment set
4. Verify they migrate correctly (check console for migration, no visual changes)

