### PR TITLE
Add initial size metadata for dashboard widgets

### DIFF
--- a/docs/explanations/architecture/dashboard-widgets.md
+++ b/docs/explanations/architecture/dashboard-widgets.md
@@ -21,7 +21,7 @@ A widget is a directory under `widgets/`, discovered by convention; there is no 
 ```
 widgets/hello-world/
 ├── widget.json        static metadata (name, title, description, category, presentation)
-├── widget.ts          metadata module: default-exports title, icon, attributes, example
+├── widget.ts          metadata module: default-exports title, icon, attributes, example, defaultPlacement
 ├── render.tsx         render module: default-exports the React component
 └── style.module.css   optional, injected at runtime by the build
 ```
@@ -62,7 +62,7 @@ The registry exists as a class (rather than the manifest being read directly by 
 
 The package is the single source of truth for what a widget _is_ on the client, shared by widget authors and hosts. It exposes three kinds of resources and deliberately nothing else:
 
--   **Contract types**: `WidgetType`, `WidgetName`, `WidgetIcon`, `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`. Authors type `widget.ts` / `render.tsx` against them; hosts consume the same shapes. Nothing re-exports them.
+-   **Contract types**: `WidgetType`, `WidgetTypeMetadata`, `WidgetDefaultPlacement`, `WidgetName`, `WidgetIcon`, `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`. Authors type `widget.ts` / `render.tsx` against them; hosts consume the same shapes. Consumers import them directly from `@wordpress/widget-primitives`.
 -   **Discovery**: `useWidgetTypes( records )` takes host-supplied widget-module records, dynamically imports each record's `widget_module` to retrieve the live metadata, and merges both halves into `WidgetType[]`. The record's `presentation` (originating in `widget.json`) wins over the module's value. The hook reaches for no store or endpoint: the host fetches the records however it wants (the dashboard reads its own `widgetModule` core-data entity, backed by `/wp/v2/widget-modules`) and passes them in.
 -   **Rendering**: `<WidgetRender>` resolves a `WidgetType.renderModule` through a host-provided `ResolveWidgetModule` and mounts the component with the `attributes` / `setAttributes` contract. On a WordPress page the resolver can be as simple as `( id ) => import( id )`, provided the hosting page exposed the module in its import map; hosts with other loading strategies supply their own resolver.
 
@@ -73,6 +73,11 @@ Equally important is what the package does not do: no chrome, no layout, no pers
 A host is any context that renders widgets; the contract privileges none of them. The dashboard engine ([`@wordpress/widget-dashboard`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/widget-dashboard), mounted by `routes/dashboard/`) is the host this repository ships today, and it illustrates what a host owns: it registers the `widgetModule` core-data entity when its route module loads (before the dashboard renders), reads the entity's records and passes them to `useWidgetTypes( records )`, owns the layout array and its persistence, wraps every instance in its own chrome (header, toolbars, error boundary, Suspense fallback), and passes `resolveWidgetModule` down through its context (overridable for tests and Storybook).
 
 The same `WidgetType` could equally be rendered by a sidebar, a plugin panel, or an application outside wp-admin; the choice of where and how to render belongs entirely to the host. Every host is a consumer of the package; not every consumer is a host: tests, Storybook, or a picker that only lists widget types consume the same contract without rendering anything.
+
+When a host creates a dashboard tile, it may use the widget type's
+`defaultPlacement` metadata as the preferred initial size. The field is limited
+to `width` and `height` spans so the widget can describe its own footprint
+without controlling dashboard order or other host-specific placement state.
 
 ## Why a standalone package
 

--- a/docs/explanations/architecture/dashboard-widgets.md
+++ b/docs/explanations/architecture/dashboard-widgets.md
@@ -21,7 +21,7 @@ A widget is a directory under `widgets/`, discovered by convention; there is no 
 ```
 widgets/hello-world/
 ├── widget.json        static metadata (name, title, description, category, presentation)
-├── widget.ts          metadata module: default-exports title, icon, attributes, example, defaultPlacement
+├── widget.ts          metadata module: default-exports title, icon, attributes, example, initialSize
 ├── render.tsx         render module: default-exports the React component
 └── style.module.css   optional, injected at runtime by the build
 ```
@@ -62,7 +62,7 @@ The registry exists as a class (rather than the manifest being read directly by 
 
 The package is the single source of truth for what a widget _is_ on the client, shared by widget authors and hosts. It exposes three kinds of resources and deliberately nothing else:
 
--   **Contract types**: `WidgetType`, `WidgetTypeMetadata`, `WidgetDefaultPlacement`, `WidgetName`, `WidgetIcon`, `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`. Authors type `widget.ts` / `render.tsx` against them; hosts consume the same shapes. Consumers import them directly from `@wordpress/widget-primitives`.
+-   **Contract types**: `WidgetType`, `WidgetTypeMetadata`, `WidgetInitialSize`, `WidgetName`, `WidgetIcon`, `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`. Authors type `widget.ts` / `render.tsx` against them; hosts consume the same shapes. Consumers import them directly from `@wordpress/widget-primitives`.
 -   **Discovery**: `useWidgetTypes( records )` takes host-supplied widget-module records, dynamically imports each record's `widget_module` to retrieve the live metadata, and merges both halves into `WidgetType[]`. The record's `presentation` (originating in `widget.json`) wins over the module's value. The hook reaches for no store or endpoint: the host fetches the records however it wants (the dashboard reads its own `widgetModule` core-data entity, backed by `/wp/v2/widget-modules`) and passes them in.
 -   **Rendering**: `<WidgetRender>` resolves a `WidgetType.renderModule` through a host-provided `ResolveWidgetModule` and mounts the component with the `attributes` / `setAttributes` contract. On a WordPress page the resolver can be as simple as `( id ) => import( id )`, provided the hosting page exposed the module in its import map; hosts with other loading strategies supply their own resolver.
 
@@ -74,10 +74,10 @@ A host is any context that renders widgets; the contract privileges none of them
 
 The same `WidgetType` could equally be rendered by a sidebar, a plugin panel, or an application outside wp-admin; the choice of where and how to render belongs entirely to the host. Every host is a consumer of the package; not every consumer is a host: tests, Storybook, or a picker that only lists widget types consume the same contract without rendering anything.
 
-When a host creates a dashboard tile, it may use the widget type's
-`defaultPlacement` metadata as the preferred initial size. The field is limited
-to `width` and `height` spans so the widget can describe its own footprint
-without controlling dashboard order or other host-specific placement state.
+When a host creates a dashboard tile, it may use the widget type's `initialSize`
+metadata as a semantic hint about the preferred initial form factor. The
+dashboard maps those values to its current layout model; grid spans, lanes,
+ordering, and persistence remain host-specific placement state.
 
 ## Why a standalone package
 

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -15,3 +15,5 @@
 -   Grid-settings kit for host-side persistence: `WidgetGridSettings`,
     `DEFAULT_GRID`, `normalizeGridSettings`, `ROW_HEIGHT_PRESETS`,
     `DEFAULT_ROW_HEIGHT`, and `WIDGET_DASHBOARD_COLUMN_COUNT`.
+-   Widget insertion respects `defaultPlacement` metadata for the initial
+    tile size.

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -15,5 +15,5 @@
 -   Grid-settings kit for host-side persistence: `WidgetGridSettings`,
     `DEFAULT_GRID`, `normalizeGridSettings`, `ROW_HEIGHT_PRESETS`,
     `DEFAULT_ROW_HEIGHT`, and `WIDGET_DASHBOARD_COLUMN_COUNT`.
--   Widget insertion respects `defaultPlacement` metadata for the initial
-    tile size.
+-   Widget insertion respects `initialSize` metadata for the initial form
+    factor.

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -180,7 +180,7 @@ import { Page } from '@wordpress/admin-ui';
 
 The "Add widget" button in `<WidgetDashboard.Actions />` opens a modal inserter. It lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a "Select" action with bulk support so users can insert one or several widgets in a single layout change.
 
-On confirmation, the inserter creates instances (using each type's `example.attributes` as the initial values) and appends them to the staged layout. A widget type may provide `defaultPlacement` metadata with `width` and `height` to control the initial tile size. The dashboard merges those fields with its fallback placement and keeps insertion order internal; an `order` value in widget metadata is ignored. The dialog closes after a successful insertion or when the user dismisses it.
+On confirmation, the inserter creates instances (using each type's `example.attributes` as the initial values) and appends them to the staged layout. A widget type may provide `initialSize` metadata (`compact`, `regular`, `wide`, or `large`) to hint at its preferred initial form factor. The dashboard maps that semantic hint to its active layout model and keeps grid spans, lanes, and insertion order internal to the dashboard. The dialog closes after a successful insertion or when the user dismisses it.
 
 ## Grid settings
 

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -4,6 +4,7 @@
 This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes. While it is published as 0.x, breaking changes may ship in minor releases.
 
 This prerelease depends on WordPress core-private APIs and is built to run inside WordPress core. It is not yet safe to install and run as a standalone npm dependency from an external plugin.
+
 </div>
 
 Stateless rendering engine for widget dashboards. `WidgetDashboard` renders an editable grid of widget instances behind a consumer-controlled edit mode: drag-to-reorder, resize, a modal inserter, per-widget and grid-level settings, and command-palette integration.
@@ -179,7 +180,7 @@ import { Page } from '@wordpress/admin-ui';
 
 The "Add widget" button in `<WidgetDashboard.Actions />` opens a modal inserter. It lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a "Select" action with bulk support so users can insert one or several widgets in a single layout change.
 
-On confirmation, the inserter creates instances (using each type's `example.attributes` as the initial values) and appends them to the staged layout. The dialog closes after a successful insertion or when the user dismisses it.
+On confirmation, the inserter creates instances (using each type's `example.attributes` as the initial values) and appends them to the staged layout. A widget type may provide `defaultPlacement` metadata with `width` and `height` to control the initial tile size. The dashboard merges those fields with its fallback placement and keeps insertion order internal; an `order` value in widget metadata is ignored. The dialog closes after a successful insertion or when the user dismisses it.
 
 ## Grid settings
 

--- a/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
+++ b/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
@@ -35,13 +35,36 @@ describe( 'createDashboardWidget', () => {
 		} );
 	} );
 
-	it( 'merges widget default placement values with the dashboard fallback', () => {
+	it( 'maps compact initial size to a compact placement', () => {
 		const instance = createDashboardWidget( {
 			...baseType,
-			defaultPlacement: {
-				width: 2,
-				height: 1,
-			},
+			initialSize: 'compact',
+		} );
+
+		expect( instance.placement ).toEqual( {
+			width: 1,
+			height: 1,
+			order: 0,
+		} );
+	} );
+
+	it( 'maps regular initial size to the default placement', () => {
+		const instance = createDashboardWidget( {
+			...baseType,
+			initialSize: 'regular',
+		} );
+
+		expect( instance.placement ).toEqual( {
+			width: 1,
+			height: 2,
+			order: 0,
+		} );
+	} );
+
+	it( 'maps wide initial size to a wide placement', () => {
+		const instance = createDashboardWidget( {
+			...baseType,
+			initialSize: 'wide',
 		} );
 
 		expect( instance.placement ).toEqual( {
@@ -51,15 +74,25 @@ describe( 'createDashboardWidget', () => {
 		} );
 	} );
 
-	it( 'ignores unsupported widget default placement fields', () => {
+	it( 'maps large initial size to a large placement', () => {
 		const instance = createDashboardWidget( {
 			...baseType,
-			defaultPlacement: {
-				width: 2,
-				height: 1,
-				order: 99,
-			} as WidgetType[ 'defaultPlacement' ] & { order: number },
+			initialSize: 'large',
 		} );
+
+		expect( instance.placement ).toEqual( {
+			width: 2,
+			height: 2,
+			order: 0,
+		} );
+	} );
+
+	it( 'ignores unsupported runtime placement fields', () => {
+		const instance = createDashboardWidget( {
+			...baseType,
+			initialSize: 'wide',
+			order: 99,
+		} as WidgetType & { order: number } );
 
 		expect( instance.placement ).toEqual( {
 			width: 2,

--- a/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
+++ b/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
@@ -35,6 +35,39 @@ describe( 'createDashboardWidget', () => {
 		} );
 	} );
 
+	it( 'merges widget default placement values with the dashboard fallback', () => {
+		const instance = createDashboardWidget( {
+			...baseType,
+			defaultPlacement: {
+				width: 2,
+				height: 1,
+			},
+		} );
+
+		expect( instance.placement ).toEqual( {
+			width: 2,
+			height: 1,
+			order: 0,
+		} );
+	} );
+
+	it( 'ignores unsupported widget default placement fields', () => {
+		const instance = createDashboardWidget( {
+			...baseType,
+			defaultPlacement: {
+				width: 2,
+				height: 1,
+				order: 99,
+			} as WidgetType[ 'defaultPlacement' ] & { order: number },
+		} );
+
+		expect( instance.placement ).toEqual( {
+			width: 2,
+			height: 1,
+			order: 0,
+		} );
+	} );
+
 	it( 'uses initialAttributes when provided', () => {
 		const instance = createDashboardWidget< { greeting: string } >(
 			baseType,

--- a/packages/widget-dashboard/src/utils/create-dashboard-widget/create-dashboard-widget.ts
+++ b/packages/widget-dashboard/src/utils/create-dashboard-widget/create-dashboard-widget.ts
@@ -6,7 +6,10 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import type { WidgetType } from '@wordpress/widget-primitives';
+import type {
+	WidgetInitialSize,
+	WidgetType,
+} from '@wordpress/widget-primitives';
 
 /**
  * Internal dependencies
@@ -19,12 +22,31 @@ const DEFAULT_PLACEMENT: GridTilePlacement = {
 	order: 0,
 };
 
+const INITIAL_SIZE_PLACEMENTS: Record< WidgetInitialSize, GridTilePlacement > =
+	{
+		compact: {
+			width: 1,
+			height: 1,
+			order: 0,
+		},
+		regular: DEFAULT_PLACEMENT,
+		wide: {
+			width: 2,
+			height: 1,
+			order: 0,
+		},
+		large: {
+			width: 2,
+			height: 2,
+			order: 0,
+		},
+	};
+
 /**
  * Create a new dashboard widget from a widget type.
  *
- * Generates a unique id and applies the dashboard fallback placement,
- * overridden by the type's supported `defaultPlacement` fields. If no
- * initial attributes are provided, falls back to the type's
+ * Generates a unique id and applies the dashboard placement for the type's
+ * `initialSize`. If no initial attributes are provided, falls back to the type's
  * `example.attributes`.
  *
  * @param widgetType        Source widget type.
@@ -34,17 +56,15 @@ export function createDashboardWidget< T >(
 	widgetType: WidgetType,
 	initialAttributes?: T
 ): DashboardWidget< T > {
-	const { width, height } = widgetType.defaultPlacement ?? {};
+	const placement =
+		INITIAL_SIZE_PLACEMENTS[ widgetType.initialSize ?? 'regular' ] ??
+		DEFAULT_PLACEMENT;
 
 	return {
 		uuid: uuid(),
 		type: widgetType.name,
 		attributes:
 			initialAttributes ?? ( widgetType.example?.attributes as T ),
-		placement: {
-			...DEFAULT_PLACEMENT,
-			...( width !== undefined ? { width } : {} ),
-			...( height !== undefined ? { height } : {} ),
-		},
+		placement: { ...placement },
 	};
 }

--- a/packages/widget-dashboard/src/utils/create-dashboard-widget/create-dashboard-widget.ts
+++ b/packages/widget-dashboard/src/utils/create-dashboard-widget/create-dashboard-widget.ts
@@ -22,9 +22,10 @@ const DEFAULT_PLACEMENT: GridTilePlacement = {
 /**
  * Create a new dashboard widget from a widget type.
  *
- * Generates a unique id and applies default placement. If no initial
- * attributes are provided, falls back to the type's `example.attributes`
- * (matching the `widget.json` schema).
+ * Generates a unique id and applies the dashboard fallback placement,
+ * overridden by the type's supported `defaultPlacement` fields. If no
+ * initial attributes are provided, falls back to the type's
+ * `example.attributes`.
  *
  * @param widgetType        Source widget type.
  * @param initialAttributes Initial attributes; default to the type's example.
@@ -33,11 +34,17 @@ export function createDashboardWidget< T >(
 	widgetType: WidgetType,
 	initialAttributes?: T
 ): DashboardWidget< T > {
+	const { width, height } = widgetType.defaultPlacement ?? {};
+
 	return {
 		uuid: uuid(),
 		type: widgetType.name,
 		attributes:
 			initialAttributes ?? ( widgetType.example?.attributes as T ),
-		placement: DEFAULT_PLACEMENT,
+		placement: {
+			...DEFAULT_PLACEMENT,
+			...( width !== undefined ? { width } : {} ),
+			...( height !== undefined ? { height } : {} ),
+		},
 	};
 }

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -12,5 +12,4 @@
     resolves widget types from host-supplied `WidgetModuleRecord[]`.
 -   Contract types: `WidgetType`, `WidgetName`, `WidgetIcon`,
     `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`.
--   `defaultPlacement` widget metadata for declaring a preferred initial
-    tile size.
+-   `initialSize` widget metadata for declaring a preferred initial form factor.

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -12,3 +12,5 @@
     resolves widget types from host-supplied `WidgetModuleRecord[]`.
 -   Contract types: `WidgetType`, `WidgetName`, `WidgetIcon`,
     `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`.
+-   `defaultPlacement` widget metadata for declaring a preferred initial
+    tile size.

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -50,9 +50,34 @@ With no records, or an empty list, `useWidgetTypes()` returns an empty list.
     loading), imports each record's metadata, and returns the resolved
     `WidgetType[]` plus a flag that is true while they are still resolving.
 -   Contract types: `WidgetType`, `WidgetName`, `WidgetIcon`,
-    `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`.
+    `WidgetTypeMetadata`, `WidgetDefaultPlacement`, `WidgetRenderProps`,
+    `ResolveWidgetModule`, `WidgetModuleRecord`.
     `WidgetIcon` is a rendered SVG element; hosts pass it to their icon
     primitive as is.
+
+## Widget metadata
+
+Widget metadata can include `defaultPlacement` to describe the preferred
+initial tile size when a host inserts a new widget instance:
+
+```ts
+import type { WidgetTypeMetadata } from '@wordpress/widget-primitives';
+
+const metadata = {
+	apiVersion: 1,
+	name: 'my-plugin/orders',
+	title: 'Average items per order',
+	defaultPlacement: {
+		width: 2,
+		height: 1,
+	},
+} satisfies WidgetTypeMetadata;
+
+export default metadata;
+```
+
+`defaultPlacement` supports only `width` and `height`. Host-controlled fields
+such as insertion order are not part of the widget metadata contract.
 
 ## Architecture
 

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -50,15 +50,15 @@ With no records, or an empty list, `useWidgetTypes()` returns an empty list.
     loading), imports each record's metadata, and returns the resolved
     `WidgetType[]` plus a flag that is true while they are still resolving.
 -   Contract types: `WidgetType`, `WidgetName`, `WidgetIcon`,
-    `WidgetTypeMetadata`, `WidgetDefaultPlacement`, `WidgetRenderProps`,
+    `WidgetTypeMetadata`, `WidgetInitialSize`, `WidgetRenderProps`,
     `ResolveWidgetModule`, `WidgetModuleRecord`.
     `WidgetIcon` is a rendered SVG element; hosts pass it to their icon
     primitive as is.
 
 ## Widget metadata
 
-Widget metadata can include `defaultPlacement` to describe the preferred
-initial tile size when a host inserts a new widget instance:
+Widget metadata can include `initialSize` to describe the preferred form factor
+when a host inserts a new widget instance:
 
 ```ts
 import type { WidgetTypeMetadata } from '@wordpress/widget-primitives';
@@ -67,17 +67,16 @@ const metadata = {
 	apiVersion: 1,
 	name: 'my-plugin/orders',
 	title: 'Average items per order',
-	defaultPlacement: {
-		width: 2,
-		height: 1,
-	},
+	initialSize: 'wide',
 } satisfies WidgetTypeMetadata;
 
 export default metadata;
 ```
 
-`defaultPlacement` supports only `width` and `height`. Host-controlled fields
-such as insertion order are not part of the widget metadata contract.
+`initialSize` supports `compact`, `regular`, `wide`, and `large`. The values are
+semantic hints; each host maps them to its own layout model. Host-controlled
+fields such as grid spans, lanes, and insertion order are not part of the widget
+metadata contract.
 
 ## Architecture
 

--- a/packages/widget-primitives/src/index.ts
+++ b/packages/widget-primitives/src/index.ts
@@ -14,6 +14,8 @@ export { useWidgetTypes } from './hooks';
 export type {
 	WidgetName,
 	WidgetIcon,
+	WidgetDefaultPlacement,
+	WidgetTypeMetadata,
 	WidgetType,
 	WidgetRenderProps,
 	ResolveWidgetModule,

--- a/packages/widget-primitives/src/index.ts
+++ b/packages/widget-primitives/src/index.ts
@@ -14,7 +14,7 @@ export { useWidgetTypes } from './hooks';
 export type {
 	WidgetName,
 	WidgetIcon,
-	WidgetDefaultPlacement,
+	WidgetInitialSize,
 	WidgetTypeMetadata,
 	WidgetType,
 	WidgetRenderProps,

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -28,7 +28,25 @@ export type WidgetName = `${ string }/${ string }`;
 export type WidgetIcon = ReactElement< ComponentProps< 'svg' > >;
 
 /**
- * Literal contents of a widget's `widget.json` metadata file.
+ * Default tile size a host can use when inserting a widget into a layout.
+ *
+ * Hosts own ordering and any host-specific placement fields. Widget metadata
+ * only declares the preferred initial span.
+ */
+export interface WidgetDefaultPlacement {
+	/**
+	 * Preferred initial column span.
+	 */
+	width?: number;
+
+	/**
+	 * Preferred initial row span.
+	 */
+	height?: number;
+}
+
+/**
+ * Literal contents of a widget's metadata module.
  *
  * Captures the *authoring* shape only; module entry points and style
  * assets are discovered by convention from the widget directory, not
@@ -79,6 +97,13 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	 *   surrounding chrome.
 	 */
 	presentation?: 'framed' | 'content-bleed' | 'full-bleed';
+
+	/**
+	 * Preferred initial tile size when a host inserts a new widget instance.
+	 * Hosts may ignore this hint, and insertion order is intentionally not
+	 * part of the widget metadata contract.
+	 */
+	defaultPlacement?: WidgetDefaultPlacement;
 
 	/**
 	 * Search aliases hosts use to match the widget in their pickers.

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -28,22 +28,16 @@ export type WidgetName = `${ string }/${ string }`;
 export type WidgetIcon = ReactElement< ComponentProps< 'svg' > >;
 
 /**
- * Default tile size a host can use when inserting a widget into a layout.
+ * Preferred initial size a host can use when inserting a widget into a
+ * layout. The values describe widget intent; hosts map them to their own
+ * layout model.
  *
- * Hosts own ordering and any host-specific placement fields. Widget metadata
- * only declares the preferred initial span.
+ * - `'compact'`: minimal footprint for simple summaries or controls.
+ * - `'regular'`: default footprint for standard widgets.
+ * - `'wide'`: extra horizontal space for widgets with side-by-side content.
+ * - `'large'`: extra horizontal and vertical space for dense widgets.
  */
-export interface WidgetDefaultPlacement {
-	/**
-	 * Preferred initial column span.
-	 */
-	width?: number;
-
-	/**
-	 * Preferred initial row span.
-	 */
-	height?: number;
-}
+export type WidgetInitialSize = 'compact' | 'regular' | 'wide' | 'large';
 
 /**
  * Literal contents of a widget's metadata module.
@@ -99,11 +93,10 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	presentation?: 'framed' | 'content-bleed' | 'full-bleed';
 
 	/**
-	 * Preferred initial tile size when a host inserts a new widget instance.
-	 * Hosts may ignore this hint, and insertion order is intentionally not
-	 * part of the widget metadata contract.
+	 * Preferred initial size when a host inserts a new widget instance.
+	 * Hosts may ignore this hint or map it to their own layout model.
 	 */
-	defaultPlacement?: WidgetDefaultPlacement;
+	initialSize?: WidgetInitialSize;
 
 	/**
 	 * Search aliases hosts use to match the widget in their pickers.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes none.

Adds `initialSize` widget metadata so widget authors can declare a semantic preferred initial form factor: `compact`, `regular`, `wide`, or `large`.

(Related: [Customizable Dashboard Tracking Issue](https://github.com/WordPress/gutenberg/issues/79231))

## Why?

Some widgets need a different default footprint than the dashboard fallback. For example, compact summary widgets may need to start with extra horizontal room. The widget contract should describe that author intent without exposing dashboard grid implementation details such as `width`, `height`, lanes, or `order`.

## How?

- Adds `WidgetInitialSize` and `initialSize?: WidgetInitialSize` to `@wordpress/widget-primitives`.
- Exports `WidgetTypeMetadata` and `WidgetInitialSize` for widget authors.
- Updates `createDashboardWidget()` to privately map semantic `initialSize` values to dashboard grid placement:
  - absent or `regular`: `1x2`
  - `compact`: `1x1`
  - `wide`: `2x1`
  - `large`: `2x2`
- Keeps `order` internal to the dashboard flow. It is not part of the metadata type, and runtime placement-like fields are ignored.
- Updates package docs, architecture docs, changelogs, and focused tests.

## Testing Instructions

Run:

```bash
npm run test:unit -- packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
```

Expected: the `createDashboardWidget` suite passes, including fallback placement, all `initialSize` mappings, and ignored unsupported placement fields.

Additional checks run locally:

```bash
npm run format -- docs/explanations/architecture/dashboard-widgets.md packages/widget-primitives/README.md packages/widget-dashboard/README.md packages/widget-primitives/CHANGELOG.md packages/widget-dashboard/CHANGELOG.md packages/widget-primitives/src/types.ts packages/widget-primitives/src/index.ts packages/widget-dashboard/src/utils/create-dashboard-widget/create-dashboard-widget.ts packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
./node_modules/.bin/tsc -p packages/widget-primitives/tsconfig.json --pretty false --noEmit
git diff --check
```

Notes:

- `./node_modules/.bin/tsc -p packages/widget-dashboard/tsconfig.json --pretty false --noEmit` is blocked in this checkout by stale or missing generated `build-types` for referenced packages.
- The pre-commit ESLint task is blocked in this checkout because `eslint-plugin-react-hooks` is missing from local dependencies.

### Testing Instructions for Keyboard

No user-interface interaction changed.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Implemented with assistance from Codex. The changes are reviewed before moving this PR out of draft.
