### PR TITLE
feat: Update the build blocks manifest to exclude experimental blocks in build 

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -114,11 +114,13 @@ Options:
 
 -   `--input`: Specify the input directory (default: 'build')
 -   `--output`: Specify the output file path (default: 'build/blocks-manifest.php')
+-   `--exclude-experimental`: Exclude blocks marked as experimental (with `"__experimental": true` in block.json) from the manifest. This is useful when building for WordPress Core to prevent experimental block code from being bundled.
 
 Example:
 
 ```bash
 wp-scripts build-blocks-manifest --input=src --output=dist/blocks-manifest.php
+wp-scripts build-blocks-manifest --input=src --output=dist/blocks-manifest.php --exclude-experimental
 ```
 
 This command will scan the specified input directory for `block.json` files,

--- a/packages/scripts/scripts/build-blocks-manifest.js
+++ b/packages/scripts/scripts/build-blocks-manifest.js
@@ -17,6 +17,8 @@ const defaultInputDir = 'build';
 const inputDir = getArgFromCLI( '--input' ) || defaultInputDir;
 const defaultOutputFile = path.join( inputDir, 'blocks-manifest.php' );
 const outputFile = getArgFromCLI( '--output' ) || defaultOutputFile;
+const excludeExperimental =
+	getArgFromCLI( '--exclude-experimental' ) !== undefined;
 
 const resolvedInputDir = path.resolve( process.cwd(), inputDir );
 if ( ! fs.existsSync( resolvedInputDir ) ) {
@@ -37,6 +39,12 @@ const blocks = {};
 
 blockJsonFiles.forEach( ( file ) => {
 	const blockJson = JSON.parse( fs.readFileSync( file, 'utf8' ) );
+
+	// Skip experimental blocks if --exclude-experimental flag is set
+	if ( excludeExperimental && blockJson.__experimental === true ) {
+		return;
+	}
+
 	const directoryName = path.basename( path.dirname( file ) );
 	blocks[ directoryName ] = blockJson;
 } );

--- a/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
+++ b/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
@@ -37,6 +37,16 @@ return array(
 		'editorStyle' => 'file:./index.css',
 		'style' => 'file:./style-index.css'
 	),
+	'experimental-block' => array(
+		'$schema' => 'https://schemas.wp.org/trunk/block.json',
+		'apiVersion' => 3,
+		'__experimental' => true,
+		'name' => 'my-plugin/experimental-block',
+		'title' => 'Experimental Block',
+		'category' => 'text',
+		'icon' => 'beaker',
+		'description' => 'An experimental block for testing.'
+	),
 	'image-gallery' => array(
 		'$schema' => 'https://schemas.wp.org/trunk/block.json',
 		'apiVersion' => 3,

--- a/packages/scripts/scripts/test/build-blocks-manifest.js
+++ b/packages/scripts/scripts/test/build-blocks-manifest.js
@@ -98,4 +98,31 @@ describe( 'build-blocks-manifest script', () => {
 		// Ensure that the output file was not created
 		expect( fs.existsSync( outputFile ) ).toBe( false );
 	} );
+
+	it( 'should exclude experimental blocks when --exclude-experimental flag is set', () => {
+		const inputDir = path.join( fixturesPath, 'input' );
+		const outputFile = path.join(
+			outputPath,
+			'blocks-manifest-filtered.php'
+		);
+
+		// Run the build-blocks-manifest script with --exclude-experimental flag
+		const scriptPath = path.resolve(
+			__dirname,
+			'..',
+			'build-blocks-manifest.js'
+		);
+		execSync(
+			`node ${ scriptPath } --input=${ inputDir } --output=${ outputFile } --exclude-experimental`
+		);
+
+		const generatedContent = fs.readFileSync( outputFile, 'utf8' );
+
+		// Check that experimental blocks are not included
+		expect( generatedContent ).not.toContain( 'experimental-block' );
+		// Check that non-experimental blocks are included
+		expect( generatedContent ).toContain( 'custom-header' );
+		expect( generatedContent ).toContain( 'image-gallery' );
+		expect( generatedContent ).toContain( 'simple-button' );
+	} );
 } );

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/experimental-block/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/experimental-block/block.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"__experimental": true,
+	"name": "my-plugin/experimental-block",
+	"title": "Experimental Block",
+	"category": "text",
+	"icon": "beaker",
+	"description": "An experimental block for testing."
+}

--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -174,16 +174,24 @@ async function build() {
 				output: 'build/scripts/widgets/blocks/blocks-manifest.php',
 			},
 		];
