### PR TITLE
Image Block: Prevent global link colors from leaking into linked image borders

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -6,6 +6,7 @@
 	> a,
 	> figure > a {
 		display: inline-block;
+		color: inherit;
 	}
 
 	img {


### PR DESCRIPTION
## What?

Closes #53070 

This PR updates the core styles of the Image block to explicitly set `color: inherit;` on the anchor tag when an image is wrapped in a link. This prevents the link tag from taking on the theme's global link color (or the browser's default link color) which otherwise cascades down to the image's border.

## Why?
Currently, if an Image block is linked to a URL or Media File, the image is wrapped in an `<a>` element. Global Theme JSON styles apply the site's designated link color to this anchor. Because the `color` property is inherited, the link's color cascades down to the `<img>` element. If the image uses a custom border with no explicitly defined border color (which defaults to `currentColor`), the border unexpectedly takes on the link color. 

Excluding the image anchors from the global `ELEMENTS` selector via `:not(:has(> img))` is insufficient, as it causes the `<a>` tag to fall back to the browser's native default link color, which still breaks the border color.

## How?
- Added `color: inherit;` to the `.wp-block-image > a` and `.wp-block-image > figure > a` CSS rules.
- This ensures the link always inherits the neutral text color from the parent `.wp-block-image` block, rather than falling back to global link styles or browser defaults.

## Testing Instructions
1. Open the editor and insert an **Image** block.
2. In the block settings, add a custom border width (e.g., 5px) without explicitly defining a border color.
3. Link the image to a URL or a Media File.
4. Preview the page on the frontend and confirm the image border remains the default text color and does not take on the theme's link color or the browser's default blue.
5. Insert a **Gallery** block containing multiple images.
6. Apply a custom border width to Images of Gallery block.
7. In the Gallery block options, set **"Link to"** to **"Media file"**.
8. Preview the page and verify the borders for all gallery images remain correctly colored.

## Screenshots or Screencast

### Before Fix :

https://github.com/user-attachments/assets/6d42d558-1084-4012-9e55-525392189e7e

### After Fix :

https://github.com/user-attachments/assets/48c0b38c-09e5-47c0-ac94-c7e3902a811f

## Use of AI Tools
Initial technical analysis and PR documentation for this fix were drafted with the assistance of AI tools. All changes are done manually and verified manually
