### PR TITLE
View Config API and REST Endpoint: make them core ready

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -10,3 +10,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/78977
 * https://github.com/WordPress/gutenberg/pull/79195
 * https://github.com/WordPress/gutenberg/pull/76934
+* https://github.com/WordPress/gutenberg/pull/79347

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -84,13 +84,31 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 
 		$config = gutenberg_get_entity_view_config( $kind, $name );
 
+		/*
+		 * The schema types these as objects, but PHP encodes empty arrays as
+		 * JSON arrays ([]). Cast the object-typed values that may be empty so
+		 * they serialize as JSON objects ({}) and match the schema.
+		 */
+		$default_view = $config['default_view'];
+		if ( isset( $default_view['layout'] ) ) {
+			$default_view['layout'] = (object) $default_view['layout'];
+		}
+
+		$default_layouts = $config['default_layouts'];
+		foreach ( $default_layouts as $view_type => $layout ) {
+			if ( isset( $layout['layout'] ) ) {
+				$layout['layout'] = (object) $layout['layout'];
+			}
+			$default_layouts[ $view_type ] = (object) $layout;
+		}
+
 		$response = array(
 			'kind'            => $kind,
 			'name'            => $name,
-			'default_view'    => $config['default_view'],
-			'default_layouts' => $config['default_layouts'],
+			'default_view'    => $default_view,
+			'default_layouts' => $default_layouts,
 			'view_list'       => $config['view_list'],
-			'form'            => $config['form'],
+			'form'            => (object) $config['form'],
 		);
 
 		return rest_ensure_response( $response );

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -129,9 +129,10 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array_merge(
 						array(
-							'type' => array(
+							'type'   => array(
 								'type' => 'string',
 							),
+							'layout' => $this->get_combined_layout_schema(),
 						),
 						$view_base_properties
 					),
@@ -427,7 +428,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array_merge(
 				$this->get_table_layout_schema()['properties'],
-				$this->get_grid_layout_schema()['properties']
+				$this->get_grid_layout_schema()['properties'],
+				$this->get_list_layout_schema()['properties']
 			),
 		);
 	}

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -47,7 +47,8 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true // override existing route defined by core, if it exists
 		);
 	}
 

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -300,10 +300,6 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 
 	return $config;
 }
