### PR TITLE
Pullquote Block: Add citation letter case (text transform) control to the Styles panel

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -808,7 +808,7 @@ Give special visual emphasis to a quote from your text.
 -	**Name:** [core/pullquote](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-pullquote/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
 -	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
--	**Attributes:** citation, value
+-	**Attributes:** citation, citationTextTransform, value
 
 ## Query Loop
 

--- a/packages/block-library/src/pullquote/README.md
+++ b/packages/block-library/src/pullquote/README.md
@@ -16,6 +16,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 |-----------|------|---------|-------------|
 | `value` | `rich-text` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `rich-text`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `p`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `citation` | `rich-text` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `rich-text`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `cite`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `citationTextTransform` | `string` | — | — |
 
 ## Supports
 

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -18,6 +18,9 @@
 			"source": "rich-text",
 			"selector": "cite",
 			"role": "content"
+		},
+		"citationTextTransform": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -2,25 +2,44 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
+import CitationTextTransformControl from '../utils/citation-text-transform-control';
 import useDeprecatedTextAlign from '../utils/deprecated-text-align-attributes';
 
 function PullQuoteEdit( props ) {
 	const { attributes, setAttributes, isSelected, insertBlocksAfter } = props;
 	useDeprecatedTextAlign( props );
-	const { citation, value } = attributes;
+	const { citation, value, citationTextTransform } = attributes;
 	const blockProps = useBlockProps();
 	const shouldShowCitation = ! RichText.isEmpty( citation ) || isSelected;
 
 	return (
 		<>
+			<InspectorControls group="styles">
+				<PanelBody title={ __( 'Citation' ) }>
+					<CitationTextTransformControl
+						value={ citationTextTransform }
+						onChange={ ( nextCitationTextTransform ) =>
+							setAttributes( {
+								citationTextTransform:
+									nextCitationTextTransform,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<Figure { ...blockProps }>
 				<BlockQuote>
 					<RichText
@@ -42,7 +61,10 @@ function PullQuoteEdit( props ) {
 						<RichText
 							identifier="citation"
 							tagName="cite"
-							style={ { display: 'block' } }
+							style={ {
+								display: 'block',
+								textTransform: citationTextTransform,
+							} }
 							value={ citation }
 							aria-label={ __( 'Pullquote citation text' ) }
 							placeholder={

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -4,7 +4,7 @@
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { citation, value } = attributes;
+	const { citation, value, citationTextTransform } = attributes;
 	const shouldShowCitation = ! RichText.isEmpty( citation );
 
 	return (
@@ -12,7 +12,15 @@ export default function save( { attributes } ) {
 			<blockquote>
 				<RichText.Content tagName="p" value={ value } />
 				{ shouldShowCitation && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="cite"
+						value={ citation }
+						style={
+							citationTextTransform
+								? { textTransform: citationTextTransform }
+								: undefined
+						}
+					/>
 				) }
 			</blockquote>
 		</figure>

--- a/packages/block-library/src/utils/citation-text-transform-control.js
+++ b/packages/block-library/src/utils/citation-text-transform-control.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	reset,
+	formatCapitalize,
+	formatLowercase,
+	formatUppercase,
+} from '@wordpress/icons';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+} from '@wordpress/components';
+
+const CITATION_TEXT_TRANSFORMS = [
+	{
+		label: __( 'None' ),
+		value: 'none',
+		icon: reset,
+	},
+	{
+		label: __( 'Uppercase' ),
+		value: 'uppercase',
+		icon: formatUppercase,
+	},
+	{
+		label: __( 'Lowercase' ),
+		value: 'lowercase',
+		icon: formatLowercase,
+	},
+	{
+		label: __( 'Capitalize' ),
+		value: 'capitalize',
+		icon: formatCapitalize,
+	},
+];
+
+/**
+ * Control to facilitate letter case (text transform) selections for the
+ * Pullquote block's citation text, independent of the typography settings
+ * applied to the main quote text.
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.value    Currently selected citation text transform.
+ * @param {Function} props.onChange Handles change in citation text transform selection.
+ *
+ * @return {Element} Citation text transform control.
+ */
+export default function CitationTextTransformControl( { value, onChange } ) {
+	return (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			isDeselectable
+			label={ __( 'Letter case' ) }
+			value={ value }
+			onChange={ ( newValue ) => {
+				onChange( newValue === value ? undefined : newValue );
+			} }
+		>
+			{ CITATION_TEXT_TRANSFORMS.map( ( option ) => (
+				<ToggleGroupControlOptionIcon
+					key={ option.value }
+					value={ option.value }
+					icon={ option.icon }
+					label={ option.label }
+				/>
+			) ) }
+		</ToggleGroupControl>
+	);
+}


### PR DESCRIPTION
## What?
Closes #40922

Adds a "Letter case" control (None / Uppercase / Lowercase / Capitalize) for the citation text inside the Pullquote block, accessible from the **Styles** tab in the block sidebar. Previously, text transform could only be applied to the block as a whole, with no way to style the citation independently from the quote text through the Editor UI.

## Why?
The Pullquote block already exposes a typography panel that lets users change the letter case of the main quote text. However, there was no equivalent control for the `<cite>` element. While it has been possible to style citations via `theme.json` since #43543, there was no Editor UI for direct styling, making it inaccessible to users who don't work with theme files.

## Testing Instructions
1. Create a new post or page.
2. Insert a **Pullquote** block.
3. Type some quote text, then move to the citation field and type a citation.
4. With the block selected, open the **Settings** sidebar and click the **Styles** tab.
5. Expand the **Citation** panel.
6. Confirm a **Letter case** toggle group is visible with four options: None, Uppercase, Lowercase, Capitalize.
7. Click **Uppercase**, verify the citation text in the editor immediately renders in uppercase.
8. Switch to **Lowercase**, verify the citation text updates accordingly.
9. Click the currently-active option again, verify it deselects (returns to unstyled).
10. Save the post, then view it on the front end.
11. Confirm the main quote text is **not** affected by changes to this control.
12. Open an existing post that contains a Pullquote block (no `citationTextTransform` attribute). Confirm it renders exactly as before with no visual change.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/6c4bfc27-217d-4043-9ab6-f163438aed01