### PR TITLE
Block Bindings: Support binding to innerBlocks (generic mechanism)

### DIFF
--- a/lib/compat/wordpress-7.1/block-bindings.php
+++ b/lib/compat/wordpress-7.1/block-bindings.php
@@ -74,7 +74,18 @@ function gutenberg_restore_list_item_inner_blocks_after_binding( $block_content,
 		return $block_content;
 	}
 
-	if ( ! gutenberg_list_item_metadata_has_content_binding( $instance->parsed_block['attrs']['metadata'] ?? null ) ) {
+	$metadata = $instance->parsed_block['attrs']['metadata'] ?? null;
+
+	/*
+	 * An `innerBlocks` binding needs no special-casing here. When the
+	 * `render_block_data` substitution (added below) ran, `$instance->inner_blocks`
+	 * already holds the substituted children: on cores that preserve inner
+	 * blocks while applying the content binding the `str_contains` check below
+	 * skips the re-append (no double output), and on WP 6.9/7.0 — where the
+	 * content binding wipes the whole `<li>` inner HTML — the restoration
+	 * re-appends the substituted children exactly as it does the block's own.
+	 */
+	if ( ! gutenberg_list_item_metadata_has_content_binding( $metadata ) ) {
 		return $block_content;
 	}
 
@@ -99,3 +110,638 @@ function gutenberg_restore_list_item_inner_blocks_after_binding( $block_content,
 	return substr( $block_content, 0, $closer_position ) . $inner_blocks_html . substr( $block_content, $closer_position );
 }
 add_filter( 'render_block', 'gutenberg_restore_list_item_inner_blocks_after_binding', 10, 3 );
+
+/*
+ * Substitutes a block's inner blocks from a bound source on the server.
+ *
+ * When a block declares an `innerBlocks` binding in its
+ * `metadata.bindings`, the bound source supplies the block's child tree as a
+ * serialized block-markup string. The filters below resolve that value before
+ * the block renders and replace the parsed block's `innerBlocks` and
+ * `innerContent`, so the frontend renders the source-supplied tree (with nested
+ * bindings resolved recursively by Core) instead of the block's own serialized
+ * children.
+ *
+ * The following filters can be removed once the minimum required WordPress
+ * version is 7.1 or newer.
+ */
+
+if ( ! defined( 'GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY' ) ) {
+	/**
+	 * Context key carrying the guard keys of the bound inner-block areas that are
+	 * ancestors of the block currently being rendered.
+	 *
+	 * Ancestry travels inside block context, so it is naturally scoped to the
+	 * currently-rendering subtree: it dies with the subtree and cannot leak
+	 * request-wide, and it survives third-party `render_block_data` filters that
+	 * rebuild the parsed-block array, because it lives on the `WP_Block`
+	 * instance's context rather than on the parsed block.
+	 *
+	 * @since 7.1.0
+	 */
+	define( 'GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY', 'gutenberg/innerBlocksBindingAncestry' );
+}
+
+if ( ! defined( 'GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH' ) ) {
+	/**
+	 * Hard cap on the nesting depth of bound inner-block areas.
+	 *
+	 * Context-carried ancestry cannot cross context boundaries (`do_blocks()`,
+	 * `core/post-template`'s per-iteration render), so a request-global depth
+	 * counter guarantees termination for cycles that cross them.
+	 *
+	 * @since 7.1.0
+	 */
+	define( 'GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH', 32 );
+}
+
+/**
+ * Returns a block's `innerBlocks` binding descriptor, or null when absent/invalid.
+ *
+ * The same check gates the substitution, the top-level takeover, and the
+ * depth-counter decrement, so pairing between them is re-derived from the
+ * block's own attributes and survives parsed-block rebuilds by third-party
+ * `render_block_data` filters.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block The parsed block.
+ * @return array|null The binding descriptor (with a non-empty string `source`), or null.
+ */
+function gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) {
+	$binding = $parsed_block['attrs']['metadata']['bindings']['innerBlocks'] ?? null;
+	if ( ! is_array( $binding ) || empty( $binding['source'] ) || ! is_string( $binding['source'] ) ) {
+		return null;
+	}
+	return $binding;
+}
+
+/**
+ * Builds the recursion-guard key for an `innerBlocks` binding.
+ *
+ * The key combines the source name, the binding arguments, and the resolved
+ * values of the context the source declares in `uses_context`. A nested binding
+ * is a cycle only when all three match: a context-dependent source (e.g. keyed
+ * by `postId`) legitimately appears twice when a bound area renders another post
+ * containing a block bound to the same source and args, and must not be flagged.
+ * A source with empty `uses_context` is context-independent by declaration, so
+ * the same source and args nested is a true cycle.
+ *
+ * @since 7.1.0
+ *
+ * @param string                        $source_name       The binding source name.
+ * @param array                         $source_args       The binding arguments.
+ * @param WP_Block_Bindings_Source      $source            The registered source.
+ * @param array                         $available_context The bound block's available context.
+ * @return string The guard key.
+ */
+function gutenberg_block_bindings_get_binding_guard_key( $source_name, $source_args, $source, $available_context ) {
+	$context_subset = array();
+	if ( ! empty( $source->uses_context ) ) {
+		foreach ( $source->uses_context as $context_name ) {
+			if ( array_key_exists( $context_name, $available_context ) ) {
+				$context_subset[ $context_name ] = $available_context[ $context_name ];
+			}
+		}
+	}
+
+	ksort( $source_args );
+	ksort( $context_subset );
+
+	return $source_name . '|' . wp_json_encode( $source_args ) . '|' . wp_json_encode( $context_subset );
+}
+
+/**
+ * Returns (by reference) the number of bound inner-block areas currently rendering.
+ *
+ * Incremented by `gutenberg_block_bindings_replace_inner_blocks()` for every
+ * block carrying an `innerBlocks` binding descriptor and decremented by
+ * `gutenberg_block_bindings_close_bound_block()` once such a block has rendered.
+ * During a runaway descent no render completes, so no decrements occur and the
+ * counter grows with bound depth, guaranteeing a hard stop at
+ * `GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH` even when the cycle crosses context
+ * boundaries the ancestry cannot follow.
+ *
+ * @since 7.1.0
+ *
+ * @return int The current bound-render depth.
+ */
+function &gutenberg_block_bindings_bound_render_depth() {
+	static $depth = 0;
+	return $depth;
+}
+
+/**
+ * Returns the default context used when render_block() renders a top-level block.
+ *
+ * Mirrors core's context setup in render_block(): the global-post defaults plus
+ * the `render_block_context` filter. Only used as a fallback when a nested bound
+ * block's `WP_Block` instance cannot be located on its parent (top-level blocks
+ * are handled by `gutenberg_block_bindings_render_top_level_bound_block()`,
+ * which applies the filter itself). This fallback is the sole remaining spot
+ * where `render_block_context` may run an extra time for a block; the branch is
+ * practically unreachable in core's render loop.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block The parsed block being rendered.
+ * @return array Default block context.
+ */
+function gutenberg_block_bindings_get_default_context( $parsed_block ) {
+	global $post;
+
+	$default_context = array();
+
+	if ( $post instanceof WP_Post ) {
+		$default_context = array(
+			'postId'   => $post->ID,
+			'postType' => $post->post_type,
+		);
+	}
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$default_context = apply_filters( 'render_block_context', $default_context, $parsed_block, null );
+
+	return is_array( $default_context ) ? $default_context : array();
+}
+
+/**
+ * Reads a WP_Block instance's inherited available context.
+ *
+ * @since 7.1.0
+ *
+ * @param WP_Block $block The block instance.
+ * @return array The block's available context.
+ */
+function gutenberg_block_bindings_get_available_context( $block ) {
+	static $get_available_context = null;
+
+	if ( ! $block instanceof WP_Block ) {
+		return array();
+	}
+
+	if ( null === $get_available_context ) {
+		/*
+		 * Sources can request context inherited through ancestors that the bound
+		 * block itself does not declare in `uses_context`. The protected
+		 * `available_context` property is the faithful source for those values.
+		 */
+		$get_available_context = Closure::bind(
+			static function ( $block_instance ) {
+				return $block_instance->available_context;
+			},
+			null,
+			WP_Block::class
+		);
+	}
+
+	$available_context = $get_available_context( $block );
+	return is_array( $available_context ) ? $available_context : array();
+}
+
+/**
+ * Finds the WP_Block instance currently being filtered inside its parent.
+ *
+ * `WP_Block_List::offsetGet()` caches the constructed instance, so the object
+ * returned here is the same object core's render loop renders — mutating its
+ * context propagates to the block's (substituted) children.
+ *
+ * @since 7.1.0
+ *
+ * @param array    $source_block The unmodified parsed block.
+ * @param WP_Block $parent_block The parent block instance.
+ * @return WP_Block|null The matching child instance, or null.
+ */
+function gutenberg_block_bindings_find_inner_block_instance( $source_block, $parent_block ) {
+	if ( ! $parent_block instanceof WP_Block || empty( $parent_block->inner_blocks ) ) {
+		return null;
+	}
+
+	foreach ( $parent_block->inner_blocks as $inner_block ) {
+		if ( $inner_block instanceof WP_Block && $inner_block->parsed_block === $source_block ) {
+			return $inner_block;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Rebuilds a block's `innerContent` template around a new set of inner blocks.
+ *
+ * A block's `innerContent` is a template array that interleaves the block's own
+ * static HTML chunks (strings) with one `null` placeholder per inner block, in
+ * render order. For example `core/group` parses to
+ * `array( '<div…>', null, null, '</div>' )` (the wrapper chunks plus one `null`
+ * per child) and `core/list-item` to `array( '<li>…', null, '</li>' )`.
+ *
+ * When inner blocks are substituted from a binding source, the host block's own
+ * static chunks (its chrome, such as the `<div>`/`</div>` or `<li>`/`</li>`
+ * wrapper) must be preserved while the `null` placeholders are replaced to match
+ * the NEW inner blocks (whose count may differ from the original). This keeps the
+ * leading static chunk(s) before the first placeholder and the trailing static
+ * chunk(s) after the last placeholder, emitting exactly one `null` per new inner
+ * block in between.
+ *
+ * Edge cases:
+ *
+ * - Original template with no `null` placeholder (e.g. an empty container that
+ *   parsed to a single closed-wrapper chunk): inserts the new placeholders before
+ *   the final closing tag when one can be identified, so sourced children still
+ *   render inside the host wrapper. If no closing tag is available, the new
+ *   placeholders are appended after all existing static chunks.
+ * - Original template that is empty (no static chunks and no placeholders): falls
+ *   back to one `null` per new inner block, with no surrounding static chunks.
+ * - Zero new inner blocks (an intentionally-empty area): only the host's static
+ *   chunks remain, so the wrapper renders empty.
+ *
+ * @since 7.1.0
+ *
+ * @param array $original_inner_content The host block's existing `innerContent` template.
+ * @param int   $new_block_count        The number of substituted inner blocks.
+ * @return array The rebuilt `innerContent` template: the host's static chunks with
+ *               exactly `$new_block_count` `null` placeholders in inner-block position.
+ */
+function gutenberg_block_bindings_rebuild_inner_content( $original_inner_content, $new_block_count ) {
+	if ( ! is_array( $original_inner_content ) ) {
+		$original_inner_content = array();
+	}
+
+	$placeholders = array_fill( 0, $new_block_count, null );
+
+	// Locate the original inner-block placeholders (the `null` slots).
+	$null_positions = array();
+	foreach ( $original_inner_content as $index => $chunk ) {
+		if ( null === $chunk ) {
+			$null_positions[] = $index;
+		}
+	}
+
+	/*
+	 * No placeholder to anchor on. Empty containers such as an empty Group parse
+	 * to a single closed-wrapper chunk (`<div ...></div>`), so insert the new
+	 * slots before the final closing tag when possible. This preserves the host
+	 * wrapper around source-supplied children even when the serialized fallback
+	 * originally had no children.
+	 */
+	if ( empty( $null_positions ) ) {
+		for ( $index = count( $original_inner_content ) - 1; $index >= 0; $index-- ) {
+			$chunk = $original_inner_content[ $index ];
+			if ( ! is_string( $chunk ) || ! preg_match( '#</[A-Za-z][^>]*>\s*$#', $chunk, $matches, PREG_OFFSET_CAPTURE ) ) {
+				continue;
+			}
+
+			$closing_offset = $matches[0][1];
+			$leading        = array_slice( $original_inner_content, 0, $index );
+			$before_closer  = substr( $chunk, 0, $closing_offset );
+			$after_closer   = substr( $chunk, $closing_offset );
+			if ( '' !== $before_closer ) {
+				$leading[] = $before_closer;
+			}
+
+			$trailing = array();
+			if ( '' !== $after_closer ) {
+				$trailing[] = $after_closer;
+			}
+			$trailing = array_merge( $trailing, array_slice( $original_inner_content, $index + 1 ) );
+
+			return array_merge( $leading, $placeholders, $trailing );
+		}
+
+		// No usable closing tag: keep any static chunks, then append the new slots.
+		return array_merge( array_values( $original_inner_content ), $placeholders );
+	}
+
+	$first_null = $null_positions[0];
+	$last_null  = $null_positions[ count( $null_positions ) - 1 ];
+
+	// Preserve the leading static chunks (before the first placeholder) and the
+	// trailing static chunks (after the last placeholder); replace everything in
+	// between with one placeholder per new inner block.
+	$leading  = array_slice( $original_inner_content, 0, $first_null );
+	$trailing = array_slice( $original_inner_content, $last_null + 1 );
+
+	return array_merge( $leading, $placeholders, $trailing );
+}
+
+/**
+ * Resolves a block's `innerBlocks` binding and substitutes the parsed block's
+ * inner blocks.
+ *
+ * Shared by the nested-block substitution
+ * (`gutenberg_block_bindings_replace_inner_blocks()`) and the top-level takeover
+ * (`gutenberg_block_bindings_render_top_level_bound_block()`). Constructs a
+ * transient `WP_Block` (so the source can read both the block's attributes and
+ * context), calls the source's `get_value()` for the `innerBlocks` attribute,
+ * and substitutes the result:
+ *
+ * - A non-empty string is parsed with `parse_blocks()` and becomes the block's
+ *   inner blocks; `innerContent` is rebuilt around the host's own static chunks
+ *   so the substituted children render IN PLACE (the host's chrome, such as a
+ *   `<div>`/`<li>` wrapper, is preserved and the children render exactly once).
+ * - An empty string `''` is an intentionally-empty area: the inner blocks are
+ *   cleared and only the host's static chunks remain, so the wrapper renders
+ *   empty (no fallback children).
+ * - `null` (absence) leaves the parsed block untouched, so the block's own
+ *   serialized children render as a fallback.
+ *
+ * Recursion guard: a source can supply markup containing another block bound to
+ * the same source (directly, or through a cycle of sources), so the substitution
+ * is skipped when the binding's guard key — source, args, and the resolved
+ * values of the context the source consumes — already appears in the
+ * currently-rendering bound ancestry, or when nesting exceeds the hard depth
+ * cap. The returned `ancestry` is non-null only when substitution actually
+ * produced children; the caller must place it under the
+ * `GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY` context key of the block
+ * about to render so the substituted children inherit it.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block      The parsed block carrying the binding.
+ * @param array $available_context The context available to the block.
+ * @return array {
+ *     The resolution result.
+ *
+ *     @type array      $parsed_block The parsed block, with substituted inner blocks
+ *                                    when a value resolved.
+ *     @type array|null $ancestry     The full ancestry list (ancestors plus this
+ *                                    binding's guard key) to propagate to the
+ *                                    substituted children, or null when nothing
+ *                                    needs propagating.
+ * }
+ */
+function gutenberg_block_bindings_resolve_inner_blocks( $parsed_block, $available_context ) {
+	$unchanged = array(
+		'parsed_block' => $parsed_block,
+		'ancestry'     => null,
+	);
+
+	$binding = gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block );
+	if ( null === $binding ) {
+		return $unchanged;
+	}
+
+	$source = get_block_bindings_source( $binding['source'] );
+	if ( null === $source ) {
+		return $unchanged;
+	}
+
+	$source_args = ! empty( $binding['args'] ) && is_array( $binding['args'] ) ? $binding['args'] : array();
+	$guard_key   = gutenberg_block_bindings_get_binding_guard_key( $binding['source'], $source_args, $source, $available_context );
+
+	$ancestry = $available_context[ GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] ?? array();
+	if ( ! is_array( $ancestry ) ) {
+		$ancestry = array();
+	}
+
+	if ( in_array( $guard_key, $ancestry, true ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %s: The bound source name. */
+					__( 'The "innerBlocks" binding source "%s" supplies a block bound to itself; the nested binding is skipped to prevent infinite recursion.', 'gutenberg' ),
+					$binding['source']
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	/*
+	 * The depth counter (not just the ancestry length) must be checked here:
+	 * cycles crossing context boundaries (`do_blocks()`, `core/post-template`)
+	 * re-enter as top-level blocks with fresh context, so the counter is the
+	 * only state that survives them.
+	 */
+	if (
+		count( $ancestry ) >= GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH ||
+		gutenberg_block_bindings_bound_render_depth() >= GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH
+	) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %d: The maximum nesting depth of bound inner-block areas. */
+					__( 'Bound inner blocks are nested more than %d levels deep; the binding is skipped to prevent infinite recursion.', 'gutenberg' ),
+					GUTENBERG_BLOCK_BINDINGS_MAX_BOUND_DEPTH
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	$block_instance = new WP_Block( $parsed_block, $available_context );
+
+	if ( ! empty( $source->uses_context ) ) {
+		foreach ( $source->uses_context as $context_name ) {
+			if ( array_key_exists( $context_name, $available_context ) ) {
+				$block_instance->context[ $context_name ] = $available_context[ $context_name ];
+			}
+		}
+	}
+
+	$source_value = $source->get_value( $source_args, $block_instance, 'innerBlocks' );
+
+	// Absence: leave the parsed block untouched so the serialized fallback renders.
+	if ( null === $source_value ) {
+		return $unchanged;
+	}
+
+	if ( ! is_string( $source_value ) ) {
+		// Surface a misuse instead of silently parsing a non-string value.
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %s: The bound source name. */
+					__( 'The "innerBlocks" binding source "%s" must return a serialized block-markup string, an empty string, or null.', 'gutenberg' ),
+					$binding['source']
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	if ( '' === $source_value ) {
+		// Intentionally empty area: no inner blocks, but keep the host's static
+		// chunks so its wrapper renders empty (no fallback children). No children
+		// means nothing can recurse, so no ancestry needs propagating.
+		$parsed_block['innerContent'] = gutenberg_block_bindings_rebuild_inner_content( $parsed_block['innerContent'] ?? array(), 0 );
+		$parsed_block['innerBlocks']  = array();
+		return array(
+			'parsed_block' => $parsed_block,
+			'ancestry'     => null,
+		);
+	}
+
+	// A non-empty string: parse it and rebuild inner content around the host's
+	// own static chunks so the substituted children render in place.
+	$parsed_block['innerBlocks']  = parse_blocks( $source_value );
+	$parsed_block['innerContent'] = gutenberg_block_bindings_rebuild_inner_content(
+		$parsed_block['innerContent'] ?? array(),
+		count( $parsed_block['innerBlocks'] )
+	);
+
+	return array(
+		'parsed_block' => $parsed_block,
+		'ancestry'     => array_merge( $ancestry, array( $guard_key ) ),
+	);
+}
+
+/**
+ * Substitutes a nested block's inner blocks from its `innerBlocks` binding source.
+ *
+ * Hooked on `render_block_data`, which fires for every block (including each
+ * inner block) before it renders, with the signature
+ * `( $parsed_block, $source_block, $parent_block )`.
+ *
+ * Top-level blocks (`$parent_block === null`) only get depth accounting here;
+ * their substitution is handled by
+ * `gutenberg_block_bindings_render_top_level_bound_block()`, which applies this
+ * very filter before resolving.
+ *
+ * @since 7.1.0
+ *
+ * @param array         $parsed_block The parsed block being filtered.
+ * @param array         $source_block An unmodified copy of the parsed block.
+ * @param WP_Block|null $parent_block The parent block instance, or null at the top level.
+ * @return array The parsed block, with substituted inner blocks when a value resolves.
+ */
+function gutenberg_block_bindings_replace_inner_blocks( $parsed_block, $source_block, $parent_block ) {
+	if ( null === gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		return $parsed_block;
+	}
+
+	/*
+	 * Every block carrying the binding descriptor — any parent, any outcome —
+	 * increments the depth counter, symmetric by construction with the
+	 * decrement in `gutenberg_block_bindings_close_bound_block()`, which pairs
+	 * on the same re-derivable descriptor check.
+	 */
+	$depth = &gutenberg_block_bindings_bound_render_depth();
+	++$depth;
+
+	if ( ! $parent_block instanceof WP_Block ) {
+		return $parsed_block;
+	}
+
+	/*
+	 * Prefer the actual WP_Block instance being rendered so source callbacks
+	 * receive inherited context through arbitrary ancestry, even through
+	 * intermediate blocks that neither use nor provide that context.
+	 */
+	$source_instance   = gutenberg_block_bindings_find_inner_block_instance( $source_block, $parent_block );
+	$available_context = $source_instance instanceof WP_Block
+		? gutenberg_block_bindings_get_available_context( $source_instance )
+		: gutenberg_block_bindings_get_default_context( $parsed_block );
+
+	$result = gutenberg_block_bindings_resolve_inner_blocks( $parsed_block, $available_context );
+
+	/*
+	 * Propagate the bound ancestry to the substituted children by mutating the
+	 * cached instance's context: core's render loop detects the context change
+	 * against its pre-filter snapshot and rebuilds the children with it merged
+	 * into their available context. When the instance could not be located
+	 * (practically unreachable in core's loop), cycle detection for this
+	 * subtree degrades to the global depth cap.
+	 */
+	if ( null !== $result['ancestry'] && $source_instance instanceof WP_Block ) {
+		$source_instance->context[ GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] = $result['ancestry'];
+	}
+
+	return $result['parsed_block'];
+}
+add_filter( 'render_block_data', 'gutenberg_block_bindings_replace_inner_blocks', 10, 3 );
+
+/**
+ * Renders a top-level block carrying an `innerBlocks` binding, replacing core's
+ * `render_block()` tail.
+ *
+ * Hooked on `pre_render_block` at `PHP_INT_MAX` so every other callback runs
+ * first (a non-null value from one of them is passed through untouched). Core's
+ * `render_block()` applies the `render_block_context` filter itself, but the
+ * substitution has to run before the block is constructed — applying the filter
+ * early AND letting core apply it again would run non-idempotent callbacks
+ * twice. Short-circuiting `render_block()` and replicating its tail here runs
+ * `render_block_data` and `render_block_context` exactly once, and resolution
+ * sees the real, post-filter context. The `render_block` and
+ * `render_block_{name}` filters still fire inside `WP_Block::render()`.
+ *
+ * @since 7.1.0
+ *
+ * @param string|null   $pre_render   The pre-rendered content, or null.
+ * @param array         $parsed_block The parsed block being rendered.
+ * @param WP_Block|null $parent_block The parent block instance, or null at the top level.
+ * @return string|null The rendered block for top-level bound blocks; otherwise `$pre_render`.
+ */
+function gutenberg_block_bindings_render_top_level_bound_block( $pre_render, $parsed_block, $parent_block ) {
+	if (
+		null !== $pre_render ||
+		null !== $parent_block ||
+		null === gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block )
+	) {
+		return $pre_render;
+	}
+
+	global $post;
+
+	// Replicates the tail of render_block(), verified against 7.1-alpha.
+	$source_block = $parsed_block;
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block, null );
+
+	$context = array();
+
+	if ( $post instanceof WP_Post ) {
+		$context['postId']   = $post->ID;
+		$context['postType'] = $post->post_type;
+	}
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$context = apply_filters( 'render_block_context', $context, $parsed_block, null );
+	if ( ! is_array( $context ) ) {
+		$context = array();
+	}
+
+	// The binding is re-read from the post-filter parsed block by the resolver;
+	// a descriptor removed by a `render_block_data` filter resolves to a no-op.
+	$result       = gutenberg_block_bindings_resolve_inner_blocks( $parsed_block, $context );
+	$parsed_block = $result['parsed_block'];
+	if ( null !== $result['ancestry'] ) {
+		$context[ GUTENBERG_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] = $result['ancestry'];
+	}
+
+	$block = new WP_Block( $parsed_block, $context );
+
+	return $block->render();
+}
+add_filter( 'pre_render_block', 'gutenberg_block_bindings_render_top_level_bound_block', PHP_INT_MAX, 3 );
+
+/**
+ * Decrements the bound-render depth once a bound block has rendered.
+ *
+ * Companion to `gutenberg_block_bindings_replace_inner_blocks()`: pairing is by
+ * the same re-derivable descriptor check on the block's own attributes (which
+ * survives parsed-block rebuilds by third-party filters), and the decrement is
+ * clamped at zero so mispaired decrements from direct `WP_Block::render()`
+ * calls cannot underflow the counter.
+ *
+ * @since 7.1.0
+ *
+ * @param string $block_content The rendered block content.
+ * @param array  $parsed_block  The parsed block.
+ * @return string The unchanged block content.
+ */
+function gutenberg_block_bindings_close_bound_block( $block_content, $parsed_block ) {
+	if ( null !== gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		$depth = &gutenberg_block_bindings_bound_render_depth();
+		$depth = max( 0, $depth - 1 );
+	}
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_block_bindings_close_bound_block', 20, 2 );

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 -   Grid: Add a "Fill available space" option to the grid layout that switches the auto-placement keyword from `auto-fill` to `auto-fit`, so columns stretch to fill the row instead of leaving empty tracks. ([#79356](https://github.com/WordPress/gutenberg/pull/79356))
 -   List View: a block that supports `listView` is now excluded from the List View when it has no inner blocks and disallows insertion (`allowedBlocks` is `[]` or `false`), since there is nothing to show, rearrange, or add. ([#78932](https://github.com/WordPress/gutenberg/pull/78932))
+-   Block Bindings: support binding an InnerBlocks area through `metadata.bindings.innerBlocks`, including source-supplied serialized block markup, write-back, and read-only locking. ([#79379](https://github.com/WordPress/gutenberg/pull/79379))
 
 ## 15.21.1 (2026-06-16)
 

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -22,21 +22,12 @@ import { useCallback, useContext, useMemo } from '@wordpress/element';
 import BlockContext from '../block-context';
 import isURLLike from '../link-control/is-url-like';
 import {
+	getBlockBindingsContext,
 	hasPatternOverridesDefaultBinding,
 	replacePatternOverridesDefaultBinding,
 } from '../../utils/block-bindings';
 import { unlock } from '../../lock-unlock';
 import { PrivateBlockContext } from '../block-list/private-block-context';
-
-/**
- * Default value used for blocks which do not define their own context needs,
- * used to guarantee that a block's `context` prop will always be an object. It
- * is assigned as a constant since it is always expected to be an empty object,
- * and in order to avoid unnecessary React reconciliations of a changing object.
- *
- * @type {{}}
- */
-const DEFAULT_BLOCK_CONTEXT = {};
 
 const Edit = ( props ) => {
 	const { name } = props;
@@ -69,32 +60,23 @@ const EditWithGeneratedProps = ( props ) => {
 	const { bindableAttributes } = useContext( PrivateBlockContext );
 
 	const { blockBindings, context, hasPatternOverrides } = useMemo( () => {
-		// Assign context values using the block type's declared context needs.
-		const computedContext = blockType?.usesContext
-			? Object.fromEntries(
-					Object.entries( blockContext ).filter( ( [ key ] ) =>
-						blockType.usesContext.includes( key )
-					)
-			  )
-			: DEFAULT_BLOCK_CONTEXT;
-		// Add context requested by Block Bindings sources.
-		if ( attributes?.metadata?.bindings ) {
-			Object.values( attributes?.metadata?.bindings || {} ).forEach(
-				( binding ) => {
-					registeredSources[ binding?.source ]?.usesContext?.forEach(
-						( key ) => {
-							computedContext[ key ] = blockContext[ key ];
-						}
-					);
-				}
-			);
-		}
 		return {
 			blockBindings: replacePatternOverridesDefaultBinding(
 				attributes?.metadata?.bindings,
 				bindableAttributes
 			),
-			context: computedContext,
+			// Assign context values using the block type's declared context
+			// needs, plus the context requested by the block's bindings
+			// sources.
+			context: getBlockBindingsContext(
+				blockContext,
+				blockType?.usesContext,
+				attributes?.metadata?.bindings
+					? Object.values( attributes.metadata.bindings ).map(
+							( binding ) => registeredSources[ binding?.source ]
+					  )
+					: undefined
+			),
 			hasPatternOverrides: hasPatternOverridesDefaultBinding(
 				attributes?.metadata?.bindings
 			),

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,13 +7,20 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useMergeRefs } from '@wordpress/compose';
-import { forwardRef, useMemo, memo } from '@wordpress/element';
+import {
+	forwardRef,
+	useContext,
+	useMemo,
+	useState,
+	memo,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	getBlockSupport,
 	store as blocksStore,
 	__unstableGetInnerBlocksProps as getInnerBlocksProps,
 } from '@wordpress/blocks';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -23,6 +30,12 @@ import DefaultBlockAppender from './default-block-appender';
 import useNestedSettingsUpdate from './use-nested-settings-update';
 import useInnerBlockTemplateSync from './use-inner-block-template-sync';
 import useBlockContext from './use-block-context';
+import {
+	boundInnerBlocksAncestry,
+	getInnerBlocksBinding,
+	useBoundInnerBlocksProps,
+	useInnerBlocksBindingKey,
+} from './use-bound-inner-blocks';
 import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
@@ -156,6 +169,55 @@ function ControlledInnerBlocks( props ) {
 	return <UncontrolledInnerBlocks { ...props } />;
 }
 
+function BoundInnerBlocks( { binding, ...props } ) {
+	const boundInnerBlocksProps = useBoundInnerBlocksProps(
+		props.clientId,
+		binding,
+		props.blockType
+	);
+	// The gate in `useInnerBlocksProps` guarantees `props` never carries
+	// caller-controlled `value`/`onChange`/`onInput` here, so this spread
+	// order only lets the binding override generic options (layout,
+	// templateLock for read-only, etc.).
+	const innerBlocksProps = {
+		...props,
+		...boundInnerBlocksProps,
+	};
+	const InnerBlocks = hasControlledInnerBlocks( innerBlocksProps )
+		? ControlledInnerBlocks
+		: UncontrolledInnerBlocks;
+
+	// Record this bound area in the ancestry consumed by nested bindings, so a
+	// source supplying a block bound to itself resolves as absence instead of
+	// recursing. The pushed key must be the context-aware one — the same key
+	// nested bindings check against — or a cycle at matching context would
+	// only be cut by the depth cap.
+	const ancestry = useContext( boundInnerBlocksAncestry );
+	const isControlled = boundInnerBlocksProps !== undefined;
+	const key = useInnerBlocksBindingKey( binding );
+	const nextAncestry = useMemo( () => {
+		return isControlled && key ? [ ...ancestry, key ] : ancestry;
+	}, [ ancestry, key, isControlled ] );
+
+	return (
+		<boundInnerBlocksAncestry.Provider value={ nextAncestry }>
+			<InnerBlocks { ...innerBlocksProps } />
+		</boundInnerBlocksAncestry.Provider>
+	);
+}
+
+/**
+ * Inner blocks are controlled (driven by an external `value`/`onChange`, e.g.
+ * a binding source or a controlling entity) when both are present.
+ *
+ * @param {Object} innerBlocksProps The resolved inner-blocks props.
+ *
+ * @return {boolean} `true` when both `value` and `onChange` are present.
+ */
+function hasControlledInnerBlocks( innerBlocksProps ) {
+	return !! ( innerBlocksProps.value && innerBlocksProps.onChange );
+}
+
 const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
 	const innerBlocksProps = useInnerBlocksProps( { ref }, props );
 	return (
@@ -195,6 +257,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		( select ) => {
 			const {
 				getBlockName,
+				getBlockAttributes,
 				isZoomOut,
 				getTemplateLock,
 				getBlockRootClientId,
@@ -220,6 +283,9 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const blockEditingMode = getBlockEditingMode( clientId );
 			const parentClientId = getBlockRootClientId( clientId );
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
+			const innerBlocksBinding = getInnerBlocksBinding(
+				getBlockAttributes( clientId )
+			);
 
 			let _isDropZoneDisabled = blockEditingMode === 'disabled';
 
@@ -243,6 +309,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				parentClientId,
 				isDropZoneDisabled: _isDropZoneDisabled,
 				defaultLayout,
+				innerBlocksBinding,
 			};
 		},
 		[ clientId ]
@@ -255,6 +322,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		parentClientId,
 		isDropZoneDisabled,
 		defaultLayout,
+		innerBlocksBinding,
 	} = selected;
 
 	const blockDropZoneRef = useBlockDropZone( {
@@ -282,10 +350,55 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		defaultLayout,
 		...options,
 	};
-	const InnerBlocks =
-		innerBlocksProps.value && innerBlocksProps.onChange
-			? ControlledInnerBlocks
-			: UncontrolledInnerBlocks;
+	const InnerBlocks = hasControlledInnerBlocks( innerBlocksProps )
+		? ControlledInnerBlocks
+		: UncontrolledInnerBlocks;
+
+	// Caller-supplied controlled props (an entity provider such as a
+	// template part or synced pattern passing `value`/`onChange`/`onInput`)
+	// always take precedence: an `innerBlocks` binding only drives
+	// otherwise-uncontrolled containers.
+	const hasCallerControlledProps =
+		options.value !== undefined ||
+		options.onChange !== undefined ||
+		options.onInput !== undefined;
+	if ( innerBlocksBinding && hasCallerControlledProps ) {
+		warning(
+			`The "innerBlocks" block binding to source "${ innerBlocksBinding.source }" is ignored because the block's inner blocks are already controlled through caller-supplied value/onChange props.`
+		);
+	}
+
+	// Once an area has been bound, keep BoundInnerBlocks mounted even after the
+	// binding is removed: releasing control empties the container on teardown,
+	// and the still-mounted resolver is what re-seeds it with the last
+	// controlled tree. Ordinary, never-bound areas skip the component entirely.
+	// A binding suppressed by caller-controlled props never engaged, so it
+	// must not latch the container onto the bound path.
+	const bindingApplies = !! innerBlocksBinding && ! hasCallerControlledProps;
+	const [ wasBound, setWasBound ] = useState( bindingApplies );
+	if ( bindingApplies && ! wasBound ) {
+		setWasBound( true );
+	}
+
+	let children;
+	if ( ! clientId ) {
+		children = <BlockListItems { ...options } />;
+	} else if (
+		! hasCallerControlledProps &&
+		( innerBlocksBinding || wasBound )
+	) {
+		children = (
+			<BoundInnerBlocks
+				{ ...innerBlocksProps }
+				clientId={ clientId }
+				binding={ innerBlocksBinding }
+			/>
+		);
+	} else {
+		children = (
+			<InnerBlocks { ...innerBlocksProps } clientId={ clientId } />
+		);
+	}
 
 	return {
 		...props,
@@ -295,11 +408,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			'block-editor-block-list__layout',
 			__unstableDisableLayoutClassNames ? '' : layoutClassNames
 		),
-		children: clientId ? (
-			<InnerBlocks { ...innerBlocksProps } clientId={ clientId } />
-		) : (
-			<BlockListItems { ...options } />
-		),
+		children,
 	};
 }
 

--- a/packages/block-editor/src/components/inner-blocks/test/use-bound-inner-blocks.js
+++ b/packages/block-editor/src/components/inner-blocks/test/use-bound-inner-blocks.js
@@ -1,0 +1,1745 @@
+/**
+ * External dependencies
+ */
+import { render, renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select as globalSelect, useSelect } from '@wordpress/data';
+import { RawHTML } from '@wordpress/element';
+import {
+	createBlock,
+	getBlockTypes,
+	parse,
+	registerBlockBindingsSource,
+	registerBlockType,
+	serialize,
+	unregisterBlockBindingsSource,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+import { BlockContextProvider } from '../../block-context';
+import useBlockSync from '../../provider/use-block-sync';
+import { SelectionContext } from '../../provider/selection-context';
+import {
+	boundInnerBlocksAncestry,
+	getInnerBlocksBinding,
+	getInnerBlocksBindingKey,
+	useBoundInnerBlocksProps,
+	useInnerBlocksBindingKey,
+} from '../use-bound-inner-blocks';
+
+const PARAGRAPH_MARKUP =
+	'<!-- wp:paragraph -->\n<p>Bound paragraph</p>\n<!-- /wp:paragraph -->';
+
+describe( 'useBoundInnerBlocksProps', () => {
+	const registeredSources = [];
+	let mountedHooks = [];
+
+	function registerSource( name, source ) {
+		registerBlockBindingsSource( { name, label: name, ...source } );
+		registeredSources.push( name );
+	}
+
+	// Renders the hook and tracks it so it can be unmounted inside `act` during
+	// teardown. The hook's `useSelect` subscriptions would otherwise flush a
+	// store notification during the automatic, out-of-`act` cleanup. The
+	// binding is derived reactively from the block's attributes with the same
+	// `getInnerBlocksBinding` predicate production code uses.
+	function renderBoundHook( clientId, options ) {
+		const view = renderHook( () => {
+			const binding = useSelect(
+				( select ) =>
+					getInnerBlocksBinding(
+						select( blockEditorStore ).getBlockAttributes(
+							clientId
+						)
+					),
+				[]
+			);
+			return useBoundInnerBlocksProps( clientId, binding );
+		}, options );
+		mountedHooks.push( view );
+		return view;
+	}
+
+	beforeEach( () => {
+		registerBlockType( 'core/paragraph', {
+			apiVersion: 3,
+			category: 'text',
+			title: 'Paragraph',
+			attributes: {
+				content: { type: 'string', source: 'html', selector: 'p' },
+			},
+			save: ( { attributes } ) => (
+				<p>
+					<RawHTML>{ attributes.content }</RawHTML>
+				</p>
+			),
+		} );
+		registerBlockType( 'core/test-container', {
+			apiVersion: 3,
+			category: 'text',
+			title: 'Test container',
+			usesContext: [ 'test/block-type-context' ],
+			attributes: {
+				metadata: { type: 'object' },
+				stored: { type: 'string' },
+			},
+			save: () => null,
+		} );
+	} );
+
+	afterEach( async () => {
+		// Unmount inside `act` so each hook's `useSelect` subscription teardown
+		// (and any pending store notification) is flushed before the store and
+		// block types are reset, rather than landing as an out-of-`act` update
+		// during the automatic cleanup.
+		await act( async () => {
+			mountedHooks.forEach( ( { unmount } ) => unmount() );
+		} );
+		mountedHooks = [];
+		dispatch( blockEditorStore ).resetBlocks( [] );
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+		registeredSources.forEach( ( name ) =>
+			unregisterBlockBindingsSource( name )
+		);
+		registeredSources.length = 0;
+	} );
+
+	function setupBlock( metadata ) {
+		const block = createBlock(
+			'core/test-container',
+			metadata ? { metadata } : {}
+		);
+		// Reset blocks inside `act` so the resulting store notification settles
+		// before the hook renders, keeping the initial render free of a
+		// follow-up out-of-`act` update.
+		act( () => {
+			dispatch( blockEditorStore ).resetBlocks( [ block ] );
+		} );
+		return block.clientId;
+	}
+
+	// Mirrors the state the production sync engine establishes while a binding
+	// is applied: `ControlledInnerBlocks`' `useBlockSync` flags the container
+	// as having controlled inner blocks (before its first subscriber run) and
+	// seeds the store children from the resolved value. Unit tests that
+	// exercise write-back or release behavior seed the same state, because the
+	// resolver keys off it: writes for a container the sync engine does not
+	// own are dropped, and the release capture reads the store children.
+	function markContainerControlled( clientId, blocks ) {
+		act( () => {
+			dispatch( blockEditorStore ).setHasControlledInnerBlocks(
+				clientId,
+				true
+			);
+			if ( blocks ) {
+				dispatch( blockEditorStore ).replaceInnerBlocks(
+					clientId,
+					blocks
+				);
+			}
+		} );
+	}
+
+	it( 'returns undefined for a falsy clientId', () => {
+		const { result } = renderBoundHook( '' );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a block without any bindings', () => {
+		const clientId = setupBlock();
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a block with an unrelated attribute binding', () => {
+		const clientId = setupBlock( {
+			bindings: {
+				content: { source: 'core/post-meta', args: { key: 'x' } },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when the bound source is not registered', () => {
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/unknown-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it.each( [
+		[ 'non-string source', { source: { name: 'core/test-source' } } ],
+		[ 'empty source', { source: '' } ],
+	] )(
+		'returns undefined when the innerBlocks binding has a malformed %s',
+		( _label, innerBlocksBinding ) => {
+			const clientId = setupBlock( {
+				bindings: {
+					innerBlocks: innerBlocksBinding,
+				},
+			} );
+
+			const { result } = renderBoundHook( clientId );
+
+			expect( result.current ).toBeUndefined();
+		}
+	);
+
+	// Read path: a serialized string resolves to controlled blocks.
+	it( 'parses the serialized source string into controlled value blocks', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'hero' },
+				},
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeDefined();
+		expect( Array.isArray( result.current.value ) ).toBe( true );
+		expect( result.current.value ).toHaveLength( 1 );
+		expect( result.current.value[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( result.current.value[ 0 ].attributes.content ).toBe(
+			'Bound paragraph'
+		);
+		expect( typeof result.current.onChange ).toBe( 'function' );
+		expect( typeof result.current.onInput ).toBe( 'function' );
+	} );
+
+	// The source receives the documented batch shape.
+	it( 'calls getValues with the documented innerBlocks bindings shape', () => {
+		const getValues = jest.fn( () => ( {
+			innerBlocks: PARAGRAPH_MARKUP,
+		} ) );
+		registerSource( 'core/test-source', { getValues } );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'hero' },
+				},
+			},
+		} );
+
+		renderBoundHook( clientId );
+
+		expect( getValues ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				clientId,
+				bindings: { innerBlocks: { args: { key: 'hero' } } },
+			} )
+		);
+	} );
+
+	it( 'passes block type and source context values to getValues', () => {
+		const getValues = jest.fn( () => ( {
+			innerBlocks: PARAGRAPH_MARKUP,
+		} ) );
+		registerSource( 'core/test-source', {
+			usesContext: [ 'test/source-context' ],
+			getValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'hero' },
+				},
+			},
+		} );
+
+		const wrapper = ( { children } ) => (
+			<BlockContextProvider
+				value={ {
+					'test/block-type-context': 'from-block-type',
+					'test/source-context': 'from-source',
+				} }
+			>
+				{ children }
+			</BlockContextProvider>
+		);
+
+		renderBoundHook( clientId, { wrapper } );
+
+		expect( getValues ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: {
+					'test/block-type-context': 'from-block-type',
+					'test/source-context': 'from-source',
+				},
+			} )
+		);
+	} );
+
+	// Absence (`undefined`) leaves the block uncontrolled so it can render
+	// its own fallback children.
+	it( 'returns undefined when the source value is undefined (absence)', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: undefined } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	// Absence (`null`) leaves the block uncontrolled so it can render its
+	// own fallback children.
+	it( 'returns undefined when the source value is null (absence)', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: null } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	// Empty string means an intentionally empty controlled area.
+	it( 'returns controlled value of [] for an empty string (intentionally empty)', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: '' } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current ).toBeDefined();
+		expect( result.current.value ).toEqual( [] );
+		expect( typeof result.current.onChange ).toBe( 'function' );
+	} );
+
+	// Write-back: editing serializes the subtree and calls setValues.
+	it( 'serializes the edited subtree and calls setValues on persistent change', () => {
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: '' } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'hero' },
+				},
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		const newBlocks = [
+			createBlock( 'core/paragraph', { content: 'Edited' } ),
+		];
+		act( () => {
+			result.current.onChange( newBlocks, {} );
+		} );
+
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+		const call = setValues.mock.calls[ 0 ][ 0 ];
+		expect( call.clientId ).toBe( clientId );
+		expect( call.bindings.innerBlocks.args ).toEqual( { key: 'hero' } );
+		expect( call.bindings.innerBlocks.newValue ).toBe(
+			serialize( newBlocks )
+		);
+		// Round-trips back to the same block.
+		expect( parse( call.bindings.innerBlocks.newValue )[ 0 ].name ).toBe(
+			'core/paragraph'
+		);
+	} );
+
+	// Transient input also writes back.
+	it( 'serializes and calls setValues on transient input', () => {
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: '' } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		const newBlocks = [
+			createBlock( 'core/paragraph', { content: 'Typing' } ),
+		];
+		act( () => {
+			result.current.onInput( newBlocks, {} );
+		} );
+
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+		expect(
+			setValues.mock.calls[ 0 ][ 0 ].bindings.innerBlocks.newValue
+		).toBe( serialize( newBlocks ) );
+	} );
+
+	// Echo stability: when `getValues` returns the exact
+	// string the resolver just emitted from a write, the controlled `value`
+	// keeps a stable reference rather than re-parsing into a fresh block array
+	// (which would look foreign to `useBlockSync` and reset the subtree).
+	it( 'keeps the controlled value reference-stable when getValues echoes the just-written string', () => {
+		// The source persists the written string into the container's
+		// `metadata.bindings.innerBlocks.args.stored` slot and reads it back
+		// from there, so `useSelect` re-derives `serialized` from real store
+		// state (a store notification fires) — mirroring how a real source
+		// round-trips a write through `getValues`.
+		const setValues = jest.fn( ( { select, clientId: id, bindings } ) => {
+			const metadata =
+				select( blockEditorStore ).getBlockAttributes( id ).metadata;
+			dispatch( blockEditorStore ).updateBlockAttributes( id, {
+				metadata: {
+					...metadata,
+					bindings: {
+						...metadata.bindings,
+						innerBlocks: {
+							...metadata.bindings.innerBlocks,
+							args: { stored: bindings.innerBlocks.newValue },
+						},
+					},
+				},
+			} );
+		} );
+		registerSource( 'core/test-source', {
+			getValues: ( { bindings } ) => ( {
+				innerBlocks: bindings.innerBlocks.args?.stored ?? '',
+			} ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		// Write a tree; the resolver caches the emitted { serialized, blocks }
+		// and the source stores it, so the next read echoes that exact string.
+		const edited = [
+			createBlock( 'core/paragraph', { content: 'Echoed' } ),
+		];
+		act( () => {
+			result.current.onChange( edited, {} );
+		} );
+
+		const echoedValue = result.current.value;
+		expect( echoedValue[ 0 ].attributes.content ).toBe( 'Echoed' );
+
+		// Writing the same blocks again echoes the same string; the controlled
+		// value must stay reference-equal rather than re-parse to a fresh array.
+		act( () => {
+			result.current.onChange( edited, {} );
+		} );
+		expect( result.current.value ).toBe( echoedValue );
+	} );
+
+	// A genuinely different serialized string produces a
+	// new (reference-changed) value — the cache only short-circuits an exact
+	// echo of the last write, never a real external change.
+	it( 'produces a new value reference when the source string genuinely changes', () => {
+		let stored = PARAGRAPH_MARKUP;
+		// A write that stores a string different from `newValue`, so the next
+		// read is not an echo of what the resolver emitted and must parse fresh.
+		// The `args` change forces the `serialized` selector's deps to change so
+		// `useSelect` re-derives the read (mirroring a real external change).
+		let version = 0;
+		const setValues = jest.fn( ( { select, clientId: id } ) => {
+			stored =
+				'<!-- wp:paragraph -->\n<p>Different</p>\n<!-- /wp:paragraph -->';
+			version += 1;
+			const metadata =
+				select( blockEditorStore ).getBlockAttributes( id ).metadata;
+			dispatch( blockEditorStore ).updateBlockAttributes( id, {
+				metadata: {
+					...metadata,
+					bindings: {
+						...metadata.bindings,
+						innerBlocks: {
+							...metadata.bindings.innerBlocks,
+							args: { version },
+						},
+					},
+				},
+			} );
+		} );
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: stored } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+		const firstValue = result.current.value;
+		expect( firstValue[ 0 ].attributes.content ).toBe( 'Bound paragraph' );
+
+		// The write stores a different string than it emitted (not an echo).
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'Ignored' } ) ],
+				{}
+			);
+		} );
+
+		expect( result.current.value ).not.toBe( firstValue );
+		expect( result.current.value[ 0 ].attributes.content ).toBe(
+			'Different'
+		);
+	} );
+
+	// onInput is a transient edit: when the source writes through the
+	// block-editor store, the write is marked not-persistent so mid-typing
+	// does not spam undo history, while onChange is a persistent edit that
+	// does not mark the change, so a completed edit lands as exactly one
+	// coherent undo level.
+	it( 'routes onInput through a non-persistent write and onChange through a persistent write', () => {
+		// The source persists through the block-editor store using the
+		// dispatch handed to `setValues`, so the transient mark applies to
+		// its write.
+		const setValues = jest.fn(
+			( { dispatch: sourceDispatch, clientId: id, bindings } ) => {
+				sourceDispatch( blockEditorStore ).updateBlockAttributes( id, {
+					stored: bindings.innerBlocks.newValue,
+				} );
+			}
+		);
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: '' } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const markNotPersistent = jest.spyOn(
+			dispatch( blockEditorStore ),
+			'__unstableMarkNextChangeAsNotPersistent'
+		);
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		const blocks = [
+			createBlock( 'core/paragraph', { content: 'Typing' } ),
+		];
+
+		// Transient input: marks the source's block-editor write as
+		// not-persistent.
+		act( () => {
+			result.current.onInput( blocks, {} );
+		} );
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+		expect( markNotPersistent ).toHaveBeenCalledTimes( 1 );
+		expect(
+			globalSelect( blockEditorStore ).isLastBlockChangePersistent()
+		).toBe( false );
+
+		// Persistent change: does not mark the change as not-persistent.
+		markNotPersistent.mockClear();
+		setValues.mockClear();
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'Committed' } ) ],
+				{}
+			);
+		} );
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+		expect( markNotPersistent ).not.toHaveBeenCalled();
+
+		markNotPersistent.mockRestore();
+	} );
+
+	// The not-persistent mark taints whichever action next reaches the
+	// block-editor reducer. A source that persists elsewhere (e.g. a
+	// core-data entity) never consumes it, so arming it up front would make
+	// the user's NEXT unrelated edit non-persistent (no undo level). The
+	// mark must only be armed when the source dispatches to the block-editor
+	// store.
+	it( 'does not arm the non-persistent mark for a source that does not write through the block-editor store', () => {
+		// Persists outside the block-editor store: no dispatch to it.
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: '' } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const markNotPersistent = jest.spyOn(
+			dispatch( blockEditorStore ),
+			'__unstableMarkNextChangeAsNotPersistent'
+		);
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		act( () => {
+			result.current.onInput(
+				[ createBlock( 'core/paragraph', { content: 'Typing' } ) ],
+				{}
+			);
+		} );
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+		expect( markNotPersistent ).not.toHaveBeenCalled();
+
+		// The user's next unrelated edit must land as its own persistent
+		// change (a dangling mark would record it as non-persistent, merging
+		// it into the previous undo level).
+		act( () => {
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				stored: 'unrelated edit',
+			} );
+		} );
+		expect(
+			globalSelect( blockEditorStore ).isLastBlockChangePersistent()
+		).toBe( true );
+
+		markNotPersistent.mockRestore();
+	} );
+
+	// Undo/redo guard: a transient write that merely echoes the source's
+	// current value must not call setValues. This is the no-op echo an ancestor
+	// controller reset produces when it re-clones this subtree during undo/redo:
+	// the shared `useBlockSync` subscription fires before the controlled-value
+	// reset effect and reports the still-live children as a not-persistent
+	// change. Re-asserting that value would clobber the undo. A persistent
+	// commit of the same value still writes so a completed edit lands as one
+	// coherent undo level.
+	it( 'skips a transient write that echoes the source value but keeps the persistent write', () => {
+		// A canonical source string so `serialize( parse( string ) ) === string`,
+		// matching what the resolver records as the last-known value on read.
+		const canonical = serialize( [
+			createBlock( 'core/paragraph', { content: 'Bound' } ),
+		] );
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: canonical } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		// Transient echo of the current value (the ancestor-reset reclone case):
+		// serialize equals the source's current value → no write.
+		act( () => {
+			result.current.onInput( result.current.value, {} );
+		} );
+		expect( setValues ).not.toHaveBeenCalled();
+
+		// A persistent commit of the same value still seals the edit, even when
+		// its serialized output matches the last-known value.
+		act( () => {
+			result.current.onChange( result.current.value, {} );
+		} );
+		expect( setValues ).toHaveBeenCalledTimes( 1 );
+
+		// A transient write whose content genuinely differs is not an echo and
+		// is persisted.
+		act( () => {
+			result.current.onInput(
+				[ createBlock( 'core/paragraph', { content: 'Typed' } ) ],
+				{}
+			);
+		} );
+		expect( setValues ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	// Read-only: canUserEditValue false means templateLock + no appender.
+	it( 'locks the area when canUserEditValue is false', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+			canUserEditValue: () => false,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current.templateLock ).toBe( 'all' );
+		expect( result.current.renderAppender ).toBe( false );
+	} );
+
+	// Read-only areas do not write back on change.
+	it( 'does not call setValues when the area is read-only', () => {
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues,
+			canUserEditValue: () => false,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'No' } ) ],
+				{}
+			);
+		} );
+
+		expect( setValues ).not.toHaveBeenCalled();
+	} );
+
+	// Ownership guard: an entity-driven reset (undo/redo) can re-take
+	// ownership of the container — clearing its controlled flag — in the same
+	// tick it removes the binding. The still-subscribed sync engine then
+	// reports the entity's restored children as an outgoing edit; writing
+	// them back would clobber the source value, so the resolver drops writes
+	// for a container the sync engine does not own.
+	it( 'drops a write for a container the sync engine does not own', () => {
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		// The container was never flagged as controlled (or the flag was
+		// cleared by a reset): the write must be dropped.
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'Restored' } ) ],
+				{}
+			);
+		} );
+
+		expect( setValues ).not.toHaveBeenCalled();
+	} );
+
+	// Editable areas are not locked by the resolver.
+	it( 'does not lock the area when canUserEditValue is true', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+			canUserEditValue: () => true,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( result.current.templateLock ).toBeUndefined();
+		expect( result.current.renderAppender ).toBeUndefined();
+	} );
+
+	// Write-back failure surfaces when setValues is missing.
+	it( 'surfaces an error when an editable binding has no setValues', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			// No setValues, but editable.
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'X' } ) ],
+				{}
+			);
+		} );
+
+		expect( consoleError ).toHaveBeenCalled();
+		consoleError.mockRestore();
+	} );
+
+	// Write-back failure surfaces when setValues throws.
+	it( 'surfaces an error when setValues throws and does not swallow it', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		const setValues = jest.fn( () => {
+			throw new Error( 'boom' );
+		} );
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		markContainerControlled( clientId );
+
+		act( () => {
+			result.current.onChange(
+				[ createBlock( 'core/paragraph', { content: 'X' } ) ],
+				{}
+			);
+		} );
+
+		expect( setValues ).toHaveBeenCalled();
+		expect( consoleError ).toHaveBeenCalled();
+		consoleError.mockRestore();
+	} );
+
+	// The read-only gate receives the binding's args, matching the
+	// established source signature used by attribute bindings, so
+	// args-dependent sources (e.g. core/post-meta) can gate per-field.
+	it( 'passes the binding args to canUserEditValue', () => {
+		const canUserEditValue = jest.fn( () => true );
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+			canUserEditValue,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'hero' },
+				},
+			},
+		} );
+
+		renderBoundHook( clientId );
+
+		expect( canUserEditValue ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				args: { key: 'hero' },
+				clientId,
+				attributeName: 'innerBlocks',
+			} )
+		);
+	} );
+
+	// Read-only enforcement: templateLock does not prevent editing child
+	// content, so the resolver additionally disables the editing mode of every
+	// block in the bound subtree (rendering the child wrappers inert).
+	it( 'disables the editing mode of the bound subtree when read-only, and re-enables it on unmount', async () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+			canUserEditValue: () => false,
+		} );
+		const container = createBlock(
+			'core/test-container',
+			{
+				metadata: {
+					bindings: {
+						innerBlocks: { source: 'core/test-source', args: {} },
+					},
+				},
+			},
+			[
+				createBlock( 'core/paragraph', { content: 'Locked child' }, [
+					// A grandchild proves the whole subtree is disabled, not
+					// just the direct children.
+					createBlock( 'core/paragraph', { content: 'Nested' } ),
+				] ),
+			]
+		);
+		act( () => {
+			dispatch( blockEditorStore ).resetBlocks( [ container ] );
+		} );
+		const [ childId ] = globalSelect( blockEditorStore ).getBlockOrder(
+			container.clientId
+		);
+		const [ grandChildId ] =
+			globalSelect( blockEditorStore ).getBlockOrder( childId );
+
+		const view = renderBoundHook( container.clientId );
+
+		expect(
+			globalSelect( blockEditorStore ).getBlockEditingMode( childId )
+		).toBe( 'disabled' );
+		expect(
+			globalSelect( blockEditorStore ).getBlockEditingMode( grandChildId )
+		).toBe( 'disabled' );
+
+		// Releasing the binding releases the lock.
+		await act( async () => {
+			view.unmount();
+		} );
+		expect(
+			globalSelect( blockEditorStore ).getBlockEditingMode( childId )
+		).toBe( 'default' );
+	} );
+
+	// Recursion guard: a binding whose (source, args) already appears in the
+	// bound ancestry resolves as absence instead of recursing.
+	it( 'resolves as absence when the same (source, args) binding appears in the bound ancestry', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		const getValues = jest.fn( () => ( {
+			innerBlocks: PARAGRAPH_MARKUP,
+		} ) );
+		registerSource( 'core/test-source', { getValues } );
+		const binding = { source: 'core/test-source', args: { key: 'hero' } };
+		const clientId = setupBlock( { bindings: { innerBlocks: binding } } );
+
+		const wrapper = ( { children } ) => (
+			<boundInnerBlocksAncestry.Provider
+				value={ [ getInnerBlocksBindingKey( binding ) ] }
+			>
+				{ children }
+			</boundInnerBlocksAncestry.Provider>
+		);
+
+		const { result } = renderBoundHook( clientId, { wrapper } );
+
+		expect( result.current ).toBeUndefined();
+		expect( getValues ).not.toHaveBeenCalled();
+		expect( consoleError ).toHaveBeenCalled();
+		consoleError.mockRestore();
+	} );
+
+	// The same source with different args is composition, not recursion.
+	it( 'still resolves when an ancestor uses the same source with different args', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { key: 'inner' },
+				},
+			},
+		} );
+
+		const wrapper = ( { children } ) => (
+			<boundInnerBlocksAncestry.Provider
+				value={ [
+					getInnerBlocksBindingKey( {
+						source: 'core/test-source',
+						args: { key: 'outer' },
+					} ),
+				] }
+			>
+				{ children }
+			</boundInnerBlocksAncestry.Provider>
+		);
+
+		const { result } = renderBoundHook( clientId, { wrapper } );
+
+		expect( result.current ).toBeDefined();
+		expect( result.current.value ).toHaveLength( 1 );
+	} );
+
+	// The guard key is context-aware: the same source and args resolving
+	// under different values of the context the source declares it consumes
+	// is composition (e.g. per-post areas nested through a provider), not
+	// recursion.
+	it( 'still resolves when an ancestor used the same source and args under different source-used context', () => {
+		registerSource( 'core/test-source', {
+			usesContext: [ 'test/source-context' ],
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+		} );
+		const binding = { source: 'core/test-source', args: {} };
+		const clientId = setupBlock( { bindings: { innerBlocks: binding } } );
+
+		const wrapper = ( { children } ) => (
+			<BlockContextProvider value={ { 'test/source-context': 'inner' } }>
+				<boundInnerBlocksAncestry.Provider
+					value={ [
+						getInnerBlocksBindingKey( binding, {
+							'test/source-context': 'outer',
+						} ),
+					] }
+				>
+					{ children }
+				</boundInnerBlocksAncestry.Provider>
+			</BlockContextProvider>
+		);
+
+		const { result } = renderBoundHook( clientId, { wrapper } );
+
+		expect( result.current ).toBeDefined();
+		expect( result.current.value ).toHaveLength( 1 );
+	} );
+
+	// A nested binding matching an ancestor on source, args AND the resolved
+	// source-used context values is a true cycle and resolves as absence.
+	it( 'resolves as absence when the same source, args and source-used context appear in the ancestry', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		const getValues = jest.fn( () => ( {
+			innerBlocks: PARAGRAPH_MARKUP,
+		} ) );
+		registerSource( 'core/test-source', {
+			usesContext: [ 'test/source-context' ],
+			getValues,
+		} );
+		const binding = { source: 'core/test-source', args: {} };
+		const clientId = setupBlock( { bindings: { innerBlocks: binding } } );
+
+		const wrapper = ( { children } ) => (
+			<BlockContextProvider value={ { 'test/source-context': 'same' } }>
+				<boundInnerBlocksAncestry.Provider
+					value={ [
+						getInnerBlocksBindingKey( binding, {
+							'test/source-context': 'same',
+						} ),
+					] }
+				>
+					{ children }
+				</boundInnerBlocksAncestry.Provider>
+			</BlockContextProvider>
+		);
+
+		const { result } = renderBoundHook( clientId, { wrapper } );
+
+		expect( result.current ).toBeUndefined();
+		expect( getValues ).not.toHaveBeenCalled();
+		expect( consoleError ).toHaveBeenCalled();
+		consoleError.mockRestore();
+	} );
+
+	// `useInnerBlocksBindingKey` produces the same context-aware key the
+	// resolver checks against, so bound containers push a matching entry
+	// onto the ancestry.
+	it( 'useInnerBlocksBindingKey returns the context-aware guard key', () => {
+		registerSource( 'core/test-source', {
+			usesContext: [ 'test/source-context' ],
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+		} );
+		const binding = { source: 'core/test-source', args: { key: 'hero' } };
+
+		const wrapper = ( { children } ) => (
+			<BlockContextProvider
+				value={ {
+					'test/source-context': 'from-provider',
+					'test/unrelated-context': 'ignored',
+				} }
+			>
+				{ children }
+			</BlockContextProvider>
+		);
+
+		const view = renderHook( () => useInnerBlocksBindingKey( binding ), {
+			wrapper,
+		} );
+		mountedHooks.push( view );
+
+		expect( view.result.current ).toBe(
+			getInnerBlocksBindingKey( binding, {
+				'test/source-context': 'from-provider',
+			} )
+		);
+		// Only the source-declared context enters the key.
+		expect( view.result.current ).not.toContain( 'ignored' );
+	} );
+
+	it( 'useInnerBlocksBindingKey returns undefined for an unregistered source', () => {
+		const view = renderHook( () =>
+			useInnerBlocksBindingKey( {
+				source: 'core/unknown-source',
+				args: {},
+			} )
+		);
+		mountedHooks.push( view );
+
+		expect( view.result.current ).toBeUndefined();
+	} );
+
+	// Releasing control (binding removed, or the source flipping to absence)
+	// must keep the content the container held at the release: the resolver
+	// captures the store children in the layout phase of the release commit
+	// and re-seeds them if the departing sync engine's teardown emptied the
+	// container. These unit tests pin the hook's contract against the store
+	// state; the "integration with useBlockSync" suite exercises the real
+	// engine's teardown ordering.
+	it( 'keeps the bound content when the source flips to absence', () => {
+		// The source reads its value from the binding args so the test can
+		// flip it to absence through a real store update.
+		registerSource( 'core/test-source', {
+			getValues: ( { bindings } ) => ( {
+				innerBlocks: bindings.innerBlocks.args?.stored,
+			} ),
+			setValues: jest.fn(),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { stored: PARAGRAPH_MARKUP },
+				},
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		expect( result.current.value ).toHaveLength( 1 );
+		markContainerControlled( clientId, result.current.value );
+
+		// Flip the source to absence. The harness mounts no sync engine, so
+		// no teardown empties the container; the captured children stay put
+		// and no re-seed is dispatched.
+		act( () => {
+			const metadata =
+				globalSelect( blockEditorStore ).getBlockAttributes(
+					clientId
+				).metadata;
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				metadata: {
+					...metadata,
+					bindings: {
+						...metadata.bindings,
+						innerBlocks: {
+							...metadata.bindings.innerBlocks,
+							args: {},
+						},
+					},
+				},
+			} );
+		} );
+
+		expect( result.current ).toBeUndefined();
+		const restored = globalSelect( blockEditorStore ).getBlocks( clientId );
+		expect( restored ).toHaveLength( 1 );
+		expect( restored[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( restored[ 0 ].attributes.content ).toBe( 'Bound paragraph' );
+	} );
+
+	it( 'keeps the bound content when the binding is deliberately removed', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		expect( result.current.value ).toHaveLength( 1 );
+		markContainerControlled( clientId, result.current.value );
+
+		// Detach: remove the binding from the block's attributes.
+		act( () => {
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				metadata: {},
+			} );
+		} );
+
+		expect( result.current ).toBeUndefined();
+		const restored = globalSelect( blockEditorStore ).getBlocks( clientId );
+		expect( restored ).toHaveLength( 1 );
+		expect( restored[ 0 ].attributes.content ).toBe( 'Bound paragraph' );
+	} );
+
+	// Undo of "add binding": the entity reverts to "no binding + own
+	// children" through a reset that re-takes ownership of the container.
+	// The store-level contract this test mirrors (see `withBlockReset`) is
+	// that such a reset clears the controlled flag and applies the entity's
+	// children; the resolver must leave those children alone rather than
+	// clobber them with the last controlled tree.
+	it( 'leaves entity-restored children alone when the binding is released by an external reset', () => {
+		const setValues = jest.fn();
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues,
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		expect( result.current.value ).toHaveLength( 1 );
+
+		// Mirror the production sync engine: mark controlled and seed the
+		// store with the bound tree.
+		markContainerControlled( clientId, result.current.value );
+
+		// Entity-driven reset (undo): the incoming container carries its own
+		// restored children and no binding, so `withBlockReset` releases the
+		// preserved controller — the flag is dropped and the incoming
+		// children are applied. This is the exact production dispatch; no
+		// manual flag handling.
+		act( () => {
+			dispatch( blockEditorStore ).resetBlocks( [
+				{
+					clientId,
+					name: 'core/test-container',
+					attributes: {},
+					isValid: true,
+					innerBlocks: [
+						createBlock( 'core/paragraph', {
+							content: 'Own child',
+						} ),
+					],
+				},
+			] );
+		} );
+
+		expect( result.current ).toBeUndefined();
+		const children = globalSelect( blockEditorStore ).getBlocks( clientId );
+		expect( children ).toHaveLength( 1 );
+		expect( children[ 0 ].attributes.content ).toBe( 'Own child' );
+		expect( setValues ).not.toHaveBeenCalled();
+	} );
+
+	// Same as above with an empty restored tree: a container that had no
+	// children before the binding was added must stay empty after the undo —
+	// the resolver must not re-seed the bound tree just because the count is
+	// zero.
+	it( 'does not re-seed the bound tree when an external reset restores an empty container', () => {
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+			setValues: jest.fn(),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+		expect( result.current.value ).toHaveLength( 1 );
+		markContainerControlled( clientId, result.current.value );
+
+		// Undo lands on "empty container, no binding". The incoming block is
+		// childless, but removing the binding is itself the release signal
+		// `withBlockReset` honors — the empty container must not be re-seeded
+		// with the bound tree.
+		act( () => {
+			dispatch( blockEditorStore ).resetBlocks( [
+				{
+					clientId,
+					name: 'core/test-container',
+					attributes: {},
+					isValid: true,
+					innerBlocks: [],
+				},
+			] );
+		} );
+
+		expect( result.current ).toBeUndefined();
+		expect(
+			globalSelect( blockEditorStore ).getBlocks( clientId )
+		).toHaveLength( 0 );
+	} );
+
+	// A non-string value fails loudly rather than silently parsing.
+	it( 'surfaces an error and stays uncontrolled for a non-string source value', () => {
+		const consoleError = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		registerSource( 'core/test-source', {
+			getValues: () => ( { innerBlocks: { not: 'a string' } } ),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: { source: 'core/test-source', args: {} },
+			},
+		} );
+
+		const { result } = renderBoundHook( clientId );
+
+		expect( consoleError ).toHaveBeenCalled();
+		expect( result.current ).toBeUndefined();
+		consoleError.mockRestore();
+	} );
+
+	// Undo/redo identity: reverting the source to a previously resolved
+	// string must return the previously resolved array — same identity, same
+	// external clientIds — so the sync engine's selection restoration can map
+	// the recorded caret into the re-cloned subtree.
+	it( 'resolves a reverted source value to the previously resolved blocks (undo/redo identity)', () => {
+		registerSource( 'core/test-source', {
+			getValues: ( { bindings } ) => ( {
+				innerBlocks: bindings.innerBlocks.args?.stored,
+			} ),
+			setValues: jest.fn(),
+		} );
+		const clientId = setupBlock( {
+			bindings: {
+				innerBlocks: {
+					source: 'core/test-source',
+					args: { stored: PARAGRAPH_MARKUP },
+				},
+			},
+		} );
+
+		function storeValue( markup ) {
+			const metadata =
+				globalSelect( blockEditorStore ).getBlockAttributes(
+					clientId
+				).metadata;
+			dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+				metadata: {
+					...metadata,
+					bindings: {
+						...metadata.bindings,
+						innerBlocks: {
+							...metadata.bindings.innerBlocks,
+							args: { stored: markup },
+						},
+					},
+				},
+			} );
+		}
+
+		const { result } = renderBoundHook( clientId );
+		const firstValue = result.current.value;
+		expect( firstValue[ 0 ].attributes.content ).toBe( 'Bound paragraph' );
+
+		act( () => {
+			storeValue(
+				'<!-- wp:paragraph -->\n<p>Changed</p>\n<!-- /wp:paragraph -->'
+			);
+		} );
+		expect( result.current.value ).not.toBe( firstValue );
+
+		// The revert (undo) resolves back to the same array identity.
+		act( () => {
+			storeValue( PARAGRAPH_MARKUP );
+		} );
+		expect( result.current.value ).toBe( firstValue );
+	} );
+
+	// End-to-end behavior with the real controlled sync engine: the parse
+	// cache's identity guarantees are what keep typing from re-cloning the
+	// subtree (echo suppression) and what let the caret be restored after an
+	// undo/redo re-clone.
+	describe( 'integration with useBlockSync', () => {
+		function registerStoredSource() {
+			// Round-trips writes through the container's binding args, so
+			// `getValues` echoes the exact written string on the next read.
+			registerSource( 'core/test-source', {
+				getValues: ( { bindings } ) => ( {
+					innerBlocks: bindings.innerBlocks.args?.stored ?? '',
+				} ),
+				setValues: ( {
+					select,
+					dispatch: sourceDispatch,
+					clientId: id,
+					bindings,
+				} ) => {
+					const metadata =
+						select( blockEditorStore ).getBlockAttributes(
+							id
+						).metadata;
+					sourceDispatch( blockEditorStore ).updateBlockAttributes(
+						id,
+						{
+							metadata: {
+								...metadata,
+								bindings: {
+									...metadata.bindings,
+									innerBlocks: {
+										...metadata.bindings.innerBlocks,
+										args: {
+											stored: bindings.innerBlocks
+												.newValue,
+										},
+									},
+								},
+							},
+						}
+					);
+				},
+			} );
+		}
+
+		function renderBoundSyncedArea( clientId, selectionRef ) {
+			const view = renderHook(
+				() => {
+					const binding = useSelect(
+						( select ) =>
+							getInnerBlocksBinding(
+								select( blockEditorStore ).getBlockAttributes(
+									clientId
+								)
+							),
+						[]
+					);
+					const props = useBoundInnerBlocksProps( clientId, binding );
+					useBlockSync( {
+						clientId,
+						value: props?.value,
+						onChange: props?.onChange,
+						onInput: props?.onInput,
+					} );
+					return props;
+				},
+				{
+					wrapper: ( { children } ) => (
+						<SelectionContext.Provider
+							value={ {
+								getSelection: () => selectionRef.current,
+								onChangeSelection: () => {},
+							} }
+						>
+							{ children }
+						</SelectionContext.Provider>
+					),
+				}
+			);
+			mountedHooks.push( view );
+			return view;
+		}
+
+		it( 'keeps the store subtree intact while typing (write-back echo suppression)', () => {
+			registerStoredSource();
+			const clientId = setupBlock( {
+				bindings: {
+					innerBlocks: {
+						source: 'core/test-source',
+						args: { stored: PARAGRAPH_MARKUP },
+					},
+				},
+			} );
+			const selectionRef = { current: undefined };
+
+			renderBoundSyncedArea( clientId, selectionRef );
+
+			// The sync engine cloned the value into the store.
+			const [ child ] =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( child.name ).toBe( 'core/paragraph' );
+
+			// Type into the cloned child: the subscription reports the change,
+			// the write-back stores it, and the echo resolves to the exact
+			// outgoing array — no reset, no re-clone.
+			act( () => {
+				dispatch( blockEditorStore ).updateBlockAttributes(
+					child.clientId,
+					{ content: 'edited' }
+				);
+			} );
+
+			const childrenAfterEdit =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( childrenAfterEdit ).toHaveLength( 1 );
+			expect( childrenAfterEdit[ 0 ].clientId ).toBe( child.clientId );
+			expect( childrenAfterEdit[ 0 ].attributes.content ).toBe(
+				'edited'
+			);
+		} );
+
+		it( 'restores the caret into the re-cloned subtree when the source reverts (undo)', () => {
+			registerStoredSource();
+			const clientId = setupBlock( {
+				bindings: {
+					innerBlocks: {
+						source: 'core/test-source',
+						args: { stored: PARAGRAPH_MARKUP },
+					},
+				},
+			} );
+			const selectionRef = { current: undefined };
+
+			const { result } = renderBoundSyncedArea( clientId, selectionRef );
+
+			const initialValue = result.current.value;
+			// External (value-side) id of the paragraph; stable across the
+			// edit because the sync engine restores external ids on outgoing
+			// changes.
+			const externalId = initialValue[ 0 ].clientId;
+			const internalBefore =
+				globalSelect( blockEditorStore ).getBlocks( clientId )[ 0 ]
+					.clientId;
+			expect( internalBefore ).not.toBe( externalId );
+
+			// Edit, then record a caret position against the external id, the
+			// way the entity records selection.
+			act( () => {
+				dispatch( blockEditorStore ).updateBlockAttributes(
+					internalBefore,
+					{ content: 'edited' }
+				);
+			} );
+			selectionRef.current = {
+				selectionStart: {
+					clientId: externalId,
+					attributeKey: 'content',
+					offset: 3,
+				},
+				selectionEnd: {
+					clientId: externalId,
+					attributeKey: 'content',
+					offset: 3,
+				},
+			};
+
+			// Revert the source to the original markup (undo). The cached
+			// identity brings back the original external ids, so the freshly
+			// rebuilt id mapping still contains the recorded caret's id.
+			act( () => {
+				const metadata =
+					globalSelect( blockEditorStore ).getBlockAttributes(
+						clientId
+					).metadata;
+				dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+					metadata: {
+						...metadata,
+						bindings: {
+							...metadata.bindings,
+							innerBlocks: {
+								...metadata.bindings.innerBlocks,
+								args: { stored: PARAGRAPH_MARKUP },
+							},
+						},
+					},
+				} );
+			} );
+
+			// The cache returns the identical value array…
+			expect( result.current.value ).toBe( initialValue );
+
+			// …the sync engine still re-clones the store subtree (its
+			// contract for every non-echo incoming value)…
+			const [ childAfterRevert ] =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( childAfterRevert.clientId ).not.toBe( internalBefore );
+			expect( childAfterRevert.attributes.content ).toBe(
+				'Bound paragraph'
+			);
+
+			// …and the caret recorded against the external id is restored
+			// inside the re-cloned subtree.
+			expect(
+				globalSelect( blockEditorStore ).getSelectionStart()
+			).toEqual( {
+				clientId: childAfterRevert.clientId,
+				attributeKey: 'content',
+				offset: 3,
+			} );
+		} );
+
+		// Production-shaped harness: like `BoundInnerBlocks`, the sync engine
+		// lives in a child component that only mounts while the binding
+		// resolves, so releasing the binding unmounts it and runs its real
+		// teardown (clear the controlled flag, empty the container) in the
+		// passive phase of the release commit.
+		function ControlledSync( props ) {
+			useBlockSync( props );
+			return null;
+		}
+
+		function mountProductionBoundArea( clientId ) {
+			const resultRef = { current: undefined };
+			function BoundArea() {
+				const binding = useSelect(
+					( select ) =>
+						getInnerBlocksBinding(
+							select( blockEditorStore ).getBlockAttributes(
+								clientId
+							)
+						),
+					[]
+				);
+				const props = useBoundInnerBlocksProps( clientId, binding );
+				resultRef.current = props;
+				return props ? (
+					<ControlledSync
+						clientId={ clientId }
+						value={ props.value }
+						onChange={ props.onChange }
+						onInput={ props.onInput }
+					/>
+				) : null;
+			}
+			const view = render(
+				<SelectionContext.Provider
+					value={ {
+						getSelection: () => undefined,
+						onChangeSelection: () => {},
+					} }
+				>
+					<BoundArea />
+				</SelectionContext.Provider>
+			);
+			mountedHooks.push( view );
+			return resultRef;
+		}
+
+		// Deliberate detach with the real engine: the unmounting sync
+		// engine's teardown empties the container; the resolver's release
+		// capture re-seeds the blocks the user was looking at.
+		it( 'keeps the bound content when the binding is detached (real teardown)', () => {
+			registerSource( 'core/test-source', {
+				getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+				setValues: jest.fn(),
+			} );
+			const clientId = setupBlock( {
+				bindings: {
+					innerBlocks: { source: 'core/test-source', args: {} },
+				},
+			} );
+
+			const resultRef = mountProductionBoundArea( clientId );
+
+			// The sync engine cloned the bound value into the store and
+			// flagged the container.
+			const [ child ] =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( child.name ).toBe( 'core/paragraph' );
+			expect(
+				globalSelect( blockEditorStore ).areInnerBlocksControlled(
+					clientId
+				)
+			).toBe( true );
+
+			// Detach: remove the binding. The sync engine unmounts and its
+			// teardown wipes the container; the release capture re-seeds it.
+			act( () => {
+				dispatch( blockEditorStore ).updateBlockAttributes( clientId, {
+					metadata: {},
+				} );
+			} );
+
+			expect( resultRef.current ).toBeUndefined();
+			expect(
+				globalSelect( blockEditorStore ).areInnerBlocksControlled(
+					clientId
+				)
+			).toBe( false );
+			const restored =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( restored ).toHaveLength( 1 );
+			expect( restored[ 0 ].attributes.content ).toBe(
+				'Bound paragraph'
+			);
+		} );
+
+		// Entity-driven release with production ordering: a root-controller
+		// reset (marked not persistent, no manual flag handling) removes the
+		// binding. `withBlockReset` releases the preserved controller and
+		// applies the entity's children; the resolver must neither write the
+		// released children back to the source nor clobber them with the
+		// bound tree.
+		it( 'does not write back to the source and keeps content when an external reset releases the binding', () => {
+			const setValues = jest.fn();
+			registerSource( 'core/test-source', {
+				getValues: () => ( { innerBlocks: PARAGRAPH_MARKUP } ),
+				setValues,
+			} );
+			const clientId = setupBlock( {
+				bindings: {
+					innerBlocks: { source: 'core/test-source', args: {} },
+				},
+			} );
+
+			const resultRef = mountProductionBoundArea( clientId );
+			expect(
+				globalSelect( blockEditorStore ).getBlocks( clientId )
+			).toHaveLength( 1 );
+
+			// Undo at the root controller: the entity reverts to "no binding
+			// + own children" — exactly the dispatch `useBlockSync`'s root
+			// branch performs. No manual flag manipulation: production code
+			// never clears the flag before the reset.
+			const container = createBlock( 'core/test-container', {}, [
+				createBlock( 'core/paragraph', { content: 'Own child' } ),
+			] );
+			container.clientId = clientId;
+			act( () => {
+				dispatch(
+					blockEditorStore
+				).__unstableMarkNextChangeAsNotPersistent();
+				dispatch( blockEditorStore ).resetBlocks( [ container ] );
+			} );
+
+			// The binding is released…
+			expect( resultRef.current ).toBeUndefined();
+			// …the source value is never clobbered with the released
+			// children…
+			expect( setValues ).not.toHaveBeenCalled();
+			// …and the container holds the entity's restored children — not
+			// the bound tree, and not the emptiness left by the departing
+			// sync engine's teardown.
+			const children =
+				globalSelect( blockEditorStore ).getBlocks( clientId );
+			expect( children ).toHaveLength( 1 );
+			expect( children[ 0 ].attributes.content ).toBe( 'Own child' );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/inner-blocks/use-bound-inner-blocks.js
+++ b/packages/block-editor/src/components/inner-blocks/use-bound-inner-blocks.js
@@ -1,0 +1,550 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useRegistry } from '@wordpress/data';
+import { parse, serialize, store as blocksStore } from '@wordpress/blocks';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import BlockContext from '../block-context';
+import {
+	getBlockBindingsContext,
+	getInnerBlocksBinding,
+	INNER_BLOCKS_BINDING_KEY,
+} from '../../utils/block-bindings';
+import { unlock } from '../../lock-unlock';
+
+export { getInnerBlocksBinding };
+
+const EMPTY_ARRAY = [];
+const EMPTY_CONTEXT = {};
+const EMPTY_RESOLUTION = { serialized: undefined, isReadOnly: false };
+const INVALID_VALUE = {};
+
+/**
+ * Bounds the per-binding parse cache. The controlled sync engine re-clones
+ * every non-echo incoming value into fresh internal clientIds, so the cache
+ * cannot prevent remounts of the bound subtree; what it preserves is the
+ * identity — and with it the external clientIds — of a previously resolved
+ * value array. That (a) lets a write-back's echo resolve to the exact array
+ * reference the sync engine queued as outgoing, short-circuiting a
+ * reset/re-clone on every keystroke, and (b) makes undo/redo revert to a
+ * value whose external clientIds still key the sync engine's selection
+ * restoration, so the caret is re-placed inside the re-cloned subtree. Past
+ * this size, older values re-parse: content stays correct, but selection
+ * restoration is skipped for that history step.
+ */
+const MAX_PARSE_CACHE_SIZE = 20;
+
+/**
+ * Hard ceiling for nested bound areas. A cycle between two or more sources
+ * whose args change on every level defeats the exact-key recursion check;
+ * the depth cap guarantees termination regardless.
+ */
+const MAX_BOUND_DEPTH = 32;
+
+/**
+ * Inserts a parsed tree into the cache as its newest entry — so a just-written
+ * value can never be the eviction victim before its echo arrives — and evicts
+ * the oldest entries beyond {@link MAX_PARSE_CACHE_SIZE}.
+ *
+ * @param {Object}   parseCache The parse cache record holding the entries Map.
+ * @param {string}   serialized The serialized string keying the entry.
+ * @param {Object[]} blocks     The parsed blocks to cache.
+ */
+function cacheParsedValue( parseCache, serialized, blocks ) {
+	const { entries } = parseCache;
+	entries.delete( serialized );
+	entries.set( serialized, blocks );
+	while ( entries.size > MAX_PARSE_CACHE_SIZE ) {
+		entries.delete( entries.keys().next().value );
+	}
+}
+
+/**
+ * Tracks the chain of guard keys of the bound areas above the current block,
+ * so a source that supplies markup containing a block bound to the same
+ * source (directly or through a cycle) is detected and resolved as absence
+ * instead of recursing without bound.
+ */
+export const boundInnerBlocksAncestry = createContext( EMPTY_ARRAY );
+
+function sortKeys( object ) {
+	const sorted = {};
+	for ( const key of Object.keys( object ).sort() ) {
+		sorted[ key ] = object[ key ];
+	}
+	return sorted;
+}
+
+/**
+ * Returns the recursion-guard key identifying a binding: the source name, its
+ * serialized args, and the resolved values of the context the source declares
+ * it consumes (its `usesContext`). Nested blocks bound to the same source form
+ * a cycle only when all three match — the same source resolving under
+ * different args or different source-used context values is composition, not
+ * recursion. Mirrors the guard-key semantics of the PHP renderer.
+ *
+ * @param {Object|undefined} binding       The inner-blocks binding descriptor.
+ * @param {Object}           sourceContext The subset of the block's context
+ *                                         the source declares it consumes.
+ *
+ * @return {string|undefined} The guard key, or undefined without a binding.
+ */
+export function getInnerBlocksBindingKey(
+	binding,
+	sourceContext = EMPTY_CONTEXT
+) {
+	if ( typeof binding?.source !== 'string' || binding.source === '' ) {
+		return undefined;
+	}
+	return `${ binding.source }|${ JSON.stringify(
+		sortKeys( binding.args ?? {} )
+	) }|${ JSON.stringify( sortKeys( sourceContext ) ) }`;
+}
+
+/**
+ * Returns the subset of the block's resolved context that the binding source
+ * declares it consumes — the context part of the recursion-guard key. A
+ * source without `usesContext` is context-independent by declaration, so its
+ * key carries no context.
+ *
+ * @param {Object|undefined} source       The registered bindings source.
+ * @param {Object}           blockContext The block's resolved context.
+ *
+ * @return {Object} The source-used context subset.
+ */
+function getBindingGuardContext( source, blockContext ) {
+	const guardContext = {};
+	source?.usesContext?.forEach( ( key ) => {
+		if ( blockContext[ key ] !== undefined ) {
+			guardContext[ key ] = blockContext[ key ];
+		}
+	} );
+	return guardContext;
+}
+
+/**
+ * Returns the context-aware recursion-guard key for a block's `innerBlocks`
+ * binding, or `undefined` when the binding is absent or its source is not
+ * registered. Bound containers push this key onto the ancestry consumed by
+ * nested bindings, so it must be derived from the same inputs
+ * {@link useBoundInnerBlocksProps} checks against.
+ *
+ * @param {Object|undefined} binding The inner-blocks binding descriptor.
+ *
+ * @return {string|undefined} The guard key.
+ */
+export function useInnerBlocksBindingKey( binding ) {
+	const blockContext = useContext( BlockContext );
+	const sourceName =
+		typeof binding?.source === 'string' && binding.source !== ''
+			? binding.source
+			: undefined;
+	const source = useSelect(
+		( select ) =>
+			sourceName
+				? unlock( select( blocksStore ) ).getBlockBindingsSource(
+						sourceName
+				  )
+				: undefined,
+		[ sourceName ]
+	);
+
+	return useMemo( () => {
+		if ( ! source ) {
+			return undefined;
+		}
+		return getInnerBlocksBindingKey(
+			binding,
+			getBindingGuardContext( source, blockContext )
+		);
+	}, [ source, binding, blockContext ] );
+}
+
+/**
+ * Resolves controlled inner-block props from an `innerBlocks` binding source.
+ *
+ * Source values use the serialized block-markup contract: `undefined`/`null`
+ * means fallback to the block's own children, `''` means an intentionally empty
+ * area, and any other string is parsed into controlled blocks.
+ *
+ * The hook also owns three lifecycle guarantees of the bound area:
+ *
+ * - **Release keeps content**: when the area stops being controlled (the
+ *   binding was removed, the source flipped to absence, or an undo/redo
+ *   reset released it), the controlled sync engine empties the container on
+ *   teardown; this hook captures whatever children the container holds at
+ *   the release commit — the bound blocks on a deliberate detach, the
+ *   entity's restored children after an undo reset — and re-seeds them if
+ *   the container was emptied, so releasing a binding never destroys
+ *   content and never clobbers an undo.
+ * - **Read-only is enforced**: a source whose `canUserEditValue` returns
+ *   `false` gets its subtree's editing mode set to `disabled` (rendering the
+ *   child wrappers inert), on top of `templateLock`/appender removal.
+ * - **Recursion terminates**: a binding whose (source, args, source-used
+ *   context) already appears in the bound ancestry — or nested beyond
+ *   {@link MAX_BOUND_DEPTH} — is resolved as absence.
+ *
+ * @param {string}           clientId  The block client ID.
+ * @param {Object|undefined} binding   The inner-blocks binding descriptor.
+ * @param {Object}           blockType Optional pre-resolved block type.
+ *
+ * @return {Object|undefined} Controlled inner-block props, or undefined.
+ */
+export function useBoundInnerBlocksProps( clientId, binding, blockType ) {
+	const registry = useRegistry();
+	const blockContext = useContext( BlockContext );
+	const ancestry = useContext( boundInnerBlocksAncestry );
+	// Parsed trees keyed by serialized string, so re-resolving a previously
+	// seen value (echo after write-back, undo/redo) returns the same array
+	// identity — and thus the same external clientIds — instead of freshly
+	// parsed clientIds. See MAX_PARSE_CACHE_SIZE for what that preserves.
+	const parseCacheRef = useRef( {
+		sourceName: undefined,
+		entries: new Map(),
+	} );
+	// The serialized string last applied (from the source or a write-back);
+	// transient writes that re-serialize to it are dropped as echoes.
+	const lastSerializedRef = useRef( undefined );
+	const didWarnRecursionRef = useRef( false );
+
+	const sourceName =
+		typeof binding?.source === 'string' && binding.source !== ''
+			? binding.source
+			: undefined;
+	const args = sourceName ? binding?.args : undefined;
+
+	const source = useSelect(
+		( select ) => {
+			if ( ! sourceName ) {
+				return undefined;
+			}
+
+			return unlock( select( blocksStore ) ).getBlockBindingsSource(
+				sourceName
+			);
+		},
+		[ sourceName ]
+	);
+
+	const guardContext = useMemo(
+		() => getBindingGuardContext( source, blockContext ),
+		[ source, blockContext ]
+	);
+	const recursionKey = source
+		? getInnerBlocksBindingKey( binding, guardContext )
+		: undefined;
+	const isRecursive =
+		!! recursionKey &&
+		( ancestry.includes( recursionKey ) ||
+			ancestry.length >= MAX_BOUND_DEPTH );
+	useEffect( () => {
+		if ( isRecursive && ! didWarnRecursionRef.current ) {
+			didWarnRecursionRef.current = true;
+			// eslint-disable-next-line no-console
+			console.error(
+				`The "innerBlocks" binding source "${ sourceName }" supplies a block bound to itself; the nested binding resolves as absence to prevent infinite recursion.`
+			);
+		}
+	}, [ isRecursive, sourceName ] );
+
+	const resolvedBlockType = useSelect(
+		( select ) => {
+			if ( blockType || ! clientId ) {
+				return blockType;
+			}
+
+			const blockName =
+				select( blockEditorStore ).getBlockName( clientId );
+			return blockName
+				? select( blocksStore ).getBlockType( blockName )
+				: undefined;
+		},
+		[ blockType, clientId ]
+	);
+
+	const context = useMemo(
+		() =>
+			getBlockBindingsContext(
+				blockContext,
+				resolvedBlockType?.usesContext,
+				[ source ]
+			),
+		[ source, blockContext, resolvedBlockType ]
+	);
+
+	const { serialized, isReadOnly } = useSelect(
+		( select ) => {
+			if ( isRecursive || ! source?.getValues ) {
+				return EMPTY_RESOLUTION;
+			}
+
+			const values = source.getValues( {
+				select,
+				context,
+				clientId,
+				bindings: { [ INNER_BLOCKS_BINDING_KEY ]: { args } },
+			} );
+			const rawValue = values?.[ INNER_BLOCKS_BINDING_KEY ];
+			const nextSerialized = rawValue === null ? undefined : rawValue;
+			const serializedValue =
+				nextSerialized !== undefined &&
+				typeof nextSerialized !== 'string'
+					? INVALID_VALUE
+					: nextSerialized;
+
+			return {
+				serialized: serializedValue,
+				isReadOnly:
+					serializedValue !== undefined &&
+					serializedValue !== INVALID_VALUE &&
+					source.canUserEditValue?.( {
+						select,
+						context,
+						args,
+						clientId,
+						attributeName: INNER_BLOCKS_BINDING_KEY,
+					} ) === false,
+			};
+		},
+		[ isRecursive, source, context, clientId, args ]
+	);
+
+	const value = useMemo( () => {
+		if ( serialized === undefined ) {
+			return undefined;
+		}
+
+		if ( serialized === INVALID_VALUE ) {
+			// eslint-disable-next-line no-console
+			console.error(
+				`The "innerBlocks" binding source "${ sourceName }" returned a non-string value. The value must be a serialized block-markup string.`
+			);
+			return undefined;
+		}
+
+		const parseCache = parseCacheRef.current;
+		if ( parseCache.sourceName !== sourceName ) {
+			parseCache.sourceName = sourceName;
+			parseCache.entries.clear();
+		}
+
+		let blocks = parseCache.entries.get( serialized );
+		if ( ! blocks ) {
+			blocks = serialized === '' ? [] : parse( serialized );
+		}
+		cacheParsedValue( parseCache, serialized, blocks );
+
+		lastSerializedRef.current = serialized;
+		return blocks;
+	}, [ serialized, sourceName ] );
+
+	const writeBack = useCallback(
+		( blocks, persistent ) => {
+			if ( isReadOnly ) {
+				return;
+			}
+
+			// An entity-driven reset (undo/redo) can re-take ownership of the
+			// container in the same tick it removes the binding; the still-
+			// subscribed controlled sync engine then reports the restored
+			// children as an outgoing edit before React re-renders. Writing
+			// that back would clobber the source value with the entity's own
+			// children, so a write for a container the sync engine no longer
+			// owns is dropped. While a binding is applied, the sync engine
+			// flags the container before its first subscriber run.
+			if (
+				clientId &&
+				! registry
+					.select( blockEditorStore )
+					.areInnerBlocksControlled( clientId )
+			) {
+				return;
+			}
+
+			if ( ! source?.setValues ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`The "innerBlocks" binding source "${ sourceName }" is editable but does not implement "setValues"; the edit could not be persisted.`
+				);
+				return;
+			}
+
+			const newValue = serialize( blocks );
+			if ( ! persistent && newValue === lastSerializedRef.current ) {
+				return;
+			}
+
+			lastSerializedRef.current = newValue;
+			cacheParsedValue( parseCacheRef.current, newValue, blocks );
+			registry.batch( () => {
+				try {
+					// The non-persistent mark taints whichever action next
+					// reaches the block-editor reducer. A source persisting
+					// outside the block-editor store (e.g. a core-data
+					// entity) never consumes it, so arming it up front would
+					// leak onto the user's next unrelated edit, recording it
+					// as non-persistent. Arm it lazily instead, only when the
+					// source asks to dispatch to the block-editor store.
+					const blockEditorDispatch =
+						registry.dispatch( blockEditorStore );
+					const sourceDispatch = persistent
+						? registry.dispatch
+						: ( storeNameOrDescriptor ) => {
+								const actions = registry.dispatch(
+									storeNameOrDescriptor
+								);
+								if ( actions === blockEditorDispatch ) {
+									blockEditorDispatch.__unstableMarkNextChangeAsNotPersistent();
+								}
+								return actions;
+						  };
+					source.setValues( {
+						select: registry.select,
+						dispatch: sourceDispatch,
+						context,
+						clientId,
+						bindings: {
+							[ INNER_BLOCKS_BINDING_KEY ]: {
+								args,
+								newValue,
+							},
+						},
+					} );
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						`The "innerBlocks" binding source "${ sourceName }" failed to persist the edit.`,
+						error
+					);
+				}
+			} );
+		},
+		[ isReadOnly, source, sourceName, registry, context, clientId, args ]
+	);
+
+	const onChange = useCallback(
+		( blocks ) => writeBack( blocks, true ),
+		[ writeBack ]
+	);
+	const onInput = useCallback(
+		( blocks ) => writeBack( blocks, false ),
+		[ writeBack ]
+	);
+
+	const boundProps = useMemo( () => {
+		if ( ! source || value === undefined ) {
+			return undefined;
+		}
+
+		const props = { value, onChange, onInput };
+		if ( isReadOnly ) {
+			props.templateLock = 'all';
+			props.renderAppender = false;
+		}
+		return props;
+	}, [ source, value, onChange, onInput, isReadOnly ] );
+
+	// Read-only enforcement. `templateLock: 'all'` only removes structural
+	// controls (appender, movers, delete); child content stays editable while
+	// writeBack drops the edit — silent data loss. Setting the editing mode of
+	// every block in the bound subtree to `disabled` renders the child
+	// wrappers inert, so a read-only area cannot be edited at all.
+	const readOnlyClientIds = useSelect(
+		( select ) => {
+			if ( ! isReadOnly || ! clientId ) {
+				return EMPTY_ARRAY;
+			}
+			return select( blockEditorStore ).getClientIdsOfDescendants(
+				clientId
+			);
+		},
+		[ isReadOnly, clientId ]
+	);
+	useEffect( () => {
+		if ( ! readOnlyClientIds.length ) {
+			return;
+		}
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+		registry.batch( () => {
+			readOnlyClientIds.forEach( ( id ) =>
+				setBlockEditingMode( id, 'disabled' )
+			);
+		} );
+		return () => {
+			registry.batch( () => {
+				readOnlyClientIds.forEach( ( id ) =>
+					unsetBlockEditingMode( id )
+				);
+			} );
+		};
+	}, [ readOnlyClientIds, registry ] );
+
+	// Release keeps content. When control is released, the controlled sync
+	// engine's teardown empties the container (its passive cleanup runs
+	// after the layout effects of the release commit, but before this hook's
+	// passive effect). Whatever the container held at the release commit is
+	// what the user must keep seeing:
+	//
+	// - Deliberate detach / source flipped to absence: the store still holds
+	//   the bound blocks, so capturing and re-seeding them turns "release"
+	//   into "keep the content, drop the binding".
+	// - Entity-driven release (an undo/redo reset re-took ownership of the
+	//   container and applied its own children): the capture holds the
+	//   entity's restored children, so if the departing sync engine wipes
+	//   them they are re-seeded; if the store kept them (the container ends
+	//   up non-empty), nothing is dispatched.
+	//
+	// Capturing the store children — instead of the last resolved source
+	// tree — is what makes an undo of "add binding" land on the entity's
+	// restored children rather than on the bound tree.
+	const wasControlledRef = useRef( false );
+	const wasControlledLayoutRef = useRef( false );
+	const releasedBlocksRef = useRef( EMPTY_ARRAY );
+	useLayoutEffect( () => {
+		const isControlled = boundProps !== undefined;
+		if ( wasControlledLayoutRef.current && ! isControlled && clientId ) {
+			// Layout phase of the release commit: the sync engine's teardown
+			// has not run yet, so this reads the pre-teardown children.
+			releasedBlocksRef.current = registry
+				.select( blockEditorStore )
+				.getBlocks( clientId );
+		}
+		wasControlledLayoutRef.current = isControlled;
+	} );
+	useEffect( () => {
+		const isControlled = boundProps !== undefined;
+		if ( wasControlledRef.current && ! isControlled && clientId ) {
+			const restoreBlocks = releasedBlocksRef.current;
+			releasedBlocksRef.current = EMPTY_ARRAY;
+			const { getBlockCount } = registry.select( blockEditorStore );
+			if ( restoreBlocks.length && getBlockCount( clientId ) === 0 ) {
+				const {
+					replaceInnerBlocks,
+					__unstableMarkNextChangeAsNotPersistent,
+				} = registry.dispatch( blockEditorStore );
+				// Not persistent: the restore belongs to the same user action
+				// (the binding removal or the undo) rather than forming its
+				// own undo level.
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceInnerBlocks( clientId, restoreBlocks );
+			}
+		}
+		wasControlledRef.current = isControlled;
+	} );
+
+	return boundProps;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -21,6 +21,7 @@ import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
 import { sectionRootClientIdKey, isIsolatedEditorKey } from './private-keys';
 import { unlock } from '../lock-unlock';