-if ( has_filter( 'get_entity_view_config_postType_page', '_wp_get_entity_view_config_post_type_page' ) ) {
-	remove_filter( 'get_entity_view_config_postType_page', '_wp_get_entity_view_config_post_type_page' );
-}
-add_filter( 'get_entity_view_config_postType_page', '_gutenberg_get_entity_view_config_post_type_page', 10, 1 );
 
 /**
  * Provides the view configuration for the `post` post type.
@@ -380,10 +376,6 @@ function _gutenberg_get_entity_view_config_post_type_post( $config ) {
 
 	return $config;
 }
-if ( has_filter( 'get_entity_view_config_postType_post', '_wp_get_entity_view_config_post_type_post' ) ) {
-	remove_filter( 'get_entity_view_config_postType_post', '_wp_get_entity_view_config_post_type_post' );
-}
-add_filter( 'get_entity_view_config_postType_post', '_gutenberg_get_entity_view_config_post_type_post', 10, 1 );
 
 /**
  * Provides the view configuration for the `wp_block` post type.
@@ -472,10 +464,6 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $config ) {
 
 	return $config;
 }
-if ( has_filter( 'get_entity_view_config_postType_wp_block', '_wp_get_entity_view_config_post_type_wp_block' ) ) {
-	remove_filter( 'get_entity_view_config_postType_wp_block', '_wp_get_entity_view_config_post_type_wp_block' );
-}
-add_filter( 'get_entity_view_config_postType_wp_block', '_gutenberg_get_entity_view_config_post_type_wp_block', 10, 1 );
 
 /**
  * Provides the view configuration for the `wp_template_part` post type.
@@ -556,10 +544,6 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $config )
 
 	return $config;
 }
-if ( has_filter( 'get_entity_view_config_postType_wp_template_part', '_wp_get_entity_view_config_post_type_wp_template_part' ) ) {
-	remove_filter( 'get_entity_view_config_postType_wp_template_part', '_wp_get_entity_view_config_post_type_wp_template_part' );
-}
-add_filter( 'get_entity_view_config_postType_wp_template_part', '_gutenberg_get_entity_view_config_post_type_wp_template_part', 10, 1 );
 
 /**
  * Provides the view configuration for the `wp_template` post type.
@@ -768,7 +752,32 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
 
 	return $config;
 }
-if ( has_filter( 'get_entity_view_config_postType_wp_template', '_wp_get_entity_view_config_post_type_wp_template' ) ) {
-	remove_filter( 'get_entity_view_config_postType_wp_template', '_wp_get_entity_view_config_post_type_wp_template' );
+
+/**
+ * Registers the Gutenberg entity view configuration filters, overriding any
+ * defaults that WordPress core may have already registered.
+ *
+ * Core registers its own `_wp_get_entity_view_config_post_type_*` callbacks on
+ * the shared `get_entity_view_config_{$kind}_{$name}` hooks. The Gutenberg
+ * plugin always ships the newest configuration, so it removes the core defaults
+ * and installs its own `_gutenberg_*` callbacks instead.
+ *
+ * This runs on `init` rather than at file include time so that the core
+ * defaults are guaranteed to be registered first, regardless of whether core
+ * registers them at include time or lazily on a hook.
+ */
+function gutenberg_register_entity_view_config_filters() {
+	$post_types = array( 'page', 'post', 'wp_block', 'wp_template_part', 'wp_template' );
+
+	foreach ( $post_types as $post_type ) {
+		$hook        = "get_entity_view_config_postType_{$post_type}";
+		$wp_callback = "_wp_get_entity_view_config_post_type_{$post_type}";
+		$gb_callback = "_gutenberg_get_entity_view_config_post_type_{$post_type}";
+
+		if ( has_filter( $hook, $wp_callback ) ) {
+			remove_filter( $hook, $wp_callback );
+		}
+		add_filter( $hook, $gb_callback, 10, 1 );
+	}
 }
