### PR TITLE
Media Editor: Fix crop canvas pinch zoom

### DIFF
--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -286,6 +286,11 @@ export class InteractionController {
 		if ( e.button !== 0 ) {
 			return;
 		}
+		// Touch gestures are handled by touchstart/touchmove. Starting the
+		// pointer drag path too can briefly toggle drag UI before pinch begins.
+		if ( e.pointerType === 'touch' ) {
+			return;
+		}
 		e.preventDefault();
 
 		// Blur any focused handle so its focus ring doesn't linger,

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -568,6 +568,7 @@ export class InteractionController {
 		if ( ! touch ) {
 			return;
 		}
+		moveEvent.preventDefault();
 
 		cancelAnimationFrame( this.rafId );
 		this.rafId = requestAnimationFrame( () => {
@@ -641,20 +642,28 @@ export class InteractionController {
 							? ( my - startMy ) / visSize.height
 							: 0;
 
-					// Focal-point zoom correction.
-					const zoomRatio = s.zoom !== 0 ? 1 - newZoom / s.zoom : 0;
-					const focalNormX = mx / visSize.width;
-					const focalNormY = my / visSize.height;
-					const zoomCropX =
-						s.pan.x + ( focalNormX - s.pan.x ) * zoomRatio;
-					const zoomCropY =
-						s.pan.y + ( focalNormY - s.pan.y ) * zoomRatio;
+					// Focal-point zoom correction. Keep this based on the
+					// pinch-start state; using the current reducer state here
+					// compounds prior touchmove frames and makes a fixed pinch
+					// center drift after the image is already zoomed or panned.
+					const zoomRatio =
+						touch.startZoom !== 0
+							? 1 - newZoom / touch.startZoom
+							: 0;
+					const startFocalNormX = startMx / visSize.width;
+					const startFocalNormY = startMy / visSize.height;
 
-					// Combined: pan drift + zoom correction.
+					// Combined: midpoint drift + zoom around the pinch-start
+					// midpoint, so moving both fingers together pans while
+					// symmetric pinches keep the start center stationary.
 					const newCropX =
-						touch.startPanX + panDx + ( zoomCropX - s.pan.x );
+						touch.startPanX +
+						panDx +
+						( startFocalNormX - touch.startPanX ) * zoomRatio;
 					const newCropY =
-						touch.startPanY + panDy + ( zoomCropY - s.pan.y );
+						touch.startPanY +
+						panDy +
+						( startFocalNormY - touch.startPanY ) * zoomRatio;
 
 					const { pan: clampedCrop } = restrictPanZoom(
 						{

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -291,6 +291,38 @@ describe( 'InteractionController', () => {
 			el._fire( 'pointerup', createPointerEvent() );
 		} );
 
+		it( 'ignores touch pointerdown so touch gestures own touch input', () => {
+			const state = makeState( { zoom: 2 } );
+			const onGestureStart = jest.fn();
+			const onStatusChange = jest.fn();
+			const { controller } = createController( state, {
+				onGestureStart,
+				onStatusChange,
+			} );
+			const el = createMockElement();
+			const event = createPointerEvent( {
+				clientX: 100,
+				clientY: 100,
+				pointerType: 'touch',
+			} );
+
+			controller.handlePointerDown( event, el );
+
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( el.focus ).not.toHaveBeenCalled();
+			expect( el.setPointerCapture ).not.toHaveBeenCalled();
+			expect( el.addEventListener ).not.toHaveBeenCalled();
+			expect( onGestureStart ).not.toHaveBeenCalled();
+			expect( onStatusChange ).not.toHaveBeenCalled();
+
+			el._fire(
+				'pointermove',
+				createPointerEvent( { clientX: 150, clientY: 120 } )
+			);
+
+			expect( actionMocks.setPan ).not.toHaveBeenCalled();
+		} );
+
 		it( 'stops dispatching after pointerup', () => {
 			const state = makeState( { zoom: 2 } );
 			const { controller } = createController( state );

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -888,6 +888,54 @@ describe( 'InteractionController', () => {
 			expect( actionMocks.setZoomAtPoint ).toHaveBeenCalled();
 		} );
 
+		it( 'keeps a repeated pinch zoom anchored to the pinch-start midpoint from a zoomed and panned state', () => {
+			let state = makeState( {
+				zoom: 2,
+				pan: { x: 0.1, y: -0.05 },
+			} );
+			actionMocks.setZoomAtPoint.mockImplementation( ( zoom, pan ) => {
+				state = { ...state, zoom, pan };
+			} );
+			const { controller } = createController( state, {
+				getState: () => state,
+			} );
+			const doc = createMockDocument();
+			const rect = createContainerRect();
+
+			controller.handleTouchStart(
+				createTouchEvent( [
+					{ clientX: 300, clientY: 180 },
+					{ clientX: 400, clientY: 180 },
+				] ),
+				rect,
+				doc
+			);
+
+			doc._fire(
+				'touchmove',
+				createTouchEvent( [
+					{ clientX: 275, clientY: 180 },
+					{ clientX: 425, clientY: 180 },
+				] )
+			);
+			doc._fire(
+				'touchmove',
+				createTouchEvent( [
+					{ clientX: 250, clientY: 180 },
+					{ clientX: 450, clientY: 180 },
+				] )
+			);
+
+			expect( actionMocks.setZoomAtPoint ).toHaveBeenCalledTimes( 2 );
+			const [ zoom, pan ] =
+				actionMocks.setZoomAtPoint.mock.calls[
+					actionMocks.setZoomAtPoint.mock.calls.length - 1
+				];
+			expect( zoom ).toBeCloseTo( 4 );
+			expect( pan.x ).toBeCloseTo( 0 );
+			expect( pan.y ).toBeCloseTo( -0.2 );
+		} );
+
 		it( 'calls onGestureStart for pinch, onGestureEnd on touchend', () => {
 			const state = makeState( { zoom: 1 } );
 			const onGestureStart = jest.fn();

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -829,6 +829,26 @@ describe( 'InteractionController', () => {
 			expect( actionMocks.setPan ).toHaveBeenCalled();
 		} );
 
+		it( 'prevents default on touchmove so the page does not scroll mid-gesture', () => {
+			const state = makeState( { zoom: 2 } );
+			const { controller } = createController( state );
+			const doc = createMockDocument();
+			const rect = createContainerRect();
+
+			controller.handleTouchStart(
+				createTouchEvent( [ { clientX: 100, clientY: 100 } ] ),
+				rect,
+				doc
+			);
+
+			const moveEvent = createTouchEvent( [
+				{ clientX: 150, clientY: 120 },
+			] );
+			doc._fire( 'touchmove', moveEvent );
+
+			expect( moveEvent.preventDefault ).toHaveBeenCalled();
+		} );
+
 		it( 'calls onGestureStart/onGestureEnd for single-finger pan', () => {
 			const state = makeState( { zoom: 2 } );
 			const onGestureStart = jest.fn();

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -193,6 +193,8 @@ export interface StencilProps {
 	aspectRatio?: number;
 	/** Whether the crop handles are shown for freeform resizing. */
 	freeformCrop?: boolean;
+	/** Whether resize handles should ignore pointer and keyboard input. */
+	isResizeDisabled?: boolean;
 	/** CSS transition string for settle animation. */
 	stencilTransition?: string;
 	/** Maximum crop rect bounds based on current zoom/rotation. */

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -822,6 +822,12 @@ function CropperInner(
 		clearTimeout( settleTimerRef.current );
 
 		if ( isCancellingForPinch ) {
+			// A pinch took over mid-resize. Tear down resize UI without
+			// settling or firing onGestureEnd: the pinch owns the gesture
+			// boundary and fires the end on its own touchend. The resize and
+			// the pinch therefore collapse into a single undo step, since
+			// `beginGesture` is idempotent and the snapshot captured at resize
+			// start is flushed by the pinch's `endGesture`.
 			isSettlingRef.current = false;
 			setSettling( false );
 			resetViewport();

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -379,6 +379,12 @@ function CropperInner(
 	const [ isResizing, setIsResizing ] = useState( false );
 	const isResizingRef = useRef( false );
 	const isSettlingRef = useRef( false );
+	const [ isTouchPinching, setIsTouchPinchingState ] = useState( false );
+	const isTouchPinchingRef = useRef( false );
+	const setTouchPinching = useCallback( ( isPinching: boolean ) => {
+		isTouchPinchingRef.current = isPinching;
+		setIsTouchPinchingState( isPinching );
+	}, [] );
 	// Direction of the handle the user is currently resizing — pointer or
 	// keyboard. `null` outside of an active resize. Drives the live
 	// dimensions tooltip overlay.
@@ -593,6 +599,26 @@ function CropperInner(
 		onPointerDownCapture: () => {
 			setIsFocusVisible( false );
 		},
+		onTouchStartCapture: ( event: React.TouchEvent< HTMLDivElement > ) => {
+			if ( event.touches.length > 1 ) {
+				setTouchPinching( true );
+			}
+		},
+		onTouchMoveCapture: ( event: React.TouchEvent< HTMLDivElement > ) => {
+			if ( event.touches.length > 1 ) {
+				setTouchPinching( true );
+			}
+		},
+		onTouchEndCapture: ( event: React.TouchEvent< HTMLDivElement > ) => {
+			if ( event.touches.length === 0 ) {
+				setTouchPinching( false );
+			}
+		},
+		onTouchCancelCapture: ( event: React.TouchEvent< HTMLDivElement > ) => {
+			if ( event.touches.length === 0 ) {
+				setTouchPinching( false );
+			}
+		},
 		onKeyDownCapture: ( event: React.KeyboardEvent< HTMLDivElement > ) => {
 			// Modifier-only keypresses precede another key rather than
 			// indicating deliberate keyboard interaction on their own.
@@ -603,6 +629,14 @@ function CropperInner(
 			}
 		},
 		onPointerDown: ( event: React.PointerEvent< HTMLDivElement > ) => {
+			if (
+				isResizingRef.current ||
+				isTouchPinchingRef.current ||
+				( event.pointerType === 'touch' && event.isPrimary === false )
+			) {
+				event.preventDefault();
+				return;
+			}
 			handlers.onPointerDown?.( event );
 			// Re-assert false after handlers run — el.focus() inside the
 			// handler fires onFocus, which may otherwise set it back to true.
@@ -667,6 +701,9 @@ function CropperInner(
 
 	const handleCropChange = useCallback(
 		( rect: NormalizedRect ) => {
+			if ( isTouchPinchingRef.current ) {
+				return;
+			}
 			setCropRect( rect );
 			// During a resize drag, pan the viewport so the handle stays
 			// visible even when the crop extends beyond the canvas edge.
@@ -752,6 +789,9 @@ function CropperInner(
 
 	const handleResizeStart = useCallback(
 		( handle?: HandlePosition ) => {
+			if ( isTouchPinchingRef.current ) {
+				return;
+			}
 			// Freeze the magnification at its current value so grabbing a
 			// handle doesn't reset the zoom; it holds for the whole drag.
 			setFrozenViewScale( viewScaleRest );
@@ -775,9 +815,19 @@ function CropperInner(
 	 * and reset the viewport pan back to neutral.
 	 */
 	const handleResizeEnd = useCallback( () => {
+		const isCancellingForPinch = isTouchPinchingRef.current;
 		isResizingRef.current = false;
 		setIsResizing( false );
 		setActiveHandle( null );
+		clearTimeout( settleTimerRef.current );
+
+		if ( isCancellingForPinch ) {
+			isSettlingRef.current = false;
+			setSettling( false );
+			resetViewport();
+			return;
+		}
+
 		isSettlingRef.current = true;
 		setSettling( true );
 		// Reset viewport pan first so it transitions back to zero in sync
@@ -785,7 +835,6 @@ function CropperInner(
 		resetViewport();
 		settleCrop();
 		onGestureEnd?.();
-		clearTimeout( settleTimerRef.current );
 		settleTimerRef.current = setTimeout( () => {
 			isSettlingRef.current = false;
 			setSettling( false );
@@ -983,6 +1032,7 @@ function CropperInner(
 						onEscape={ handleEscape }
 						aspectRatio={ aspectRatio }
 						freeformCrop={ freeformCrop }
+						isResizeDisabled={ isTouchPinching }
 						stencilTransition={ settleStencilTransition }
 						cropBounds={ cropBounds }
 						minCropSize={ minCropSize }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -101,6 +101,7 @@ type RectangleStencilProps = StencilProps;
  * @param props.onResizeEnd        Callback fired when a resize drag ends (mouseup).
  * @param props.aspectRatio        Optional fixed aspect ratio (width / height).
  * @param props.freeformCrop       Whether resize handles are shown.
+ * @param props.isResizeDisabled   Whether resize handles should ignore pointer and keyboard input.
  * @param props.stencilTransition  CSS transition string for settle animation.
  * @param props.cropBounds         Maximum crop rect bounds from camera (zoom/rotation-aware).
  * @param props.onEscape           Called when Escape is pressed on a resize handle.
@@ -118,6 +119,7 @@ export function RectangleStencil( {
 	onResizeEnd,
 	aspectRatio,
 	freeformCrop = false,
+	isResizeDisabled = false,
 	stencilTransition,
 	cropBounds,
 	onEscape,
@@ -143,6 +145,9 @@ export function RectangleStencil( {
 	const keyboardResizeActiveRef = useRef( false );
 	const resizeHandleDescriptionId = useId();
 	const hasLockedRatio = !! ( aspectRatio && aspectRatio > 0 );
+	const activePointerResizeRef = useRef< {
+		cancel: ( notifyResizeEnd?: boolean ) => void;
+	} | null >( null );
 
 	// Clear the pending keyboard settle timer on unmount so it can't
 	// fire onResizeEnd / dispatch onto an unmounted parent.
@@ -150,8 +155,15 @@ export function RectangleStencil( {
 		return () => {
 			clearTimeout( keyboardSettleTimerRef.current );
 			keyboardResizeActiveRef.current = false;
+			activePointerResizeRef.current?.cancel( false );
 		};
 	}, [] );
+
+	useEffect( () => {
+		if ( isResizeDisabled ) {
+			activePointerResizeRef.current?.cancel();
+		}
+	}, [ isResizeDisabled ] );
 
 	// Latest callbacks for the drag listeners. The drag closure in
 	// handlePointerDown reads from this ref so it always sees current
@@ -212,6 +224,14 @@ export function RectangleStencil( {
 	 */
 	const handlePointerDown = useCallback(
 		( handle: HandlePosition, event: React.PointerEvent ) => {
+			if (
+				isResizeDisabled ||
+				( event.pointerType === 'touch' && event.isPrimary === false )
+			) {
+				event.preventDefault();
+				event.stopPropagation();
+				return;
+			}
 			if ( event.button !== 0 ) {
 				return;
 			}
@@ -278,7 +298,10 @@ export function RectangleStencil( {
 			// Guard against duplicate firing: pointerup and
 			// lostpointercapture both fire on normal release.
 			let ended = false;
-			const onEnd = () => {
+			const endResize = (
+				notifyResizeEnd = true,
+				restoreFocus = true
+			) => {
 				if ( ended ) {
 					return;
 				}
@@ -290,17 +313,26 @@ export function RectangleStencil( {
 				el.removeEventListener( 'pointermove', onMove );
 				el.removeEventListener( 'pointerup', onEnd );
 				el.removeEventListener( 'lostpointercapture', onEnd );
-				latestHandlersRef.current?.onResizeEnd?.();
+				activePointerResizeRef.current = null;
+				if ( notifyResizeEnd ) {
+					latestHandlersRef.current?.onResizeEnd?.();
+				}
 				// Restore focus to the handle so arrow keys work
 				// immediately after a mouse drag. Browsers suppress
 				// :focus-visible after pointer interactions, so the
 				// focus ring stays hidden until the user presses a key.
-				el.focus( { preventScroll: true } );
+				if ( restoreFocus ) {
+					el.focus( { preventScroll: true } );
+				}
 			};
+			const cancelResize = ( notifyResizeEnd = true ) =>
+				endResize( notifyResizeEnd, false );
+			const onEnd = () => endResize();
 
 			el.addEventListener( 'pointermove', onMove );
 			el.addEventListener( 'pointerup', onEnd );
 			el.addEventListener( 'lostpointercapture', onEnd );
+			activePointerResizeRef.current = { cancel: cancelResize };
 
 			onResizeStart?.( handle );
 			// Cancel any pending keyboard settle so it can't fire onResizeEnd
@@ -309,7 +341,7 @@ export function RectangleStencil( {
 			clearTimeout( keyboardSettleTimerRef.current );
 			keyboardResizeActiveRef.current = false;
 		},
-		[ cropRect, onResizeStart ]
+		[ cropRect, isResizeDisabled, onResizeStart ]
 	);
 
 	/**
@@ -396,6 +428,10 @@ export function RectangleStencil( {
 	const handleKeyDown = useCallback(
 		( handle: HandlePosition, event: React.KeyboardEvent ) => {
 			const key = event.key;
+
+			if ( isResizeDisabled ) {
+				return;
+			}
 
 			if ( key === 'Escape' ) {
 				event.preventDefault();
@@ -503,6 +539,7 @@ export function RectangleStencil( {
 			onEscape,
 			keyboardResizeStep,
 			snapCropRect,
+			isResizeDisabled,
 		]
 	);
 
@@ -560,7 +597,11 @@ export function RectangleStencil( {
 						onPointerDown={ ( event ) =>
 							handlePointerDown( pos, event )
 						}
-						onTouchStart={ ( event ) => event.stopPropagation() }
+						onTouchStart={ ( event ) => {
+							if ( event.touches.length < 2 ) {
+								event.stopPropagation();
+							}
+						} }
 						onKeyDown={ ( event ) => handleKeyDown( pos, event ) }
 						aria-label={ getHandleLabel( pos ) }
 						aria-describedby={ resizeHandleDescriptionId }

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -33,23 +33,29 @@ function renderStencil(
 	const onResizeStart = jest.fn();
 	const onResizeEnd = jest.fn();
 	const onEscape = jest.fn();
+	const props = {
+		cropRect: DEFAULT_CROP_RECT,
+		containerSize: CONTAINER_SIZE,
+		imageSize: IMAGE_SIZE,
+		onCropChange,
+		onResizeStart,
+		onResizeEnd,
+		onEscape,
+		freeformCrop: true,
+		cropBounds: CROP_BOUNDS,
+		...overrides,
+	};
 
-	render(
-		<RectangleStencil
-			cropRect={ DEFAULT_CROP_RECT }
-			containerSize={ CONTAINER_SIZE }
-			imageSize={ IMAGE_SIZE }
-			onCropChange={ onCropChange }
-			onResizeStart={ onResizeStart }
-			onResizeEnd={ onResizeEnd }
-			onEscape={ onEscape }
-			freeformCrop
-			cropBounds={ CROP_BOUNDS }
-			{ ...overrides }
-		/>
-	);
+	const utils = render( <RectangleStencil { ...props } /> );
 
-	return { onCropChange, onResizeStart, onResizeEnd, onEscape };
+	return {
+		...utils,
+		props,
+		onCropChange,
+		onResizeStart,
+		onResizeEnd,
+		onEscape,
+	};
 }
 
 describe( 'RectangleStencil', () => {
@@ -362,6 +368,76 @@ describe( 'RectangleStencil', () => {
 			} );
 
 			expect( firstHandle.focus ).toHaveBeenCalled();
+		} );
+
+		it( 'does not start a pointer resize while resizing is disabled', () => {
+			const { onResizeStart } = renderStencil( {
+				isResizeDisabled: true,
+			} );
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.pointerDown( firstHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+			} );
+
+			expect( onResizeStart ).not.toHaveBeenCalled();
+		} );
+
+		it( 'cancels an active pointer resize when resizing becomes disabled', () => {
+			const { props, rerender, onResizeStart, onResizeEnd } =
+				renderStencil();
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.pointerDown( firstHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+			} );
+
+			expect( onResizeStart ).toHaveBeenCalledTimes( 1 );
+			expect( onResizeEnd ).not.toHaveBeenCalled();
+
+			rerender( <RectangleStencil { ...props } isResizeDisabled /> );
+
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+
+			fireEvent.pointerUp( firstHandle, { pointerId: 1 } );
+
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'only stops touchstart propagation for single-touch handle gestures', () => {
+			const onTouchStart = jest.fn();
+			render(
+				<div onTouchStart={ onTouchStart }>
+					<RectangleStencil
+						cropRect={ DEFAULT_CROP_RECT }
+						containerSize={ CONTAINER_SIZE }
+						imageSize={ IMAGE_SIZE }
+						onCropChange={ jest.fn() }
+						freeformCrop
+						cropBounds={ CROP_BOUNDS }
+					/>
+				</div>
+			);
+			const [ firstHandle ] = screen.getAllByRole( 'button' );
+
+			fireEvent.touchStart( firstHandle, {
+				touches: [ { clientX: 100, clientY: 100 } ],
+			} );
+			expect( onTouchStart ).not.toHaveBeenCalled();
+
+			fireEvent.touchStart( firstHandle, {
+				touches: [
+					{ clientX: 100, clientY: 100 },
+					{ clientX: 160, clientY: 100 },
+				],
+			} );
+			expect( onTouchStart ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -66,9 +66,13 @@ describe( 'Cropper', () => {
 				MouseEvent
 			) {
 				pointerId: number;
+				pointerType: string;
+				isPrimary: boolean;
 				constructor( type: string, init: PointerEventInit = {} ) {
 					super( type, init );
 					this.pointerId = init.pointerId ?? 0;
+					this.pointerType = init.pointerType ?? '';
+					this.isPrimary = init.isPrimary ?? false;
 				}
 			};
 		}
@@ -474,6 +478,44 @@ describe( 'Cropper', () => {
 		expect( controller.setZoomAtPoint ).not.toHaveBeenCalled();
 
 		fireEvent.pointerUp( resizeHandle, { pointerId: 1 } );
+	} );
+
+	it( 'does not start canvas drag from touch pointer events', async () => {
+		const controller = createController();
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming
+				showGrid="interactive"
+				freeformCrop
+			/>
+		);
+
+		await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		fireEvent.pointerDown( canvas, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+			pointerType: 'touch',
+			isPrimary: true,
+		} );
+		fireEvent.pointerMove( canvas, {
+			button: 0,
+			clientX: 150,
+			clientY: 120,
+			pointerId: 1,
+			pointerType: 'touch',
+			isPrimary: true,
+		} );
+
+		expect( canvas ).not.toHaveClass( SHOW_GRID_CLASS );
+		expect( controller.setPan ).not.toHaveBeenCalled();
 	} );
 
 	it( 'cancels handle resize when a touch gesture becomes a pinch', async () => {

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -476,6 +476,108 @@ describe( 'Cropper', () => {
 		fireEvent.pointerUp( resizeHandle, { pointerId: 1 } );
 	} );
 
+	it( 'cancels handle resize when a touch gesture becomes a pinch', async () => {
+		const originalRAF = globalThis.requestAnimationFrame;
+		const originalCAF = globalThis.cancelAnimationFrame;
+		globalThis.requestAnimationFrame = ( cb: FrameRequestCallback ) => {
+			cb( 0 );
+			return 0;
+		};
+		globalThis.cancelAnimationFrame = jest.fn();
+
+		try {
+			const controller = createController();
+			const onGestureEnd = jest.fn();
+			render(
+				<Cropper
+					src="test.jpg"
+					controller={ controller }
+					showDimming={ false }
+					freeformCrop
+					onGestureEnd={ onGestureEnd }
+				/>
+			);
+
+			const resizeHandle = await screen.findByRole( 'button', {
+				name: 'Resize top-left corner',
+			} );
+			const canvas = screen.getByRole( 'group', {
+				name: 'Crop area',
+			} );
+
+			fireEvent.pointerDown( resizeHandle, {
+				button: 0,
+				clientX: 100,
+				clientY: 100,
+				pointerId: 1,
+				pointerType: 'touch',
+				isPrimary: true,
+			} );
+
+			( controller.setPan as jest.Mock ).mockClear();
+			fireEvent.pointerDown( canvas, {
+				button: 0,
+				clientX: 250,
+				clientY: 200,
+				pointerId: 2,
+				pointerType: 'touch',
+				isPrimary: false,
+			} );
+			fireEvent.pointerMove( canvas, {
+				button: 0,
+				clientX: 275,
+				clientY: 200,
+				pointerId: 2,
+				pointerType: 'touch',
+				isPrimary: false,
+			} );
+
+			expect( controller.setPan ).not.toHaveBeenCalled();
+
+			fireEvent.touchStart( canvas, {
+				touches: [
+					{ clientX: 250, clientY: 200 },
+					{ clientX: 350, clientY: 200 },
+				],
+			} );
+
+			await act( async () => {
+				await Promise.resolve();
+			} );
+
+			expect( controller.settleCrop ).not.toHaveBeenCalled();
+			expect( onGestureEnd ).not.toHaveBeenCalled();
+
+			( controller.setCropRect as jest.Mock ).mockClear();
+			( controller.setZoomAtPoint as jest.Mock ).mockClear();
+
+			fireEvent.pointerMove( resizeHandle, {
+				button: 0,
+				clientX: 60,
+				clientY: 60,
+				pointerId: 1,
+				pointerType: 'touch',
+				isPrimary: true,
+			} );
+			fireEvent.touchMove( document, {
+				touches: [
+					{ clientX: 225, clientY: 200 },
+					{ clientX: 375, clientY: 200 },
+				],
+			} );
+
+			expect( controller.setCropRect ).not.toHaveBeenCalled();
+			expect( controller.setZoomAtPoint ).toHaveBeenCalled();
+
+			fireEvent.touchEnd( canvas, { touches: [] } );
+
+			expect( onGestureEnd ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			globalThis.requestAnimationFrame = originalRAF;
+			globalThis.cancelAnimationFrame = originalCAF;
+		}
+	} );
+
 	// View-scale: at rest, the scene magnifies so an under-filling crop fills
 	// the canvas. Canvas is mocked at 600x400. A tall 400x1200 image contain-
 	// fits to a 133.33x400 footprint (fills the height, 133px of 600 wide). A


### PR DESCRIPTION
## What

Fixes crop canvas pinch zoom behavior in the media editor modal.

- Pinch zoom now keeps the pinch-start midpoint anchored when zooming from an already zoomed, panned, or cropped state.
- Crop resize handles are disabled and any active handle resize is cancelled when a touch gesture becomes a pinch.
- Secondary touch pointer events are prevented from starting canvas pan or handle resize while a pinch is active.
- Touch pointer events no longer start the canvas drag path before the touch pinch path owns the gesture.

## Why

The intended behavior was for pinch zoom to zoom around the center of the pinch. The previous math mixed pinch-start values with the current reducer state from each touchmove frame, so repeated frames could compound and drift away from the pinch center after the image was already zoomed or panned.

There was also a gesture ownership issue between crop resize handles and pinch zoom. If a pinch started while interacting with a handle, resize and pan paths could still receive events, causing interference with the pinch gesture.

Touch input was also entering both pointer and touch handling. The first finger could briefly start the pointer drag path before the second finger promoted the interaction to a pinch, which could flash the drag UI at the start of a pinch.

## How

Pinch zoom now calculates focal-point correction from the pinch-start zoom, pan, and midpoint for every frame, while still applying midpoint drift as pan when both fingers move together.

The cropper tracks active touch pinches at the canvas capture boundary and passes a resize-disabled state to the rectangle stencil. The stencil ignores disabled resize input, consumes secondary touch pointerdowns, and cancels active pointer resizes. When resize cancellation happens because a pinch starts, the cropper clears resize UI state without settling or ending the gesture boundary; the pinch gesture owns the final end event.

The interaction controller now ignores touch pointerdown events because touch panning and pinch zoom are handled by the touch event path.

## Testing Instructions

**[Playground test link for this PR 79332](https://playground.wordpress.net/gutenberg.html?pr=79332)**

**[Playground test link for trunk (for comparison)](https://playground.wordpress.net/?gutenberg-branch=trunk)**

1. Open the media editor modal on a touch device.
2. Select an image and enter crop mode.
3. Zoom or crop the image so it is no longer in its default centered state.
4. Pinch zoom from a point away from the canvas center.
5. Confirm the image zooms around the center of the pinch, without drifting back toward the canvas center.
6. Start dragging a crop resize handle, then place a second finger on the canvas to begin a pinch.
7. Confirm the handle resize stops immediately and the pinch zoom continues without moving the crop handles.
8. Start a pinch with one finger touching near or on a crop handle.
9. Confirm the crop handles do not move and the image responds only to the pinch gesture.
10. Start a normal finger-and-thumb pinch and confirm the crop overlay does not briefly flicker into the drag state when the pinch begins.


## Before


https://github.com/user-attachments/assets/1bcd0b62-34e3-4138-8574-fbf711248073



## After

https://github.com/user-attachments/assets/2dd01701-746b-4b93-9b14-95d5e24af385


