### PR TITLE
ConfirmDialog: Document AlertDialog as successor in Storybook

### DIFF
--- a/packages/components/src/confirm-dialog/stories/index.story.tsx
+++ b/packages/components/src/confirm-dialog/stories/index.story.tsx
@@ -36,6 +36,7 @@ const meta: Meta< typeof ConfirmDialog > = {
 		componentStatus: {
 			status: 'recommended',
 			whereUsed: 'global',
+			notes: 'Will be superseded by `AlertDialog` in `@wordpress/ui`, but continue using for now.',
 		},
 		docs: { canvas: { sourceState: 'shown' } },
 	},


### PR DESCRIPTION
## What?

Adds a `componentStatus.notes` entry to the `ConfirmDialog` Storybook story, documenting that it will be superseded by `AlertDialog` in `@wordpress/ui`.

## Why?

`AlertDialog` is the design-system successor for the confirm/cancel dialog pattern, but `ConfirmDialog` remains the recommended component for now. This note makes that migration path visible in Storybook, consistent with other components that have `@wordpress/ui` successors (e.g. `Modal` → `Dialog`, `Button` → `Button`).

## Testing Instructions

1. Run Storybook.
2. Open **Components → Overlays → ConfirmDialog**.
3. Confirm the component status notes mention `AlertDialog` in `@wordpress/ui`.