-add_filter( 'get_entity_view_config_postType_wp_template', '_gutenberg_get_entity_view_config_post_type_wp_template', 10, 1 );
+add_action( 'init', 'gutenberg_register_entity_view_config_filters' );

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -31,13 +31,13 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 	$default_view    = array(
 		'type'       => 'table',
 		'filters'    => array(),
-		'perPage'    => 20,
 		'sort'       => array(
 			'field'     => 'title',
 			'direction' => 'asc',
 		),
-		'titleField' => 'title',
+		'perPage'    => 20,
 		'fields'     => array( 'author', 'status' ),
+		'titleField' => 'title',
 	);
 	$default_layouts = array(
 		'table' => array(),

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -157,13 +157,38 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 		wp_set_current_user( self::$editor_id );
 
 		$response = $this->dispatch_request( 'postType', 'page' );
-		$data     = $response->get_data();
-		$config   = gutenberg_get_entity_view_config( 'postType', 'page' );
+		// Normalize through JSON to compare what a client actually receives:
+		// the response's object casts collapse back to the source arrays.
+		$data   = json_decode( wp_json_encode( $response->get_data() ), true );
+		$config = gutenberg_get_entity_view_config( 'postType', 'page' );
 
 		$this->assertSame( $config['default_view'], $data['default_view'] );
 		$this->assertSame( $config['default_layouts'], $data['default_layouts'] );
 		$this->assertSame( $config['view_list'], $data['view_list'] );
 		$this->assertSame( $config['form'], $data['form'] );
+	}
+
+	/**
+	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_empty_object_fields_serialize_as_json_objects() {
+		wp_set_current_user( self::$editor_id );
+
+		// An entity with no provider yields empty default_layouts entries and form.
+		$decoded = json_decode( wp_json_encode( $this->dispatch_request( 'custom_kind', 'custom_name' )->get_data() ) );
+
+		$this->assertIsObject( $decoded->form );
+		$this->assertIsObject( $decoded->default_layouts->table );
+		$this->assertIsObject( $decoded->default_layouts->grid );
+		$this->assertIsObject( $decoded->default_layouts->list );
+
+		// wp_template_part yields an empty default_view.layout and grid layout.
+		$decoded = json_decode( wp_json_encode( $this->dispatch_request( 'postType', 'wp_template_part' )->get_data() ) );
+
+		$this->assertIsObject( $decoded->default_view->layout );
+		$this->assertIsObject( $decoded->default_layouts->grid->layout );
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_REST_View_Config_Controller_7_1 functionality.
+ *
+ * @package gutenberg
+ *
+ * @coversDefaultClass Gutenberg_REST_View_Config_Controller_7_1
+ */
+class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
+
+	/**
+	 * The REST route the controller registers.
+	 */
+	const ROUTE = '/wp/v2/view-config';
+
+	/**
+	 * Editor user id (has `edit_posts`).
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * Subscriber user id (lacks `edit_posts`).
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Creates shared users.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * Deletes shared users.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$editor_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	/**
+	 * Dispatches a request to the view-config route.
+	 *
+	 * @param string $kind Entity kind.
+	 * @param string $name Entity name.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_request( $kind = 'postType', $name = 'page' ) {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		if ( null !== $kind ) {
+			$request->set_param( 'kind', $kind );
+		}
+		if ( null !== $name ) {
+			$request->set_param( 'name', $name );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * The route is registered.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+	}
+
+	/**
+	 * Editors (with `edit_posts`) can read the view config.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_items
+	 */
+	public function test_get_items_allows_users_with_edit_posts() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->dispatch_request();
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Subscribers (without `edit_posts`) are forbidden.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_forbids_users_without_edit_posts() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$response = $this->dispatch_request();
+
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
+	}
+
+	/**
+	 * Logged-out users are unauthorized.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_requires_authentication() {
+		wp_set_current_user( 0 );
+
+		$response = $this->dispatch_request();
+
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
+	}
+
+	/**
+	 * Both `kind` and `name` are required.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_get_items_requires_kind_and_name() {
+		wp_set_current_user( self::$editor_id );
+
+		$missing_name = $this->dispatch_request( 'postType', null );
+		$this->assertErrorResponse( 'rest_missing_callback_param', $missing_name, 400 );
+
+		$missing_kind = $this->dispatch_request( null, 'page' );
+		$this->assertErrorResponse( 'rest_missing_callback_param', $missing_kind, 400 );
+	}
+
+	/**
+	 * The response echoes the requested entity and the documented config keys.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_returns_entity_and_config_shape() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->dispatch_request( 'postType', 'page' );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'postType', $data['kind'] );
+		$this->assertSame( 'page', $data['name'] );
+		$this->assertArrayHasKey( 'default_view', $data );
+		$this->assertArrayHasKey( 'default_layouts', $data );
+		$this->assertArrayHasKey( 'view_list', $data );
+		$this->assertArrayHasKey( 'form', $data );
+	}
+
+	/**
+	 * The response body matches gutenberg_get_entity_view_config() for the entity.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_matches_underlying_config() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->dispatch_request( 'postType', 'page' );
+		$data     = $response->get_data();
+		$config   = gutenberg_get_entity_view_config( 'postType', 'page' );
+
+		$this->assertSame( $config['default_view'], $data['default_view'] );
+		$this->assertSame( $config['default_layouts'], $data['default_layouts'] );
+		$this->assertSame( $config['view_list'], $data['view_list'] );
+		$this->assertSame( $config['form'], $data['form'] );
+	}
+
+	/**
+	 * The item schema exposes the documented top-level properties.
+	 *
+	 * @covers ::get_item_schema
+	 */
+	public function test_get_item_schema() {
+		$controller = new Gutenberg_REST_View_Config_Controller_7_1();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertSame( 'view-config', $schema['title'] );
+		$this->assertSameSets(
+			array( 'kind', 'name', 'default_view', 'default_layouts', 'view_list', 'form' ),
+			array_keys( $schema['properties'] )
+		);
+	}
+}

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -220,5 +220,4 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
 		$this->assertSame( self::DEFAULT_FORM, $config['form'] );
 	}
