### PR TITLE
Theme: Skip serializing `data-wpds-root-provider="false"` on non-root providers

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Code Quality
 
--   `ThemeProvider`: Stop serializing `data-wpds-root-provider="false"` on non-root providers by only setting the attribute when `isRoot` is `true`.
+-   `ThemeProvider`: Stop serializing `data-wpds-root-provider="false"` on non-root providers by only setting the attribute when `isRoot` is `true` ([#79253](https://github.com/WordPress/gutenberg/pull/79253)).
 -   Declare `postcss`, `esbuild`, and `vite` as optional peer dependencies for the bundler plugins, and move `@types/react` from `dependencies` to an optional peer dependency ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
 
 ## 0.15.1 (2026-06-16)

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Code Quality
 
+-   `ThemeProvider`: Stop serializing `data-wpds-root-provider="false"` on non-root providers by only setting the attribute when `isRoot` is `true`.
 -   Declare `postcss`, `esbuild`, and `vite` as optional peer dependencies for the bundler plugins, and move `@types/react` from `dependencies` to an optional peer dependency ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
 
 ## 0.15.1 (2026-06-16)

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -70,7 +70,7 @@ export const ThemeProvider = ( {
 			) : null }
 			<div
 				data-wpds-theme-provider-id={ instanceId }
-				data-wpds-root-provider={ isRoot }
+				data-wpds-root-provider={ isRoot || undefined }
 				data-wpds-corner-radius={ cornerRadiusPreset }
 				className={ styles.root }
 			>


### PR DESCRIPTION
## What?
See #77462 (point **I3**).

Stops `ThemeProvider` from rendering `data-wpds-root-provider="false"` on every non-root provider.

## Why?
The attribute is only ever matched as `="true"` (by the prebuilt CSS and the runtime selector). Serializing `"false"` on every non-root provider is just dead markup.

## How?
Set the attribute with `data-wpds-root-provider={ isRoot || undefined }` so React omits it entirely when `isRoot` is `false`.

## Testing Instructions
1. Render a `<ThemeProvider>` without `isRoot` and confirm the wrapper `<div>` has no `data-wpds-root-provider` attribute.
2. Render a `<ThemeProvider isRoot>` and confirm the wrapper `<div>` still has `data-wpds-root-provider="true"`.
3. Run `npm run test:unit packages/theme`.

## Use of AI Tools
This PR was authored with the assistance of AI tooling (Cursor); all changes were reviewed by me.