### PR TITLE
Image block: stop interpreting `$`/`\` in img attributes as regex backreferences

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -290,12 +290,12 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$body_content = $processor->get_updated_html();
 
 	// Adds a button alongside image in the body content.
+	// Extract the img tag using preg_match for structured access.
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 
-	$button =
-		$img[0]
-		. '<button
+	if ( isset( $img[0] ) ) {
+		$button_html = '<button
 			class="lightbox-trigger"
 			type="button"
 			aria-haspopup="dialog"
@@ -310,7 +310,13 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 			</svg>
 		</button>';
 
-	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );
+		// Build the replacement: img tag + button.
+		// Use str_replace for literal replacement instead of preg_replace to avoid
+		// PCRE backreference interpretation of $ and \ sequences in user-controlled
+		// image attributes (e.g., alt="Just $5 today").
+		$button       = $img[0] . $button_html;
+		$body_content = str_replace( $img[0], $button, $body_content );
+	}
 
 	add_action( 'wp_footer', 'block_core_image_print_lightbox_overlay' );
 

--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -126,4 +126,46 @@ class Tests_Blocks_Render_Image extends WP_UnitTestCase {
 		$rendered_block = gutenberg_render_block_core_image( $attributes, $content, $block );
 		$this->assertSame( '<figure class="wp-block-image"><img src="canola.jpg"/></figure>', $rendered_block );
 	}
+
+	/**
+	 * Ensures `$`/`\` sequences in image attributes (e.g. a price in the alt
+	 * text, or a filename containing `$1`) are not interpreted as regular
+	 * expression backreferences when the lightbox trigger button is injected.
+	 *
+	 * The lightbox button is added by the `render_block_core/image` filter, so
+	 * the block must be rendered through `WP_Block::render()` for the filter to
+	 * run — calling the render callback directly does not exercise this path.
+	 *
+	 * @covers ::block_core_image_render_lightbox
+	 */
+	public function test_should_not_treat_dollar_sequences_in_img_as_backreferences_in_lightbox() {
+		$content = '<figure class="wp-block-image"><img src="http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/2021/04/price-$1-canola.jpg" alt="Only $1 today"/></figure>';
+
+		$parsed_blocks = parse_blocks( '<!-- wp:image {"lightbox":{"enabled":true}} -->' . $content . '<!-- /wp:image -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$block         = new WP_Block( $parsed_block );
+
+		$rendered_block = $block->render();
+
+		// The lightbox trigger button should have been injected.
+		$this->assertStringContainsString(
+			'class="lightbox-trigger"',
+			$rendered_block,
+			'The lightbox trigger button was not injected, so the regression path was not exercised.'
+		);
+
+		// The `$1` sequences must survive unchanged in both alt and src.
+		$this->assertStringContainsString(
+			'alt="Only $1 today"',
+			$rendered_block,
+			'The alt text containing "$1" was corrupted by backreference interpretation.'
+		);
+		$this->assertStringContainsString(
+			'price-$1-canola.jpg',
+			$rendered_block,
+			'The src filename containing "$1" was corrupted by backreference interpretation.'
+		);
+
+		remove_all_filters( 'render_block_core/image' );
+	}
 }


### PR DESCRIPTION
## What?

Closes #79368

Stops `$`/`\` sequences in image attributes (e.g. a price in the alt text, or a filename containing `$1`) from being interpreted as regular expression backreferences when the lightbox trigger button is injected in `block_core_image_render_lightbox()`.

## Why?

`block_core_image_render_lightbox()` injects the lightbox trigger button by calling `preg_replace( '/<img[^>]+>/', $button, $body_content )`, where `$button` begins with the matched `<img>` tag (`$img[0]`) and therefore embeds author-controlled attribute values (`src`, `alt`, `title`, `class`).

In a `preg_replace()` replacement string, sequences like `$1`, `${1}`, `\1` are treated as backreferences. So an image whose alt text or filename contains such a sequence (e.g. `alt="Only $1 today"`) has it silently rewritten — a reference to a non-existent capture group is replaced with an empty string — producing broken `alt`/`src` in the rendered lightbox. This is not XSS (output stays attribute-escaped), but it mangles legitimate content and is hard for site owners to diagnose.

## How?

A `core/image` block contains exactly one `<img>`, so a literal replacement is sufficient and safe. Switches from `preg_replace()` to `str_replace( $img[0], $button, $body_content )`, guarded by an `isset( $img[0] )` check. No backreference behaviour was intended here, so this is a pure correctness fix with no markup change for normal images.

Adds a regression test that renders a lightbox-enabled image whose alt text and src filename both contain `$1`, and asserts the sequences survive intact. The test renders through `WP_Block::render()` rather than calling the render callback directly, since the lightbox button is added via the `render_block_core/image` filter, which only runs through the full render path.

## Testing Instructions

1. Add an Image block to a post and enable its lightbox ("Expand on click").
2. Set the alt text to `Only $1 today` (or use an image whose filename contains `$1`).
3. View the post on the front end and inspect the rendered `<img>`.
4. Confirm the alt text and src render exactly as authored, with the `$1` intact.

Or run the unit test:
`npm run test:unit:php -- --filter test_should_not_treat_dollar_sequences_in_img_as_backreferences_in_lightbox`

## Screenshots or screencast

Not applicable. This is a correctness fix with no intended visual change for normal images.

## Use of AI Tools

Claude was used to help draft the PR description and the regression test. All code changes were reviewed and validated by the author.