### PR TITLE
Style Engine: add trusted CSS serialization for Theme JSON

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2565,36 +2565,22 @@ class WP_Theme_JSON_Gutenberg {
 	 * creates the corresponding ruleset.
 	 *
 	 * @since 5.8.0
-	 * @since 7.1.0 Skip declarations whose value is not a plain string (booleans, arrays, objects, etc.).
+	 * @since 7.2.0 Route to Style Engine trusted compiler.
 	 *
 	 * @param string $selector     CSS selector.
 	 * @param array  $declarations List of declarations.
-	 * @return string The resulting CSS ruleset.
+	 * @return string The compiled CSS rule.
 	 */
 	protected static function to_ruleset( $selector, $declarations ) {
 		if ( empty( $declarations ) ) {
 			return '';
 		}
 
-		$declaration_block = array_reduce(
+		return WP_Style_Engine_Gutenberg::compile_css(
 			$declarations,
-			static function ( $carry, $element ) {
-				$value = $element['value'];
-
-				if ( is_numeric( $value ) ) {
-					$value = (string) $value;
-				}
-
-				if ( ! is_string( $value ) ) {
-					return $carry;
-				}
-
-				return $carry .= $element['name'] . ': ' . $value . ';';
-			},
-			''
+			$selector,
+			array( 'sanitize' => false )
 		);
-
-		return $selector . '{' . $declaration_block . '}';
 	}
 
 	/**

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -701,14 +701,31 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		/**
 		 * Returns compiled CSS from css_declarations.
 		 *
-		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 * @param string[]|array[] $css_declarations An associative array of CSS definitions, e.g. array( "$property" => "$value", "$property" => "$value" ),
+		 *                                           or an ordered list of Theme JSON declarations, e.g. array( array( 'name' => "$property", 'value' => "$value" ) ).
+		 * @param string           $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+		 * @param array            $options          {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $sanitize Whether to sanitize declarations before compiling. Default true.
+		 * }
 		 *
 		 * @return string A compiled CSS string.
 		 */
-		public static function compile_css( $css_declarations, $css_selector ) {
+		public static function compile_css( $css_declarations, $css_selector, $options = array() ) {
 			if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
 				return '';
+			}
+
+			$options = wp_parse_args(
+				$options,
+				array(
+					'sanitize' => true,
+				)
+			);
+
+			if ( ! $options['sanitize'] ) {
+				return static::compile_declarations_unfiltered( $css_declarations, $css_selector );
 			}
 
 			// Return an entire rule if there is a selector.
@@ -719,6 +736,75 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 
 			$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
 			return $css_declarations->get_declarations_string();
+		}
+
+		/**
+		 * Normalizes CSS declarations to an ordered declaration list.
+		 *
+		 * This accepts Style Engine's associative property/value declarations and Theme JSON's
+		 * ordered list of name/value declaration objects. It does not sanitize declarations.
+		 * The function skips declarations whose value is not a plain string (booleans, arrays, objects, etc.).
+		 *
+		 * @param array $declarations CSS declarations.
+		 * @return array Ordered CSS declarations.
+		 */
+		private static function normalize_declarations( $declarations ) {
+			$normalized = array();
+
+			foreach ( $declarations as $property => $value ) {
+				if ( is_array( $value ) && array_key_exists( 'name', $value ) && array_key_exists( 'value', $value ) ) {
+					$property = $value['name'];
+					$value    = $value['value'];
+				}
+
+				if ( ! is_string( $property ) ) {
+					continue;
+				}
+
+				$property = trim( $property );
+				if ( '' === $property ) {
+					continue;
+				}
+
+				if ( is_numeric( $value ) ) {
+					$value = (string) $value;
+				}
+
+				if ( ! is_string( $value ) ) {
+					continue;
+				}
+
+				$normalized[] = array(
+					'property' => $property,
+					'value'    => $value,
+				);
+			}
+
+			return $normalized;
+		}
+
+		/**
+		 * Compiles trusted CSS declarations without sanitizing.
+		 *
+		 * This path is intended for internally generated CSS, such as Theme JSON output.
+		 *
+		 * @param array  $css_declarations CSS declarations.
+		 * @param string $css_selector     Optional. CSS selector.
+		 * @return string A compiled CSS string.
+		 */
+		private static function compile_declarations_unfiltered( $css_declarations, $css_selector = '' ) {
+			$declarations      = static::normalize_declarations( $css_declarations );
+			$declaration_block = '';
+
+			foreach ( $declarations as $declaration ) {
+				$declaration_block .= $declaration['property'] . ': ' . $declaration['value'] . ';';
+			}
+
+			if ( $css_selector ) {
+				return $css_selector . '{' . $declaration_block . '}';
+			}
+
+			return $declaration_block;
 		}
 
 		/**

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -901,4 +901,86 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '.foo{@media (orientation: landscape){background-color:blue;}}.foo{@media (min-width > 1024px){background-color:cotton-blue;}}', $compiled_stylesheet );
 	}
+
+	/**
+	 * Tests that compile_css() keeps its sanitized output by default.
+	 *
+	 * @covers WP_Style_Engine_Gutenberg::compile_css
+	 */
+	public function test_compile_css_sanitizes_declarations_by_default() {
+		$compiled_css = WP_Style_Engine_Gutenberg::compile_css(
+			array(
+				'color'  => 'red',
+				'margin' => '0',
+			),
+			'.test'
+		);
+
+		$this->assertSame( '.test{color:red;margin:0;}', $compiled_css );
+	}
+
+	/**
+	 * Tests that compile_css() can serialize trusted Theme JSON declaration lists.
+	 *
+	 * @covers WP_Style_Engine_Gutenberg::compile_css
+	 */
+	public function test_compile_css_serializes_trusted_theme_json_declarations() {
+		$compiled_css = WP_Style_Engine_Gutenberg::compile_css(
+			array(
+				array(
+					'name'  => 'color',
+					'value' => 'red',
+				),
+				array(
+					'name'  => 'color',
+					'value' => 'blue',
+				),
+				array(
+					'name'  => 'margin',
+					'value' => 0,
+				),
+				array(
+					'name'  => 'opacity',
+					'value' => true,
+				),
+				array(
+					'name'  => 'padding',
+					'value' => false,
+				),
+				array(
+					'name'  => 'gap',
+					'value' => array(),
+				),
+				array(
+					'name' => 'line-height',
+				),
+				array(
+					'name'  => '',
+					'value' => '1',
+				),
+			),
+			'.test',
+			array( 'sanitize' => false )
+		);
+
+		$this->assertSame( '.test{color: red;color: blue;margin: 0;}', $compiled_css );
+	}
+
+	/**
+	 * Tests that trusted compile_css() can serialize inline declarations.
+	 *
+	 * @covers WP_Style_Engine_Gutenberg::compile_css
+	 */
+	public function test_compile_css_serializes_trusted_inline_declarations() {
+		$compiled_css = WP_Style_Engine_Gutenberg::compile_css(
+			array(
+				'color'  => 'red',
+				'margin' => 0,
+			),
+			'',
+			array( 'sanitize' => false )
+		);
+
+		$this->assertSame( 'color: red;margin: 0;', $compiled_css );
+	}
 }


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/issues/65728.


This PR is part of a stack:

- https://github.com/WordPress/gutenberg/pull/79302 (this PR) 
- https://github.com/WordPress/gutenberg/pull/79303
- https://github.com/WordPress/gutenberg/pull/79463

This introduces an internal Style Engine path for serializing trusted, generated Theme JSON declarations without routing them through `safecss_filter_attr()`.

Changes included:

- Adds an optional internal `sanitize` flag to `WP_Style_Engine::compile_css()`.
- Adds ordered declaration normalization for both Style Engine associative declarations and Theme JSON `name`/`value` declaration lists.
- Preserves declaration order and duplicate properties in the trusted path.
- Updates `WP_Theme_JSON_Gutenberg::to_ruleset()` to delegate to the trusted Style Engine path.
- Adds Style Engine tests for default sanitized output and trusted Theme JSON serialization.

## Why?

`WP_Theme_JSON_Gutenberg::to_ruleset()` currently owns CSS string serialization directly. Prior attempts to replace it with Style Engine compilation were premature because the existing Style Engine declaration compiler sanitizes declarations with `safecss_filter_attr()`, while Theme JSON is serializing internally generated CSS.

This PR establishes the first pipeline boundary: Theme JSON can hand trusted generated declarations to Style Engine for serialization without changing existing stylesheet behavior.

It intentionally does not move broader style computation yet.

## Testing Instructions

### Manual testing

1. There should be no regressions basically 😄 
2. Open the frontend and view page source or inspect the document head.
3. Find the `global-styles-inline-css` style tag.
4. Confirm internally generated layout CSS is still present, including rules like:

```css
body .is-layout-flex{display: flex;}
body .is-layout-grid{display: grid;}
```

These rules are a useful manual regression check because they come from Theme JSON/layout style generation and should not be filtered as user-authored CSS.

5. Open the Site Editor.
6. Add or edit content containing a Group block, Buttons block, Heading block, Separator block, and an Image block.
7. In the Styles panel, change several global/block styles, for example:

- site background and text colors;
- Button border radius or border color;
- Heading typography;
- Group padding or background;
- Separator color.

8. Save the styles and view the frontend.
9. Confirm the editor preview and frontend both still reflect the selected Global Styles, with no missing layout styles, preset classes, or block-specific CSS.
10. Inspect the frontend `global-styles-inline-css` again and confirm it still contains variables, preset classes, and block rules generated from Theme JSON.

