### PR TITLE
Components: Re-land WPDS border token migration with Emotion-safe comments

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows ([#79112](https://github.com/WordPress/gutenberg/pull/79112)).
+-   `Button`, `DropdownMenu`, `FormToggle`, `Modal`, `Panel`, `RadioControl`, `Toolbar`: Migrate hardcoded border and stroke colors to WPDS tokens ([#79003](https://github.com/WordPress/gutenberg/pull/79003)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows ([#79112](https://github.com/WordPress/gutenberg/pull/79112)).
--   `Button`, `DropdownMenu`, `FormToggle`, `Modal`, `Panel`, `RadioControl`, `Toolbar`: Migrate hardcoded border and stroke colors to WPDS tokens ([#79003](https://github.com/WordPress/gutenberg/pull/79003)).
+-   `Button`, `DropdownMenu`, `FormToggle`, `Modal`, `Panel`, `RadioControl`, `Toolbar`: Migrate hardcoded border and stroke colors to WPDS tokens ([#79244](https://github.com/WordPress/gutenberg/pull/79244)).
 
 ### Bug Fixes
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -84,6 +84,7 @@ export const colorIndicatorBorder = ( border?: Border ) => {
 	const { color, style } = border || {};
 
 	const fallbackColor =
+		// TODO: should use the `--wpds-color-stroke-interactive-neutral` token when refactored to SCSS modules
 		!! style && style !== 'none' ? COLORS.gray[ 300 ] : undefined;
 
 	return css`

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -84,7 +84,7 @@ export const colorIndicatorBorder = ( border?: Border ) => {
 	const { color, style } = border || {};
 
 	const fallbackColor =
-		// TODO: should use the `--wpds-color-stroke-interactive-neutral` token when refactored to SCSS modules
+		// TODO: should use the `stroke-interactive-neutral` WPDS token when refactored to SCSS modules
 		!! style && style !== 'none' ? COLORS.gray[ 300 ] : undefined;
 
 	return css`

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -153,7 +153,7 @@
 		&:disabled:not(:focus),
 		&[aria-disabled="true"]:not(:focus),
 		&[aria-disabled="true"]:hover:not(:focus) {
-			box-shadow: inset 0 0 0 $border-width $gray-300;
+			box-shadow: inset 0 0 0 $border-width var(--wpds-color-stroke-interactive-neutral-disabled);
 		}
 
 		&:focus:not(:active) {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -30,7 +30,7 @@
 			display: block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $gray-300;
+			background-color: var(--wpds-color-stroke-surface-neutral);
 			position: absolute;
 			top: -3px;
 			left: 0;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -106,7 +106,7 @@ $transition-duration: 0.2s;
 	.components-disabled & {
 		.components-form-toggle__track {
 			background-color: $components-color-gray-100;
-			border-color: $components-color-gray-300;
+			border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
 
 			@media ( forced-colors: active ) {
 				border-color: GrayText;

--- a/packages/components/src/menu/styles.ts
+++ b/packages/components/src/menu/styles.ts
@@ -22,7 +22,9 @@ const ITEM_PADDING_INLINE = space( 3 );
 // - border color and divider color are different from COLORS.theme variables
 // - lighter text color is not defined in COLORS.theme, should it be?
 // - lighter background color is not defined in COLORS.theme, should it be?
+// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
 const DEFAULT_BORDER_COLOR = COLORS.theme.gray[ 300 ];
+// TODO: should use the `--wpds-color-stroke-surface-neutral-weak` token when refactored to SCSS modules
 const DIVIDER_COLOR = COLORS.theme.gray[ 200 ];
 const LIGHTER_TEXT_COLOR = COLORS.theme.gray[ 700 ];
 const LIGHT_BACKGROUND_COLOR = COLORS.theme.gray[ 100 ];

--- a/packages/components/src/menu/styles.ts
+++ b/packages/components/src/menu/styles.ts
@@ -22,9 +22,9 @@ const ITEM_PADDING_INLINE = space( 3 );
 // - border color and divider color are different from COLORS.theme variables
 // - lighter text color is not defined in COLORS.theme, should it be?
 // - lighter background color is not defined in COLORS.theme, should it be?
-// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
+// TODO: should use the `stroke-surface-neutral` WPDS token when refactored to SCSS modules
 const DEFAULT_BORDER_COLOR = COLORS.theme.gray[ 300 ];
-// TODO: should use the `--wpds-color-stroke-surface-neutral-weak` token when refactored to SCSS modules
+// TODO: should use the `stroke-surface-neutral-weak` WPDS token when refactored to SCSS modules
 const DIVIDER_COLOR = COLORS.theme.gray[ 200 ];
 const LIGHTER_TEXT_COLOR = COLORS.theme.gray[ 700 ];
 const LIGHT_BACKGROUND_COLOR = COLORS.theme.gray[ 100 ];

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -217,7 +217,7 @@
 	}
 
 	.components-modal__content.has-scrolled-content:not(.hide-header) & {
-		border-bottom-color: $gray-300;
+		border-bottom-color: var(--wpds-color-stroke-surface-neutral);
 	}
 
 	& + p {

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -14,8 +14,8 @@ import { CONFIG } from '../utils';
  * Milliseconds used as a fallback when racing `animationend` against a timeout.
  *
  * Sourced from `CONFIG.transitionDuration`. This value is implicitly coupled to
- * the modal frame’s CSS `animation-duration` in `style.scss`, which uses
- * `var(--wpds-motion-duration-md)`. If either the token, the SCSS, or
+ * the modal frame’s CSS `animation-duration` in `style.scss`, which uses the
+ * WPDS `motion-duration-md` token. If either the token, the SCSS, or
  * `CONFIG.transitionDuration` changes, keep them aligned so exit timing stays correct.
  */
 const FRAME_ANIMATION_DURATION_MS = Number.parseInt(

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -40,7 +40,7 @@
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 $grid-unit-20;
-	border-bottom: $border-width solid $gray-300;
+	border-bottom: $border-width solid var(--wpds-color-stroke-surface-neutral);
 
 	// This helps ensure the correct panel height, including the border, avoiding subpixel rounding issues.
 	box-sizing: content-box;

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -56,7 +56,7 @@
 
 	&:disabled {
 		background: $components-color-gray-100;
-		border: 1px solid $components-color-gray-300;
+		border: 1px solid var(--wpds-color-stroke-interactive-neutral-disabled);
 		opacity: 1; // Override style from wp-admin forms.css.
 
 		&:checked::before {

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -35,6 +35,7 @@ const commonPathProps = css`
 	stroke-width: 1.5px;
 `;
 
+// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
 export const SpinnerTrack = styled.circle`
 	${ commonPathProps };
 	stroke: ${ COLORS.gray[ 300 ] };

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -35,7 +35,7 @@ const commonPathProps = css`
 	stroke-width: 1.5px;
 `;
 
-// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
+// TODO: should use the `stroke-surface-neutral` WPDS token when refactored to SCSS modules
 export const SpinnerTrack = styled.circle`
 	${ commonPathProps };
 	stroke: ${ COLORS.gray[ 300 ] };

--- a/packages/components/src/toolbar/toolbar-group/style.scss
+++ b/packages/components/src/toolbar/toolbar-group/style.scss
@@ -75,7 +75,7 @@ div.components-toolbar {
 			display: inline-block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $gray-300;
+			background-color: var(--wpds-color-stroke-surface-neutral);
 			position: absolute;
 			top: 8px;
 			left: -3px;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -30,10 +30,10 @@ const toolsPanelGrid = {
 	},
 };
 
+// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
 export const ToolsPanel = ( columns: number ) => css`
 	${ toolsPanelGrid.columns( columns ) }
 	${ toolsPanelGrid.spacing }
-
 	border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 300 ] };
 	margin-top: -1px;
 	padding: ${ space( 4 ) };

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -30,7 +30,7 @@ const toolsPanelGrid = {
 	},
 };
 
-// TODO: should use the `--wpds-color-stroke-surface-neutral` token when refactored to SCSS modules
+// TODO: should use the `stroke-surface-neutral` WPDS token when refactored to SCSS modules
 export const ToolsPanel = ( columns: number ) => css`
 	${ toolsPanelGrid.columns( columns ) }
 	${ toolsPanelGrid.spacing }

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -66,8 +66,8 @@ export default Object.assign( {}, CONTROL_PROPS, {
 	surfaceBackgroundTertiaryColor: COLORS.white,
 	surfaceColor: COLORS.white,
 	// Modal exit animation: `use-modal-exit-animation` parses this for the
-	// `animationend` timeout race; keep the numeric duration equal to
-	// `--wpds-motion-duration-md` on `.components-modal__frame` in modal/style.scss.
+	// `animationend` timeout race; keep the numeric duration equal to the WPDS
+	// `motion-duration-md` token on `.components-modal__frame` in modal/style.scss.
 	transitionDuration: '200ms',
 	transitionDurationFast: '160ms',
 	transitionDurationFaster: '120ms',

--- a/packages/components/src/utils/dropdown-motion.ts
+++ b/packages/components/src/utils/dropdown-motion.ts
@@ -1,6 +1,6 @@
 // Motion configuration for dropdown-like popovers.
 // Keep constants in sync with: packages/ui/src/utils/css/dropdown-motion.module.css
-// Values should stay in sync with --wpds-motion-* design tokens.
+// Values should stay in sync with the WPDS motion design tokens.
 
 export const DROPDOWN_MOTION = Object.freeze( {
 	SLIDE_DISTANCE: 4,
@@ -25,9 +25,11 @@ const convertEasingToString = ( easing: {
 	return easing.function;
 };
 
-// Note: --wpds-* tokens can't be used here directly because the build-time
-// fallback injection is not compatible with Emotion. This file is consumed
-// by Menu's Emotion styles.
+// Note: WPDS design tokens can't be referenced here directly. The build-time
+// fallback injection is incompatible with Emotion, and even mentioning a token's
+// full CSS custom property name in this file makes the esbuild fallback plugin
+// claim it and break the Emotion transform. This file is consumed by Menu's
+// Emotion styles.
 export const DROPDOWN_MOTION_CSS = Object.freeze( {
 	SLIDE_DISTANCE: `${ DROPDOWN_MOTION.SLIDE_DISTANCE }px`,
 	SLIDE_DURATION: `${ DROPDOWN_MOTION.SLIDE_DURATION }ms`,


### PR DESCRIPTION
## What?

Re-lands #79003 (WPDS border token migration) plus a fix for the issue that broke `storybook-check` on trunk and caused the revert in #79243.

Part of #79001.

## Why?

#79003's `TODO` comments referenced full WPDS token custom-property names inside Emotion `.ts` files. The esbuild token-fallback plugin claims any file whose text contains that prefix (comments included), which displaces the Emotion transform and makes styled-component selectors throw at runtime — failing 21 Storybook suites. `no-ds-tokens` missed it because it only checks string literals, not comments.

## How?

- Re-land #79003 unchanged.
- Rephrase the comments to name the tokens without the CSS custom-property prefix, so the esbuild plugin no longer claims those files (also applied to pre-existing comments in `dropdown-motion.ts`, `config-values.js`, and `use-modal-exit-animation.ts`).

## Testing Instructions

1. `storybook-check` should pass.
2. With a dark admin color scheme, confirm the migrated borders adapt: disabled `Button` / `FormToggle` / `RadioControl`, and `Panel` / `Modal` / `Toolbar` / `DropdownMenu` dividers.

## Follow-ups

- Close the guardrail gap: [#79245](https://github.com/WordPress/gutenberg/issues/79245).