### PR TITLE
Inserter: Add a visible focus indicator to the scrollable tab panel

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   List View: a block that supports `listView` is now excluded from the List View when it has no inner blocks and disallows insertion (`allowedBlocks` is `[]` or `false`), since there is nothing to show, rearrange, or add. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
 
+### Bug Fixes
+
+-   Tabbed Sidebar: Add a visible focus indicator to the scrollable tab panel so the keyboard focus that some browsers place on it (e.g. the block inserter in Firefox) is no longer invisible ([#47013](https://github.com/WordPress/gutenberg/issues/47013)).
+
 ## 15.21.1 (2026-06-16)
 
 ## 15.21.0 (2026-06-10)

--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -35,4 +35,26 @@
 	flex-direction: column;
 	overflow-y: auto;
 	scrollbar-gutter: auto;
+
+	// Some browsers (notably Firefox) make scrollable containers keyboard
+	// focusable so the panel can be scrolled with the arrow keys. That adds a
+	// tab stop on the panel itself, which is otherwise invisible to sighted
+	// keyboard users because the `Tabs` component only shows a focus ring via
+	// its Ariakit-managed `[data-focus-visible]` state (unset here, as the
+	// panel is rendered with `focusable={ false }`) while still resetting
+	// `:focus { outline: none }`. Provide a visible focus indicator for it.
+	//
+	// Notes:
+	// - Scoped to the parent so it out-specifies the `Tabs` `:focus` reset,
+	//   which Emotion injects later at equal specificity.
+	// - Longhands are used because Firefox drops the `outline` shorthand when
+	//   its value is built from `var()` custom properties.
+	// - The outline is inset because the parent container is `overflow: hidden`.
+	// See https://github.com/WordPress/gutenberg/issues/47013.
+	.block-editor-tabbed-sidebar &:focus-visible {
+		outline-width: var(--wp-admin-border-width-focus);
+		outline-style: solid;
+		outline-color: var(--wp-admin-theme-color);
+		outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+	}
 }


### PR DESCRIPTION
## What?

Adds a visible `:focus-visible` outline to the block inserter's scrollable tab panel (`TabbedSidebar`), so the keyboard tab stop that some browsers place on it is no longer invisible.

Fixes #47013.

## Why?

Some browsers (notably **Firefox**; also Chrome under certain conditions) make scrollable containers keyboard‑focusable so the panel can be scrolled with the arrow keys. In the inserter this adds a sequential tab stop on the scroll panel itself — between the tab list and the search field — with **no visible focus indicator**, which is confusing for sighted keyboard users (see the accessibility feedback in the issue thread).

The panel already has an accessible name (`aria-labelledby` the active tab), so the remaining gap is purely the missing visible affordance.

## How?

A `:focus-visible` outline is added to `.block-editor-tabbed-sidebar__tabpanel`. Three details were necessary to make it actually render:

- **Scoped to the parent** (`.block-editor-tabbed-sidebar …`) so it out‑specifies the `Tabs` component's own `:focus { outline: none }` reset. That component only renders a focus ring via its Ariakit‑managed `[data-focus-visible]` state, which is never set here because the panel is rendered with `focusable={ false }` — yet the `outline: none` reset still applies. At equal specificity Emotion injects that rule later, so it would otherwise win.
- **Longhand `outline-*` properties** instead of the shorthand, because Firefox drops the `outline` shorthand when its value is built from `var()` custom properties.
- **Inset outline** (negative `outline-offset`), because the parent container is `overflow: hidden` and an outset ring would be clipped.

Only the `TabbedSidebar` consumer is affected; other `Tabs` usages are untouched.

## Testing Instructions

1. Open the post editor in **Firefox**.
2. Open the block inserter and move focus to the "Blocks" tab.
3. Press <kbd>Tab</kbd>. Focus lands on the scrollable panel — it now shows a visible inset focus outline (it was previously invisible).
4. Press <kbd>Tab</kbd> again to continue into the search field / block list.

In Chromium the panel does not receive this tab stop, so behavior there is unchanged.

## Screenshots

Focus ring on the scrollable panel (Firefox):

<!-- The blue inset outline frames the scrollable block list area when it receives keyboard focus. -->
Before fix
<img width="350" height="800" alt="gutenberg-47013-before" src="https://github.com/user-attachments/assets/ab091b95-d928-42da-9373-b9ac5452f707" />
After fix
<img width="350" height="800" alt="gutenberg-47013-after" src="https://github.com/user-attachments/assets/10c6597f-9707-49e6-8d80-f6df7272bf3e" />
