### PR TITLE
chore: remove @wordpress/vips dependency from root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
 				"@wordpress/release-tools": "file:./tools/release",
 				"@wordpress/scripts": "file:./packages/scripts",
 				"@wordpress/stylelint-tools": "file:./tools/stylelint",
-				"@wordpress/vips": "file:./packages/vips",
 				"concurrently": "^3.5.0",
 				"cross-env": "^7.0.3",
 				"husky": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
 		"@wordpress/release-tools": "file:./tools/release",
 		"@wordpress/scripts": "file:./packages/scripts",
 		"@wordpress/stylelint-tools": "file:./tools/stylelint",
-		"@wordpress/vips": "file:./packages/vips",
 		"concurrently": "^3.5.0",
 		"cross-env": "^7.0.3",
 		"husky": "^7.0.0",


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #75041

## Why ?
Remove @wordpress/vips from the root package.json as it's present in the place where it's present.
