### PR TITLE
File Block: Combine audio/video/image to file transforms

### DIFF
--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -62,41 +62,14 @@ const transforms = {
 		},
 		{
 			type: 'block',
-			blocks: [ 'core/audio' ],
+			blocks: [ 'core/audio', 'core/video', 'core/image' ],
 			transform: ( attributes ) => {
+				// Audio/Video use `src`, Image uses `url`.
+				const href = attributes.src ?? attributes.url;
 				return createBlock( 'core/file', {
-					href: attributes.src,
-					fileName: attributes.caption,
-					textLinkHref: attributes.src,
-					id: attributes.id,
-					anchor: attributes.anchor,
-					downloadButtonText,
-				} );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/video' ],
-			transform: ( attributes ) => {
-				return createBlock( 'core/file', {
-					href: attributes.src,
-					fileName: attributes.caption,
-					textLinkHref: attributes.src,
-					id: attributes.id,
-					anchor: attributes.anchor,
-					downloadButtonText,
-				} );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/image' ],
-			transform: ( attributes ) => {
-				return createBlock( 'core/file', {
-					href: attributes.url,
-					fileName:
-						attributes.caption || getFilename( attributes.url ),
-					textLinkHref: attributes.url,
+					href,
+					fileName: attributes.caption || getFilename( href ),
+					textLinkHref: href,
 					id: attributes.id,
 					anchor: attributes.anchor,
 					downloadButtonText,


### PR DESCRIPTION
## What?
The `core/audio`, `core/video`, and `core/image` → `core/file` transforms had near-identical bodies, so this PR merges them into a single transform.

Audio/Video use `src`, Image uses `url`, handled via `attributes.src ?? attributes.url`. The `getFilename()` filename fallback (previously only on Image) now applies to all three, so captionless audio/video gets a filename instead of none.

## Testing Instructions
1. Open a post or page.
2. Insert Audio, Video and Image blocks.
3. Confirm that the File block shows up in the Transform menu.
4. Confirm that transformations are working as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="746" height="657" alt="CleanShot 2026-06-16 at 17 42 48" src="https://github.com/user-attachments/assets/38ede975-cb49-4035-8687-cf2f2fd0d327" />


## Use of AI Tools

Assisted by Claude.