### PR TITLE
DataViews: Fix infinite-scroll list jumping while a page loads

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
--   DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads, which made the list jump when scrolling down to load more.
+-   DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads, which made the list jump when scrolling down to load more. [#79334](https://github.com/WordPress/gutenberg/pull/79334)
 
 ### Code Quality
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   DataViewsPicker: Add a new `pickerActivity` layout that renders selectable items as a vertical activity timeline. [#78941](https://github.com/WordPress/gutenberg/pull/78941)
 
+### Bug Fixes
+
+-   DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads, which made the list jump when scrolling down to load more.
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -1,0 +1,120 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViews from '../index';
+import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../constants';
+import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
+import type { View } from '../../types';
+import { actions, data as fixtureData, fields } from './fixtures';
+
+// The fixtures only contain ~50 rows; repeat them (with unique ids) so there
+// are enough rows to scroll through several infinite-scroll pages.
+const data = Array.from( { length: 6 }, ( _, batch ) =>
+	fixtureData.map( ( item ) => ( {
+		...item,
+		id: item.id + batch * 1000,
+		name: {
+			...item.name,
+			title: `${ item.name.title } #${ batch + 1 }`,
+		},
+	} ) )
+).flat();
+
+const PAGE = 20;
+// Simulated network latency per page. The jump reproduces when the user keeps
+// scrolling during this window, so it needs to be long enough to scroll within.
+const LOAD_DELAY_MS = 700;
+
+/**
+ * Reproduces a real-world infinite-scroll consumer (e.g. a notifications list)
+ * that the static `InfiniteScroll` story does not: data is revealed one page at
+ * a time *asynchronously* and `isLoading` toggles for each page. Scroll down
+ * continuously and the list jumps upward as each page settles — the scroll
+ * handler captures an anchor when it advances the window, but by the time the
+ * page resolves and the anchor is "restored" the user has scrolled further, and
+ * the restoration snaps back to the capture-time position, undoing that scroll.
+ */
+const AsyncInfiniteScroll = () => {
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_LIST,
+		search: '',
+		startPosition: 1,
+		perPage: PAGE,
+		filters: [],
+		fields: [ 'satellites' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+		infiniteScrollEnabled: true,
+	} );
+
+	// A "server" that reveals rows one page at a time, asynchronously.
+	const [ loadedCount, setLoadedCount ] = useState( PAGE );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const loadingRef = useRef( false );
+
+	const loadedData = useMemo(
+		() => data.slice( 0, loadedCount ),
+		[ loadedCount ]
+	);
+	const { data: shownData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( loadedData, view, fields ),
+		[ loadedData, view ]
+	);
+
+	// Keep two pages buffered ahead of the scroll window. The async gap below is
+	// what lets the user keep scrolling while a page loads.
+	const startPosition = view.startPosition ?? 1;
+	useEffect( () => {
+		if (
+			startPosition + PAGE * 2 <= loadedCount ||
+			loadingRef.current ||
+			loadedCount >= data.length
+		) {
+			return undefined;
+		}
+		loadingRef.current = true;
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setLoadedCount( ( count ) =>
+				Math.min( count + PAGE, data.length )
+			);
+			setIsLoading( false );
+			loadingRef.current = false;
+		}, LOAD_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ startPosition, loadedCount ] );
+
+	return (
+		<>
+			<style>{ `
+			.dataviews-wrapper {
+				height: 600px;
+				overflow: auto;
+			}
+		` }</style>
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ shownData }
+				view={ view }
+				fields={ fields }
+				onChangeView={ setView }
+				isLoading={ isLoading }
+				actions={ actions }
+				defaultLayouts={ {
+					[ LAYOUT_TABLE ]: true,
+					[ LAYOUT_GRID ]: true,
+					[ LAYOUT_LIST ]: true,
+				} }
+			/>
+		</>
+	);
+};
+
+export default AsyncInfiniteScroll;

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -13,6 +13,7 @@ import LayoutGridComponent from './layout-grid';
 import LayoutListComponent from './layout-list';
 import LayoutCustomComponent from './layout-custom';
 import InfiniteScrollComponent from './infinite-scroll';
+import AsyncInfiniteScrollComponent from './async-infinite-scroll';
 import WithCardComponent from './with-card';
 import FreeCompositionComponent from './free-composition';
 import MinimalUIComponent from './minimal-ui';
