### PR TITLE
File Block: Replace on-mount downloadButtonText effect with a default variation

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -23,9 +23,9 @@ import {
 	store as blockEditorStore,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useCopyToClipboard } from '@wordpress/compose';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -90,26 +90,13 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	const { toggleSelection } = useDispatch( blockEditorStore );
 
 	useUploadMediaFromBlobURL( {
 		url: temporaryURL,
 		onChange: onSelectFile,
 		onError: onUploadError,
 	} );
-
-	// Note: Handle setting a default value for `downloadButtonText` via HTML API
-	// when it supports replacing text content for HTML tags.
-	useEffect( () => {
-		if ( RichText.isEmpty( downloadButtonText ) ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				downloadButtonText: _x( 'Download', 'button label' ),
-			} );
-		}
-		// This effect should only run on mount.
-	}, [] );
 
 	function onSelectFile( newMedia ) {
 		if ( ! newMedia || ! newMedia.url ) {

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -14,6 +14,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 import { unlock } from '../lock-unlock';
 
 const { fieldsKey, formKey } = unlock( blocksPrivateApis );
@@ -34,6 +35,7 @@ export const settings = {
 	deprecated,
 	edit,
 	save,
+	variations,
 };
 
 if ( window.__experimentalContentOnlyInspectorFields ) {

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -5,7 +5,11 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { _x } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
+
+// Transforms bypass the default variation, so set the localized default here.
+const downloadButtonText = _x( 'Download', 'button label' );
 
 const transforms = {
 	from: [
@@ -47,6 +51,7 @@ const transforms = {
 							createBlock( 'core/file', {
 								blob: blobURL,
 								fileName: file.name,
+								downloadButtonText,
 							} )
 						);
 					}
@@ -65,6 +70,7 @@ const transforms = {
 					textLinkHref: attributes.src,
 					id: attributes.id,
 					anchor: attributes.anchor,
+					downloadButtonText,
 				} );
 			},
 		},
@@ -78,6 +84,7 @@ const transforms = {
 					textLinkHref: attributes.src,
 					id: attributes.id,
 					anchor: attributes.anchor,
+					downloadButtonText,
 				} );
 			},
 		},
@@ -92,6 +99,7 @@ const transforms = {
 					textLinkHref: attributes.url,
 					id: attributes.id,
 					anchor: attributes.anchor,
+					downloadButtonText,
 				} );
 			},
 		},

--- a/packages/block-library/src/file/variations.js
+++ b/packages/block-library/src/file/variations.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+const variations = [
+	{
+		name: 'default',
+		isDefault: true,
+		// Translatable defaults can't live in `block.json`, so set it here.
+		attributes: {
+			downloadButtonText: _x( 'Download', 'button label' ),
+		},
+	},
+];
+
+export default variations;


### PR DESCRIPTION
## What?
PR replaced the on-mount `useEffect` that imperatively set the localized `downloadButtonText` default ("Download") with a declarative `isDefault` block variation, mirroring the Search block pattern.

This also fixed an odd bug with the File block in StrickMode, when reloading a newly saved post, it becomes dirty again. Related #73378.

P.S. I've wanted to remove this effect for a while. Props @t-hamano for suggesting this method in a different PR.

## Testing Instructions
1. Open a post or page.
2. Insert a File block and select a file.
3. Confirm that the download button default text is correctly set.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/90455816-3bbf-448d-aa9e-bad3694025be

## Use of AI Tools

Assisted by Claude.