### PR TITLE
Patterns: Migrate modals to @wordpress/ui components and fix rename input width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51948,6 +51948,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/ui": "file:../ui",
 				"@wordpress/url": "file:../url"
 			},
 			"engines": {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -35,9 +35,4 @@
 .edit-site-list__rename-modal {
 	// The rename dropdown popover is open at the same time as the rename modal. The latter has to be higher.
 	z-index: z-index(".edit-site-list__rename-modal");
-	.components-base-control {
-		@include break-medium() {
-			width: $grid-unit * 40;
-		}
-	}
 }

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -65,6 +65,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/ui": "file:../ui",
 		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -1,14 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-	__experimentalText as WCText,
-	TextControl,
-	Modal,
-} from '@wordpress/components';
+import { Button, TextControl, Modal } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useId } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
@@ -60,12 +54,12 @@ export function AllowOverridesModal( {
 					handleSubmit();
 				} }
 			>
-				<VStack spacing="6">
-					<WCText id={ descriptionId }>
+				<Stack direction="column" gap="xl">
+					<Text id={ descriptionId }>
 						{ __(
 							'Overrides are changes you make to a block within a synced pattern instance. Use overrides to customize a synced pattern instance to suit its new context. Name this block to specify an override.'
 						) }
-					</WCText>
+					</Text>
 					<TextControl
 						__next40pxDefaultSize
 						value={ editedBlockName }
