### PR TITLE
Site Editor: Change 'Identity' nav item position

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -34,6 +34,13 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 					>
 						{ __( 'Styles' ) }
 					</SidebarNavigationItemGlobalStyles>
+					<SidebarNavigationItemIdentity
+						to="/identity"
+						uid="identity-navigation-item"
+						icon={ siteLogo }
+					>
+						{ _x( 'Identity', 'site identity' ) }
+					</SidebarNavigationItemIdentity>
 					<SidebarNavigationItem
 						uid="navigation-navigation-item"
 						to="/navigation"
@@ -42,13 +49,6 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 					>
 						{ __( 'Navigation' ) }
 					</SidebarNavigationItem>
-					<SidebarNavigationItemIdentity
-						to="/identity"
-						uid="identity-navigation-item"
-						icon={ siteLogo }
-					>
-						{ _x( 'Identity', 'site identity' ) }
-					</SidebarNavigationItemIdentity>
 					<SidebarNavigationItem
 						uid="page-navigation-item"
 						to="/page"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -27,13 +27,6 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
 			{ isBlockBasedTheme && (
 				<>
-					<SidebarNavigationItemGlobalStyles
-						to="/styles"
-						uid="global-styles-navigation-item"
-						icon={ styles }
-					>
-						{ __( 'Styles' ) }
-					</SidebarNavigationItemGlobalStyles>
 					<SidebarNavigationItemIdentity
 						to="/identity"
 						uid="identity-navigation-item"
@@ -41,14 +34,13 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 					>
 						{ _x( 'Identity', 'site identity' ) }
 					</SidebarNavigationItemIdentity>
-					<SidebarNavigationItem
-						uid="navigation-navigation-item"
-						to="/navigation"
-						withChevron
-						icon={ navigation }
+					<SidebarNavigationItemGlobalStyles
+						to="/styles"
+						uid="global-styles-navigation-item"
+						icon={ styles }
 					>
-						{ __( 'Navigation' ) }
-					</SidebarNavigationItem>
+						{ __( 'Styles' ) }
+					</SidebarNavigationItemGlobalStyles>
 					<SidebarNavigationItem
 						uid="page-navigation-item"
 						to="/page"
@@ -58,12 +50,12 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 						{ __( 'Pages' ) }
 					</SidebarNavigationItem>
 					<SidebarNavigationItem
-						uid="template-navigation-item"
-						to="/template"
+						uid="navigation-navigation-item"
+						to="/navigation"
 						withChevron
-						icon={ layout }
+						icon={ navigation }
 					>
-						{ __( 'Templates' ) }
+						{ __( 'Navigation' ) }
 					</SidebarNavigationItem>
 				</>
 			) }
@@ -85,6 +77,16 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 			>
 				{ __( 'Patterns' ) }
 			</SidebarNavigationItem>
+			{ isBlockBasedTheme && (
+				<SidebarNavigationItem
+					uid="template-navigation-item"
+					to="/template"
+					withChevron
+					icon={ layout }
+				>
+					{ __( 'Templates' ) }
+				</SidebarNavigationItem>
+			) }
 		</ItemGroup>
 	);
 }


### PR DESCRIPTION
## What?
PR moves "Identity" nav below Styles and above the Navigation items.

## Why?
Can't really put my finger on it, but for some reason, the old position always bothered me. Nav items with chevron have sub-sidebar navigation as well. I guess it makes sense to group them.

## Testing Instructions
1. Open the Site Editor.
2. Confirm the "Identity" sidebar screen works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="301" height="581" alt="CleanShot 2026-06-17 at 23 39 25" src="https://github.com/user-attachments/assets/28f98046-c161-492a-87dc-4b1ac706967d" />|<img width="301" height="490" alt="CleanShot 2026-06-18 at 09 38 13" src="https://github.com/user-attachments/assets/45baddfa-8dd1-4680-94f1-8afa81916fdf" />|


## Use of AI Tools
None.