### PR TITLE
Gate v2 Site Editor styles for classic themes

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -21,15 +21,44 @@ function gutenberg_register_site_editor_admin_page() {
 add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
 
 /**
+ * Check whether the current classic theme supports the Style Book.
+ *
+ * @return bool True if the current classic theme supports the Style Book.
+ */
+function gutenberg_site_editor_v2_current_classic_theme_supports_style_book() {
+	if ( wp_is_block_theme() ) {
+		return false;
+	}
+
+	if ( current_theme_supports( 'editor-styles' ) ) {
+		return true;
+	}
+
+	return function_exists( 'wp_theme_has_theme_json' ) &&
+		wp_theme_has_theme_json();
+}
+
+/**
  * Register default menu items for the site editor page.
  */
 function gutenberg_site_editor_register_default_menu_items() {
+	$is_block_theme                            = wp_is_block_theme();
+	$current_theme_supports_site_editor_styles = $is_block_theme ||
+		gutenberg_site_editor_v2_current_classic_theme_supports_style_book();
+
 	gutenberg_register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
-	gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
-	gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
-	gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
-	gutenberg_register_site_editor_v2_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );
-	gutenberg_register_site_editor_v2_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
+
+	if ( $current_theme_supports_site_editor_styles ) {
+		gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
+	}
+
+	if ( $is_block_theme ) {
+		gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
+		gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );
+		gutenberg_register_site_editor_v2_menu_item( 'templates', __( 'Templates', 'gutenberg' ), '/templates', '' );
+		gutenberg_register_site_editor_v2_menu_item( 'templateParts', __( 'Template Parts', 'gutenberg' ), '/template-parts', '' );
+	}
+
 	gutenberg_register_site_editor_v2_menu_item( 'patterns', __( 'Patterns', 'gutenberg' ), '/patterns', '' );
 }
 add_action( 'site-editor-v2_init', 'gutenberg_site_editor_register_default_menu_items', 5 );

