### PR TITLE
Widget Primitives: make contract and story docs host-agnostic

### DIFF
--- a/packages/widget-primitives/src/components/widget-render/stories/index.story.tsx
+++ b/packages/widget-primitives/src/components/widget-render/stories/index.story.tsx
@@ -15,7 +15,7 @@ import '@wordpress/dataviews/build-style/style.css';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { Suspense, useId, useMemo, useState } from '@wordpress/element';
-import { wordpress } from '@wordpress/icons';
+import { globe } from '@wordpress/icons';
 import { Card, Icon, Stack } from '@wordpress/ui';
 
 /**
@@ -116,7 +116,7 @@ const demoWidgetType: WidgetType< DemoAttributes > = {
 	name: 'demo/hello-world',
 	title: 'Hello World',
 	description: 'Minimal widget that greets worlds near and far.',
-	icon: wordpress,
+	icon: globe,
 	renderModule: 'demo/widgets/hello-world/render',
 	attributes: [
 		{
@@ -140,7 +140,7 @@ const demoWidgetType: WidgetType< DemoAttributes > = {
 	},
 };
 
-// What `import( widget.renderModule )` resolves to on a WordPress page.
+// What `import( widget.renderModule )` resolves to in a real host.
 const resolveDemoModule = async () => ( {
 	default: DemoWidget as ComponentType< WidgetRenderProps< unknown > >,
 } );
@@ -162,7 +162,7 @@ const meta: Meta< typeof WidgetRender > = {
 
 A host provides three things:
 
-- \`widgetType\`: the widget's metadata, as declared by its author. On a WordPress page it arrives through \`useWidgetTypes()\`.
+- \`widgetType\`: the widget's metadata, as declared by its author. In a host it arrives through \`useWidgetTypes()\`.
 - \`resolveWidgetModule\`: how the render component is loaded. Dynamic \`import()\` against an import map, eagerly enqueued script modules, or a custom resolver are all valid strategies.
 - \`setAttributes\` (optional): grants the widget write access to its own attributes. Omit it and the widget renders read-only.
 `,

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -121,9 +121,9 @@ export interface WidgetTypeMetadata< Item = unknown > {
  * Runtime widget type consumed by hosts.
  *
  * Extends `WidgetTypeMetadata` with runtime-only fields, notably
- * `renderModule`. The PHP layer (`widget-types.php`) emits these in
- * snake_case; `useWidgetTypes` is the single boundary that maps them to
- * camelCase.
+ * `renderModule`. Hosts supply the raw records in snake_case
+ * (`WidgetModuleRecord`); `useWidgetTypes` is the single boundary that
+ * resolves them into this camelCase shape.
  */
 export interface WidgetType< Item = unknown >
 	extends WidgetTypeMetadata< Item > {
@@ -169,9 +169,9 @@ export type ResolveWidgetModule = (
 ) => Promise< WidgetModule >;
 
 /**
- * Per-widget data a host feeds to `useWidgetTypes`, in snake_case wire
- * format. Matches the `/wp/v2/widget-modules` REST shape, so a WordPress
- * host can pass core-data records unchanged.
+ * Per-widget record a host feeds to `useWidgetTypes`, in snake_case wire
+ * format. The host fetches these however it likes; only the field shape is
+ * part of the contract.
  */
 export interface WidgetModuleRecord {
 	/**


### PR DESCRIPTION
## What

Removes WordPress-specific references from the documentation of `@wordpress/widget-primitives` so the package's docs match its stated host-agnostic contract.

This is a docs-only change: JSDoc, Storybook prose, and one demo icon. No runtime code, types, or public API change.

## Why

The package exists precisely to be a host-agnostic toolkit, but the canonical contract documented otherwise. `WidgetType` named a PHP file (`widget-types.php`), `WidgetModuleRecord` named a REST endpoint (`/wp/v2/widget-modules`) along with core-data and "WordPress host", and the Storybook demo framed the generic render/discovery flow as happening "on a WordPress page".

That couples the contract to a single host in the exact place that is meant to be host-neutral. In one spot it was also inaccurate: `useWidgetTypes()` is the universal discovery path, not a WordPress detail.

The host-specific "where the records come from" knowledge already lives, correctly scoped, in the package README ("On a WordPress site...") and in the architecture document. Nothing is lost by removing it from the canonical types.

## How

- `types.ts` `WidgetType`: drop the `widget-types.php` / "PHP layer" reference. The JSDoc now points to the sibling `WidgetModuleRecord` type and keeps the snake_case to camelCase boundary story.
- `types.ts` `WidgetModuleRecord`: drop the `/wp/v2/widget-modules`, core-data, and "WordPress host" references. The wire record now describes itself (only the field shape is part of the contract).
- `index.story.tsx`: replace two "On a WordPress page" framings with host-neutral wording ("in a real host" and "In a host").
- `index.story.tsx`: swap the demo widget icon from `wordpress` to `globe`, neutral and a better fit for the demo's "worlds" theme.

Intentionally left untouched: the README's scoped "On a WordPress site..." paragraph and the architecture doc, which remain the correct home for host-specific notes.

## Testing

This is a documentation and comment change; verification is light.

1. Lint stays clean:

```
npm run lint:js -- packages/widget-primitives/src/types.ts packages/widget-primitives/src/components/widget-render/stories/index.story.tsx
```

2. Run Storybook and open Widget Primitives → WidgetRender:

```
npm run storybook:dev
```

The demo now renders with a globe icon. The Default, WithSettings, and WithHostChrome stories behave exactly as before, and the docs prose reads host-neutral (no "On a WordPress page").

3. Confirm there is no behavior change: the whole diff is comments, Storybook prose, and one icon import.

```
git diff trunk...HEAD
```

## Follow-ups

- [ ] Decide whether `WidgetModuleRecord` should expose a camelCase boundary (host-agnostic at the type level too), pushing the snake_case to camelCase adapter into the WordPress host wiring. This is a larger design call, tracked separately.
- [ ] Optional: give the package's Storybook Introduction a package-scoped intro instead of rendering the full WordPress-pipeline architecture document.