### PR TITLE
Site Title: Allow unlinking the title on the homepage

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -967,7 +967,7 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 -	**Name:** [core/site-title](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-site-title/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget
+-	**Attributes:** isLink, level, levelOptions, linkTarget, shouldUnlinkOnHomepage
 
 ## Social Icon
 

--- a/packages/block-library/src/site-title/README.md
+++ b/packages/block-library/src/site-title/README.md
@@ -18,6 +18,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `levelOptions` | `array` | `[0,1,2,3,4,5,6]` | — |
 | `isLink` | `boolean` | `true` | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `linkTarget` | `string` | `"_self"` | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `shouldUnlinkOnHomepage` | `boolean` | `false` | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 
 ## Supports
 

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -24,6 +24,11 @@
 			"type": "string",
 			"default": "_self",
 			"role": "content"
+		},
+		"shouldUnlinkOnHomepage": {
+			"type": "boolean",
+			"default": false,
+			"role": "content"
 		}
 	},
 	"example": {

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -31,7 +31,8 @@ export default function SiteTitleEdit( props ) {
 
 	const { attributes, setAttributes, insertBlocksAfter } = props;
 
-	const { level, levelOptions, isLink, linkTarget } = attributes;
+	const { level, levelOptions, isLink, linkTarget, shouldUnlinkOnHomepage } =
+		attributes;
 	const { canUserEdit, title } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -116,6 +117,7 @@ export default function SiteTitleEdit( props ) {
 						setAttributes( {
 							isLink: true,
 							linkTarget: '_self',
+							shouldUnlinkOnHomepage: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -151,6 +153,31 @@ export default function SiteTitleEdit( props ) {
 									} )
 								}
 								checked={ linkTarget === '_blank' }
+							/>
+						</ToolsPanelItem>
+					) }
+					{ isLink && (
+						<ToolsPanelItem
+							hasValue={ () => shouldUnlinkOnHomepage }
+							label={ __( 'Unlink on the homepage' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									shouldUnlinkOnHomepage: false,
+								} )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								label={ __( 'Unlink on the homepage' ) }
+								help={ __(
+									'Avoids a redundant link to the page visitors are already on.'
+								) }
+								onChange={ ( value ) =>
+									setAttributes( {
+										shouldUnlinkOnHomepage: value,
+									} )
+								}
+								checked={ shouldUnlinkOnHomepage }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -30,7 +30,11 @@ function render_block_core_site_title( $attributes ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
 	}
 
-	if ( $attributes['isLink'] ) {
+	// Don't link the site title to the homepage when we're already on the homepage,
+	// if the block is configured to omit the link there.
+	$should_unlink_on_homepage = ! empty( $attributes['shouldUnlinkOnHomepage'] ) && is_front_page() && ! is_paged();
+
+	if ( $attributes['isLink'] && ! $should_unlink_on_homepage ) {
 		$aria_current = ! is_paged() && ( is_front_page() || is_home() && ( (int) get_option( 'page_for_posts' ) !== get_queried_object_id() ) ) ? ' aria-current="page"' : '';
 		$link_target  = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
 
@@ -41,6 +45,8 @@ function render_block_core_site_title( $attributes ) {
 			$aria_current,
 			esc_html( $site_title )
 		);
+	} else {
+		$site_title = esc_html( $site_title );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classes ) ) );
 
@@ -48,8 +54,7 @@ function render_block_core_site_title( $attributes ) {
 		'<%1$s %2$s>%3$s</%1$s>',
 		$tag_name,
 		$wrapper_attributes,
-		// already pre-escaped if it is a link.
-		$attributes['isLink'] ? $site_title : esc_html( $site_title )
+		$site_title
 	);
 }
 


### PR DESCRIPTION
## What?
Closes #42864

Adds a new "Unlink on the homepage" toggle to the Site Title block, so the title text isn't wrapped in a link to the homepage when the page being viewed already is the homepage.

## Why?
When "Make title link to home" is enabled, the Site Title block always wraps the title in a link to the homepage, even when visitors are already on the homepage. Linking a page to itself doesn't serve any purpose and is the kind of redundant link assistive technology users in particular have to needlessly tab through. The Site Logo block already solves this via the unlink-homepage-logo theme support, but no equivalent existed for Site Title until now.

## Testing Instructions
1. Add the Site Title block to a template (e.g. via the Site Editor, in the header template part), or to a post/page.
2. In the block's settings panel, confirm "Make title link to home" is enabled, then enable the new "Unlink on the homepage" toggle.
3. Save/publish.
4. Visit the site's homepage on the front end, the site title should render as plain text with no link.
5. Visit any other page (e.g. a single post, or the same page in the editor), the site title should still link to the homepage as before.
6. Toggle "Unlink on the homepage" back off and confirm the title links to home on every page, including the homepage (this is the pre-existing behavior).

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/547390a5-7c3c-44d2-aea7-f542adb95ed6

