### PR TITLE
Style Engine: add trusted CSS rule compilation

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2473,7 +2473,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The new stylesheet.
 	 */
 	protected function get_css_variables( $nodes, $origins ) {
-		$stylesheet = '';
+		$css_rules = array();
 		foreach ( $nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
 				continue;
@@ -2522,11 +2522,17 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			foreach ( $vars_by_selector as $rule_selector => $declarations ) {
-				$stylesheet .= static::to_ruleset( $rule_selector, $declarations );
+				$css_rules[] = array(
+					'selector'     => $rule_selector,
+					'declarations' => $declarations,
+				);
 			}
 		}
 
-		return $stylesheet;
+		return WP_Style_Engine_Gutenberg::compile_css_rules(
+			$css_rules,
+			array( 'sanitize' => false )
+		);
 	}
 
 	/**
@@ -2565,7 +2571,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * creates the corresponding ruleset.
 	 *
 	 * @since 5.8.0
-	 * @since 7.2.0 Route to Style Engine trusted compiler.
+	 * @since 7.2.0 Route to Style Engine trusted rule compiler.
 	 *
 	 * @param string $selector     CSS selector.
 	 * @param array  $declarations List of declarations.
@@ -2576,9 +2582,13 @@ class WP_Theme_JSON_Gutenberg {
 			return '';
 		}
 
-		return WP_Style_Engine_Gutenberg::compile_css(
-			$declarations,
-			$selector,
+		return WP_Style_Engine_Gutenberg::compile_css_rules(
+			array(
+				array(
+					'selector'     => $selector,
+					'declarations' => $declarations,
+				),
+			),
 			array( 'sanitize' => false )
 		);
 	}

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -739,6 +739,60 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		}
 
 		/**
+		 * Compiles an ordered list of CSS rules.
+		 *
+		 * @param array $css_rules An ordered list of CSS rules. Each rule accepts:
+		 *                         - `selector`: CSS selector.
+		 *                         - `declarations`: CSS declarations. Can be an associative property/value array,
+		 *                           or an ordered Theme JSON declaration list with `name` and `value` keys.
+		 *                         - `rules_group`: Optional parent CSS selector or nested @rule.
+		 * @param array $options   {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $sanitize Whether to sanitize the CSS output. Default true.
+		 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default false.
+		 *     @type bool $prettify Whether to add new lines and indents to output. Default depends on `SCRIPT_DEBUG`.
+		 * }
+		 * @return string A compiled CSS stylesheet.
+		 */
+		public static function compile_css_rules( $css_rules, $options = array() ) {
+			if ( empty( $css_rules ) || ! is_array( $css_rules ) ) {
+				return '';
+			}
+
+			$options = wp_parse_args(
+				$options,
+				array(
+					'sanitize' => true,
+				)
+			);
+
+			if ( ! $options['sanitize'] ) {
+				return static::compile_rules_unfiltered( $css_rules );
+			}
+
+			$css_rule_objects = array();
+			foreach ( $css_rules as $css_rule ) {
+				if ( ! static::is_css_rule_shape_valid( $css_rule ) ) {
+					continue;
+				}
+
+				$rules_group        = isset( $css_rule['rules_group'] ) && is_string( $css_rule['rules_group'] ) ? $css_rule['rules_group'] : '';
+				$css_rule_objects[] = new WP_Style_Engine_CSS_Rule(
+					$css_rule['selector'],
+					$css_rule['declarations'],
+					$rules_group
+				);
+			}
+
+			if ( empty( $css_rule_objects ) ) {
+				return '';
+			}
+
+			return static::compile_stylesheet_from_css_rules( $css_rule_objects, $options );
+		}
+
+		/**
 		 * Normalizes CSS declarations to an ordered declaration list.
 		 *
 		 * This accepts Style Engine's associative property/value declarations and Theme JSON's
@@ -790,9 +844,10 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @param array  $css_declarations CSS declarations.
 		 * @param string $css_selector     Optional. CSS selector.
+		 * @param string $rules_group      Optional. A parent CSS selector or nested @rule.
 		 * @return string A compiled CSS string.
 		 */
