### PR TITLE
Add PluginArea to boot roots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47720,6 +47720,7 @@
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/lazy-editor": "file:../lazy-editor",
 				"@wordpress/notices": "file:../notices",
+				"@wordpress/plugins": "file:../plugins",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -57,6 +57,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/lazy-editor": "file:../lazy-editor",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",

--- a/packages/boot/src/components/plugin-area/index.tsx
+++ b/packages/boot/src/components/plugin-area/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { PluginArea as WPPluginArea } from '@wordpress/plugins';
+
+export default function PluginArea() {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	return (
+		<WPPluginArea
+			onError={ ( name ) => {
+				createErrorNotice(
+					sprintf(
+						/* translators: %s: plugin name */
+						__(
+							'The "%s" plugin has encountered an error and cannot be rendered.'
+						),
+						name
+					)
+				);
+			} }
+		/>
+	);
+}

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -29,6 +29,7 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
 import Sidebar from '../sidebar';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
+import PluginArea from '../plugin-area';
 import useRouteTitle from '../app/use-route-title';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
@@ -65,6 +66,7 @@ export default function Root() {
 	return (
 		<SlotFillProvider>
 			<Tooltip.Provider>
+				<PluginArea />
 				<ThemeProvider
 					isRoot
 					color={ { ...themeColors, background: '#f8f8f8' } }

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -18,6 +18,7 @@ import { privateApis as themePrivateApis } from '@wordpress/theme';
  */
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
+import PluginArea from '../plugin-area';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import './style.scss';
@@ -47,6 +48,7 @@ export default function RootSinglePage() {
 
 	return (
 		<SlotFillProvider>
+			<PluginArea />
 			<ThemeProvider
 				isRoot
 				color={ { ...themeColors, background: '#f8f8f8' } }

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -21,6 +21,7 @@
 		{ "path": "../keycodes" },
 		{ "path": "../lazy-editor" },
 		{ "path": "../notices" },
+		{ "path": "../plugins" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
 		{ "path": "../route" },


### PR DESCRIPTION
## What?
Mounts `PluginArea` in the boot root components so registered plugin fills can render in the boot shell.

## Why?
The boot layout already provides `SlotFillProvider`, but without `PluginArea` registered plugins do not get a render target.

## Testing
- `./node_modules/.bin/tsgo -p packages/boot/tsconfig.json --pretty false`
- `git diff --cached --check` before commit
- pre-commit staged-file checks ran successfully