### PR TITLE
DataForm panel layout: fix double-clicking a field row leaving the flyout stuck open

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
-- DataForm panel layout: fix double-clicking a field row leaving the flyout stuck open. [#](https://github.com/WordPress/gutenberg/pull/)
+- DataForm panel layout: fix double-clicking a field row leaving the flyout stuck open. [#79348](https://github.com/WordPress/gutenberg/pull/79348)
 - DataForm panel layout: use `overflow: clip` on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+- DataForm panel layout: fix double-clicking a field row leaving the flyout stuck open. [#](https://github.com/WordPress/gutenberg/pull/)
 - DataForm panel layout: use `overflow: clip` on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -152,8 +152,8 @@ function PanelDropdown< Item >( {
 						validity={ validity }
 						touched={ touched }
 						disabled={ fieldDefinition.readOnly === true }
+						isOpen={ isOpen }
 						onClick={ onToggle }
-						aria-expanded={ isOpen }
 					/>
 				) }
 				renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -197,7 +197,7 @@ function PanelModal< Item >( {
 				touched={ touched }
 				disabled={ fieldDefinition.readOnly === true }
 				onClick={ () => setIsOpen( true ) }
-				aria-expanded={ isOpen }
+				isOpen={ isOpen }
 			/>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -34,8 +34,8 @@ export default function SummaryButton< Item >( {
 	validity,
 	touched,
 	disabled,
+	isOpen,
 	onClick,
-	'aria-expanded': ariaExpanded,
 }: {
 	data: Item;
 	field: NormalizedFormField;
@@ -44,8 +44,8 @@ export default function SummaryButton< Item >( {
 	validity?: FieldValidity;
 	touched: boolean;
 	disabled?: boolean;
+	isOpen: boolean;
 	onClick: () => void;
-	'aria-expanded'?: boolean;
 } ) {
 	const { labelPosition, editVisibility } =
 		field.layout as NormalizedPanelLayout;
@@ -81,11 +81,20 @@ export default function SummaryButton< Item >( {
 		  );
 
 	const rowRef = useRef< HTMLDivElement >( null );
+	const editButtonRef = useRef< HTMLButtonElement >( null );
 
-	const handleRowClick = () => {
-		const selection =
-			rowRef.current?.ownerDocument.defaultView?.getSelection();
-		if ( selection && selection.toString().length > 0 ) {
+	const handleRowClick = ( event: React.MouseEvent ) => {
+		// Prevent a drag-to-select from opening the flyout — focus could move
+		// in and lose the selection. Skip the guard for double-clicks (standard
+		// button behavior), an already-open flyout, and the edit button.
+		if (
+			! isOpen &&
+			event.detail < 2 &&
+			! editButtonRef.current?.contains( event.target as Node ) &&
+			rowRef.current?.ownerDocument.defaultView
+				?.getSelection()
+				?.toString()
+		) {
 			return;
 		}
 		onClick();
@@ -165,11 +174,12 @@ export default function SummaryButton< Item >( {
 			</span>
 			{ ! disabled && (
 				<Button
+					ref={ editButtonRef }
 					className="dataforms-layouts-panel__field-trigger-icon"
 					label={ ariaLabel }
 					icon={ pencil }
 					size="small"
-					aria-expanded={ ariaExpanded }
+					aria-expanded={ isOpen }
 					aria-haspopup="dialog"
 					aria-describedby={ `${ controlId }` }
 				/>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This was noticed by @jasmussen [here](https://github.com/WordPress/gutenberg/pull/76934#issuecomment-4741118420).

There is a bug in `panel` DataForm layout where the `onClick` handler of the row is guarded against the existence of a `selection`. I guess this was added because of the whole row being a click target to open the dialog and wanted to still allow users to select some text (e.g. from labels).


If we double-click on the label of the field it would preserve the selection (browser functionality) and wouldn't trigger the `onClick` again. That would result in not being able to open a new flyout if we would click the pencil edit button and also not being able to close the opened flyout when we click in a different row.

This PR updates that logic to prevent a drag-to-select from opening the flyout — focus could move in and lose the selection. Also skips the guard for double-clicks, an already-open flyout, and the edit button.


## Testing Instructions
1. Go to quick edit for a page in site editor (uses `panel` DataForm layout)
2. double click at the `label` of the field and then click a different row
3. No stacked flyouts should be there
4. Additionally have a selection in field label and try to click the `edit` pencil icon in a different row.
5. The new flyout should open properly

### Before


https://github.com/user-attachments/assets/28c2b69c-f1d4-43a2-828d-5cf1e4e0a136




### After

https://github.com/user-attachments/assets/11f83bda-28de-4aae-82c4-876ab19cc324