@@ -76,7 +70,7 @@ export function AllowOverridesModal( {
 						placeholder={ placeholder }
 						onChange={ setEditedBlockName }
 					/>
-					<HStack justify="right">
+					<Stack justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -93,8 +87,8 @@ export function AllowOverridesModal( {
 						>
 							{ __( 'Enable' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			</form>
 		</Modal>
 	);
@@ -117,14 +111,14 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 					onClose();
 				} }
 			>
-				<VStack spacing="6">
-					<WCText id={ descriptionId }>
+				<Stack direction="column" gap="xl">
+					<Text id={ descriptionId }>
 						{ __(
 							'Are you sure you want to disable overrides? Disabling overrides will revert all applied overrides for this block throughout instances of this pattern.'
 						) }
-					</WCText>
+					</Text>
 
-					<HStack justify="right">
+					<Stack justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -140,8 +134,8 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 						>
 							{ __( 'Disable' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			</form>
 		</Modal>
 	);

--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -117,8 +117,7 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 							'Are you sure you want to disable overrides? Disabling overrides will revert all applied overrides for this block throughout instances of this pattern.'
 						) }
 					</Text>
-
-					<Stack justify="end">
+					<Stack gap="sm" justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -126,7 +125,6 @@ export function DisallowOverridesModal( { onClose, onSave } ) {
 						>
 							{ __( 'Cancel' ) }
 						</Button>
-
 						<Button
 							__next40pxDefaultSize
 							variant="primary"

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -142,7 +142,7 @@ export function CreatePatternModalContents( {
 						);
 					} }
 				/>
-				<Stack justify="end">
+				<Stack gap="sm" justify="end">
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
@@ -153,7 +153,6 @@ export function CreatePatternModalContents( {
 					>
 						{ __( 'Cancel' ) }
 					</Button>
-
 					<Button
 						__next40pxDefaultSize
 						variant="primary"

--- a/packages/patterns/src/components/create-pattern-modal.js
+++ b/packages/patterns/src/components/create-pattern-modal.js
@@ -5,10 +5,9 @@ import {
 	Modal,
 	Button,
 	TextControl,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	ToggleControl,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __, _x } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -115,7 +114,7 @@ export function CreatePatternModalContents( {
 				onCreate( title, syncType );
 			} }
 		>
-			<VStack spacing="5">
+			<Stack direction="column" gap="lg">
 				<TextControl
 					label={ __( 'Name' ) }
 					value={ title }
@@ -143,7 +142,7 @@ export function CreatePatternModalContents( {
 						);
 					} }
 				/>
-				<HStack justify="right">
+				<Stack justify="end">
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
@@ -164,8 +163,8 @@ export function CreatePatternModalContents( {
 					>
 						{ confirmLabel }
 					</Button>
-				</HStack>
-			</VStack>
+				</Stack>
+			</Stack>
 		</form>
 	);
 }

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -148,7 +148,7 @@ export default function RenamePatternCategoryModal( {
 							</span>
 						) }
 					</Stack>
-					<Stack justify="end">
+					<Stack gap="sm" justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"

--- a/packages/patterns/src/components/rename-pattern-category-modal.js
+++ b/packages/patterns/src/components/rename-pattern-category-modal.js
@@ -1,13 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	Modal,
-	Button,
-	TextControl,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Modal, Button, TextControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useId, useRef, useState } from '@wordpress/element';
@@ -133,8 +128,8 @@ export default function RenamePatternCategoryModal( {
 			{ ...props }
 		>
 			<form onSubmit={ onSave }>
-				<VStack spacing="5">
-					<VStack spacing="2">
+				<Stack direction="column" gap="lg">
+					<Stack direction="column" gap="sm">
 						<TextControl
 							ref={ textControlRef }
 							__next40pxDefaultSize
@@ -152,8 +147,8 @@ export default function RenamePatternCategoryModal( {
 								{ validationMessage }
 							</span>
 						) }
-					</VStack>
-					<HStack justify="right">
+					</Stack>
+					<Stack justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -172,8 +167,8 @@ export default function RenamePatternCategoryModal( {
 						>
 							{ __( 'Save' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			</form>
 		</Modal>
 	);

--- a/packages/patterns/src/components/rename-pattern-modal.js
+++ b/packages/patterns/src/components/rename-pattern-modal.js
@@ -1,13 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Modal,
-	TextControl,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -96,7 +91,7 @@ export default function RenamePatternModal( {
 			size="small"
 		>
 			<form onSubmit={ onRename }>
-				<VStack spacing="5">
+				<Stack direction="column" gap="lg">
 					<TextControl
 						__next40pxDefaultSize
 						label={ __( 'Name' ) }
@@ -105,7 +100,7 @@ export default function RenamePatternModal( {
 						required
 					/>
 
-					<HStack justify="right">
+					<Stack justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -121,8 +116,8 @@ export default function RenamePatternModal( {
 						>
 							{ __( 'Save' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			</form>
 		</Modal>
 	);

--- a/packages/patterns/src/components/rename-pattern-modal.js
+++ b/packages/patterns/src/components/rename-pattern-modal.js
@@ -99,8 +99,7 @@ export default function RenamePatternModal( {
 						onChange={ setName }
 						required
 					/>
-
-					<Stack justify="end">
+					<Stack gap="sm" justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -108,7 +107,6 @@ export default function RenamePatternModal( {
 						>
 							{ __( 'Cancel' ) }
 						</Button>
-
 						<Button
 							__next40pxDefaultSize
 							variant="primary"

--- a/packages/patterns/src/components/style.scss
+++ b/packages/patterns/src/components/style.scss
@@ -37,11 +37,6 @@
 
 .patterns-rename-pattern-category-modal__validation-message {
 	color: $alert-red;
-
-	// Match the input size.
-	@include break-medium() {
-		width: $grid-unit * 40;
-	}
 }
 
 .pattern-overrides-control__allow-overrides-button {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1537,26 +1537,6 @@
 			"count": 1
 		}
 	},
-	"packages/patterns/src/components/allow-overrides-modal.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
-	"packages/patterns/src/components/create-pattern-modal.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
-	"packages/patterns/src/components/rename-pattern-category-modal.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
-	"packages/patterns/src/components/rename-pattern-modal.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
 	"packages/preferences/src/components/preferences-modal-tabs/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 6


### PR DESCRIPTION
## What?
PR migrates the pattern modal components (`AllowOverridesModal`, `DisallowOverridesModal`, `CreatePatternModal`, `RenamePatternModal`, `RenamePatternCategoryModal`) off the deprecated `__experimental` `HStack`/`VStack`/`Text` from `@wordpress/components` to the recommended `Stack` and `Text` components from `@wordpress/ui`, resolving the related ESLint errors.

Also fixes a bug where the name field in the "Rename pattern category" modal couldn't expand to the modal's full width on larger screens, by removing leftover fixed-width CSS that's no longer needed now that the modals use a defined size.

## Testing Instructions
1. Open a post or page.
2. Add blocks and create a pattern from it.
3. Confirm the modal has no visual regressions.
4. Open the new pattern in the editor.
5. Test overrides modals from the Advanced panel screen.
6. Confirm they also don't have visual regressions.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="535" height="311" alt="CleanShot 2026-06-16 at 15 43 26" src="https://github.com/user-attachments/assets/03820e80-b5c7-48a3-9263-91fcf62c350f" />|<img width="484" height="292" alt="CleanShot 2026-06-16 at 15 56 21" src="https://github.com/user-attachments/assets/c21d95ca-14aa-44cc-8bb6-19c6f2d3410f" />|

## Use of AI Tools

Assisted by Claude.
