### PR TITLE
DataForm: Fix panel field control overflow clipping and remove button overrides

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Bug Fix
 
-- DataForm panel layout: use `overflow: clip` (with `overflow: hidden` fallback) on field controls so focus rings of inner elements are no longer clipped.
+- DataForm panel layout: use `overflow: clip` (with `overflow: hidden` fallback) on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality
 
 - Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
-- DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those styles are now handled by the rendered controls themselves.
+- DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those styles are now handled by the rendered controls themselves. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 - `DataViewsPicker`: `DataViewsPicker.BulkActionToolbar` now renders only the bulk-selection info and action buttons, without pagination, matching `DataViews.BulkActionToolbar`. The full footer it previously rendered (including pagination) is now exposed as `DataViewsPicker.Footer`, matching `DataViews.Footer`. [#79180](https://github.com/WordPress/gutenberg/pull/79180)
 
+### Bug Fix
+
+- DataForm panel layout: use `overflow: clip` (with `overflow: hidden` fallback) on field controls so focus rings of inner elements are no longer clipped.
+
 ### Code Quality
 
 - Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
+- DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those styles are now handled by the rendered controls themselves.
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Bug Fix
 
-- DataForm panel layout: use `overflow: clip` (with `overflow: hidden` fallback) on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
+- DataForm panel layout: use `overflow: clip` on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality
 
 - Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
-- DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those styles are now handled by the rendered controls themselves. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
+- DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those overrides are no longer needed. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Internal
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -124,10 +124,11 @@
 	line-height: var(--wpds-typography-line-height-md);
 	display: flex;
 	align-items: center;
-	overflow: hidden; // Fallback for browsers that don't support `overflow: clip`.
 	overflow: clip;
-	// Leave room so the focus ring of an inner control isn't clipped.
-	overflow-clip-margin: var(--wpds-border-width-focus);
+	// padding-inline + negative margin-inline creates room within the
+	// clip boundary for focus rings of inner controls.
+	padding-inline: var(--wpds-border-width-focus);
+	margin-inline: calc(-1 * var(--wpds-border-width-focus));
 	word-break: break-word;
 	font-weight: var(--wpds-typography-font-weight-medium);
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -124,29 +124,15 @@
 	line-height: var(--wpds-typography-line-height-md);
 	display: flex;
 	align-items: center;
-	overflow: hidden;
+	overflow: hidden; // Fallback for browsers that don't support `overflow: clip`.
+	overflow: clip;
+	// Leave room so the focus ring of an inner control isn't clipped.
+	overflow-clip-margin: var(--wpds-border-width-focus);
 	word-break: break-word;
 	font-weight: var(--wpds-typography-font-weight-medium);
 
 	> * {
 		min-width: 0;
-	}
-
-	.components-button {
-		max-width: 100%;
-		text-align: left;
-		white-space: normal;
-		text-wrap: balance; // Fallback for Safari.
-		text-wrap: pretty;
-		min-height: vars.$button-size-compact;
-	}
-
-	&.components-button.is-link[aria-disabled="true"] {
-		text-decoration: none;
-	}
-
-	.components-dropdown {
-		max-width: 100%;
 	}
 }
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from: https://github.com/WordPress/gutenberg/pull/79195

These changes were introduced [here](https://github.com/WordPress/gutenberg/pull/75204) and they are targeting Button and dropdown components inside a field's render function.

There is no core field use case for that and it's probably leftover from [here](https://github.com/WordPress/gutenberg/pull/75290) where we replaced `Button` with a `span`. While there could be some external consumers that could use this implementation detail, I think the impact would not be big and that it's reasonable to **not**  have random styles like that in DataViews package.

## Testing Instructions
1. Everything around `panel` layout in DataForm should be like it was before (both in trunk like the quick edit in site editor) and in storybook (`npm run storybook:dev`).
