### PR TITLE
Post Editor: Use the correct directory for recent preload improvements

### DIFF
--- a/backport-changelog/7.1/11948.md
+++ b/backport-changelog/7.1/11948.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11948
 
 * https://github.com/WordPress/gutenberg/pull/78565
+* https://github.com/WordPress/gutenberg/pull/79359

--- a/lib/compat/wordpress-7.0/preload.php
+++ b/lib/compat/wordpress-7.0/preload.php
@@ -26,31 +26,3 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_9', 10, 2 );
-
-/**
- * Preload bound single-resource GETs the post editor would otherwise
- * fetch post-mount.
- *
- * @param array                   $paths   REST API paths.
- * @param WP_Block_Editor_Context $context Block editor context.
- * @return array
- */
-function gutenberg_block_editor_preload_paths_post_editor_bound_gets( $paths, $context ) {
-	if ( 'core/edit-post' !== $context->name || ! isset( $context->post ) ) {
-		return $paths;
-	}
-	$paths[] = '/wp/v2/templates/lookup?slug=front-page';
-	$paths[] = '/wp/v2/taxonomies?context=edit';
-	$paths[] = array( '/wp/v2/posts', 'OPTIONS' );
-
-	$author_id = (int) get_post_field( 'post_author', $context->post->ID );
-	if ( $author_id ) {
-		$paths[] = sprintf(
-			'/wp/v2/users/%d?context=view&_fields=id,name',
-			$author_id
-		);
-	}
-
-	return $paths;
-}
-add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_post_editor_bound_gets', 10, 2 );

--- a/lib/compat/wordpress-7.1/preload.php
+++ b/lib/compat/wordpress-7.1/preload.php
@@ -6,19 +6,15 @@
  */
 
 /**
- * Filters the block editor preload paths to include media processing fields.
- *
- * The packages/core-data/src/entities.js file requests additional fields
- * (image_sizes, image_size_threshold) on the root endpoint that are not
- * included in WordPress Core's default preload paths. This filter ensures
- * the preloaded URL matches exactly what the JavaScript requests.
+ * Filters the block editor preload paths.
  *
  * @since 20.1.0
  *
- * @param array $paths REST API paths to preload.
+ * @param array                   $paths   REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Block editor context.
  * @return array Filtered preload paths.
  */
-function gutenberg_block_editor_preload_paths_root_fields( $paths ) {
+function gutenberg_block_editor_preload_paths_7_1( $paths, $context ) {
 	// Complete list of fields expected by packages/core-data/src/entities.js.
 	// This must match exactly for preloading to work (same fields, same order).
 	// @see packages/core-data/src/entities.js rootEntitiesConfig.__unstableBase
@@ -32,6 +28,20 @@ function gutenberg_block_editor_preload_paths_root_fields( $paths ) {
 		}
 	}
 
+	if ( 'core/edit-post' === $context->name && isset( $context->post ) ) {
+		$paths[] = '/wp/v2/templates/lookup?slug=front-page';
+		$paths[] = '/wp/v2/taxonomies?context=edit';
+		$paths[] = array( rest_get_route_for_post_type_items( $context->post->post_type ), 'OPTIONS' );
+
+		$author_id = (int) get_post_field( 'post_author', $context->post->ID );
+		if ( post_type_supports( $context->post->post_type, 'author' ) && $author_id > 0 ) {
+			$paths[] = sprintf(
+				'/wp/v2/users/%d?context=view&_fields=id,name',
+				$author_id
+			);
+		}
+	}
+
 	return $paths;
 }
-add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_root_fields' );
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_7_1', 10, 2 );


### PR DESCRIPTION
## What?
This is a follow-up to #78565.

PR makes the following changes to the new preloaded paths.

  - Merges into existing preloaded paths for WP 7.1. This is the target version for changes.
  - Resolve the OPTIONS route via `rest_get_route_for_post_type_items( $context->post->post_type )` instead of a hardcoded `/wp/v2/posts`.
  - Only preload the author when the post type supports `author` and an author is set.

## Testing

- Post editor: confirm the templates-lookup, taxonomies, post-type OPTIONS, and author requests are preloaded (no post-mount fetch).
- Custom post type without author support: confirm no author preload is added.
- Root endpoint `/?_fields=…` still rewritten to the full field list.


## Testing Instructions
1. Open post editor for different post types - posts, pages, patterns.
2. Confirm there's no warning in DevTools for never-consumed preloaded paths.