### PR TITLE
Site Editor: Introduce isHidden prop for SidebarNavigationItem

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -22,6 +22,17 @@ import { SidebarNavigationContext } from '../sidebar';
 const { useHistory, useLink, useLocation } = unlock( routerPrivateApis );
 
 export default function SidebarNavigationItem( {
+	isHidden = false,
+	...props
+} ) {
+	if ( isHidden ) {
+		return null;
+	}
+
+	return <SidebarNavigationItemContent { ...props } />;
+}
+
+function SidebarNavigationItemContent( {
 	className,
 	icon,
 	withChevron = false,

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -33,11 +33,15 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 				{ _x( 'Identity', 'site identity' ) }
 			</SidebarNavigationItem>
 			<SidebarNavigationItem
-				to="/styles"
-				uid="global-styles-navigation-item"
+				to={ isBlockBasedTheme ? '/styles' : '/stylebook' }
+				uid={
+					isBlockBasedTheme
+						? 'global-styles-navigation-item'
+						: 'stylebook-navigation-item'
+				}
 				icon={ styles }
-				activeOnRouteName="styles"
-				isHidden={ ! isBlockBasedTheme }
+				activeOnRouteName={ isBlockBasedTheme ? 'styles' : undefined }
+				withChevron={ ! isBlockBasedTheme }
 			>
 				{ __( 'Styles' ) }
 			</SidebarNavigationItem>
@@ -58,15 +62,6 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 				isHidden={ ! isBlockBasedTheme }
 			>
 				{ __( 'Navigation' ) }
-			</SidebarNavigationItem>
-			<SidebarNavigationItem
-				uid="stylebook-navigation-item"
-				to="/stylebook"
-				withChevron
-				icon={ styles }
-				isHidden={ isBlockBasedTheme }
-			>
-				{ __( 'Styles' ) }
 			</SidebarNavigationItem>
 			<SidebarNavigationItem
 				uid="patterns-navigation-item"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -23,52 +23,51 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
-			{ isBlockBasedTheme && (
-				<>
-					<SidebarNavigationItem
-						to="/identity"
-						uid="identity-navigation-item"
-						icon={ siteLogo }
-						activeOnRouteName="identity"
-					>
-						{ _x( 'Identity', 'site identity' ) }
-					</SidebarNavigationItem>
-					<SidebarNavigationItem
-						to="/styles"
-						uid="global-styles-navigation-item"
-						icon={ styles }
-						activeOnRouteName="styles"
-					>
-						{ __( 'Styles' ) }
-					</SidebarNavigationItem>
-					<SidebarNavigationItem
-						uid="page-navigation-item"
-						to="/page"
-						withChevron
-						icon={ page }
-					>
-						{ __( 'Pages' ) }
-					</SidebarNavigationItem>
-					<SidebarNavigationItem
-						uid="navigation-navigation-item"
-						to="/navigation"
-						withChevron
-						icon={ navigation }
-					>
-						{ __( 'Navigation' ) }
-					</SidebarNavigationItem>
-				</>
-			) }
-			{ ! isBlockBasedTheme && (
-				<SidebarNavigationItem
-					uid="stylebook-navigation-item"
-					to="/stylebook"
-					withChevron
-					icon={ styles }
-				>
-					{ __( 'Styles' ) }
-				</SidebarNavigationItem>
-			) }
+			<SidebarNavigationItem
+				to="/identity"
+				uid="identity-navigation-item"
+				icon={ siteLogo }
+				activeOnRouteName="identity"
+				isHidden={ ! isBlockBasedTheme }
+			>
+				{ _x( 'Identity', 'site identity' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem
+				to="/styles"
+				uid="global-styles-navigation-item"
+				icon={ styles }
+				activeOnRouteName="styles"
+				isHidden={ ! isBlockBasedTheme }
+			>
+				{ __( 'Styles' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem
+				uid="page-navigation-item"
+				to="/page"
+				withChevron
+				icon={ page }
+				isHidden={ ! isBlockBasedTheme }
+			>
+				{ __( 'Pages' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem
+				uid="navigation-navigation-item"
+				to="/navigation"
+				withChevron
+				icon={ navigation }
+				isHidden={ ! isBlockBasedTheme }
+			>
+				{ __( 'Navigation' ) }
+			</SidebarNavigationItem>
+			<SidebarNavigationItem
+				uid="stylebook-navigation-item"
+				to="/stylebook"
+				withChevron
+				icon={ styles }
+				isHidden={ isBlockBasedTheme }
+			>
+				{ __( 'Styles' ) }
+			</SidebarNavigationItem>
 			<SidebarNavigationItem
 				uid="patterns-navigation-item"
 				to="/pattern"
@@ -77,16 +76,15 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 			>
 				{ __( 'Patterns' ) }
 			</SidebarNavigationItem>
-			{ isBlockBasedTheme && (
-				<SidebarNavigationItem
-					uid="template-navigation-item"
-					to="/template"
-					withChevron
-					icon={ layout }
-				>
-					{ __( 'Templates' ) }
-				</SidebarNavigationItem>
-			) }
+			<SidebarNavigationItem
+				uid="template-navigation-item"
+				to="/template"
+				withChevron
+				icon={ layout }
+				isHidden={ ! isBlockBasedTheme }
+			>
+				{ __( 'Templates' ) }
+			</SidebarNavigationItem>
 		</ItemGroup>
 	);
 }


### PR DESCRIPTION
## What?
PR adds an `isHidden` prop to `SidebarNavigationItem` so visibility is controlled declaratively on the item itself, replacing the `{ condition && (...) }` wrapper blocks in the main Design sidebar.

**Changes:**

- **`sidebar-navigation-item`** - `SidebarNavigationItem` now accepts `isHidden` (default `false`); returns `null` when hidden. Rendering logic moved to an internal `SidebarNavigationItemContent` component.
- **`sidebar-navigation-screen-main`** - Flattened the block-theme/classic-theme conditional groups into a single flat list, each item using `isHidden={ ! isBlockBasedTheme }` (or the inverse). The previously duplicated Styles items (global styles vs. stylebook) are collapsed into one item that swaps `to`/`uid`/`activeOnRouteName`/`withChevron` based on `isBlockBasedTheme`.

No behavioral/ordering change for users: block themes show Identity, Styles, Pages, Navigation, Templates, Patterns; classic themes show Styles (→ stylebook) and Patterns.

## Testing Instructions
1. Open Site Editor or Design (classic theme) admin pages.
2. Confirm that sidebar navigation items are displayed as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Classic Theme|Block Theme|
|-|-|
|<img width="299" height="394" alt="CleanShot 2026-06-19 at 17 00 07" src="https://github.com/user-attachments/assets/6867ff5e-118f-4605-b2fa-04b0bb2d66ca" />|<img width="301" height="516" alt="CleanShot 2026-06-19 at 17 00 28" src="https://github.com/user-attachments/assets/2013b618-1416-4ec4-b76e-84695965f86c" />

## Use of AI Tools

Assisted by Claude.