### PR TITLE
Video: Apply `inert` directly instead of wrapping in `Disabled`

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { isBlobURL } from '@wordpress/blob';
 import {
-	Disabled,
 	Spinner,
 	Placeholder,
 	__experimentalToolsPanel as ToolsPanel,
@@ -235,21 +234,15 @@ function VideoEdit( {
 				</ToolsPanel>
 			</InspectorControls>
 			<figure { ...blockProps }>
-				{ /*
-                Disable the video tag if the block is not selected
-                so the user clicking on it won't play the
-                video when the controls are enabled.
-            */ }
-				<Disabled isDisabled={ ! isSingleSelected }>
-					<video
-						controls={ controls }
-						poster={ poster }
-						src={ src || temporaryURL }
-						ref={ videoPlayer }
-					>
-						<Tracks tracks={ tracks } />
-					</video>
-				</Disabled>
+				<video
+					controls={ controls }
+					inert={ ! isSingleSelected ? 'true' : undefined }
+					poster={ poster }
+					src={ src || temporaryURL }
+					ref={ videoPlayer }
+				>
+					<Tracks tracks={ tracks } />
+				</video>
 				{ !! temporaryURL && <Spinner /> }
 				<Caption
 					attributes={ attributes }


### PR DESCRIPTION
## What?
The Video block's edit component wrapped the `<video>` in a `Disabled` component to prevent playback when the block isn't selected. The only behavior needed here is `inert`, so apply it directly to the `<video>` element instead.

Benefits:
- Removes an extra DOM node, so editor markup matches the frontend (`save`) output: `<figure> -> <video>`.
- Drops the `Disabled` dependency and its unused styles/context for this block.

## Testing Instructions
1. Open a post or page.
2. Add the Video block and select a video.
3. With controls enabled and the block deselected, clicking the video
should not play it or focus the controls.

### Testing Instructions for Keyboard
Same.
