### PR TITLE
Media Editor: Align crop settle state with transition completion

### DIFF
--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -870,7 +870,8 @@ function CropperInner(
 		( event: React.TransitionEvent< HTMLDivElement > ) => {
 			if (
 				! isSettlingRef.current ||
-				event.propertyName !== 'transform'
+				event.propertyName !== 'transform' ||
+				event.target !== event.currentTarget
 			) {
 				return;
 			}

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -60,6 +60,9 @@ const CROP_RECT_EPSILON = 1e-6;
 const CARDINAL_ROTATION_EPSILON = 1e-6;
 /** Duration of the settle transform transition after resize end. */
 const SETTLE_TRANSITION_DURATION_MS = 200;
+// Fallback timer for when the computed transform is unchanged and no
+// `transitionend` fires. Sits past the CSS duration so it only wins the race
+// when the transition genuinely never runs.
 const SETTLE_TRANSITION_FALLBACK_MS = SETTLE_TRANSITION_DURATION_MS + 100;
 const SETTLE_TRANSFORM_TRANSITION = `transform ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`;
 const SETTLE_STENCIL_TRANSITION = [
@@ -856,15 +859,19 @@ function CropperInner(
 		// Normal completion is driven by transitionend so settling cannot clear
 		// before the browser has actually finished animating. Keep a fallback for
 		// cases where the computed transform is unchanged and no event fires.
-		settleTimerRef.current = setTimeout( () => {
-			finishSettling();
-		}, SETTLE_TRANSITION_FALLBACK_MS );
+		settleTimerRef.current = setTimeout(
+			finishSettling,
+			SETTLE_TRANSITION_FALLBACK_MS
+		);
 	}, [ finishSettling, settleCrop, onGestureEnd, resetViewport ] );
 
 	/**
-	 * Finish settling when the stage transform transition actually completes.
-	 * Other transitionend events can bubble up from cropper descendants, so only
-	 * the transform transition should clear the settle state.
+	 * Finish settling when the settle transform transition actually completes.
+	 * The handler lives on the stage, but in the common (un-panned) case the
+	 * transform transition runs on the image layer and its `transitionend`
+	 * bubbles up to here. Other transitionend events (stencil left/top/width/
+	 * height) also bubble up, so only the transform transition should clear the
+	 * settle state.
 	 */
 	const handleSettleTransitionEnd = useCallback(
 		( event: React.TransitionEvent< HTMLDivElement > ) => {

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -877,8 +877,7 @@ function CropperInner(
 		( event: React.TransitionEvent< HTMLDivElement > ) => {
 			if (
 				! isSettlingRef.current ||
-				event.propertyName !== 'transform' ||
-				event.target !== event.currentTarget
+				event.propertyName !== 'transform'
 			) {
 				return;
 			}

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -58,6 +58,16 @@ import { VISUALLY_HIDDEN_STYLE } from '../visually-hidden-style';
 const CROP_RECT_EPSILON = 1e-6;
 /** Threshold for deciding whether rotation is at a 90-degree stop. */
 const CARDINAL_ROTATION_EPSILON = 1e-6;
+/** Duration of the settle transform transition after resize end. */
+const SETTLE_TRANSITION_DURATION_MS = 200;
+const SETTLE_TRANSITION_FALLBACK_MS = SETTLE_TRANSITION_DURATION_MS + 100;
+const SETTLE_TRANSFORM_TRANSITION = `transform ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`;
+const SETTLE_STENCIL_TRANSITION = [
+	`left ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`,
+	`top ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`,
+	`width ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`,
+	`height ${ SETTLE_TRANSITION_DURATION_MS }ms ease-out`,
+].join( ', ' );
 
 /**
  * Props for the Cropper component.
@@ -745,9 +755,14 @@ function CropperInner(
 		[ setCropRect, setViewportPan, canvasSize, scaledVisualSize ]
 	);
 
-	// Settling animation: brief linear transition after resize end.
+	// Settling animation: brief transition after resize end.
 	const [ settling, setSettling ] = useState( false );
 	const settleTimerRef = useRef< ReturnType< typeof setTimeout > >();
+	const finishSettling = useCallback( () => {
+		clearTimeout( settleTimerRef.current );
+		isSettlingRef.current = false;
+		setSettling( false );
+	}, [] );
 
 	// Clear the pending settle timer on unmount so it can't fire a
 	// state update on an unmounted component.
@@ -801,13 +816,11 @@ function CropperInner(
 			// Clear any in-flight settle so transitions don't apply during the
 			// new drag (rapid successive resizes would otherwise inherit the
 			// previous settle animation).
-			clearTimeout( settleTimerRef.current );
-			isSettlingRef.current = false;
-			setSettling( false );
+			finishSettling();
 			resetViewport();
 			onGestureStart?.();
 		},
-		[ onGestureStart, resetViewport, viewScaleRest ]
+		[ finishSettling, onGestureStart, resetViewport, viewScaleRest ]
 	);
 
 	/**
@@ -828,8 +841,7 @@ function CropperInner(
 			// the pinch therefore collapse into a single undo step, since
 			// `beginGesture` is idempotent and the snapshot captured at resize
 			// start is flushed by the pinch's `endGesture`.
-			isSettlingRef.current = false;
-			setSettling( false );
+			finishSettling();
 			resetViewport();
 			return;
 		}
@@ -841,20 +853,35 @@ function CropperInner(
 		resetViewport();
 		settleCrop();
 		onGestureEnd?.();
+		// Normal completion is driven by transitionend so settling cannot clear
+		// before the browser has actually finished animating. Keep a fallback for
+		// cases where the computed transform is unchanged and no event fires.
 		settleTimerRef.current = setTimeout( () => {
-			isSettlingRef.current = false;
-			setSettling( false );
-		}, 200 );
-	}, [ settleCrop, onGestureEnd, resetViewport ] );
+			finishSettling();
+		}, SETTLE_TRANSITION_FALLBACK_MS );
+	}, [ finishSettling, settleCrop, onGestureEnd, resetViewport ] );
+
+	const handleSettleTransitionEnd = useCallback(
+		( event: React.TransitionEvent< HTMLDivElement > ) => {
+			if (
+				! isSettlingRef.current ||
+				event.propertyName !== 'transform'
+			) {
+				return;
+			}
+			finishSettling();
+		},
+		[ finishSettling ]
+	);
 
 	let imageTransition: string | undefined;
 	if ( settling ) {
-		imageTransition = 'transform 200ms ease-out';
+		imageTransition = SETTLE_TRANSFORM_TRANSITION;
 	} else if ( isZooming ) {
 		imageTransition = 'transform 150ms linear';
 	}
 	const settleStencilTransition = settling
-		? 'left 200ms ease-out, top 200ms ease-out, width 200ms ease-out, height 200ms ease-out'
+		? SETTLE_STENCIL_TRANSITION
 		: undefined;
 
 	// Compute the image's CSS style. The element keeps its contain-fit box; the
@@ -903,7 +930,7 @@ function CropperInner(
 	// Transitions back to zero during the settle animation.
 	// will-change promotes the stage to its own compositor layer while the
 	// transform is active, keeping per-frame pan updates off the main thread.
-	const settleTransition = settling ? 'transform 200ms ease-out' : undefined;
+	const settleTransition = settling ? SETTLE_TRANSFORM_TRANSITION : undefined;
 	const willChange = isResizing || settling ? 'transform' : undefined;
 	let stageStyle: React.CSSProperties | undefined;
 	if ( viewportState.pan.x !== 0 || viewportState.pan.y !== 0 ) {
@@ -1005,6 +1032,7 @@ function CropperInner(
 					className="wp-media-editor-image-editor__stage"
 					data-testid="cropper-stage"
 					style={ stageStyle }
+					onTransitionEnd={ handleSettleTransitionEnd }
 				>
 					{ /* The image layer */ }
 					<img

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -861,6 +861,11 @@ function CropperInner(
 		}, SETTLE_TRANSITION_FALLBACK_MS );
 	}, [ finishSettling, settleCrop, onGestureEnd, resetViewport ] );
 
+	/**
+	 * Finish settling when the stage transform transition actually completes.
+	 * Other transitionend events can bubble up from cropper descendants, so only
+	 * the transform transition should clear the settle state.
+	 */
 	const handleSettleTransitionEnd = useCallback(
 		( event: React.TransitionEvent< HTMLDivElement > ) => {
 			if (

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -446,6 +446,87 @@ describe( 'Cropper', () => {
 		jest.useRealTimers();
 	} );
 
+	it( 'clears settling via the fallback timer when no transitionend fires', async () => {
+		jest.useFakeTimers();
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const stage = screen.getByTestId( 'cropper-stage' );
+
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		// Without a transitionend, settling persists past the CSS duration...
+		act( () => jest.advanceTimersByTime( 200 ) );
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		// ...and is cleared by the fallback timer (CSS duration + 100ms).
+		act( () => jest.advanceTimersByTime( 100 ) );
+		expect( stage ).not.toHaveStyle(
+			'transition: transform 200ms ease-out'
+		);
+
+		jest.useRealTimers();
+	} );
+
+	it( 'ignores non-transform transitionend events while settling', async () => {
+		jest.useFakeTimers();
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const stage = screen.getByTestId( 'cropper-stage' );
+
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		// A stencil left/top/width/height transitionend must not clear settling.
+		const stencilTransitionEnd = new Event( 'transitionend', {
+			bubbles: true,
+		} );
+		Object.defineProperty( stencilTransitionEnd, 'propertyName', {
+			value: 'left',
+		} );
+		fireEvent( stage, stencilTransitionEnd );
+
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		jest.useRealTimers();
+	} );
+
 	it( 'pans the canvas when a keyboard resize extends the crop past the canvas edge', async () => {
 		jest.useFakeTimers();
 

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -431,13 +431,16 @@ describe( 'Cropper', () => {
 		act( () => jest.advanceTimersByTime( 200 ) );
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
+		// The transform transition runs on the image and bubbles up to the
+		// stage handler, so fire from the image to exercise the real path.
+		const image = screen.getByTestId( 'cropper-image' );
 		const transitionEndEvent = new Event( 'transitionend', {
 			bubbles: true,
 		} );
 		Object.defineProperty( transitionEndEvent, 'propertyName', {
 			value: 'transform',
 		} );
-		fireEvent( stage, transitionEndEvent );
+		fireEvent( image, transitionEndEvent );
 
 		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -345,7 +345,7 @@ describe( 'Cropper', () => {
 		);
 	} );
 
-	it( 'clears settling state when a new resize starts before the settle timer fires', async () => {
+	it( 'clears settling state when a new resize starts before the settle fallback fires', async () => {
 		jest.useFakeTimers();
 
 		render(
@@ -376,7 +376,7 @@ describe( 'Cropper', () => {
 		// The settle transition should now be active on the stage.
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
-		// Start a new resize before the 200 ms settle timer fires.
+		// Start a new resize before the settle fallback fires.
 		fireEvent.pointerDown( handle, {
 			button: 0,
 			clientX: 100,
@@ -389,14 +389,59 @@ describe( 'Cropper', () => {
 			'transition: transform 200ms ease-out'
 		);
 
-		// Advance past the old settle timer; it was cancelled so the stage
+		// Advance past the old settle fallback; it was cancelled so the stage
 		// should still have no transition.
-		act( () => jest.advanceTimersByTime( 200 ) );
+		act( () => jest.advanceTimersByTime( 300 ) );
 		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'
 		);
 
 		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'keeps settling active until the settle transform transition ends', async () => {
+		jest.useFakeTimers();
+
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ createController() }
+				showDimming={ false }
+				freeformCrop
+			/>
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize top-left corner',
+		} );
+		const stage = screen.getByTestId( 'cropper-stage' );
+
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		act( () => jest.advanceTimersByTime( 200 ) );
+		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
+
+		const transitionEndEvent = new Event( 'transitionend', {
+			bubbles: true,
+		} );
+		Object.defineProperty( transitionEndEvent, 'propertyName', {
+			value: 'transform',
+		} );
+		fireEvent( stage, transitionEndEvent );
+
+		expect( stage ).not.toHaveStyle(
+			'transition: transform 200ms ease-out'
+		);
 
 		jest.useRealTimers();
 	} );


### PR DESCRIPTION
## What

Updates the media editor cropper settle animation so the `settling` state is cleared when the CSS `transform` transition actually ends, instead of relying on a matching `200ms` JavaScript timer.

The timer remains as a fallback for cases where no transition event fires.

Pick up here: https://github.com/WordPress/gutenberg/pull/79332#pullrequestreview-4529911233 Thanks!

## Why

The previous implementation used both a `200ms` CSS transition and a `200ms` JS timeout. 

Since the timeout starts before the browser commits and paints the transition, it could clear the settling state slightly before the visual animation completed, potentially causing a subtle one-frame flicker at the end of crop settling.

I can't reproduce anything strange on trunk but I think this is a worthy consolidation regardless.


## How

- Centralizes the settle transition duration.
- Clears settle state from the stage `transitionend` event for `transform`.
- Keeps a small timeout fallback beyond the CSS duration.
- Adds regression coverage to ensure settling does not clear exactly at `200ms` before the transition ends.

## Testing Instructions

Basically check for regressions. 😄 

1. Open the editor and add/select an image.
2. Open the media editor modal.
3. Enter crop mode.
4. Resize the crop handles, then release the pointer.
5. Confirm the image/crop settles smoothly without a flicker at the end of the animation.
6. Repeat while zoomed in and while the crop is near the canvas edge.
7. Start a second resize immediately after releasing the first one.
8. Confirm the new resize starts without inheriting the previous settle transition.