-		private static function compile_declarations_unfiltered( $css_declarations, $css_selector = '' ) {
+		private static function compile_declarations_unfiltered( $css_declarations, $css_selector = '', $rules_group = '' ) {
 			$declarations      = static::normalize_declarations( $css_declarations );
 			$declaration_block = '';
 
@@ -800,11 +855,66 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 				$declaration_block .= $declaration['property'] . ': ' . $declaration['value'] . ';';
 			}
 
+			if ( empty( $declaration_block ) ) {
+				return '';
+			}
+
 			if ( $css_selector ) {
-				return $css_selector . '{' . $declaration_block . '}';
+				$css_rule = $css_selector . '{' . $declaration_block . '}';
+
+				if ( $rules_group ) {
+					return $rules_group . '{' . $css_rule . '}';
+				}
+
+				return $css_rule;
 			}
 
 			return $declaration_block;
+		}
+
+		/**
+		 * Compiles trusted CSS rules without sanitizing.
+		 *
+		 * This path is intended for internally generated CSS, such as Theme JSON output.
+		 *
+		 * @param array $css_rules CSS rules.
+		 * @return string A compiled CSS stylesheet.
+		 */
+		private static function compile_rules_unfiltered( $css_rules ) {
+			$stylesheet = '';
+
+			foreach ( $css_rules as $css_rule ) {
+				if ( ! static::is_css_rule_shape_valid( $css_rule ) ) {
+					continue;
+				}
+
+				$rules_group = isset( $css_rule['rules_group'] ) && is_string( $css_rule['rules_group'] ) ? $css_rule['rules_group'] : '';
+				$stylesheet .= static::compile_declarations_unfiltered(
+					$css_rule['declarations'],
+					$css_rule['selector'],
+					$rules_group
+				);
+			}
+
+			return $stylesheet;
+		}
+
+		/**
+		 * Returns whether a value has the CSS rule shape required for compilation.
+		 *
+		 * This does not sanitize the selector or declarations.
+		 *
+		 * @param mixed $css_rule CSS rule.
+		 * @return bool Whether the CSS rule can be compiled.
+		 */
+		private static function is_css_rule_shape_valid( $css_rule ) {
+			return (
+				is_array( $css_rule ) &&
+				! empty( $css_rule['selector'] ) &&
+				is_string( $css_rule['selector'] ) &&
+				! empty( $css_rule['declarations'] ) &&
+				is_array( $css_rule['declarations'] )
+			);
 		}
 
 		/**

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -983,4 +983,87 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'color: red;margin: 0;', $compiled_css );
 	}
+
+	/**
+	 * Tests that compile_css_rules() keeps its sanitized output by default.
+	 *
+	 * @covers WP_Style_Engine_Gutenberg::compile_css_rules
+	 */
+	public function test_compile_css_rules_sanitizes_declarations_by_default() {
+		$compiled_css = WP_Style_Engine_Gutenberg::compile_css_rules(
+			array(
+				array(
+					'selector'     => '.test',
+					'declarations' => array(
+						'color'  => 'red',
+						'margin' => '0',
+					),
+				),
+			),
+			array( 'prettify' => false )
+		);
+
+		$this->assertSame( '.test{color:red;margin:0;}', $compiled_css );
+	}
+
+	/**
+	 * Tests that trusted compile_css_rules() preserves Theme JSON rule and declaration order.
+	 *
+	 * @covers WP_Style_Engine_Gutenberg::compile_css_rules
+	 */
+	public function test_compile_css_rules_serializes_trusted_theme_json_rules() {
+		$compiled_css = WP_Style_Engine_Gutenberg::compile_css_rules(
+			array(
+				array(
+					'selector'     => '.first',
+					'declarations' => array(
+						array(
+							'name'  => 'color',
+							'value' => 'red',
+						),
+						array(
+							'name'  => 'color',
+							'value' => 'blue',
+						),
+						array(
+							'name'  => 'margin',
+							'value' => 0,
+						),
+						array(
+							'name'  => 'padding',
+							'value' => false,
+						),
+					),
+				),
+				array(
+					'selector'     => '.second',
+					'declarations' => array(
+						'display' => 'flex',
+					),
+				),
+				array(
+					'selector'     => '.empty',
+					'declarations' => array(
+						array(
+							'name'  => 'gap',
+							'value' => array(),
+						),
+					),
+				),
+				array(
+					'selector'     => '.third',
+					'rules_group'  => '@media (min-width: 600px)',
+					'declarations' => array(
+						array(
+							'name'  => 'display',
+							'value' => 'grid',
+						),
+					),
+				),
+			),
+			array( 'sanitize' => false )
+		);
+
+		$this->assertSame( '.first{color: red;color: blue;margin: 0;}.second{display: flex;}@media (min-width: 600px){.third{display: grid;}}', $compiled_css );
+	}
 }


### PR DESCRIPTION
This PR is part of a stack:

- https://github.com/WordPress/gutenberg/pull/79302 
- https://github.com/WordPress/gutenberg/pull/79303 (this PR) 
- https://github.com/WordPress/gutenberg/pull/79463

## What?

This is a larger POC stacked on #79302. It takes the next step in moving Theme JSON style output toward a clearer pipeline by adding trusted rule-list compilation to the Style Engine and migrating one narrow Theme JSON producer to use it.

The PR adds `WP_Style_Engine::compile_css_rules()` for ordered CSS rule arrays, preserving Theme JSON declaration order when `sanitize` is false. It also updates `WP_Theme_JSON_Gutenberg::to_ruleset()` to use the rule compiler and changes `get_css_variables()` to collect rule arrays before asking the Style Engine to compile the stylesheet.

## Why?

The previous PR moves trusted declaration serialization into the Style Engine, but Theme JSON still mostly owns stylesheet assembly. This PR demonstrates the intended architecture more clearly:

