### PR TITLE
Experimental: Expand Editor Inspector: Use DataForm experiment to template parts

### DIFF
--- a/backport-changelog/7.1/11272.md
+++ b/backport-changelog/7.1/11272.md
@@ -11,3 +11,4 @@ https://github.com/WordPress/wordpress-develop/pull/11272
 * https://github.com/WordPress/gutenberg/pull/79195
 * https://github.com/WordPress/gutenberg/pull/76934
 * https://github.com/WordPress/gutenberg/pull/79347
+* https://github.com/WordPress/gutenberg/pull/79399

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -542,6 +542,20 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $config )
 
 	$config['view_list'] = $view_list;
 
+	$config['form'] = array(
+		'layout' => array( 'type' => 'panel' ),
+		'fields' => array(
+			array(
+				'id'     => 'last_edited_date',
+				'layout' => array(
+					'type'          => 'panel',
+					'labelPosition' => 'none',
+				),
+			),
+			'revisions',
+		),
+	);
+
 	return $config;
 }
 

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -43,7 +43,9 @@ export default function PostSummary( { onActionPerformed } ) {
 	);
 	if (
 		window?.__experimentalDataFormInspector &&
-		[ 'page', 'post', 'wp_template' ].includes( postType )
+		[ 'page', 'post', 'wp_template', 'wp_template_part' ].includes(
+			postType
+		)
 	) {
 		return <DataFormPostSummary onActionPerformed={ onActionPerformed } />;
 	}


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076
Similar to: https://github.com/WordPress/gutenberg/pull/76934

This PR just expands the DF experiment for template parts.


## Testing Instructions
1. In site editor go to `patterns`. The template parts' lists should be the same with trunk (no changes there)
2. Select to edit a template part
3. Template parts summary panel should show the same fields as trunk




## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="279" height="188" alt="Screenshot 2026-06-22 at 4 24 37 PM" src="https://github.com/user-attachments/assets/15dbfb65-8f30-41e5-aad3-96a769ac7086" />|<img width="279" height="188" alt="Screenshot 2026-06-22 at 4 24 16 PM" src="https://github.com/user-attachments/assets/2df64a52-b7de-4ccf-b166-712858491266" />|


