### PR TITLE
Docs: Fix typos in README files

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,10 @@
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
 -   Point the legacy `--wp-components-*` color fallbacks at the design system tokens (`--wpds-*` / `--wp-admin-theme-color*`), so component styles get sensible defaults from the prebuilt token stylesheet without a runtime `<ThemeProvider>` ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 
+### Documentation
+
+-   `Menu`: Fix `overriden` typo to `overridden` in `CheckboxItemProps` and `RadioItemProps`.
+
 ### Code Quality
 
 -   Move `@types/react` from `dependencies` to an optional peer dependency so consumers' React type version is used [#79095](https://github.com/WordPress/gutenberg/pull/79095).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Documentation
 
--   `Menu`: Fix `overriden` typo to `overridden` in `CheckboxItemProps` and `RadioItemProps`.
+-   `Menu`: Fix `overriden` typo to `overridden` in `CheckboxItemProps` and `RadioItemProps`. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
 
 ### Code Quality
 

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -306,7 +306,7 @@ that don't support the native `disabled` attribute.
 The checked state of the radio menu item when it is initially rendered.
 Use when not wanting to control its checked state.
 
-Note: this prop will be overriden by the `checked` prop, if it is defined.
+Note: this prop will be overridden by the `checked` prop, if it is defined.
 
 ##### `hideOnClick`
 
@@ -404,7 +404,7 @@ that don't support the native `disabled` attribute.
 The checked state of the checkbox menu item when it is initially rendered.
 Use when not wanting to control its checked state.
 
