### PR TITLE
Add welcome guide to site editor v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47712,6 +47712,7 @@
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/lazy-editor": "file:../lazy-editor",
 				"@wordpress/notices": "file:../notices",
+				"@wordpress/preferences": "file:../preferences",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -57,6 +57,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/lazy-editor": "file:../lazy-editor",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from '@wordpress/route';
  */
 import type { CanvasData } from '../../store/types';
 import BootBackButton from './back-button';
+import WelcomeGuideFills from '../welcome-guide/fills';
 
 interface CanvasProps {
 	canvas: CanvasData;
@@ -81,7 +82,11 @@ export default function Canvas( { canvas }: CanvasProps ) {
 							: [],
 					} }
 					backButton={ backButton }
-				/>
+				>
+					{ ! canvas.isPreview && (
+						<WelcomeGuideFills postType={ canvas.postType } />
+					) }
+				</Editor>
 			</div>
 			{ canvas.isPreview && canvas.editLink && (
 				<div

--- a/packages/boot/src/components/welcome-guide/editor.tsx
+++ b/packages/boot/src/components/welcome-guide/editor.tsx
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideImage from './image';
+
+export default function WelcomeGuideEditor() {
+	const { toggle } = useDispatch( preferencesStore );
+
+	const { isActive, isBlockBasedTheme } = useSelect( ( select ) => {
+		return {
+			isActive: !! select( preferencesStore ).get(
+				'core/edit-site',
+				'welcomeGuide'
+			),
+			isBlockBasedTheme:
+				select( coreStore ).getCurrentTheme()?.is_block_theme,
+		};
+	}, [] );
+
+	if ( ! isActive || ! isBlockBasedTheme ) {
+		return null;
+	}
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide guide-editor"
+			contentLabel={ __( 'Welcome to the site editor' ) }
+			finishButtonText={ __( 'Get started' ) }
+			onFinish={ () => toggle( 'core/edit-site', 'welcomeGuide' ) }
+			pages={ [
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc="https://s.w.org/images/block-editor/edit-your-site.svg?1"
+							animatedSrc="https://s.w.org/images/block-editor/edit-your-site.gif?1"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Edit your site' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'Design everything on your site — from the header right down to the footer — using blocks.'
+								) }
+							</p>
+							<p className="edit-site-welcome-guide__text">
+								{ createInterpolateElement(
+									__(
+										'Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
+									),
+									{
+										StylesIconImage: (
+											<img
+												alt={ __( 'styles' ) }
+												src="data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z' fill='%231E1E1E'/%3E%3C/svg%3E%0A"
+											/>
+										),
+									}
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/fills.tsx
+++ b/packages/boot/src/components/welcome-guide/fills.tsx
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import WelcomeGuide from '.';
+import WelcomeGuideMenuItem from './menu-item';
+
+const { PreferencesModal, ToolsMoreMenuGroup } = unlock( editorPrivateApis );
+
+export default function WelcomeGuideFills( {
+	postType,
+}: {
+	postType?: string;
+} ) {
+	const { setDefaults } = useDispatch( preferencesStore );
+
+	useEffect( () => {
+		setDefaults( 'core/edit-site', {
+			welcomeGuide: true,
+			welcomeGuideStyles: true,
+			welcomeGuidePage: true,
+			welcomeGuideTemplate: true,
+		} );
+	}, [ setDefaults ] );
+
+	return (
+		<>
+			<ToolsMoreMenuGroup>
+				<WelcomeGuideMenuItem />
+			</ToolsMoreMenuGroup>
+			<PreferencesModal />
+			<WelcomeGuide postType={ postType } />
+		</>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/image.tsx
+++ b/packages/boot/src/components/welcome-guide/image.tsx
@@ -1,0 +1,17 @@
+export default function WelcomeGuideImage( {
+	nonAnimatedSrc,
+	animatedSrc,
+}: {
+	nonAnimatedSrc: string;
+	animatedSrc: string;
+} ) {
+	return (
+		<picture className="edit-site-welcome-guide__image">
+			<source
+				srcSet={ nonAnimatedSrc }
+				media="(prefers-reduced-motion: reduce)"
+			/>
+			<img src={ animatedSrc } width="312" height="240" alt="" />
+		</picture>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/index.tsx
+++ b/packages/boot/src/components/welcome-guide/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideEditor from './editor';
+import WelcomeGuidePage from './page';
+import WelcomeGuideTemplate from './template';
+
+export default function WelcomeGuide( { postType }: { postType?: string } ) {
+	return (
+		<>
+			<WelcomeGuideEditor />
+			{ postType === 'page' && <WelcomeGuidePage /> }
+			{ postType === 'wp_template' && <WelcomeGuideTemplate /> }
+		</>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/menu-item.tsx
+++ b/packages/boot/src/components/welcome-guide/menu-item.tsx
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+export default function WelcomeGuideMenuItem() {
+	const { toggle } = useDispatch( preferencesStore );
+
+	return (
+		<MenuItem onClick={ () => toggle( 'core/edit-site', 'welcomeGuide' ) }>
+			{ __( 'Welcome Guide' ) }
+		</MenuItem>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/page.tsx
+++ b/packages/boot/src/components/welcome-guide/page.tsx
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+export default function WelcomeGuidePage() {
+	const { toggle } = useDispatch( preferencesStore );
+
+	const isVisible = useSelect( ( select ) => {
+		const isPageActive = !! select( preferencesStore ).get(
+			'core/edit-site',
+			'welcomeGuidePage'
+		);
+		const isEditorActive = !! select( preferencesStore ).get(
+			'core/edit-site',
+			'welcomeGuide'
+		);
+		return isPageActive && ! isEditorActive;
+	}, [] );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	const heading = __( 'Editing a page' );
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide guide-page"
+			contentLabel={ heading }
+			finishButtonText={ __( 'Continue' ) }
+			onFinish={ () => toggle( 'core/edit-site', 'welcomeGuidePage' ) }
+			pages={ [
+				{
+					image: (
+						<video
+							className="edit-site-welcome-guide__video"
+							autoPlay
+							loop
+							muted
+							width="312"
+							height="240"
+						>
+							<source
+								src="https://s.w.org/images/block-editor/editing-your-page.mp4"
+								type="video/mp4"
+							/>
+						</video>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ heading }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts.
+									'It’s now possible to edit page content in the site editor. To customize other parts of the page like the header and footer switch to editing the template using the settings sidebar.'
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/boot/src/components/welcome-guide/style.scss
+++ b/packages/boot/src/components/welcome-guide/style.scss
@@ -1,0 +1,62 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.edit-site-welcome-guide {
+	width: 312px;
+
+	&.guide-editor .edit-site-welcome-guide__image {
+		background: #00a0d2;
+	}
+
+	&.guide-page .edit-site-welcome-guide__video {
+		border-right: #3858e9 $grid-unit-20 solid;
+		border-top: #3858e9 $grid-unit-20 solid;
+	}
+
+	&.guide-template .edit-site-welcome-guide__video {
+		border-left: #3858e9 $grid-unit-20 solid;
+		border-top: #3858e9 $grid-unit-20 solid;
+	}
+
+	&__image {
+		margin: 0 0 $grid-unit-20;
+
+		> img {
+			display: block;
+			max-width: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&__heading {
+		font-family: $default-font;
+		font-size: 24px;
+		line-height: 1.4;
+		margin: $grid-unit-20 0 $grid-unit-20 0;
+		padding: 0 $grid-unit-40;
+	}
+
+	&__text {
+		font-size: $default-font-size;
+		line-height: 1.4;
+		margin: 0 0 $grid-unit-20 0;
+		padding: 0 $grid-unit-40;
+
+		img {
+			vertical-align: bottom;
+		}
+	}
+
+	&__inserter-icon {
+		margin: 0 4px;
+		vertical-align: text-top;
+	}
+
+	.components-button {
+		&:hover {
+			svg {
+				fill: $white;
+			}
+		}
+	}
+}

--- a/packages/boot/src/components/welcome-guide/template.tsx
+++ b/packages/boot/src/components/welcome-guide/template.tsx
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { store as editorStore } from '@wordpress/editor';
+
+export default function WelcomeGuideTemplate() {
+	const { toggle } = useDispatch( preferencesStore );
+
+	const { isActive, hasPreviousEntity } = useSelect( ( select ) => {
+		const { getEditorSettings } = select( editorStore );
+		const { get } = select( preferencesStore );
+		return {
+			isActive: get( 'core/edit-site', 'welcomeGuideTemplate' ),
+			hasPreviousEntity:
+				!! getEditorSettings().onNavigateToPreviousEntityRecord,
+		};
+	}, [] );
+	const isVisible = isActive && hasPreviousEntity;
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	const heading = __( 'Editing a template' );
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide guide-template"
+			contentLabel={ heading }
+			finishButtonText={ __( 'Continue' ) }
+			onFinish={ () =>
+				toggle( 'core/edit-site', 'welcomeGuideTemplate' )
+			}
+			pages={ [
+				{
+					image: (
+						<video
+							className="edit-site-welcome-guide__video"
+							autoPlay
+							loop
+							muted
+							width="312"
+							height="240"
+						>
+							<source
+								src="https://s.w.org/images/block-editor/editing-your-template.mp4"
+								type="video/mp4"
+							/>
+						</video>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ heading }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'Note that the same template can be used by multiple pages, so any changes made here may affect other pages on the site. To switch back to editing the page content click the ‘Back’ button in the toolbar.'
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -2,6 +2,7 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "./experimental-omnibar.scss" as *;
+@use "./components/welcome-guide/style.scss" as *;
 
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -21,6 +21,7 @@
 		{ "path": "../keycodes" },
 		{ "path": "../lazy-editor" },
 		{ "path": "../notices" },
+		{ "path": "../preferences" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
 		{ "path": "../route" },

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -27,6 +27,7 @@ interface EditorProps {
 	postId?: string;
 	settings?: Record< string, any >;
 	backButton?: ReactNode;
+	children?: ReactNode;
 }
 
 /**
@@ -37,6 +38,7 @@ interface EditorProps {
  * @param {string}    props.postId     Optional post ID to edit. If not provided, resolves to homepage.
  * @param {Object}    props.settings   Optional extra settings to merge with editor settings
  * @param {ReactNode} props.backButton Optional back button to render in editor header
+ * @param {ReactNode} props.children   Optional editor children to render inside the editor provider
  * @return The editor component with loading states
  */
 export function Editor( {
@@ -44,6 +46,7 @@ export function Editor( {
 	postId,
 	settings,
 	backButton,
+	children,
 }: EditorProps ) {
 	// Resolve homepage when no postType/postId provided
 	const homePage = useSelect(
@@ -122,6 +125,7 @@ export function Editor( {
 			styles={ finalSettings.styles }
 		>
 			{ backButton && <BackButton>{ backButton }</BackButton> }
+			{ children }
 		</PrivateEditor>
 	);
 }


### PR DESCRIPTION
## What?
Closes none.

Adds the Site Editor welcome guide entry points to the v2 Site Editor.

## Why?
The v2 editor canvas used the lazy editor shell without the Site Editor welcome guide preferences, guide mount, or Tools menu item that are available in v1.

## How?
Boot now renders v2-specific welcome guide fills inside the lazy editor, initializes the `core/edit-site` welcome guide defaults, and exposes the Welcome Guide item through the editor Tools menu.

## Testing Instructions
1. Run `npm run wp-env status` and start the environment if needed.
2. Visit `wp-admin/admin.php?page=site-editor-v2`.
3. Open an editable canvas and confirm the welcome guide appears for a block theme.
4. Close the guide, open the editor Options menu, and confirm Tools > Welcome Guide opens it again.

### Testing Instructions for Keyboard
Use the keyboard to focus the Options menu, open it with Enter or Space, tab to Welcome Guide, activate it, and confirm the guide dialog can be navigated and dismissed.

## Screenshots or screencast
N/A.

## Use of AI Tools
Created with assistance from OpenAI Codex; the diff was reviewed and validated before submission.
