### PR TITLE
Site Editor: Handle `aria-current` natively in `SidebarNavigationItem`

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -6,11 +6,8 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalItem as Item,
-	__experimentalHStack as HStack,
-	FlexBlock,
-} from '@wordpress/components';
+import { __experimentalItem as Item, FlexBlock } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { isRTL } from '@wordpress/i18n';
 import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -22,7 +19,7 @@ import { useContext } from '@wordpress/element';
 import { unlock } from '../../lock-unlock';
 import { SidebarNavigationContext } from '../sidebar';
 
-const { useHistory, useLink } = unlock( routerPrivateApis );
+const { useHistory, useLink, useLocation } = unlock( routerPrivateApis );
 
 export default function SidebarNavigationItem( {
 	className,
@@ -32,11 +29,16 @@ export default function SidebarNavigationItem( {
 	uid,
 	to,
 	onClick,
+	activeOnRouteName,
 	children,
 	...props
 } ) {
 	const history = useHistory();
+	const linkProps = useLink( to );
+	const { name } = useLocation();
 	const { navigate } = useContext( SidebarNavigationContext );
+
+	const isActive = activeOnRouteName && name === activeOnRouteName;
 	// If there is no custom click handler, create one that navigates to `params`.
 	function handleClick( e ) {
 		if ( onClick ) {
@@ -48,7 +50,6 @@ export default function SidebarNavigationItem( {
 			navigate( 'forward', `[id="${ uid }"]` );
 		}
 	}
-	const linkProps = useLink( to );
 
 	return (
 		<Item
@@ -60,9 +61,10 @@ export default function SidebarNavigationItem( {
 			id={ uid }
 			onClick={ handleClick }
 			href={ to ? linkProps.href : undefined }
+			aria-current={ isActive ? true : undefined }
 			{ ...props }
 		>
-			<HStack justify="flex-start">
+			<Stack direction="row" align="center" justify="start" gap="sm">
 				{ icon && (
 					<Icon
 						style={ { fill: 'currentcolor' } }
@@ -79,7 +81,7 @@ export default function SidebarNavigationItem( {
 					/>
 				) }
 				{ ! withChevron && suffix }
-			</HStack>
+			</Stack>
 		</Item>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -8,6 +8,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs } from '@wordpress/url';
+import { useGlobalStylesRevisions } from '@wordpress/global-styles-ui';
 
 /**
  * Internal dependencies
@@ -15,22 +16,10 @@ import { addQueryArgs } from '@wordpress/url';
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import { unlock } from '../../lock-unlock';
 import { store as editSiteStore } from '../../store';
-import SidebarNavigationItem from '../sidebar-navigation-item';
-import { useGlobalStylesRevisions } from '@wordpress/global-styles-ui';
 import SidebarNavigationScreenDetailsFooter from '../sidebar-navigation-screen-details-footer';
 import { MainSidebarNavigationContent } from '../sidebar-navigation-screen-main';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
-
-export function SidebarNavigationItemGlobalStyles( props ) {
-	const { name } = useLocation();
-	return (
-		<SidebarNavigationItem
-			{ ...props }
-			aria-current={ name === 'styles' }
-		/>
-	);
-}
 
 export default function SidebarNavigationScreenGlobalStyles() {
 	const history = useHistory();

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -62,9 +62,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 				description={ __(
 					'Customize the appearance of your website using the block editor.'
 				) }
-				content={
-					<MainSidebarNavigationContent activeItem="styles-navigation-item" />
-				}
+				content={ <MainSidebarNavigationContent /> }
 				footer={
 					shouldShowGlobalStylesFooter && (
 						<SidebarNavigationScreenDetailsFooter

--- a/packages/edit-site/src/components/sidebar-navigation-screen-identity/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-identity/index.js
@@ -2,27 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
-import { unlock } from '../../lock-unlock';
-import SidebarNavigationItem from '../sidebar-navigation-item';
 import { MainSidebarNavigationContent } from '../sidebar-navigation-screen-main';
-
-const { useLocation } = unlock( routerPrivateApis );
-
-export function SidebarNavigationItemIdentity( props ) {
-	const { name } = useLocation();
-	return (
-		<SidebarNavigationItem
-			{ ...props }
-			aria-current={ name === 'identity' }
-		/>
-	);
-}
 
 export default function SidebarNavigationScreenIdentity() {
 	return (

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -19,28 +19,28 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationItem from '../sidebar-navigation-item';
-import { SidebarNavigationItemGlobalStyles } from '../sidebar-navigation-screen-global-styles';
-import { SidebarNavigationItemIdentity } from '../sidebar-navigation-screen-identity';
 
 export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
 			{ isBlockBasedTheme && (
 				<>
-					<SidebarNavigationItemIdentity
+					<SidebarNavigationItem
 						to="/identity"
 						uid="identity-navigation-item"
 						icon={ siteLogo }
+						activeOnRouteName="identity"
 					>
 						{ _x( 'Identity', 'site identity' ) }
-					</SidebarNavigationItemIdentity>
-					<SidebarNavigationItemGlobalStyles
+					</SidebarNavigationItem>
+					<SidebarNavigationItem
 						to="/styles"
 						uid="global-styles-navigation-item"
 						icon={ styles }
+						activeOnRouteName="styles"
 					>
 						{ __( 'Styles' ) }
-					</SidebarNavigationItemGlobalStyles>
+					</SidebarNavigationItem>
 					<SidebarNavigationItem
 						uid="page-navigation-item"
 						to="/page"

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -900,11 +900,6 @@
 			"count": 1
 		}
 	},
-	"packages/edit-site/src/components/sidebar-navigation-item/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/edit-site/src/components/sidebar-navigation-screen-global-styles/content.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
`SidebarNavigationItem` previously couldn't mark itself as the active route, so two thin wrapper components (`SidebarNavigationItemGlobalStyles`, `SidebarNavigationItemIdentity`) existed solely to read `useLocation()` and pass down `aria-current`.

This adds an optional `activeOnRouteName` prop to `SidebarNavigationItem`. When set, the item compares it against the current route `name` from `useLocation()` and sets `aria-current` itself. Both wrapper components are removed; the two root items in the main sidebar now pass `activeOnRouteName="styles"` / `"identity"` directly.

- Removes two abstraction components
- Centralizes active-state handling in `SidebarNavigationItem`

**Alternative considered:** auto-derive active state from the existing `to` prop by matching against `location.path` (no extra prop at all). Requires parsing the path for matching - `path.split('?')[0]`.

## Testing Instructions
1. Open the Site Editor.
2. Confirm that sidebar navigation items render as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="300" height="563" alt="CleanShot 2026-06-18 at 10 58 41" src="https://github.com/user-attachments/assets/3b4034a7-3dc5-47fe-b148-10b179564a51" />

## Use of AI Tools

Assisted by Claude.