+
+		// Check if building for WordPress Core to exclude experimental blocks
+		const isWordPressCore = process.env.IS_WORDPRESS_CORE === 'true' ||
+			process.argv.includes( 'IS_WORDPRESS_CORE=true' );
+
 		for ( const { input, output } of blocksDirs ) {
-			await exec(
-				'wp-scripts',
-				[
-					'build-blocks-manifest',
-					`--input=${ input }`,
-					`--output=${ output }`,
-				],
-				{ silent: true }
-			);
+			const manifestArgs = [
+				'build-blocks-manifest',
+				`--input=${ input }`,
+				`--output=${ output }`,
+			];
+
+			// Exclude experimental blocks when building for WordPress Core
+			if ( isWordPressCore ) {
+				manifestArgs.push( '--exclude-experimental' );
+			}
+
+			await exec( 'wp-scripts', manifestArgs, { silent: true } );
 		}
 
 		console.log( '\n📦 Building workspace :wp targets...' );

--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -176,8 +176,9 @@ async function build() {
 		];
 
 		// Check if building for WordPress Core to exclude experimental blocks
-		const isWordPressCore = process.env.IS_WORDPRESS_CORE === 'true' ||
-			process.argv.includes( 'IS_WORDPRESS_CORE=true' );
+		const hasWordPressCoreArg = process.argv.includes(
+			'IS_WORDPRESS_CORE=true'
+		);
 
 		for ( const { input, output } of blocksDirs ) {
 			const manifestArgs = [
@@ -187,7 +188,9 @@ async function build() {
 			];
 
 			// Exclude experimental blocks when building for WordPress Core
-			if ( isWordPressCore ) {
+			if ( globalThis.IS_WORDPRESS_CORE ) {
+				manifestArgs.push( '--exclude-experimental' );
+			} else if ( hasWordPressCoreArg ) {
 				manifestArgs.push( '--exclude-experimental' );
 			}
 

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -249,16 +249,24 @@ async function dev() {
 						output: 'build/scripts/widgets/blocks/blocks-manifest.php',
 					},
 				];
+
+				// Check if building for WordPress Core to exclude experimental blocks
+				const isWordPressCore = process.env.IS_WORDPRESS_CORE === 'true' ||
+					process.argv.includes( 'IS_WORDPRESS_CORE=true' );
+
 				for ( const { input, output: outputPath } of blocksDirs ) {
-					await exec(
-						'wp-scripts',
-						[
-							'build-blocks-manifest',
-							`--input=${ input }`,
-							`--output=${ outputPath }`,
-						],
-						{ silent: true }
-					);
+					const manifestArgs = [
+						'build-blocks-manifest',
+						`--input=${ input }`,
+						`--output=${ outputPath }`,
+					];
+
+					// Exclude experimental blocks when building for WordPress Core
+					if ( isWordPressCore ) {
+						manifestArgs.push( '--exclude-experimental' );
+					}
+
+					await exec( 'wp-scripts', manifestArgs, { silent: true } );
 				}
 
 				readyMarkerFile.create();

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -251,8 +251,9 @@ async function dev() {
 				];
 
 				// Check if building for WordPress Core to exclude experimental blocks
-				const isWordPressCore = process.env.IS_WORDPRESS_CORE === 'true' ||
-					process.argv.includes( 'IS_WORDPRESS_CORE=true' );
+				const hasWordPressCoreArg = process.argv.includes(
+					'IS_WORDPRESS_CORE=true'
+				);
 
 				for ( const { input, output: outputPath } of blocksDirs ) {
 					const manifestArgs = [
@@ -262,7 +263,9 @@ async function dev() {
 					];
 
 					// Exclude experimental blocks when building for WordPress Core
-					if ( isWordPressCore ) {
+					if ( globalThis.IS_WORDPRESS_CORE ) {
+						manifestArgs.push( '--exclude-experimental' );
+					} else if ( hasWordPressCoreArg ) {
 						manifestArgs.push( '--exclude-experimental' );
 					}
 


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
https://github.com/WordPress/gutenberg/issues/79203

Restores build-time exclusion of experimental blocks (__experimental: true) from stable WordPress core bundles — an optimization lost when the build migrated from Webpack to ESBuild in #72032.


## Why?
Experimental blocks aren't registered in core, but since the Webpack → ESBuild migration, their code still ships in stable bundles, unnecessarily inflating bundle size and slowing page loads. This restores the optimization originally added in #40655.


## How?
Re-implements the experimental block exclusion within the new ESBuild build pipeline, mirroring the previous Webpack-based logic.

## Testing Instructions

- Run npm run build.
- Check the generated bundle/manifest — blocks marked __experimental: true should be excluded from the stable build.
- Confirm the Gutenberg plugin build still includes experimental blocks as before.


## Screenshots or screencast <!-- if applicable -->


