### PR TITLE
Ignore markdown linting for backport-changelog MD files

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
+backport-changelog
 bin
 build
 node_modules


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The `md` files in `backport-changelog`  don't follow the rules defined in the gutenberg project's markdownlint.json.

Some contributors may find that if their code editor has built-in markdown formatting, when trying to save a `backport-changelog` file, the editor formats the file unexpectedly. The automated CI tools in the project then reject the formatted file.

To attempt to fix this, I'm adding `backport-changelog` to the `.markdownlintignore` file.

Unfortunately it won't solve the issue for all contributors and their editors (like me) because they might be using `markdownlint-cli2` in their editor, which DOESN'T support `.markdownlintignore`, but DOES support `markdownlint.json`. (https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli)

It seems the world of markdown linting is fractured and broken.

Maybe it'll help some people though, and it seems like the right thing to do. 🤷 

## Use of AI Tools
Some analysis from codex (I personally wasn't aware of the presence of a `.markdownlintignore` file, or any markdown linting at all).
