### PR TITLE
Components: Add autoFocus prop to AlignmentMatrixControl, use for Cover block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -54,7 +54,7 @@ function BlockAlignmentMatrixControl( props ) {
 
 	return (
 		<Dropdown
-			popoverProps={ { placement: 'bottom-start' } }
+			popoverProps={ { placement: 'bottom-start', focusOnMount: false } }
 			renderToggle={ ( { onToggle, isOpen } ) => {
 				const openOnArrowDown = ( event ) => {
 					if ( ! isOpen && event.keyCode === DOWN ) {
@@ -77,7 +77,12 @@ function BlockAlignmentMatrixControl( props ) {
 				);
 			} }
 			renderContent={ () => (
-				<AlignmentMatrixControl onChange={ onChange } value={ value } />
+				<AlignmentMatrixControl
+					// eslint-disable-next-line jsx-a11y/no-autofocus -- To avoid race conditions with matrix initialization, let it focus itself rather than relying on dropdown focusOnMount.
+					autoFocus
+					onChange={ onChange }
+					value={ value }
+				/>
 			) }
 		/>
 	);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `AlignmentMatrixControl`: Add an `autoFocus` prop that focuses the active cell on mount, for use when the control is revealed in a popover or dialog.
 -   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows ([#79112](https://github.com/WordPress/gutenberg/pull/79112)).
 -   `Button`, `DropdownMenu`, `FormToggle`, `Modal`, `Panel`, `RadioControl`, `Toolbar`: Migrate hardcoded border and stroke colors to WPDS tokens ([#79244](https://github.com/WordPress/gutenberg/pull/79244)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `AlignmentMatrixControl`: Add an `autoFocus` prop that focuses the active cell on mount, for use when the control is revealed in a popover or dialog.
+-   `AlignmentMatrixControl`: Add an `autoFocus` prop that focuses the active cell on mount, for use when the control is revealed in a popover or dialog ([#79354](https://github.com/WordPress/gutenberg/pull/79354)).
 -   `BaseControl`: Apply `text-wrap: pretty` to help text to avoid typographic widows ([#79112](https://github.com/WordPress/gutenberg/pull/79112)).
 -   `Button`, `DropdownMenu`, `FormToggle`, `Modal`, `Panel`, `RadioControl`, `Toolbar`: Migrate hardcoded border and stroke colors to WPDS tokens ([#79244](https://github.com/WordPress/gutenberg/pull/79244)).
 

--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -30,10 +30,16 @@ const Example = () => {
  - Required: No
  - Default: `false`
 
-If `true`, the currently active cell receives focus when the control
-mounts. Intended for cases where the control is revealed in a popover or
-dialog and focus should move to it; leave it `false` for inline usage so
-the control does not steal focus on mount.
+If `true`, focuses the currently active cell receives when mounted.
+
+Intended for cases where the control is revealed in a popover or dialog
+and focus should move to it. AlignmentMatrixControl's initialization is
+asynchronous, and all rendered cells are tabbable until initialization
+is complete. This create race conditions when competing with programmatic
+focus management initiated when popovers are opened, where that focus
+management itself may be asynchronous. To avoid such race conditions,
+disable the external focus management and use this prop instead to focus
+the active cell once initialization is complete.
 
 ### `defaultValue`
 

--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -24,6 +24,17 @@ const Example = () => {
 
 ## Props
 
+### `autoFocus`
+
+ - Type: `boolean`
+ - Required: No
+ - Default: `false`
+
+If `true`, the currently active cell receives focus when the control
+mounts. Intended for cases where the control is revealed in a popover or
+dialog and focus should move to it; leave it `false` for inline usage so
+the control does not steal focus on mount.
+
 ### `defaultValue`
 
  - Type: `"center" | "top left" | "top center" | "top right" | "center left" | "center center" | "center right" | "bottom left" | "bottom center" | "bottom right"`

--- a/packages/components/src/alignment-matrix-control/cell.tsx
+++ b/packages/components/src/alignment-matrix-control/cell.tsx
@@ -21,12 +21,15 @@ import styles from './style.module.scss';
 export default function Cell( {
 	id,
 	value,
+	autoFocus,
 	...props
 }: WordPressComponentProps< AlignmentMatrixControlCellProps, 'span', false > ) {
 	return (
 		<Tooltip text={ ALIGNMENT_LABEL[ value ] }>
 			<Composite.Item
 				id={ id }
+				// eslint-disable-next-line jsx-a11y/no-autofocus -- This is a pass-through, and the appropriateness of autoFocus should be determined by the consumer.
+				autoFocus={ autoFocus }
 				render={
 					<span
 						{ ...props }

--- a/packages/components/src/alignment-matrix-control/index.tsx
+++ b/packages/components/src/alignment-matrix-control/index.tsx
@@ -29,6 +29,7 @@ function UnforwardedAlignmentMatrixControl( {
 	value,
 	onChange,
 	width = 92,
+	autoFocus = false,
 	...props
 }: WordPressComponentProps< AlignmentMatrixControlProps, 'div', false > ) {
 	const baseId = useInstanceId(
@@ -36,6 +37,10 @@ function UnforwardedAlignmentMatrixControl( {
 		'alignment-matrix-control',
 		id
 	);
+
+	const defaultActiveId = getItemId( baseId, defaultValue );
+	const activeId = getItemId( baseId, value );
+	const resolvedActiveId = activeId ?? defaultActiveId;
 
 	const setActiveId = useCallback<
 		NonNullable< React.ComponentProps< typeof Composite >[ 'setActiveId' ] >
@@ -57,8 +62,8 @@ function UnforwardedAlignmentMatrixControl( {
 
 	return (
 		<Composite
-			defaultActiveId={ getItemId( baseId, defaultValue ) }
-			activeId={ getItemId( baseId, value ) }
+			defaultActiveId={ defaultActiveId }
+			activeId={ activeId }
 			setActiveId={ setActiveId }
 			rtl={ isRTL() }
 			render={
@@ -79,13 +84,20 @@ function UnforwardedAlignmentMatrixControl( {
 					}
 					key={ index }
 				>
-					{ cells.map( ( cell ) => (
-						<Cell
-							id={ getItemId( baseId, cell ) }
-							key={ cell }
-							value={ cell }
-						/>
-					) ) }
+					{ cells.map( ( cell ) => {
+						const cellId = getItemId( baseId, cell );
+						return (
+							<Cell
+								id={ cellId }
+								key={ cell }
+								value={ cell }
+								// eslint-disable-next-line jsx-a11y/no-autofocus -- This is a pass-through, and the appropriateness of autoFocus should be determined by the consumer.
+								autoFocus={
+									autoFocus && cellId === resolvedActiveId
+								}
+							/>
+						);
+					} ) }
 				</Composite.Row>
 			) ) }
 		</Composite>

--- a/packages/components/src/alignment-matrix-control/types.ts
+++ b/packages/components/src/alignment-matrix-control/types.ts
@@ -38,6 +38,21 @@ export type AlignmentMatrixControlProps = {
 	 * @default 92
 	 */
 	width?: number;
+	/**
+	 * If `true`, focuses the currently active cell receives when mounted.
+	 *
+	 * Intended for cases where the control is revealed in a popover or dialog
+	 * and focus should move to it. AlignmentMatrixControl's initialization is
+	 * asynchronous, and all rendered cells are tabbable until initialization
+	 * is complete. This create race conditions when competing with programmatic
+	 * focus management initiated when popovers are opened, where that focus
+	 * management itself may be asynchronous. To avoid such race conditions,
+	 * disable the external focus management and use this prop instead to focus
+	 * the active cell once initialization is complete.
+	 *
+	 * @default false
+	 */
+	autoFocus?: boolean;
 };
 
 export type AlignmentMatrixControlIconProps = Pick<


### PR DESCRIPTION
## What?

Adds a new `autoFocus` prop to the `AlignmentMatrixControl` component and updates the Cover block to use it in place of relying on Dropdown `focusOnMount`.

## Why?

Seeks to avoid a possible race condition between `AlignmentMatrixControl`'s asynchronous initialization and `focusOnMount`'s asynchronous detection of focusable elements.

The extended commit description has more details:

>Ariakit Composite initialization is asynchronous via requestAnimationFrame, because its roving tabindex can only be computed once all cell items are rendered. This asynchronous initialization can conflict with other autofocus behaviors which themselves may be asynchronous in different ways (e.g. [useFocusOnMount scheduling via `setTimeout(0)`](https://github.com/WordPress/gutenberg/blob/e2ca4961c5874d8b24b3e5e0c81adddab7947907/packages/compose/src/hooks/use-focus-on-mount/index.ts#L69-L87)). In the browser this is usually fine, but it's not a strong guarantee, and breaks in environments like JSDOM which define their own unique behavior for scheduling (rAF as a 16ms timeout).
>
>If useFocusOnMount runs before composite initializes, all composite items are tabbable, and the first cell is selected, but the expected behavior would be that focus is only assigned once initialized, since it may not be the first cell that's the active one.

This was motivated by #79353, which had to work around this issue by introducing a [test utility overriding `requestAnimationFrame`](https://github.com/WordPress/gutenberg/blob/e0d12e598fbe39c7e22aedb86ab78d547185ece6/packages/block-library/src/cover/test/edit.js#L42-L84) to emulate the browser behavior. But the browser behavior is not a strong guarantee, and there is a real risk of a race condition.

## Testing Instructions

Verify that Cover block tests pass: `npm run test:unit packages/block-library/src/cover/test/edit.js` (note that Cover block is the only consumer of this component)

Verify that focus shifts to the alignment matrix center cell and does not dirty post in doing so:

1. Go to Posts > Add Post
2. Add a Cover block
3. Pick a color or assign an image
4. Save the post
5. Select the Cover block container so that the block toolbar is shown
6. Click the "Change content position" block toolbar item (or activate it with keyboard, which is preferable because it'll show a focus indicator in the next step)
7. Observe that the "Center" cell is selected and focused, and that the post is not dirtied ("Saved" is shown in the top-right of the editor)

## Screenshots or screencast <!-- if applicable -->

<img width="457" height="230" alt="image" src="https://github.com/user-attachments/assets/5efdd060-5ae0-4305-91e7-f55dad3e0089" />

## Use of AI Tools

There was a lot of deep research here between Cursor Composer and Claude Opus 4.8 models. Implementations were initially authored by AI, with further refinement and iterations based on continued research. This was split from work that started in #79353.