### PR TITLE
Global styles: defensively skip invalid global styles preset origins

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2420,7 +2420,14 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
 				continue;
 			}
-			foreach ( $preset_per_origin[ $origin ] as $preset ) {
+			$presets_for_origin = $preset_per_origin[ $origin ];
+			if ( ! is_array( $presets_for_origin ) ) {
+				continue;
+			}
+			foreach ( $presets_for_origin as $preset ) {
+				if ( ! is_array( $preset ) || ! isset( $preset['slug'] ) ) {
+					continue;
+				}
 				$slug = _wp_to_kebab_case( $preset['slug'] );
 
 				$value = '';
@@ -2466,7 +2473,14 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
 				continue;
 			}
-			foreach ( $preset_per_origin[ $origin ] as $preset ) {
+			$presets_for_origin = $preset_per_origin[ $origin ];
+			if ( ! is_array( $presets_for_origin ) ) {
+				continue;
+			}
+			foreach ( $presets_for_origin as $preset ) {
+				if ( ! is_array( $preset ) || ! isset( $preset['slug'] ) ) {
+					continue;
+				}
 				$slug = _wp_to_kebab_case( $preset['slug'] );
 
 				// Use the array as a set so we don't get duplicates.
@@ -4113,7 +4127,13 @@ class WP_Theme_JSON_Gutenberg {
 				if ( ! isset( $duotone_presets[ $origin ] ) ) {
 					continue;
 				}
+				if ( ! is_array( $duotone_presets[ $origin ] ) ) {
+					continue;
+				}
 				foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
+					if ( ! is_array( $duotone_preset ) ) {
+						continue;
+					}
 					$filters .= wp_get_duotone_filter_svg( $duotone_preset );
 				}
 			}

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -59,7 +59,7 @@ interface PresetMetadata {
  * Preset collection by origin
  */
 interface PresetsByOrigin {
-	[ origin: string ]: any[];
+	[ origin: string ]: unknown;
 }
 
 /**
@@ -236,6 +236,8 @@ const RESPONSIVE_BREAKPOINTS: Record< string, string > = {
 	tablet: '@media (480px < width <= 782px)',
 };
 
+const PRESET_ORIGINS = [ 'default', 'theme', 'custom' ];
+
 /**
  * Transform given preset tree into a set of preset class declarations.
  *
@@ -261,34 +263,32 @@ function getPresetsClasses(
 				path,
 				[]
 			) as PresetsByOrigin;
-			[ 'default', 'theme', 'custom' ].forEach( ( origin ) => {
-				if ( presetByOrigin[ origin ] ) {
-					presetByOrigin[ origin ].forEach(
-						( { slug }: { slug: string } ) => {
-							classes!.forEach(
-								( {
-									classSuffix,
-									propertyName,
-								}: CSSClassConfig ) => {
-									const classSelectorToUse = `.has-${ kebabCase(
-										slug
-									) }-${ classSuffix }`;
-									const selectorToUse = blockSelector
-										.split( ',' ) // Selector can be "h1, h2, h3"
-										.map(
-											( selector ) =>
-												`${ selector }${ classSelectorToUse }`
-										)
-										.join( ',' );
-									const value = `var(--wp--preset--${ cssVarInfix }--${ kebabCase(
-										slug
-									) })`;
-									declarations += `${ selectorToUse }{${ propertyName }: ${ value } !important;}`;
-								}
-							);
+			PRESET_ORIGINS.forEach( ( origin ) => {
+				const presets = presetByOrigin?.[ origin ];
+				if ( ! Array.isArray( presets ) ) {
+					return;
+				}
+
+				presets.forEach( ( { slug }: { slug: string } ) => {
+					classes!.forEach(
+						( { classSuffix, propertyName }: CSSClassConfig ) => {
+							const classSelectorToUse = `.has-${ kebabCase(
+								slug
+							) }-${ classSuffix }`;
+							const selectorToUse = blockSelector
+								.split( ',' ) // Selector can be "h1, h2, h3"
+								.map(
+									( selector ) =>
+										`${ selector }${ classSelectorToUse }`
+								)
+								.join( ',' );
+							const value = `var(--wp--preset--${ cssVarInfix }--${ kebabCase(
+								slug
+							) })`;
+							declarations += `${ selectorToUse }{${ propertyName }: ${ value } !important;}`;
 						}
 					);
-				}
+				} );
 			} );
 			return declarations;
 		},
@@ -309,15 +309,19 @@ function getPresetsSvgFilters(
 			{}
 		) as PresetsByOrigin;
 		return [ 'default', 'theme' ]
-			.filter( ( origin ) => presetByOrigin[ origin ] )
-			.flatMap( ( origin ) =>
-				presetByOrigin[ origin ].map( ( preset: any ) =>
+			.flatMap( ( origin ) => {
+				const presets = presetByOrigin?.[ origin ];
+				if ( ! Array.isArray( presets ) ) {
+					return [];
+				}
+
+				return presets.map( ( preset: any ) =>
 					getDuotoneFilter(
 						`wp-duotone-${ preset.slug }`,
 						preset.colors
 					)
-				)
-			)
+				);
+			} )
 			.join( '' );
 	} );
 }
@@ -1441,11 +1445,13 @@ function getPresetVarDeclarations(
 	) as PresetsByOrigin;
 
 	const declarations: string[] = [];
-	for ( const origin of [ 'default', 'theme', 'custom' ] ) {
-		if ( ! presetByOrigin[ origin ] ) {
+	for ( const origin of PRESET_ORIGINS ) {
+		const presetsForOrigin = presetByOrigin?.[ origin ];
+		if ( ! Array.isArray( presetsForOrigin ) ) {
 			continue;
 		}
-		for ( const value of presetByOrigin[ origin ] ) {
+
+		for ( const value of presetsForOrigin ) {
 			const slug = kebabCase( value.slug );
 			if ( valueKey && ! valueFunc ) {
 				declarations.push(

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -393,6 +393,29 @@ describe( 'global styles renderer', () => {
 				':root{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--preset--color--white-2-black: value;--wp--custom--white-2-black: value;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
 			);
 		} );
+
+		it( 'should ignore malformed preset origins when generating custom properties', () => {
+			const tree = {
+				settings: {
+					color: {
+						palette: {
+							default: {},
+							custom: [
+								{
+									name: 'Assembler Primary',
+									slug: 'assembler-primary',
+									color: '#123456',
+								},
+							],
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			expect( generateCustomProperties( tree, {} ) ).toEqual(
+				':root{--wp--preset--color--assembler-primary: #123456;}'
+			);
+		} );
 	} );
 
 	describe( 'transformToStyles', () => {
@@ -1259,6 +1282,44 @@ describe( 'global styles renderer', () => {
 				transformToStyles( Object.freeze( tree ), 'body' )
 			).toEqual(
 				':root { --wp--style--global--content-size: 840px; --wp--style--global--wide-size: 1100px;}:where(body) {margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }'
+			);
+		} );
+
+		it( 'should ignore malformed preset origins when generating preset classes', () => {
+			const tree = {
+				settings: {
+					color: {
+						palette: {
+							default: {},
+							theme: {},
+							custom: [
+								{
+									name: 'Assembler Primary',
+									slug: 'assembler-primary',
+									color: '#123456',
+								},
+							],
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const styles = transformToStyles(
+				tree,
+				{},
+				false,
+				false,
+				true,
+				true,
+				{
+					...minimalStyleOptions,
+					blockStyles: false,
+					presets: true,
+				}
+			);
+
+			expect( styles ).toEqual(
+				'.has-assembler-primary-color{color: var(--wp--preset--color--assembler-primary) !important;}.has-assembler-primary-background-color{background-color: var(--wp--preset--color--assembler-primary) !important;}.has-assembler-primary-border-color{border-color: var(--wp--preset--color--assembler-primary) !important;}'
 			);
 		} );
 	} );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -766,6 +766,41 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_ignores_malformed_preset_origins() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							'default' => array(
+								'malformed' => true,
+							),
+							'theme'   => true,
+							'custom'  => array(
+								array(
+									'name'  => 'Assembler Primary',
+									'slug'  => 'assembler-primary',
+									'color' => '#123456',
+								),
+							),
+						),
+					),
+				),
+			),
+			'custom'
+		);
+
+		$this->assertSameCSS(
+			':root{--wp--preset--color--assembler-primary: #123456;}',
+			$theme_json->get_stylesheet( array( 'variables' ) )
+		);
+		$this->assertSameCSS(
+			'.has-assembler-primary-color{color: var(--wp--preset--color--assembler-primary) !important;}.has-assembler-primary-background-color{background-color: var(--wp--preset--color--assembler-primary) !important;}.has-assembler-primary-border-color{border-color: var(--wp--preset--color--assembler-primary) !important;}',
+			$theme_json->get_stylesheet( array( 'presets' ) )
+		);
+	}
+
 	public function test_get_stylesheet_preset_css_vars_use_feature_selector() {
 		register_block_type(
 			'test/feature-selector',


### PR DESCRIPTION

## What

This PR prevents the editor from crashing when persisted global styles contain invalid preset origin values.


## Why

It's a rare edge case, but

## How

The global styles renderer now checks that each preset origin is an array before iterating it. Invalid origins are skipped defensively, while valid origins such as a `custom` palette still generate CSS variables and preset utility classes.



## Manual Testing



<details>

<summary>Update Global styles with some malformed JSON</summary>

```js
(async () => {
	const brokenPalette = {
		default: { malformed: true },
		theme: { malformed: true },
		custom: [
			{
				name: 'Assembler Primary',
				slug: 'assembler-primary',
				color: '#123456',
			},
		],
	};

	const activeThemes = await wp.apiFetch( {
		path: '/wp/v2/themes?status=active',
	} );

	const globalStylesUrl =
		activeThemes?.[ 0 ]?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href;

	const globalStylesId = globalStylesUrl?.match(
		/\/global-styles\/(\d+)(?:\?|$)/
	)?.[ 1 ];

	const current = await wp.apiFetch( {
		path: `/wp/v2/global-styles/${ globalStylesId }?context=edit`,
	} );

	const nextSettings = structuredClone( current.settings || {} );
	nextSettings.color = {
		...( nextSettings.color || {} ),
		palette: brokenPalette,
	};

	await wp.apiFetch( {
		path: `/wp/v2/global-styles/${ globalStylesId }`,
		method: 'POST',
		data: {
			settings: nextSettings,
			styles: current.styles || {},
		},
	} );

	console.log( { globalStylesId } );
})();


```

</details>



1. Open the site editor.
2. Confirm the editor loads without a `forEach` is not a function console error.
3. Open the post editor.
4 Confirm the editor loads.
5. Confirm the valid custom palette still generates preset output, for example `.has-test-primary-color`.
6. Confirm the PHP warning isn't there `Warning: Trying to access array offset on true in /var/www/html/wp-content/plugins/gutenberg/lib/class-wp-theme-json-gutenberg.php`