### PR TITLE
Dashboard: revert H1 to "Dashboard" and fix heading hierarchy

### DIFF
--- a/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.tsx
+++ b/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.tsx
@@ -122,7 +122,7 @@ function Header( { titleId, widgetType }: HeaderProps ) {
 						<Icon icon={ widgetType.icon } />
 					</span>
 				) }
-				<Card.Title id={ titleId } render={ <h3 /> }>
+				<Card.Title id={ titleId } render={ <h2 /> }>
 					{ widgetType.title }
 				</Card.Title>
 			</Stack>

--- a/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
@@ -181,7 +181,7 @@ describe( 'WidgetDashboard', () => {
 		).toBeInTheDocument();
 		expect( screen.getByText( 'does/not-exist' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'heading', { level: 3 } )
+			screen.queryByRole( 'heading', { level: 2 } )
 		).not.toBeInTheDocument();
 	} );
 

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -2,10 +2,9 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as viewportStore } from '@wordpress/viewport';
 import {
@@ -48,27 +47,6 @@ function Dashboard() {
 		[]
 	);
 
-	const greetingName = useSelect( ( select ) => {
-		const user = select( coreStore ).getCurrentUser();
-		if ( ! user ) {
-			return undefined;
-		}
-
-		const displayName = user.name?.trim();
-		if ( displayName ) {
-			return displayName;
-		}
-
-		if ( 'username' in user && typeof user.username === 'string' ) {
-			const username = user.username.trim();
-			if ( username ) {
-				return username;
-			}
-		}
-
-		return user.slug;
-	}, [] );
-
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const handleLayoutChange = ( next: DashboardWidget[] ) => {
@@ -78,16 +56,9 @@ function Dashboard() {
 		} );
 	};
 
-	let pageTitle: string = __( 'Dashboard' );
-	if ( editMode ) {
-		pageTitle = __( 'Customize Dashboard' );
-	} else if ( greetingName ) {
-		pageTitle = sprintf(
-			/* translators: %s: current user's display name. */
-			__( 'Howdy, %s' ),
-			greetingName
-		);
-	}
+	const pageTitle = editMode
+		? __( 'Customize Dashboard' )
+		: __( 'Dashboard' );
 
 	return (
 		<WidgetDashboard

--- a/routes/dashboard/stage.tsx
+++ b/routes/dashboard/stage.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #79240
This reverts the dashboard title back to “Dashboard” and fixes the heading order in the new Dashboard experience.

## Why?
The main H1 should clearly say what the page is about. “Howdy, admin” does not. The widget headings also skipped a level, which is not good for accessibility.

## How?
The main page title now stays as “Dashboard” unless edit mode is active. Widget titles now use H2 instead of H3 so the heading order is correct.

## Testing Instructions
1. Enable the New Dashboard experience in Gutenberg.
2. Open wp-admin/admin.php?page=dashboard-wp-admin.
3. Check that the main heading says “Dashboard”.
4. Inspect the widget headings and confirm they use the correct heading level.
5. Toggle edit mode by pressing "Customize" and make sure the title still changes to “Customize Dashboard”.

## Screenshots or screencast 
### Before:
https://github.com/user-attachments/assets/9db405d9-a849-4839-be0b-fbd6c770d37e

### After:
https://github.com/user-attachments/assets/2604c996-adf4-4fe5-98f9-a877b806073e

