### PR TITLE
Blocks: Use positional sprintf placeholders in avatar, comment, and search renderers

### DIFF
--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -67,7 +67,7 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 			// translators: 1: Author archive link. 2: Link target. %3$s Aria label. %4$s Avatar image.
 			$avatar_block = sprintf( '<a href="%1$s" target="%2$s" %3$s class="wp-block-avatar__link">%4$s</a>', esc_url( get_author_posts_url( $author_id ) ), esc_attr( $attributes['linkTarget'] ), $label, $avatar_block );
 		}
-		return sprintf( '<div %1s>%2s</div>', $wrapper_attributes, $avatar_block );
+		return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $avatar_block );
 	}
 	$comment = get_comment( $block->context['commentId'] );
 	if ( ! $comment ) {
@@ -93,7 +93,7 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 		}
 		$avatar_block = sprintf( '<a href="%1$s" target="%2$s" %3$s class="wp-block-avatar__link">%4$s</a>', esc_url( $comment->comment_author_url ), esc_attr( $attributes['linkTarget'] ), $label, $avatar_block );
 	}
-	return sprintf( '<div %1s>%2s</div>', $wrapper_attributes, $avatar_block );
+	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $avatar_block );
 }
 
 /**

--- a/packages/block-library/src/comment-author-avatar/index.php
+++ b/packages/block-library/src/comment-author-avatar/index.php
@@ -64,7 +64,7 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 	if ( isset( $spacing_attributes ) ) {
 		return sprintf( '<div style="%1$s">%2$s</div>', esc_attr( $spacing_string ), $avatar_block );
 	}
-	return sprintf( '<div>%1$s</div>', $avatar_block );
+	return sprintf( '<div>%s</div>', $avatar_block );
 }
 
 /**

--- a/packages/block-library/src/comment-author-avatar/index.php
+++ b/packages/block-library/src/comment-author-avatar/index.php
@@ -57,7 +57,7 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 		array(
 			'height'     => $height,
 			'width'      => $width,
-			'extra_attr' => sprintf( 'style="%1$s"', $styles ),
+			'extra_attr' => sprintf( 'style="%s"', $styles ),
 			'class'      => $classes,
 		)
 	);

--- a/packages/block-library/src/comment-author-avatar/index.php
+++ b/packages/block-library/src/comment-author-avatar/index.php
@@ -57,14 +57,14 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 		array(
 			'height'     => $height,
 			'width'      => $width,
-			'extra_attr' => sprintf( 'style="%1s"', $styles ),
+			'extra_attr' => sprintf( 'style="%1$s"', $styles ),
 			'class'      => $classes,
 		)
 	);
 	if ( isset( $spacing_attributes ) ) {
-		return sprintf( '<div style="%1s">%2s</div>', esc_attr( $spacing_string ), $avatar_block );
+		return sprintf( '<div style="%1$s">%2$s</div>', esc_attr( $spacing_string ), $avatar_block );
 	}
-	return sprintf( '<div>%1s</div>', $avatar_block );
+	return sprintf( '<div>%1$s</div>', $avatar_block );
 }
 
 /**

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -40,7 +40,7 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 	$link               = get_comment_author_url( $comment );
 
 	if ( ! empty( $link ) && ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
-		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
+		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1$s" target="%2$s" >%3$s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
 	}
 	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
 		$comment_author = wp_kses( $comment_author, array() );

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -37,7 +37,7 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 	$link = get_comment_link( $comment );
 
 	if ( ! empty( $attributes['isLink'] ) ) {
-		$formatted_date = sprintf( '<a href="%1s">%2s</a>', esc_url( $link ), $formatted_date );
+		$formatted_date = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $link ), $formatted_date );
 	}
 
 	return sprintf(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -192,7 +192,7 @@ function render_block_core_search( $attributes ) {
 	}
 
 	return sprintf(
-		'<form role="search" method="get" action="%1s" %2s %3s>%4s</form>',
+		'<form role="search" method="get" action="%1$s" %2$s %3$s>%4$s</form>',
 		esc_url( home_url( '/' ) ),
 		$wrapper_attributes,
 		$form_directives,


### PR DESCRIPTION
Closes #79289

### What
Follow-up to #78933. The same non-positional `%1s`/`%2s` sprintf placeholders were still present in five more block renderers — `avatar`, `comment-author-avatar`, `comment-author-name`, `comment-date`, and `search`.

### How
This PR switches them to the positional `%1$s`/`%2$s` form used across the rest of block-library.

No output change: Originally surfaced in Trac #65396.
