### PR TITLE
Button: Use font weight token

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Code Quality
 
+-   `Button`: Reference the medium font-weight design token instead of a literal value. No visual change ([#79278](https://github.com/WordPress/gutenberg/pull/79278)).
 -   Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used ([#79095](https://github.com/WordPress/gutenberg/pull/79095)).
 -   `Button` and `AlertDialog`: Reference the tone-specific `brand`/`error` disabled color tokens for disabled states instead of the `neutral` ones, to match each element's tone. Disabled `Select`/`Autocomplete`/`Combobox` list items also adopt the `brand` disabled background token. No visual change ([#79124](https://github.com/WordPress/gutenberg/pull/79124)).
 

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -10,7 +10,7 @@
 
 		.button {
 			/* Internal variables */
-			--wp-ui-button-font-weight: 499;
+			--wp-ui-button-font-weight: var(--wpds-typography-font-weight-medium);
 
 			--wp-ui-button-background-color: var(--wpds-color-background-interactive-brand-strong);
 			--wp-ui-button-background-color-active: var(--wpds-color-background-interactive-brand-strong-active);


### PR DESCRIPTION
## What?
Updates `@wordpress/ui` `Button` so its default font-weight custom property references the design-system medium font-weight token instead of hardcoding `499`.

## Why?
`Button` should inherit the design-system typography token like the other `@wordpress/ui` typography surfaces, while keeping `--wp-ui-button-font-weight` available as the component-level override point.

## How?
Replaces the literal default value for `--wp-ui-button-font-weight` with `var(--wpds-typography-font-weight-medium)` in `packages/ui/src/button/style.module.css`, and adds the corresponding `@wordpress/ui` changelog entry.

## Testing Instructions
1. Run `npm run lint:css -- packages/ui/src/button/style.module.css`.
2. Run `npm run test:unit packages/ui/src/button/test`.

### Testing Instructions for Keyboard
No keyboard-specific interaction changes. Existing Button keyboard behavior is covered by the Button unit tests.

## Screenshots or screencast
Not applicable; the token currently resolves to the same value, so this should have no visual change.

## Use of AI Tools
Prepared with assistance from OpenAI Codex.