### PR TITLE
Components: Make ResizableBox children prop optional

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internal
 
+-   `ResizableBox`: Make the `children` prop optional ([#79370](https://github.com/WordPress/gutenberg/pull/79370)).
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
 -   Point the legacy `--wp-components-*` color fallbacks at the design system tokens (`--wpds-*` / `--wp-admin-theme-color*`), so component styles get sensible defaults from the prebuilt token stylesheet without a runtime `<ThemeProvider>` ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from '@wordpress/element';
 import clsx from 'clsx';
 import { Resizable } from 're-resizable';
 import type { ResizableProps } from 're-resizable';
-import type { ReactNode, ForwardedRef } from 'react';
+import type { ForwardedRef } from 'react';
 
 /**
  * Internal dependencies
@@ -88,7 +88,6 @@ const HANDLE_STYLES = {
 };
 
 type ResizableBoxProps = ResizableProps & {
-	children: ReactNode;
 	showHandle?: boolean;
 	__experimentalShowTooltip?: boolean;
 	__experimentalTooltipProps?: Parameters< typeof ResizeTooltip >[ 0 ];


### PR DESCRIPTION
## What?

Make the `children` prop of the `ResizableBox` component optional.

## Why?

While using this component in a TypeScript project, I noticed that `children` is marked as required, which forces consumers to pass children even when they don't render any. I had to render a dummy child to avoid a type error.

https://github.com/t-hamano/flexible-spacer-block/blob/a6a50e9a6781565a155ab8bfd7887845059a676d/src/edit.tsx#L434-L437

In practice, there are already valid use cases that render `ResizableBox` without children. For example, in Gutenberg itself:

- [`resizable-box-popover/index.js`](https://github.com/WordPress/gutenberg/blob/c9432ffd36efa64d0ac84dc33489ba35a1e6e448/packages/block-editor/src/components/resizable-box-popover/index.js#L22) 
- [`image/image.js`](https://github.com/WordPress/gutenberg/blob/c9432ffd36efa64d0ac84dc33489ba35a1e6e448/packages/block-library/src/image/image.js#L1354)
- [`grid/grid-item-resizer.js`](https://github.com/WordPress/gutenberg/blob/c9432ffd36efa64d0ac84dc33489ba35a1e6e448/packages/block-editor/src/components/grid/grid-item-resizer.js#L117)
- [`spacer/edit.js`](https://github.com/WordPress/gutenberg/blob/c9432ffd36efa64d0ac84dc33489ba35a1e6e448/packages/block-library/src/spacer/edit.js#L52)

[The underlying `ResizableProps` from `re-resizable` already declares `children` as optional](https://github.com/bokuweb/re-resizable/blob/dcadcbed0470ef9f75a22f660285d91f414958a3/src/index.tsx#L107), so the required `children` here is an unnecessary, stricter override.

`children` was made required in [#35062](https://github.com/WordPress/gutenberg/pull/35062), but the reason is unclear from the PR.

## Testing Instructions

1. Run the type build and confirm there are no type errors:

   ```bash
   npx tsgo --build packages/components/tsconfig.json
   ```

2. Confirm that using `ResizableBox` without children no longer raises a type error:

   ```tsx
   import { ResizableBox } from '@wordpress/components';
   const x = <ResizableBox />;
   ```

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus). All changes were reviewed by the author.
