### PR TITLE
Handle WP.org SVN missing tag warnings

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -238,7 +238,8 @@ jobs:
                     echo "exists=true" >> "$GITHUB_OUTPUT"
                   else
                     svn_status=$?
-                    if grep -q 'E160013' "$svn_error_file"; then
+                    # WP.org SVN may report a missing tag as W160013 followed by E200009.
+                    if grep -Eq 'E160013|W160013|E200009|non-existent' "$svn_error_file"; then
                       echo "exists=false" >> "$GITHUB_OUTPUT"
                     else
                       cat "$svn_error_file" >&2
@@ -312,7 +313,8 @@ jobs:
                     echo "exists=true" >> "$GITHUB_OUTPUT"
                   else
                     svn_status=$?
-                    if grep -q 'E160013' "$svn_error_file"; then
+                    # WP.org SVN may report a missing tag as W160013 followed by E200009.
+                    if grep -Eq 'E160013|W160013|E200009|non-existent' "$svn_error_file"; then
                       echo "exists=false" >> "$GITHUB_OUTPUT"
                     else
                       cat "$svn_error_file" >&2


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/78476


Updates the Gutenberg plugin upload workflow so a missing WordPress.org SVN tag is recognized when `svn list` reports `W160013` and `E200009`, not only `E160013`.

## Why?

During the Gutenberg 23.4.0 stable release, the workflow checked whether `tags/23.4.0` already existed before committing to the plugin SVN repository. The tag did not exist, but WP.org SVN returned:

```text
svn: warning: W160013: URL 'https://plugins.svn.wordpress.org/gutenberg/tags/23.4.0' non-existent in revision ...
svn: E200009: Could not list all targets because some targets don't exist
```

The workflow only treated `E160013` as "tag missing", so it failed before the release commit could run.

## How?

Both stable upload paths now treat `E160013`, `W160013`, `E200009`, or `non-existent` output from `svn list` as `exists=false`. Other SVN errors still print the error and fail the workflow.

## Testing Instructions

- Confirmed the observed WP.org SVN missing-tag output matches the new pattern.
- Confirmed an unrelated connection error does not match and remains fatal.
- Ran `git diff --check`.

`actionlint` was not installed locally, so I could not run full workflow linting.
