### PR TITLE
Mount preferences modal in lazy editor

### DIFF
--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -20,7 +20,11 @@ import { useEditorSettings } from '../../hooks/use-editor-settings';
 import { useEditorAssets } from '../../hooks/use-editor-assets';
 import { unlock } from '../../lock-unlock';
 
-const { Editor: PrivateEditor, BackButton } = unlock( editorPrivateApis );
+const {
+	Editor: PrivateEditor,
+	BackButton,
+	PreferencesModal,
+} = unlock( editorPrivateApis );
 
 interface EditorProps {
 	postType?: string;
@@ -121,6 +125,7 @@ export function Editor( {
 			settings={ finalSettings }
 			styles={ finalSettings.styles }
 		>
+			<PreferencesModal />
 			{ backButton && <BackButton>{ backButton }</BackButton> }
 		</PrivateEditor>
 	);


### PR DESCRIPTION
## What?
Mounts the editor `PreferencesModal` inside the lazy editor shell.

## Why?
The shared editor More menu dispatches `openModal( 'editor/preferences' )`; this gives that action a mounted modal target in the lazy editor.

## Testing
- `./node_modules/.bin/tsgo -p packages/lazy-editor/tsconfig.json --pretty false`
- `git diff --check` before commit
- pre-commit staged-file checks ran successfully