### PR TITLE
[codex] Add mobile surfaces to v2 site editor routes

### DIFF
--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -8,6 +8,7 @@ import type { ComponentType } from 'react';
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 import { Page } from '@wordpress/admin-ui';
 import {
 	privateApis as routePrivateApis,
@@ -124,11 +125,29 @@ function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
 
 		const Stage = module.stage;
 		const Inspector = module.inspector;
+		const MobileContent = module.mobileContent;
+		const MobileSidebar = module.mobileSidebar;
 
 		return createLazyRoute( route.path )( {
 			component: function RouteComponent() {
 				const { inspector: showInspector } =
 					useLoaderData( { from: route.path } ) ?? {};
+				const isMobileViewport = useViewportMatch( 'medium', '<' );
+				const MobileSurface = MobileContent || MobileSidebar;
+
+				if ( isMobileViewport && MobileSurface ) {
+					return (
+						<div
+							className={
+								MobileContent
+									? 'boot-layout__mobile-content'
+									: 'boot-layout__mobile-sidebar'
+							}
+						>
+							<MobileSurface />
+						</div>
+					);
+				}
 
 				return (
 					<>

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -83,7 +83,9 @@
 }
 
 .boot-layout__stage,
-.boot-layout__inspector {
+.boot-layout__inspector,
+.boot-layout__mobile-sidebar,
+.boot-layout__mobile-content {
 	flex: 1;
 	overflow-y: auto;
 	background: var(--wpds-color-background-surface-neutral);
@@ -134,6 +136,19 @@
 	@include mixins.break-medium {
 		z-index: auto;
 	}
+}
+
+.boot-layout__mobile-sidebar,
+.boot-layout__mobile-content {
+	z-index: 2;
+
+	@include mixins.break-medium {
+		display: none;
+	}
+}
+
+.boot-layout__mobile-sidebar {
+	background: var(--wpds-color-background-surface-neutral-weak);
 }
 
 .boot-layout__canvas {
@@ -197,7 +212,9 @@
 }
 
 .boot-layout.has-full-canvas .boot-layout__stage,
-.boot-layout.has-full-canvas .boot-layout__inspector {
+.boot-layout.has-full-canvas .boot-layout__inspector,
+.boot-layout.has-full-canvas .boot-layout__mobile-sidebar,
+.boot-layout.has-full-canvas .boot-layout__mobile-content {
 	display: none;
 }
 

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -23,11 +23,13 @@ export interface MenuItem {
 
 /**
  * Route surfaces exported from content_module.
- * Stage is required, inspector is optional.
+ * Stage is the main content surface. Inspector and mobile surfaces are optional.
  */
 export interface RouteSurfaces {
 	stage?: ComponentType;
 	inspector?: ComponentType;
+	mobileSidebar?: ComponentType;
+	mobileContent?: ComponentType;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
No issue.

Adds v2 route-specific mobile surfaces to the boot route contract.

## Why?
This lets extensible Site Editor routes provide mobile-specific sidebar or content UI, matching the v1 route contract.

## How?
The route adapter now prefers exported `mobileContent` or `mobileSidebar` below the medium breakpoint and the boot shell styles those surfaces full-screen.

## Testing Instructions
1. Open `admin.php?page=site-editor-v2`.
2. Navigate to a route whose content module exports `mobileContent` or `mobileSidebar`.
3. Resize below the medium breakpoint and verify the route-specific mobile surface is shown instead of the default stage and inspector surfaces.

### Testing Instructions for Keyboard
Use the keyboard to navigate into the mobile route surface and confirm focus remains within the route-specific surface while it is visible.

## Screenshots or screencast

N/A.

## Use of AI Tools

Authored with OpenAI Codex and reviewed by the contributor.