-Note: this prop will be overriden by the `checked` prop, if it is defined.
+Note: this prop will be overridden by the `checked` prop, if it is defined.
 
 ##### `hideOnClick`
 

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -258,7 +258,7 @@ export interface CheckboxItemProps {
 	 * The checked state of the checkbox menu item when it is initially rendered.
 	 * Use when not wanting to control its checked state.
 	 *
-	 * Note: this prop will be overriden by the `checked` prop, if it is defined.
+	 * Note: this prop will be overridden by the `checked` prop, if it is defined.
 	 */
 	defaultChecked?: Ariakit.MenuItemCheckboxProps[ 'defaultChecked' ];
 	/**
@@ -321,7 +321,7 @@ export interface RadioItemProps {
 	 * The checked state of the radio menu item when it is initially rendered.
 	 * Use when not wanting to control its checked state.
 	 *
-	 * Note: this prop will be overriden by the `checked` prop, if it is defined.
+	 * Note: this prop will be overridden by the `checked` prop, if it is defined.
 	 */
 	defaultChecked?: Ariakit.MenuItemRadioProps[ 'defaultChecked' ];
 	/**

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+-   Fix `thats` typo to `that's` in external template documentation.
+
 ## 4.91.1 (2026-06-16)
 
 ## 4.91.0 (2026-06-10)

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Documentation
 
--   Fix `thats` typo to `that's` in external template documentation.
+-   Fix `thats` typo to `that's` in external template documentation. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
 
 ## 4.91.1 (2026-06-16)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Documentation
 
--   Fix `thats` typo to `that's` in external template documentation. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
+-   Fix `thats` typo to `that` in external template documentation. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
 
 ## 4.91.1 (2026-06-16)
 

--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -98,7 +98,7 @@ The following configurable variables are used with the template files. Template 
 -   `namespace` (default: `'create-block'`) – the internal namespace for the block name.
 -   `title` (no default) – a display title for your block.
 -   `description` (no default) – a short description for your block.
--   `dashicon` (no default) – an icon property that's makes it easier to identify a block ([available values](https://developer.wordpress.org/resource/dashicons/)).
+-   `dashicon` (no default) – an icon property that makes it easier to identify a block ([available values](https://developer.wordpress.org/resource/dashicons/)).
 -   `category` (default: `'widgets'`) – blocks are grouped into categories to help users browse and discover them. The categories provided by core are `text`, `media`, `design`, `widgets`, `theme`, and `embed`.
 -   `textdomain` (defaults to the `slug` value) – the text domain used to make strings translatable ([more info](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)).
 -   `attributes` (no default) – block attributes ([more details](https://developer.wordpress.org/block-editor/developers/block-api/block-attributes/)).

--- a/packages/create-block/docs/external-template.md
+++ b/packages/create-block/docs/external-template.md
@@ -98,7 +98,7 @@ The following configurable variables are used with the template files. Template 
 -   `namespace` (default: `'create-block'`) – the internal namespace for the block name.
 -   `title` (no default) – a display title for your block.
 -   `description` (no default) – a short description for your block.
--   `dashicon` (no default) – an icon property thats makes it easier to identify a block ([available values](https://developer.wordpress.org/resource/dashicons/)).
+-   `dashicon` (no default) – an icon property that's makes it easier to identify a block ([available values](https://developer.wordpress.org/resource/dashicons/)).
 -   `category` (default: `'widgets'`) – blocks are grouped into categories to help users browse and discover them. The categories provided by core are `text`, `media`, `design`, `widgets`, `theme`, and `embed`.
 -   `textdomain` (defaults to the `slug` value) – the text domain used to make strings translatable ([more info](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)).
 -   `attributes` (no default) – block attributes ([more details](https://developer.wordpress.org/block-editor/developers/block-api/block-attributes/)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,6 +16,10 @@
 - DataForm panel layout: remove button/dropdown-specific overrides from `.dataforms-layouts-panel__field-control`; those overrides are no longer needed. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 - DataForm panel layout: align `label-side` gap with the regular layout by using `--wpds-dimension-gap-sm` (8px). [#79311](https://github.com/WordPress/gutenberg/pull/79311)
 
+### Documentation
+
+- Fix `overriden` typo to `overridden` in README.
+
 ### Internal
 
 - Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Documentation
 
-- Fix `overriden` typo to `overridden` in README.
+- Fix `overriden` typo to `overridden` in README. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
 
 ### Internal
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1669,7 +1669,7 @@ When the field declares a type, it gets a default sort function:
 }
 ```
 
-The default sorting can be overriden by providing a custom sort function. It takes the following arguments:
+The default sorting can be overridden by providing a custom sort function. It takes the following arguments:
 
 -   `a`: the first item to compare
 -   `b`: the second item to compare
@@ -1717,7 +1717,7 @@ Fields that define a type come with default validation for the type. For example
 }
 ```
 
-The validation rules can be overriden by the field author. For example, to set the field as required, or to provide a custom validation so that only even numbers are valid:
+The validation rules can be overridden by the field author. For example, to set the field as required, or to provide a custom validation so that only even numbers are valid:
 
 ```js
 {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Documentation
 
--   Fix `genereated` typo to `generated` in README.
+-   Fix `genereated` typo to `generated` in README. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
 
 ## 0.16.1 (2026-06-16)
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+-   Fix `genereated` typo to `generated` in README.
+
 ## 0.16.1 (2026-06-16)
 
 ## 0.16.0 (2026-06-10)

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -181,7 +181,7 @@ Configure your root `package.json` with a `wpPlugin` object to control global na
 
 ### `wpPlugin.name`
 
-Name used to prefix genereated PHP functions. Must follow function name rules in PHP, i.e. valid name starts with a letter or underscore, followed by any number of letters, numbers, or underscores.
+Name used to prefix generated PHP functions. Must follow function name rules in PHP, i.e. valid name starts with a letter or underscore, followed by any number of letters, numbers, or underscores.
 
 ```json
 {


### PR DESCRIPTION
## What?
Fix minor spelling typos in documentation files.

## Why?
Improve documentation quality and correctness.

## How?
- `overriden` → `overridden` in `packages/components/src/menu/README.md` (×2)
- `thats` → `that's` in `packages/create-block/docs/external-template.md`
- `overriden` → `overridden` in `packages/dataviews/README.md` (×2)
- `genereated` → `generated` in `packages/wp-build/README.md`
