### PR TITLE
Widget Primitives: make `@types/react` an optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53718,6 +53718,11 @@
 				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"packages/widgets": {

--- a/packages/widget-primitives/package.json
+++ b/packages/widget-primitives/package.json
@@ -63,6 +63,11 @@
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
## What?

Marks `@types/react` as an optional peer dependency of `@wordpress/widget-primitives` through `peerDependenciesMeta`.

## Why?

`@types/react` is only useful to consumers that use TypeScript.

Marking it optional avoids an unmet-peer warning for plain-JavaScript consumers, and matches the convention already followed by other React packages.

## Testing

Metadata-only change, with no runtime or test impact. After install, `@types/react` no longer reports as a missing peer for consumers that do not use TypeScript.
