### PR TITLE
Command Palette: Fix duplicate enqueue breaking the palette in the Site Editor

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -352,6 +352,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 			$hook_suffix = 'block-editor-assets';
 
 			// Remove unwanted scripts/styles.
+			remove_action( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' );
 			remove_action( 'admin_enqueue_scripts', 'wp_auth_check_load' );
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 			remove_action( 'admin_print_styles', 'print_emoji_styles' );


### PR DESCRIPTION
Fixes #79390

## What?

Follow up to #79196.

Fixes the Command Palette not opening on the Site Editor (`admin.php?page=site-editor-v2`) and other boot-based admin pages.

## Why?

#79196 dropped the `lib/compat/wordpress-6.9/` directory. One of the removed files used to swap core's `wp_enqueue_command_palette_assets` out of the `admin_enqueue_scripts` hook, and the `/wp-block-editor/v1/assets` REST endpoint relied on that.

Without it, core's `wp_enqueue_command_palette_assets` stays hooked, and the editor then loads `wp-core-commands` a second time, splitting the `core/commands` store into two instances. `initializeCommandPalette()` runs, but the palette never opens.

## How?

Removes the action before the asset capture in `get_assets()`, so the Command Palette is enqueued only once — on the page itself.

## Testing Instructions

1. Enable the Extensible Site Editor experiment.
2. Open the site editor.
3. Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd>.
4. The Command Palette opens.

## Use of AI Tools

Root cause analysis and the fix were assisted by Claude Code. All changes were reviewed by the author.