+import { getInnerBlocksBinding } from '../utils/block-bindings';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
 
@@ -587,6 +588,25 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			for ( const clientId of preservedControlledInnerBlocks ) {
 				// Only preserve if the parent block still exists.
 				if ( ! newState.byClientId.has( clientId ) ) {
+					continue;
+				}
+				// A reset that removes a block's `innerBlocks` binding
+				// releases the bound controller: the incoming block has
+				// re-taken ownership of its children (e.g. an undo landing
+				// before the binding was added), so preserving the old
+				// controlled sub-tree would clobber them — and a container
+				// that was empty before the binding must come back empty.
+				// Only the binding's presence in the block's own attributes
+				// signals this hand-back; incoming children alone do not,
+				// because root-level snapshots carry the controlled clones
+				// as children of every controlled container (template parts,
+				// patterns), and those must keep their controllers.
+				if (
+					getInnerBlocksBinding( state.attributes.get( clientId ) ) &&
+					! getInnerBlocksBinding(
+						newState.attributes.get( clientId )
+					)
+				) {
 					continue;
 				}
 				newState.controlledInnerBlocks.add( clientId );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2603,6 +2603,279 @@ describe( 'state', () => {
 					).toEqual( [ 'content-inner' ] );
 				} );
 
+				it( 'should release a bound controlled block across RESET_BLOCKS when the incoming block drops the binding and carries its own children', () => {
+					const boundAttributes = {
+						metadata: {
+							bindings: {
+								innerBlocks: { source: 'core/test-source' },
+							},
+						},
+					};
+					const withControlledContent = blocks(
+						blocks(
+							blocks( undefined, {
+								type: 'RESET_BLOCKS',
+								blocks: [
+									{
+										clientId: 'chicken',
+										name: 'core/test-block',
+										attributes: boundAttributes,
+										innerBlocks: [],
+									},
+								],
+							} ),
+							{
+								type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+								clientId: 'chicken',
+								hasControlledInnerBlocks: true,
+							}
+						),
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'chicken',
+							blocks: [
+								{ clientId: 'content', innerBlocks: [] },
+							],
+						}
+					);
+
+					// Undo of "add binding": the incoming block drops the
+					// binding and carries the entity's restored (nested)
+					// children, which must win over the preserved bound tree.
+					const state = blocks( withControlledContent, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [
+									{
+										clientId: 'own-child',
+										name: 'core/test-block',
+										attributes: {},
+										innerBlocks: [
+											{
+												clientId: 'own-grandchild',
+												name: 'core/test-block',
+												attributes: {},
+												innerBlocks: [],
+											},
+										],
+									},
+								],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.has( 'chicken' ) ).toBe(
+						false
+					);
+					expect(
+						getBlocks( { blocks: state }, 'chicken' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'own-child' ] );
+					expect(
+						getBlocks( { blocks: state }, 'own-child' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'own-grandchild' ] );
+				} );
+
+				it( 'should preserve a non-bound controlled block across RESET_BLOCKS when the incoming block carries snapshot children', () => {
+					const withControlledContent = blocks(
+						blocks(
+							blocks( undefined, {
+								type: 'RESET_BLOCKS',
+								blocks: [
+									{
+										clientId: 'chicken',
+										name: 'core/test-block',
+										attributes: {},
+										innerBlocks: [],
+									},
+								],
+							} ),
+							{
+								type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+								clientId: 'chicken',
+								hasControlledInnerBlocks: true,
+							}
+						),
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'chicken',
+							blocks: [
+								{ clientId: 'content', innerBlocks: [] },
+							],
+						}
+					);
+
+					// Root-level snapshots leak the controlled clones as
+					// children of a controlled container (the tree fix-up
+					// mutates its root-visible entry), so an undo can dispatch
+					// a reset whose incoming container carries those children.
+					// Without a binding hand-back, the entity controller
+					// (template part, pattern) must keep the container.
+					const state = blocks( withControlledContent, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [
+									{
+										clientId: 'content',
+										name: 'core/test-block',
+										attributes: {},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.has( 'chicken' ) ).toBe(
+						true
+					);
+					expect(
+						getBlocks( { blocks: state }, 'chicken' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'content' ] );
+				} );
+
+				it( 'should preserve a controlled block across RESET_BLOCKS when the incoming children are an innerBlocks binding fallback', () => {
+					const boundAttributes = {
+						metadata: {
+							bindings: {
+								innerBlocks: { source: 'core/test-source' },
+							},
+						},
+					};
+					const withControlledContent = blocks(
+						blocks(
+							blocks( undefined, {
+								type: 'RESET_BLOCKS',
+								blocks: [
+									{
+										clientId: 'chicken',
+										name: 'core/test-block',
+										attributes: boundAttributes,
+										innerBlocks: [],
+									},
+								],
+							} ),
+							{
+								type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+								clientId: 'chicken',
+								hasControlledInnerBlocks: true,
+							}
+						),
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'chicken',
+							blocks: [
+								{ clientId: 'content', innerBlocks: [] },
+							],
+						}
+					);
+
+					// The incoming block still declares the binding: its
+					// serialized children are the binding's fallback content,
+					// not an ownership claim.
+					const state = blocks( withControlledContent, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: boundAttributes,
+								innerBlocks: [
+									{
+										clientId: 'fallback-child',
+										name: 'core/test-block',
+										attributes: {},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.has( 'chicken' ) ).toBe(
+						true
+					);
+					expect(
+						getBlocks( { blocks: state }, 'chicken' ).map(
+							( b ) => b.clientId
+						)
+					).toEqual( [ 'content' ] );
+				} );
+
+				it( 'should release a bound controlled block across RESET_BLOCKS when the incoming block drops the binding, even childless', () => {
+					const withControlledContent = blocks(
+						blocks(
+							blocks( undefined, {
+								type: 'RESET_BLOCKS',
+								blocks: [
+									{
+										clientId: 'chicken',
+										name: 'core/test-block',
+										attributes: {
+											metadata: {
+												bindings: {
+													innerBlocks: {
+														source: 'core/test-source',
+													},
+												},
+											},
+										},
+										innerBlocks: [],
+									},
+								],
+							} ),
+							{
+								type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+								clientId: 'chicken',
+								hasControlledInnerBlocks: true,
+							}
+						),
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'chicken',
+							blocks: [
+								{ clientId: 'content', innerBlocks: [] },
+							],
+						}
+					);
+
+					// Undo of "add binding" on a previously empty container:
+					// the incoming block is childless, but dropping the binding
+					// is itself the release — the container must come back
+					// empty, not keep the bound tree.
+					const state = blocks( withControlledContent, {
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'chicken',
+								name: 'core/test-block',
+								attributes: {},
+								innerBlocks: [],
+							},
+						],
+					} );
+
+					expect( state.controlledInnerBlocks.has( 'chicken' ) ).toBe(
+						false
+					);
+					expect(
+						getBlocks( { blocks: state }, 'chicken' )
+					).toHaveLength( 0 );
+				} );
+
 				it( 'should forget controlledInnerBlocks during full RESET_BLOCKS', () => {
 					const templateBlock = {
 						clientId: 'template',

--- a/packages/block-editor/src/utils/block-bindings.ts
+++ b/packages/block-editor/src/utils/block-bindings.ts
@@ -1,8 +1,86 @@
 type Binding = { source?: string };
 type Bindings = Record< string, Binding >;
+type BlockBindingsSource = { usesContext?: readonly string[] };
+type InnerBlocksBinding = {
+	source: string;
+	args?: Record< string, unknown >;
+};
 
 const DEFAULT_ATTRIBUTE = '__default';
 const PATTERN_OVERRIDES_SOURCE = 'core/pattern-overrides';
+
+/**
+ * The reserved `metadata.bindings` key binding a block's inner blocks to a
+ * source, as opposed to binding one of its attributes.
+ */
+export const INNER_BLOCKS_BINDING_KEY = 'innerBlocks';
+const EMPTY_CONTEXT: Record< string, unknown > = {};
+
+/**
+ * Returns the `metadata.bindings.innerBlocks` descriptor held in a block's
+ * attributes, or `undefined` when the block declares no usable binding.
+ *
+ * This predicate is the single gate deciding whether the binding machinery
+ * mounts at all; ordinary inner-block areas pay only this attribute read.
+ *
+ * @param attributes The block attributes.
+ *
+ * @return The inner-blocks binding descriptor.
+ */
+export function getInnerBlocksBinding(
+	attributes: Record< string, any > | undefined
+): InnerBlocksBinding | undefined {
+	const binding =
+		attributes?.metadata?.bindings?.[ INNER_BLOCKS_BINDING_KEY ];
+
+	return typeof binding?.source === 'string' && binding.source !== ''
+		? binding
+		: undefined;
+}
+
+/**
+ * Assembles the context made available to a block's bindings sources: the
+ * entries of the surrounding block context declared by the block type's
+ * `usesContext`, plus the entries declared by the given sources' `usesContext`.
+ *
+ * Only entries present in the surrounding block context are copied — a
+ * declared key with no provider never becomes an own (undefined-valued) key
+ * of the result, so `key in context` checks stay meaningful.
+ *
+ * @param blockContext         The surrounding block context.
+ * @param blockTypeUsesContext The block type's declared context needs.
+ * @param sources              Block-bindings sources whose declared context to add.
+ *
+ * @return The context for resolving the block's bindings.
+ */
+export function getBlockBindingsContext(
+	blockContext: Record< string, unknown >,
+	blockTypeUsesContext: readonly string[] | undefined,
+	sources: readonly ( BlockBindingsSource | undefined )[] | undefined
+): Record< string, unknown > {
+	let context: Record< string, unknown > | undefined;
+	if ( blockTypeUsesContext ) {
+		for ( const [ key, value ] of Object.entries( blockContext ) ) {
+			if ( blockTypeUsesContext.includes( key ) ) {
+				context ??= {};
+				context[ key ] = value;
+			}
+		}
+	}
+	if ( sources ) {
+		for ( const source of sources ) {
+			source?.usesContext?.forEach( ( key ) => {
+				if ( key in blockContext ) {
+					context ??= {};
+					context[ key ] = blockContext[ key ];
+				}
+			} );
+		}
+	}
+	// A stable empty object avoids re-renders for consumers that compare the
+	// context by reference.
+	return context ?? EMPTY_CONTEXT;
+}
 
 /**
  * Checks if the block has the `__default` binding for pattern overrides.

--- a/packages/block-editor/src/utils/test/block-bindings.js
+++ b/packages/block-editor/src/utils/test/block-bindings.js
@@ -1,0 +1,181 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getBlockBindingsContext,
+	hasPatternOverridesDefaultBinding,
+	replacePatternOverridesDefaultBinding,
+} from '../block-bindings';
+
+describe( 'hasPatternOverridesDefaultBinding', () => {
+	it( 'returns true when the `__default` binding targets pattern overrides', () => {
+		expect(
+			hasPatternOverridesDefaultBinding( {
+				__default: { source: 'core/pattern-overrides' },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'returns false when there is no `__default` binding', () => {
+		expect(
+			hasPatternOverridesDefaultBinding( {
+				content: { source: 'core/pattern-overrides' },
+			} )
+		).toBe( false );
+	} );
+
+	it( 'returns false when the `__default` binding targets another source', () => {
+		expect(
+			hasPatternOverridesDefaultBinding( {
+				__default: { source: 'core/post-meta' },
+			} )
+		).toBe( false );
+	} );
+
+	it( 'returns false for undefined bindings', () => {
+		expect( hasPatternOverridesDefaultBinding( undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'replacePatternOverridesDefaultBinding', () => {
+	it( 'expands `__default` to a binding for each supported attribute', () => {
+		const result = replacePatternOverridesDefaultBinding(
+			{ __default: { source: 'core/pattern-overrides' } },
+			[ 'content', 'url', 'alt' ]
+		);
+
+		expect( result ).toEqual( {
+			content: { source: 'core/pattern-overrides' },
+			url: { source: 'core/pattern-overrides' },
+			alt: { source: 'core/pattern-overrides' },
+		} );
+	} );
+
+	it( 'retains explicit non-pattern-override bindings while expanding `__default`', () => {
+		const result = replacePatternOverridesDefaultBinding(
+			{
+				__default: { source: 'core/pattern-overrides' },
+				url: { source: 'core/post-meta', args: { key: 'my_url' } },
+			},
+			[ 'content', 'url' ]
+		);
+
+		expect( result ).toEqual( {
+			content: { source: 'core/pattern-overrides' },
+			url: { source: 'core/post-meta', args: { key: 'my_url' } },
+		} );
+	} );
+
+	it( 'returns the bindings untouched when there is no `__default` pattern-override binding', () => {
+		const bindings = { content: { source: 'core/pattern-overrides' } };
+
+		expect(
+			replacePatternOverridesDefaultBinding( bindings, [ 'content' ] )
+		).toBe( bindings );
+	} );
+
+	// Regression guard: the `__default` expansion only iterates the block
+	// type's supported *attributes*, so it can never synthesize an
+	// `innerBlocks` binding. Existing `__default` pattern-override blocks
+	// must not implicitly gain an inner-block binding.
+	it( 'never synthesizes an `innerBlocks` binding when expanding `__default`', () => {
+		// A realistic set of supported *attribute* names — `innerBlocks` is not
+		// an attribute and is therefore never present here.
+		const supportedAttributes = [ 'content', 'url', 'alt', 'title' ];
+
+		const result = replacePatternOverridesDefaultBinding(
+			{ __default: { source: 'core/pattern-overrides' } },
+			supportedAttributes
+		);
+
+		// Every produced binding key corresponds to a supported attribute…
+		expect( Object.keys( result ) ).toEqual( supportedAttributes );
+		// …and `innerBlocks` is never among them.
+		expect( result ).not.toHaveProperty( 'innerBlocks' );
+	} );
+
+	it( 'does not add an `innerBlocks` binding even when supportedAttributes is empty', () => {
+		const result = replacePatternOverridesDefaultBinding(
+			{ __default: { source: 'core/pattern-overrides' } },
+			[]
+		);
+
+		expect( result ).toEqual( {} );
+		expect( result ).not.toHaveProperty( 'innerBlocks' );
+	} );
+} );
+
+describe( 'getBlockBindingsContext', () => {
+	const blockContext = {
+		postId: 1,
+		postType: 'post',
+		'pattern/overrides': { content: 'x' },
+	};
+
+	it( 'copies the block-type-declared entries present in the block context', () => {
+		expect(
+			getBlockBindingsContext(
+				blockContext,
+				[ 'postId', 'postType' ],
+				undefined
+			)
+		).toEqual( { postId: 1, postType: 'post' } );
+	} );
+
+	it( 'omits block-type-declared keys absent from the block context', () => {
+		const result = getBlockBindingsContext(
+			blockContext,
+			[ 'postId', 'core/missing' ],
+			undefined
+		);
+
+		expect( result ).toEqual( { postId: 1 } );
+		// The declared-but-unprovided key must not become an own
+		// (undefined-valued) key, so `key in context` checks stay meaningful.
+		expect( result ).not.toHaveProperty( 'core/missing' );
+	} );
+
+	it( 'adds source-declared entries present in the block context', () => {
+		expect(
+			getBlockBindingsContext(
+				blockContext,
+				[ 'postId' ],
+				[
+					{ usesContext: [ 'pattern/overrides' ] },
+					{ usesContext: [ 'postType' ] },
+				]
+			)
+		).toEqual( {
+			postId: 1,
+			postType: 'post',
+			'pattern/overrides': { content: 'x' },
+		} );
+	} );
+
+	it( 'omits source-declared keys absent from the block context', () => {
+		const result = getBlockBindingsContext( blockContext, undefined, [
+			{ usesContext: [ 'core/missing' ] },
+		] );
+
+		expect( result ).toEqual( {} );
+		expect( result ).not.toHaveProperty( 'core/missing' );
+	} );
+
+	it( 'ignores unregistered (undefined) sources and sources without usesContext', () => {
+		expect(
+			getBlockBindingsContext( blockContext, undefined, [
+				undefined,
+				{},
+				{ usesContext: [ 'postId' ] },
+			] )
+		).toEqual( { postId: 1 } );
+	} );
+
+	it( 'returns a stable empty object when nothing is declared', () => {
+		const first = getBlockBindingsContext( blockContext, undefined, [] );
+		const second = getBlockBindingsContext( blockContext, [], undefined );
+
+		expect( first ).toEqual( {} );
+		expect( second ).toBe( first );
+	} );
+} );

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Block Bindings: document `innerBlocks` as a reserved binding key in `metadata.bindings`, using serialized block markup through existing source callbacks. ([#79379](https://github.com/WordPress/gutenberg/pull/79379))
+
 ## 15.23.0 (2026-07-01)
 
 ## 15.22.0 (2026-06-24)

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -564,6 +564,28 @@ export interface ParseOptions {
 
 /**
  * An object describing a Block Bindings source.
+ *
+ * In addition to a block's attributes, a source's `getValues`, `setValues`, and
+ * `canUserEditValue` callbacks may operate on a block's **inner blocks** through
+ * the reserved `innerBlocks` key inside the block's `metadata.bindings` map (i.e.
+ * `metadata.bindings.innerBlocks = { source, args? }`). `innerBlocks` is **not**
+ * a block attribute: it is a reserved structural slot, so it never collides with
+ * an attribute of the same name and needs no separate source-registration flag.
+ *
+ * The canonical value for the reserved `innerBlocks` key is a **serialized
+ * block-markup string** — the same format `serialize()` produces and `parse()`
+ * consumes in JavaScript (and `serialize_blocks()`/`parse_blocks()` produce/consume
+ * in PHP) — so the editor and the frontend resolve to equivalent inner blocks for
+ * the same source state. Three states are distinguished:
+ *
+ * - `undefined` (absence): the source supplies nothing; the block falls back to
+ *   its own serialized inner blocks.
+ * - `''` (empty): an intentionally-empty inner-block area (`parse( '' )` → `[]`);
+ *   the serialized fallback is **not** used.
+ * - a serialized block-markup string: parsed into the inner-block tree.
+ *
+ * `undefined`/absence and `''`/empty are deliberately distinct: a source MUST
+ * return `undefined` (not `''`) to request the serialized fallback.
  */
 export interface BlockBindingsSource {
 	/**
@@ -580,14 +602,35 @@ export interface BlockBindingsSource {
 	usesContext?: string[];
 	/**
 	 * Optional function to get the values from the source.
+	 *
+	 * Called with `{ select, context, clientId, bindings }`. The returned object
+	 * is keyed by binding name, mapping each bound attribute name to its resolved
+	 * value. The reserved `innerBlocks` key is handled like any other binding key:
+	 * its value is a **serialized block-markup string** (the same format `parse()`
+	 * consumes), `undefined` for absence (the block falls back to its own
+	 * serialized inner blocks), or `''` for an intentionally-empty area. No
+	 * dedicated inner-block callback exists — inner blocks ride the reserved
+	 * `innerBlocks` key through this same callback.
 	 */
 	getValues?: Function;
 	/**
 	 * Optional function to update multiple values connected to the source.
+	 *
+	 * Called with `{ select, dispatch, context, clientId, bindings }`, where each
+	 * entry of `bindings` is `{ args, newValue }`. The reserved `innerBlocks` key
+	 * is handled like any other binding key: its `newValue` is the **serialized
+	 * block-markup string** of the edited inner-block subtree (the same format
+	 * `serialize()` produces). No dedicated inner-block callback exists — inner
+	 * blocks ride the reserved `innerBlocks` key through this same callback.
 	 */
 	setValues?: Function;
 	/**
 	 * Optional function to determine if the user can edit the value.
+	 *
+	 * Called with `{ select, context, clientId, attributeName }`. When invoked for
+	 * the reserved `innerBlocks` key, `attributeName` is `'innerBlocks'`; returning
+	 * `false` marks the bound inner-block area read-only in the editor (no appender,
+	 * children locked).
 	 */
 	canUserEditValue?: Function;
 	/**

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -82,6 +82,55 @@ function gutenberg_test_block_bindings_registration() {
 		)
 	);
 
+	/*
+	 * Inner-blocks example/test binding sources.
+	 *
+	 * The frontend counterpart of the JS sources registered in
+	 * `block-bindings/index.js`. These resolve the reserved `innerBlocks`
+	 * attribute to a fixed serialized block-markup string (and `null` for any
+	 * other attribute), proving the inner-block binding mechanism on the server
+	 * independently of `core/pattern-overrides`.
+	 *
+	 * They are deliberately CONTEXT-FREE: no `uses_context` is declared and the
+	 * value is resolved purely from the fixture, so resolution is identical
+	 * whether the bound block is top-level (`$parent_block === null`) or nested.
+	 * The fixture string is duplicated verbatim from the JS plugin so the
+	 * editor (`parse()`) and the frontend (`parse_blocks()`) produce the same
+	 * inner blocks for the same source state.
+	 */
+	$inner_blocks_fixture = "<!-- wp:paragraph -->\n<p>Source Paragraph 1</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Source Paragraph 2</p>\n<!-- /wp:paragraph -->";
+
+	$inner_blocks_get_value = function ( $source_args, $block_instance, $attribute_name ) use ( $inner_blocks_fixture ) {
+		if ( 'innerBlocks' === $attribute_name ) {
+			return $inner_blocks_fixture;
+		}
+		return null;
+	};
+
+	register_block_bindings_source(
+		'testing/inner-blocks-source',
+		array(
+			'label'              => 'Inner Blocks Source',
+			'get_value_callback' => $inner_blocks_get_value,
+		)
+	);
+	register_block_bindings_source(
+		'testing/inner-blocks-source-read-only',
+		array(
+			'label'              => 'Inner Blocks Source (Read Only)',
+			'get_value_callback' => $inner_blocks_get_value,
+		)
+	);
+	register_block_bindings_source(
+		'testing/inner-blocks-source-absence',
+		array(
+			'label'              => 'Inner Blocks Source (Absence)',
+			'get_value_callback' => function () {
+				return null;
+			},
+		)
+	);
+
 	// Register "movie" custom post type.
 	register_post_type(
 		'movie',

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -59,3 +59,94 @@ registerBlockBindingsSource( {
 	getValues,
 	canUserEditValue: () => true,
 } );
+
+/**
+ * Inner-blocks example/test binding sources.
+ *
+ * These sources exercise the reserved `innerBlocks` binding key independently of
+ * `core/pattern-overrides`, proving the mechanism end to end (read, write,
+ * read-only, absence). They are deliberately **context-free** — they read no
+ * block/ancestry context and resolve purely from a fixed fixture — so the editor
+ * read (here) and the frontend read (the PHP source registered in
+ * `block-bindings.php`) always match for the same source state regardless of
+ * where the bound block sits in the tree.
+ *
+ * The fixture string below is the canonical serialized block markup the read
+ * sources supply. It is duplicated verbatim in the PHP plugin
+ * (`block-bindings.php`) so the JS/PHP equivalence of the value contract can be
+ * observed: parsing it in the editor (`parse()`) and on the frontend
+ * (`parse_blocks()`) yields the same inner blocks.
+ *
+ * @type {string}
+ */
+const innerBlocksFixture =
+	'<!-- wp:paragraph -->\n<p>Source Paragraph 1</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Source Paragraph 2</p>\n<!-- /wp:paragraph -->';
+
+/**
+ * Resolves the reserved `innerBlocks` key to the fixed fixture string,
+ * demonstrating the read (supply) path for inner-block bindings.
+ *
+ * @param {Object} options          Resolution options provided by the resolver.
+ * @param {Object} options.bindings The bindings payload; the resolver passes the
+ *                                  reserved `innerBlocks` key under it.
+ * @return {Object} A values object carrying `innerBlocks` as a serialized
+ *                   block-markup string when that key is bound.
+ */
+const getInnerBlocksValues = ( { bindings } ) => {
+	const newValues = {};
+	if ( bindings?.innerBlocks ) {
+		newValues.innerBlocks = innerBlocksFixture;
+	}
+	return newValues;
+};
+
+/**
+ * Records the serialized inner blocks received from an edit by storing them in a
+ * post-meta field, demonstrating the write-back path. The e2e suite reads the
+ * field back to assert the source received the edited blocks.
+ *
+ * @param {Object} options          Resolution options provided by the resolver.
+ * @param {Object} options.dispatch The data-registry `dispatch`.
+ * @param {Object} options.context  The block context (carries `postType`/`postId`).
+ * @param {Object} options.bindings The bindings payload, including the reserved
+ *                                  `innerBlocks` key with its serialized `newValue`.
+ */
+const setInnerBlocksValues = ( { dispatch, context, bindings } ) => {
+	const newValue = bindings?.innerBlocks?.newValue;
+	if ( newValue === undefined ) {
+		return;
+	}
+	dispatch( 'core' ).editEntityRecord(
+		'postType',
+		context?.postType,
+		context?.postId,
+		{
+			meta: { text_custom_field: newValue },
+		}
+	);
+};
+
+registerBlockBindingsSource( {
+	name: 'testing/inner-blocks-source',
+	label: 'Inner Blocks Source',
+	usesContext: [ 'postType', 'postId' ],
+	getValues: getInnerBlocksValues,
+	setValues: setInnerBlocksValues,
+	canUserEditValue: () => true,
+} );
+
+registerBlockBindingsSource( {
+	name: 'testing/inner-blocks-source-read-only',
+	label: 'Inner Blocks Source (Read Only)',
+	usesContext: [ 'postType', 'postId' ],
+	getValues: getInnerBlocksValues,
+	setValues: setInnerBlocksValues,
+	canUserEditValue: () => false,
+} );
+
+registerBlockBindingsSource( {
+	name: 'testing/inner-blocks-source-absence',
+	label: 'Inner Blocks Source (Absence)',
+	getValues: () => ( {} ),
+	canUserEditValue: () => true,
+} );

--- a/phpunit/block-bindings-innerblocks-test.php
+++ b/phpunit/block-bindings-innerblocks-test.php
@@ -1,0 +1,1213 @@
+<?php
+/**
+ * Tests for the Block Bindings inner-blocks substitution on `render_block_data`.
+ *
+ * @package gutenberg
+ */
+class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
+
+	const SOURCE_NAME         = 'test/inner-blocks-source';
+	const CONTEXT_SOURCE_NAME = 'test/inner-blocks-context-source';
+
+	/**
+	 * Registers the block types used to host and provide context for bound inner blocks.
+	 */
+	public static function wpSetUpBeforeClass() {
+		/*
+		 * A generic container block whose render callback renders its inner blocks.
+		 * It mirrors a locally-controlled container that can carry an
+		 * `innerBlocks` binding.
+		 */
+		register_block_type(
+			'test/container',
+			array(
+				'render_callback' => static function ( $attributes, $content ) {
+					return '<div class="test-container">' . $content . '</div>';
+				},
+			)
+		);
+
+		/*
+		 * A static container block with NO render callback whose chrome lives in
+		 * its `innerContent` template (its `<div>` wrapper), mirroring blocks like
+		 * `core/group` / `core/list-item`. Used to prove the substitution preserves
+		 * the host's own static markup around the substituted inner blocks rather
+		 * than discarding it.
+		 */
+		register_block_type(
+			'test/static-container',
+			array()
+		);
+
+		/*
+		 * A provider block that mirrors `core/block`: it provides the
+		 * `pattern/overrides` context from its `content` attribute and renders
+		 * its inner blocks. Used to verify that the filter passes inherited
+		 * context to source callbacks.
+		 */
+		register_block_type(
+			'test/provider',
+			array(
+				'attributes'       => array(
+					'content' => array(
+						'type'    => 'object',
+						'default' => array(),
+					),
+				),
+				'provides_context' => array(
+					'pattern/overrides' => 'content',
+				),
+				'render_callback'  => static function ( $attributes, $content ) {
+					return '<div class="test-provider">' . $content . '</div>';
+				},
+			)
+		);
+
+		/*
+		 * A provider block that supplies the `postId` context from an attribute,
+		 * mirroring Query Loop's per-post context. Used to verify the recursion
+		 * guard keys on the context a source declares it consumes.
+		 */
+		register_block_type(
+			'test/post-provider',
+			array(
+				'attributes'       => array(
+					'postId' => array(
+						'type' => 'number',
+					),
+				),
+				'provides_context' => array(
+					'postId' => 'postId',
+				),
+				'render_callback'  => static function ( $attributes, $content ) {
+					return $content;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Cleans up any block bindings sources registered during a test.
+	 */
+	public function tear_down() {
+		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
+			if ( str_starts_with( $source_name, 'test/' ) ) {
+				unregister_block_bindings_source( $source_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Unregisters the shared block types.
+	 */
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/container' );
+		unregister_block_type( 'test/static-container' );
+		unregister_block_type( 'test/provider' );
+		unregister_block_type( 'test/post-provider' );
+	}
+
+	/**
+	 * Registers a context-free inner-blocks source returning the given value.
+	 *
+	 * @param mixed $source_value The value the source returns for the `innerBlocks` attribute.
+	 */
+	private function register_inner_blocks_source( $source_value ) {
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => 'Inner blocks test source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $source_value ) {
+					if ( 'innerBlocks' === $attribute_name ) {
+						return $source_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Builds a `test/container` block bound to the inner-blocks source.
+	 *
+	 * @param string $fallback_inner The serialized fallback inner blocks markup.
+	 * @return array The parsed block.
+	 */
+	private function bound_container_parsed_block( $fallback_inner = '<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' ) {
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			$fallback_inner .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		return $parsed[0];
+	}
+
+	/**
+	 * A source-supplied serialized string is parsed and rendered, replacing the
+	 * block's own serialized fallback children.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_string_value_substitutes_and_renders_inner_blocks() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The source-supplied inner block should be rendered.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children must not be rendered when a value is supplied.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Substituted child' ),
+			'The substituted child must be rendered exactly once (no double-render).'
+		);
+	}
+
+	/**
+	 * A `null` value is treated as absence; the block's own serialized children
+	 * render as a fallback.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_null_value_renders_serialized_fallback() {
+		$this->register_inner_blocks_source( null );
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children should render when the source returns null.'
+		);
+	}
+
+	/**
+	 * An empty string is treated as an intentionally-empty area; no inner blocks
+	 * render and the serialized fallback is not used.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_empty_string_renders_empty_area() {
+		$this->register_inner_blocks_source( '' );
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'An empty string value must not render the serialized fallback children.'
+		);
+		$this->assertSame(
+			'<div class="test-container"></div>',
+			trim( $result ),
+			'An empty string value should render an empty inner-blocks area.'
+		);
+	}
+
+	/**
+	 * A substituted inner block that itself carries a binding resolves
+	 * recursively when Core re-renders the rebuilt inner blocks.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_substituted_inner_block_with_binding_resolves_recursively() {
+		// Source for the inner paragraph's `content` attribute.
+		register_block_bindings_source(
+			'test/recursive-content',
+			array(
+				'label'              => 'Recursive content source',
+				'get_value_callback' => static function () {
+					return 'Recursive value';
+				},
+			)
+		);
+
+		// The outer container's inner-blocks source returns a paragraph that is
+		// itself bound to the recursive content source.
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/recursive-content"}}}} --><p>placeholder</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Recursive value',
+			$result,
+			'A binding on a substituted inner block should resolve recursively.'
+		);
+		$this->assertStringNotContainsString(
+			'placeholder',
+			$result,
+			'The substituted inner block binding should replace its placeholder content.'
+		);
+	}
+
+	/**
+	 * A bound block that is the direct child of a context provider resolves its
+	 * override value via inherited context and renders the overridden inner blocks
+	 * instead of the fallback.
+	 *
+	 * This proves the filter surfaces `pattern/overrides` from inherited
+	 * available context, not from `$parent_block->context`.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_nested_context_dependent_source_resolves_override() {
+		$block_name        = 'Overridable Group';
+		$override_markup   = '<!-- wp:paragraph --><p>Overridden child</p><!-- /wp:paragraph -->';
+		$attributes_seen   = array();
+		$context_value_set = array(
+			$block_name => array(
+				'innerBlocks' => $override_markup,
+			),
+		);
+
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( &$attributes_seen ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					// Record that metadata.name was populated on the transient instance.
+					$attributes_seen['metadata_name'] = $block_instance->attributes['metadata']['name'] ?? null;
+
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					if ( null === $metadata_name ) {
+						return null;
+					}
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		// The bound container sits directly inside the provider block.
+		$inner_container = '<!-- wp:test/container {"metadata":{"name":"' . $block_name . '","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Group fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+
+		$provider_markup = '<!-- wp:test/provider ' . wp_json_encode( array( 'content' => $context_value_set ) ) . ' -->' .
+			$inner_container .
+			'<!-- /wp:test/provider -->';
+
+		$parsed = parse_blocks( $provider_markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Overridden child',
+			$result,
+			'The override value must resolve and render on the frontend via inherited context.'
+		);
+		$this->assertStringNotContainsString(
+			'Group fallback',
+			$result,
+			'The bound container fallback must not render when the override resolves.'
+		);
+		$this->assertSame(
+			$block_name,
+			$attributes_seen['metadata_name'],
+			'The transient block instance must expose metadata.name to the source.'
+		);
+	}
+
+	/**
+	 * A context-dependent source must still resolve when the provider is above
+	 * an intermediate block that neither uses nor provides that context.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_context_dependent_source_resolves_through_intermediate_block() {
+		$block_name      = 'Nested Overridable Group';
+		$override_markup = '<!-- wp:paragraph --><p>Deep overridden child</p><!-- /wp:paragraph -->';
+
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		$bound_container = '<!-- wp:test/container {"metadata":{"name":"' . $block_name . '","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Deep fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+
+		$wrapper_markup = '<!-- wp:test/container -->' .
+			$bound_container .
+			'<!-- /wp:test/container -->';
+
+		$provider_markup = '<!-- wp:test/provider ' . wp_json_encode(
+			array(
+				'content' => array(
+					$block_name => array(
+						'innerBlocks' => $override_markup,
+					),
+				),
+			)
+		) . ' -->' .
+			$wrapper_markup .
+			'<!-- /wp:test/provider -->';
+
+		$parsed = parse_blocks( $provider_markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Deep overridden child',
+			$result,
+			'The source should receive inherited context through the intermediate block.'
+		);
+		$this->assertStringNotContainsString(
+			'Deep fallback',
+			$result,
+			'The fallback must not render when the inherited context resolves.'
+		);
+	}
+
+	/**
+	 * Top-level (`$parent_block === null`), args-only source: substitution works
+	 * with no fatal when the bound block is rendered directly.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_free_source_substitutes() {
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => 'Args-only inner blocks source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' === $attribute_name && isset( $source_args['markup'] ) ) {
+						return $source_args['markup'];
+					}
+					return null;
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '","args":{"markup":"<!-- wp:paragraph --><p>Top level child</p><!-- /wp:paragraph -->"}}}}} --><!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Top level child',
+			$result,
+			'An args-only source should resolve at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The fallback must not render when an args-only source resolves at the top level.'
+		);
+	}
+
+	/**
+	 * Top-level (`$parent_block === null`), context-dependent source: returns
+	 * `null` because no ancestry context is available, the filter falls through to
+	 * the serialized fallback, and no PHP error/warning is raised (no null
+	 * dereference of `$parent_block`).
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_dependent_source_falls_back_without_error() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					if ( null === $metadata_name ) {
+						return null;
+					}
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"name":"Top Level Group","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		// Promote PHP errors/warnings/notices to exceptions for this render.
+		$caught        = null;
+		$error_handler = static function ( $errno, $errstr ) use ( &$caught ) {
+			$caught = $errstr;
+			return true;
+		};
+		set_error_handler( $error_handler );
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNull(
+			$caught,
+			'Rendering a top-level context-dependent bound block must not raise a PHP error/warning.'
+		);
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'A context-dependent source that cannot resolve at the top level must fall back to the serialized children.'
+		);
+	}
+
+	/**
+	 * Builds a `test/static-container` block bound to the inner-blocks source.
+	 *
+	 * The host has NO render callback; its `<div>` wrapper lives in the
+	 * `innerContent` template, so its rendered chrome comes from the host's own
+	 * static chunks rather than from a callback.
+	 *
+	 * @param string $fallback_inner The serialized fallback inner blocks markup.
+	 * @return array The parsed block.
+	 */
+	private function bound_static_container_parsed_block( $fallback_inner = '<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' ) {
+		$markup = '<!-- wp:test/static-container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<div class="static-wrapper">' . $fallback_inner . '</div>' .
+			'<!-- /wp:test/static-container -->';
+		$parsed = parse_blocks( $markup );
+		return $parsed[0];
+	}
+
+	/**
+	 * A static host whose wrapper lives in `innerContent` keeps that wrapper
+	 * around the substituted children instead of discarding it.
+	 *
+	 * @covers ::gutenberg_block_bindings_rebuild_inner_content
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_preserves_wrapper_around_substituted_children() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'<div class="static-wrapper">',
+			$result,
+			'The host block static wrapper must be preserved around the substituted children.'
+		);
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The source-supplied inner block should be rendered.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children must not be rendered when a value is supplied.'
+		);
+		// The substituted child must sit INSIDE the preserved wrapper.
+		$this->assertMatchesRegularExpression(
+			'#<div class="static-wrapper">.*Substituted child.*</div>#s',
+			trim( $result ),
+			'The substituted child must render inside the host wrapper, not replace it.'
+		);
+	}
+
+	/**
+	 * A static host with no fallback children still keeps source-supplied
+	 * children inside its closed wrapper.
+	 *
+	 * @covers ::gutenberg_block_bindings_rebuild_inner_content
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_without_fallback_children_inserts_substituted_children_inside_wrapper() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_static_container_parsed_block( '' );
+		$result = render_block( $parsed );
+
+		$this->assertMatchesRegularExpression(
+			'#^<div class="static-wrapper"><p[^>]*>Substituted child</p></div>$#',
+			trim( $result ),
+			'The substituted child must render inside the closed host wrapper.'
+		);
+	}
+
+	/**
+	 * A static host with more substituted children than the original keeps a
+	 * single surrounding wrapper with one `null` slot per new child.
+	 *
+	 * @covers ::gutenberg_block_bindings_rebuild_inner_content
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_wrapper_preserved_when_child_count_changes() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>First</p><!-- /wp:paragraph -->' .
+			'<!-- wp:paragraph --><p>Second</p><!-- /wp:paragraph -->' .
+			'<!-- wp:paragraph --><p>Third</p><!-- /wp:paragraph -->'
+		);
+
+		// Original host has a single child; the source supplies three.
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertSame(
+			1,
+			substr_count( $result, '<div class="static-wrapper">' ),
+			'The host opening wrapper chunk must appear exactly once.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, '</div>' ),
+			'The host closing wrapper chunk must appear exactly once.'
+		);
+		foreach ( array( 'First', 'Second', 'Third' ) as $child ) {
+			$this->assertStringContainsString(
+				$child,
+				$result,
+				"The substituted child '$child' should render inside the wrapper."
+			);
+		}
+		$this->assertMatchesRegularExpression(
+			'#<div class="static-wrapper">.*First.*Second.*Third.*</div>#s',
+			trim( $result ),
+			'All substituted children must render inside the single preserved wrapper, in order.'
+		);
+	}
+
+	/**
+	 * An empty-string source on a static host keeps the host's wrapper but
+	 * renders no children inside it.
+	 *
+	 * @covers ::gutenberg_block_bindings_rebuild_inner_content
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_empty_string_keeps_empty_wrapper() {
+		$this->register_inner_blocks_source( '' );
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertSame(
+			'<div class="static-wrapper"></div>',
+			trim( $result ),
+			'An empty string value should keep the host wrapper and render it empty.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'An empty string value must not render the serialized fallback children.'
+		);
+	}
+
+	/**
+	 * Absence (`null`) on a static host leaves the parsed block untouched, so the
+	 * host's own serialized children render inside the wrapper.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_null_value_renders_serialized_fallback() {
+		$this->register_inner_blocks_source( null );
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'<div class="static-wrapper">',
+			$result,
+			'The host wrapper should still render on the fallback path.'
+		);
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children should render when the source returns null.'
+		);
+	}
+
+	/**
+	 * Unit-level coverage of the `innerContent` rebuild rule, including the
+	 * edge cases (no placeholder, empty template, zero new blocks).
+	 *
+	 * @covers ::gutenberg_block_bindings_rebuild_inner_content
+	 *
+	 * @dataProvider data_rebuild_inner_content
+	 *
+	 * @param array $original  The original `innerContent` template.
+	 * @param int   $count     The number of new inner blocks.
+	 * @param array $expected  The expected rebuilt template.
+	 * @param string $message  Assertion message.
+	 */
+	public function test_rebuild_inner_content_rule( $original, $count, $expected, $message ) {
+		$this->assertSame(
+			$expected,
+			gutenberg_block_bindings_rebuild_inner_content( $original, $count ),
+			$message
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_rebuild_inner_content_rule}.
+	 *
+	 * @return array[] Cases of [ original, new count, expected, message ].
+	 */
+	public function data_rebuild_inner_content() {
+		return array(
+			'group wrapper, fewer/equal children' => array(
+				array( '<div>', null, null, '</div>' ),
+				1,
+				array( '<div>', null, '</div>' ),
+				'Leading/trailing chunks preserved; one null per new block.',
+			),
+			'group wrapper, more children'        => array(
+				array( '<div>', null, '</div>' ),
+				3,
+				array( '<div>', null, null, null, '</div>' ),
+				'More new blocks than original placeholders emit one null each between the wrapper chunks.',
+			),
+			'list-item wrapper, single child'     => array(
+				array( '<li>Hello', null, '</li>' ),
+				2,
+				array( '<li>Hello', null, null, '</li>' ),
+				'The list-item wrapper chunks are preserved around the new placeholders.',
+			),
+			'zero new blocks keeps only chrome'   => array(
+				array( '<div>', null, '</div>' ),
+				0,
+				array( '<div>', '</div>' ),
+				'Zero new blocks keep only the host static chunks (empty wrapper).',
+			),
+			'closed wrapper inserts new slots'    => array(
+				array( '<div></div>' ),
+				2,
+				array( '<div>', null, null, '</div>' ),
+				'A closed wrapper with no null placeholder inserts new slots before the final closing tag.',
+			),
+			'closing chunk inserts new slots'     => array(
+				array( '<div>', '</div>' ),
+				2,
+				array( '<div>', null, null, '</div>' ),
+				'A separate closing chunk with no null placeholder receives new slots before the closing tag.',
+			),
+			'no closing tag appends new slots'    => array(
+				array( '<div>' ),
+				2,
+				array( '<div>', null, null ),
+				'A template with no null placeholder and no closing tag appends the new slots after the static chunks.',
+			),
+			'empty template falls back to nulls'  => array(
+				array(),
+				2,
+				array( null, null ),
+				'An empty template falls back to one null per new block.',
+			),
+			'empty template, zero new blocks'     => array(
+				array(),
+				0,
+				array(),
+				'An empty template with zero new blocks stays empty.',
+			),
+		);
+	}
+
+	/**
+	 * A context-blind source supplying markup that contains another block bound
+	 * to the same source and args must not recurse: the nested binding is
+	 * skipped and the nested block's own serialized children render instead.
+	 *
+	 * @covers ::gutenberg_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage gutenberg_block_bindings_resolve_inner_blocks
+	 */
+	public function test_self_referential_source_does_not_recurse() {
+		// The source's value embeds another container bound to the same source.
+		$this->register_inner_blocks_source(
+			'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Cycle fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->'
+		);
+
+		$result = render_block( $this->bound_container_parsed_block() );
+
+		// The outer substitution ran (the fallback did not render at the top),
+		// and the nested, cyclic binding fell back to its own children exactly
+		// once — rendering terminated instead of recursing.
+		$this->assertStringContainsString(
+			'Cycle fallback',
+			$result,
+			'The nested cyclic binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Cycle fallback' ),
+			'The cyclic binding must render exactly once.'
+		);
+		$this->assertSame(
+			2,
+			substr_count( $result, '<div class="test-container">' ),
+			'Exactly two nested containers must render: the bound host and the one substituted level.'
+		);
+	}
+
+	/**
+	 * The recursion guard is scoped to the currently-rendering ancestry:
+	 * sequential (sibling) areas bound to the same source both substitute.
+	 *
+	 * @covers ::gutenberg_block_bindings_resolve_inner_blocks
+	 */
+	public function test_sequential_bound_areas_are_not_affected_by_the_recursion_guard() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$first  = render_block( $this->bound_container_parsed_block() );
+		$second = render_block( $this->bound_container_parsed_block() );
+
+		$this->assertStringContainsString( 'Substituted', $first, 'The first bound area must substitute.' );
+		$this->assertStringContainsString(
+			'Substituted',
+			$second,
+			'A subsequent bound area using the same source must substitute: the guard ancestry must not outlive the first render.'
+		);
+	}
+
+	/**
+	 * Top-level context parity with core: context supplied through the standard
+	 * `render_block_context` filter (widgets, templates, plugins) reaches the
+	 * source callback, matching what core's render_block() would provide.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_resolves_through_render_block_context_filter() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'test/filtered-context' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$value = $block_instance->context['test/filtered-context'] ?? null;
+					if ( null === $value ) {
+						return null;
+					}
+					return '<!-- wp:paragraph --><p>' . $value . '</p><!-- /wp:paragraph -->';
+				},
+			)
+		);
+
+		$add_context = static function ( $context ) {
+			$context['test/filtered-context'] = 'From the filter';
+			return $context;
+		};
+		add_filter( 'render_block_context', $add_context );
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			remove_filter( 'render_block_context', $add_context );
+		}
+
+		$this->assertStringContainsString(
+			'From the filter',
+			$result,
+			'Context supplied via the render_block_context filter must reach the source at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The substituted children must replace the serialized fallback.'
+		);
+	}
+
+	/**
+	 * The recursion guard keys on the context the source declares it consumes:
+	 * a `postId`-dependent source legitimately nests the same binding under
+	 * providers supplying different `postId` values (a Query Loop rendering
+	 * other posts) and must not be flagged as a cycle.
+	 *
+	 * @covers ::gutenberg_block_bindings_get_binding_guard_key
+	 * @covers ::gutenberg_block_bindings_resolve_inner_blocks
+	 */
+	public function test_context_dependent_source_nested_across_posts_is_not_flagged_as_cycle() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Post-dependent inner blocks source',
+				'uses_context'       => array( 'postId' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+
+					$post_id = $block_instance->context['postId'] ?? 0;
+					if ( $post_id >= 3 ) {
+						// Terminate the descent with an intentionally-empty area.
+						return '';
+					}
+
+					$next_id = $post_id + 1;
+					return '<!-- wp:paragraph --><p>Level ' . $next_id . '</p><!-- /wp:paragraph -->' .
+						'<!-- wp:test/post-provider {"postId":' . $next_id . '} -->' .
+						'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+						'<!-- wp:paragraph --><p>Guard fallback</p><!-- /wp:paragraph -->' .
+						'<!-- /wp:test/container -->' .
+						'<!-- /wp:test/post-provider -->';
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Guard fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		foreach ( array( 'Level 1', 'Level 2', 'Level 3' ) as $level ) {
+			$this->assertStringContainsString(
+				$level,
+				$result,
+				"The nested binding for '$level' must substitute: same source and args under a different postId is not a cycle."
+			);
+		}
+		$this->assertStringNotContainsString(
+			'Guard fallback',
+			$result,
+			'No level of the nested bindings may be skipped by the recursion guard.'
+		);
+	}
+
+	/**
+	 * The ancestry travels through intermediate blocks that neither use nor
+	 * provide context: a grandchild bound with an identical guard key is
+	 * skipped even when a plain container sits in between.
+	 *
+	 * @covers ::gutenberg_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage gutenberg_block_bindings_resolve_inner_blocks
+	 */
+	public function test_cycle_through_intermediate_block_is_detected() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:test/container -->' .
+			'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Intermediate cycle fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->' .
+			'<!-- /wp:test/container -->'
+		);
+
+		$result = render_block( $this->bound_container_parsed_block() );
+
+		$this->assertStringContainsString(
+			'Intermediate cycle fallback',
+			$result,
+			'The grandchild cyclic binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Intermediate cycle fallback' ),
+			'The grandchild cyclic binding must render exactly once.'
+		);
+	}
+
+	/**
+	 * A `render_block_data` filter at a later priority that returns a freshly
+	 * built parsed-block array (a documented, common plugin pattern) must not
+	 * leak guard state: every subsequent area bound to the same source and args
+	 * still substitutes.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 * @covers ::gutenberg_block_bindings_close_bound_block
+	 */
+	public function test_parsed_block_rebuilt_by_later_filter_does_not_leak_guard_state() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$rebuild = static function ( $parsed_block ) {
+			return array_intersect_key(
+				$parsed_block,
+				array_flip( array( 'blockName', 'attrs', 'innerBlocks', 'innerContent', 'innerHTML' ) )
+			);
+		};
+		add_filter( 'render_block_data', $rebuild, 11 );
+
+		try {
+			// More renders than the depth cap proves neither the guard ancestry
+			// nor the depth counter accumulates across sequential renders.
+			for ( $i = 0; $i < 40; $i++ ) {
+				$result = render_block( $this->bound_container_parsed_block() );
+				$this->assertStringContainsString(
+					'Substituted',
+					$result,
+					"Bound area $i must substitute even when a later filter rebuilds the parsed block."
+				);
+			}
+		} finally {
+			remove_filter( 'render_block_data', $rebuild, 11 );
+		}
+	}
+
+	/**
+	 * The `render_block_context` filter runs exactly once for a top-level bound
+	 * block, and the context it injects is visible to the source's resolution.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_render_block_context_filter_runs_once_for_top_level_bound_block() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'test/filtered-context' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$value = $block_instance->context['test/filtered-context'] ?? null;
+					if ( null === $value ) {
+						return null;
+					}
+					return '<!-- wp:paragraph --><p>' . $value . '</p><!-- /wp:paragraph -->';
+				},
+			)
+		);
+
+		$invocations = 0;
+		$spy         = static function ( $context, $parsed_block ) use ( &$invocations ) {
+			if ( 'context-once-top' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$invocations;
+				$context['test/filtered-context'] = 'Injected by the spy';
+			}
+			return $context;
+		};
+		add_filter( 'render_block_context', $spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"context-once-top","metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_context', $spy, 10 );
+		}
+
+		$this->assertSame(
+			1,
+			$invocations,
+			'The render_block_context filter must run exactly once for a top-level bound block.'
+		);
+		$this->assertStringContainsString(
+			'Injected by the spy',
+			$result,
+			'Context injected by the render_block_context filter must be visible to the source at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The substituted children must replace the serialized fallback.'
+		);
+	}
+
+	/**
+	 * The `render_block_context` filter runs exactly once for a bound block
+	 * nested inside another block: core's own inner-loop application, with zero
+	 * added by the substitution.
+	 *
+	 * @covers ::gutenberg_block_bindings_replace_inner_blocks
+	 */
+	public function test_render_block_context_filter_runs_once_for_nested_bound_block() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$invocations = 0;
+		$spy         = static function ( $context, $parsed_block ) use ( &$invocations ) {
+			if ( 'context-once-nested' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$invocations;
+			}
+			return $context;
+		};
+		add_filter( 'render_block_context', $spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container -->' .
+			'<!-- wp:test/container {"testMarker":"context-once-nested","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_context', $spy, 10 );
+		}
+
+		$this->assertSame(
+			1,
+			$invocations,
+			'The render_block_context filter must run exactly once for a nested bound block.'
+		);
+		$this->assertStringContainsString(
+			'Substituted',
+			$result,
+			'The nested bound block must substitute.'
+		);
+	}
+
+	/**
+	 * The top-level takeover preserves the filter contract of render_block():
+	 * `render_block_data` and `render_block` each fire exactly once for the
+	 * bound block.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_takeover_runs_data_and_render_filters_once() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$data_calls   = 0;
+		$render_calls = 0;
+		$data_spy     = static function ( $parsed_block ) use ( &$data_calls ) {
+			if ( 'takeover-fidelity' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$data_calls;
+			}
+			return $parsed_block;
+		};
+		$render_spy   = static function ( $block_content, $parsed_block ) use ( &$render_calls ) {
+			if ( 'takeover-fidelity' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$render_calls;
+			}
+			return $block_content;
+		};
+		add_filter( 'render_block_data', $data_spy, 5 );
+		add_filter( 'render_block', $render_spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"takeover-fidelity","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_data', $data_spy, 5 );
+			remove_filter( 'render_block', $render_spy, 10 );
+		}
+
+		$this->assertSame( 1, $data_calls, 'render_block_data must fire exactly once for a top-level bound block.' );
+		$this->assertSame( 1, $render_calls, 'render_block must fire exactly once for a top-level bound block.' );
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The top-level bound block must substitute.'
+		);
+	}
+
+	/**
+	 * A `pre_render_block` callback registered before the takeover that returns
+	 * a non-null value wins: the takeover passes it through untouched and no
+	 * substitution occurs.
+	 *
+	 * @covers ::gutenberg_block_bindings_render_top_level_bound_block
+	 */
+	public function test_earlier_pre_render_block_filter_wins_over_takeover() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$short_circuit = static function ( $pre_render, $parsed_block ) {
+			if ( 'takeover-short-circuit' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				return '<p>Short-circuited</p>';
+			}
+			return $pre_render;
+		};
+		add_filter( 'pre_render_block', $short_circuit, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"takeover-short-circuit","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			remove_filter( 'pre_render_block', $short_circuit, 10 );
+		}
+
+		$this->assertSame(
+			'<p>Short-circuited</p>',
+			$result,
+			'An earlier pre_render_block callback returning a value must win over the takeover.'
+		);
+		$this->assertStringNotContainsString(
+			'Substituted child',
+			$result,
+			'No substitution may occur when render_block() is short-circuited by another callback.'
+		);
+	}
+
+	/**
+	 * A cycle crossing a context boundary (`do_blocks()` inside a dynamic
+	 * block's render callback, like a template part) cannot be caught by the
+	 * context-carried ancestry; the global depth backstop must terminate it.
+	 *
+	 * @covers ::gutenberg_block_bindings_bound_render_depth
+	 * @covers ::gutenberg_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage gutenberg_block_bindings_resolve_inner_blocks
+	 */
+	public function test_depth_backstop_terminates_cycle_crossing_do_blocks() {
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Backstop fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		register_block_type(
+			'test/do-blocks-renderer',
+			array(
+				'render_callback' => static function () use ( $markup ) {
+					return do_blocks( $markup );
+				},
+			)
+		);
+
+		$this->register_inner_blocks_source( '<!-- wp:test/do-blocks-renderer /-->' );
+
+		$parsed = parse_blocks( $markup );
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			unregister_block_type( 'test/do-blocks-renderer' );
+		}
+
+		$this->assertStringContainsString(
+			'Backstop fallback',
+			$result,
+			'The capped binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Backstop fallback' ),
+			'Rendering must terminate at the depth cap: the fallback renders exactly once.'
+		);
+	}
+}

--- a/phpunit/block-bindings-list-item-test.php
+++ b/phpunit/block-bindings-list-item-test.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Tests for the `core/list-item` block bindings shim reconciliation.
+ *
+ * The legacy `gutenberg_restore_list_item_inner_blocks_after_binding` shim
+ * (WordPress 7.1 compat) restores a List Item's nested inner blocks after a
+ * `content` binding replaces the whole `<li>`. With the inner-blocks binding
+ * feature (WordPress 7.1 compat), a List Item can also bind its `innerBlocks`,
+ * in which case the new `render_block_data` substitution is authoritative for
+ * the inner blocks. These tests verify the two mechanisms are reconciled:
+ *
+ * - A List Item with both a bound `content` attribute and bound `innerBlocks`
+ *   renders its inner blocks exactly once: on cores that preserve inner blocks
+ *   while applying the content binding the shim's `str_contains` check skips
+ *   the re-append, and on WP 6.9/7.0 — where the content binding wipes the
+ *   whole `<li>` inner HTML — the shim restores the substituted children.
+ * - A List Item with only a bound `content` attribute behaves as before: the
+ *   legacy shim still restores its inner blocks.
+ *
+ * @package gutenberg
+ */
+class Tests_Block_Bindings_List_Item extends WP_UnitTestCase {
+
+	const CONTENT_SOURCE_NAME      = 'test/list-item-content';
+	const INNER_BLOCKS_SOURCE_NAME = 'test/list-item-inner-blocks';
+
+	/**
+	 * Cleans up any block bindings sources registered during a test.
+	 */
+	public function tear_down() {
+		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
+			if ( str_starts_with( $source_name, 'test/' ) ) {
+				unregister_block_bindings_source( $source_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a source supplying a List Item's `content` rich text.
+	 *
+	 * @param string $content_value The value returned for the `content` attribute.
+	 */
+	private function register_content_source( $content_value ) {
+		register_block_bindings_source(
+			self::CONTENT_SOURCE_NAME,
+			array(
+				'label'              => 'List item content source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $content_value ) {
+					if ( 'content' === $attribute_name ) {
+						return $content_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Registers a source supplying a List Item's serialized inner blocks.
+	 *
+	 * @param mixed $inner_blocks_value The value returned for the `innerBlocks` attribute.
+	 */
+	private function register_inner_blocks_source( $inner_blocks_value ) {
+		register_block_bindings_source(
+			self::INNER_BLOCKS_SOURCE_NAME,
+			array(
+				'label'              => 'List item inner blocks source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $inner_blocks_value ) {
+					if ( 'innerBlocks' === $attribute_name ) {
+						return $inner_blocks_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * A List Item with both a bound `content` attribute and bound `innerBlocks`
+	 * renders its inner blocks exactly once.
+	 *
+	 * The new substitution supplies and renders the source inner blocks; on
+	 * cores that preserve them while applying the content binding, the shim's
+	 * `str_contains` check must skip the re-append (no double-render).
+	 *
+	 * @covers ::gutenberg_restore_list_item_inner_blocks_after_binding
+	 */
+	public function test_content_and_inner_blocks_binding_renders_inner_blocks_once() {
+		$this->register_content_source( 'Bound item text' );
+		$this->register_inner_blocks_source(
+			'<!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>Substituted nested item</li><!-- /wp:list-item --></ul><!-- /wp:list -->'
+		);
+
+		$markup = '<!-- wp:list-item {"metadata":{"bindings":{"content":{"source":"' . self::CONTENT_SOURCE_NAME . '"},"innerBlocks":{"source":"' . self::INNER_BLOCKS_SOURCE_NAME . '"}}}} -->' .
+			'<li>Original text<!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>Original nested item</li><!-- /wp:list-item --></ul><!-- /wp:list --></li>' .
+			'<!-- /wp:list-item -->';
+
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		// The `content` binding is authoritative for the `<li>` rich text.
+		$this->assertStringContainsString(
+			'Bound item text',
+			$result,
+			'The content binding should supply the list item rich text.'
+		);
+
+		// The `innerBlocks` binding is authoritative for the inner blocks.
+		$this->assertStringContainsString(
+			'Substituted nested item',
+			$result,
+			'The innerBlocks binding should supply the nested list.'
+		);
+		$this->assertStringNotContainsString(
+			'Original nested item',
+			$result,
+			'The original serialized inner blocks must not render when innerBlocks is bound.'
+		);
+
+		// The nested list must render exactly once (no double-render).
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Substituted nested item' ),
+			'The bound inner blocks must render exactly once (no double-render).'
+		);
+	}
+
+	/**
+	 * On WP 6.9/7.0, applying the content binding wipes the whole `<li>` inner
+	 * HTML — including inner blocks substituted by the `innerBlocks` binding.
+	 * The shim must restore them exactly as it restores a block's own children.
+	 *
+	 * This calls the shim directly with block content that no longer contains
+	 * the inner blocks' rendered HTML (the wiped state those cores produce).
+	 * An early-return keyed on the mere presence of an `innerBlocks` binding
+	 * would silently drop the substituted children on the very versions the
+	 * shim exists for; the `str_contains` check alone already prevents a
+	 * double-append on fixed cores.
+	 *
+	 * @covers ::gutenberg_restore_list_item_inner_blocks_after_binding
+	 */
+	public function test_shim_restores_substituted_inner_blocks_when_content_binding_wiped_them() {
+		$parsed_block = array(
+			'blockName' => 'core/list-item',
+			'attrs'     => array(
+				'metadata' => array(
+					'bindings' => array(
+						'content'     => array( 'source' => self::CONTENT_SOURCE_NAME ),
+						'innerBlocks' => array( 'source' => self::INNER_BLOCKS_SOURCE_NAME ),
+					),
+				),
+			),
+		);
+
+		// A real instance whose inner blocks render to markup not present in the
+		// supplied `$block_content`, so the `str_contains` guard would not fire.
+		$instance = new WP_Block(
+			array(
+				'blockName'    => 'core/list-item',
+				'attrs'        => $parsed_block['attrs'],
+				'innerBlocks'  => array(
+					array(
+						'blockName'    => 'core/list',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<ul class="wp-block-list"></ul>',
+						'innerContent' => array( '<ul class="wp-block-list">', '</ul>' ),
+					),
+				),
+				'innerHTML'    => '<li></li>',
+				'innerContent' => array( '<li>', null, '</li>' ),
+			)
+		);
+
+		$block_content = '<li>Bound item text</li>';
+
+		$result = gutenberg_restore_list_item_inner_blocks_after_binding(
+			$block_content,
+			$parsed_block,
+			$instance
+		);
+
+		$this->assertStringContainsString(
+			'<ul class="wp-block-list"></ul>',
+			$result,
+			'The shim must restore the substituted inner blocks when the content binding wiped them.'
+		);
+		$this->assertStringEndsWith(
+			'</li>',
+			$result,
+			'The restored inner blocks must be re-appended inside the closing </li>.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, '<ul class="wp-block-list"></ul>' ),
+			'The restored inner blocks must render exactly once.'
+		);
+	}
+
+	/**
+	 * A List Item with only a bound `content` attribute behaves as before. The
+	 * legacy shim still restores the nested inner blocks dropped when the content
+	 * binding replaces the `<li>`.
+	 *
+	 * @covers ::gutenberg_restore_list_item_inner_blocks_after_binding
+	 */
+	public function test_content_only_binding_restores_inner_blocks_unchanged() {
+		$this->register_content_source( 'Bound item text' );
+
+		$markup = '<!-- wp:list-item {"metadata":{"bindings":{"content":{"source":"' . self::CONTENT_SOURCE_NAME . '"}}}} -->' .
+			'<li>Original text<!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>Nested item</li><!-- /wp:list-item --></ul><!-- /wp:list --></li>' .
+			'<!-- /wp:list-item -->';
+
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		// The content binding supplies the rich text.
+		$this->assertStringContainsString(
+			'Bound item text',
+			$result,
+			'The content binding should supply the list item rich text.'
+		);
+
+		// The shim restores the nested list dropped when the content binding
+		// replaced the `<li>`, and it renders exactly once.
+		$this->assertStringContainsString(
+			'Nested item',
+			$result,
+			'The legacy shim should restore the nested inner blocks for a content-only binding.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Nested item' ),
+			'The restored inner blocks must render exactly once.'
+		);
+	}
+}

--- a/test/e2e/specs/editor/various/block-bindings/inner-blocks.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/inner-blocks.spec.js
@@ -1,0 +1,290 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Builds the attributes for a `core/group` whose inner blocks are bound to the
+ * given source. A `backgroundColor` is set so the group renders as a designed
+ * container rather than the empty-group variation picker placeholder (the
+ * placeholder gates on the group's own — here, source-controlled — children),
+ * which models the real authoring scenario: a locked design with a freeform,
+ * source-supplied inner-block area.
+ *
+ * @param {string} source The binding source name to bind `innerBlocks` to.
+ * @return {Object} The `core/group` block attributes.
+ */
+function boundGroupAttributes( source ) {
+	return {
+		backgroundColor: 'vivid-cyan-blue',
+		metadata: {
+			bindings: {
+				innerBlocks: { source },
+			},
+		},
+	};
+}
+
+test.describe( 'Block bindings: innerBlocks', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'gutenberg-test-block-bindings' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost( { title: 'Test innerBlocks bindings' } );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
+	} );
+
+	test( 'editable source: read path supplies inner blocks in editor and frontend', async ( {
+		editor,
+		page,
+	} ) => {
+		// Bind a core/group's inner blocks to the editable example source. The
+		// source supplies two paragraphs, which must replace the group's own
+		// empty children in the editor.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: boundGroupAttributes( 'testing/inner-blocks-source' ),
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const paragraphs = groupBlock.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+
+		// The source-supplied inner blocks appear in the editor.
+		await expect( paragraphs.nth( 0 ) ).toHaveText( 'Source Paragraph 1' );
+		await expect( paragraphs.nth( 1 ) ).toHaveText( 'Source Paragraph 2' );
+
+		// The same read path renders on the frontend.
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		await expect(
+			page.locator( '.entry-content .wp-block-group p' )
+		).toContainText( [ 'Source Paragraph 1', 'Source Paragraph 2' ] );
+	} );
+
+	test( 'editable source: edits to the bound area are received by the source (write-back)', async ( {
+		editor,
+		page,
+	} ) => {
+		// Editing the bound inner blocks serializes the edited subtree and
+		// hands it to the source's setValues, which records it in the
+		// `text_custom_field` post meta. Reading the meta back proves the
+		// source received the edited blocks.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: boundGroupAttributes( 'testing/inner-blocks-source' ),
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const firstParagraph = groupBlock
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+
+		await expect( firstParagraph ).toHaveText( 'Source Paragraph 1' );
+
+		// Edit the first supplied paragraph.
+		await editor.selectBlocks( firstParagraph );
+		await firstParagraph.selectText();
+		await page.keyboard.type( 'Edited Paragraph 1' );
+
+		await expect( firstParagraph ).toHaveText( 'Edited Paragraph 1' );
+
+		// The source stores received serialized blocks in `text_custom_field`.
+		await expect
+			.poll( async () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core' )
+							.getEditedEntityRecord(
+								'postType',
+								window.wp.data
+									.select( 'core/editor' )
+									.getCurrentPostType(),
+								window.wp.data
+									.select( 'core/editor' )
+									.getCurrentPostId()
+							)?.meta?.text_custom_field
+				)
+			)
+			.toContain( 'Edited Paragraph 1' );
+	} );
+
+	test( 'read-only source: the bound area has no appender and children cannot be selected, moved, or removed', async ( {
+		editor,
+		page,
+	} ) => {
+		// A source whose canUserEditValue is false locks the bound area: no
+		// appender, and the children's editing mode is disabled — they cannot
+		// even be selected, so no child toolbar (movers, delete) is reachable.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: boundGroupAttributes(
+				'testing/inner-blocks-source-read-only'
+			),
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const firstParagraph = groupBlock
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+
+		// The supplied inner blocks still render (read path works).
+		await expect( firstParagraph ).toHaveText( 'Source Paragraph 1' );
+
+		// No appender is rendered inside the locked area.
+		await expect(
+			groupBlock.getByRole( 'button', { name: 'Add block' } )
+		).toBeHidden();
+
+		// Clicking over a locked child selects the bound container itself —
+		// the child is inert, so selection (and with it the child's toolbar,
+		// movers, and delete) is unreachable.
+		await groupBlock.click();
+		await expect
+			.poll( () =>
+				page.evaluate( () => {
+					const { select } = window.wp.data;
+					const clientId =
+						select(
+							'core/block-editor'
+						).getSelectedBlockClientId();
+					return (
+						clientId &&
+						select( 'core/block-editor' ).getBlockName( clientId )
+					);
+				} )
+			)
+			.toBe( 'core/group' );
+	} );
+
+	test( 'read-only source: children cannot be typed into (no silent data loss)', async ( {
+		editor,
+		page,
+	} ) => {
+		// The read-only lock must prevent content edits, not only structural
+		// changes: an edit that rendered in the canvas but was dropped by the
+		// suppressed write-back would silently vanish on reload. The bound
+		// subtree's editing mode is disabled (the child wrappers are inert),
+		// so typing must not change the content at all.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: boundGroupAttributes(
+				'testing/inner-blocks-source-read-only'
+			),
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const firstParagraph = groupBlock
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+
+		await expect( firstParagraph ).toHaveText( 'Source Paragraph 1' );
+
+		// The bound subtree's wrappers are inert, so pointer interaction
+		// cannot reach the content at all.
+		await expect( firstParagraph ).toHaveAttribute( 'inert', 'true' );
+
+		// A selection-driven typing attempt cannot edit the content either.
+		await editor.selectBlocks( firstParagraph );
+		await page.keyboard.type( 'INJECTED' );
+
+		await expect( firstParagraph ).toHaveText( 'Source Paragraph 1' );
+	} );
+
+	test( 'detach: removing the binding keeps the current inner blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		// Removing the binding releases control of the area. The block must
+		// keep the tree the user was looking at (like detaching a pattern),
+		// not be emptied by the controlled-sync teardown.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: boundGroupAttributes( 'testing/inner-blocks-source' ),
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const paragraphs = groupBlock.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+
+		await expect( paragraphs.nth( 0 ) ).toHaveText( 'Source Paragraph 1' );
+
+		// Remove the innerBlocks binding, keeping other metadata intact.
+		await page.evaluate( () => {
+			const { select, dispatch } = window.wp.data;
+			const [ group ] = select( 'core/block-editor' ).getBlocks();
+			dispatch( 'core/block-editor' ).updateBlockAttributes(
+				group.clientId,
+				{ metadata: {} }
+			);
+		} );
+
+		// The source-supplied children survive the detach.
+		await expect( paragraphs.nth( 0 ) ).toHaveText( 'Source Paragraph 1' );
+		await expect( paragraphs.nth( 1 ) ).toHaveText( 'Source Paragraph 2' );
+
+		// And the area is now an ordinary editable one: edits stay local.
+		await editor.selectBlocks( paragraphs.nth( 0 ) );
+		await paragraphs.nth( 0 ).selectText();
+		await page.keyboard.type( 'Detached edit' );
+		await expect( paragraphs.nth( 0 ) ).toHaveText( 'Detached edit' );
+	} );
+
+	test( 'absence: a source supplying no value falls back to the block own serialized children', async ( {
+		editor,
+	} ) => {
+		// The absence source returns no `innerBlocks` value, so the bound group
+		// stays uncontrolled and renders its own serialized children.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				metadata: {
+					bindings: {
+						innerBlocks: {
+							source: 'testing/inner-blocks-source-absence',
+						},
+					},
+				},
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Own fallback paragraph' },
+				},
+			],
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const paragraph = groupBlock.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+
+		// The block own serialized child renders, not the source fixture.
+		await expect( paragraph ).toHaveText( 'Own fallback paragraph' );
+		await expect( paragraph ).toHaveCount( 1 );
+	} );
+} );


### PR DESCRIPTION
> [!WARNING]
> **🚧 Do not review yet — work in progress.** This needs more input, more testing, and more knowledge-gathering before it is ready. I will mark it ready and request review when it is.

## What?

Extends the Block Bindings mechanism so a registered binding source can supply and receive a block's **inner blocks** (its child block tree), not just scalar attributes.

Part of #61225. **This PR is the generic, source-agnostic mechanism only** — the first real consumer (`core/pattern-overrides`) and the user-facing documentation are intentionally **not** included here (see "Scope" below).

A block declares the binding with a reserved `innerBlocks` key inside `metadata.bindings`, on the container that owns the inner blocks:

```html
<!-- wp:group {"metadata":{"bindings":{"innerBlocks":{"source":"my/source"}}}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```

The value contract is a single **serialized block-markup string**, parsed at each runtime boundary (`parse()` in JS, `parse_blocks()` in PHP):

| Source returns | Result |
| --- | --- |
| `undefined` (JS) / `null` (PHP) | Absence → fall back to the block's own serialized children |
| `''` | Intentionally-empty area (no fallback) |
| a serialized string | Parsed into the controlled inner-block tree |

No new source callbacks are introduced — the reserved key flows through the existing `getValues` / `setValues` / `canUserEditValue` (JS, with `canUserEditValue` receiving the binding's `args`) and `get_value_callback` (PHP, read-only) API.

## Why?

Block Bindings could only bind scalar attributes. Many use cases need a source to own a block's child tree. This adds that capability generically, decoupled from any particular consumer.

## How?

- **Generic injection seam** in `useInnerBlocksProps` (`useBoundInnerBlocksProps`): makes any locally-controlled container controlled when it declares the binding, reusing the existing controlled-inner-blocks engine (`useBlockSync`).
- **Undo/redo + write-back**: edits write back through the source as one coherent undo level, and undo/redo of those edits works — the resolver skips a transient write that merely echoes the source's current value, and a bounded parse cache replays previously seen values with the **same block identities**, so stepping through history does not remount the subtree or drop selection.
- **Read-only enforcement**: a source whose `canUserEditValue` returns `false` locks the area structurally (`templateLock: 'all'`, no appender) **and disables the editing mode of the bound subtree** (the child wrappers render inert). Content in a read-only area cannot be edited at all — an edit that rendered but was dropped by the suppressed write-back would be silent data loss.
- **Release restores content**: removing the binding (detach), or a source flipping to absence, re-seeds the container with the last controlled tree instead of leaving it emptied by the controlled-sync teardown — releasing a binding keeps what the user was looking at.
- **Recursion guards in both runtimes**: a source supplying a block bound to itself (directly or through a cycle of sources) resolves as absence instead of recursing — a bound-ancestry context plus a hard depth cap in the editor; on the server, a render stack keyed by `(source, args)` pushed on `render_block_data` and released on `render_block`, plus `_doing_it_wrong`.
- **Server-side substitution** on `render_block_data` (WP 7.1 compat): replaces a bound block's inner blocks and rebuilds its `innerContent` template around the host's own static chunks, so the source tree renders in place with nested bindings resolved recursively. Top-level context mirrors core's `render_block()` setup, **including the `render_block_context` filter**.
- **`core/list-item` reconciliation**: when a list item declares both a `content` and an `innerBlocks` binding, the shim's existing containment check prevents a double render on fixed cores; on WP 6.9/7.0 — where applying the content binding wipes the whole `<li>` inner HTML — the shim restores the substituted children exactly as it restores a block's own.
- An **example/test binding source** (in the e2e plugins) exercises read / write / read-only / absence without depending on any consumer.

## Scope — what is deliberately NOT here

- **`core/pattern-overrides` consumer** (editable freeform area in a synced pattern) and its synced-pattern editing carve-outs. It depends on a **per-instance override storage model still under design**: today it would serialize the edited subtree as a markup string into the placed `core/block`'s `content` attribute, which inflates (~2–4× via attribute escaping), duplicates per instance, and re-serializes the whole subtree per commit. That storage question is being worked separately before the consumer ships.
- **User-facing documentation** — added at release time, not here.
- **Known perf follow-up**: transient input (`onInput`) currently serializes the full bound subtree per change to support echo suppression; on very large areas this could add typing latency. Tracked as a follow-up, entangled with the transient-write contract.

## Testing Instructions

1. Register a binding source returning serialized markup for the reserved `innerBlocks` key (or use the e2e example source in `packages/e2e-tests/plugins/block-bindings/`).
2. Add a container declaring `metadata.bindings.innerBlocks`. Confirm the source-supplied children render in the editor and on the frontend, edits write back, undo/redo of those edits preserves selection, a read-only source locks the area (no appender, children inert — typing does nothing), removing the binding keeps the current children, and absence falls back to the block's own children.

Automated coverage:

- **JS unit** (`use-bound-inner-blocks`): value contract, write-back/echo/undo guards, `canUserEditValue` args, read-only subtree editing-mode enforcement, recursion-guard ancestry (including same-source-different-args composition), release-restores-content.
- **PHP unit** (`phpunit/block-bindings-innerblocks-test.php`, `block-bindings-list-item-test.php`): substitution, absence, empty area, static-chunk preservation, nested/recursive resolution, context inheritance (including via `render_block_context`), recursion-guard termination and sequential-area release, list-item reconciliation including the WP 6.9/7.0 wiped-content restoration.
- **e2e** (`block-bindings/inner-blocks.spec.js`): editor+frontend read path, write-back, read-only (structure locked, children not selectable, typing produces no change), detach keeps content, absence fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
