### PR TITLE
[codex] Fix HEIC crop orientation in Mobile Safari

### DIFF
--- a/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
+++ b/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
@@ -32,6 +32,61 @@ export type Modifier =
 	  };
 
 /**
+ * Build Core-compatible modifiers for normalizing EXIF orientation.
+ *
+ * Core applies modifiers sequentially and its `rotate` angle is
+ * clockwise-positive in the REST payload, so orientations 5 and 7 are
+ * expressed as flip-first, rotate-second.
+ *
+ * @param orientation EXIF orientation value.
+ * @return Ordered modifier array; empty for normal/unknown orientation.
+ */
+export function buildExifOrientationModifiers(
+	orientation: number
+): Modifier[] {
+	switch ( orientation ) {
+		case 2:
+			return [
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+			];
+		case 3:
+			return [ { type: 'rotate', args: { angle: 180 } } ];
+		case 4:
+			return [
+				{
+					type: 'flip',
+					args: { flip: { horizontal: false, vertical: true } },
+				},
+			];
+		case 5:
+			return [
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+				{ type: 'rotate', args: { angle: 270 } },
+			];
+		case 6:
+			return [ { type: 'rotate', args: { angle: 90 } } ];
+		case 7:
+			return [
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+				{ type: 'rotate', args: { angle: 90 } },
+			];
+		case 8:
+			return [ { type: 'rotate', args: { angle: 270 } } ];
+		default:
+			return [];
+	}
+}
+
+/**
  * Tolerance (percent) used to decide whether a crop rect is effectively
  * full-frame. Sub-pixel / float-ulp deltas below this value are treated
  * as no crop. Matches the historical threshold used by the legacy

--- a/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
+++ b/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
@@ -61,7 +61,10 @@ import { mat2d, vec2 } from 'gl-matrix';
 /**
  * Internal dependencies
  */
