### PR TITLE
Fields: Move author fields for templates and template parts

### DIFF
--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -1,16 +1,9 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useState, useMemo, useId } from '@wordpress/element';
+import { useMemo, useId } from '@wordpress/element';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Icon } from '@wordpress/icons';
 import { parse } from '@wordpress/blocks';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
@@ -22,7 +15,6 @@ import {
 	PATTERN_SYNC_TYPES,
 	OPERATOR_IS,
 } from '../../utils/constants';
-import { useAddedBy } from '../page-templates/hooks';
 import { unlock } from '../../lock-unlock';
 
 const { useStyle } = unlock( editorPrivateApis );
@@ -116,43 +108,4 @@ export const patternStatusField = {
 		isPrimary: true,
 	},
 	enableSorting: false,
-};
-
-function AuthorField( { item } ) {
-	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
-	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
-
-	return (
-		<HStack alignment="left" spacing={ 0 }>
-			{ imageUrl && (
-				<div
-					className={ clsx( 'fields-controls__author-avatar', {
-						'is-loaded': isImageLoaded,
-					} ) }
-				>
-					<img
-						onLoad={ () => setIsImageLoaded( true ) }
-						alt=""
-						src={ imageUrl }
-					/>
-				</div>
-			) }
-			{ ! imageUrl && (
-				<div className="fields-controls__author-icon">
-					<Icon icon={ icon } />
-				</div>
-			) }
-			<span className="fields-controls__author-name">{ text }</span>
-		</HStack>
-	);
-}
-
-export const templatePartAuthorField = {
-	label: __( 'Author' ),
-	id: 'author',
-	getValue: ( { item } ) => item.author_text,
-	render: AuthorField,
-	filterBy: {
-		isPrimary: true,
-	},
 };

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useView, useViewConfig } from '@wordpress/views';
@@ -26,15 +26,12 @@ import { unlock } from '../../lock-unlock';
 import usePatterns, { useAugmentPatternsWithPermissions } from './use-patterns';
 import PatternsActions from './actions';
 import { useEditPostAction } from '../dataviews-actions';
-import {
-	patternStatusField,
-	previewField,
-	templatePartAuthorField,
-} from './fields';
+import { patternStatusField, previewField } from './fields';
 import usePatternCategories from '../sidebar-navigation-screen-patterns/use-pattern-categories';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
-const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
+const { usePostActions, usePostFields, patternTitleField } =
+	unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
@@ -107,38 +104,27 @@ export default function DataviewsPatterns() {
 		syncStatus: viewSyncStatus,
 	} );
 
-	const { records } = useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
-		per_page: -1,
+	const templatePartFields = usePostFields( {
+		postType: TEMPLATE_PART_POST_TYPE,
 	} );
