### PR TITLE
Verse block: add background gradient support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -1138,7 +1138,7 @@ Insert poetry. Use special spacing formats. Or quote song lyrics.
 
 -	**Name:** [core/verse](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-verse/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
+-	**Supports:** anchor, background (backgroundImage, backgroundSize, gradient), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
 -	**Attributes:** content
 
 ## Video

--- a/packages/block-library/src/verse/README.md
+++ b/packages/block-library/src/verse/README.md
@@ -25,6 +25,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):
   - `backgroundImage`: `true`
   - `backgroundSize`: `true`
+  - `gradient`: `true`
 - [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
   - [`gradients`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-gradients): `true`
   - [`link`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-link): `true`

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -21,8 +21,10 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
-				"backgroundImage": true
+				"backgroundImage": true,
+				"gradient": true
 			}
 		},
 		"color": {

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -289,6 +289,36 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that Verse combines background gradient and image styles.
+	 *
+	 * @covers ::gutenberg_render_background_support
+	 */
+	public function test_verse_background_gradient_and_image_are_combined() {
+		$apos = $this->get_apostrophe_entity();
+
+		$block = array(
+			'blockName' => 'core/verse',
+			'attrs'     => array(
+				'style' => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'https://example.com/image.jpg',
+						),
+						'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_background_support( '<pre class="wp-block-verse">Verse</pre>', $block );
+
+		$this->assertSame(
+			'<pre style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;" class="wp-block-verse has-background">Verse</pre>',
+			$actual
+		);
+	}
+
+	/**
 	 * Tests that combined background gradient and image CSS values pass KSES.
 	 *
 	 * WordPress's safecss_filter_attr() handles gradient and url() values

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -313,7 +313,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 		$actual = gutenberg_render_background_support( '<pre class="wp-block-verse">Verse</pre>', $block );
 
 		$this->assertSame(
-			'<pre style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;" class="wp-block-verse has-background">Verse</pre>',
+			'<pre class="wp-block-verse has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover">Verse</pre>',
 			$actual
 		);
 	}

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -312,10 +312,12 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 
 		$actual = gutenberg_render_background_support( '<pre class="wp-block-verse">Verse</pre>', $block );
 
-		$this->assertSame(
-			'<pre class="wp-block-verse has-background" style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover">Verse</pre>',
+		$this->assertStringContainsString( 'class="wp-block-verse has-background"', $actual );
+		$this->assertStringContainsString(
+			'style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;"',
 			$actual
 		);
+		$this->assertStringNotContainsString( 'background:linear-gradient', $actual );
 	}
 
 	/**

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -289,38 +289,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that Verse combines background gradient and image styles.
-	 *
-	 * @covers ::gutenberg_render_background_support
-	 */
-	public function test_verse_background_gradient_and_image_are_combined() {
-		$apos = $this->get_apostrophe_entity();
-
-		$block = array(
-			'blockName' => 'core/verse',
-			'attrs'     => array(
-				'style' => array(
-					'background' => array(
-						'backgroundImage' => array(
-							'url' => 'https://example.com/image.jpg',
-						),
-						'gradient'        => 'linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%)',
-					),
-				),
-			),
-		);
-
-		$actual = gutenberg_render_background_support( '<pre class="wp-block-verse">Verse</pre>', $block );
-
-		$this->assertStringContainsString( 'class="wp-block-verse has-background"', $actual );
-		$this->assertStringContainsString(
-			'style="background-image:linear-gradient(135deg,rgb(255,0,0) 0%,rgb(0,0,255) 100%), url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;"',
-			$actual
-		);
-		$this->assertStringNotContainsString( 'background:linear-gradient', $actual );
-	}
-
-	/**
 	 * Tests that combined background gradient and image CSS values pass KSES.
 	 *
 	 * WordPress's safecss_filter_attr() handles gradient and url() values


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75859

Adds `background.gradient` support to the Verse block so background gradients are handled by the background support path when used with background images.

This also updates the generated block docs and adds a PHP regression test for `core/verse` rendering a combined gradient and image background.

## Why?

The Verse block supported background images through `supports.background.backgroundImage`, but gradients were still only declared through legacy `supports.color.gradients`. That meant the gradient was serialized as `background: ...` while the image was serialized as `background-image: ...`, causing the image declaration to override the gradient.

With `supports.background.gradient` enabled, the editor migrates/writes the gradient to `style.background.gradient`, and the background support code can emit a single combined declaration:

```css
background-image: linear-gradient(...), url(...);
```

## Testing Instructions

1. Upload your favourite image.
2. Open the post editor and insert a Verse block.
3. Select the Verse block and open the block Styles panel.
4. In Background, set a gradient.
5. In Background, set a background image using your favourite image.
6. Save the post.
7. View the post on the frontend.
8. Inspect the Verse block markup in the browser dev tools.
9. Confirm the Verse block has one combined `background-image` declaration containing both the gradient and image, for example:
   ```css
   background-image: linear-gradient(...), url(...);
   ```
10. Confirm the Verse block does not output the old conflicting pair:
   ```css
   background: linear-gradient(...);
   background-image: url(...);
   ```
11. As a comparison check, repeat the same gradient plus image setup on a Group block and confirm Verse now behaves the same way.

For regressions:

1. Open a post containing existing Verse blocks that were created before this change, including blocks with no background styles and, if available, blocks with existing color/gradient styles.
2. Confirm those existing Verse blocks still render correctly in the editor and frontend, with no validation errors and no visual regression.

| Before | After |
|--------|--------|
| <img width="1284" height="703" alt="Screenshot 2026-06-22 at 4 27 53 pm" src="https://github.com/user-attachments/assets/18553688-cd2a-4253-8136-059283f4eb76" /> | <img width="1295" height="698" alt="Screenshot 2026-06-22 at 4 31 21 pm" src="https://github.com/user-attachments/assets/9d4a8ae5-2562-4ccd-bf3b-f4eded18c258" /> | 