-
 }

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Tests for the entity view configuration API.
+ *
+ * @package gutenberg
+ *
+ * @covers ::gutenberg_get_entity_view_config
+ */
+class Tests_View_Config_API extends WP_UnitTestCase {
+
+	/**
+	 * The documented top-level keys of a view configuration.
+	 *
+	 * @var string[]
+	 */
+	const CONFIG_KEYS = array( 'default_view', 'default_layouts', 'view_list', 'form' );
+
+	/**
+	 * The default view configuration shared by all entities.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_VIEW = array(
+		'type'       => 'table',
+		'filters'    => array(),
+		'perPage'    => 20,
+		'sort'       => array(
+			'field'     => 'title',
+			'direction' => 'asc',
+		),
+		'titleField' => 'title',
+		'fields'     => array( 'author', 'status' ),
+	);
+
+	/**
+	 * The default layouts shared by all entities.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_LAYOUTS = array(
+		'table' => array(),
+		'grid'  => array(),
+		'list'  => array(),
+	);
+
+	/**
+	 * The default view list for an entity with no specific provider.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_VIEW_LIST = array(
+		array(
+			'title' => 'All items',
+			'slug'  => 'all',
+		),
+	);
+
+	/**
+	 * The default form configuration shared by all entities.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_FORM = array();
+
+	/**
+	 * Tears down each test.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'get_entity_view_config_postType_unregistered_cpt' );
+		remove_all_filters( 'get_entity_view_config_custom_kind_custom_name' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The default configuration exposes the documented shape for an unknown entity.
+	 */
+	public function test_returns_default_config_shape_for_unknown_entity() {
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertIsArray( $config );
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
+		$this->assertSame( self::DEFAULT_LAYOUTS, $config['default_layouts'] );
+		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
+		$this->assertSame( self::DEFAULT_FORM, $config['form'] );
+	}
+
+	/**
+	 * The base "all items" view falls back to a generic title for an unknown post type.
+	 */
+	public function test_view_list_falls_back_to_generic_all_items_title() {
+		$config = gutenberg_get_entity_view_config( 'postType', 'does_not_exist' );
+
+		$this->assertCount( 1, $config['view_list'] );
+		$this->assertSame( 'all', $config['view_list'][0]['slug'] );
+		$this->assertSame( 'All items', $config['view_list'][0]['title'] );
+	}
+
+	/**
+	 * For a registered post type, the "all items" view uses the post type's label.
+	 */
+	public function test_view_list_uses_post_type_all_items_label() {
+		register_post_type(
+			'view_config_cpt',
+			array(
+				'labels' => array(
+					'all_items' => 'All Custom Things',
+				),
+			)
+		);
+
+		$config = gutenberg_get_entity_view_config( 'postType', 'view_config_cpt' );
+
+		$this->assertSame( 'All Custom Things', $config['view_list'][0]['title'] );
+
+		unregister_post_type( 'view_config_cpt' );
+	}
+
+	/**
+	 * The dynamic filter receives the default config and the entity descriptor.
+	 */
+	public function test_filter_receives_config_and_entity() {
+		$received_entity = null;
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $config, $entity ) use ( &$received_entity ) {
+				$received_entity = $entity;
+				return $config;
+			},
+			10,
+			2
+		);
+
+		gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertSame(
+			array(
+				'kind' => 'custom_kind',
+				'name' => 'custom_name',
+			),
+			$received_entity
+		);
+	}
+
+	/**
+	 * A filter can override the configuration values.
+	 */
+	public function test_filter_can_override_config() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $config ) {
+				$config['default_view']['type'] = 'grid';
+				return $config;
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertSame( 'grid', $config['default_view']['type'] );
+	}
+
+	/**
+	 * Dropped keys are backfilled with their defaults.
+	 */
+	public function test_filter_dropped_keys_are_backfilled() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function () {
+				// Return a config that is missing most of the documented keys.
+				return array( 'form' => array( 'custom' => true ) );
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		$this->assertSame( array( 'custom' => true ), $config['form'] );
+		// Backfilled from defaults.
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
+		$this->assertSame( self::DEFAULT_LAYOUTS, $config['default_layouts'] );
+		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
+	}
+
+	/**
+	 * Keys introduced by a filter that are not part of the documented shape are discarded.
+	 */
+	public function test_filter_unknown_keys_are_discarded() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $config ) {
+				$config['not_a_real_key'] = 'nope';
+				return $config;
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertArrayNotHasKey( 'not_a_real_key', $config );
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+	}
+
+	/**
+	 * A non-array filter return falls back to the default config.
+	 */
+	public function test_non_array_filter_return_falls_back_to_default() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function () {
+				return 'not an array';
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertIsArray( $config );
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
+		$this->assertSame( self::DEFAULT_LAYOUTS, $config['default_layouts'] );
+		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
+		$this->assertSame( self::DEFAULT_FORM, $config['form'] );
+	}
+
+}

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -23,13 +23,13 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	const DEFAULT_VIEW = array(
 		'type'       => 'table',
 		'filters'    => array(),
-		'perPage'    => 20,
 		'sort'       => array(
 			'field'     => 'title',
 			'direction' => 'asc',
 		),
-		'titleField' => 'title',
+		'perPage'    => 20,
 		'fields'     => array( 'author', 'status' ),
+		'titleField' => 'title',
 	);
 
 	/**


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/76544

## What?

Adds PHPUnit test coverage for the entity view configuration API and corresponding REST endpoint. It also fixes three contract mismatches between the `wp/v2/view-config` REST schema and the data it actually returns, and hardens how the plugin overrides core once this API and endpoint land in WordPress core.

## Why?

To make it core ready.

## How?

- New tests for `gutenberg_get_entity_view_config()` (`phpunit/view-config-api-test.php`).
- New tests for `Gutenberg_REST_View_Config_Controller_7_1` (`phpunit/class-gutenberg-rest-view-config-controller-test.php`).
- Schema and response fixes in `class-gutenberg-rest-view-config-controller-7-1.php`.
- Registers the `wp/v2/view-config` route with `$override = true` so the plugin's controller replaces core's once core ships the endpoint.
- Consolidates the per-post-type filter swaps into a single `gutenberg_register_entity_view_config_filters()` hooked to `init`, guaranteeing core's defaults are present before they're removed while still running before any REST request.

## Testing Instructions

1. Ensure the test environment is running: `npm run wp-env-test start`.
2. Run the new suites:
   ```bash
   npm run test:unit:php:base -- --filter 'Tests_REST_View_Config_Controller|Tests_View_Config_API'
   ```
3. Both suites should pass (17 tests, 75 assertions).
4. Optionally confirm the serialization fix by hitting `GET /wp/v2/view-config?kind=custom&name=custom` as an editor and verifying `form` and the empty `default_layouts` entries render as `{}` rather than `[]`.

## Use of AI Tools

This PR was authored with the assistance of Claude (Claude Code). AI was used to draft the tests, identify the schema/response mismatches, implement the fixes, harden the plugin's override of the forthcoming core API, and write this description. All changes were reviewed, run against the PHPUnit suite, and verified by the PR author.
