### PR TITLE
Load site editor context for lazy editor

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -90,10 +90,14 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 		 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 		 */
 		public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis
-			// Simplified context handling: mobile vs default.
-			// Only 'mobile' context is special; everything else uses the default editor context.
+			// Simplified context handling: mobile, Site Editor, or default post editor.
 			$context_param       = $request->get_param( 'context' );
-			$editor_context_name = 'mobile' === $context_param ? 'core/mobile' : 'core/edit-post';
+			$editor_context_name = 'core/edit-post';
+			if ( 'mobile' === $context_param ) {
+				$editor_context_name = 'core/mobile';
+			} elseif ( 'site-editor' === $context_param ) {
+				$editor_context_name = 'core/edit-site';
+			}
 
 			// Apply mobile-specific settings filter only for mobile context.
 			if ( 'mobile' === $context_param ) {
@@ -341,15 +345,28 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 			// Load WordPress admin environment.
 			$this->load_admin_environment();
 
+			$context_param  = $request->get_param( 'context' );
+			$is_site_editor = 'site-editor' === $context_param;
+
 			// Set up the block editor context.
-			set_current_screen();
+			if ( $is_site_editor ) {
+				set_current_screen( 'site-editor' );
+			} else {
+				set_current_screen();
+			}
 			$current_screen = get_current_screen();
 			if ( $current_screen ) {
 				$current_screen->is_block_editor( true );
 			}
 
+			global $hook_suffix, $pagenow;
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$hook_suffix = 'block-editor-assets';
+			$hook_suffix = $is_site_editor ? 'site-editor.php' : 'block-editor-assets';
+			if ( $is_site_editor ) {
+				// Some Site Editor plugins still gate editor asset enqueues on the legacy page.
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$pagenow = 'site-editor.php';
+			}
 
 			// Remove unwanted scripts/styles.
 			remove_action( 'admin_enqueue_scripts', 'wp_auth_check_load' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -51118,6 +51118,7 @@
 			"version": "1.14.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/asset-loader": "file:../asset-loader",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
@@ -51129,7 +51130,8 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/global-styles-engine": "file:../global-styles-engine",
 				"@wordpress/i18n": "file:../i18n",
-				"@wordpress/private-apis": "file:../private-apis"
+				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/url": "file:../url"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -74,6 +74,7 @@ export default function Canvas( { canvas }: CanvasProps ) {
 				<Editor
 					postType={ canvas.postType }
 					postId={ canvas.postId }
+					context="site-editor"
 					settings={ {
 						isPreviewMode: canvas.isPreview,
 						styles: canvas.isPreview

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -44,6 +44,7 @@
 	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"dependencies": {
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/asset-loader": "file:../asset-loader",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",
@@ -55,7 +56,8 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/global-styles-engine": "file:../global-styles-engine",
 		"@wordpress/i18n": "file:../i18n",
-		"@wordpress/private-apis": "file:../private-apis"
+		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {
 		"@types/react": "^18.3.27",

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -25,6 +25,7 @@ const { Editor: PrivateEditor, BackButton } = unlock( editorPrivateApis );
 interface EditorProps {
 	postType?: string;
 	postId?: string;
+	context?: 'post-editor' | 'site-editor';
 	settings?: Record< string, any >;
 	backButton?: ReactNode;
 }
@@ -35,6 +36,7 @@ interface EditorProps {
  * @param {Object}    props            Component props
  * @param {string}    props.postType   Optional post type to edit. If not provided, resolves to homepage.
  * @param {string}    props.postId     Optional post ID to edit. If not provided, resolves to homepage.
+ * @param {string}    props.context    Optional editor context for settings and assets.
  * @param {Object}    props.settings   Optional extra settings to merge with editor settings
  * @param {ReactNode} props.backButton Optional back button to render in editor header
  * @return The editor component with loading states
@@ -42,6 +44,7 @@ interface EditorProps {
 export function Editor( {
 	postType,
 	postId,
+	context = 'post-editor',
 	settings,
 	backButton,
 }: EditorProps ) {
@@ -86,8 +89,9 @@ export function Editor( {
 	// Load editor settings and assets
 	const { isReady: settingsReady, editorSettings } = useEditorSettings( {
 		stylesId,
+		context,
 	} );
-	const { isReady: assetsReady } = useEditorAssets();
+	const { isReady: assetsReady } = useEditorAssets( context );
 	const finalSettings = useMemo(
 		() => ( {
 			...editorSettings,

--- a/packages/lazy-editor/src/hooks/use-editor-assets.tsx
+++ b/packages/lazy-editor/src/hooks/use-editor-assets.tsx
@@ -2,22 +2,35 @@
  * WordPress dependencies
  */
 import loadAssets from '@wordpress/asset-loader';
+import apiFetch from '@wordpress/api-fetch';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useState, useEffect } from '@wordpress/element';
 import { resolveSelect, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
 
-let loadAssetsPromise: Promise< void >;
+type EditorContext = 'post-editor' | 'site-editor';
 
-export async function loadEditorAssets() {
+const loadAssetsPromises = new Map< EditorContext, Promise< void > >();
+
+export async function loadEditorAssets(
+	context: EditorContext = 'post-editor'
+) {
 	const load = async () => {
-		const editorAssets = await unlock(
-			resolveSelect( coreDataStore )
-		).getEditorAssets();
+		const editorAssets =
+			context === 'post-editor'
+				? await unlock(
+						resolveSelect( coreDataStore )
+				  ).getEditorAssets()
+				: await apiFetch< Record< string, any > >( {
+						path: addQueryArgs( '/wp-block-editor/v1/assets', {
+							context,
+						} ),
+				  } );
 		await loadAssets(
 			editorAssets.scripts || {},
 			editorAssets.inline_scripts || { before: {}, after: {} },
@@ -28,28 +41,35 @@ export async function loadEditorAssets() {
 		);
 	};
 
-	if ( ! loadAssetsPromise ) {
-		loadAssetsPromise = load();
+	if ( ! loadAssetsPromises.has( context ) ) {
+		loadAssetsPromises.set( context, load() );
 	}
 
-	return loadAssetsPromise;
+	return loadAssetsPromises.get( context ) as Promise< void >;
 }
 
 /**
  * This is a React hook that handles loading editor assets from the REST API.
  *
+ * @param {string} context The editor context to load assets for.
  * @return Editor assets loading state.
  */
-export function useEditorAssets() {
-	const editorAssets = useSelect( ( select ) => {
-		return unlock( select( coreDataStore ) ).getEditorAssets();
-	}, [] );
+export function useEditorAssets( context: EditorContext = 'post-editor' ) {
+	const editorAssets = useSelect(
+		( select ) => {
+			if ( context !== 'post-editor' ) {
+				return true;
+			}
+			return unlock( select( coreDataStore ) ).getEditorAssets();
+		},
+		[ context ]
+	);
 
 	const [ assetsLoaded, setAssetsLoaded ] = useState( false );
 
 	useEffect( () => {
 		if ( editorAssets && ! assetsLoaded ) {
-			loadEditorAssets()
+			loadEditorAssets( context )
 				.then( () => {
 					setAssetsLoaded( true );
 				} )
@@ -58,7 +78,7 @@ export function useEditorAssets() {
 					console.error( 'Failed to load editor assets:', error );
 				} );
 		}
-	}, [ editorAssets, assetsLoaded ] );
+	}, [ editorAssets, assetsLoaded, context ] );
 
 	return {
 		isReady: !! editorAssets && assetsLoaded,

--- a/packages/lazy-editor/src/hooks/use-editor-settings.tsx
+++ b/packages/lazy-editor/src/hooks/use-editor-settings.tsx
@@ -2,9 +2,11 @@
  * WordPress dependencies
  */
 import { generateGlobalStyles } from '@wordpress/global-styles-engine';
+import apiFetch from '@wordpress/api-fetch';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -12,15 +14,44 @@ import { useSelect } from '@wordpress/data';
 import { useUserGlobalStyles } from './use-global-styles';
 import { unlock } from '../lock-unlock';
 
+type EditorContext = 'post-editor' | 'site-editor';
+
+const settingsPromises = new Map<
+	EditorContext,
+	Promise< Record< string, any > >
+>();
+
+async function fetchEditorSettings( context: EditorContext ) {
+	if ( ! settingsPromises.has( context ) ) {
+		settingsPromises.set(
+			context,
+			apiFetch< Record< string, any > >( {
+				path: addQueryArgs( '/wp-block-editor/v1/settings', {
+					context,
+				} ),
+			} )
+		);
+	}
+
+	return settingsPromises.get( context ) as Promise< Record< string, any > >;
+}
+
 /**
  * This is a React hook that provides the editor settings from the REST API.
  *
  * @param {Object} props            - The props object.
  * @param {string} [props.stylesId] - The ID of the user's global styles to use.
+ * @param {string} [props.context]  - The editor context to load settings for.
  * @return Editor settings.
  */
-export function useEditorSettings( { stylesId }: { stylesId: string } ) {
-	const { editorSettings } = useSelect(
+export function useEditorSettings( {
+	stylesId,
+	context = 'post-editor',
+}: {
+	stylesId: string;
+	context?: EditorContext;
+} ) {
+	const coreEditorSettings = useSelect(
 		( select ) => ( {
 			editorSettings: unlock(
 				select( coreDataStore )
@@ -28,6 +59,30 @@ export function useEditorSettings( { stylesId }: { stylesId: string } ) {
 		} ),
 		[]
 	);
+	const [ contextualEditorSettings, setContextualEditorSettings ] =
+		useState< Record< string, any > | null >( null );
+
+	useEffect( () => {
+		if ( context === 'post-editor' ) {
+			return;
+		}
+
+		let isMounted = true;
+		fetchEditorSettings( context ).then( ( fetchedSettings ) => {
+			if ( isMounted ) {
+				setContextualEditorSettings( fetchedSettings );
+			}
+		} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ context ] );
+
+	const editorSettings =
+		context === 'post-editor'
+			? coreEditorSettings.editorSettings
+			: contextualEditorSettings;
 
 	const { user: globalStyles } = useUserGlobalStyles( stylesId );
 	const [ globalStylesCSS ] = generateGlobalStyles( globalStyles );

--- a/packages/lazy-editor/tsconfig.json
+++ b/packages/lazy-editor/tsconfig.json
@@ -6,6 +6,7 @@
 		"checkJs": false
 	},
 	"references": [
+		{ "path": "../api-fetch" },
 		{ "path": "../asset-loader" },
 		{ "path": "../block-editor" },
 		{ "path": "../blocks" },
@@ -16,6 +17,7 @@
 		{ "path": "../editor" },
 		{ "path": "../global-styles-engine" },
 		{ "path": "../i18n" },
-		{ "path": "../private-apis" }
+		{ "path": "../private-apis" },
+		{ "path": "../url" }
 	]
 }


### PR DESCRIPTION
## What?
Adds a `site-editor` context path for lazy editor settings and assets. The boot canvas passes that context, and the REST settings/assets controller maps it to the Site Editor screen and editor context.

## Why?
The lazy editor needs site-editor-specific settings and enqueued assets when it is rendering the v2 Site Editor canvas.

## Testing
- `./node_modules/.bin/tsgo -p packages/lazy-editor/tsconfig.json --pretty false`
- `./node_modules/.bin/tsgo -p packages/boot/tsconfig.json --pretty false`
- `php -l lib/experimental/class-wp-rest-block-editor-settings-controller.php`
- `git diff --cached --check` before commit
- pre-commit staged-file checks ran successfully