### PR TITLE
CI: Run PHP unit tests on PHP 8.4 and 8.5

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -173,17 +173,21 @@ jobs:
             fail-fast: true
             matrix:
                 event: ['${{ github.event_name }}']
-                php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+                php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
                 exclude:
-                    # On PRs: Only test PHP 7.4 and 8.3, single-site, latest WP
+                    # On PRs: Only test PHP 7.4 and 8.5, single-site, latest WP
                     - event: 'pull_request'
                       php: '8.0'
                     - event: 'pull_request'
                       php: '8.1'
                     - event: 'pull_request'
                       php: '8.2'
+                    - event: 'pull_request'
+                      php: '8.3'
+                    - event: 'pull_request'
+                      php: '8.4'
                     - event: 'pull_request'
                       multisite: true
                     - event: 'pull_request'
@@ -194,6 +198,10 @@ jobs:
                     - php: '8.1'
                       wordpress: 'previous major version'
                     - php: '8.2'
+                      wordpress: 'previous major version'
+                    - php: '8.3'
+                      wordpress: 'previous major version'
+                    - php: '8.4'
                       wordpress: 'previous major version'
 
         env:

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -27,7 +27,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
 		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $navigation_link_block );
 
@@ -61,7 +63,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
 		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $site_title_block );
 
@@ -99,7 +103,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
 		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $heading_block );
 
@@ -153,7 +159,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Setup an empty testing instance of `WP_Navigation_Block_Renderer` and save the original.
 		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_markup_for_inner_block' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $heading_block );
 
@@ -175,7 +183,9 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	public function test_gutenberg_get_inner_blocks_from_navigation_post_returns_empty_block_list() {
 		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
 		$method     = $reflection->getMethod( 'get_inner_blocks_from_navigation_post' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$attributes = array( 'ref' => 0 );
 
 		$actual   = $method->invoke( $reflection, $attributes );

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -64,7 +64,9 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 		$wp_block_supports = WP_Block_Supports::get_instance();
 		$reflection        = new ReflectionClass( $wp_block_supports );
 		$property          = $reflection->getProperty( 'block_to_render' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( $wp_block_supports, $block );
 	}
 

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -112,7 +112,9 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_get_slug_from_attribute( $data_attr, $expected ) {
 
 		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'get_slug_from_attribute' );
-		$reflection->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
 
 		$this->assertSame( $expected, $reflection->invoke( null, $data_attr ) );
 	}
@@ -134,7 +136,9 @@ class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_is_preset( $data_attr, $expected ) {
 		$reflection = new ReflectionMethod( 'WP_Duotone_Gutenberg', 'is_preset' );
-		$reflection->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
 
 		$this->assertSame( $expected, $reflection->invoke( null, $data_attr ) );
 	}

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -75,11 +75,15 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		static::$property_blocks_cache = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'blocks_cache' );
-		static::$property_blocks_cache->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			static::$property_blocks_cache->setAccessible( true );
+		}
 		static::$property_blocks_cache_orig_value = static::$property_blocks_cache->getValue();
 
 		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'core' );
-		static::$property_core->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			static::$property_core->setAccessible( true );
+		}
 		static::$property_core_orig_value = static::$property_core->getValue();
 	}
 
@@ -285,7 +289,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_has_same_registered_blocks_when_all_blocks_not_cached( $origin, array $cache = array() ) {
 		$has_same_registered_blocks = new ReflectionMethod( WP_Theme_JSON_Resolver_Gutenberg::class, 'has_same_registered_blocks' );
-		$has_same_registered_blocks->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$has_same_registered_blocks->setAccessible( true );
+		}
 		$expected_cache = $this->get_registered_block_names();
 
 		// Set up the blocks cache for the origin.
@@ -358,7 +364,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_has_same_registered_blocks_when_all_blocks_are_cached( $origin ) {
 		$has_same_registered_blocks = new ReflectionMethod( WP_Theme_JSON_Resolver_Gutenberg::class, 'has_same_registered_blocks' );
-		$has_same_registered_blocks->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$has_same_registered_blocks->setAccessible( true );
+		}
 		$expected_cache = $this->get_registered_block_names();
 
 		// Set up the cache with all registered blocks.
