### PR TITLE
Editor: Use `Stack` for post summary

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { DataForm } from '@wordpress/dataviews';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useMemo } from '@wordpress/element';
 import { useViewConfig } from '@wordpress/views';
 
@@ -299,7 +299,7 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	};
 	return (
 		<PostPanelSection className="editor-post-summary">
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="lg">
 				<PostCardPanel
 					postType={ postType }
 					postId={ postId }
@@ -312,7 +312,7 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					onChange={ onChange }
 				/>
 				<PostTrash onActionPerformed={ onActionPerformed } />
-			</VStack>
+			</Stack>
 		</PostPanelSection>
 	);
 }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -73,7 +73,7 @@ function ClassicPostSummary( { onActionPerformed } ) {
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
 					<>
-						<VStack spacing={ 4 }>
+						<Stack direction="column" gap="lg">
 							<PostCardPanel
 								postType={ postType }
 								postId={ postId }
@@ -81,13 +81,13 @@ function ClassicPostSummary( { onActionPerformed } ) {
 							/>
 							<PostFeaturedImagePanel withPanelBody={ false } />
 							<PostExcerptPanel />
-							<VStack spacing={ 1 }>
+							<Stack direction="column" gap="xs">
 								<PostContentInformation />
 								<PostLastEditedPanel />
-							</VStack>
+							</Stack>
 							{ ! isRemovedPostStatusPanel && (
-								<VStack spacing={ 4 }>
-									<VStack spacing={ 1 }>
+								<Stack direction="column" gap="lg">
+									<Stack direction="column" gap="xs">
 										<PostStatusPanel />
 										<PostSchedulePanel />
 										<PostURLPanel />
@@ -102,13 +102,13 @@ function ClassicPostSummary( { onActionPerformed } ) {
 										<SiteDiscussion />
 										<PostFormatPanel />
 										{ fills }
-									</VStack>
+									</Stack>
 									<PostTrash
 										onActionPerformed={ onActionPerformed }
 									/>
-								</VStack>
+								</Stack>
 							) }
-						</VStack>
+						</Stack>
 					</>
 				) }
 			</PluginPostStatusInfo.Slot>

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1078,11 +1078,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/sidebar/dataform-post-summary.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/sidebar/header.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1096,11 +1091,6 @@
 	"packages/editor/src/components/sidebar/post-revision-summary.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
-		}
-	},
-	"packages/editor/src/components/sidebar/post-summary.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
 		}
 	},
 	"packages/editor/src/components/site-discussion/index.js": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just uses `Stack` for `ClassicPostSummary`  and the `DataFormPostSummary` components.

## Testing Instructions
1. Summary component should be identical to trunk
2. Same goes for the summary component under `Editor Inspector: Use DataForm` experiment
