### PR TITLE
Remove ObliviousHarmony from CODEOWNERS for packages/env

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,7 +126,7 @@
 /packages/report-flaky-tests                    @kevin940726
 
 # wp-env
-/packages/env                                   @ObliviousHarmony @t-hamano
+/packages/env                                   @t-hamano
 
 # PHP
 /lib                                            @spacedmonkey


### PR DESCRIPTION
This change was proposed by @ObliviousHarmony himself and has his approval. I would like to express our sincere gratitude once again for his significant contributions thus far 🎉