@@ -798,7 +806,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 		// Force-unset $i18n_schema property to "unload" translation schema.
 		$property = new ReflectionProperty( $theme_json_resolver, 'i18n_schema' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, null );
 
 		// A completely empty theme.json data set still has the 'version' key when parsed.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4213,7 +4213,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$reflection_class = new ReflectionClass( WP_Theme_JSON_Gutenberg::class );
 
 		$get_property_value_method = $reflection_class->getMethod( 'get_property_value' );
-		$get_property_value_method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$get_property_value_method->setAccessible( true );
+		}
 		$result = $get_property_value_method->invoke( null, $styles, $path );
 
 		$this->assertSame( '', $result );
@@ -6614,7 +6616,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 		$reflection = new ReflectionMethod( $theme_json, 'process_blocks_custom_css' );
-		$reflection->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
 
 		$this->assertSame( $expected, $reflection->invoke( $theme_json, $input['css'], $input['selector'] ) );
 	}
@@ -6939,7 +6943,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_style_variation_selector' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$actual = $func->invoke( null, 'custom', $selector );
 
@@ -7019,7 +7025,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'scope_style_node_selectors' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$node = array(
 			'name'      => 'core/image',
@@ -7066,7 +7074,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_nodes' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$theme_json = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -7100,7 +7110,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_nodes' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$theme_json = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -7143,7 +7155,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_nodes' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$theme_json = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -7195,7 +7209,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
 
 		$func = $theme_json->getMethod( 'get_block_nodes' );
-		$func->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$func->setAccessible( true );
+		}
 
 		$theme_json = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -7991,7 +8007,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_to_ruleset_skips_non_scalar_values_and_casts_numerics() {
 		$reflection = new ReflectionMethod( WP_Theme_JSON_Gutenberg::class, 'to_ruleset' );
-		$reflection->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
 		$declarations = array(
 			array(
 				'name'  => 'color',


### PR DESCRIPTION
## What?
Add PHP 8.4 and 8.5 to the PHP unit test matrix.

## Why?
WordPress 6.9 officially supports PHP 8.5 (see [PHP 8.5 support in WordPress 6.9](https://make.wordpress.org/core/2025/11/21/php-8-5-support-in-wordpress-6-9/)), and WordPress Core's own test suite already runs against 8.5. Since the Gutenberg plugin support WordPress 6.9 and above, the unit tests on the Gutenberg plugin should be tested with PHP 8.5 as well.

## How?

This PR changes how unit tests are executed as follows:

## PR

### Before

| PHP | single-site / latest WP | multisite / latest WP | single-site / previous WP | multisite / previous WP |
|-----|-------------------------|-----------------------|---------------------------|-------------------------|
| 7.4 | ✓ | | | |
| 8.3 | ✓ | | | |

### After

| PHP | single-site / latest WP | multisite / latest WP | single-site / previous WP | multisite / previous WP |
|-----|-------------------------|-----------------------|---------------------------|-------------------------|
| 7.4 | ✓ | | | |
| 8.5 | ✓ | | | |

## trunk

### Before

| PHP | single-site / latest WP | multisite / latest WP | single-site / previous WP | multisite / previous WP |
|-----|-------------------------|-----------------------|---------------------------|-------------------------|
| 7.4 | ✓ | ✓ | ✓ | ✓ |
| 8.0 | ✓ | ✓ | | |
| 8.1 | ✓ | ✓ | | |
| 8.2 | ✓ | ✓ | | |
| 8.3 | ✓ | ✓ | ✓ | ✓ |

### After

| PHP | single-site / latest WP | multisite / latest WP | single-site / previous WP | multisite / previous WP |
|-----|-------------------------|-----------------------|---------------------------|-------------------------|
| 7.4 | ✓ | ✓ | ✓ | ✓ |
| 8.0 | ✓ | ✓ | | |
| 8.1 | ✓ | ✓ | | |
| 8.2 | ✓ | ✓ | | |
| 8.3 | ✓ | ✓ | | |
| 8.4 | ✓ | ✓ | | |
| 8.5 | ✓ | ✓ | ✓ | ✓ |



## Testing Instructions

First, let's see how many errors occur.

## Use of AI Tools
This PR was authored with assistance from Claude Code (Claude Opus 4.8). All changes were reviewed by the author.
