### PR TITLE
Widget Primitives: document the experiment-gated REST endpoint

### DIFF
--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -32,6 +32,12 @@ The contract types and `<WidgetRender>` work in any React application. The
 `@wordpress/core-data`, so it expects to run against a WordPress site that
 exposes the `/wp/v2/widget-modules` REST endpoint.
 
+That endpoint ships with the Gutenberg plugin and, at this experimental
+stage, is registered only while the `gutenberg-dashboard-widgets` experiment
+is enabled. On a site without it, `useWidgetTypes()` resolves to an empty
+list; the contract types and `<WidgetRender>` do not depend on the endpoint
+and work regardless.
+
 ## Public API
 
 -   `<WidgetRender>`: canonical entry point for any host that mounts a widget.


### PR DESCRIPTION
## What?

Adds a note to the `@wordpress/widget-primitives` README explaining that `useWidgetTypes()` depends on the `/wp/v2/widget-modules` REST endpoint, which is currently registered only while the `gutenberg-dashboard-widgets` experiment is enabled.

Docs-only change. Part of #79231.

## Why?

The package is published to npm as experimental, so it can be consumed outside Gutenberg. The README already noted that `useWidgetTypes()` needs the `/wp/v2/widget-modules` endpoint, but not that the endpoint lives behind the `gutenberg-dashboard-widgets` experiment today.

That distinction is what an external consumer needs to know: without the experiment enabled, the contract types and `<WidgetRender>` still work, but `useWidgetTypes()` resolves to an empty list because the endpoint is not registered (`lib/load.php` only requires the controller when the experiment is on).

The gate is temporary. It is lifted by the PHP relocation tracked in #79231, which moves the API from `lib/experimental/` to `lib/compat/` and commits the endpoint to Core.

## How?

Adds one paragraph to the Setup section of `packages/widget-primitives/README.md`. No code changes.

## Testing Instructions

- Open `packages/widget-primitives/README.md` and read the Setup section.
- Confirm the new paragraph reads correctly and the markdown renders without issues.

No functional testing required (documentation only).