### PR TITLE
Connectors: Add a PHP field registry for typed connector configuration

### DIFF
--- a/lib/compat/wordpress-7.1/class-wp-connector-field-registry.php
+++ b/lib/compat/wordpress-7.1/class-wp-connector-field-registry.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * Connector Fields API: WP_Connector_Field_Registry class.
+ *
+ * @package gutenberg
+ * @since 7.1.0
+ */
+
+if ( ! class_exists( 'WP_Connector_Field_Registry' ) ) {
+	/**
+	 * Manages the registration and lookup of configuration fields for connectors.
+	 *
+	 * Connectors declared via {@see WP_Connector_Registry::register()} describe a
+	 * single authentication mechanism (`api_key` or `none`) plus a handful of
+	 * display metadata fields. This registry lets plugins attach any number of
+	 * additional, typed configuration fields to those connectors so users can
+	 * configure things like server URLs, model preferences, or organisation IDs
+	 * from the Connectors admin screen.
+	 *
+	 * This is an internal class. Use the public API functions to interact with
+	 * connector fields:
+	 *
+	 *  - `register_connector_field()`
+	 *  - `unregister_connector_field()`
+	 *  - `wp_get_connector_field()`
+	 *  - `wp_get_connector_fields()`
+	 *  - `wp_get_connector_field_value()`
+	 *
+	 * @since 7.1.0
+	 * @access private
+	 *
+	 * @phpstan-type ConnectorField array{
+	 *     name: non-empty-string,
+	 *     type: 'string'|'boolean'|'integer'|'number'|'array'|'object',
+	 *     control: 'text'|'url'|'email'|'number'|'password'|'textarea'|'select'|'checkbox'|'custom',
+	 *     label: non-empty-string,
+	 *     description: string,
+	 *     placeholder: string,
+	 *     default: mixed,
+	 *     sensitive: bool,
+	 *     show_in_rest: bool|array<string, mixed>,
+	 *     choices: array<string, string>|null,
+	 *     sanitize_callback: callable|null,
+	 *     auth_callback: callable|null,
+	 *     env_var_name: string|null,
+	 *     constant_name: string|null,
+	 *     credentials_url: string|null,
+	 *     setting_name: non-empty-string
+	 * }
+	 */
+	final class WP_Connector_Field_Registry {
+		/**
+		 * The singleton instance of the registry.
+		 *
+		 * @since 7.1.0
+		 */
+		private static ?WP_Connector_Field_Registry $instance = null;
+
+		/**
+		 * Registered fields, keyed by connector ID and then by field name.
+		 *
+		 * @since 7.1.0
+		 * @var array<string, array<string, array>>
+		 * @phpstan-var array<string, array<string, ConnectorField>>
+		 */
+		private array $registered_fields = array();
+
+		/**
+		 * Allowed values for the `type` field argument (the stored data type).
+		 *
+		 * Mirrors the data types accepted by `register_setting()` and
+		 * `register_meta()` so the field's REST schema and Settings API
+		 * registration stay consistent with core conventions.
+		 *
+		 * @since 7.1.0
+		 * @var array<int, string>
+		 */
+		private const DATA_TYPES = array(
+			'string',
+			'boolean',
+			'integer',
+			'number',
+			'array',
+			'object',
+		);
+
+		/**
+		 * Allowed values for the `control` field argument (the UI input hint).
+		 *
+		 * Kept distinct from the data `type` — a field can store a `string`
+		 * yet render as a `url`, `password`, `select`, or `textarea`. `custom`
+		 * signals the field is rendered by a plugin-provided component.
+		 *
+		 * @since 7.1.0
+		 * @var array<int, string>
+		 */
+		private const CONTROLS = array(
+			'text',
+			'url',
+			'email',
+			'number',
+			'password',
+			'textarea',
+			'select',
+			'checkbox',
+			'custom',
+		);
+
+		/**
+		 * Registers a configuration field for an existing connector.
+		 *
+		 * See {@see register_connector_field()} for the full argument description.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $connector_id The connector identifier. Must already be registered.
+		 * @param string $field_name   The field slug. Must match `/^[a-z0-9_-]+$/`.
+		 * @param array  $args         Field arguments.
+		 * @return array|null The registered field on success, null on failure.
+		 */
+		public function register( string $connector_id, string $field_name, array $args ): ?array {
+			if ( ! wp_is_connector_registered( $connector_id ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Connector ID. */
+					sprintf( __( 'Connector "%s" is not registered. Register the connector before adding fields.', 'gutenberg' ), esc_html( $connector_id ) ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( ! preg_match( '/^[a-z0-9_-]+$/', $field_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Connector field name must contain only lowercase alphanumeric characters, hyphens, and underscores.', 'gutenberg' ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( isset( $this->registered_fields[ $connector_id ][ $field_name ] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Field name, 2: Connector ID. */
+						__( 'Field "%1$s" is already registered for connector "%2$s".', 'gutenberg' ),
+						esc_html( $field_name ),
+						esc_html( $connector_id )
+					),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			// Resolve the data type. Defaults to 'string', mirroring
+			// register_setting()/register_meta().
+			$type = $args['type'] ?? 'string';
+			if ( ! is_string( $type ) || ! in_array( $type, self::DATA_TYPES, true ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Field name, 2: Comma-separated list of valid data types. */
+						__( 'Connector field "%1$s" has an invalid "type". Must be one of: %2$s.', 'gutenberg' ),
+						esc_html( $field_name ),
+						esc_html( implode( ', ', self::DATA_TYPES ) )
+					),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			// Resolve the UI control. Defaults to a sensible control for the
+			// data type when not explicitly provided.
+			$control = $args['control'] ?? self::default_control_for_type( $type );
+			if ( ! is_string( $control ) || ! in_array( $control, self::CONTROLS, true ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Field name, 2: Comma-separated list of valid controls. */
+						__( 'Connector field "%1$s" has an invalid "control". Must be one of: %2$s.', 'gutenberg' ),
+						esc_html( $field_name ),
+						esc_html( implode( ', ', self::CONTROLS ) )
+					),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( empty( $args['label'] ) || ! is_string( $args['label'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Field name. */
+					sprintf( __( 'Connector field "%s" requires a non-empty "label" string.', 'gutenberg' ), esc_html( $field_name ) ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( 'select' === $control ) {
+				if ( empty( $args['choices'] ) || ! is_array( $args['choices'] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Field name. */
+						sprintf( __( 'Connector field "%s" of type "select" requires a non-empty "choices" array.', 'gutenberg' ), esc_html( $field_name ) ),
+						'7.1.0'
+					);
+					return null;
+				}
+
+				// Every choice must map a non-empty string key (the value the
+				// server will store) to a non-empty string label (what the user
+				// sees). Reject the registration rather than silently rendering
+				// a broken select.
+				foreach ( $args['choices'] as $choice_key => $choice_label ) {
+					if ( ! is_string( $choice_key ) || '' === $choice_key ) {
+						_doing_it_wrong(
+							__METHOD__,
+							/* translators: %s: Field name. */
+							sprintf( __( 'Connector field "%s" has a "choices" entry with an invalid key. Keys must be non-empty strings.', 'gutenberg' ), esc_html( $field_name ) ),
+							'7.1.0'
+						);
+						return null;
+					}
+					if ( ! is_string( $choice_label ) || '' === $choice_label ) {
+						_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+								/* translators: 1: Field name, 2: Choice key. */
+								__( 'Connector field "%1$s" choice "%2$s" requires a non-empty string label.', 'gutenberg' ),
+								esc_html( $field_name ),
+								esc_html( $choice_key )
+							),
+							'7.1.0'
+						);
+						return null;
+					}
+				}
+			}
+
+			if ( isset( $args['sanitize_callback'] ) && ! is_callable( $args['sanitize_callback'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Field name. */
+					sprintf( __( 'Connector field "%s" sanitize_callback must be callable.', 'gutenberg' ), esc_html( $field_name ) ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( isset( $args['auth_callback'] ) && ! is_callable( $args['auth_callback'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Field name. */
+					sprintf( __( 'Connector field "%s" auth_callback must be callable.', 'gutenberg' ), esc_html( $field_name ) ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			if ( isset( $args['show_in_rest'] ) && ! is_bool( $args['show_in_rest'] ) && ! is_array( $args['show_in_rest'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Field name. */
+					sprintf( __( 'Connector field "%s" show_in_rest must be a boolean or an array.', 'gutenberg' ), esc_html( $field_name ) ),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			$connector = wp_get_connector( $connector_id );
+
+			if ( isset( $args['setting_name'] ) ) {
+				if ( ! is_string( $args['setting_name'] ) || '' === $args['setting_name'] ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Field name. */
+						sprintf( __( 'Connector field "%s" setting_name must be a non-empty string.', 'gutenberg' ), esc_html( $field_name ) ),
+						'7.1.0'
+					);
+					return null;
+				}
+				$setting_name = $args['setting_name'];
+			} else {
+				// Align the auto-generated name with the scheme already used by
+				// `_wp_connectors_register_default_ai_providers()` for legacy
+				// `api_key` settings: `ai_provider` connectors get the shortened
+				// `ai` prefix so all fields on the same connector share a stable
+				// root. Other connector types keep their type slug verbatim.
+				$type_prefix  = 'ai_provider' === $connector['type'] ? 'ai' : $connector['type'];
+				$setting_name = str_replace( '-', '_', "connectors_{$type_prefix}_{$connector_id}_{$field_name}" );
+			}
+
+			$choices = isset( $args['choices'] ) && is_array( $args['choices'] ) ? $args['choices'] : null;
+
+			// Resolve REST exposure. Connector fields are configured exclusively
+			// over the Settings REST API on the Connectors screen, so this
+			// defaults to true (unlike register_setting()'s `false`) — a field
+			// that is not exposed cannot be edited by the UI. The `array` form
+			// carries a custom schema, matching register_setting().
+			$show_in_rest = $args['show_in_rest'] ?? true;
+			if ( true === $show_in_rest && null !== $choices ) {
+				// A select's choices are the canonical REST `enum`, mirroring how
+				// core constrains options such as `default_ping_status`.
+				$show_in_rest = array(
+					'schema' => array( 'enum' => array_keys( $choices ) ),
+				);
+			}
+
+			$field = array(
+				'name'              => $field_name,
+				'type'              => $type,
+				'control'           => $control,
+				'label'             => $args['label'],
+				'description'       => isset( $args['description'] ) && is_string( $args['description'] ) ? $args['description'] : '',
+				'placeholder'       => isset( $args['placeholder'] ) && is_string( $args['placeholder'] ) ? $args['placeholder'] : '',
+				'default'           => $args['default'] ?? self::default_value_for_type( $type ),
+				'sensitive'         => ! empty( $args['sensitive'] ),
+				'show_in_rest'      => $show_in_rest,
+				'choices'           => $choices,
+				'sanitize_callback' => $args['sanitize_callback'] ?? null,
+				'auth_callback'     => $args['auth_callback'] ?? null,
+				'env_var_name'      => isset( $args['env_var_name'] ) && is_string( $args['env_var_name'] ) ? $args['env_var_name'] : null,
+				'constant_name'     => isset( $args['constant_name'] ) && is_string( $args['constant_name'] ) ? $args['constant_name'] : null,
+				'credentials_url'   => isset( $args['credentials_url'] ) && is_string( $args['credentials_url'] ) ? $args['credentials_url'] : null,
+				'setting_name'      => $setting_name,
+			);
+
+			$this->registered_fields[ $connector_id ][ $field_name ] = $field;
+
+			return $field;
+		}
+
+		/**
+		 * Unregisters a field from a connector.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $connector_id The connector identifier.
+		 * @param string $field_name   The field slug.
+		 * @return array|null The unregistered field on success, null on failure.
+		 */
+		public function unregister( string $connector_id, string $field_name ): ?array {
+			if ( ! isset( $this->registered_fields[ $connector_id ][ $field_name ] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Field name, 2: Connector ID. */
+						__( 'Field "%1$s" is not registered for connector "%2$s".', 'gutenberg' ),
+						esc_html( $field_name ),
+						esc_html( $connector_id )
+					),
+					'7.1.0'
+				);
+				return null;
+			}
+
+			$field = $this->registered_fields[ $connector_id ][ $field_name ];
+			unset( $this->registered_fields[ $connector_id ][ $field_name ] );
+			if ( empty( $this->registered_fields[ $connector_id ] ) ) {
+				unset( $this->registered_fields[ $connector_id ] );
+			}
+
+			return $field;
+		}
+
+		/**
+		 * Checks whether a field is registered on a connector.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $connector_id The connector identifier.
+		 * @param string $field_name   The field slug.
+		 * @return bool True if the field is registered, false otherwise.
+		 */
+		public function is_registered( string $connector_id, string $field_name ): bool {
+			return isset( $this->registered_fields[ $connector_id ][ $field_name ] );
+		}
+
+		/**
+		 * Retrieves a single registered field.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $connector_id The connector identifier.
+		 * @param string $field_name   The field slug.
+		 * @return array|null The field data, or null if not registered.
+		 */
+		public function get_registered( string $connector_id, string $field_name ): ?array {
+			return $this->registered_fields[ $connector_id ][ $field_name ] ?? null;
+		}
+
+		/**
+		 * Retrieves all fields registered on a connector.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $connector_id The connector identifier.
+		 * @return array<string, array> Fields keyed by field name.
+		 */
+		public function get_all_registered( string $connector_id ): array {
+			return $this->registered_fields[ $connector_id ] ?? array();
+		}
+
+		/**
+		 * Returns the default UI control for a given data type.
+		 *
+		 * Used when a field declares a `type` but no explicit `control`.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $type The data type.
+		 * @return string The default control slug.
+		 */
+		private static function default_control_for_type( string $type ): string {
+			switch ( $type ) {
+				case 'boolean':
+					return 'checkbox';
+				case 'integer':
+				case 'number':
+					return 'number';
+				default:
+					return 'text';
+			}
+		}
+
+		/**
+		 * Returns the type-appropriate "empty" default for a field that does
+		 * not declare an explicit `default`.
+		 *
+		 * Keeps the registered default consistent with the field's declared
+		 * data type and REST schema (a boolean defaults to `false`, not `''`).
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $type The data type.
+		 * @return mixed The default value for the type.
+		 */
+		private static function default_value_for_type( string $type ) {
+			switch ( $type ) {
+				case 'boolean':
+					return false;
+				case 'integer':
+					return 0;
+				case 'number':
+					return 0.0;
+				case 'array':
+				case 'object':
+					return array();
+				default:
+					return '';
+			}
+		}
+
+		/**
+		 * Retrieves the main instance of the registry class.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @return WP_Connector_Field_Registry The main registry instance.
+		 */
+		public static function get_instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		/**
+		 * Overrides or clears the singleton instance.
+		 *
+		 * Intended for the PHPUnit test harness and internal callers that need
+		 * deterministic registry state between cases. Pass `null` to force the
+		 * next `get_instance()` call to create a fresh registry.
+		 *
+		 * @since 7.1.0
+		 * @access private
+		 *
+		 * @param WP_Connector_Field_Registry|null $instance The instance to set, or null to reset.
+		 */
+		public static function set_instance( ?self $instance ): void {
+			self::$instance = $instance;
+		}
+	}
+}

--- a/lib/compat/wordpress-7.1/connectors.php
+++ b/lib/compat/wordpress-7.1/connectors.php
@@ -1,0 +1,598 @@
+<?php
+/**
+ * Connector Fields API.
+ *
+ * Public functions and lifecycle hooks for {@see WP_Connector_Field_Registry}.
+ *
+ * @package gutenberg
+ * @since 7.1.0
+ */
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+
+if ( ! function_exists( 'register_connector_field' ) ) {
+	/**
+	 * Registers a configuration field for an already-registered connector.
+	 *
+	 * Lets plugins add one or more fields to a connector's entry on the
+	 * Connectors admin screen. Typical uses include a server URL for locally
+	 * hosted services, a default model selection, or an organisation ID.
+	 *
+	 * Connectors declared with `api_key` authentication receive an implicit
+	 * `api_key` field automatically, so plugins do not need to re-declare it.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @see WP_Connector_Field_Registry::register()
+	 *
+	 * @param string $connector_id The connector identifier. Must already be registered.
+	 * @param string $field_name   The field slug. Must match `/^[a-z0-9_-]+$/`.
+	 * @param array  $args {
+	 *     @type string         $type              Optional. The stored data type, mirroring
+	 *                                             register_setting(): 'string', 'boolean',
+	 *                                             'integer', 'number', 'array', or 'object'.
+	 *                                             Default 'string'.
+	 *     @type string         $control           Optional. The UI input to render: 'text', 'url',
+	 *                                             'email', 'number', 'password', 'textarea',
+	 *                                             'select', 'checkbox', or 'custom'. Defaults to a
+	 *                                             control derived from `type` (boolean → checkbox,
+	 *                                             integer/number → number, otherwise text).
+	 *     @type string         $label             Required. Translatable label.
+	 *     @type string         $description       Optional. Help text.
+	 *     @type string         $placeholder       Optional. Placeholder.
+	 *     @type mixed          $default           Optional. Default option value.
+	 *     @type bool           $sensitive         Optional. Mask in REST + UI. Default false.
+	 *     @type bool|array     $show_in_rest      Optional. Whether/how to expose the setting over
+	 *                                             REST. Accepts a boolean or an array carrying a
+	 *                                             custom `schema`, matching register_setting().
+	 *                                             Defaults to true (the Connectors screen edits
+	 *                                             fields exclusively over REST). For a 'select'
+	 *                                             control, `choices` are exposed as the schema
+	 *                                             `enum` automatically.
+	 *     @type array|null     $choices           Optional. Required for the 'select' control. A
+	 *                                             `[ value => label ]` map.
+	 *     @type callable|null  $sanitize_callback Optional. Sanitizes the value on save. When
+	 *                                             omitted, a sane default is chosen from `control`.
+	 *     @type callable|null  $auth_callback     Optional. Capability gate for reading/exposing the
+	 *                                             field, mirroring register_meta(). Defaults to a
+	 *                                             `manage_options` check.
+	 *     @type string|null    $env_var_name      Optional. Environment variable override.
+	 *     @type string|null    $constant_name     Optional. PHP constant override.
+	 *     @type string|null    $setting_name      Optional. Explicit option name.
+	 *     @type string|null    $credentials_url   Optional. URL where the user can obtain the value.
+	 * }
+	 * @return array|null Field data on success, null on failure.
+	 */
+	function register_connector_field( string $connector_id, string $field_name, array $args ): ?array {
+		return WP_Connector_Field_Registry::get_instance()->register( $connector_id, $field_name, $args );
+	}
+}
+
+if ( ! function_exists( 'unregister_connector_field' ) ) {
+	/**
+	 * Unregisters a configuration field from a connector.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $connector_id The connector identifier.
+	 * @param string $field_name   The field slug.
+	 * @return array|null The unregistered field on success, null on failure.
+	 */
+	function unregister_connector_field( string $connector_id, string $field_name ): ?array {
+		return WP_Connector_Field_Registry::get_instance()->unregister( $connector_id, $field_name );
+	}
+}
+
+if ( ! function_exists( 'wp_get_connector_field' ) ) {
+	/**
+	 * Retrieves a single registered field.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $connector_id The connector identifier.
+	 * @param string $field_name   The field slug.
+	 * @return array|null The field data, or null if not registered.
+	 */
+	function wp_get_connector_field( string $connector_id, string $field_name ): ?array {
+		return WP_Connector_Field_Registry::get_instance()->get_registered( $connector_id, $field_name );
+	}
+}
+
+if ( ! function_exists( 'wp_get_connector_fields' ) ) {
+	/**
+	 * Retrieves all fields registered on a connector.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $connector_id The connector identifier.
+	 * @return array<string, array> Fields keyed by field name.
+	 */
+	function wp_get_connector_fields( string $connector_id ): array {
+		return WP_Connector_Field_Registry::get_instance()->get_all_registered( $connector_id );
+	}
+}
+
+if ( ! function_exists( 'wp_get_connector_field_value' ) ) {
+	/**
+	 * Resolves the effective value for a connector field.
+	 *
+	 * Checks in order: environment variable, PHP constant, database option,
+	 * registered default.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $connector_id The connector identifier.
+	 * @param string $field_name   The field slug.
+	 * @return mixed The resolved value, or null if the field is not registered.
+	 */
+	function wp_get_connector_field_value( string $connector_id, string $field_name ) {
+		$field = wp_get_connector_field( $connector_id, $field_name );
+		if ( null === $field ) {
+			return null;
+		}
+
+		if ( ! empty( $field['env_var_name'] ) ) {
+			$env_value = getenv( $field['env_var_name'] );
+			if ( false !== $env_value && '' !== $env_value ) {
+				return $env_value;
+			}
+		}
+
+		if ( ! empty( $field['constant_name'] ) && defined( $field['constant_name'] ) ) {
+			$const_value = constant( $field['constant_name'] );
+			if ( null !== $const_value && '' !== $const_value ) {
+				return $const_value;
+			}
+		}
+
+		$db_value = get_option( $field['setting_name'], null );
+		if ( null !== $db_value && '' !== $db_value ) {
+			return $db_value;
+		}
+
+		return $field['default'];
+	}
+}
+
+/**
+ * Materialises an implicit `api_key` field for every connector that was
+ * declared with `api_key` authentication but did not register the field
+ * explicitly via {@see register_connector_field()}.
+ *
+ * Hooked at priority 9999 so it runs after every other `wp_connectors_init`
+ * subscriber, meaning plugins can pre-empt the synthetic field by calling
+ * {@see register_connector_field()} themselves earlier.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param WP_Connector_Registry $registry The connector registry instance.
+ */
+function _gutenberg_connector_fields_synthesize_legacy( WP_Connector_Registry $registry ): void {
+	$field_registry = WP_Connector_Field_Registry::get_instance();
+
+	foreach ( $registry->get_all_registered() as $connector_id => $connector ) {
+		$auth = $connector['authentication'];
+		if ( 'api_key' !== $auth['method'] ) {
+			continue;
+		}
+		if ( $field_registry->is_registered( $connector_id, 'api_key' ) ) {
+			continue;
+		}
+
+		$args = array(
+			'type'         => 'string',
+			'control'      => 'password',
+			'label'        => sprintf(
+				/* translators: %s: Connector name. */
+				__( '%s API Key', 'gutenberg' ),
+				$connector['name']
+			),
+			'description'  => sprintf(
+				/* translators: %s: Connector name. */
+				__( 'API key for the %s connector.', 'gutenberg' ),
+				$connector['name']
+			),
+			'sensitive'    => true,
+			'show_in_rest' => true,
+		);
+
+		if ( ! empty( $auth['setting_name'] ) ) {
+			$args['setting_name'] = $auth['setting_name'];
+		}
+		if ( ! empty( $auth['env_var_name'] ) ) {
+			$args['env_var_name'] = $auth['env_var_name'];
+		}
+		if ( ! empty( $auth['constant_name'] ) ) {
+			$args['constant_name'] = $auth['constant_name'];
+		}
+		if ( ! empty( $auth['credentials_url'] ) ) {
+			$args['credentials_url'] = $auth['credentials_url'];
+		}
+
+		$field_registry->register( $connector_id, 'api_key', $args );
+	}
+}
+add_action( 'wp_connectors_init', '_gutenberg_connector_fields_synthesize_legacy', 9999 );
+
+/**
+ * Masks a sensitive string value for display, showing only the last 4
+ * characters. Mirrors the behaviour of core's `_wp_connectors_mask_api_key()`
+ * but is self-contained so the field API is not coupled to a private core
+ * helper whose behaviour may diverge or be overridden by the Gutenberg
+ * experimental Connectors implementation.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $value The sensitive value to mask.
+ * @return string The masked value, e.g. `"••••••••fj39"`.
+ */
+function _gutenberg_connector_fields_mask( string $value ): string {
+	if ( strlen( $value ) <= 4 ) {
+		return $value;
+	}
+
+	return str_repeat( "\u{2022}", min( strlen( $value ) - 4, 16 ) ) . substr( $value, -4 );
+}
+
+/**
+ * Determines where a field's effective value came from.
+ *
+ * Returns the first source that provides a non-empty value, checked in this
+ * order: environment variable, PHP constant, database option. When nothing
+ * is set, returns `'none'`.
+ *
+ * Self-contained so the field API does not depend on the private core helper
+ * `_wp_connectors_get_api_key_source()`, which the Gutenberg experimental
+ * Connectors implementation overrides with its own copy.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $setting_name  Option name to consult.
+ * @param string $env_var_name  Optional env var to consult.
+ * @param string $constant_name Optional PHP constant to consult.
+ * @return string One of 'env', 'constant', 'database', 'none'.
+ */
+function _gutenberg_connector_fields_resolve_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			return 'env';
+		}
+	}
+
+	if ( '' !== $constant_name && defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
+		if ( is_string( $const_value ) && '' !== $const_value ) {
+			return 'constant';
+		}
+	}
+
+	$db_value = get_option( $setting_name, '' );
+	if ( '' !== $db_value ) {
+		return 'database';
+	}
+
+	return 'none';
+}
+
+/**
+ * Returns the default sanitizer callable for a connector field control.
+ *
+ * The control captures presentation intent (url / email / textarea /
+ * checkbox), while the numeric caster is chosen from the data `type` so an
+ * `integer` field stores an int and a `number` field stores a float.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $control Connector field control.
+ * @param string $type    Connector field data type.
+ * @return callable Sanitizer callable.
+ */
+function _gutenberg_connector_fields_default_sanitizer( string $control, string $type = 'string' ): callable {
+	switch ( $control ) {
+		case 'url':
+			return 'esc_url_raw';
+		case 'email':
+			return 'sanitize_email';
+		case 'number':
+			if ( 'integer' === $type ) {
+				return static function ( $value ): int {
+					return is_numeric( $value ) ? (int) $value : 0;
+				};
+			}
+			return static function ( $value ): float {
+				// Cast to float explicitly so Settings API sees a stable type
+				// regardless of whether the user submitted an int string, a
+				// float string, or a non-numeric value. Non-numeric input
+				// normalises to 0.0 so the option always stores a valid number.
+				return is_numeric( $value ) ? (float) $value : 0.0;
+			};
+		case 'checkbox':
+			return static function ( $value ): bool {
+				return (bool) $value;
+			};
+		case 'textarea':
+			return 'sanitize_textarea_field';
+		default:
+			return 'sanitize_text_field';
+	}
+}
+
+/**
+ * Determines whether the current user may read/write a connector field.
+ *
+ * Runs the field's `auth_callback` when provided; otherwise falls back to a
+ * `manage_options` check (the capability the Settings REST controller already
+ * requires). Mirrors the role `register_meta()`'s `auth_callback` plays for
+ * protected meta.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param array  $field        The registered field.
+ * @param string $connector_id The connector identifier.
+ * @return bool Whether the current user is authorized for the field.
+ */
+function _gutenberg_connector_fields_user_can( array $field, string $connector_id ): bool {
+	if ( isset( $field['auth_callback'] ) && is_callable( $field['auth_callback'] ) ) {
+		return (bool) call_user_func( $field['auth_callback'], $connector_id, $field['name'] );
+	}
+
+	return current_user_can( 'manage_options' );
+}
+
+/**
+ * Registers a `register_setting()` entry for every connector field.
+ *
+ * Replacement for core's `_wp_register_default_connector_settings()`, which
+ * only registers the legacy api_key option. This variant iterates every field
+ * declared via {@see register_connector_field()} — including the synthetic
+ * `api_key` field injected for legacy api_key connectors.
+ *
+ * @since 7.1.0
+ * @access private
+ */
+function _gutenberg_connector_fields_register_settings(): void {
+	$ai_registry         = class_exists( AiClient::class ) ? AiClient::defaultRegistry() : null;
+	$registered_settings = get_registered_settings();
+
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
+		foreach ( wp_get_connector_fields( $connector_id ) as $field_name => $field ) {
+			$setting_name = $field['setting_name'];
+
+			if ( isset( $registered_settings[ $setting_name ] ) ) {
+				continue;
+			}
+
+			// Preserve legacy behaviour: for an AI provider's api_key field, skip
+			// registration when the provider class is missing from the AI Client
+			// registry so we do not expose a dangling option.
+			if (
+				'api_key' === $field_name &&
+				'ai_provider' === $connector_data['type'] &&
+				$ai_registry &&
+				! $ai_registry->hasProvider( $connector_id )
+			) {
+				continue;
+			}
+
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					// `type` is already a valid Settings API data type
+					// (string/boolean/integer/number/array/object).
+					'type'              => $field['type'],
+					'label'             => $field['label'],
+					'description'       => $field['description'],
+					'default'           => $field['default'],
+					// Pass the bool|array form straight through; register_setting()
+					// merges a custom `schema` (e.g. a select's `enum`) natively.
+					'show_in_rest'      => $field['show_in_rest'],
+					'sanitize_callback' => is_callable( $field['sanitize_callback'] )
+						? $field['sanitize_callback']
+						: _gutenberg_connector_fields_default_sanitizer( $field['control'], $field['type'] ),
+				)
+			);
+		}
+	}
+}
+
+/**
+ * REST response post-dispatch: mask sensitive field values and validate updates.
+ *
+ * Replacement for core's `_wp_connectors_rest_settings_dispatch()`, which only
+ * handles the legacy api_key option. Iterates every registered field instead
+ * and masks any field flagged as `sensitive` before emitting the response.
+ *
+ * Per-field validation is intentionally NOT a registration concern (matching
+ * register_setting(), which folds validation into the sanitize callback or the
+ * REST schema). The one exception preserved here is the AI-provider api_key
+ * live-validation that core already performed, so behaviour is unchanged for
+ * existing connectors.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_REST_Server   $server   The server instance.
+ * @param WP_REST_Request  $request  The request object.
+ * @return WP_REST_Response
+ */
+function _gutenberg_connector_fields_rest_dispatch( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
+	if ( '/wp/v2/settings' !== $request->get_route() ) {
+		return $response;
+	}
+
+	$data = $response->get_data();
+	if ( ! is_array( $data ) ) {
+		return $response;
+	}
+
+	$is_update = 'POST' === $request->get_method() || 'PUT' === $request->get_method();
+
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
+		foreach ( wp_get_connector_fields( $connector_id ) as $field_name => $field ) {
+			if ( empty( $field['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$setting_name = $field['setting_name'];
+			if ( ! array_key_exists( $setting_name, $data ) ) {
+				continue;
+			}
+
+			// Enforce the field's auth gate symmetrically with the
+			// script-module-data path. Remove (don't merely skip) the value so
+			// a field guarded by a stricter `auth_callback` than the endpoint's
+			// own `manage_options` is never exposed unmasked.
+			if ( ! _gutenberg_connector_fields_user_can( $field, $connector_id ) ) {
+				unset( $data[ $setting_name ] );
+				continue;
+			}
+
+			$value = $data[ $setting_name ];
+
+			// Preserve core's AI-provider api_key live validation: reject and
+			// blank an invalid key on update. No generic per-field validation
+			// hook — see the function docblock.
+			//
+			// The class_exists() guard is required: _wp_connectors_is_ai_api_key_valid()
+			// dereferences AiClient::defaultRegistry(), which fatals when the WP
+			// AI Client library is not loaded. (The experimental dispatch this
+			// replaces carried the same guard.)
+			if (
+				$is_update &&
+				is_string( $value ) && '' !== $value &&
+				'api_key' === $field_name &&
+				'ai_provider' === $connector_data['type'] &&
+				! empty( $field['sensitive'] ) &&
+				class_exists( '\WordPress\AiClient\AiClient' ) &&
+				true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id )
+			) {
+				update_option( $setting_name, '' );
+				$data[ $setting_name ] = '';
+				continue;
+			}
+
+			if ( ! empty( $field['sensitive'] ) && is_string( $value ) && '' !== $value ) {
+				$data[ $setting_name ] = _gutenberg_connector_fields_mask( $value );
+			}
+		}
+	}
+
+	$response->set_data( $data );
+	return $response;
+}
+
+/**
+ * Replacement script-module-data filter that exposes the `configSchema`.
+ *
+ * Delegates to core's filter to produce the baseline payload, then appends a
+ * per-connector `configSchema` array consumed by the React admin screen to
+ * render typed fields.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param array<string, mixed> $data Existing script module data.
+ * @return array<string, mixed>
+ */
+function _gutenberg_connector_fields_script_module_data( array $data ): array {
+	if ( ! isset( $data['connectors'] ) || ! is_array( $data['connectors'] ) ) {
+		return $data;
+	}
+
+	foreach ( $data['connectors'] as $connector_id => &$connector_out ) {
+		$config_schema = array();
+
+		foreach ( wp_get_connector_fields( $connector_id ) as $field_name => $field ) {
+			if ( empty( $field['show_in_rest'] ) ) {
+				continue;
+			}
+
+			// Do not expose fields the current user is not authorized to see.
+			if ( ! _gutenberg_connector_fields_user_can( $field, $connector_id ) ) {
+				continue;
+			}
+
+			$field_value  = wp_get_connector_field_value( $connector_id, $field_name );
+			$field_source = _gutenberg_connector_fields_resolve_source(
+				$field['setting_name'],
+				$field['env_var_name'] ?? '',
+				$field['constant_name'] ?? ''
+			);
+
+			if ( ! empty( $field['sensitive'] ) && is_string( $field_value ) && '' !== $field_value ) {
+				$field_value = _gutenberg_connector_fields_mask( $field_value );
+			}
+
+			$config_schema[] = array(
+				'name'           => $field_name,
+				'type'           => $field['type'],
+				'control'        => $field['control'],
+				'label'          => $field['label'],
+				'description'    => $field['description'],
+				'placeholder'    => $field['placeholder'],
+				'settingName'    => $field['setting_name'],
+				'value'          => $field_value,
+				'default'        => $field['default'],
+				'source'         => $field_source,
+				'sensitive'      => ! empty( $field['sensitive'] ),
+				'readOnly'       => in_array( $field_source, array( 'env', 'constant' ), true ),
+				'isStored'       => in_array( $field_source, array( 'env', 'constant', 'database' ), true ),
+				'choices'        => $field['choices'],
+				'credentialsUrl' => $field['credentials_url'],
+			);
+		}
+
+		$connector_out['configSchema'] = $config_schema;
+	}
+	unset( $connector_out );
+
+	return $data;
+}
+
+/**
+ * Swaps the existing connector lifecycle hooks for the field-aware versions.
+ *
+ * Two sets of hooks may be active at this point:
+ *
+ * 1. **Core** (`_wp_connectors_*` from `wp-includes/connectors.php`) — always
+ *    present on WordPress ≥ 7.0.
+ * 2. **Gutenberg experimental** (`_gutenberg_*` from
+ *    `lib/experimental/connectors/default-connectors.php`) — parallel
+ *    implementation shipped with the Gutenberg plugin that, when active,
+ *    takes precedence over the core callbacks.
+ *
+ * Both sets register on global file scope and must be unhooked before they
+ * fire on `init` / `rest_post_dispatch`. Runs on `plugins_loaded` so that the
+ * global-scope `add_action()` / `add_filter()` calls in both files have
+ * already executed but no hooked callback has fired yet.
+ *
+ * @since 7.1.0
+ * @access private
+ */
+function _gutenberg_connector_fields_replace_hooks(): void {
+	// 1. Swap `register_setting()` pass to iterate every connector field.
+	remove_action( 'init', '_wp_register_default_connector_settings', 20 );
+	remove_action( 'init', '_gutenberg_register_default_connector_settings', 20 );
+	add_action( 'init', '_gutenberg_connector_fields_register_settings', 20 );
+
+	// 2. Swap the REST dispatch filter so sensitive fields across the board
+	// are masked and validated generically.
+	remove_filter( 'rest_post_dispatch', '_wp_connectors_rest_settings_dispatch', 10 );
+	remove_filter( 'rest_post_dispatch', '_gutenberg_connectors_rest_settings_dispatch', 10 );
+	add_filter( 'rest_post_dispatch', '_gutenberg_connector_fields_rest_dispatch', 10, 3 );
+
+	// 3. Append `configSchema` to the existing script-module-data payload.
+	// Runs at priority 20 — after the core / experimental filter has populated
+	// `connectors`, so we can enrich each entry with its field schema.
+	add_filter( 'script_module_data_options-connectors-wp-admin', '_gutenberg_connector_fields_script_module_data', 20 );
+}
+add_action( 'plugins_loaded', '_gutenberg_connector_fields_replace_hooks' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,6 +74,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/collaboration.php';
 	require __DIR__ . '/compat/wordpress-7.1/block-bindings.php';
+	require __DIR__ . '/compat/wordpress-7.1/class-wp-connector-field-registry.php';
+	require __DIR__ . '/compat/wordpress-7.1/connectors.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### New Features
+
+-   `DefaultConnectorSettings` now accepts an optional `configSchema` prop and
+    renders one typed control per declared field with a single Save button for
+    the whole connector (all changed fields persist together). Each
+    field separates its stored data `type` (`string`, `boolean`, `integer`,
+    `number`, `array`, `object` — matching `register_setting()`) from its UI
+    `control` (`text`, `url`, `email`, `password`, `number`, `textarea`,
+    `select`, `checkbox`, and a `custom` placeholder for future slot-fill
+    integration). When `configSchema` is omitted, the component falls back to
+    the legacy single-API-key form so existing consumers keep working.
+-   New public TypeScript types: `ConnectorField`, `ConnectorFieldType` (data
+    type), `ConnectorFieldControl` (UI control), `FieldValueSource`.
+-   `ConnectorConfig` and `ConnectorRenderProps` gain an optional
+    `configSchema` field carrying the per-connector field list from the
+    Connectors script-module-data payload.
+
 ### Code Quality
 
 -   Add missing `@types/react` dependency. [#78882](https://github.com/WordPress/gutenberg/pull/78882).
+
+## 1.0.0 (Unreleased)
+
+### New Features
+
+-   Initial release of the WordPress Connectors client library.

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -1,0 +1,159 @@
+# WordPress Connectors
+
+Client library for the WordPress Connectors API. Lets plugins register custom render functions for the Connectors admin screen (`Settings → Connectors`) and declare typed configuration fields that WordPress renders and persists through the Settings REST API.
+
+## Table of Contents
+
+-   [Installation](#installation)
+-   [Usage](#usage)
+    -   [Register a custom render for a connector](#register-a-custom-render-for-a-connector)
+    -   [Let WordPress render typed fields (recommended)](#let-wordpress-render-typed-fields-recommended)
+-   [API Reference](#api-reference)
+    -   [Exports](#exports)
+    -   [Field types](#field-types)
+    -   [The `configSchema` entry shape](#the-configschema-entry-shape)
+-   [PHP API](#php-api)
+-   [Back compatibility](#back-compatibility)
+-   [Development](#development)
+
+## Installation
+
+The client ships with WordPress Core as a script module and is automatically registered on the Connectors admin screen. Plugins can depend on `@wordpress/connectors` via its script-module ID:
+
+```php
+wp_register_script_module(
+    'my-plugin/connector-settings',
+    plugins_url( 'assets/js/connector-settings.js', __FILE__ ),
+    array(
+        array( 'import' => 'static', 'id' => '@wordpress/connectors' ),
+    ),
+    '1.0.0'
+);
+wp_enqueue_script_module( 'my-plugin/connector-settings' );
+```
+
+## Usage
+
+### Register a custom render for a connector
+
+Useful when a connector needs UI that cannot be expressed as a flat list of fields (OAuth flows, multi-step setup wizards, live token validation).
+
+```tsx
+import {
+    __experimentalRegisterConnector as registerConnector,
+    __experimentalConnectorItem as ConnectorItem,
+} from '@wordpress/connectors';
+
+registerConnector( 'my-plugin/local-llm', {
+    render: ( { name, description, logo } ) => (
+        <ConnectorItem logo={ logo } name={ name } description={ description }>
+            <MyCustomSettingsForm />
+        </ConnectorItem>
+    ),
+} );
+```
+
+The render receives the server-provided metadata for the connector and is free to fetch and persist its own state — typically through `@wordpress/core-data`'s `useEntityRecord( 'root', 'site' )`, which maps to the Settings REST API.
+
+### Let WordPress render typed fields (recommended)
+
+For most connectors, declaring fields on the PHP side is enough — WordPress renders the form automatically with a single Save button for the connector, inline validation help, env-var / constant source detection, and masking of sensitive values.
+
+PHP:
+
+```php
+add_action( 'wp_connectors_init', function () {
+    register_connector_field(
+        'local-llm',
+        'base_url',
+        array(
+            'control'           => 'url',
+            'label'             => __( 'Server URL', 'my-plugin' ),
+            'description'       => __( 'Base URL of your local LLM server.', 'my-plugin' ),
+            'default'           => 'http://127.0.0.1:1337/v1',
+            'sanitize_callback' => 'esc_url_raw',
+        )
+    );
+} );
+```
+
+That field appears on the Connectors screen as a URL input with a Save button; no plugin-side JavaScript required. Every field in the connector's `configSchema` is rendered by the shared `DefaultConnectorSettings` component, so a plugin can opt into the custom-render path (above) only when the typed-field surface isn't enough.
+
+## API Reference
+
+### Exports
+
+| Export | Kind | Purpose |
+| ------ | ---- | ------- |
+| `__experimentalRegisterConnector( slug, config )` | function | Merges render + metadata into the connector store. Subsequent calls for the same slug upsert. |
+| `__experimentalUnregisterConnector( slug )` | function | Removes a previously registered connector. |
+| `__experimentalConnectorItem` | component | Row shell used on the Connectors admin screen. Pass `logo`, `name`, `description`, and children representing the settings UI. |
+| `__experimentalDefaultConnectorSettings` | component | Default settings form. When given a `configSchema`, renders typed controls; otherwise renders the legacy API-key form. |
+| `ConnectorConfig`, `ConnectorRenderProps` | types | Props consumed by the admin page render loop. Include optional `configSchema`. |
+| `ConnectorField`, `ConnectorFieldType`, `ConnectorFieldControl`, `FieldValueSource` | types | Describe a single configuration field emitted by the PHP Connector Fields API. |
+| `__experimentalApiKeySource` | type | Legacy source indicator used by the single-API-key form. |
+| `privateApis` | object | Internal store + constants exposed for Gutenberg-owned modules. Not a stable surface. |
+
+### Data type vs. control
+
+A field separates **what it stores** (`type`) from **how it renders** (`control`), mirroring how `register_setting()` types data while leaving presentation to the UI. A field can store a `string` yet render as a `url`, `password`, or `select`.
+
+`ConnectorFieldType` (stored data type, defaults to `string`) is one of: `string`, `boolean`, `integer`, `number`, `array`, `object`.
+
+`ConnectorFieldControl` (UI input, defaults from the data type) maps as follows:
+
+| Control | Rendered as |
+| ------- | ----------- |
+| `text` | `TextControl` (default for `string`) |
+| `url` | `TextControl` with `type="url"` |
+| `email` | `TextControl` with `type="email"` |
+| `password` | `TextControl` with `type="password"` |
+| `number` | `NumberControl` (default for `integer` / `number`) |
+| `textarea` | `TextareaControl` |
+| `select` | `SelectControl`; `choices` (a `{ value: label }` map) is required |
+| `checkbox` | `CheckboxControl` (default for `boolean`) |
+| `custom` | Not rendered by the default component — reserved for a future slot-fill API |
+
+### The `configSchema` entry shape
+
+Each entry in `ConnectorRenderProps.configSchema` is a `ConnectorField` produced by the PHP side of the Connectors API. The most relevant fields:
+
+-   `name` — stable field identifier unique within a connector.
+-   `type` — the stored data type (one of the `ConnectorFieldType` values).
+-   `control` — the UI control to render (one of the `ConnectorFieldControl` values).
+-   `label` / `description` / `placeholder` — translatable strings presented to the user.
+-   `settingName` — the underlying WordPress option. Custom renders save to this name via the Settings REST API.
+-   `value` — current effective value, masked if `sensitive` is true.
+-   `source` — `"env" | "constant" | "database" | "default"`. Used to decide whether the input should be read-only.
+-   `sensitive` / `readOnly` / `isStored` / `credentialsUrl` / `choices` — render hints.
+
+## PHP API
+
+The client-side API is paired with a PHP field registry shipped by the Gutenberg plugin (`lib/compat/wordpress-7.1/`). See the [Connector Fields API handbook page](https://developer.wordpress.org/plugins/connectors/) for the full reference. Core entry points:
+
+-   `register_connector_field( $connector_id, $field_name, $args )` — declare a typed field.
+-   `unregister_connector_field( $connector_id, $field_name )` — remove one.
+-   `wp_get_connector_field( $connector_id, $field_name )` / `wp_get_connector_fields( $connector_id )` — read registered metadata.
+-   `wp_get_connector_field_value( $connector_id, $field_name )` — resolve the effective value, honouring environment-variable and PHP-constant overrides.
+
+Fields declared via `register_connector_field()` are surfaced to this package through the per-connector `configSchema` key injected into the `script_module_data_options-connectors-wp-admin` filter.
+
+## Back compatibility
+
+Connectors that only declared a legacy `api_key` authentication (the only shape supported before this release) continue to render unchanged. A back-compat shim synthesises an implicit `api_key` field for them at `wp_connectors_init` priority 9999, using the same setting name as before so no database migration is required.
+
+## Development
+
+See the [`@wordpress/packages` guide](https://github.com/WordPress/gutenberg/tree/HEAD/packages) for how to build, test, and publish Gutenberg packages.
+
+Run this package's tests with:
+
+```bash
+npm run test:unit packages/connectors
+```
+
+Run the matching PHP tests (from a running wp-env):
+
+```bash
+npm run test:unit:php -- --filter=Tests_Connector_Field_Registry
+```

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -6,10 +6,14 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalItem as Item,
 	__experimentalText as WCText,
+	__experimentalNumberControl as NumberControl,
 	ExternalLink,
 	FlexBlock,
 	Button,
 	TextControl,
+	TextareaControl,
+	SelectControl,
+	CheckboxControl,
 } from '@wordpress/components';
 import { createInterpolateElement, useId, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -18,7 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { ReactNode } from 'react';
-import type { ApiKeySource } from './types';
+import type { ApiKeySource, ConnectorField } from './types';
 
 export interface ConnectorItemProps {
 	className?: string;
@@ -66,9 +70,384 @@ export function ConnectorItem( {
 	);
 }
 
-export type { ApiKeySource } from './types';
+export type { ApiKeySource, ConnectorField } from './types';
 
 export interface DefaultConnectorSettingsProps {
+	/**
+	 * Legacy single-field callback invoked with the API key value when the
+	 * user saves. Used only when {@link DefaultConnectorSettingsProps.configSchema}
+	 * is not supplied.
+	 */
+	onSave?: ( apiKey: string ) => void | Promise< void >;
+	/**
+	 * Multi-field callback invoked with a `{ fieldName: value }` map of the
+	 * fields the user changed when they save the connector. Used only when
+	 * {@link DefaultConnectorSettingsProps.configSchema} is supplied. The whole
+	 * connector is saved with a single button, so this receives every changed
+	 * field at once.
+	 */
+	onSaveFields?: (
+		values: Record< string, unknown >
+	) => void | Promise< void >;
+	onRemove?: () => void;
+	initialValue?: string;
+	helpUrl?: string;
+	helpLabel?: string;
+	readOnly?: boolean;
+	keySource?: ApiKeySource;
+	/**
+	 * Typed configuration fields for the connector. When provided, the
+	 * component renders every field with a single Save button for the whole
+	 * connector. When omitted, the legacy single-API-key form is rendered for
+	 * back-compat.
+	 */
+	configSchema?: ConnectorField[];
+}
+
+/**
+ * Default settings form for connectors.
+ *
+ * When a `configSchema` is provided, renders every field as a typed control
+ * with a single Save button for the whole connector; all changed fields are
+ * persisted together in one request. When omitted, falls back to the legacy
+ * single-API-key form for connectors that have not yet adopted the Connector
+ * Fields API.
+ *
+ * @param props              Component props.
+ * @param props.onSave       Legacy single-field save callback.
+ * @param props.onSaveFields Schema save callback receiving a `{ name: value }`
+ *                           map of the changed fields.
+ * @param props.onRemove     Invoked when the user removes the connector.
+ * @param props.initialValue Initial value for the legacy API key field.
+ * @param props.helpUrl      Documentation URL for obtaining an API key.
+ * @param props.helpLabel    Custom label for the help link.
+ * @param props.readOnly     Whether the legacy form is read-only.
+ * @param props.keySource    Source of the legacy API key.
+ * @param props.configSchema Typed fields declared by the connector.
+ */
+export function DefaultConnectorSettings( {
+	onSave,
+	onSaveFields,
+	onRemove,
+	initialValue = '',
+	helpUrl,
+	helpLabel,
+	readOnly = false,
+	keySource,
+	configSchema,
+}: DefaultConnectorSettingsProps ) {
+	if ( configSchema && configSchema.length > 0 ) {
+		return (
+			<SchemaForm
+				configSchema={ configSchema }
+				onSaveFields={ onSaveFields }
+			/>
+		);
+	}
+
+	return (
+		<LegacyApiKeyForm
+			onSave={ onSave }
+			onRemove={ onRemove }
+			initialValue={ initialValue }
+			helpUrl={ helpUrl }
+			helpLabel={ helpLabel }
+			readOnly={ readOnly }
+			keySource={ keySource }
+		/>
+	);
+}
+
+/* --------------------------------------------------------------------------
+ * Schema-driven renderer
+ * -------------------------------------------------------------------------- */
+
+interface SchemaFormProps {
+	configSchema: ConnectorField[];
+	onSaveFields?: (
+		values: Record< string, unknown >
+	) => void | Promise< void >;
+}
+
+/**
+ * Builds the `{ name: value }` baseline map for a schema.
+ *
+ * @param configSchema Typed fields declared by the connector.
+ * @return Map of field name to its current input value.
+ */
+function schemaToValues(
+	configSchema: ConnectorField[]
+): Record< string, string | boolean > {
+	const values: Record< string, string | boolean > = {};
+	for ( const field of configSchema ) {
+		values[ field.name ] = toInputValue( field.value ?? field.default );
+	}
+	return values;
+}
+
+/**
+ * Renders all of a connector's fields with a single Save button that persists
+ * every changed field together.
+ *
+ * @param props              Component props.
+ * @param props.configSchema Typed fields declared by the connector.
+ * @param props.onSaveFields Callback receiving the `{ name: value }` map of
+ *                           changed fields.
+ */
+function SchemaForm( { configSchema, onSaveFields }: SchemaFormProps ) {
+	const [ values, setValues ] = useState<
+		Record< string, string | boolean >
+	>( () => schemaToValues( configSchema ) );
+	// Baseline the dirty check against the last successfully-saved snapshot so
+	// the Save button settles after a save.
+	const [ savedValues, setSavedValues ] = useState<
+		Record< string, string | boolean >
+	>( () => schemaToValues( configSchema ) );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ saveError, setSaveError ] = useState< string | null >( null );
+
+	// Fields the user can actually edit (excludes env/constant-sourced and
+	// plugin-rendered `custom` fields).
+	const editableFields = configSchema.filter(
+		( field ) => field.control !== 'custom' && ! field.readOnly
+	);
+	const isDirty = editableFields.some(
+		( field ) => values[ field.name ] !== savedValues[ field.name ]
+	);
+
+	const handleSave = async () => {
+		setSaveError( null );
+		setIsSaving( true );
+		try {
+			const changed: Record< string, unknown > = {};
+			for ( const field of editableFields ) {
+				if ( values[ field.name ] !== savedValues[ field.name ] ) {
+					changed[ field.name ] = values[ field.name ];
+				}
+			}
+			await onSaveFields?.( changed );
+			setSavedValues( { ...values } );
+		} catch ( error ) {
+			setSaveError(
+				error instanceof Error
+					? error.message
+					: __( 'It was not possible to save these settings.' )
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<VStack spacing={ 4 } className="connector-settings">
+			{ configSchema.map( ( field ) => {
+				if ( field.control === 'custom' ) {
+					// Plugin-rendered fields rely on a slot-fill (future work).
+					return null;
+				}
+				return (
+					<div
+						key={ field.name }
+						className={ `connector-settings__field connector-settings__field--${ field.control }` }
+					>
+						{ renderFieldControl( {
+							field,
+							value: values[ field.name ],
+							onChange: ( next ) => {
+								if ( field.readOnly ) {
+									return;
+								}
+								setSaveError( null );
+								setValues( ( prev ) => ( {
+									...prev,
+									[ field.name ]: next,
+								} ) );
+							},
+							disabled: field.readOnly || isSaving,
+							help: getFieldHelp( field, null ),
+						} ) }
+					</div>
+				);
+			} ) }
+			{ saveError && (
+				<span role="alert" className="connector-settings__error">
+					{ saveError }
+				</span>
+			) }
+			{ editableFields.length > 0 && (
+				<HStack justify="flex-start">
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						disabled={ ! isDirty || isSaving }
+						accessibleWhenDisabled
+						isBusy={ isSaving }
+						onClick={ handleSave }
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</HStack>
+			) }
+		</VStack>
+	);
+}
+
+interface RenderFieldControlArgs {
+	field: ConnectorField;
+	value: string | boolean;
+	onChange: ( next: string | boolean ) => void;
+	disabled: boolean;
+	help: ReactNode | undefined;
+}
+
+function renderFieldControl( {
+	field,
+	value,
+	onChange,
+	disabled,
+	help,
+}: RenderFieldControlArgs ): ReactNode {
+	switch ( field.control ) {
+		case 'checkbox':
+			return (
+				<CheckboxControl
+					label={ field.label }
+					checked={ Boolean( value ) }
+					onChange={ ( next: boolean ) => onChange( next ) }
+					disabled={ disabled }
+					help={ help }
+				/>
+			);
+
+		case 'select':
+			return (
+				<SelectControl
+					__next40pxDefaultSize
+					label={ field.label }
+					value={ String( value ) }
+					options={ choicesToOptions( field.choices ) }
+					onChange={ ( next: string ) => onChange( next ) }
+					disabled={ disabled }
+					help={ help }
+				/>
+			);
+
+		case 'textarea':
+			return (
+				<TextareaControl
+					label={ field.label }
+					value={ String( value ) }
+					placeholder={ field.placeholder }
+					onChange={ ( next: string ) => onChange( next ) }
+					disabled={ disabled }
+					help={ help }
+				/>
+			);
+
+		case 'number':
+			return (
+				<NumberControl
+					__next40pxDefaultSize
+					label={ field.label }
+					value={ String( value ) }
+					placeholder={ field.placeholder }
+					onChange={ ( next ) => onChange( next ?? '' ) }
+					disabled={ disabled }
+					help={ help }
+				/>
+			);
+
+		case 'password':
+		case 'url':
+		case 'email':
+		case 'text':
+		default:
+			return (
+				<TextControl
+					__next40pxDefaultSize
+					type={ field.control === 'password' ? 'password' : 'text' }
+					label={ field.label }
+					value={ String( value ) }
+					placeholder={ field.placeholder }
+					onChange={ ( next: string ) => onChange( next ) }
+					disabled={ disabled }
+					help={ help }
+				/>
+			);
+	}
+}
+
+function getFieldHelp(
+	field: ConnectorField,
+	saveError: string | null
+): ReactNode | undefined {
+	if ( saveError ) {
+		return (
+			<span role="alert" className="connector-settings__error">
+				{ saveError }
+			</span>
+		);
+	}
+
+	if ( field.source === 'env' ) {
+		return __( 'This value is configured using an environment variable.' );
+	}
+	if ( field.source === 'constant' ) {
+		return __( 'This value is configured as a constant.' );
+	}
+
+	const description = field.description;
+	if ( field.credentialsUrl ) {
+		const linkLabel = field.credentialsUrl.replace( /^https?:\/\//, '' );
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: optional description text, 2: link to provider credentials. */
+				__( '%1$s Get it at %2$s' ),
+				description ?? '',
+				'<a></a>'
+			),
+			{
+				a: (
+					<ExternalLink href={ field.credentialsUrl }>
+						{ linkLabel }
+					</ExternalLink>
+				),
+			}
+		);
+	}
+
+	return description;
+}
+
+function choicesToOptions(
+	choices: Record< string, string > | null | undefined
+): Array< { label: string; value: string } > {
+	if ( ! choices ) {
+		return [];
+	}
+	return Object.entries( choices ).map( ( [ value, label ] ) => ( {
+		value,
+		label,
+	} ) );
+}
+
+function toInputValue(
+	raw: string | number | boolean | null | undefined
+): string | boolean {
+	if ( typeof raw === 'boolean' ) {
+		return raw;
+	}
+	if ( raw === null || raw === undefined ) {
+		return '';
+	}
+	return String( raw );
+}
+
+/* --------------------------------------------------------------------------
+ * Legacy single-API-key form — unchanged behaviour for pre-7.1 connectors.
+ * -------------------------------------------------------------------------- */
+
+interface LegacyApiKeyFormProps {
 	onSave?: ( apiKey: string ) => void | Promise< void >;
 	onRemove?: () => void;
 	initialValue?: string;
@@ -78,19 +457,7 @@ export interface DefaultConnectorSettingsProps {
 	keySource?: ApiKeySource;
 }
 
-/**
- * Default settings form for connectors.
- *
- * @param props              - Component props.
- * @param props.onSave       - Callback invoked with the API key when the user saves.
- * @param props.onRemove     - Callback invoked when the user removes the connector.
- * @param props.initialValue - Initial value for the API key field.
- * @param props.helpUrl      - URL to documentation for obtaining an API key.
- * @param props.helpLabel    - Custom label for the help link. Defaults to the URL without protocol.
- * @param props.readOnly     - Whether the form is in read-only mode.
- * @param props.keySource    - The source of the API key: 'env', 'constant', 'database', or 'none'.
- */
-export function DefaultConnectorSettings( {
+function LegacyApiKeyForm( {
 	onSave,
 	onRemove,
 	initialValue = '',
@@ -98,7 +465,7 @@ export function DefaultConnectorSettings( {
 	helpLabel,
 	readOnly = false,
 	keySource,
-}: DefaultConnectorSettingsProps ) {
+}: LegacyApiKeyFormProps ) {
 	const [ apiKey, setApiKey ] = useState( initialValue );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ saveError, setSaveError ] = useState< string | null >( null );

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -7,5 +7,12 @@ export {
 	DefaultConnectorSettings as __experimentalDefaultConnectorSettings,
 } from './connector-item';
 export type { ApiKeySource as __experimentalApiKeySource } from './types';
-export type { ConnectorConfig, ConnectorRenderProps } from './types';
+export type {
+	ConnectorConfig,
+	ConnectorRenderProps,
+	ConnectorField,
+	ConnectorFieldType,
+	ConnectorFieldControl,
+	FieldValueSource,
+} from './types';
 export { privateApis } from './private-apis';

--- a/packages/connectors/src/test/connector-item.tsx
+++ b/packages/connectors/src/test/connector-item.tsx
@@ -1,0 +1,309 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { DefaultConnectorSettings } from '../connector-item';
+import type { ConnectorField } from '../types';
+
+function baseField(
+	overrides: Partial< ConnectorField > = {}
+): ConnectorField {
+	return {
+		name: 'base_url',
+		type: 'string',
+		control: 'url',
+		label: 'Server URL',
+		description: '',
+		placeholder: '',
+		settingName: 'connectors_ai_openai_base_url',
+		value: '',
+		default: '',
+		source: 'default',
+		sensitive: false,
+		readOnly: false,
+		isStored: false,
+		choices: null,
+		credentialsUrl: null,
+		...overrides,
+	};
+}
+
+describe( 'DefaultConnectorSettings — legacy single-API-key form', () => {
+	it( 'renders the API Key input when no configSchema is passed', () => {
+		render( <DefaultConnectorSettings /> );
+
+		expect(
+			screen.getByRole( 'textbox', { name: /api key/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'calls onSave with the typed key', async () => {
+		const onSave = jest.fn();
+		const user = userEvent.setup();
+
+		render( <DefaultConnectorSettings onSave={ onSave } /> );
+
+		await user.type(
+			screen.getByRole( 'textbox', { name: /api key/i } ),
+			'sk-test-key'
+		);
+		await user.click( screen.getByRole( 'button', { name: /save/i } ) );
+
+		expect( onSave ).toHaveBeenCalledWith( 'sk-test-key' );
+	} );
+} );
+
+describe( 'DefaultConnectorSettings — schema-driven form', () => {
+	it( 'renders a typed URL input for a url field', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( {
+						label: 'Server URL',
+						placeholder: 'https://example/v1',
+					} ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'textbox', { name: /server url/i } )
+		).toHaveAttribute( 'placeholder', 'https://example/v1' );
+	} );
+
+	it( 'renders a password input for a password field', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( {
+						name: 'api_key',
+						control: 'password',
+						label: 'API Key',
+						sensitive: true,
+					} ),
+				] }
+			/>
+		);
+
+		// Password inputs do not surface a textbox role — query by label instead.
+		const field = screen.getByLabelText( /api key/i );
+		expect( field ).toHaveAttribute( 'type', 'password' );
+	} );
+
+	it( 'renders a select with the provided choices', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( {
+						name: 'preferred_model',
+						control: 'select',
+						label: 'Preferred model',
+						choices: { 'gpt-4': 'GPT-4', 'gpt-5': 'GPT-5' },
+					} ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'combobox', { name: /preferred model/i } )
+		).toBeInTheDocument();
+
+		const options = screen
+			.getAllByRole( 'option' )
+			.map( ( o ) => o.textContent );
+
+		expect( options ).toEqual( [ 'GPT-4', 'GPT-5' ] );
+	} );
+
+	it( 'renders a checkbox for a boolean field', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( {
+						name: 'stream_by_default',
+						type: 'boolean',
+						control: 'checkbox',
+						label: 'Stream responses by default',
+					} ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: /stream responses by default/i,
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'disables and hides Save for a read-only field (env / constant source)', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( {
+						readOnly: true,
+						source: 'env',
+						value: 'https://from-env/v1',
+					} ),
+				] }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox', { name: /server url/i } );
+		expect( input ).toBeDisabled();
+		expect(
+			screen.queryByRole( 'button', { name: /^save$/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the env-var help message for env-sourced fields', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( { source: 'env', readOnly: true } ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getByText( /configured using an environment variable/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'calls onSaveFields with the changed fields when the user saves', async () => {
+		const onSaveFields = jest.fn().mockResolvedValue( undefined );
+		const user = userEvent.setup();
+
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [ baseField() ] }
+				onSaveFields={ onSaveFields }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox', { name: /server url/i } );
+		await user.type( input, 'https://typed/v1' );
+		await user.click( screen.getByRole( 'button', { name: /^save$/i } ) );
+
+		expect( onSaveFields ).toHaveBeenCalledWith( {
+			base_url: 'https://typed/v1',
+		} );
+	} );
+
+	it( 'renders a single Save button for a multi-field connector', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( { name: 'base_url', label: 'Server URL' } ),
+					baseField( {
+						name: 'default_model',
+						control: 'text',
+						label: 'Default model',
+						settingName: 'connectors_ai_openai_default_model',
+					} ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getAllByRole( 'button', { name: /^save$/i } )
+		).toHaveLength( 1 );
+	} );
+
+	it( 'only sends changed fields and re-disables Save after a successful save', async () => {
+		const onSaveFields = jest.fn().mockResolvedValue( undefined );
+		const user = userEvent.setup();
+
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( { name: 'base_url', label: 'Server URL' } ),
+					baseField( {
+						name: 'default_model',
+						control: 'text',
+						label: 'Default model',
+						settingName: 'connectors_ai_openai_default_model',
+					} ),
+				] }
+				onSaveFields={ onSaveFields }
+			/>
+		);
+
+		// Edit only one of the two fields.
+		await user.type(
+			screen.getByRole( 'textbox', { name: /server url/i } ),
+			'https://typed/v1'
+		);
+
+		const save = screen.getByRole( 'button', { name: /^save$/i } );
+		expect( save ).not.toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.click( save );
+
+		// Only the edited field is sent.
+		expect( onSaveFields ).toHaveBeenCalledWith( {
+			base_url: 'https://typed/v1',
+		} );
+
+		// After a successful save the baseline updates, so Save re-disables.
+		expect( save ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'disables Save until a field is dirty', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [ baseField( { value: 'https://saved/v1' } ) ] }
+			/>
+		);
+
+		// The Save button uses `accessibleWhenDisabled`, so it stays focusable
+		// and signals its disabled state via `aria-disabled` rather than the
+		// native `disabled` attribute.
+		expect(
+			screen.getByRole( 'button', { name: /^save$/i } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'renders nothing for the `custom` field type (slot-fill placeholder)', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( { name: 'advanced', control: 'custom' } ),
+				] }
+			/>
+		);
+
+		// `custom` fields are intentionally un-rendered by the default component —
+		// plugins are expected to supply their own React via a slot-fill.
+		expect( screen.queryByRole( 'textbox' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders all fields when multiple are declared', () => {
+		render(
+			<DefaultConnectorSettings
+				configSchema={ [
+					baseField( { name: 'base_url', label: 'Server URL' } ),
+					baseField( {
+						name: 'organisation_id',
+						control: 'text',
+						label: 'Organisation ID',
+						settingName: 'connectors_ai_openai_organisation_id',
+					} ),
+				] }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'textbox', { name: /server url/i } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'textbox', { name: /organisation id/i } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -21,6 +21,82 @@ export interface ConnectorPlugin {
 	isActivated: boolean;
 }
 
+/**
+ * The stored data type of a connector field, mirroring the data types
+ * accepted by the PHP `register_setting()` / `register_meta()` APIs.
+ */
+export type ConnectorFieldType =
+	| 'string'
+	| 'boolean'
+	| 'integer'
+	| 'number'
+	| 'array'
+	| 'object';
+
+/**
+ * The UI control rendered for a connector field. Distinct from the stored
+ * data {@link ConnectorFieldType}: a field can store a `string` yet render as
+ * a `url`, `password`, `select`, or `textarea`. `custom` signals that the
+ * value is rendered by a plugin-provided component through a slot-fill
+ * (future work).
+ */
+export type ConnectorFieldControl =
+	| 'text'
+	| 'url'
+	| 'email'
+	| 'number'
+	| 'password'
+	| 'textarea'
+	| 'select'
+	| 'checkbox'
+	| 'custom';
+
+/**
+ * Where the effective value for a field ultimately came from.
+ *
+ * Controls whether the input is read-only (`env` / `constant`) and what help
+ * message the field presents to the user.
+ */
+export type FieldValueSource = 'env' | 'constant' | 'database' | 'none';
+
+/**
+ * A single typed configuration field declared on a connector via the PHP
+ * {@code register_connector_field()} API. The shape mirrors the PHP-side
+ * {@code configSchema} entry emitted by the script-module-data filter.
+ */
+export interface ConnectorField {
+	/** Field slug, stable identifier unique within a connector. */
+	name: string;
+	/** The stored data type. */
+	type: ConnectorFieldType;
+	/** The UI control to render. */
+	control: ConnectorFieldControl;
+	/** Translatable label rendered above the input. */
+	label: string;
+	/** Optional translatable help text rendered below the input. */
+	description?: string;
+	/** Placeholder shown inside the empty input. */
+	placeholder?: string;
+	/** Underlying WordPress option name. */
+	settingName: string;
+	/** Current value (already masked if {@link ConnectorField.sensitive}). */
+	value: string | number | boolean | null;
+	/** Registered default. */
+	default: string | number | boolean | null;
+	/** Resolution source of the current value. */
+	source: FieldValueSource;
+	/** Whether the value must be masked on display / in transit. */
+	sensitive: boolean;
+	/** Whether the input must be rendered read-only (env / constant sources). */
+	readOnly: boolean;
+	/** Whether a value is stored anywhere (env, constant or database). */
+	isStored: boolean;
+	/** For `select` / `checkbox` fields: `[value => label]` option map. */
+	choices?: Record< string, string > | null;
+	/** Optional URL where the user can acquire the value (e.g. API key console). */
+	credentialsUrl?: string | null;
+}
+
 export interface ConnectorRenderProps {
 	slug: string;
 	name: string;
@@ -29,6 +105,8 @@ export interface ConnectorRenderProps {
 	logo?: ReactNode;
 	authentication?: ConnectorAuthentication;
 	plugin?: ConnectorPlugin;
+	/** Typed configuration fields for this connector. */
+	configSchema?: ConnectorField[];
 }
 
 export interface ConnectorConfig {
@@ -39,6 +117,8 @@ export interface ConnectorConfig {
 	logo?: ReactNode;
 	authentication?: ConnectorAuthentication;
 	plugin?: ConnectorPlugin;
+	/** Typed configuration fields for this connector. */
+	configSchema?: ConnectorField[];
 	render?: ( props: ConnectorRenderProps ) => ReactNode;
 }
 

--- a/phpunit/connector-field-registry-test.php
+++ b/phpunit/connector-field-registry-test.php
@@ -1,0 +1,815 @@
+<?php
+/**
+ * Tests for the Connector Fields API.
+ *
+ * Covers:
+ *  - `register_connector_field()` / `unregister_connector_field()`
+ *  - `wp_get_connector_field()` / `wp_get_connector_fields()`
+ *  - `wp_get_connector_field_value()`
+ *  - Back-compat synthesis of the implicit `api_key` field
+ *  - Setting-name auto-generation rules
+ *  - `_gutenberg_connector_fields_mask()` /
+ *    `_gutenberg_connector_fields_resolve_source()`
+ *
+ * @package gutenberg
+ *
+ * @covers ::register_connector_field
+ * @covers ::unregister_connector_field
+ * @covers ::wp_get_connector_field
+ * @covers ::wp_get_connector_fields
+ * @covers ::wp_get_connector_field_value
+ * @covers ::_gutenberg_connector_fields_mask
+ * @covers ::_gutenberg_connector_fields_resolve_source
+ * @covers ::_gutenberg_connector_fields_synthesize_legacy
+ * @covers WP_Connector_Field_Registry
+ */
+class Tests_Connector_Field_Registry extends WP_UnitTestCase {
+
+	/**
+	 * Names of fields registered during the current test, tracked so we can
+	 * guarantee tear_down removes them without relying on test order.
+	 *
+	 * @var array<int, array{0:string, 1:string}>
+	 */
+	private array $registered = array();
+
+	/**
+	 * IDs of connectors registered during the current test, cleaned up in
+	 * tear_down so a mid-test failure cannot leak a connector into the next
+	 * test (the core connector registry is not reset between tests).
+	 *
+	 * @var array<int, string>
+	 */
+	private array $registered_connectors = array();
+
+	public function set_up() {
+		parent::set_up();
+
+		// Field reads/exposure run as a privileged admin in production (the
+		// Settings REST controller requires manage_options); match that so the
+		// per-field auth gate resolves to "allowed" by default.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Start every test with a clean field registry.
+		WP_Connector_Field_Registry::set_instance( null );
+	}
+
+	public function tear_down() {
+		foreach ( $this->registered as [ $connector_id, $field_name ] ) {
+			if ( WP_Connector_Field_Registry::get_instance()->is_registered( $connector_id, $field_name ) ) {
+				WP_Connector_Field_Registry::get_instance()->unregister( $connector_id, $field_name );
+			}
+		}
+		$this->registered = array();
+
+		foreach ( $this->registered_connectors as $connector_id ) {
+			if ( wp_is_connector_registered( $connector_id ) ) {
+				WP_Connector_Registry::get_instance()->unregister( $connector_id );
+			}
+		}
+		$this->registered_connectors = array();
+
+		WP_Connector_Field_Registry::set_instance( null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a field and tracks it for automatic cleanup.
+	 *
+	 * @param string $connector_id Connector ID.
+	 * @param string $field_name   Field slug.
+	 * @param array  $args         Field args.
+	 * @return array|null
+	 */
+	private function track( string $connector_id, string $field_name, array $args ): ?array {
+		$this->registered[] = array( $connector_id, $field_name );
+		return register_connector_field( $connector_id, $field_name, $args );
+	}
+
+	/**
+	 * Registers a connector and tracks it for automatic cleanup.
+	 *
+	 * @param string $connector_id Connector ID.
+	 * @param array  $args         Connector args.
+	 * @return array|null
+	 */
+	private function track_connector( string $connector_id, array $args ): ?array {
+		$this->registered_connectors[] = $connector_id;
+		return WP_Connector_Registry::get_instance()->register( $connector_id, $args );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * register_connector_field — happy path
+	 * ------------------------------------------------------------------- */
+
+	public function test_register_field_returns_normalised_shape() {
+		$field = $this->track(
+			'openai',
+			'base_url',
+			array(
+				'control'     => 'url',
+				'label'       => 'Server URL',
+				'description' => 'Base URL.',
+				'placeholder' => 'https://example/v1',
+				'default'     => 'https://default/v1',
+			)
+		);
+
+		$this->assertIsArray( $field );
+		$this->assertSame( 'base_url', $field['name'] );
+		// `type` defaults to the string data type; `control` carries the UI hint.
+		$this->assertSame( 'string', $field['type'] );
+		$this->assertSame( 'url', $field['control'] );
+		$this->assertSame( 'Server URL', $field['label'] );
+		$this->assertSame( 'Base URL.', $field['description'] );
+		$this->assertSame( 'https://example/v1', $field['placeholder'] );
+		$this->assertSame( 'https://default/v1', $field['default'] );
+		$this->assertFalse( $field['sensitive'] );
+		$this->assertTrue( $field['show_in_rest'] );
+		$this->assertNull( $field['choices'] );
+		$this->assertNull( $field['sanitize_callback'] );
+		$this->assertNull( $field['auth_callback'] );
+		$this->assertNull( $field['env_var_name'] );
+		$this->assertNull( $field['constant_name'] );
+	}
+
+	public function test_control_defaults_from_data_type() {
+		$field = $this->track(
+			'openai',
+			'enabled',
+			array(
+				'type'  => 'boolean',
+				'label' => 'Enabled',
+			)
+		);
+
+		// boolean → checkbox, no explicit control needed.
+		$this->assertSame( 'boolean', $field['type'] );
+		$this->assertSame( 'checkbox', $field['control'] );
+	}
+
+	public function test_auto_generated_setting_name_strips_ai_provider_suffix() {
+		// OpenAI's connector type is `ai_provider` — the generated setting
+		// name must use the shortened `ai` prefix to align with the existing
+		// `connectors_ai_openai_api_key` convention.
+		$field = $this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'Server URL',
+			)
+		);
+
+		$this->assertSame( 'connectors_ai_openai_base_url', $field['setting_name'] );
+	}
+
+	public function test_auto_generated_setting_name_uses_type_verbatim_for_non_ai() {
+		// Register a fake connector to avoid depending on Akismet's availability.
+		$this->track_connector(
+			'spam-guardian',
+			array(
+				'name'           => 'Spam Guardian',
+				'type'           => 'spam_filtering',
+				'authentication' => array( 'method' => 'none' ),
+			)
+		);
+
+		$field = $this->track(
+			'spam-guardian',
+			'threshold',
+			array(
+				'type'  => 'number',
+				'label' => 'Threshold',
+			)
+		);
+
+		$this->assertSame( 'connectors_spam_filtering_spam_guardian_threshold', $field['setting_name'] );
+	}
+
+	public function test_explicit_setting_name_is_preserved() {
+		$field = $this->track(
+			'openai',
+			'base_url',
+			array(
+				'control'      => 'url',
+				'label'        => 'Server URL',
+				'setting_name' => 'my_custom_openai_base_url',
+			)
+		);
+
+		$this->assertSame( 'my_custom_openai_base_url', $field['setting_name'] );
+	}
+
+	public function test_checkbox_does_not_require_choices() {
+		$field = $this->track(
+			'openai',
+			'stream_by_default',
+			array(
+				'type'    => 'boolean',
+				'control' => 'checkbox',
+				'label'   => 'Stream responses by default',
+			)
+		);
+
+		$this->assertIsArray( $field );
+		$this->assertSame( 'checkbox', $field['control'] );
+		$this->assertNull( $field['choices'] );
+	}
+
+	public function test_select_choices_become_rest_enum() {
+		$field = $this->track(
+			'openai',
+			'preferred_model',
+			array(
+				'control' => 'select',
+				'label'   => 'Preferred model',
+				'choices' => array(
+					'gpt-4' => 'GPT-4',
+					'gpt-5' => 'GPT-5',
+				),
+			)
+		);
+
+		// A select's choices are exposed as the REST schema `enum`, matching
+		// how register_setting() constrains options.
+		$this->assertIsArray( $field['show_in_rest'] );
+		$this->assertSame(
+			array( 'gpt-4', 'gpt-5' ),
+			$field['show_in_rest']['schema']['enum']
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * register_connector_field — validation failures
+	 * ------------------------------------------------------------------- */
+
+	public function test_rejects_unknown_connector() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'does-not-exist',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_invalid_field_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'Invalid Name',
+			array(
+				'control' => 'text',
+				'label'   => 'X',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_invalid_data_type() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'foo',
+			array(
+				'type'  => 'slider',
+				'label' => 'X',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_invalid_control() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'foo',
+			array(
+				'control' => 'slider',
+				'label'   => 'X',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_missing_label() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'foo',
+			array( 'control' => 'url' )
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_select_without_choices() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'preferred_model',
+			array(
+				'control' => 'select',
+				'label'   => 'Model',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_select_with_invalid_choice_label() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'preferred_model',
+			array(
+				'control' => 'select',
+				'label'   => 'Model',
+				'choices' => array( 'gpt-4' => '' ),
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_non_callable_sanitizer() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'base_url',
+			array(
+				'control'           => 'url',
+				'label'             => 'URL',
+				'sanitize_callback' => 'this_function_definitely_does_not_exist_xyz',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_non_callable_auth_callback() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'base_url',
+			array(
+				'control'       => 'url',
+				'label'         => 'URL',
+				'auth_callback' => 'this_function_definitely_does_not_exist_xyz',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_invalid_show_in_rest() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'base_url',
+			array(
+				'control'      => 'url',
+				'label'        => 'URL',
+				'show_in_rest' => 'yes',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_rejects_duplicate_registration() {
+		$this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::register' );
+
+		$result = register_connector_field(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Read helpers
+	 * ------------------------------------------------------------------- */
+
+	public function test_wp_get_connector_field_returns_null_for_unknown() {
+		$this->assertNull( wp_get_connector_field( 'openai', 'missing' ) );
+	}
+
+	public function test_wp_get_connector_fields_returns_empty_for_connector_with_none() {
+		$this->assertSame( array(), wp_get_connector_fields( 'openai' ) );
+	}
+
+	public function test_wp_get_connector_fields_indexes_by_name() {
+		$this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+		$this->track(
+			'openai',
+			'organisation_id',
+			array(
+				'control' => 'text',
+				'label'   => 'Org',
+			)
+		);
+
+		$fields = wp_get_connector_fields( 'openai' );
+
+		$this->assertSame( array( 'base_url', 'organisation_id' ), array_keys( $fields ) );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * unregister_connector_field
+	 * ------------------------------------------------------------------- */
+
+	public function test_unregister_returns_the_removed_field() {
+		register_connector_field(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+
+		$removed = unregister_connector_field( 'openai', 'base_url' );
+
+		$this->assertIsArray( $removed );
+		$this->assertSame( 'base_url', $removed['name'] );
+		$this->assertNull( wp_get_connector_field( 'openai', 'base_url' ) );
+	}
+
+	public function test_unregister_missing_field_triggers_doing_it_wrong() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Field_Registry::unregister' );
+
+		$this->assertNull( unregister_connector_field( 'openai', 'never_registered' ) );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * wp_get_connector_field_value — resolution order
+	 * ------------------------------------------------------------------- */
+
+	public function test_value_resolution_returns_default_when_nothing_set() {
+		$this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+				'default' => 'https://default.test/v1',
+			)
+		);
+
+		$this->assertSame(
+			'https://default.test/v1',
+			wp_get_connector_field_value( 'openai', 'base_url' )
+		);
+	}
+
+	public function test_value_resolution_returns_option_value() {
+		$this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+				'default' => 'https://default.test/v1',
+			)
+		);
+
+		update_option( 'connectors_ai_openai_base_url', 'https://stored.test/v1' );
+
+		$this->assertSame(
+			'https://stored.test/v1',
+			wp_get_connector_field_value( 'openai', 'base_url' )
+		);
+
+		delete_option( 'connectors_ai_openai_base_url' );
+	}
+
+	public function test_value_resolution_env_beats_option() {
+		$this->track(
+			'openai',
+			'base_url',
+			array(
+				'control'      => 'url',
+				'label'        => 'URL',
+				'default'      => 'https://default.test/v1',
+				'env_var_name' => 'WP_TEST_OPENAI_BASE_URL',
+			)
+		);
+
+		update_option( 'connectors_ai_openai_base_url', 'https://db.test/v1' );
+		putenv( 'WP_TEST_OPENAI_BASE_URL=https://env.test/v1' );
+
+		$this->assertSame(
+			'https://env.test/v1',
+			wp_get_connector_field_value( 'openai', 'base_url' )
+		);
+
+		putenv( 'WP_TEST_OPENAI_BASE_URL' );
+		delete_option( 'connectors_ai_openai_base_url' );
+	}
+
+	public function test_value_resolution_returns_null_for_unknown_field() {
+		$this->assertNull(
+			wp_get_connector_field_value( 'openai', 'never_registered' )
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Back-compat synthesis of the legacy api_key field
+	 * ------------------------------------------------------------------- */
+
+	public function test_synth_creates_api_key_field_for_api_key_connectors() {
+		// The synth hook runs during `wp_connectors_init`. Fire it manually
+		// against a fresh field registry to exercise the shim.
+		WP_Connector_Field_Registry::set_instance( null );
+		_gutenberg_connector_fields_synthesize_legacy( WP_Connector_Registry::get_instance() );
+
+		$field = wp_get_connector_field( 'openai', 'api_key' );
+
+		$this->assertIsArray( $field );
+		$this->assertTrue( $field['sensitive'] );
+		// The legacy API key is a string stored value rendered as a password.
+		$this->assertSame( 'string', $field['type'] );
+		$this->assertSame( 'password', $field['control'] );
+		$this->assertSame( 'connectors_ai_openai_api_key', $field['setting_name'] );
+	}
+
+	public function test_synth_is_idempotent_when_api_key_already_registered() {
+		$this->track(
+			'openai',
+			'api_key',
+			array(
+				'control' => 'password',
+				'label'   => 'Custom API Key label',
+			)
+		);
+
+		_gutenberg_connector_fields_synthesize_legacy( WP_Connector_Registry::get_instance() );
+
+		// Plugin's explicit registration must win.
+		$field = wp_get_connector_field( 'openai', 'api_key' );
+		$this->assertSame( 'Custom API Key label', $field['label'] );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Mask + source helpers
+	 * ------------------------------------------------------------------- */
+
+	public function test_mask_returns_input_when_4_chars_or_shorter() {
+		$this->assertSame( '', _gutenberg_connector_fields_mask( '' ) );
+		$this->assertSame( 'ab', _gutenberg_connector_fields_mask( 'ab' ) );
+		$this->assertSame( 'abcd', _gutenberg_connector_fields_mask( 'abcd' ) );
+	}
+
+	public function test_mask_hides_all_but_last_four() {
+		$masked = _gutenberg_connector_fields_mask( 'sk-live-0123456789fj39' );
+
+		$this->assertStringEndsWith( 'fj39', $masked );
+		$this->assertMatchesRegularExpression( '/^\x{2022}+fj39$/u', $masked );
+	}
+
+	public function test_mask_caps_bullet_prefix_at_16() {
+		$long = str_repeat( 'x', 100 ) . 'WXYZ';
+
+		$masked = _gutenberg_connector_fields_mask( $long );
+
+		// 16 bullets + 4 visible = 20 characters total.
+		$this->assertSame( 20, mb_strlen( $masked ) );
+		$this->assertStringEndsWith( 'WXYZ', $masked );
+	}
+
+	public function test_resolve_source_prefers_env_over_constant_over_db() {
+		update_option( 'test_connector_source_value', 'from-db' );
+
+		$this->assertSame(
+			'database',
+			_gutenberg_connector_fields_resolve_source( 'test_connector_source_value' )
+		);
+
+		putenv( 'WP_TEST_RESOLVE_SRC=from-env' );
+		$this->assertSame(
+			'env',
+			_gutenberg_connector_fields_resolve_source(
+				'test_connector_source_value',
+				'WP_TEST_RESOLVE_SRC'
+			)
+		);
+		putenv( 'WP_TEST_RESOLVE_SRC' );
+
+		delete_option( 'test_connector_source_value' );
+		$this->assertSame(
+			'none',
+			_gutenberg_connector_fields_resolve_source( 'test_connector_source_value' )
+		);
+	}
+	/**
+	 * A stored falsy-but-set value (0) must be returned rather than falling
+	 * through to the registered default. Regression guard for the value
+	 * resolver's strict comparisons.
+	 */
+	public function test_value_resolution_preserves_stored_zero() {
+		$this->track(
+			'openai',
+			'max_tokens',
+			array(
+				'type'    => 'integer',
+				'control' => 'number',
+				'label'   => 'Max tokens',
+				'default' => 256,
+			)
+		);
+
+		update_option( 'connectors_ai_openai_max_tokens', 0 );
+
+		$this->assertEquals( 0, wp_get_connector_field_value( 'openai', 'max_tokens' ) );
+		$this->assertNotEquals( 256, wp_get_connector_field_value( 'openai', 'max_tokens' ) );
+
+		delete_option( 'connectors_ai_openai_max_tokens' );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * REST dispatch — sensitive masking
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * Sensitive field values must be masked in the /wp/v2/settings response.
+	 */
+	public function test_rest_dispatch_masks_sensitive_field() {
+		// Synthesize the legacy api_key field for the AI providers.
+		WP_Connector_Field_Registry::set_instance( null );
+		_gutenberg_connector_fields_synthesize_legacy( WP_Connector_Registry::get_instance() );
+
+		$setting_name = 'connectors_ai_openai_api_key';
+		$raw          = 'sk-secret-0123456789abcd';
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = new WP_REST_Response( array( $setting_name => $raw ) );
+		$server   = rest_get_server();
+
+		$result = _gutenberg_connector_fields_rest_dispatch( $response, $server, $request );
+		$data   = $result->get_data();
+
+		$this->assertArrayHasKey( $setting_name, $data );
+		$this->assertNotSame( $raw, $data[ $setting_name ], 'raw key must not be exposed' );
+		$this->assertStringEndsWith( 'abcd', $data[ $setting_name ] );
+	}
+
+	/**
+	 * A non-settings route must pass through untouched.
+	 */
+	public function test_rest_dispatch_ignores_other_routes() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$response = new WP_REST_Response( array( 'connectors_ai_openai_api_key' => 'sk-secret-0123456789abcd' ) );
+
+		$result = _gutenberg_connector_fields_rest_dispatch( $response, rest_get_server(), $request );
+
+		$this->assertSame(
+			array( 'connectors_ai_openai_api_key' => 'sk-secret-0123456789abcd' ),
+			$result->get_data()
+		);
+	}
+
+	/**
+	 * An update (POST) must not fatal and must still mask a non-AI sensitive
+	 * field. Exercises the $is_update branch without entering the AI-provider
+	 * live-validation path.
+	 */
+	public function test_rest_dispatch_masks_on_update_for_non_ai_field() {
+		$this->track_connector(
+			'vault-bridge',
+			array(
+				'name'           => 'Vault Bridge',
+				'type'           => 'secret_store',
+				'authentication' => array( 'method' => 'none' ),
+			)
+		);
+		$this->track(
+			'vault-bridge',
+			'token',
+			array(
+				'control'   => 'password',
+				'label'     => 'Token',
+				'sensitive' => true,
+			)
+		);
+
+		$setting_name = 'connectors_secret_store_vault_bridge_token';
+		$request      = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$response     = new WP_REST_Response( array( $setting_name => 'tok-secret-0123456789wxyz' ) );
+
+		$result = _gutenberg_connector_fields_rest_dispatch( $response, rest_get_server(), $request );
+		$data   = $result->get_data();
+
+		$this->assertStringEndsWith( 'wxyz', $data[ $setting_name ] );
+		$this->assertNotSame( 'tok-secret-0123456789wxyz', $data[ $setting_name ] );
+	}
+
+	/**
+	 * A field guarded by a failing auth_callback must be removed from the REST
+	 * response rather than exposed (even masked).
+	 */
+	public function test_rest_dispatch_removes_field_failing_auth() {
+		$this->track_connector(
+			'vault-bridge',
+			array(
+				'name'           => 'Vault Bridge',
+				'type'           => 'secret_store',
+				'authentication' => array( 'method' => 'none' ),
+			)
+		);
+		$this->track(
+			'vault-bridge',
+			'token',
+			array(
+				'control'       => 'password',
+				'label'         => 'Token',
+				'sensitive'     => true,
+				'auth_callback' => '__return_false',
+			)
+		);
+
+		$setting_name = 'connectors_secret_store_vault_bridge_token';
+		$request      = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response     = new WP_REST_Response( array( $setting_name => 'tok-secret-0123456789wxyz' ) );
+
+		$result = _gutenberg_connector_fields_rest_dispatch( $response, rest_get_server(), $request );
+
+		$this->assertArrayNotHasKey( $setting_name, $result->get_data() );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Per-type defaults
+	 * ------------------------------------------------------------------- */
+
+	public function test_default_is_type_appropriate_when_omitted() {
+		$bool = $this->track(
+			'openai',
+			'enabled',
+			array(
+				'type'  => 'boolean',
+				'label' => 'Enabled',
+			)
+		);
+		$this->assertFalse( $bool['default'] );
+
+		$int = $this->track(
+			'openai',
+			'max_tokens',
+			array(
+				'type'  => 'integer',
+				'label' => 'Max tokens',
+			)
+		);
+		$this->assertSame( 0, $int['default'] );
+
+		$str = $this->track(
+			'openai',
+			'base_url',
+			array(
+				'control' => 'url',
+				'label'   => 'URL',
+			)
+		);
+		$this->assertSame( '', $str['default'] );
+	}
+}

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -2,15 +2,17 @@
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
+import { useId, useRef, useState } from '@wordpress/element';
 import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 	__experimentalDefaultConnectorSettings as DefaultConnectorSettings,
 	privateApis as connectorsPrivateApis,
 	type ConnectorConfig,
+	type ConnectorField,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
+import apiFetch from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
@@ -41,6 +43,7 @@ interface ConnectorData {
 		isActivated: boolean;
 	};
 	authentication: NonNullable< ConnectorConfig[ 'authentication' ] >;
+	configSchema?: ConnectorField[];
 }
 
 interface ConnectorScriptModuleData {
@@ -248,6 +251,140 @@ function ApiKeyConnector( {
 	);
 }
 
+/**
+ * Render used for connectors that declare one or more configuration fields
+ * via `register_connector_field()` on top of (or instead of) the legacy
+ * api_key authentication.
+ *
+ * Mirrors the behaviour of the legacy api_key render: shows a Configure /
+ * Edit button in the action area that toggles visibility of the field form.
+ * The form itself is rendered by `DefaultConnectorSettings`, which renders one
+ * typed control per schema entry with a single Save button for the connector.
+ *
+ * @param props              Connector render props.
+ * @param props.name         Display name of the connector.
+ * @param props.description  Description shown under the name.
+ * @param props.logo         Logo element rendered alongside the connector.
+ * @param props.configSchema Typed configuration fields for the connector.
+ */
+function SchemaConnector( {
+	name,
+	description,
+	logo,
+	configSchema,
+}: ConnectorRenderProps ) {
+	const [ isExpanded, setIsExpanded ] = useState( false );
+	// Stable id used to link the disclosure button's `aria-controls` to the
+	// panel it reveals — implements the WAI-ARIA disclosure pattern.
+	const panelId = useId();
+	// `configSchema` is a snapshot taken at page load; `field.isStored` reflects
+	// only the state the server reported then. We track the names of fields the
+	// user saves during this session so the Connected badge and "Edit" /
+	// "Configure" label flip immediately without waiting for a reload.
+	const [ locallySavedFields, setLocallySavedFields ] = useState<
+		Set< string >
+	>( () => new Set() );
+
+	if ( ! configSchema || configSchema.length === 0 ) {
+		return null;
+	}
+
+	const hasStoredFieldFromServer = configSchema.some(
+		( field ) => field.isStored
+	);
+	const isConnected = hasStoredFieldFromServer || locallySavedFields.size > 0;
+
+	let buttonLabel: string;
+	if ( isExpanded ) {
+		buttonLabel = __( 'Cancel' );
+	} else if ( isConnected ) {
+		buttonLabel = __( 'Edit' );
+	} else {
+		buttonLabel = __( 'Configure' );
+	}
+
+	return (
+		<ConnectorItem
+			logo={ logo }
+			name={ name }
+			description={ description }
+			actionArea={
+				<HStack spacing={ 3 } expanded={ false }>
+					{ isConnected && <ConnectedBadge /> }
+					<Button
+						variant={
+							isExpanded || isConnected ? 'tertiary' : 'secondary'
+						}
+						size="compact"
+						aria-expanded={ isExpanded }
+						aria-controls={ panelId }
+						onClick={ () => setIsExpanded( ( prev ) => ! prev ) }
+					>
+						{ buttonLabel }
+					</Button>
+				</HStack>
+			}
+		>
+			{ isExpanded && (
+				<div id={ panelId }>
+					<DefaultConnectorSettings
+						configSchema={ configSchema }
+						onSaveFields={ async ( changed ) => {
+							// Map field names to their option (settingName) and
+							// persist the whole connector in one Settings request.
+							const data: Record< string, unknown > = {};
+							const savedNames: string[] = [];
+							for ( const [ fieldName, value ] of Object.entries(
+								changed
+							) ) {
+								const field = configSchema.find(
+									( f ) => f.name === fieldName
+								);
+								if ( ! field ) {
+									continue;
+								}
+								data[ field.settingName ] = value;
+								savedNames.push( fieldName );
+							}
+							if ( savedNames.length === 0 ) {
+								return;
+							}
+							await apiFetch( {
+								path: '/wp/v2/settings',
+								method: 'POST',
+								data,
+							} );
+							setLocallySavedFields( ( prev ) => {
+								const next = new Set( prev );
+								savedNames.forEach( ( fieldName ) =>
+									next.add( fieldName )
+								);
+								return next;
+							} );
+						} }
+					/>
+				</div>
+			) }
+		</ConnectorItem>
+	);
+}
+
+/**
+ * Returns true when the connector declares fields beyond the legacy api_key
+ * (the synthetic api_key alone is considered a legacy-shaped connector).
+ *
+ * @param configSchema Typed configuration fields for the connector.
+ * @return Whether the schema declares any field other than `api_key`.
+ */
+function hasExtraSchemaFields(
+	configSchema: ConnectorField[] | undefined
+): boolean {
+	if ( ! configSchema || configSchema.length === 0 ) {
+		return false;
+	}
+	return configSchema.some( ( field ) => field.name !== 'api_key' );
+}
+
 // Register connectors from server-provided connector data.
 export function registerDefaultConnectors() {
 	const connectors = getConnectorData();
@@ -261,7 +398,7 @@ export function registerDefaultConnectors() {
 			continue;
 		}
 
-		const { authentication } = data;
+		const { authentication, configSchema } = data;
 
 		const connectorName = sanitize( connectorId );
 		const args: Partial< Omit< ConnectorConfig, 'slug' > > = {
@@ -271,6 +408,7 @@ export function registerDefaultConnectors() {
 			logo: getConnectorLogo( connectorId, data.logoUrl ),
 			authentication,
 			plugin: data.plugin,
+			configSchema,
 		};
 
 		// Preserve a render that was already registered for this slug by
@@ -279,8 +417,12 @@ export function registerDefaultConnectors() {
 		const existing = unlock( select( connectorsStore ) ).getConnector(
 			connectorName
 		);
-		if ( authentication.method === 'api_key' && ! existing?.render ) {
-			args.render = ApiKeyConnector;
+		if ( ! existing?.render ) {
+			if ( hasExtraSchemaFields( configSchema ) ) {
+				args.render = SchemaConnector;
+			} else if ( authentication.method === 'api_key' ) {
+				args.render = ApiKeyConnector;
+			}
 		}
 
 		registerConnector( connectorName, args );

--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -168,6 +168,9 @@ function ConnectorsPage() {
 													connector.authentication
 												}
 												plugin={ connector.plugin }
+												configSchema={
+													connector.configSchema
+												}
 											/>
 										);
 									}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #78647 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WordPress 7.0 shipped the Connectors screen, but the only field a connector can surface is a single API key. Connectors that need more — a server URL for a self-hosted service, a default model, an organisation ID — have no supported path today, so authors either build a separate admin page or replace the connector's React card wholesale via the experimental `__experimentalRegisterConnector`.

This adds the declarative counterpart, mirroring how `register_block_type()` relates to client-side block registration (as discussed on #75833): the JS renderer stays the escape hatch for complex UI; this is the convenience layer for the common case of a few typed fields.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

**PHP (`lib/compat/wordpress-7.1/`)**

- `WP_Connector_Field_Registry` — stores per-connector fields (separate class because core's `WP_Connector_Registry` is `final`; intended to fold into it on the Core side).
- Public API: `register_connector_field()`, `unregister_connector_field()`, `wp_get_connector_field()`, `wp_get_connector_fields()`, `wp_get_connector_field_value()` (resolves env var → constant → option → default).
- Field args mirror `register_setting()` / `register_meta()`: `type` (data type), `control` (UI input), `label`, `description`, `default`, `sanitize_callback`, `auth_callback`, `show_in_rest` (`bool|array`), `choices`, `setting_name`, `env_var_name`, `constant_name`.
- Each field is registered with the Settings API and exposed/persisted over `/wp/v2/settings`; sensitive fields are masked and gated by `auth_callback`.
- **Back-compat:** connectors that declared `api_key` auth get an implicit `api_key` field synthesised automatically, reusing the existing option name — no migration, existing UIs unchanged.

**JS (`packages/connectors`, `routes/connectors-home`)**

- `DefaultConnectorSettings` renders each field as a typed control (text / url / email / number / password / textarea / select / checkbox, plus a `custom` slot-fill placeholder) with a **single Save button per connector** that persists all changed fields in one request.
- New types: `ConnectorField`, `ConnectorFieldType`, `ConnectorFieldControl`, `FieldValueSource`.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Build: `npm install && npm run build`, then `npm run wp-env start`.
2. In a plugin (or an mu-plugin), on `wp_connectors_init`, register a field on an existing connector:
   ```php
   register_connector_field( 'openai', 'organization', array(
       'control' => 'text',
       'label'   => __( 'Organization ID' ),
   ) );
   ```
3. Go to **Settings → Connectors**, expand the connector, and confirm the field renders, saves, and persists across reload.
4. Confirm existing api_key-only connectors still render their key field unchanged.

PHP unit tests: `npm run test:unit:php -- --filter=Tests_Connector_Field_Registry` (39 tests). JS: `npm run test:unit packages/connectors` (14 tests).


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Tab into the connector's Configure/Edit button (exposes `aria-expanded` / `aria-controls`), Enter to expand, Tab through the fields, and Save with Enter/Space.

## Screenshots or screencast <!-- if applicable -->

I've tried to demonstrate these fields in my own **AI Provider for Osaurus** plugin, and I've [created a temporary branch](https://github.com/andreilupu/ai-provider-for-osaurus/pull/6/changes) that adopts the field registry.

And here is the screenshot of that config.

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1486" height="1399" alt="Screenshot 2026-06-20 at 21 13 59" src="https://github.com/user-attachments/assets/b9c55f0b-3199-4373-9ee7-9e653757820a" />

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI assistance: Yes
Tool(s): Claude Code - Opus 4.8
Used for:
 - Review the current implementation of the Connector screen so I can continue in the same logic.
 - Scaffold the PHP registry and the JS renderer based on a specific Spec I've given.
 - Write this description and the `@wordpress/connectors` package docs
 - Draft the unit tests
 - Two rounds of self-review after my own review between them

Every line has been read and is understood, and I can explain the approach in review. The test suites were actually executed locally (not just generated): `Tests_Connector_Field_Registry` — 39 passing; `packages/connectors` — 14 passing; and `phpcs` / `eslint` / `tsc` run clean. All referenced functions, hooks, options, tickets, and PRs were verified to exist.

## Open questions for reviewers

This is intentionally a proposal-stage PR; I'd value a steer on:

1. **Global function vs registry method.** The existing Connectors API deliberately has no global `wp_register_connector()` — registration happens via `$registry->register()` on `wp_connectors_init`. Should `register_connector_field()` be a global (as proposed, matching `register_setting()`), or a registry method for consistency?
2. **Plugin-active gate.** Core's settings registration skips connectors whose owning plugin isn't active; should field registration do the same?
3. **Scope.** Happy to split into separate PHP-API and JS-rendering PRs if that reviews better.
4. **Dynamic choices.** `select` needs concrete `choices` at registration; a future `choices_callback` would serve local-model providers better — in scope here or a follow-up?