@@ -266,6 +267,21 @@ export const WithCard = {
 
 export const InfiniteScroll = {
 	render: InfiniteScrollComponent,
+	parameters: {
+		containerHeight: '600px',
+	},
+	argTypes: {
+		containerHeight: {
+			control: false,
+			table: {
+				disable: true,
+			},
+		},
+	},
+};
+
+export const AsyncInfiniteScroll = {
+	render: AsyncInfiniteScrollComponent,
 	parameters: {
 		containerHeight: '600px',
 	},

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -28,6 +28,7 @@ function captureAnchorElement(
 	anchorElementRef: React.MutableRefObject< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >,
 	direction: 'up' | 'down'
@@ -61,6 +62,7 @@ function captureAnchorElement(
 	anchorElementRef.current = {
 		posinset,
 		viewportOffset: anchorRect.top - containerRect.top,
+		scrollTop: container.scrollTop,
 		direction,
 	};
 	return true;
@@ -95,6 +97,7 @@ export function useInfiniteScroll( {
 	const anchorElementRef = useRef< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >( null );
 	const viewRef = useRef( view );
@@ -174,8 +177,20 @@ export function useInfiniteScroll( {
 			const anchorRect = anchorElement.getBoundingClientRect();
 			const currentOffset = anchorRect.top - containerRect.top;
 
-			// Calculate how much the anchor has moved and adjust scroll to compensate
-			const scrollAdjustment = currentOffset - anchor.viewportOffset;
+			// Compensate only for the anchor being displaced by items added or
+			// removed since capture — not for the user's own scrolling in the
+			// meantime. The raw offset delta (`currentOffset - viewportOffset`)
+			// conflates both: between capture and this restore the user can keep
+			// scrolling (the next page often loads asynchronously), and that
+			// scroll shows up as offset change too. Adding back the scroll delta
+			// (`scrollTop - capturedScrollTop`) cancels the user-driven component,
+			// leaving just the content-driven shift. Without it, the restore snaps
+			// the list back to its capture-time position and undoes the scrolling
+			// the user did while the page was loading.
+			const scrollAdjustment =
+				currentOffset -
+				anchor.viewportOffset +
+				( container.scrollTop - anchor.scrollTop );
 
 			if ( Math.abs( scrollAdjustment ) > 1 ) {
 				container.scrollTop += scrollAdjustment;


### PR DESCRIPTION
## What?

Fixes a bug in DataViews infinite scroll where the list **jumps** (the scroll position is yanked upward) while you scroll down to load more, when the consumer loads pages **asynchronously**.

This PR also adds an `Async Infinite Scroll` story that reproduces the bug in one step.

## Why?

The infinite-scroll scroll-anchor restoration is meant to keep the viewport stable when items are inserted/removed (e.g. paging in older items). It works by capturing an anchor element and its viewport offset when the window advances, then re-applying that offset after the next render.

The problem: capture happens inside the throttled `scroll` handler the instant the window advances, but the restoration runs on a later render (it's gated on `isLoading`). When pages load asynchronously, the user keeps scrolling **between** capture and restore. The restoration can't distinguish that user-driven movement from a content-driven shift, so it "corrects" it — snapping the list back to where the anchor sat at capture time and undoing the scrolling the user did while the page was loading.

The existing synchronous `InfiniteScroll` story never hits this: it passes no `isLoading` and resolves data synchronously, so the restoration effect never runs and there's no async gap for the user to scroll into. Real consumers that load over the network (a notifications list, for example) hit it consistently.

## How?

Using content-position `P` and scroll `S`, an element's offset from the container top is `P − S`.

- Capture: `viewportOffset = P1 − S1`
- Restore: `currentOffset = P2 − S2`; the old adjustment `currentOffset − viewportOffset` resolves the scroll position to `P2 − P1 + S1` — i.e. it pins the anchor to its **capture-time** position, discarding the user's scroll `(S2 − S1)`. For a pure scroll-down append `P2 = P1`, so the adjustment is `S1 − S2`, exactly negating the user's scroll.

The fix stores `scrollTop` at capture and adds the intervening scroll delta back:

```
scrollAdjustment = (currentOffset − viewportOffset) + (scrollTop − capturedScrollTop) = P2 − P1
```

So only the **content-driven** shift is compensated:

- Append below the viewport (scroll down): `P2 = P1` → adjustment `0` → no jump.
- Insert above the viewport (scroll up / prepend): `P2 = P1 + H` → adjustment `H` → position correctly held.

When the user does **not** scroll during the load, `scrollTop == capturedScrollTop`, the added term is `0`, and behaviour is byte-for-byte identical to before — so this only changes the currently-broken case.

> Note: scroll anchoring depends on real layout/scroll, which jsdom does not simulate, so this is verified via the story below rather than a unit test.

## Testing Instructions

1. `npm run storybook:dev`
2. Open **DataViews → DataViews → Async Infinite Scroll**.
3. Scroll **down continuously** through several pages (each page has ~700ms simulated latency, so keep scrolling while it loads).
4. **With this PR:** the list stays put as each page settles.
5. **To see the bug:** check out `packages/dataviews/src/hooks/use-infinite-scroll.ts` from `trunk` (`git checkout trunk -- packages/dataviews/src/hooks/use-infinite-scroll.ts`), keep the story, and repeat step 3 — the list jumps upward as each page settles.

### Testing Instructions for Keyboard

Not a UI/markup change. The list can still be scrolled with the keyboard (focus a row, then `Page Down` / arrow keys); the same stability applies.

## Screenshots or screencast

|Before|After|
|-|-|
|List jumps upward as each async page settles|Scroll position stays put|

## Use of AI Tools

This change was authored with the assistance of AI tooling (Claude Code). The root cause was diagnosed against a live consumer, the fix and the repro story were reviewed and verified by a human in Storybook before submitting.