### PR TITLE
Elements tests: Accept both md5 and sequential `wp-elements-*` class names

### DIFF
--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -149,6 +149,9 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 			'background' => '#fff',
 		);
 
+		// The `wp-elements-*` class suffix is an md5 hash on older WordPress and a
+		// sequential id (via `wp_unique_prefixed_id()`) on newer cores, so the
+		// patterns below accept either form to stay green across supported versions.
 		return array(
 			'button element styles with serialization skipped' => array(
 				'color_settings'  => array(
@@ -189,7 +192,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'button' => array( 'color' => $color_styles ),
 				),
 				'block_markup'    => '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
-				'expected_markup' => '/^<p class="wp-elements-[a-f0-9]{32}">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+				'expected_markup' => '/^<p class="wp-elements-(?:[a-f0-9]{32}|[0-9]+)">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
 			),
 			'link element styles apply class to wrapper'   => array(
 				'color_settings'  => array( 'link' => true ),
@@ -197,7 +200,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'link' => array( 'color' => $color_styles ),
 				),
 				'block_markup'    => '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
-				'expected_markup' => '/^<p class="wp-elements-[a-f0-9]{32}">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+				'expected_markup' => '/^<p class="wp-elements-(?:[a-f0-9]{32}|[0-9]+)">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
 			),
 			'heading element styles apply class to wrapper' => array(
 				'color_settings'  => array( 'heading' => true ),
@@ -205,7 +208,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'heading' => array( 'color' => $color_styles ),
 				),
 				'block_markup'    => '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
-				'expected_markup' => '/^<p class="wp-elements-[a-f0-9]{32}">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+				'expected_markup' => '/^<p class="wp-elements-(?:[a-f0-9]{32}|[0-9]+)">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
 			),
 			'element styles apply class to wrapper when it has other classes' => array(
 				'color_settings'  => array( 'link' => true ),
@@ -213,7 +216,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'link' => array( 'color' => $color_styles ),
 				),
 				'block_markup'    => '<p class="has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
-				'expected_markup' => '/^<p class="has-dark-gray-background-color has-background wp-elements-[a-f0-9]{32}">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+				'expected_markup' => '/^<p class="has-dark-gray-background-color has-background wp-elements-(?:[a-f0-9]{32}|[0-9]+)">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
 			),
 			'element styles apply class to wrapper when it has other attributes' => array(
 				'color_settings'  => array( 'link' => true ),
@@ -221,7 +224,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'link' => array( 'color' => $color_styles ),
 				),
 				'block_markup'    => '<p id="anchor">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
-				'expected_markup' => '/^<p class="wp-elements-[a-f0-9]{32}" id="anchor">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+				'expected_markup' => '/^<p class="wp-elements-(?:[a-f0-9]{32}|[0-9]+)" id="anchor">Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
 			),
 		);
 	}
@@ -271,6 +274,9 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 		);
 		$color_css_rules = preg_quote( '{color:var(--wp--preset--color--vivid-red);background-color:#fff;}' );
 
+		// The `wp-elements-*` class suffix is an md5 hash on older WordPress and a
+		// sequential id (via `wp_unique_prefixed_id()`) on newer cores, so the
+		// patterns below accept either form to stay green across supported versions.
 		return array(
 			'button element styles are not applied if serialization is skipped' => array(
 				'color_settings'  => array(
@@ -318,7 +324,7 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 				'elements_styles' => array(
 					'button' => array( 'color' => $color_styles ),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} .wp-element-button, .wp-elements-[a-f0-9]{32} .wp-block-button__link' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-element-button, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-block-button__link' . $color_css_rules . '$/',
 			),
 			'link element styles are applied'            => array(
 				'color_settings'  => array( 'link' => true ),
@@ -330,15 +336,15 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} a:where\(:not\(.wp-element-button\)\)' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} a:where\(:not\(.wp-element-button\)\):hover' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) a:where\(:not\(.wp-element-button\)\)' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) a:where\(:not\(.wp-element-button\)\):hover' . $color_css_rules . '$/',
 			),
 			'generic heading element styles are applied' => array(
 				'color_settings'  => array( 'heading' => true ),
 				'elements_styles' => array(
 					'heading' => array( 'color' => $color_styles ),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} h1, .wp-elements-[a-f0-9]{32} h2, .wp-elements-[a-f0-9]{32} h3, .wp-elements-[a-f0-9]{32} h4, .wp-elements-[a-f0-9]{32} h5, .wp-elements-[a-f0-9]{32} h6' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h1, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) h2, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) h3, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) h4, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) h5, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) h6' . $color_css_rules . '$/',
 			),
 			'individual heading element styles are applied' => array(
 				'color_settings'  => array( 'heading' => true ),
@@ -350,12 +356,12 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 					'h5' => array( 'color' => $color_styles ),
 					'h6' => array( 'color' => $color_styles ),
 				),
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} h1' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} h2' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} h3' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} h4' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} h5' . $color_css_rules .
-					'.wp-elements-[a-f0-9]{32} h6' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h1' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h2' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h3' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h4' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h5' . $color_css_rules .
+					'.wp-elements-(?:[a-f0-9]{32}|[0-9]+) h6' . $color_css_rules . '$/',
 			),
 		);
 	}


### PR DESCRIPTION
## What?

Fix failing Elements PHP tests

## Why?

In https://github.com/WordPress/wordpress-develop/commit/fc826ae8a79b5ad11fa3aad4aea37c2a897a99e8#diff-ba4dd61bebec568429765848157ef087c9a4008d7d8297ba1e107214f44ec91d and https://github.com/WordPress/wordpress-develop/pull/12126 the construction of the elements class name changed from an md5 to a sequential number.

So, we need to update the tests accordingly, while factoring in that our tests might run against different WP versions (because GB supports earlier WP versions than latest trunk). I might have gotten that nuance wrong, so happy to close this PR if there's a better approach!

## How?

Update the regexes used in the elements tests to match against both the md5 approach and the sequential numbering approach.

Note: this drifts from the changes made in https://github.com/WordPress/wordpress-develop/pull/12126 as in Gutenberg we need to account for different WP versions, I believe? Either way, I think we can land this to unblock GB trunk, and can follow-up separately if need be.

## Testing Instructions

See if the tests pass now

## Use of AI Tools

Claude Code