### PR TITLE
Button: Adopt font-weight design token instead of hardcoded 499

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Internal
 
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
--   `Button`: Adopt the `--wpds-typography-font-weight-medium` design token instead of the hardcoded `499` font weight. No visual change ([#PR](https://github.com/WordPress/gutenberg/pull/PR)).
+-   `Button`: Adopt the `--wpds-typography-font-weight-medium` design token instead of the hardcoded `499` font weight. No visual change ([#79279](https://github.com/WordPress/gutenberg/pull/79279)).
 
 ## 0.15.1 (2026-06-16)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Internal
 
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
+-   `Button`: Adopt the `--wpds-typography-font-weight-medium` design token instead of the hardcoded `499` font weight. No visual change ([#PR](https://github.com/WordPress/gutenberg/pull/PR)).
 
 ## 0.15.1 (2026-06-16)
 

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -10,7 +10,7 @@
 
 		.button {
 			/* Internal variables */
-			--wp-ui-button-font-weight: 499;
+			--wp-ui-button-font-weight: var(--wpds-typography-font-weight-medium);
 
 			--wp-ui-button-background-color: var(--wpds-color-background-interactive-brand-strong);
 			--wp-ui-button-background-color-active: var(--wpds-color-background-interactive-brand-strong-active);


### PR DESCRIPTION
## What?

`ui/Button` hardcoded its font weight as `--wp-ui-button-font-weight: 499`. This switches it to reference the design system token `--wpds-typography-font-weight-medium` (which resolves to `499`).

## Why?

`499` was the only typography value in `@wordpress/ui` not sourced from a `--wpds-*` design token — every other component (`Text`, `Field`, `Link`, the global CSS defense layer, etc.) already references `--wpds-typography-font-weight-*`. Per the design system styling rules, all visual values should come from design tokens so that theming overrides flow through the token layer rather than component styles.

## How?

Replaced the literal in `packages/ui/src/button/style.module.css`:

```css
/* before */
--wp-ui-button-font-weight: 499;

/* after */
--wp-ui-button-font-weight: var(--wpds-typography-font-weight-medium);
```

The token's default value is `499`, so this is a no-op at runtime against the default theme.

## Testing Instructions

1. `npm run build:tokens` is not required — the token already exists.
2. Run Storybook and open the `Button` stories: `npm run storybook:dev`.
3. Confirm buttons render with the same (medium) font weight as before.
4. `npm run lint:css` passes (no hardcoded typography value / no manual token fallback).

### Testing Instructions for Keyboard

No UI/interaction change; not applicable.

## Screenshots or screencast

No visual change — the token resolves to the same `499` value.

|Before|After|
|-|-|
|font-weight: 499 (hardcoded)|font-weight: var(--wpds-typography-font-weight-medium) → 499|

## Use of AI Tools

This PR was authored with the assistance of an AI coding agent (Cursor). All changes were reviewed by the author.