### PR TITLE
Plugins API: Fix the plugin 'render' property validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14408,6 +14408,16 @@
 				"@types/react": "^18.0.0"
 			}
 		},
+		"node_modules/@types/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/react": "^18"
+			}
+		},
 		"node_modules/@types/requestidlecallback": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.4.tgz",
@@ -51977,7 +51987,8 @@
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"@types/react-is": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51972,7 +51972,8 @@
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-				"memize": "^2.1.0"
+				"memize": "^2.1.0",
+				"react-is": "^18.3.0"
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
@@ -52051,11 +52052,17 @@
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
-		"packages/plugins/node_modules/react-is": {
+		"packages/plugins/node_modules/pretty-format/node_modules/react-is": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"packages/plugins/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"license": "MIT"
 		},
 		"packages/postcss-plugins-preset": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -54,7 +54,8 @@
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"@types/react-is": "^18.3.1"
 	},
 	"peerDependencies": {
 		"@types/react": "^18.3.27",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,7 +49,8 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"memize": "^2.1.0"
+		"memize": "^2.1.0",
+		"react-is": "^18.3.0"
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",

--- a/packages/plugins/src/api/index.ts
+++ b/packages/plugins/src/api/index.ts
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import type { ComponentType } from 'react';
-
+import { isValidElementType } from 'react-is';
 /**
  * WordPress dependencies
  */
@@ -153,9 +153,9 @@ export function registerPlugin(
 
 	const { render, scope } = settings;
 
-	if ( typeof render !== 'function' ) {
+	if ( ! isValidElementType( render ) ) {
 		console.error(
-			'The "render" property must be specified and must be a valid function.'
+			'The "render" property must be specified and must be a valid component.'
 		);
 		return null;
 	}

--- a/packages/plugins/src/api/index.ts
+++ b/packages/plugins/src/api/index.ts
@@ -4,6 +4,7 @@
  */
 import type { ComponentType } from 'react';
 import { isValidElementType } from 'react-is';
+
 /**
  * WordPress dependencies
  */

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { memo } from '@wordpress/element';
 import { registerPlugin, unregisterPlugin, getPlugin, getPlugins } from '../';
 
 describe( 'registerPlugin', () => {
@@ -23,6 +24,24 @@ describe( 'registerPlugin', () => {
 		expect( getPlugin( name ) ).toEqual( {
 			name,
 			render: Component,
+			icon,
+		} );
+	} );
+
+	it( 'successfully registers a plugin with a memoized render', () => {
+		const name = 'plugin';
+		const icon = 'smiley';
+		const Component = () => 'plugin content';
+		const MemoizedComponent = memo( Component );
+
+		registerPlugin( name, {
+			render: MemoizedComponent,
+			icon,
+		} );
+
+		expect( getPlugin( name ) ).toEqual( {
+			name,
+			render: MemoizedComponent,
 			icon,
 		} );
 	} );

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -54,7 +54,7 @@ describe( 'registerPlugin', () => {
 	it( 'fails to register a plugin without a render function', () => {
 		registerPlugin( 'another-plugin', {} );
 		expect( console ).toHaveErroredWith(
-			'The "render" property must be specified and must be a valid function.'
+			'The "render" property must be specified and must be a valid component.'
 		);
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

PR fixes the plugin's render property validation which is failing for memoized components.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#78674  updated `withSelect` to return a memoized component. Plugins using `withSelect` in the render property now fail the `typeof === 'function'` validation.

We've previously made [similar changes](https://github.com/WordPress/gutenberg/pull/57193) for the blocks API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the [isValidElementType](https://github.com/facebook/react/blob/main/packages/shared/isValidElementType.js#L38) from the official [react-is](https://www.npmjs.com/package/react-is) library to check the edit property's validity correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add memo (or use `withSelect`) to a plugin's render property.
2. Open the post editor.
3. Confirm you see the `'The "render" property must be specified and must be a valid function.'` on trunk.
4. Confirm there's no error on this branch.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
