### PR TITLE
Site Editor: Save hub button styling while saving

### DIFF
--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { check } from '@wordpress/icons';
 
@@ -28,7 +28,7 @@ export default function SaveHub() {
 		};
 	}, [] );
 	return (
-		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>
+		<Stack className="edit-site-save-hub" direction="row" gap={ 4 }>
 			<SaveButton
 				className="edit-site-save-hub__button"
 				variant={ isDisabled && ! isSaving ? null : 'primary' }
@@ -37,6 +37,6 @@ export default function SaveHub() {
 				showReviewMessage
 				__next40pxDefaultSize
 			/>
-		</HStack>
+		</Stack>
 	);
 }

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -28,7 +28,7 @@ export default function SaveHub() {
 		};
 	}, [] );
 	return (
-		<Stack className="edit-site-save-hub" direction="row" gap={ 4 }>
+		<Stack className="edit-site-save-hub" gap="lg">
 			<SaveButton
 				className="edit-site-save-hub__button"
 				variant={ isDisabled && ! isSaving ? null : 'primary' }

--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -31,7 +31,7 @@ export default function SaveHub() {
 		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>
 			<SaveButton
 				className="edit-site-save-hub__button"
-				variant={ isDisabled ? null : 'primary' }
+				variant={ isDisabled && ! isSaving ? null : 'primary' }
 				showTooltip={ false }
 				icon={ isDisabled && ! isSaving ? check : null }
 				showReviewMessage

--- a/packages/edit-site/src/components/save-hub/style.scss
+++ b/packages/edit-site/src/components/save-hub/style.scss
@@ -5,7 +5,7 @@
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
 	flex-shrink: 0;
 	margin: 0;
-	padding: $grid-unit-20 $canvas-padding;
+	padding: $grid-unit-20;
 }
 
 .edit-site-save-hub__button {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -895,11 +895,6 @@
 			"count": 4
 		}
 	},
-	"packages/edit-site/src/components/save-hub/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/edit-site/src/components/sidebar-global-styles/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

In the site editor sidebar, the save hub button can look somehow broken while a save is in progress. The button has the `primary` variant by default but when it's saving it's removed. Then it looks grey and the text is somehow non-readable, instead of the default busy state for the primary variant.

This PR is mainly to surface the behavior and see if we should merge the fix, or ignore it.

Not sure if this was intentional, looked for messages confirming the behavior and couldn't find any. 

Tagging @WordPress/gutenberg-design for their input.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The save button has a clear variant (one that has busy and disabled states) and then it's ignored while it's busy.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updated the conditional for the variant prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the site editor.
2. Make any change.
3. Save.
4. Check the button styles (if it goes to fast, open dev tools and change the throttling)

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/40cb6219-bfd4-4c27-92ee-ee7ff2a643c9

### After

https://github.com/user-attachments/assets/218e1462-48f9-40de-9d56-913d8d471f3d

