### PR TITLE
DataForm: Align `label-side` gap of `panel` layout with `regular` layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
 - DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those overrides are no longer needed. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
+- DataForm panel layout: align `label-side` gap with the regular layout by using `--wpds-dimension-gap-sm` (8px). [#](https://github.com/WordPress/gutenberg/pull/)
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).
 - DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those overrides are no longer needed. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
-- DataForm panel layout: align `label-side` gap with the regular layout by using `--wpds-dimension-gap-sm` (8px). [#](https://github.com/WordPress/gutenberg/pull/)
+- DataForm panel layout: align `label-side` gap with the regular layout by using `--wpds-dimension-gap-sm` (8px). [#79311](https://github.com/WordPress/gutenberg/pull/79311)
 
 ### Internal
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -14,7 +14,7 @@
 
 	&--label-side {
 		flex-direction: row;
-		gap: var(--wpds-dimension-gap-md);
+		gap: var(--wpds-dimension-gap-sm);
 	}
 
 	&--label-top {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from: https://github.com/WordPress/gutenberg/pull/76934

At the above linked PR some added fields surfaced that the existing gap in `label-side` in `panel` DataForm layout could make them wrap quite easily.

This PR updates the gap to be `sm`, which also matches the gap we use for `label-side` in `regular` layout.

Some design [feedback](https://github.com/WordPress/gutenberg/pull/76934#issuecomment-4206346233) was provided by @jameskoster that it seems fine.

In genera the reduction of the `gap` is small and isn't noticeable easily, unless you had some fields with big labels.

## Testing Instructions
1. You can test in `quick edit` form in site editor for pages
2. Alternatively enable the `Editor Inspector: Use DataForm` experiment and check the summary panel for posts or pages
3. You can also check in storybook (`npm run storybook:dev`) probably with a smaller viewport



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|



|-|-|
|<img width="282" height="367" alt="Screenshot 2026-06-18 at 1 52 09 PM" src="https://github.com/user-attachments/assets/c923236e-7aa0-465f-b798-20293dfbb583" />|<img width="282" height="367" alt="Screenshot 2026-06-18 at 1 53 32 PM" src="https://github.com/user-attachments/assets/455180c5-ba9f-4393-86ad-dab109d7f02c" />|
