### PR TITLE
DataViews: Make grid and table item preview aspect ratio configurable

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,10 +11,7 @@
 -   DataViews: Generalize the ordering filter operators (`on`, `notOn`, `before`, `after`, `beforeInc`, `afterInc`, `between`) from dates to temporal values, so they also compare times of day. Comparisons for `date` and `datetime` are unchanged. [#80830](https://github.com/WordPress/gutenberg/pull/80830)
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
-
-### Enhancements
-
-- DataViews: Add an `aspectRatio` layout option to the `grid` and `table` layouts so consumers can configure the aspect ratio of item media previews from a set of preset ratios, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
+-   DataViews: Add an `aspectRatio` layout option to the `grid` and `table` layouts so consumers can configure the aspect ratio of item media previews from a set of preset ratios, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
 
 ### Bug Fix
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Enhancements
 
-- DataViews: Add an `aspectRatio` layout option to the `grid` and `table` layouts so consumers can configure the aspect ratio of item media previews, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
+- DataViews: Add an `aspectRatio` layout option to the `grid` and `table` layouts so consumers can configure the aspect ratio of item media previews from a set of preset ratios, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
 
 ### Bug Fix
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 
+### Enhancements
+
+- DataViews Grid: Add an `aspectRatio` layout option so consumers can configure the aspect ratio of grid item previews, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
+
 ### Bug Fix
 
 -   DataViews: Render the filter chip for an incomplete `between` range as if no value were set — matching how the filter itself does not apply — instead of showing a dangling bound or the literal string "undefined". A `null` bound, produced when an unfilled bound round-trips through JSON persistence, is now treated as unfilled too. [#80830](https://github.com/WordPress/gutenberg/pull/80830)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Enhancements
 
-- DataViews Grid: Add an `aspectRatio` layout option so consumers can configure the aspect ratio of grid item previews, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
+- DataViews: Add an `aspectRatio` layout option to the `grid` and `table` layouts so consumers can configure the aspect ratio of item media previews, instead of the hard-coded square. Defaults to `1/1`, so existing consumers are unaffected. [#79329](https://github.com/WordPress/gutenberg/pull/79329)
 
 ### Bug Fix
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -257,13 +257,14 @@ Properties:
 | `styles`       | ✓       | ✓             |        |              |        |            |
 | `badgeFields`  |         |               | ✓      | ✓            |        |            |
 | `previewSize`  |         |               | ✓      | ✓            |        |            |
-| `aspectRatio`  |         |               | ✓      |              |        |            |
+| `aspectRatio`  | ✓       |               | ✓      |              |        |            |
 
 `table` and `pickerTable` layouts:
 
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
 -   `enableMoving`: whether the table columns should display moving controls.
 -   `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column. The `align` property accepts `'start'`, `'center'`, or `'end'`.
+-   `aspectRatio` (`table` only): a fixed CSS [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) value (e.g. `'1/1'`, `'16/9'`, `'4/3'`) applied to the primary column's media preview. Defaults to `'1/1'`.
 
 **For column alignment (`align` property), follow these guidelines:**
 Right-align (`'end'`) whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment (`'start'`) for all other types (text, codes, labels, dates).

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -257,6 +257,7 @@ Properties:
 | `styles`       | ✓       | ✓             |        |              |        |            |
 | `badgeFields`  |         |               | ✓      | ✓            |        |            |
 | `previewSize`  |         |               | ✓      | ✓            |        |            |
+| `aspectRatio`  |         |               | ✓      |              |        |            |
 
 `table` and `pickerTable` layouts:
 
@@ -272,6 +273,7 @@ Right-align (`'end'`) whenever the cell value is fundamentally quantitative—nu
 -   `badgeFields`: a list of field's `id` to render without label and styled as badges.
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the gap between items in the grid.
 -   `previewSize`: a `number` representing the size of the preview.
+-   `aspectRatio` (`grid` only): a fixed CSS [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) value (e.g. `'1/1'`, `'16/9'`, `'4/3'`) applied uniformly to every item preview, keeping rows aligned. Defaults to `'1/1'`.
 
 `list` layout:
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -264,7 +264,7 @@ Properties:
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the size and spacing of the layout.
 -   `enableMoving`: whether the table columns should display moving controls.
 -   `styles`: additional `width`, `maxWidth`, `minWidth`, `align` styles for each field column. The `align` property accepts `'start'`, `'center'`, or `'end'`.
--   `aspectRatio` (`table` only): a fixed CSS [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) value (e.g. `'1/1'`, `'16/9'`, `'4/3'`) applied to the primary column's media preview. Defaults to `'1/1'`.
+-   `aspectRatio` (`table` only): one of the preset ratios `'1/1'`, `'4/3'`, `'3/4'`, `'3/2'`, `'2/3'`, `'16/9'`, or `'9/16'`, applied to the primary column's media preview. Defaults to `'1/1'`.
 
 **For column alignment (`align` property), follow these guidelines:**
 Right-align (`'end'`) whenever the cell value is fundamentally quantitative—numbers, decimals, currency, percentages—so that digits and decimal points line up, aiding comparison and calculation. Otherwise, default to left-alignment (`'start'`) for all other types (text, codes, labels, dates).
@@ -274,7 +274,7 @@ Right-align (`'end'`) whenever the cell value is fundamentally quantitative—nu
 -   `badgeFields`: a list of field's `id` to render without label and styled as badges.
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the gap between items in the grid.
 -   `previewSize`: a `number` representing the size of the preview.
--   `aspectRatio` (`grid` only): a fixed CSS [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) value (e.g. `'1/1'`, `'16/9'`, `'4/3'`) applied uniformly to every item preview, keeping rows aligned. Defaults to `'1/1'`.
+-   `aspectRatio` (`grid` only): one of the preset ratios `'1/1'`, `'4/3'`, `'3/4'`, `'3/2'`, `'2/3'`, `'16/9'`, or `'9/16'`, applied uniformly to every item preview, keeping rows aligned. Defaults to `'1/1'`.
 
 `list` layout:
 

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -374,7 +374,7 @@ export default function CompositeGrid< Item >( {
 	// to the default square `1/1` when unset).
 	const gridStyle: CSSProperties | undefined = view.layout?.aspectRatio
 		? ( {
-				'--dataviews-grid-media-aspect-ratio': view.layout.aspectRatio,
+				'--dataviews-media-aspect-ratio': view.layout.aspectRatio,
 		  } as CSSProperties )
 		: undefined;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { ComponentProps, ReactElement, HTMLAttributes } from 'react';
+import type {
+	ComponentProps,
+	ReactElement,
+	HTMLAttributes,
+	CSSProperties,
+} from 'react';
 
 /**
  * WordPress dependencies
@@ -364,6 +369,14 @@ export default function CompositeGrid< Item >( {
 	const { paginationInfo, resizeObserverRef } =
 		useContext( DataViewsContext );
 	const gridColumns = useGridColumns();
+	// Optional consumer-configured aspect ratio for item previews, surfaced to
+	// CSS as a custom property the media field's stylesheet reads (falling back
+	// to the default square `1/1` when unset).
+	const gridStyle: CSSProperties | undefined = view.layout?.aspectRatio
+		? ( {
+				'--dataviews-grid-media-aspect-ratio': view.layout.aspectRatio,
+		  } as CSSProperties )
+		: undefined;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
@@ -432,6 +445,7 @@ export default function CompositeGrid< Item >( {
 									}
 								) }
 								previewSize={ view.layout?.previewSize }
+								style={ gridStyle }
 								aria-busy={ isLoading }
 								ref={ resizeObserverRef }
 							/>
@@ -523,6 +537,7 @@ export default function CompositeGrid< Item >( {
 				! isInfiniteScroll && (
 					<Composite
 						role="grid"
+						style={ gridStyle }
 						className={ clsx( 'dataviews-view-grid', className, {
 							[ `has-${ view.layout?.density }-density` ]:
 								view.layout?.density &&

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -369,14 +369,14 @@ export default function CompositeGrid< Item >( {
 	const { paginationInfo, resizeObserverRef } =
 		useContext( DataViewsContext );
 	const gridColumns = useGridColumns();
-	// Optional consumer-configured aspect ratio for item previews, surfaced to
-	// CSS as a custom property the media field's stylesheet reads (falling back
-	// to the default square `1/1` when unset).
-	const gridStyle: CSSProperties | undefined = view.layout?.aspectRatio
-		? ( {
-				'--dataviews-media-aspect-ratio': view.layout.aspectRatio,
-		  } as CSSProperties )
-		: undefined;
+	// Consumer-configured aspect ratio for item previews, surfaced to CSS as a
+	// custom property the media field's stylesheet reads. Always set (with the
+	// square default), so an identically-named variable set by a consumer on
+	// an ancestor can't leak into the previews when the view doesn't configure
+	// a ratio.
+	const gridStyle: CSSProperties = {
+		'--wp-dataviews-media-aspect-ratio': view.layout?.aspectRatio ?? '1/1',
+	} as CSSProperties;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -32,6 +32,7 @@ import {
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
+import { MEDIA_ASPECT_RATIOS } from '../../../constants';
 import ItemActions from '../../dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
 import DataViewsContext from '../../dataviews-context';
@@ -369,13 +370,18 @@ export default function CompositeGrid< Item >( {
 	const { paginationInfo, resizeObserverRef } =
 		useContext( DataViewsContext );
 	const gridColumns = useGridColumns();
-	// Consumer-configured aspect ratio for item previews, surfaced to CSS as a
-	// custom property the media field's stylesheet reads. Always set (with the
-	// square default), so an identically-named variable set by a consumer on
-	// an ancestor can't leak into the previews when the view doesn't configure
-	// a ratio.
-	const gridStyle: CSSProperties = {
-		'--wp-dataviews-media-aspect-ratio': view.layout?.aspectRatio ?? '1/1',
+	// Consumer-configured aspect ratio for item previews, validated against
+	// the presets (like `density`) so arbitrary values are ignored, and
+	// surfaced to CSS as a custom property the media field's stylesheet
+	// reads. Always set (with the square default), so an identically-named
+	// variable set by a consumer on an ancestor can't leak into the previews
+	// when the view doesn't configure a ratio.
+	const gridStyle = {
+		'--wp-dataviews-media-aspect-ratio':
+			view.layout?.aspectRatio &&
+			MEDIA_ASPECT_RATIOS.includes( view.layout.aspectRatio )
+				? view.layout.aspectRatio
+				: '1/1',
 	} as CSSProperties;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const titleField = fields.find(

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -97,7 +97,7 @@
 
 	.dataviews-view-grid__media {
 		width: 100%;
-		aspect-ratio: var(--dataviews-media-aspect-ratio, 1/1);
+		aspect-ratio: var(--wp-dataviews-media-aspect-ratio, 1/1);
 		background-color: var(--wpds-color-background-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-md);
 		overflow: hidden;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -97,7 +97,7 @@
 
 	.dataviews-view-grid__media {
 		width: 100%;
-		aspect-ratio: 1/1;
+		aspect-ratio: var(--dataviews-grid-media-aspect-ratio, 1/1);
 		background-color: var(--wpds-color-background-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-md);
 		overflow: hidden;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -97,7 +97,7 @@
 
 	.dataviews-view-grid__media {
 		width: 100%;
-		aspect-ratio: var(--dataviews-grid-media-aspect-ratio, 1/1);
+		aspect-ratio: var(--dataviews-media-aspect-ratio, 1/1);
 		background-color: var(--wpds-color-background-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-md);
 		overflow: hidden;

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-primary.tsx
@@ -11,7 +11,7 @@ import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import type { NormalizedField } from '../../../types';
+import type { MediaAspectRatio, NormalizedField } from '../../../types';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
 
 function ColumnPrimary< Item >( {
@@ -19,6 +19,7 @@ function ColumnPrimary< Item >( {
 	level,
 	titleField,
 	mediaField,
+	mediaAspectRatio,
 	descriptionField,
 	onClickItem,
 	renderItemLink,
@@ -28,6 +29,7 @@ function ColumnPrimary< Item >( {
 	level?: number;
 	titleField?: NormalizedField< Item >;
 	mediaField?: NormalizedField< Item >;
+	mediaAspectRatio?: MediaAspectRatio;
 	descriptionField?: NormalizedField< Item >;
 	onClickItem?: ( item: Item ) => void;
 	renderItemLink?: (
@@ -37,6 +39,21 @@ function ColumnPrimary< Item >( {
 	) => ReactElement;
 	isItemClickable: ( item: Item ) => boolean;
 } ) {
+	// Srcset/size hint for the media render. The preview box is 32px square
+	// by default; when the view configures `layout.aspectRatio`, the box
+	// keeps the 32px height while the ratio derives its width, clamped by
+	// the stylesheet's 60px `max-width`, so widen the hint to match the
+	// rendered size and avoid picking an undersized (blurry) source.
+	let mediaSizes = '32px';
+	if ( mediaAspectRatio ) {
+		const [ ratioWidth, ratioHeight ] = mediaAspectRatio
+			.split( '/' )
+			.map( Number );
+		mediaSizes = `${ Math.min(
+			60,
+			Math.round( ( 32 * ratioWidth ) / ratioHeight )
+		) }px`;
+	}
 	return (
 		<Stack direction="row" gap="md" align="flex-start" justify="flex-start">
 			{ mediaField && (
@@ -57,7 +74,7 @@ function ColumnPrimary< Item >( {
 					<mediaField.render
 						item={ item }
 						field={ mediaField }
-						config={ { sizes: '32px' } }
+						config={ { sizes: mediaSizes } }
 					/>
 				</ItemClickWrapper>
 			) }

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -24,7 +24,7 @@ import { isAppleOS } from '@wordpress/keycodes';
 import DataViewsContext from '../../dataviews-context';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
 import ItemActions from '../../dataviews-item-actions';
-import { sortValues } from '../../../constants';
+import { MEDIA_ASPECT_RATIOS, sortValues } from '../../../constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
 	useHasAPossibleBulkAction,
@@ -33,6 +33,7 @@ import {
 } from '../../dataviews-bulk-actions';
 import type {
 	Action,
+	MediaAspectRatio,
 	NormalizedField,
 	ViewTable as ViewTableType,
 	ViewTableProps,
@@ -76,6 +77,7 @@ interface TableRowProps< Item > {
 	view: ViewTableType;
 	titleField?: NormalizedField< Item >;
 	mediaField?: NormalizedField< Item >;
+	mediaAspectRatio?: MediaAspectRatio;
 	descriptionField?: NormalizedField< Item >;
 	selection: string[];
 	getItemId: ( item: Item ) => string;
@@ -127,6 +129,7 @@ function TableRow< Item >( {
 	view,
 	titleField,
 	mediaField,
+	mediaAspectRatio,
 	descriptionField,
 	selection,
 	getItemId,
@@ -204,6 +207,7 @@ function TableRow< Item >( {
 						level={ level }
 						titleField={ showTitle ? titleField : undefined }
 						mediaField={ showMedia ? mediaField : undefined }
+						mediaAspectRatio={ mediaAspectRatio }
 						descriptionField={
 							showDescription ? descriptionField : undefined
 						}
@@ -391,13 +395,19 @@ function ViewTable< Item >( {
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
 	const isRtl = isRTL();
 	// Consumer-configured aspect ratio for the primary column's media preview,
-	// surfaced to CSS as a custom property the media stylesheet reads. Always
-	// set (with the square default), so an identically-named variable set by a
-	// consumer on an ancestor can't leak into the previews when the view
-	// doesn't configure a ratio. The sizing itself only engages behind the
-	// `has-media-aspect-ratio` modifier below.
-	const tableStyle: CSSProperties = {
-		'--wp-dataviews-media-aspect-ratio': view.layout?.aspectRatio ?? '1/1',
+	// validated against the presets (like `density`) so arbitrary values are
+	// ignored, and surfaced to CSS as a custom property the media stylesheet
+	// reads. The property is always set (with the square default), so an
+	// identically-named variable set by a consumer on an ancestor can't leak
+	// into the previews when the view doesn't configure a ratio. The sizing
+	// itself only engages behind the `has-media-aspect-ratio` modifier below.
+	const mediaAspectRatio =
+		view.layout?.aspectRatio &&
+		MEDIA_ASPECT_RATIOS.includes( view.layout.aspectRatio )
+			? view.layout.aspectRatio
+			: undefined;
+	const tableStyle = {
+		'--wp-dataviews-media-aspect-ratio': mediaAspectRatio ?? '1/1',
 	} as CSSProperties;
 	if ( ! hasData ) {
 		return (
@@ -423,7 +433,7 @@ function ViewTable< Item >( {
 						),
 					'has-bulk-actions': hasBulkActions,
 					'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
-					'has-media-aspect-ratio': !! view.layout?.aspectRatio,
+					'has-media-aspect-ratio': !! mediaAspectRatio,
 				} ) }
 				style={ tableStyle }
 				aria-busy={ isLoading }
@@ -629,6 +639,9 @@ function ViewTable< Item >( {
 											view={ view }
 											titleField={ titleField }
 											mediaField={ mediaField }
+											mediaAspectRatio={
+												mediaAspectRatio
+											}
 											descriptionField={
 												descriptionField
 											}
@@ -673,6 +686,7 @@ function ViewTable< Item >( {
 										view={ view }
 										titleField={ titleField }
 										mediaField={ mediaField }
+										mediaAspectRatio={ mediaAspectRatio }
 										descriptionField={ descriptionField }
 										selection={ selection }
 										getItemId={ getItemId }

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ComponentProps, CSSProperties, ReactElement } from 'react';
 
 /**
  * WordPress dependencies
@@ -390,6 +390,14 @@ function ViewTable< Item >( {
 		};
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
 	const isRtl = isRTL();
+	// Optional consumer-configured aspect ratio for the primary column's media
+	// preview, surfaced to CSS as a custom property the media stylesheet reads
+	// (falling back to the default square `1/1` when unset).
+	const tableStyle: CSSProperties | undefined = view.layout?.aspectRatio
+		? ( {
+				'--dataviews-media-aspect-ratio': view.layout.aspectRatio,
+		  } as CSSProperties )
+		: undefined;
 	if ( ! hasData ) {
 		return (
 			<div
@@ -415,6 +423,7 @@ function ViewTable< Item >( {
 					'has-bulk-actions': hasBulkActions,
 					'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
 				} ) }
+				style={ tableStyle }
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 				role={ isInfiniteScroll ? 'feed' : undefined }

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -390,14 +390,15 @@ function ViewTable< Item >( {
 		};
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
 	const isRtl = isRTL();
-	// Optional consumer-configured aspect ratio for the primary column's media
-	// preview, surfaced to CSS as a custom property the media stylesheet reads
-	// (falling back to the default square `1/1` when unset).
-	const tableStyle: CSSProperties | undefined = view.layout?.aspectRatio
-		? ( {
-				'--dataviews-media-aspect-ratio': view.layout.aspectRatio,
-		  } as CSSProperties )
-		: undefined;
+	// Consumer-configured aspect ratio for the primary column's media preview,
+	// surfaced to CSS as a custom property the media stylesheet reads. Always
+	// set (with the square default), so an identically-named variable set by a
+	// consumer on an ancestor can't leak into the previews when the view
+	// doesn't configure a ratio. The sizing itself only engages behind the
+	// `has-media-aspect-ratio` modifier below.
+	const tableStyle: CSSProperties = {
+		'--wp-dataviews-media-aspect-ratio': view.layout?.aspectRatio ?? '1/1',
+	} as CSSProperties;
 	if ( ! hasData ) {
 		return (
 			<div
@@ -422,6 +423,7 @@ function ViewTable< Item >( {
 						),
 					'has-bulk-actions': hasBulkActions,
 					'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
+					'has-media-aspect-ratio': !! view.layout?.aspectRatio,
 				} ) }
 				style={ tableStyle }
 				aria-busy={ isLoading }

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -275,9 +275,15 @@
 }
 
 .dataviews-column-primary__media {
+	// The preview box: a fixed height keeps rows uniform while the
+	// (consumer-configurable) aspect ratio sets the width. Sized on the
+	// wrapper rather than the img so custom media field renders are covered
+	// too; ratios wider than ~17/9 at this height are clipped by `max-width`
+	// rather than allowed to crowd out the title.
+	height: var(--wpds-dimension-size-md);
+	aspect-ratio: var(--dataviews-media-aspect-ratio, 1/1);
 	max-width: 60px;
 	min-width: var(--wpds-dimension-size-md);
-	min-height: var(--wpds-dimension-size-md);
 	overflow: hidden;
 	position: relative;
 	flex-shrink: 0;
@@ -285,8 +291,8 @@
 	border-radius: var(--wpds-border-radius-md);
 
 	img {
-		width: var(--wpds-dimension-size-md);
-		height: var(--wpds-dimension-size-md);
+		width: 100%;
+		height: 100%;
 		object-fit: cover;
 	}
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -275,15 +275,9 @@
 }
 
 .dataviews-column-primary__media {
-	// The preview box: a fixed height keeps rows uniform while the
-	// (consumer-configurable) aspect ratio sets the width. Sized on the
-	// wrapper rather than the img so custom media field renders are covered
-	// too; ratios wider than ~17/9 at this height are clipped by `max-width`
-	// rather than allowed to crowd out the title.
-	height: var(--wpds-dimension-size-md);
-	aspect-ratio: var(--dataviews-media-aspect-ratio, 1/1);
 	max-width: 60px;
 	min-width: var(--wpds-dimension-size-md);
+	min-height: var(--wpds-dimension-size-md);
 	overflow: hidden;
 	position: relative;
 	flex-shrink: 0;
@@ -291,8 +285,8 @@
 	border-radius: var(--wpds-border-radius-md);
 
 	img {
-		width: 100%;
-		height: 100%;
+		width: var(--wpds-dimension-size-md);
+		height: var(--wpds-dimension-size-md);
 		object-fit: cover;
 	}
 
@@ -305,6 +299,23 @@
 		height: 100%;
 		box-shadow: inset 0 0 0 var(--wpds-border-width-xs) rgba(0, 0, 0, 0.1);
 		border-radius: var(--wpds-border-radius-md);
+	}
+}
+
+// Only when the view configures `layout.aspectRatio` (the table then carries
+// the `has-media-aspect-ratio` modifier): the preview box takes a fixed
+// height while the configured ratio sets its width, keeping rows uniform.
+// Sized on the wrapper rather than the img so custom media field renders are
+// covered too; ratios wider than ~17/9 at this height are clipped by the base
+// rule's `max-width` rather than allowed to crowd out the title. Views
+// without `aspectRatio` keep the base sizing above, unchanged.
+.dataviews-view-table.has-media-aspect-ratio .dataviews-column-primary__media {
+	height: var(--wpds-dimension-size-md);
+	aspect-ratio: var(--wp-dataviews-media-aspect-ratio, 1/1);
+
+	img {
+		width: 100%;
+		height: 100%;
 	}
 }
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -312,6 +312,10 @@
 .dataviews-view-table.has-media-aspect-ratio .dataviews-column-primary__media {
 	height: var(--wpds-dimension-size-md);
 	aspect-ratio: var(--wp-dataviews-media-aspect-ratio, 1/1);
+	// Release the base rule's `min-width`: it equals the fixed height, so for
+	// ratios narrower than 1/1 the ratio-derived width would fall below it
+	// and the minimum would win, forcing the box back to a square.
+	min-width: 0;
 
 	img {
 		width: 100%;

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-items.tsx
@@ -19,7 +19,7 @@ export const GridItems = forwardRef<
 		className?: string;
 		previewSize: number | undefined;
 	} & ComponentPropsWithoutRef< 'div' >
->( ( { className, previewSize, ...props }, ref ) => {
+>( ( { className, previewSize, style, ...props }, ref ) => {
 	return (
 		<div
 			ref={ ref }
@@ -28,6 +28,7 @@ export const GridItems = forwardRef<
 				gridTemplateColumns:
 					previewSize &&
 					`repeat(auto-fill, minmax(${ previewSize }px, 1fr))`,
+				...style,
 			} }
 			{ ...props }
 		/>

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -57,3 +57,17 @@ export const LAYOUT_PICKER_TABLE = 'pickerTable';
 export const LAYOUT_PICKER_ACTIVITY = 'pickerActivity';
 
 export const DAYS_OF_WEEK: DayNumber[] = [ 0, 1, 2, 3, 4, 5, 6 ];
+
+// The preset aspect ratios available for item media previews. Source of
+// truth for the `MediaAspectRatio` type (derived from this array), and used
+// by layouts to validate the configured `layout.aspectRatio` before
+// applying it.
+export const MEDIA_ASPECT_RATIOS = [
+	'1/1',
+	'4/3',
+	'3/4',
+	'3/2',
+	'2/3',
+	'16/9',
+	'9/16',
+] as const;

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -236,6 +236,19 @@ export interface ColumnStyle {
 
 export type Density = 'compact' | 'balanced' | 'comfortable';
 
+/**
+ * The preset aspect ratios available for item media previews, mirroring
+ * Core's default `aspect-ratio` presets.
+ */
+export type MediaAspectRatio =
+	| '1/1'
+	| '4/3'
+	| '3/4'
+	| '3/2'
+	| '2/3'
+	| '16/9'
+	| '9/16';
+
 export interface ViewTable extends ViewBase {
 	type: 'table';
 
@@ -256,11 +269,11 @@ export interface ViewTable extends ViewBase {
 		enableMoving?: boolean;
 
 		/**
-		 * A fixed aspect ratio for the primary column's media preview, as a
-		 * CSS `aspect-ratio` value (e.g. `'1/1'`, `'16/9'`, `'4/3'`). Applied
-		 * uniformly to every row. Defaults to `'1/1'`.
+		 * A fixed aspect ratio for the primary column's media preview, one of
+		 * the preset ratios. Applied uniformly to every row. Defaults to
+		 * `'1/1'`.
 		 */
-		aspectRatio?: string;
+		aspectRatio?: MediaAspectRatio;
 	};
 }
 
@@ -306,11 +319,11 @@ export interface ViewGrid extends ViewBase {
 		density?: Density;
 
 		/**
-		 * A fixed aspect ratio for the grid item previews (the media field), as
-		 * a CSS `aspect-ratio` value (e.g. `'1/1'`, `'16/9'`, `'4/3'`). Applied
-		 * uniformly to every item so rows stay aligned. Defaults to `'1/1'`.
+		 * A fixed aspect ratio for the grid item previews (the media field),
+		 * one of the preset ratios. Applied uniformly to every item so rows
+		 * stay aligned. Defaults to `'1/1'`.
 		 */
-		aspectRatio?: string;
+		aspectRatio?: MediaAspectRatio;
 	};
 }
 

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -18,6 +18,7 @@ import type {
 	SortDirection,
 } from './field-api';
 import type { SetSelection } from './private';
+import type { MEDIA_ASPECT_RATIOS } from '../constants';
 
 /**
  * The filters applied to the dataset.
@@ -238,16 +239,11 @@ export type Density = 'compact' | 'balanced' | 'comfortable';
 
 /**
  * The preset aspect ratios available for item media previews, mirroring
- * Core's default `aspect-ratio` presets.
+ * Core's default `aspect-ratio` presets. Derived from the
+ * `MEDIA_ASPECT_RATIOS` constant, which layouts also use to validate the
+ * configured value at runtime, so the two can't drift apart.
  */
-export type MediaAspectRatio =
-	| '1/1'
-	| '4/3'
-	| '3/4'
-	| '3/2'
-	| '2/3'
-	| '16/9'
-	| '9/16';
+export type MediaAspectRatio = ( typeof MEDIA_ASPECT_RATIOS )[ number ];
 
 export interface ViewTable extends ViewBase {
 	type: 'table';

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -297,6 +297,13 @@ export interface ViewGrid extends ViewBase {
 		 * The density of the grid layout.
 		 */
 		density?: Density;
+
+		/**
+		 * A fixed aspect ratio for the grid item previews (the media field), as
+		 * a CSS `aspect-ratio` value (e.g. `'1/1'`, `'16/9'`, `'4/3'`). Applied
+		 * uniformly to every item so rows stay aligned. Defaults to `'1/1'`.
+		 */
+		aspectRatio?: string;
 	};
 }
 

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -254,6 +254,13 @@ export interface ViewTable extends ViewBase {
 		 * Whether the view allows column moving.
 		 */
 		enableMoving?: boolean;
+
+		/**
+		 * A fixed aspect ratio for the primary column's media preview, as a
+		 * CSS `aspect-ratio` value (e.g. `'1/1'`, `'16/9'`, `'4/3'`). Applied
+		 * uniformly to every row. Defaults to `'1/1'`.
+		 */
+		aspectRatio?: string;
 	};
 }
 


### PR DESCRIPTION
## What?

See #60891

The DataViews `grid` layout renders item previews (the media field) at a hard-coded `1/1` (square) aspect ratio, and the `table` layout does the same for the primary column's media preview. This adds an `aspectRatio` option to the `grid` and `table` `layout` configs so consumers can choose the shape, defaulting to `1/1` so nothing changes for existing consumers.

## Why?

#60891 asks for the grid preview aspect ratio to be consumer configurable — a square crop isn't ideal for every dataset (tall templates, wide media, video thumbnails, etc.). For example, a video library wants `16/9` previews so the thumbnail matches how the video actually appears.

A previous attempt (#63487) stalled on the UX of a **user-facing toggle** between `1/1` and `auto` (variable per-item ratios), which raised "visual rivers" / masonry concerns. This PR deliberately sidesteps that debate: it exposes a single **consumer-set, uniform** aspect ratio, applied identically to every item — the form even the prior reviewers were comfortable with ("it should change the aspect ratio of _all_ previews"). The user-facing toggle and `auto`/variable per-item ratios are intentionally left as a follow-up.

Scope is limited to the `grid` and `table` layouts; `pickerGrid`/`pickerTable` parity is a straightforward follow-up.

## How?

- Adds `aspectRatio?: MediaAspectRatio` to `ViewGrid['layout']` and `ViewTable['layout']`, where `MediaAspectRatio` is a union of preset ratios (`'1/1' | '4/3' | '3/4' | '3/2' | '2/3' | '16/9' | '9/16'`, mirroring Core's default aspect-ratio presets) — the same constrained-union pattern as `density`. Starting with presets keeps the API easy to widen later without a breaking change, and avoids consumers setting degenerate ratios.
- The value is surfaced as a `--wp-dataviews-media-aspect-ratio` CSS custom property (matching the existing `--wp-dataviews-color-background` naming) on the layout root (the grid container — both the standard and infinite-scroll roots — and the `table` element). The property is always set, defaulting to `1/1`, so a same-named variable set by a consumer on an ancestor can't leak into the previews.
- Grid: the existing `.dataviews-view-grid__media` rule reads it with a `1/1` fallback: `aspect-ratio: var(--wp-dataviews-media-aspect-ratio, 1/1)`.
- Table: gated behind a `has-media-aspect-ratio` modifier (same pattern as `has-*-density`) that the table only carries when the view sets `layout.aspectRatio`. Under the modifier, the `.dataviews-column-primary__media` wrapper takes `height` + `aspect-ratio`, with the `img` filling it — sizing the wrapper rather than the `img` keeps custom media field renders (nested elements instead of a bare `img`) covered too. Row heights are unchanged; the preview widens instead, and a `16/9` preview at the default height still fits the wrapper's existing `max-width`. Without `aspectRatio`, the base rules are exactly what trunk ships today.
- Net effect: every existing consumer is unaffected — the grid keeps its `1/1` default and the table keeps its current sizing until a view opts in.

## Testing Instructions

1. In a `grid` DataView, set the layout's `aspectRatio`, e.g. `view = { type: 'grid', layout: { aspectRatio: '16/9' }, … }`.
2. Confirm the item previews render at the configured ratio (16:9 rectangles) instead of squares, with rows staying aligned (uniform heights).
3. Try other fixed ratios (e.g. `'4/3'`, `'1/1'`) and confirm they apply uniformly to every item.
4. In a `table` DataView with a media field, set `layout.aspectRatio: '16/9'` and confirm the primary column's thumbnail renders 16:9 at the same height — row heights don't change.
5. Remove `aspectRatio` (or use an existing grid/table consumer such as the Pages/Templates views) and confirm previews stay square (`1/1`) — no regression.
6. Confirm `previewSize` and `density` still work alongside it.

### Testing Instructions for Keyboard

No interaction changes — the option only affects preview dimensions, so existing keyboard navigation of the grid and table is unaffected.

## Screenshots or screencast

|Before (`1/1`)|After (`aspectRatio: '16/9'`)|
|-|-|
|<img width="3102" height="1954" alt="Table layout square" src="https://github.com/user-attachments/assets/a06499e1-35ef-48e1-8896-8e471194fa73" />|<img width="3108" height="1966" alt="Table layout wide" src="https://github.com/user-attachments/assets/3c8d4baa-9a9f-464a-9944-7432fc2eeb27" />|
|Square previews|16:9 previews|

## Use of AI Tools

This PR was authored with the assistance of AI tooling (Claude Code). The implementation, scope decisions, and this description were AI-assisted and reviewed by me before submission; I take responsibility for the contents.