-import { buildModifiers } from '../build-modifiers';
+import {
+	buildExifOrientationModifiers,
+	buildModifiers,
+} from '../build-modifiers';
 import type { Modifier } from '../build-modifiers';
 import {
 	createExportCamera,
@@ -353,5 +356,57 @@ describe( 'buildModifiers ↔ Export-camera parity', () => {
 		// expected from floating-point. Anything larger is a real bug.
 		expect( server.x ).toBeCloseTo( exported.x, 0 );
 		expect( server.y ).toBeCloseTo( exported.y, 0 );
+	} );
+} );
+
+describe( 'buildExifOrientationModifiers', () => {
+	it.each( [
+		[ 1, [] ],
+		[
+			2,
+			[
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+			],
+		],
+		[ 3, [ { type: 'rotate', args: { angle: 180 } } ] ],
+		[
+			4,
+			[
+				{
+					type: 'flip',
+					args: { flip: { horizontal: false, vertical: true } },
+				},
+			],
+		],
+		[
+			5,
+			[
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+				{ type: 'rotate', args: { angle: 270 } },
+			],
+		],
+		[ 6, [ { type: 'rotate', args: { angle: 90 } } ] ],
+		[
+			7,
+			[
+				{
+					type: 'flip',
+					args: { flip: { horizontal: true, vertical: false } },
+				},
+				{ type: 'rotate', args: { angle: 90 } },
+			],
+		],
+		[ 8, [ { type: 'rotate', args: { angle: 270 } } ] ],
+		[ 9, [] ],
+	] )( 'maps EXIF orientation %s', ( orientation, expected ) => {
+		expect( buildExifOrientationModifiers( orientation ) ).toEqual(
+			expected
+		);
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor-provider/index.tsx
+++ b/packages/media-editor/src/components/media-editor-provider/index.tsx
@@ -13,6 +13,13 @@ export interface Media {
 	source_url?: string;
 	mime_type?: string;
 	alt_text?: string;
+	exif_orientation?: number;
+	media_details?: {
+		width?: number;
+		height?: number;
+		source_image?: string;
+		[ key: string ]: any;
+	};
 	title?: string | { rendered?: string; raw?: string };
 	caption?: string | { rendered?: string; raw?: string };
 	description?: string | { rendered?: string; raw?: string };

--- a/packages/media-editor/src/components/media-editor/test/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/test/use-save-media-editor.ts
@@ -1,0 +1,72 @@
+/**
+ * Internal dependencies
+ */
+import { getHeicExifOrientationModifiers } from '../use-save-media-editor';
+
+describe( 'getHeicExifOrientationModifiers', () => {
+	it( 'returns the attachment EXIF orientation modifier for Mobile Safari HEIC uploads', () => {
+		expect(
+			getHeicExifOrientationModifiers(
+				{
+					exif_orientation: 6,
+					media_details: {
+						source_image: 'photo.HEIC',
+					},
+				},
+				true
+			)
+		).toEqual( [ { type: 'rotate', args: { angle: 90 } } ] );
+	} );
+
+	it( 'does not apply outside Mobile Safari', () => {
+		expect(
+			getHeicExifOrientationModifiers(
+				{
+					exif_orientation: 6,
+					media_details: {
+						source_image: 'photo.heic',
+					},
+				},
+				false
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'does not apply to non-HEIC source images', () => {
+		expect(
+			getHeicExifOrientationModifiers(
+				{
+					exif_orientation: 6,
+					media_details: {
+						source_image: 'photo.jpg',
+					},
+				},
+				true
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'ignores missing or normal EXIF orientation', () => {
+		expect(
+			getHeicExifOrientationModifiers(
+				{
+					exif_orientation: 1,
+					media_details: {
+						source_image: 'photo.heif',
+					},
+				},
+				true
+			)
+		).toEqual( [] );
+		expect(
+			getHeicExifOrientationModifiers(
+				{
+					media_details: {
+						source_image: 'photo.heif',
+					},
+				},
+				true
+			)
+		).toEqual( [] );
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
+++ b/packages/media-editor/src/components/media-editor/use-save-media-editor.ts
@@ -15,6 +15,7 @@ import type { Media } from '../media-editor-provider';
 import type { MediaEditorController } from '../../state';
 import {
 	buildModifiers,
+	buildExifOrientationModifiers,
 	type Modifier,
 } from '../media-editor-modal/build-modifiers';
 
@@ -30,6 +31,9 @@ const METADATA_EDIT_KEYS = [
 
 // Scope media editor snackbars so they don't leak into the host editor/page.
 export const MEDIA_EDITOR_NOTICES_CONTEXT = 'media-editor';
+
+const HEIC_SOURCE_IMAGE_REGEX = /\.hei[cf]$/i;
+const NON_SAFARI_IOS_BROWSER_REGEX = /\b(CriOS|FxiOS|EdgiOS|OPiOS)\b/;
 
 type PendingMetadataEdits = Record< string, unknown > | undefined;
 
@@ -56,14 +60,64 @@ interface UseSaveMediaEditorReturn {
 	save: () => Promise< void >;
 }
 
-function getCropModifiers( cropper: MediaEditorController ): Modifier[] {
+function isMobileSafari() {
+	if ( typeof navigator === 'undefined' ) {
+		return false;
+	}
+
+	const { userAgent, platform, maxTouchPoints } = navigator;
+	const isIOS =
+		/iP(ad|hone|od)/.test( userAgent ) ||
+		( platform === 'MacIntel' && maxTouchPoints > 1 );
+
+	return (
+		isIOS &&
+		/Safari\//.test( userAgent ) &&
+		! NON_SAFARI_IOS_BROWSER_REGEX.test( userAgent )
+	);
+}
+
+function isHeicSourceImage( media?: Media | null ): boolean {
+	const sourceImage = media?.media_details?.source_image;
+	return (
+		typeof sourceImage === 'string' &&
+		HEIC_SOURCE_IMAGE_REGEX.test( sourceImage )
+	);
+}
+
+export function getHeicExifOrientationModifiers(
+	media?: Media | null,
+	isMobileSafariBrowser = isMobileSafari()
+): Modifier[] {
+	const orientation = Number( media?.exif_orientation );
+	if (
+		! isMobileSafariBrowser ||
+		! isHeicSourceImage( media ) ||
+		! Number.isInteger( orientation )
+	) {
+		return [];
+	}
+
+	return buildExifOrientationModifiers( orientation );
+}
+
+function getCropModifiers(
+	cropper: MediaEditorController,
+	media?: Media | null
+): Modifier[] {
 	if ( ! cropper.isCropperDirty || ! cropper.state.image ) {
 		return [];
 	}
-	return buildModifiers( cropper.state, {
+	const modifiers = buildModifiers( cropper.state, {
 		width: cropper.state.image.naturalWidth,
 		height: cropper.state.image.naturalHeight,
 	} );
+
+	if ( modifiers.length === 0 ) {
+		return modifiers;
+	}
+
+	return [ ...getHeicExifOrientationModifiers( media ), ...modifiers ];
 }
 
 function getMetadataEdits(
@@ -107,7 +161,7 @@ export function useSaveMediaEditor( {
 		setIsSaving( true );
 		try {
 			let saved: Media | null | undefined;
-			const modifiers = getCropModifiers( cropper );
+			const modifiers = getCropModifiers( cropper, media );
 			const previous =
 				modifiers.length > 0 && media
 					? {


### PR DESCRIPTION
## What
- Applies attachment `exif_orientation` as `/edit` modifiers for Mobile Safari HEIC-origin crops.
- Guards on Mobile Safari and `media_details.source_image` ending in `.heic`/`.heif`.

**[Open PR #79340 in Playground](https://playground.wordpress.net/gutenberg.html?pr=79340)**


## Testing
- `npm run test:unit -- packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts packages/media-editor/src/components/media-editor/test/use-save-media-editor.ts`
- `npm run lint:js -- packages/media-editor/src/components/media-editor-modal/build-modifiers.ts packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts packages/media-editor/src/components/media-editor-provider/index.tsx packages/media-editor/src/components/media-editor/use-save-media-editor.ts packages/media-editor/src/components/media-editor/test/use-save-media-editor.ts`