### PR TITLE
Add site editor v2 export action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47697,7 +47697,9 @@
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/admin-ui": "file:../admin-ui",
+				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
+				"@wordpress/blob": "file:../blob",
 				"@wordpress/commands": "file:../commands",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -42,7 +42,9 @@
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/admin-ui": "file:../admin-ui",
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
+		"@wordpress/blob": "file:../blob",
 		"@wordpress/commands": "file:../commands",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/boot/src/components/site-hub/index.tsx
+++ b/packages/boot/src/components/site-hub/index.tsx
@@ -22,6 +22,7 @@ import type { UnstableBase } from '@wordpress/core-data';
  * Internal dependencies
  */
 import SiteIconLink from '../site-icon-link';
+import SiteExport from './site-export';
 import { store as bootStore } from '../../store';
 import './style.scss';
 
@@ -69,6 +70,7 @@ function SiteHub() {
 					label={ __( 'Open command palette' ) }
 					shortcut={ displayShortcut.primary( 'k' ) }
 				/>
+				<SiteExport />
 			</HStack>
 		</div>
 	);

--- a/packages/boot/src/components/site-hub/site-export.tsx
+++ b/packages/boot/src/components/site-hub/site-export.tsx
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { downloadBlob } from '@wordpress/blob';
+import { DropdownMenu, MenuItem } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
+import { download, moreVertical } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+
+export default function SiteExport() {
+	const canExport = useSelect( ( select ) => {
+		const targetHints =
+			select( coreStore ).getCurrentTheme()?._links?.[
+				'wp:export-theme'
+			]?.[ 0 ]?.targetHints ?? {};
+
+		return !! targetHints.allow?.includes( 'GET' );
+	}, [] );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	if ( ! canExport ) {
+		return null;
+	}
+
+	async function handleExport() {
+		try {
+			const response = await apiFetch< unknown, false >( {
+				path: '/wp-block-editor/v1/export',
+				parse: false,
+				headers: {
+					Accept: 'application/zip',
+				},
+			} );
+			const blob = await response.blob();
+			const contentDisposition = response.headers.get(
+				'content-disposition'
+			);
+			const contentDispositionMatches =
+				contentDisposition?.match( /=(.+)\.zip/ );
+			const fileName = contentDispositionMatches?.[ 1 ]
+				? contentDispositionMatches[ 1 ]
+				: 'edit-site-export';
+
+			downloadBlob( fileName + '.zip', blob, 'application/zip' );
+		} catch ( errorResponse ) {
+			let error: { code?: string; message?: string } = {};
+			try {
+				error = await ( errorResponse as Response ).json();
+			} catch {}
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the site export.' );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	}
+
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Options' ) }
+			toggleProps={ {
+				variant: 'tertiary',
+				size: 'compact',
+			} }
+			popoverProps={ {
+				placement: 'bottom-start',
+			} }
+		>
+			{ ( { onClose } ) => (
+				<MenuItem
+					role="menuitem"
+					icon={ download }
+					onClick={ () => {
+						void handleExport();
+						onClose();
+					} }
+					info={ __(
+						'Download your theme with updated templates and styles.'
+					) }
+				>
+					{ _x( 'Export', 'site exporter menu item' ) }
+				</MenuItem>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -8,6 +8,8 @@
 	"references": [
 		{ "path": "../a11y" },
 		{ "path": "../admin-ui" },
+		{ "path": "../api-fetch" },
+		{ "path": "../blob" },
 		{ "path": "../components" },
 		{ "path": "../compose" },
 		{ "path": "../core-data" },


### PR DESCRIPTION
## What?

Adds an Export option to the Site Editor v2 Site Hub actions menu.

## Why?

Site Editor v1 exposes an Export menu item that downloads the active theme with updated templates and styles, but Site Editor v2 did not have an equivalent action.

## How?

Adds a Boot-local `SiteExport` component that uses the existing `wp:export-theme` capability hint and `/wp-block-editor/v1/export` endpoint, then wires it into the Site Hub Options dropdown with the required Boot package dependencies.

## Testing Instructions

1. Open `wp-admin/admin.php?page=site-editor-v2`.
2. Open the Site Hub Options menu.
3. Click Export and confirm the active theme zip downloads.

### Testing Instructions for Keyboard

1. Open `wp-admin/admin.php?page=site-editor-v2`.
2. Tab to the Site Hub Options button and press Enter.
3. Use the keyboard to choose Export and confirm the active theme zip downloads.

## Screenshots or screencast

N/A

## Use of AI Tools

OpenAI Codex was used to implement the change, run validation, and prepare this PR description.
