### PR TITLE
Scripts: Add allowScripts for npm v11+/v12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,17 @@
 		"node": ">=20.19.0",
 		"npm": ">=10.2.3"
 	},
+	"allowScripts": {
+		"@parcel/watcher": true,
+		"core-js": true,
+		"core-js-pure": true,
+		"esbuild": true,
+		"fs-ext": true,
+		"fsevents": true,
+		"leveldown": true,
+		"nx": true,
+		"unrs-resolver": true
+	},
 	"wpPlugin": {
 		"name": "gutenberg",
 		"scriptGlobal": "wp",

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -16,6 +16,43 @@ You only need to install one npm module:
 npm install @wordpress/scripts --save-dev
 ```
 
+### npm v11+ / npm v12 compatibility
+
+Starting with **npm v11.16.0**, running `npm install` may display warnings like:
+
+```
+npm warn allow-scripts @parcel/watcher@2.x.x (install: node-gyp rebuild)
+npm warn allow-scripts core-js@3.x.x (postinstall: ...)
+npm warn allow-scripts core-js-pure@3.x.x (postinstall: ...)
+npm warn allow-scripts unrs-resolver@1.x.x (postinstall: node postinstall.js)
+```
+
+These are transitive dependencies of `@wordpress/scripts` that run install-time scripts.
+The warnings are advisory today but will become blocking errors in **npm v12** (expected
+July 2026). To silence them and prepare for npm v12, add an `allowScripts` field to your
+project's root `package.json`:
+
+```json
+{
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "core-js-pure": true,
+    "unrs-resolver": true
+  }
+}
+```
+
+Alternatively, run:
+
+```bash
+npm approve-scripts @parcel/watcher core-js core-js-pure unrs-resolver
+```
+
+This command will write the allowlist into your `package.json` automatically. Do **not**
+run `npm install --ignore-scripts` as a workaround — it breaks the native file-system
+watcher used by webpack and silently degrades `wp-scripts start` watch performance.
+
 **Note**: This package requires Node.js version with long-term support status (check [Active LTS or Maintenance LTS releases](https://nodejs.org/en/about/previous-releases)). It is not compatible with older versions.
 
 ## Setup


### PR DESCRIPTION
## What?
Addresses the `npm warn allow-scripts` warnings reported in #79259 that appear when running `npm install` with npm >= 11.16.0.

## Why?
npm v11.16.0 introduced a preview of npm v12's new security model, which will block transitive dependency install scripts by default. Several transitive dependencies in this monorepo (like `@parcel/watcher`, `core-js`, and `esbuild`) rely on install scripts. Without an explicit `allowScripts` allowlist in the **root `package.json`**, these trigger warnings today and will fail entirely in npm v12. 

*Note: `allowScripts` is only respected at the root of the project being installed, so downstream `@wordpress/scripts` users will need to configure this in their own projects.*

## How?
1. Added `allowScripts` to the root `package.json` for the 9 packages that trigger warnings in the monorepo.
2. Added an "npm v11+ / npm v12 compatibility" note to `packages/scripts/README.md` guiding downstream developers on how to prepare their projects.

## Testing Instructions
1. Using npm 11.16.0 or higher, run `npm install`.
2. Verify that there are no `npm warn allow-scripts` warnings.
3. Run `npm run lint:pkg-json` to ensure the package.json remains valid.