-
-	const authors = useMemo( () => {
-		if ( ! records ) {
-			return EMPTY_ARRAY;
-		}
-		const authorsSet = new Set();
-		records.forEach( ( template ) => {
-			authorsSet.add( template.author_text );
-		} );
-		return Array.from( authorsSet ).map( ( author ) => ( {
-			value: author,
-			label: author,
-		} ) );
-	}, [ records ] );
+	const templatePartAuthorField = templatePartFields.find(
+		( field ) => field.id === 'author'
+	);
 
 	const fields = useMemo( () => {
 		const _fields = [ previewField, patternTitleField ];
 
 		if ( postType === PATTERN_TYPES.user ) {
 			_fields.push( patternStatusField );
-		} else if ( postType === TEMPLATE_PART_POST_TYPE ) {
-			_fields.push( {
-				...templatePartAuthorField,
-				elements: authors,
-			} );
+		} else if (
+			postType === TEMPLATE_PART_POST_TYPE &&
+			templatePartAuthorField
+		) {
+			_fields.push( templatePartAuthorField );
 		}
 
 		return _fields;
-	}, [ postType, authors ] );
+	}, [ postType, templatePartAuthorField ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		// Search is managed server-side as well as filters for patterns.

--- a/packages/edit-site/src/components/page-templates/index-legacy.js
+++ b/packages/edit-site/src/components/page-templates/index-legacy.js
@@ -19,7 +19,7 @@ import AddNewTemplate from '../add-new-template-legacy';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
-import { authorField, previewField } from './fields';
+import { previewField } from './fields';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -86,40 +86,10 @@ export default function PageTemplates() {
 		[ history, path, view?.type ]
 	);
 
-	const authors = useMemo( () => {
-		if ( ! records ) {
-			return [];
-		}
-		const authorsSet = new Set();
-		records.forEach( ( template ) => {
-			authorsSet.add( template.author_text );
-		} );
-		return Array.from( authorsSet ).map( ( author ) => ( {
-			value: author,
-			label: author,
-		} ) );
-	}, [ records ] );
-
 	const postFields = usePostFields( { postType: TEMPLATE_POST_TYPE } );
 	const fields = useMemo( () => {
-		const __fields = [
-			previewField,
-			{
-				...authorField,
-				elements: authors,
-			},
-		];
-		// TODO: Only `description` and `title` are sourced from the shared
-		// `@wordpress/fields` registry so far. The remaining local fields
-		// (e.g. `previewField`, `authorField`) should also be evaluated for
-		// migration to the shared registry.
-		return [
-			...__fields,
-			...( postFields || [] ).filter( ( field ) =>
-				[ 'description', 'title' ].includes( field.id )
-			),
-		];
-	}, [ authors, postFields ] );
+		return [ previewField, ...( postFields || [] ) ];
+	}, [ postFields ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( records, view, fields );

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -30,6 +30,8 @@ import {
 	slugField,
 	statusField,
 	authorField,
+	templateAuthorField,
+	templatePartAuthorField,
 	titleField,
 	templateField,
 	templateTitleField,
@@ -267,7 +269,12 @@ export const registerPostTypeSchema =
 				postTypeConfig.supports?.thumbnail &&
 					currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
 					featuredImageField,
-				postTypeConfig.supports?.author && authorField,
+				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
+					postTypeConfig.supports?.author &&
+					authorField,
+				postTypeConfig.slug === 'wp_template' && templateAuthorField,
+				postTypeConfig.slug === 'wp_template_part' &&
+					templatePartAuthorField,
 				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&
 					statusField,
 				! DESIGN_POST_TYPES.includes( postTypeConfig.slug ) &&

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -224,9 +224,25 @@ Status field for BasePost.
 
 Sticky field for BasePost.
 
+### templateAuthorField
+
+Author field for templates.
+
+_Type_
+
+-   `Field< Template >`
+
 ### templateField
 
 Template field for BasePost.
+
+### templatePartAuthorField
+
+Author field for template parts.
+
+_Type_
+
+-   `Field< TemplatePart >`
 
 ### templateTitleField
 

--- a/packages/fields/src/fields/description/index.tsx
+++ b/packages/fields/src/fields/description/index.tsx
@@ -55,6 +55,7 @@ export const readOnlyDescriptionField: Field< Template > = {
 	readOnly: true,
 	isVisible: ( item ) => ! isCustomTemplate( item ) && !! item.description,
 	enableSorting: false,
+	enableHiding: false,
 	filterBy: false,
 };
 

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -16,6 +16,10 @@ export { default as dateField } from './date';
 export { default as scheduledDateField } from './scheduled-date';
 export { default as lastEditedDateField } from './last-edited';
 export { default as authorField } from './author';
+export {
+	templateAuthorField,
+	templatePartAuthorField,
+} from './template-author';
 export { default as notesField } from './notes';
 export { default as excerptField } from './excerpt';
 export {

--- a/packages/fields/src/fields/template-author/index.tsx
+++ b/packages/fields/src/fields/template-author/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import TemplateAuthorView from './view';
+import type { Template, TemplatePart } from '../../types';
+
+async function getAuthorElements(
+	postType: 'wp_template' | 'wp_template_part'
+) {
+	const records = ( await resolveSelect( coreStore ).getEntityRecords(
+		'postType',
+		postType,
+		{ per_page: -1 }
+	) ) as ( Template | TemplatePart )[] | null;
+
+	const seen = new Set< string >();
+	const elements: { value: string; label: string }[] = [];
+	for ( const record of records ?? [] ) {
+		const value = record.author_text;
+		if ( value && ! seen.has( value ) ) {
+			seen.add( value );
+			elements.push( { value, label: value } );
+		}
+	}
+	return elements;
+}
+
+/**
+ * Author field for templates.
+ */
+export const templateAuthorField: Field< Template > = {
+	label: __( 'Author' ),
+	id: 'author',
+	getValue: ( { item } ) => item.author_text,
+	render: TemplateAuthorView,
+	enableSorting: false,
+	getElements: () => getAuthorElements( 'wp_template' ),
+};
+
+/**
+ * Author field for template parts.
+ */
+export const templatePartAuthorField: Field< TemplatePart > = {
+	label: __( 'Author' ),
+	id: 'author',
+	getValue: ( { item } ) => item.author_text,
+	render: TemplateAuthorView,
+	enableSorting: false,
+	filterBy: {
+		isPrimary: true,
+	},
+	getElements: () => getAuthorElements( 'wp_template_part' ),
+};

--- a/packages/fields/src/fields/template-author/index.tsx
+++ b/packages/fields/src/fields/template-author/index.tsx
@@ -18,7 +18,7 @@ async function getAuthorElements(
 	const records = ( await resolveSelect( coreStore ).getEntityRecords(
 		'postType',
 		postType,
-		{ per_page: -1 }
+		{ per_page: -1, _fields: 'id,author_text' }
 	) ) as ( Template | TemplatePart )[] | null;
 
 	const seen = new Set< string >();
@@ -41,7 +41,6 @@ export const templateAuthorField: Field< Template > = {
 	id: 'author',
 	getValue: ( { item } ) => item.author_text,
 	render: TemplateAuthorView,
-	enableSorting: false,
 	getElements: () => getAuthorElements( 'wp_template' ),
 };
 

--- a/packages/fields/src/fields/template-author/view.tsx
+++ b/packages/fields/src/fields/template-author/view.tsx
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	commentAuthorAvatar as authorIcon,
+	layout as themeIcon,
+	plugins as pluginIcon,
+	globe as globeIcon,
+} from '@wordpress/icons';
+import { Icon, Stack } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import type { Template, TemplatePart } from '../../types';
+
+export function getIconForSource(
+	originalSource: Template[ 'original_source' ]
+) {
+	switch ( originalSource ) {
+		case 'theme':
+			return themeIcon;
+		case 'plugin':
+			return pluginIcon;
+		case 'site':
+			return globeIcon;
+		default:
+			return authorIcon;
+	}
+}
+
+export default function TemplateAuthorView( {
+	item,
+}: {
+	item: Template | TemplatePart;
+} ) {
+	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+	const originalSource = item.original_source;
+	const icon = getIconForSource( originalSource );
+	const text = item.author_text;
+	const authorId = item.author;
+
+	const imageUrl = useSelect(
+		( select ) => {
+			if ( originalSource === 'site' ) {
+				const siteData = select( coreStore ).getEntityRecord< {
+					site_logo?: number;
+				} >( 'root', '__unstableBase' );
+				const logoId = siteData?.site_logo;
+				if ( ! logoId ) {
+					return undefined;
+				}
+				return select( coreStore ).getEntityRecord< {
+					source_url: string;
+				} >( 'postType', 'attachment', logoId )?.source_url;
+			}
+
+			if ( originalSource !== 'user' || ! authorId ) {
+				return undefined;
+			}
+			return select( coreStore ).getUser( authorId )?.avatar_urls?.[ 48 ];
+		},
+		[ originalSource, authorId ]
+	);
+
+	return (
+		<Stack align="center">
+			{ imageUrl && (
+				<div
+					className={ clsx( 'fields-controls__author-avatar', {
+						'is-loaded': isImageLoaded,
+					} ) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt={ __( 'Author avatar' ) }
+						src={ imageUrl }
+					/>
+				</div>
+			) }
+			{ ! imageUrl && (
+				<div className="fields-controls__author-icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
+			<span className="fields-controls__author-name">{ text }</span>
+		</Stack>
+	);
+}

--- a/packages/fields/src/fields/template-author/view.tsx
+++ b/packages/fields/src/fields/template-author/view.tsx
@@ -1,8 +1,11 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -19,9 +22,7 @@ import { Icon, Stack } from '@wordpress/ui';
  */
 import type { Template, TemplatePart } from '../../types';
 
-export function getIconForSource(
-	originalSource: Template[ 'original_source' ]
-) {
+function getIconForSource( originalSource: Template[ 'original_source' ] ) {
 	switch ( originalSource ) {
 		case 'theme':
 			return themeIcon;
@@ -69,7 +70,7 @@ export default function TemplateAuthorView( {
 	);
 
 	return (
-		<Stack align="center">
+		<Stack direction="row" align="center">
 			{ imageUrl && (
 				<div
 					className={ clsx( 'fields-controls__author-avatar', {
@@ -78,7 +79,7 @@ export default function TemplateAuthorView( {
 				>
 					<img
 						onLoad={ () => setIsImageLoaded( true ) }
-						alt={ __( 'Author avatar' ) }
+						alt=""
 						src={ imageUrl }
 					/>
 				</div>

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -89,7 +89,13 @@ export interface BasePostWithEmbeddedFeaturedMedia extends BasePost {
 	_embedded: EmbeddedFeaturedMedia;
 }
 
-export interface Template extends CommonPost {
+interface TemplateAuthorFields {
+	author?: number;
+	author_text: string;
+	original_source?: 'theme' | 'plugin' | 'site' | 'user';
+}
+
+export interface Template extends CommonPost, TemplateAuthorFields {
 	type: 'wp_template';
 	is_custom: boolean;
 	source: string;
@@ -100,7 +106,7 @@ export interface Template extends CommonPost {
 	description?: string;
 }
 
-export interface TemplatePart extends CommonPost {
+export interface TemplatePart extends CommonPost, TemplateAuthorFields {
 	type: 'wp_template_part';
 	source: string;
 	origin: string;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -870,11 +870,6 @@
 			"count": 3
 		}
 	},
-	"packages/edit-site/src/components/page-patterns/fields.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/edit-site/src/components/page-templates/fields.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
There are some remaining fields in the site editor that can be moved in the `fields` package in order for consumers to rely on `usePostFields`. 

This PR creates the  `templateAuthorField` `templatePartAuthorField` which share lots of functionality and don't need to be internal fields in edit-site package. 

### Notes
I haven't removed the previous `authorField` for templates as it's being used for the template activation experiment and wanted to have a smaller scope for this PR.


## Testing Instructions
1. Author field for `templates` and `template parts` in site editor should be identical in presentation, content and functionality(filtering).

## Use of AI Tools
Opus 4.8 with direction, changes and review