```text
Theme JSON data
  -> Theme JSON computes declarations
  -> Theme JSON emits ordered CSS rules
  -> Style Engine compiles the stylesheet
```

CSS variables are a good first end-to-end slice because that code already groups declarations by selector and has less coupling to layout, duotone, custom CSS, and block style computation.

## Before / After

Before:

```text
Theme JSON computes declarations
Theme JSON groups by selector
Theme JSON concatenates CSS strings
```

After:

```text
Theme JSON computes declarations
Theme JSON groups into rule arrays
Style Engine compiles the stylesheet
```

This is still only the first step. The goal is not to add more helper methods to `WP_Theme_JSON_Gutenberg`; the goal is to move style generation responsibilities out of that class. This PR establishes the Style Engine side of the boundary so follow-ups can extract Theme JSON rule collection into smaller collaborators.

## Where this goes next

Follow-up PRs should continue reducing `WP_Theme_JSON_Gutenberg` by moving producers out of the class, rather than only making methods inside it cleaner:

1. Extract CSS variable rule collection.
   - Move the Theme JSON-specific variable rule building out of `WP_Theme_JSON_Gutenberg`.
   - Keep `WP_Theme_JSON_Gutenberg::get_css_variables()` as a thin compatibility wrapper, or remove it when call sites can use the collaborator directly.

2. Extract preset-class rule collection.
   - Preset classes already have a selector/declaration shape and should be a good next producer after variables.

3. Extract block-class rule collection.
   - Move the code that turns style nodes into selector/declaration rules behind a smaller style-generation collaborator.

4. Leave layout, custom CSS, duotone, and style variations until later.
   - Those paths have more behavioral edge cases and should move after the rule pipeline has test coverage.

5. Extract style computation.
   - Once multiple producers emit rule arrays, start moving pieces of `compute_style_properties()` behind focused collaborators.

## Future consideration: block-specific style generators

Theme JSON currently contains a number of block-specific style hacks. Longer term, those should not keep accumulating inside `WP_Theme_JSON_Gutenberg`.

One possible direction is a style-generation registry where block supports, blocks, or filters can register custom processors. Those processors would receive structured context such as the block name, style node, settings, selector data, and stylesheet options, then return ordered declarations or CSS rules.

The important constraint is that callbacks should return structured data, not raw CSS strings:

```text
Block/style context
  -> registered style processor
  -> ordered declarations or CSS rules
  -> Style Engine compiles the stylesheet
```

That would let core move block-specific exceptions out of Theme JSON while still preserving ordering, selector handling, and the trusted/sanitized compilation boundary. This should probably come after the rule-list pipeline is established, otherwise callbacks risk becoming another string-generation escape hatch.

## Larger POC / Logical Split

This draft intentionally includes more than the smallest possible follow-up so the architecture is visible in code. If we want to split it for review, the logical sequence would be:

1. Add Style Engine rule-list compilation only.
   - Introduce `compile_css_rules()`.
   - Support associative declarations and Theme JSON ordered `{ name, value }` declaration lists.
   - Preserve rule order and declaration order in trusted mode.

2. Route `WP_Theme_JSON_Gutenberg::to_ruleset()` through the rule compiler.
   - Keep `to_ruleset()` as a compatibility wrapper.
   - Avoid changing individual Theme JSON style producers yet.

3. Migrate CSS variable generation.
   - Change `get_css_variables()` from string concatenation to rule-list collection.
   - Compile the final rule list through the Style Engine.

4. Follow up with additional low-risk producers.
   - Preset classes.
   - Block class rules that already have selector/declaration boundaries.
   - Layout and custom CSS should come later because they have more behavioral edge cases.

5. Only then start extracting style computation.
   - Once the output pipeline is stable, move pieces of `compute_style_properties()` and related style-node logic behind smaller, testable collaborators.

## Manual Testing

1. Start the local environment:

   ```bash
   npm run wp-env start -- --auto-port
   ```

2. Open the frontend and inspect the generated global styles.

3. Confirm the custom-property stylesheet still contains root and block variables, for example `--wp--preset--color--*`, `--wp--preset--font-size--*`, and block-scoped custom properties.

4. In the Site Editor, change a global style preset usage such as color, typography, or spacing, save it, and reload the frontend.

5. Confirm the frontend still receives the expected global styles and that block rendering has not lost preset variables.

## Testing

```bash
php -l packages/style-engine/src/class-wp-style-engine.php
php -l lib/class-wp-theme-json-gutenberg.php
php -l phpunit/style-engine/style-engine-test.php
vendor/bin/phpcbf packages/style-engine/src/class-wp-style-engine.php lib/class-wp-theme-json-gutenberg.php phpunit/style-engine/style-engine-test.php
vendor/bin/phpcs packages/style-engine/src/class-wp-style-engine.php lib/class-wp-theme-json-gutenberg.php phpunit/style-engine/style-engine-test.php
npm run test:unit:php:base -- --filter WP_Style_Engine_Test
npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test
```
