### PR TITLE
Mark all controlled/mode block changes non-persistent

### DIFF
--- a/packages/block-editor/src/components/block-editing-mode/index.js
+++ b/packages/block-editor/src/components/block-editing-mode/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useRegistry } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -50,8 +50,7 @@ import {
 export function useBlockEditingMode( mode ) {
 	const context = useBlockEditContext();
 	const { clientId = '' } = context;
-	const { setBlockEditingMode, unsetBlockEditingMode } =
-		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 	const globalBlockEditingMode = useSelect(
 		( select ) =>
 			// Avoid adding the subscription if not needed!
@@ -59,14 +58,23 @@ export function useBlockEditingMode( mode ) {
 		[ clientId ]
 	);
 	useEffect( () => {
-		if ( mode ) {
-			setBlockEditingMode( clientId, mode );
+		if ( ! mode ) {
+			return;
 		}
+
+		const {
+			setBlockEditingMode,
+			unsetBlockEditingMode,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
+
+		__unstableMarkNextChangeAsNotPersistent();
+		setBlockEditingMode( clientId, mode );
+
 		return () => {
-			if ( mode ) {
-				unsetBlockEditingMode( clientId );
-			}
+			__unstableMarkNextChangeAsNotPersistent();
+			unsetBlockEditingMode( clientId );
 		};
-	}, [ clientId, mode, setBlockEditingMode, unsetBlockEditingMode ] );
+	}, [ registry, clientId, mode ] );
 	return clientId ? context[ blockEditingModeKey ] : globalBlockEditingMode;
 }

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -252,6 +252,7 @@ export default function useBlockSync( {
 					cloneBlockWithMapping( block, idMappingRef.current )
 				);
 
+				__unstableMarkNextChangeAsNotPersistent();
 				setHasControlledInnerBlocks( clientId, true );
 
 				if ( subscribedRef.current ) {
@@ -280,10 +281,12 @@ export default function useBlockSync( {
 	const unsetControlledBlocks = () => {
 		__unstableMarkNextChangeAsNotPersistent();
 		if ( clientId ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setHasControlledInnerBlocks( clientId, false );
 			__unstableMarkNextChangeAsNotPersistent();
 			replaceInnerBlocks( clientId, [] );
 		} else {
+			__unstableMarkNextChangeAsNotPersistent();
 			resetBlocks( [] );
 		}
 	};

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -279,7 +279,6 @@ export default function useBlockSync( {
 	// Clean up the changes made by setControlledBlocks() when the component
 	// containing useBlockSync() unmounts.
 	const unsetControlledBlocks = () => {
-		__unstableMarkNextChangeAsNotPersistent();
 		if ( clientId ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setHasControlledInnerBlocks( clientId, false );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -362,27 +362,29 @@ function Navigation( {
 		innerBlocks,
 	} = useInnerBlocks( clientId );
 
+	const {
+		replaceInnerBlocks,
+		selectBlock,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
+
 	// Reset submenuVisibility to default if orientation changes to horizontal
 	// while "always" is selected, but only when the Navigation block or one
 	// of its inner blocks is being edited. Rendering related template parts
 	// should not mark them dirty.
 	useEffect( () => {
-		if (
-			( isSelected || isInnerBlockSelected ) &&
-			orientation === 'horizontal' &&
-			submenuVisibility === 'always'
-		) {
+		if ( orientation === 'horizontal' && submenuVisibility === 'always' ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				submenuVisibility: 'hover',
 				showSubmenuIcon: true,
 			} );
 		}
 	}, [
-		isSelected,
-		isInnerBlockSelected,
 		orientation,
 		submenuVisibility,
 		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	// Use a ref to store whether we've confirmed a page-list has submenus.
@@ -441,12 +443,6 @@ function Navigation( {
 			( templatePart ) =>
 				templatePart.area === NAVIGATION_OVERLAY_TEMPLATE_PART_AREA
 		) ?? false;
-
-	const {
-		replaceInnerBlocks,
-		selectBlock,
-		__unstableMarkNextChangeAsNotPersistent,
-	} = useDispatch( blockEditorStore );
 
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] =
 		useState( false );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -63,14 +63,16 @@ const PlaylistEdit = ( {
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	const {
+		replaceInnerBlocks,
+		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const { innerBlockTracks } = useSelect(
 		( select ) => {
@@ -121,6 +123,7 @@ const PlaylistEdit = ( {
 		if ( tracks.length === 0 ) {
 			// If there are no tracks but currentTrack is set, set it to null.
 			if ( currentTrack !== null ) {
+				__unstableMarkNextChangeAsNotPersistent();
 				updateBlockAttributes( clientId, { currentTrack: null } );
 			}
 		} else if (
@@ -128,6 +131,7 @@ const PlaylistEdit = ( {
 			firstTrackId &&
 			firstTrackId !== currentTrack
 		) {
+			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( clientId, { currentTrack: firstTrackId } );
 		}
 	}, [
@@ -136,6 +140,7 @@ const PlaylistEdit = ( {
 		firstTrackId,
 		clientId,
 		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	const onSelectTracks = useCallback(

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -63,16 +63,14 @@ const PlaylistEdit = ( {
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
-	const {
-		replaceInnerBlocks,
-		updateBlockAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
-	} = useDispatch( blockEditorStore );
+	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const { innerBlockTracks } = useSelect(
 		( select ) => {
@@ -123,7 +121,6 @@ const PlaylistEdit = ( {
 		if ( tracks.length === 0 ) {
 			// If there are no tracks but currentTrack is set, set it to null.
 			if ( currentTrack !== null ) {
-				__unstableMarkNextChangeAsNotPersistent();
 				updateBlockAttributes( clientId, { currentTrack: null } );
 			}
 		} else if (
@@ -131,7 +128,6 @@ const PlaylistEdit = ( {
 			firstTrackId &&
 			firstTrackId !== currentTrack
 		) {
-			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( clientId, { currentTrack: firstTrackId } );
 		}
 	}, [
@@ -140,7 +136,6 @@ const PlaylistEdit = ( {
 		firstTrackId,
 		clientId,
 		updateBlockAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	const onSelectTracks = useCallback(

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -8,6 +8,8 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,13 +26,21 @@ export default function EnhancedPaginationModal( {
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
 	const hasUnsupportedBlocks = useUnsupportedBlocks( clientId );
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		if ( enhancedPagination && hasUnsupportedBlocks ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { enhancedPagination: false } );
 			setOpen( true );
 		}
-	}, [ enhancedPagination, hasUnsupportedBlocks, setAttributes ] );
+	}, [
+		enhancedPagination,
+		hasUnsupportedBlocks,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	const closeModal = () => {
 		setOpen( false );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -75,7 +75,8 @@ const SiteLogo = ( {
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const cropButtonRef = useRef();
-	const { toggleSelection } = useDispatch( blockEditorStore );
+	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// Check if we're in contentOnly mode
@@ -108,6 +109,7 @@ const SiteLogo = ( {
 		// fallen out of sync. This can happen if the toggle is saved in the `on` position,
 		// but changes are later made to the site icon in the Customizer.
 		if ( shouldSyncIcon && logoId !== iconId ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { shouldSyncIcon: false } );
 		}
 	}, [] );

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -52,22 +52,31 @@ export default function DisableNonPageContentBlocks() {
 	// Child blocks of templates and templateParts are also loaded separately,
 	// so these are kept in separate effects.
 	useEffect( () => {
-		const { setBlockEditingMode, unsetBlockEditingMode } =
-			registry.dispatch( blockEditorStore );
+		const {
+			setBlockEditingMode,
+			unsetBlockEditingMode,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
 
+		__unstableMarkNextChangeAsNotPersistent();
 		setBlockEditingMode( '', 'disabled' );
 
 		return () => {
+			__unstableMarkNextChangeAsNotPersistent();
 			unsetBlockEditingMode( '' );
 		};
 	}, [ registry ] );
 
 	useEffect( () => {
-		const { setBlockEditingMode, unsetBlockEditingMode } =
-			registry.dispatch( blockEditorStore );
+		const {
+			setBlockEditingMode,
+			unsetBlockEditingMode,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
 
 		registry.batch( () => {
 			for ( const clientId of templateParts ) {
+				__unstableMarkNextChangeAsNotPersistent();
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
 		} );
@@ -75,6 +84,7 @@ export default function DisableNonPageContentBlocks() {
 		return () => {
 			registry.batch( () => {
 				for ( const clientId of templateParts ) {
+					__unstableMarkNextChangeAsNotPersistent();
 					unsetBlockEditingMode( clientId );
 				}
 			} );
@@ -82,17 +92,22 @@ export default function DisableNonPageContentBlocks() {
 	}, [ templateParts, registry ] );
 
 	useEffect( () => {
-		const { setBlockEditingMode, unsetBlockEditingMode } =
-			registry.dispatch( blockEditorStore );
+		const {
+			setBlockEditingMode,
+			unsetBlockEditingMode,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
 
 		const contentOnlySet = new Set( contentOnlyIds );
 
 		registry.batch( () => {
 			for ( const clientId of contentOnlyIds ) {
+				__unstableMarkNextChangeAsNotPersistent();
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
 			for ( const clientId of templatePartChildren ) {
 				if ( ! contentOnlySet.has( clientId ) ) {
+					__unstableMarkNextChangeAsNotPersistent();
 					setBlockEditingMode( clientId, 'disabled' );
 				}
 			}
@@ -101,10 +116,12 @@ export default function DisableNonPageContentBlocks() {
 		return () => {
 			registry.batch( () => {
 				for ( const clientId of contentOnlyIds ) {
+					__unstableMarkNextChangeAsNotPersistent();
 					unsetBlockEditingMode( clientId );
 				}
 				for ( const clientId of templatePartChildren ) {
 					if ( ! contentOnlySet.has( clientId ) ) {
+						__unstableMarkNextChangeAsNotPersistent();
 						unsetBlockEditingMode( clientId );
 					}
 				}

--- a/packages/editor/src/components/provider/navigation-block-editing-mode.js
+++ b/packages/editor/src/components/provider/navigation-block-editing-mode.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useRegistry, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -14,24 +14,30 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 
 export default function NavigationBlockEditingMode() {
+	const registry = useRegistry();
 	// In the navigation block editor,
 	// the navigation block is the only root block.
 	const blockClientId = useSelect(
 		( select ) => select( blockEditorStore ).getBlockOrder()?.[ 0 ],
 		[]
 	);
-	const { setBlockEditingMode, unsetBlockEditingMode } =
-		useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! blockClientId ) {
 			return;
 		}
+		const {
+			setBlockEditingMode,
+			unsetBlockEditingMode,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
 
+		__unstableMarkNextChangeAsNotPersistent();
 		setBlockEditingMode( blockClientId, 'contentOnly' );
 
 		return () => {
+			__unstableMarkNextChangeAsNotPersistent();
 			unsetBlockEditingMode( blockClientId );
 		};
-	}, [ blockClientId, unsetBlockEditingMode, setBlockEditingMode ] );
+	}, [ registry, blockClientId ] );
 }


### PR DESCRIPTION
This should fix #78989. When a block does a side effect edit on mount, then even though the edit is marked as non-persistent, it's written persistently to the core data entity. Instead of writing it only to the blocks store and waiting for the next (user-initiated) edit to do the persistent edit.

I found that this is caused by `setHasControlledInnerBlocks` and `setBlockEditingMode` actions that modify the `state.blocks` subtree, but they are not real edits. Then the `withPersistentBlockChange` thinks the block state has changed and resets the persistent flag. But the action done was not a real edit, it should be ignored.

This patch fixes that by adding `__unstableMarkNextChangeAsNotPersistent` to all places where `setHasControlledInnerBlocks` and `setBlockEditingMode` are called. This is ugly, but should be an effective fix that's good enough to test.

A better patch, after we verify the idea, will be for `withPersistentBlockChange` to ignore the `blockEditingModes` and `controlledInnerBlocks` subtrees.

It's interesting that `blockEditingModes` was moved into `state.blocks` in #76529. I don't think this PR caused the issue, because `controlledInnerBlocks` was already there, but it made it more serious. @danluu's AI analysis mentioned in https://github.com/WordPress/gutenberg/issues/78989#issuecomment-4640531690 correctly pointed out this PR as one of the regressing ones. The text of the analysis is a bit murky, I don't really understand it and I think the causes are different, but the bisecting and the "intuition" is right 🙂 