--- a/routes/styles/route.ts
+++ b/routes/styles/route.ts
@@ -4,11 +4,19 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { resolveIsStylesRouteSupported } from './utils';
+
+/**
  * Route configuration for styles.
  */
 export const route = {
 	title: () => __( 'Styles' ),
 	async canvas( context: any ) {
+		if ( ! ( await resolveIsStylesRouteSupported() ) ) {
+			return undefined;
+		}
 		// If stylebook preview is active, use custom canvas (StyleBookPreview)
 		// Otherwise, use default editor canvas
 		if ( context.search.preview === 'stylebook' ) {

--- a/routes/styles/stage.tsx
+++ b/routes/styles/stage.tsx
@@ -8,7 +8,12 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	Spinner,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { seen } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useEditorSettings } from '@wordpress/lazy-editor';
@@ -18,6 +23,7 @@ import { unlock } from '@wordpress/routes-lock-unlock';
  * Internal dependencies
  */
 import './style.scss';
+import { isStylesRouteSupported } from './utils';
 
 const { GlobalStylesUIWrapper, GlobalStylesActionMenu } =
 	unlock( editorPrivateApis );
@@ -26,16 +32,22 @@ function Stage() {
 	const navigate = useNavigate();
 	const search = useSearch( { strict: false } ) as any;
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	const globalStylesId = useSelect(
-		( select ) =>
-			(
+	const { currentTheme, globalStylesId } = useSelect(
+		( select ) => ( {
+			currentTheme: select( coreStore ).getCurrentTheme(),
+			globalStylesId: (
 				select( coreStore ) as any
 			 ).__experimentalGetCurrentGlobalStylesId(),
+		} ),
 		[]
 	);
-	const { editorSettings } = useEditorSettings( {
-		stylesId: globalStylesId,
-	} );
+	const { isReady: areEditorSettingsReady, editorSettings } =
+		useEditorSettings( {
+			stylesId: globalStylesId,
+		} );
+	const isReady = !! currentTheme && areEditorSettingsReady;
+	const isSupported =
+		isReady && isStylesRouteSupported( currentTheme, editorSettings );
 
 	const section = ( search.section ?? '/' ) as string;
 	const [ isStyleBookOpened, setIsStyleBookOpened ] = useState(
@@ -50,6 +62,36 @@ function Stage() {
 			},
 		} );
 	};
+
+	if ( ! isReady ) {
+		return (
+			<Page
+				headingLevel={ 2 }
+				className="routes-styles__page"
+				title={ __( 'Styles' ) }
+				hasPadding
+			>
+				<Spinner />
+			</Page>
+		);
+	}
+
+	if ( ! isSupported ) {
+		return (
+			<Page
+				headingLevel={ 2 }
+				className="routes-styles__page"
+				title={ __( 'Styles' ) }
+				hasPadding
+			>
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'The theme you are currently using does not support this screen.'
+					) }
+				</Notice>
+			</Page>
+		);
+	}
 
 	return (
 		<Page

--- a/routes/styles/utils.ts
+++ b/routes/styles/utils.ts
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { unlock } from '@wordpress/routes-lock-unlock';
+
+type Theme = {
+	is_block_theme?: boolean;
+	theme_supports?: Record< string, boolean >;
+};
+
+type EditorSettings = {
+	supportsLayout?: boolean;
+};
+
+/**
+ * Check if a classic theme supports the Style Book.
+ *
+ * @param currentTheme   The current theme data.
+ * @param editorSettings The editor settings data.
+ * @return True if a classic theme supports Style Book.
+ */
+export function isClassicThemeWithStyleBookSupport(
+	currentTheme: Theme | undefined,
+	editorSettings: EditorSettings | undefined
+) {
+	const supportsEditorStyles =
+		currentTheme?.theme_supports?.[ 'editor-styles' ];
+	// This matches the v1 Site Editor's temporary theme.json heuristic.
+	const hasThemeJson = editorSettings?.supportsLayout;
+
+	return (
+		! currentTheme?.is_block_theme &&
+		!! ( supportsEditorStyles || hasThemeJson )
+	);
+}
+
+/**
+ * Check if the Styles route is supported by the current theme.
+ *
+ * @param currentTheme   The current theme data.
+ * @param editorSettings The editor settings data.
+ * @return True if the Styles route is supported.
+ */
+export function isStylesRouteSupported(
+	currentTheme: Theme | undefined,
+	editorSettings: EditorSettings | undefined
+) {
+	return (
+		!! currentTheme?.is_block_theme ||
+		isClassicThemeWithStyleBookSupport( currentTheme, editorSettings )
+	);
+}
+
+/**
+ * Resolve whether the current theme supports the Styles route.
+ *
+ * @return True if the Styles route is supported.
+ */
+export async function resolveIsStylesRouteSupported() {
+	const [ currentTheme, editorSettings ] = await Promise.all( [
+		resolveSelect( coreStore ).getCurrentTheme(),
+		unlock( resolveSelect( coreStore ) as any ).getEditorSettings(),
+	] );
+
+	return isStylesRouteSupported( currentTheme, editorSettings );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds v2 Site Editor gating so unsupported classic themes do not get the Styles menu or Styles canvas, while classic themes with Style Book support keep access.

## Why?
V1 already has classic-theme fallback behavior for Style Book and unsupported screens, but v2 registered the Styles route/menu without the same support checks.

## How?
The v2 menu registration now checks block-theme and classic Style Book support, and the v2 Styles route/stage share a support helper that shows the unsupported notice and skips the canvas when unavailable.

## Testing Instructions
1. Activate a block theme and confirm `admin.php?page=site-editor-v2` still shows Styles, Navigation, Pages, Templates, Template Parts, and Patterns.
2. Activate a classic theme with editor styles or theme.json support and confirm v2 still shows Styles and the Style Book preview.
3. Activate a classic theme without Style Book support and confirm v2 hides Styles and direct `/styles` access shows the unsupported-theme notice.

### Testing Instructions for Keyboard
Repeat the testing steps using keyboard navigation and confirm focus reaches the available menu items and unsupported notice.

## Screenshots or screencast

N/A

## Use of AI Tools

Used OpenAI Codex to implement the change, run checks, and prepare this PR.
