### PR TITLE
Improve accessibility and consistency of the Dashboard widget headers.

### DIFF
--- a/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.module.css
+++ b/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.module.css
@@ -53,10 +53,8 @@
 
 /*
  * Bleed block edges: zero the content's block padding so the body fills the
- * card top to bottom. The top is ours to flush (a full-bleed widget hides its
- * header in a position:absolute VisuallyHidden node that stays the card's
- * :first-child and blocks Card.FullBleed's top-flush rule). The bottom pairs
- * with the `margin-block-end: 0` on the bleed scroll wrapper below.
+ * card top to bottom. The top is ours to flush. The bottom pairs with the
+ * `margin-block-end: 0` on the bleed scroll wrapper below.
  */
 .widgetChromeContentBleed {
 	padding-block: 0;

--- a/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.tsx
+++ b/routes/dashboard/widget-dashboard/components/dashboard-widget-chrome/dashboard-widget-chrome.tsx
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plugins } from '@wordpress/icons';
-import { Card, Icon, Stack, Notice, Text, VisuallyHidden } from '@wordpress/ui';
+import { Card, Icon, Stack, Notice, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -199,11 +199,9 @@ export const DashboardWidgetChrome = forwardRef<
 		);
 	}
 
-	// `presentation` encodes two independent axes. `full-bleed` hides
-	// the header; both `full-bleed` and `content-bleed` let the body
-	// break out of the content padding.
+	// `presentation` encodes two independent axes. both `full-bleed` and
+	// `content-bleed` let the body break out of the content padding.
 	const { presentation } = widgetType;
-	const isHeaderHidden = presentation === 'full-bleed';
 	const isBodyBleeding =
 		presentation === 'full-bleed' || presentation === 'content-bleed';
 	const header = <Header titleId={ titleId } widgetType={ widgetType } />;
@@ -228,12 +226,7 @@ export const DashboardWidgetChrome = forwardRef<
 				aria-labelledby={ widgetType.title ? titleId : undefined }
 				inert={ editMode ? 'true' : undefined }
 			>
-				{ isHeaderHidden ? (
-					<VisuallyHidden>{ header }</VisuallyHidden>
-				) : (
-					header
-				) }
-
+				{ header }
 				<Card.Content
 					className={ clsx(
 						styles.widgetChromeContent,

--- a/routes/dashboard/widget-primitives/types.ts
+++ b/routes/dashboard/widget-primitives/types.ts
@@ -73,10 +73,9 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	 *
 	 * - `'framed'` (default when absent): the widget renders its
 	 *   content only.
-	 * - `'content-bleed'`: the header stays visible while the content
-	 *   fills the content area edge-to-edge, with no padding.
-	 * - `'full-bleed'`: the widget renders edge-to-edge with no
-	 *   surrounding chrome.
+	 * - `'content-bleed'`: the content fills the content area edge-to-edge,
+	 *   with no padding.
+	 * - `'full-bleed'`: the widget renders edge-to-edge.
 	 */
 	presentation?: 'framed' | 'content-bleed' | 'full-bleed';
 

--- a/widgets/activity/widget.ts
+++ b/widgets/activity/widget.ts
@@ -1,8 +1,10 @@
 import { __ } from '@wordpress/i18n';
+import { trendingUp } from '@wordpress/icons';
 
 export default {
 	name: 'core/activity',
 	title: __( 'Activity' ),
+	icon: trendingUp,
 	attributes: [
 		{
 			id: 'perPage',

--- a/widgets/news/widget.ts
+++ b/widgets/news/widget.ts
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
 
 export default {
 	name: 'core/news',
 	title: __( 'WordPress news' ),
+	icon: globe,
 };

--- a/widgets/site-preview/widget.json
+++ b/widgets/site-preview/widget.json
@@ -2,6 +2,5 @@
 	"name": "core/site-preview",
 	"title": "Site preview",
 	"description": "Shows preview of the site homepage.",
-	"category": "dashboard",
-	"presentation": "full-bleed"
+	"category": "dashboard"
 }

--- a/widgets/welcome/widget.ts
+++ b/widgets/welcome/widget.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
 
 const widget = {
 	apiVersion: 1,
@@ -10,7 +11,7 @@ const widget = {
 	description: __(
 		'Displays a welcome panel to introduce users to WordPress.'
 	),
-	icon: 'wordpress',
+	icon: wordpress,
 	category: 'dashboard',
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/79313

<!-- In a few words, what is the PR actually doing? -->

- Makes Dashboard widget headers always visible.
- Adds icons to the widgets that miss it:
  - Activity widget: `trendingUp` icon
  - WordPress news widget: `globe` icon 
  - Welcome widget: `wordpress` icon

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Visible headings help all users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/79313
- Observe all the widgets show a visible header with an icon and a heading.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1560" height="5516" alt="before" src="https://github.com/user-attachments/assets/ed3a9d86-dde1-4d90-9f0e-3159a92090bb" />|<img width="1560" height="5516" alt="after" src="https://github.com/user-attachments/assets/e56d863b-4798-4ee5-97f5-2d2db6e11292" />|


## Use of AI Tools
None
