### PR TITLE
Notes: Simplify 'Show more/less' collapse logic

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note.js
+++ b/packages/editor/src/components/collab-sidebar/note.js
@@ -68,6 +68,28 @@ export function Note( {
 	const [ actionState, setActionState ] = useState( null );
 	const actionButtonRef = useRef( null );
 
+	const commentRef = useRef( null );
+	const rawContent = note?.content?.raw;
+	const [ prevContent, setPrevContent ] = useState( rawContent );
+	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ isOverflowing, setIsOverflowing ] = useState( false );
+
+	// Collapse whenever the content changes so it can be re-measured.
+	if ( prevContent !== rawContent ) {
+		setPrevContent( rawContent );
+		setIsExpanded( false );
+	}
+
+	// Measure the (clamped) content to decide whether the toggle is needed.
+	useLayoutEffect( () => {
+		const commentElement = commentRef.current;
+		if ( commentElement ) {
+			setIsOverflowing(
+				commentElement.scrollHeight > commentElement.clientHeight
+			);
+		}
+	}, [ rawContent ] );
+
 	const canResolve = note.parent === 0;
 	const isResolutionNote =
 		note.type === 'note' &&
@@ -106,28 +128,6 @@ export function Note( {
 					"Are you sure you want to delete this note? This will also delete all of this note's replies."
 			  )
 			: __( 'Are you sure you want to delete this reply?' );
-
-	const commentRef = useRef( null );
-	const rawContent = note?.content?.raw;
-	const [ prevContent, setPrevContent ] = useState( rawContent );
-	const [ isExpanded, setIsExpanded ] = useState( false );
-	const [ isOverflowing, setIsOverflowing ] = useState( false );
-
-	// Collapse whenever the content changes so it can be re-measured.
-	if ( prevContent !== rawContent ) {
-		setPrevContent( rawContent );
-		setIsExpanded( false );
-	}
-
-	// Measure the (clamped) content to decide whether the toggle is needed.
-	useLayoutEffect( () => {
-		const commentElement = commentRef.current;
-		if ( commentElement ) {
-			setIsOverflowing(
-				commentElement.scrollHeight > commentElement.clientHeight
-			);
-		}
-	}, [ rawContent ] );
 
 	const handleCancel = () => {
 		setActionState( null );

--- a/packages/editor/src/components/collab-sidebar/note.js
+++ b/packages/editor/src/components/collab-sidebar/note.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { RawHTML, useRef, useState, useEffect } from '@wordpress/element';
+import { useRef, useState, useLayoutEffect } from '@wordpress/element';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
@@ -107,41 +107,27 @@ export function Note( {
 			  )
 			: __( 'Are you sure you want to delete this reply?' );
 
-	const prevContentRef = useRef( note?.content?.raw );
 	const commentRef = useRef( null );
+	const rawContent = note?.content?.raw;
+	const [ prevContent, setPrevContent ] = useState( rawContent );
+	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isOverflowing, setIsOverflowing ] = useState( false );
-	const [ collapsed, setCollapsed ] = useState( true );
 
-	useEffect( () => {
-		if ( prevContentRef.current !== note?.content?.raw ) {
-			setCollapsed( true );
-		}
-	}, [ note?.content?.raw ] );
+	// Collapse whenever the content changes so it can be re-measured.
+	if ( prevContent !== rawContent ) {
+		setPrevContent( rawContent );
+		setIsExpanded( false );
+	}
 
-	useEffect( () => {
-		if ( ! collapsed ) {
-			return;
-		}
-
+	// Measure the (clamped) content to decide whether the toggle is needed.
+	useLayoutEffect( () => {
 		const commentElement = commentRef.current;
-		if ( ! commentElement ) {
-			return;
+		if ( commentElement ) {
+			setIsOverflowing(
+				commentElement.scrollHeight > commentElement.clientHeight
+			);
 		}
-
-		const isEdit = prevContentRef.current !== note?.content?.raw;
-		prevContentRef.current = note?.content?.raw;
-
-		if ( commentElement.scrollHeight > commentElement.clientHeight ) {
-			setIsOverflowing( true );
-
-			if ( isEdit ) {
-				setCollapsed( false );
-			}
-		} else {
-			setIsOverflowing( false );
-			setCollapsed( null );
-		}
-	}, [ collapsed, note?.content?.raw ] );
+	}, [ rawContent ] );
 
 	const handleCancel = () => {
 		setActionState( null );
@@ -197,11 +183,10 @@ export function Note( {
 				className={ clsx( 'editor-collab-sidebar-panel__note-content', {
 					'editor-collab-sidebar-panel__resolution-text':
 						isResolutionNote,
-					'is-collapsed': collapsed,
+					'is-collapsed': ! isExpanded,
 				} ) }
-			>
-				<RawHTML>{ content }</RawHTML>
-			</div>
+				dangerouslySetInnerHTML={ { __html: content ?? '' } }
+			/>
 		);
 	}
 
@@ -249,9 +234,9 @@ export function Note( {
 					className="editor-collab-sidebar-panel__show-more-button"
 					variant="unstyled"
 					size="small"
-					onClick={ () => setCollapsed( ! collapsed ) }
+					onClick={ () => setIsExpanded( ! isExpanded ) }
 				>
-					{ collapsed ? __( 'Show more' ) : __( 'Show less' ) }
+					{ ! isExpanded ? __( 'Show more' ) : __( 'Show less' ) }
 				</UIButton>
 			) }
 		</NoteCard>


### PR DESCRIPTION
## What?
A minor follow-up to #77446.

PR refactors the long-note collapse/expand handling and makes the following changes:

- Replaces the tri-state `collapsed` (`true`/`false`/`null`) and two interdependent effects with two plain booleans (`isExpanded`, `isOverflowing`) and a single `useLayoutEffect` that measures overflow.
- Resets to collapsed on content change via React's "adjust state during render" pattern instead of a dedicated effect + `prevContentRef`.
- Switches the measurement effect to `useLayoutEffect` (measure before paint, no flash).
- Drops the `RawHTML` wrapper in favor of `dangerouslySetInnerHTML` directly on the content div, removing an extra DOM node.

**A small behavior change:** editing/changing a long note no longer auto-expands it; now consistently resets to truncated + "Show more" (for both local edits and remote collaborator edits).

## Why

Reduces bookkeeping and complexity.

## Testing Instructions
1. Open a post or page.
2. Add a note with lots of text.
3. Confirm "Show more/less" collapse logic works as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
