### PR TITLE
Connectors: add application password settings UI

### DIFF
--- a/backport-changelog/7.1/12264.md
+++ b/backport-changelog/7.1/12264.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12264
+
+* https://github.com/WordPress/gutenberg/pull/79403

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -94,9 +94,13 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *                                       for application passwords.
 		 *                                       Must be a non-empty string when provided.
 		 *         @type string $constant_name   Optional. PHP constant name for the API key
-		 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
+		 *                                       (e.g. 'ANTHROPIC_API_KEY') or for application-password
+		 *                                       credentials in `username:password` format. Only checked
+		 *                                       when provided.
 		 *         @type string $env_var_name    Optional. Environment variable name for the API key
-		 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
+		 *                                       (e.g. 'ANTHROPIC_API_KEY') or for application-password
+		 *                                       credentials in `username:password` format. Only checked
+		 *                                       when provided.
 		 *     }
 		 *     @type array  $plugin         {
 		 *         Optional. Plugin data for install/activate UI.
@@ -251,7 +255,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				}
 			}
 
-			if ( 'api_key' === $args['authentication']['method'] ) {
+			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 				if ( isset( $args['authentication']['constant_name'] ) ) {
 					if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 						_doing_it_wrong(

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 * Validates the provided arguments and stores the connector in the registry.
 		 * For connectors with `api_key` or `application_password` authentication, a
 		 * `setting_name` can be provided explicitly. When omitted, setting names are
-		 * automatically generated using the pattern `connectors_{$type}_{$id}_{$credential}`,
+		 * automatically generated using the pattern `connectors_{$type}_{$id}_{$method}`,
 		 * with hyphens in the type and ID normalized to underscores. These setting
 		 * names are used for Settings API registration and REST API exposure.
 		 *

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -21,9 +21,11 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 	 *     logo_url?: non-empty-string,
 	 *     type: non-empty-string,
 	 *     authentication: array{
-	 *         method: 'api_key'|'none',
+	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
+	 *         username_setting_name?: non-empty-string,
+	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -58,11 +60,12 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *
 		 * Validates the provided arguments and stores the connector in the registry.
 		 * For connectors with `api_key` authentication, a `setting_name` can be provided
-		 * explicitly. If omitted, one is automatically generated using the pattern
-		 * `connectors_{$type}_{$id}_api_key`, with hyphens in the type and ID normalized
-		 * to underscores (e.g., connector type `spam_filtering` with ID `akismet` produces
-		 * `connectors_spam_filtering_akismet_api_key`). This setting name is used for the
-		 * Settings API registration and REST API exposure.
+		 * explicitly. For connectors with `application_password` authentication,
+		 * `username_setting_name` and `application_password_setting_name` can be provided.
+		 * When omitted, setting names are automatically generated using the pattern
+		 * `connectors_{$type}_{$id}_{$credential}`, with hyphens in the type and ID
+		 * normalized to underscores. These setting names are used for Settings API
+		 * registration and REST API exposure.
 		 *
 		 * Registering a connector with an ID that is already registered will trigger a
 		 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -84,12 +87,19 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *     @type array  $authentication {
 		 *         Required. Authentication configuration.
 		 *
-		 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
+		 *         @type string $method          Required. The authentication method: 'api_key',
+		 *                                       'application_password', or 'none'.
 		 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 		 *         @type string $setting_name    Optional. The setting name for the API key.
 		 *                                       When omitted, auto-generated as
 		 *                                       `connectors_{$type}_{$id}_api_key`.
 		 *                                       Must be a non-empty string when provided.
+		 *         @type string $username_setting_name Optional. The setting name for the username used
+		 *                                       with application password authentication. When omitted,
+		 *                                       auto-generated as `connectors_{$type}_{$id}_username`.
+		 *         @type string $application_password_setting_name Optional. The setting name for the
+		 *                                       application password. When omitted, auto-generated as
+		 *                                       `connectors_{$type}_{$id}_application_password`.
 		 *         @type string $constant_name   Optional. PHP constant name for the API key
 		 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 		 *         @type string $env_var_name    Optional. Environment variable name for the API key
@@ -114,9 +124,11 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *     logo_url?: non-empty-string,
 		 *     type: non-empty-string,
 		 *     authentication: array{
-		 *         method: 'api_key'|'none',
+		 *         method: 'api_key'|'application_password'|'none',
 		 *         credentials_url?: non-empty-string,
 		 *         setting_name?: non-empty-string,
+		 *         username_setting_name?: non-empty-string,
+		 *         application_password_setting_name?: non-empty-string,
 		 *         constant_name?: non-empty-string,
 		 *         env_var_name?: non-empty-string
 		 *     },
@@ -180,11 +192,11 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				return null;
 			}
 
-			if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'none' ), true ) ) {
+			if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'application_password', 'none' ), true ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					/* translators: %s: Connector ID. */
-					sprintf( __( 'Connector "%s" authentication method must be "api_key" or "none".' ), esc_html( $id ) ),
+					sprintf( __( 'Connector "%s" authentication method must be "api_key", "application_password", or "none".' ), esc_html( $id ) ),
 					'7.0.0'
 				);
 				return null;
@@ -208,10 +220,13 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				$connector['logo_url'] = $args['logo_url'];
 			}
 
-			if ( 'api_key' === $args['authentication']['method'] ) {
+			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 				if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 					$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 				}
+			}
+
+			if ( 'api_key' === $args['authentication']['method'] ) {
 				if ( isset( $args['authentication']['setting_name'] ) ) {
 					if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 						_doing_it_wrong(
@@ -249,6 +264,34 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 						return null;
 					}
 					$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
+				}
+			}
+
+			if ( 'application_password' === $args['authentication']['method'] ) {
+				$setting_names = array(
+					'username_setting_name'             => 'username',
+					'application_password_setting_name' => 'application_password',
+				);
+
+				foreach ( $setting_names as $setting_name_key => $setting_name_suffix ) {
+					if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
+						if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
+							_doing_it_wrong(
+								__METHOD__,
+								sprintf(
+									/* translators: 1: Connector ID, 2: Authentication setting name key. */
+									__( 'Connector "%1$s" authentication %2$s must be a non-empty string.' ),
+									esc_html( $id ),
+									esc_html( $setting_name_key )
+								),
+								'7.0.0'
+							);
+							return null;
+						}
+						$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
+					} else {
+						$connector['authentication'][ $setting_name_key ] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_name_suffix}" );
+					}
 				}
 			}
 

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *                                       or application-password credentials. When
 		 *                                       omitted, auto-generated as
 		 *                                       `connectors_{$type}_{$id}_api_key` for API
-		 *                                       keys and `connectors_{$type}_{$id}_credentials`
+		 *                                       keys and `connectors_{$type}_{$id}_application_password`
 		 *                                       for application passwords.
 		 *                                       Must be a non-empty string when provided.
 		 *         @type string $constant_name   Optional. PHP constant name for the API key
@@ -234,7 +234,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 					}
 					$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 				} else {
-					$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
+					$setting_suffix                              = $args['authentication']['method'];
 					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 				}
 

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -234,8 +234,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 					}
 					$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 				} else {
-					$setting_suffix                              = $args['authentication']['method'];
-					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
+					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$args['authentication']['method']}" );
 				}
 
 				if ( isset( $args['authentication']['constant_name'] ) ) {

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -202,6 +202,24 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				return null;
 			}
 
+			if ( 'application_password' !== $args['authentication']['method'] ) {
+				foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
+					if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
+						_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+								/* translators: 1: Connector ID, 2: Authentication setting name key. */
+								__( 'Connector "%1$s" authentication %2$s can only be provided when authentication method is "application_password".' ),
+								esc_html( $id ),
+								esc_html( $setting_name_key )
+							),
+							'7.0.0'
+						);
+						return null;
+					}
+				}
+			}
+
 			if ( 'ai_provider' === $args['type'] && ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
 				// No need for a doing_it_wrong as AI support is disabled intentionally.
 				return null;

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -24,8 +24,6 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
-	 *         username_setting_name?: non-empty-string,
-	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -59,13 +57,11 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 * Registers a new connector.
 		 *
 		 * Validates the provided arguments and stores the connector in the registry.
-		 * For connectors with `api_key` authentication, a `setting_name` can be provided
-		 * explicitly. For connectors with `application_password` authentication,
-		 * `username_setting_name` and `application_password_setting_name` can be provided.
-		 * When omitted, setting names are automatically generated using the pattern
-		 * `connectors_{$type}_{$id}_{$credential}`, with hyphens in the type and ID
-		 * normalized to underscores. These setting names are used for Settings API
-		 * registration and REST API exposure.
+		 * For connectors with `api_key` or `application_password` authentication, a
+		 * `setting_name` can be provided explicitly. When omitted, setting names are
+		 * automatically generated using the pattern `connectors_{$type}_{$id}_{$credential}`,
+		 * with hyphens in the type and ID normalized to underscores. These setting
+		 * names are used for Settings API registration and REST API exposure.
 		 *
 		 * Registering a connector with an ID that is already registered will trigger a
 		 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -90,16 +86,13 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *         @type string $method          Required. The authentication method: 'api_key',
 		 *                                       'application_password', or 'none'.
 		 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
-		 *         @type string $setting_name    Optional. The setting name for the API key.
-		 *                                       When omitted, auto-generated as
-		 *                                       `connectors_{$type}_{$id}_api_key`.
+		 *         @type string $setting_name    Optional. The setting name for the API key
+		 *                                       or application-password credentials. When
+		 *                                       omitted, auto-generated as
+		 *                                       `connectors_{$type}_{$id}_api_key` for API
+		 *                                       keys and `connectors_{$type}_{$id}_credentials`
+		 *                                       for application passwords.
 		 *                                       Must be a non-empty string when provided.
-		 *         @type string $username_setting_name Optional. The setting name for the username used
-		 *                                       with application password authentication. When omitted,
-		 *                                       auto-generated as `connectors_{$type}_{$id}_username`.
-		 *         @type string $application_password_setting_name Optional. The setting name for the
-		 *                                       application password. When omitted, auto-generated as
-		 *                                       `connectors_{$type}_{$id}_application_password`.
 		 *         @type string $constant_name   Optional. PHP constant name for the API key
 		 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 		 *         @type string $env_var_name    Optional. Environment variable name for the API key
@@ -127,8 +120,6 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 		 *         method: 'api_key'|'application_password'|'none',
 		 *         credentials_url?: non-empty-string,
 		 *         setting_name?: non-empty-string,
-		 *         username_setting_name?: non-empty-string,
-		 *         application_password_setting_name?: non-empty-string,
 		 *         constant_name?: non-empty-string,
 		 *         env_var_name?: non-empty-string
 		 *     },
@@ -202,21 +193,19 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				return null;
 			}
 
-			if ( 'application_password' !== $args['authentication']['method'] ) {
-				foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
-					if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
-						_doing_it_wrong(
-							__METHOD__,
-							sprintf(
-								/* translators: 1: Connector ID, 2: Authentication setting name key. */
-								__( 'Connector "%1$s" authentication %2$s can only be provided when authentication method is "application_password".' ),
-								esc_html( $id ),
-								esc_html( $setting_name_key )
-							),
-							'7.0.0'
-						);
-						return null;
-					}
+			foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
+				if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						sprintf(
+							/* translators: 1: Connector ID, 2: Authentication setting name key. */
+							__( 'Connector "%1$s" authentication %2$s is not supported. Use setting_name instead.' ),
+							esc_html( $id ),
+							esc_html( $setting_name_key )
+						),
+						'7.0.0'
+					);
+					return null;
 				}
 			}
 
@@ -244,7 +233,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				}
 			}
 
-			if ( 'api_key' === $args['authentication']['method'] ) {
+			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 				if ( isset( $args['authentication']['setting_name'] ) ) {
 					if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 						_doing_it_wrong(
@@ -257,8 +246,12 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 					}
 					$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 				} else {
-					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_api_key" );
+					$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
+					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 				}
+			}
+
+			if ( 'api_key' === $args['authentication']['method'] ) {
 				if ( isset( $args['authentication']['constant_name'] ) ) {
 					if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 						_doing_it_wrong(
@@ -282,42 +275,6 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 						return null;
 					}
 					$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
-				}
-			}
-
-			if ( 'application_password' === $args['authentication']['method'] ) {
-				$default_setting_names = array(
-					'username_setting_name'             => str_replace(
-						'-',
-						'_',
-						"connectors_{$connector['type']}_{$id}_username"
-					),
-					'application_password_setting_name' => str_replace(
-						'-',
-						'_',
-						"connectors_{$connector['type']}_{$id}_application_password"
-					),
-				);
-
-				foreach ( $default_setting_names as $setting_name_key => $default_setting_name ) {
-					if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
-						if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
-							_doing_it_wrong(
-								__METHOD__,
-								sprintf(
-									/* translators: 1: Connector ID, 2: Authentication setting name key. */
-									__( 'Connector "%1$s" authentication %2$s must be a non-empty string.' ),
-									esc_html( $id ),
-									esc_html( $setting_name_key )
-								),
-								'7.0.0'
-							);
-							return null;
-						}
-						$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
-					} else {
-						$connector['authentication'][ $setting_name_key ] = $default_setting_name;
-					}
 				}
 			}
 

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -197,22 +197,6 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				return null;
 			}
 
-			foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
-				if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
-					_doing_it_wrong(
-						__METHOD__,
-						sprintf(
-							/* translators: 1: Connector ID, 2: Authentication setting name key. */
-							__( 'Connector "%1$s" authentication %2$s is not supported. Use setting_name instead.' ),
-							esc_html( $id ),
-							esc_html( $setting_name_key )
-						),
-						'7.0.0'
-					);
-					return null;
-				}
-			}
-
 			if ( 'ai_provider' === $args['type'] && ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
 				// No need for a doing_it_wrong as AI support is disabled intentionally.
 				return null;
@@ -231,13 +215,13 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 				$connector['logo_url'] = $args['logo_url'];
 			}
 
-			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
+			$requires_credentials = in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true );
+
+			if ( $requires_credentials ) {
 				if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 					$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 				}
-			}
 
-			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 				if ( isset( $args['authentication']['setting_name'] ) ) {
 					if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 						_doing_it_wrong(
@@ -253,9 +237,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 					$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
 					$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 				}
-			}
 
-			if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 				if ( isset( $args['authentication']['constant_name'] ) ) {
 					if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 						_doing_it_wrong(

--- a/lib/compat/wordpress-7.0/class-wp-connector-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-connector-registry.php
@@ -268,12 +268,20 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 			}
 
 			if ( 'application_password' === $args['authentication']['method'] ) {
-				$setting_names = array(
-					'username_setting_name'             => 'username',
-					'application_password_setting_name' => 'application_password',
+				$default_setting_names = array(
+					'username_setting_name'             => str_replace(
+						'-',
+						'_',
+						"connectors_{$connector['type']}_{$id}_username"
+					),
+					'application_password_setting_name' => str_replace(
+						'-',
+						'_',
+						"connectors_{$connector['type']}_{$id}_application_password"
+					),
 				);
 
-				foreach ( $setting_names as $setting_name_key => $setting_name_suffix ) {
+				foreach ( $default_setting_names as $setting_name_key => $default_setting_name ) {
 					if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
 						if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
 							_doing_it_wrong(
@@ -290,7 +298,7 @@ if ( ! class_exists( 'WP_Connector_Registry' ) ) {
 						}
 						$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
 					} else {
-						$connector['authentication'][ $setting_name_key ] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_name_suffix}" );
+						$connector['authentication'][ $setting_name_key ] = $default_setting_name;
 					}
 				}
 			}

--- a/lib/compat/wordpress-7.0/connectors.php
+++ b/lib/compat/wordpress-7.0/connectors.php
@@ -47,15 +47,12 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 *         Authentication configuration. When method is 'api_key', includes
 	 *         credentials_url, setting_name, and optionally constant_name and
 	 *         env_var_name. When method is 'application_password', includes
-	 *         credentials_url, username_setting_name, and
-	 *         application_password_setting_name. When 'none', only method is present.
+	 *         credentials_url and setting_name. When 'none', only method is present.
 	 *
 	 *         @type string $method          The authentication method: 'api_key',
 	 *                                       'application_password', or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
-	 *         @type string $setting_name    Optional. The setting name for the API key.
-	 *         @type string $username_setting_name Optional. The setting name for the username.
-	 *         @type string $application_password_setting_name Optional. The setting name for the application password.
+	 *         @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key.
 	 *     }
@@ -77,8 +74,6 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
-	 *         username_setting_name?: non-empty-string,
-	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -120,15 +115,12 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *             Authentication configuration. When method is 'api_key', includes
 	 *             credentials_url, setting_name, and optionally constant_name and
 	 *             env_var_name. When method is 'application_password', includes
-	 *             credentials_url, username_setting_name, and
-	 *             application_password_setting_name. When 'none', only method is present.
+	 *             credentials_url and setting_name. When 'none', only method is present.
 	 *
 	 *             @type string $method          The authentication method: 'api_key',
 	 *                                           'application_password', or 'none'.
 	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
-	 *             @type string $setting_name    Optional. The setting name for the API key.
-	 *             @type string $username_setting_name Optional. The setting name for the username.
-	 *             @type string $application_password_setting_name Optional. The setting name for the application password.
+	 *             @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
 	 *             @type string $constant_name   Optional. PHP constant name for the API key.
 	 *             @type string $env_var_name    Optional. Environment variable name for the API key.
 	 *         }
@@ -151,8 +143,6 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
-	 *         username_setting_name?: non-empty-string,
-	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },

--- a/lib/compat/wordpress-7.0/connectors.php
+++ b/lib/compat/wordpress-7.0/connectors.php
@@ -46,11 +46,16 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 *     @type array  $authentication {
 	 *         Authentication configuration. When method is 'api_key', includes
 	 *         credentials_url, setting_name, and optionally constant_name and
-	 *         env_var_name. When 'none', only method is present.
+	 *         env_var_name. When method is 'application_password', includes
+	 *         credentials_url, username_setting_name, and
+	 *         application_password_setting_name. When 'none', only method is present.
 	 *
-	 *         @type string $method          The authentication method: 'api_key' or 'none'.
+	 *         @type string $method          The authentication method: 'api_key',
+	 *                                       'application_password', or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *         @type string $setting_name    Optional. The setting name for the API key.
+	 *         @type string $username_setting_name Optional. The setting name for the username.
+	 *         @type string $application_password_setting_name Optional. The setting name for the application password.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key.
 	 *     }
@@ -69,9 +74,11 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 *     logo_url?: non-empty-string,
 	 *     type: non-empty-string,
 	 *     authentication: array{
-	 *         method: 'api_key'|'none',
+	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
+	 *         username_setting_name?: non-empty-string,
+	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -112,11 +119,16 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *         @type array       $authentication {
 	 *             Authentication configuration. When method is 'api_key', includes
 	 *             credentials_url, setting_name, and optionally constant_name and
-	 *             env_var_name. When 'none', only method is present.
+	 *             env_var_name. When method is 'application_password', includes
+	 *             credentials_url, username_setting_name, and
+	 *             application_password_setting_name. When 'none', only method is present.
 	 *
-	 *             @type string $method          The authentication method: 'api_key' or 'none'.
+	 *             @type string $method          The authentication method: 'api_key',
+	 *                                           'application_password', or 'none'.
 	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *             @type string $setting_name    Optional. The setting name for the API key.
+	 *             @type string $username_setting_name Optional. The setting name for the username.
+	 *             @type string $application_password_setting_name Optional. The setting name for the application password.
 	 *             @type string $constant_name   Optional. PHP constant name for the API key.
 	 *             @type string $env_var_name    Optional. Environment variable name for the API key.
 	 *         }
@@ -136,9 +148,11 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *     logo_url?: non-empty-string,
 	 *     type: non-empty-string,
 	 *     authentication: array{
-	 *         method: 'api_key'|'none',
+	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
+	 *         username_setting_name?: non-empty-string,
+	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },

--- a/lib/compat/wordpress-7.0/connectors.php
+++ b/lib/compat/wordpress-7.0/connectors.php
@@ -44,17 +44,17 @@ if ( ! function_exists( 'wp_get_connector' ) ) {
 	 *     @type string $logo_url       Optional. URL to the connector's logo image.
 	 *     @type string $type           The connector type, e.g. 'ai_provider' or 'spam_filtering'.
 	 *     @type array  $authentication {
-	 *         Authentication configuration. When method is 'api_key', includes
-	 *         credentials_url, setting_name, and optionally constant_name and
-	 *         env_var_name. When method is 'application_password', includes
-	 *         credentials_url and setting_name. When 'none', only method is present.
+	 *         Authentication configuration. When method is 'api_key' or
+	 *         'application_password', includes credentials_url, setting_name, and
+	 *         optionally constant_name and env_var_name. When 'none', only method
+	 *         is present.
 	 *
 	 *         @type string $method          The authentication method: 'api_key',
 	 *                                       'application_password', or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *         @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
-	 *         @type string $constant_name   Optional. PHP constant name for the API key.
-	 *         @type string $env_var_name    Optional. Environment variable name for the API key.
+	 *         @type string $constant_name   Optional. PHP constant name for the API key or application-password credentials.
+	 *         @type string $env_var_name    Optional. Environment variable name for the API key or application-password credentials.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
@@ -112,17 +112,17 @@ if ( ! function_exists( 'wp_get_connectors' ) ) {
 	 *         @type string      $logo_url       Optional. URL to the connector's logo image.
 	 *         @type string      $type           The connector type, e.g. 'ai_provider' or 'spam_filtering'.
 	 *         @type array       $authentication {
-	 *             Authentication configuration. When method is 'api_key', includes
-	 *             credentials_url, setting_name, and optionally constant_name and
-	 *             env_var_name. When method is 'application_password', includes
-	 *             credentials_url and setting_name. When 'none', only method is present.
+	 *             Authentication configuration. When method is 'api_key' or
+	 *             'application_password', includes credentials_url, setting_name,
+	 *             and optionally constant_name and env_var_name. When 'none', only
+	 *             method is present.
 	 *
 	 *             @type string $method          The authentication method: 'api_key',
 	 *                                           'application_password', or 'none'.
 	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *             @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
-	 *             @type string $constant_name   Optional. PHP constant name for the API key.
-	 *             @type string $env_var_name    Optional. Environment variable name for the API key.
+	 *             @type string $constant_name   Optional. PHP constant name for the API key or application-password credentials.
+	 *             @type string $env_var_name    Optional. Environment variable name for the API key or application-password credentials.
 	 *         }
 	 *         @type array       $plugin         {
 	 *             Optional. Plugin data for install/activate UI.

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -309,11 +309,12 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
 /**
  * Masks and validates connector credentials in REST responses.
  *
- * On every `/wp/v2/settings` response, masks connector API key values so raw
- * keys are never exposed via the REST API.
+ * On every `/wp/v2/settings` response, masks connector API key and application
+ * password values so raw credentials are never exposed via the REST API.
  *
- * On POST or PUT requests, validates each updated key against the provider
- * before masking. If validation fails, the key is reverted to an empty string.
+ * On POST or PUT requests, validates each updated AI provider API key before
+ * masking. If validation fails, the key is reverted to an empty string.
+ * Application password values are masked but not validated.
  *
  * @access private
  *

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -307,7 +307,7 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
 }
 
 /**
- * Masks and validates connector API keys in REST responses.
+ * Masks and validates connector credentials in REST responses.
  *
  * On every `/wp/v2/settings` response, masks connector API key values so raw
  * keys are never exposed via the REST API.
@@ -340,6 +340,15 @@ function _gutenberg_connectors_rest_settings_dispatch( WP_REST_Response $respons
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
+
+		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
+			$setting_name = $auth['application_password_setting_name'];
+			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
+				$data[ $setting_name ] = _gutenberg_mask_api_key( $data[ $setting_name ] );
+			}
+			continue;
+		}
+
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
@@ -384,12 +393,7 @@ function _gutenberg_register_default_connector_settings(): void {
 
 	foreach ( wp_get_connectors() as $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
-			continue;
-		}
-
-		// Skip if the setting is already registered (e.g. by the connector's plugin).
-		if ( isset( $existing_settings[ $auth['setting_name'] ] ) ) {
+		if ( 'api_key' !== $auth['method'] && 'application_password' !== $auth['method'] ) {
 			continue;
 		}
 
@@ -401,10 +405,9 @@ function _gutenberg_register_default_connector_settings(): void {
 			continue;
 		}
 
-		register_setting(
-			'connectors',
-			$auth['setting_name'],
-			array(
+		$settings = array();
+		if ( 'api_key' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$settings[ $auth['setting_name'] ] = array(
 				'type'              => 'string',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
@@ -419,8 +422,49 @@ function _gutenberg_register_default_connector_settings(): void {
 				'default'           => '',
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-			)
-		);
+			);
+		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
+			$settings[ $auth['username_setting_name'] ] = array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: Connector name. */
+					__( '%s Username', 'gutenberg' ),
+					$connector_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: Connector name. */
+					__( 'Username for the %s connector.', 'gutenberg' ),
+					$connector_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			);
+			$settings[ $auth['application_password_setting_name'] ] = array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: Connector name. */
+					__( '%s Application Password', 'gutenberg' ),
+					$connector_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: Connector name. */
+					__( 'Application password for the %s connector.', 'gutenberg' ),
+					$connector_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			);
+		}
+
+		foreach ( $settings as $setting_name => $setting_args ) {
+			// Skip settings already registered by the connector's owning plugin.
+			if ( isset( $existing_settings[ $setting_name ] ) ) {
+				continue;
+			}
+			register_setting( 'connectors', $setting_name, $setting_args );
+		}
 	}
 }
 remove_action( 'init', '_wp_register_default_connector_settings', 20 );
@@ -522,6 +566,16 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 				// For non-AI connectors, consider connected if a key exists from any source.
 				$auth_out['isConnected'] = 'none' !== $auth_out['keySource'];
 			}
+		} elseif ( 'application_password' === $auth['method'] ) {
+			$username_setting_name             = $auth['username_setting_name'] ?? '';
+			$application_password_setting_name = $auth['application_password_setting_name'] ?? '';
+			$username                          = get_option( $username_setting_name, '' );
+			$application_password              = get_option( $application_password_setting_name, '' );
+
+			$auth_out['usernameSettingName']             = $username_setting_name;
+			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
+			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
+			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;
 		}
 
 		$connector_out = array(

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -269,17 +269,6 @@ function _gutenberg_mask_api_key( string $key ): string {
 }
 
 /**
- * Masks an application password without revealing any characters.
- *
- * @access private
- *
- * @return string The masked application password.
- */
-function _gutenberg_mask_application_password(): string {
-	return str_repeat( "\u{2022}", 16 );
-}
-
-/**
  * Checks whether an API key is valid for a given provider.
  *
  * @access private
@@ -356,7 +345,7 @@ function _gutenberg_connectors_rest_settings_dispatch( WP_REST_Response $respons
 		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
 			$setting_name = $auth['application_password_setting_name'];
 			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = _gutenberg_mask_application_password();
+				$data[ $setting_name ] = str_repeat( "\u{2022}", 16 );
 			}
 			continue;
 		}

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -330,7 +330,7 @@ function _gutenberg_get_application_password_credentials( array $auth ): array {
 	return array(
 		'username' => $username,
 		'password' => $password,
-		'source'   => '' !== $username || '' !== $password ? 'database' : 'none',
+		'source'   => '' !== $username && '' !== $password ? 'database' : 'none',
 	);
 }
 
@@ -397,6 +397,8 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
  * places in REST responses also keeps the stored password, so a masked
  * settings response can be submitted back to the endpoint unchanged.
  * Pass an empty string to clear a field.
+ * If the sanitized username is empty, both fields are discarded so partial
+ * credentials cannot leave an orphaned secret.
  *
  * @access private
  *
@@ -428,14 +430,21 @@ function _gutenberg_sanitize_application_password_credentials( $value ): array {
 		$credentials['password'] = isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
 	}
 
+	if ( '' === $credentials['username'] ) {
+		return array(
+			'username' => '',
+			'password' => '',
+		);
+	}
+
 	return $credentials;
 }
 
 /**
  * Masks and validates connector credentials in REST responses.
  *
- * On every `/wp/v2/settings` response, masks connector API key and application
- * password values so raw credentials are never exposed via the REST API.
+ * On every `/wp/v2/settings` response, masks connector API key values and the
+ * password field of default application-password credential objects.
  *
  * On POST or PUT requests, validates each updated AI provider API key before
  * masking. If validation fails, the key is reverted to an empty string.
@@ -526,6 +535,11 @@ function _gutenberg_register_default_connector_settings(): void {
 			continue;
 		}
 
+		if ( empty( $auth['setting_name'] ) || isset( $existing_settings[ $auth['setting_name'] ] ) ) {
+			continue;
+		}
+		$setting_name = $auth['setting_name'];
+
 		if ( ! isset( $connector_data['plugin']['is_active'] ) || ! is_callable( $connector_data['plugin']['is_active'] ) ) {
 			continue;
 		}
@@ -534,65 +548,64 @@ function _gutenberg_register_default_connector_settings(): void {
 			continue;
 		}
 
-		$settings = array();
-		if ( 'api_key' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
-			$settings[ $auth['setting_name'] ] = array(
-				'type'              => 'string',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s API Key', 'gutenberg' ),
-					$connector_data['name']
-				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'API key for the %s connector.', 'gutenberg' ),
-					$connector_data['name']
-				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
-			);
-		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
-			$settings[ $auth['setting_name'] ] = array(
-				'type'              => 'object',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s Credentials', 'gutenberg' ),
-					$connector_data['name']
-				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'Application password credentials for the %s connector.', 'gutenberg' ),
-					$connector_data['name']
-				),
-				'default'           => array(
-					'username' => '',
-					'password' => '',
-				),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'                 => 'object',
-						'properties'           => array(
-							'username' => array(
-								'type' => 'string',
-							),
-							'password' => array(
-								'type' => 'string',
-							),
-						),
-						'additionalProperties' => false,
+		if ( 'api_key' === $auth['method'] ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'string',
+					'label'             => sprintf(
+						/* translators: %s: Connector name. */
+						__( '%s API Key', 'gutenberg' ),
+						$connector_data['name']
 					),
-				),
-				'sanitize_callback' => '_gutenberg_sanitize_application_password_credentials',
+					'description'       => sprintf(
+						/* translators: %s: Connector name. */
+						__( 'API key for the %s connector.', 'gutenberg' ),
+						$connector_data['name']
+					),
+					'default'           => '',
+					'show_in_rest'      => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				)
 			);
-		}
-
-		foreach ( $settings as $setting_name => $setting_args ) {
-			// Skip settings already registered by the connector's owning plugin.
-			if ( isset( $existing_settings[ $setting_name ] ) ) {
-				continue;
-			}
-			register_setting( 'connectors', $setting_name, $setting_args );
+		} elseif ( 'application_password' === $auth['method'] ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'object',
+					'label'             => sprintf(
+						/* translators: %s: Connector name. */
+						__( '%s Credentials', 'gutenberg' ),
+						$connector_data['name']
+					),
+					'description'       => sprintf(
+						/* translators: %s: Connector name. */
+						__( 'Application password credentials for the %s connector.', 'gutenberg' ),
+						$connector_data['name']
+					),
+					'default'           => array(
+						'username' => '',
+						'password' => '',
+					),
+					'show_in_rest'      => array(
+						'schema' => array(
+							'type'                 => 'object',
+							'properties'           => array(
+								'username' => array(
+									'type' => 'string',
+								),
+								'password' => array(
+									'type' => 'string',
+								),
+							),
+							'additionalProperties' => false,
+						),
+					),
+					'sanitize_callback' => '_gutenberg_sanitize_application_password_credentials',
+				)
+			);
 		}
 	}
 }

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -309,6 +309,13 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
 /**
  * Sanitizes stored application-password credentials for a connector.
  *
+ * Credential fields that are missing or not strings keep their currently
+ * stored values, so partial updates cannot silently clear a stored secret.
+ * A password matching the mask that `_gutenberg_connectors_rest_settings_dispatch()`
+ * places in REST responses also keeps the stored password, so a masked
+ * settings response can be submitted back to the endpoint unchanged.
+ * Pass an empty string to clear a field.
+ *
  * @access private
  *
  * @param mixed $value The submitted setting value.
@@ -319,10 +326,27 @@ function _gutenberg_sanitize_application_password_credentials( $value ): array {
 		$value = array();
 	}
 
-	return array(
-		'username' => isset( $value['username'] ) && is_string( $value['username'] ) ? sanitize_text_field( $value['username'] ) : '',
-		'password' => isset( $value['password'] ) && is_string( $value['password'] ) ? sanitize_text_field( $value['password'] ) : '',
-	);
+	$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	$stored = get_option( $option );
+	if ( ! is_array( $stored ) ) {
+		$stored = array();
+	}
+
+	$credentials = array();
+	foreach ( array( 'username', 'password' ) as $field ) {
+		if ( isset( $value[ $field ] ) && is_string( $value[ $field ] ) ) {
+			$credentials[ $field ] = sanitize_text_field( $value[ $field ] );
+		} else {
+			$credentials[ $field ] = isset( $stored[ $field ] ) && is_string( $stored[ $field ] ) ? $stored[ $field ] : '';
+		}
+	}
+
+	// A masked password means a client resubmitted a masked REST response.
+	if ( str_repeat( "\u{2022}", 16 ) === $credentials['password'] ) {
+		$credentials['password'] = isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
+	}
+
+	return $credentials;
 }
 
 /**

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -268,8 +268,8 @@ function _gutenberg_parse_application_password_credentials( string $value ): arr
 	$separator = strpos( $value, ':' );
 	// Trim so surrounding whitespace or a trailing newline (common when the
 	// value comes from a file or `.env`) does not become part of the credentials.
-	$username  = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
-	$password  = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
+	$username = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
+	$password = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
 
 	if ( '' === $username || '' === $password ) {
 		return array(

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -402,15 +402,21 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
  *
  * @access private
  *
- * @param mixed $value The submitted setting value.
+ * @param mixed  $value  The submitted setting value.
+ * @param string $option The option name being sanitized. Passed explicitly by the
+ *                       registered sanitize callback; falls back to the current
+ *                       `sanitize_option_{$option}` filter name when omitted.
  * @return array{username: string, password: string} Sanitized credentials.
  */
-function _gutenberg_sanitize_application_password_credentials( $value ): array {
+function _gutenberg_sanitize_application_password_credentials( $value, string $option = '' ): array {
 	if ( ! is_array( $value ) ) {
 		$value = array();
 	}
 
-	$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	if ( '' === $option ) {
+		$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	}
+
 	$stored = get_option( $option );
 	if ( ! is_array( $stored ) ) {
 		$stored = array();
@@ -603,7 +609,9 @@ function _gutenberg_register_default_connector_settings(): void {
 							'additionalProperties' => false,
 						),
 					),
-					'sanitize_callback' => '_gutenberg_sanitize_application_password_credentials',
+					'sanitize_callback' => static function ( $value ) use ( $setting_name ) {
+						return _gutenberg_sanitize_application_password_credentials( $value, $setting_name );
+					},
 				)
 			);
 		}

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -319,7 +319,7 @@ function _gutenberg_get_application_password_credentials( array $auth ): array {
 				sprintf(
 					/* translators: %s: Environment variable name. */
 					__( 'The %s environment variable must contain application password credentials in "username:password" format.', 'gutenberg' ),
-					$env_var_name
+					esc_html( $env_var_name )
 				),
 				'7.0.0'
 			);
@@ -342,7 +342,7 @@ function _gutenberg_get_application_password_credentials( array $auth ): array {
 				sprintf(
 					/* translators: %s: PHP constant name. */
 					__( 'The %s constant must contain application password credentials in "username:password" format.', 'gutenberg' ),
-					$constant_name
+					esc_html( $constant_name )
 				),
 				'7.0.0'
 			);

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -289,8 +289,9 @@ function _gutenberg_parse_application_password_credentials( string $value ): arr
  * environment variable and constant are only checked when their respective
  * names are provided, and must contain the credentials as a single
  * `username:password` string. A non-empty environment variable or constant
- * claims the source even when malformed, in which case the resolved
- * credentials are empty.
+ * that cannot be parsed as `username:password` is reported with
+ * `_doing_it_wrong()` and ignored, so resolution falls through to the next
+ * source.
  *
  * @access private
  *
@@ -305,9 +306,21 @@ function _gutenberg_get_application_password_credentials( array $auth ): array {
 	if ( '' !== $env_var_name ) {
 		$env_value = getenv( $env_var_name );
 		if ( false !== $env_value && '' !== $env_value ) {
-			$credentials           = _gutenberg_parse_application_password_credentials( $env_value );
-			$credentials['source'] = 'env';
-			return $credentials;
+			$credentials = _gutenberg_parse_application_password_credentials( $env_value );
+			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
+				$credentials['source'] = 'env';
+				return $credentials;
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: Environment variable name. */
+					__( 'The %s environment variable must contain application password credentials in "username:password" format.', 'gutenberg' ),
+					$env_var_name
+				),
+				'7.0.0'
+			);
 		}
 	}
 
@@ -316,9 +329,21 @@ function _gutenberg_get_application_password_credentials( array $auth ): array {
 	if ( '' !== $constant_name && defined( $constant_name ) ) {
 		$const_value = constant( $constant_name );
 		if ( is_string( $const_value ) && '' !== $const_value ) {
-			$credentials           = _gutenberg_parse_application_password_credentials( $const_value );
-			$credentials['source'] = 'constant';
-			return $credentials;
+			$credentials = _gutenberg_parse_application_password_credentials( $const_value );
+			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
+				$credentials['source'] = 'constant';
+				return $credentials;
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: PHP constant name. */
+					__( 'The %s constant must contain application password credentials in "username:password" format.', 'gutenberg' ),
+					$constant_name
+				),
+				'7.0.0'
+			);
 		}
 	}
 

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -266,8 +266,10 @@ function _gutenberg_get_api_key_source( string $setting_name, string $env_var_na
  */
 function _gutenberg_parse_application_password_credentials( string $value ): array {
 	$separator = strpos( $value, ':' );
-	$username  = false === $separator ? '' : substr( $value, 0, $separator );
-	$password  = false === $separator ? '' : substr( $value, $separator + 1 );
+	// Trim so surrounding whitespace or a trailing newline (common when the
+	// value comes from a file or `.env`) does not become part of the credentials.
+	$username  = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
+	$password  = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
 
 	if ( '' === $username || '' === $password ) {
 		return array(

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -253,6 +253,88 @@ function _gutenberg_get_api_key_source( string $setting_name, string $env_var_na
 }
 
 /**
+ * Parses a `username:password` credentials string.
+ *
+ * Splits on the first colon, matching the HTTP Basic authentication
+ * userinfo format, so passwords may contain colons.
+ *
+ * @access private
+ *
+ * @param string $value The raw credentials string.
+ * @return array{username: string, password: string} Parsed credentials. Both values
+ *                                                   are empty when the string is malformed.
+ */
+function _gutenberg_parse_application_password_credentials( string $value ): array {
+	$separator = strpos( $value, ':' );
+	$username  = false === $separator ? '' : substr( $value, 0, $separator );
+	$password  = false === $separator ? '' : substr( $value, $separator + 1 );
+
+	if ( '' === $username || '' === $password ) {
+		return array(
+			'username' => '',
+			'password' => '',
+		);
+	}
+
+	return array(
+		'username' => $username,
+		'password' => $password,
+	);
+}
+
+/**
+ * Resolves application-password credentials for a connector.
+ *
+ * Checks in order: environment variable, PHP constant, database. The
+ * environment variable and constant are only checked when their respective
+ * names are provided, and must contain the credentials as a single
+ * `username:password` string. A non-empty environment variable or constant
+ * claims the source even when malformed, in which case the resolved
+ * credentials are empty.
+ *
+ * @access private
+ *
+ * @param array $auth The connector's authentication configuration.
+ * @return array{username: string, password: string, source: string} Resolved credentials and
+ *                                                                   their source: 'env', 'constant',
+ *                                                                   'database', or 'none'.
+ */
+function _gutenberg_get_application_password_credentials( array $auth ): array {
+	// Check environment variable (only if explicitly configured).
+	$env_var_name = $auth['env_var_name'] ?? '';
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			$credentials           = _gutenberg_parse_application_password_credentials( $env_value );
+			$credentials['source'] = 'env';
+			return $credentials;
+		}
+	}
+
+	// Check PHP constant (only if explicitly configured).
+	$constant_name = $auth['constant_name'] ?? '';
+	if ( '' !== $constant_name && defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
+		if ( is_string( $const_value ) && '' !== $const_value ) {
+			$credentials           = _gutenberg_parse_application_password_credentials( $const_value );
+			$credentials['source'] = 'constant';
+			return $credentials;
+		}
+	}
+
+	// Check database.
+	$stored   = get_option( $auth['setting_name'] ?? '', array() );
+	$username = is_array( $stored ) && isset( $stored['username'] ) && is_string( $stored['username'] ) ? $stored['username'] : '';
+	$password = is_array( $stored ) && isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
+
+	return array(
+		'username' => $username,
+		'password' => $password,
+		'source'   => '' !== $username || '' !== $password ? 'database' : 'none',
+	);
+}
+
+/**
  * Masks an API key, showing only the last 4 characters.
  *
  * @access private
@@ -614,14 +696,12 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 				$auth_out['isConnected'] = 'none' !== $auth_out['keySource'];
 			}
 		} elseif ( 'application_password' === $auth['method'] ) {
-			$setting_name = $auth['setting_name'] ?? '';
-			$credentials  = get_option( $setting_name, array() );
-			$username     = is_array( $credentials ) ? ( $credentials['username'] ?? '' ) : '';
-			$password     = is_array( $credentials ) ? ( $credentials['password'] ?? '' ) : '';
+			$credentials = _gutenberg_get_application_password_credentials( $auth );
 
-			$auth_out['settingName']    = $setting_name;
+			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['isConnected']    = is_string( $username ) && '' !== $username && is_string( $password ) && '' !== $password;
+			$auth_out['keySource']      = $credentials['source'];
+			$auth_out['isConnected']    = '' !== $credentials['username'] && '' !== $credentials['password'];
 		}
 
 		$connector_out = array(

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -307,6 +307,25 @@ function _gutenberg_is_ai_api_key_valid( string $key, string $provider_id ): ?bo
 }
 
 /**
+ * Sanitizes stored application-password credentials for a connector.
+ *
+ * @access private
+ *
+ * @param mixed $value The submitted setting value.
+ * @return array{username: string, password: string} Sanitized credentials.
+ */
+function _gutenberg_sanitize_application_password_credentials( $value ): array {
+	if ( ! is_array( $value ) ) {
+		$value = array();
+	}
+
+	return array(
+		'username' => isset( $value['username'] ) && is_string( $value['username'] ) ? sanitize_text_field( $value['username'] ) : '',
+		'password' => isset( $value['password'] ) && is_string( $value['password'] ) ? sanitize_text_field( $value['password'] ) : '',
+	);
+}
+
+/**
  * Masks and validates connector credentials in REST responses.
  *
  * On every `/wp/v2/settings` response, masks connector API key and application
@@ -342,10 +361,13 @@ function _gutenberg_connectors_rest_settings_dispatch( WP_REST_Response $respons
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 
-		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
-			$setting_name = $auth['application_password_setting_name'];
-			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = str_repeat( "\u{2022}", 16 );
+		if ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$setting_name = $auth['setting_name'];
+			if ( array_key_exists( $setting_name, $data ) && is_array( $data[ $setting_name ] ) ) {
+				$password = $data[ $setting_name ]['password'] ?? '';
+				if ( is_string( $password ) && '' !== $password ) {
+					$data[ $setting_name ]['password'] = str_repeat( "\u{2022}", 16 );
+				}
 			}
 			continue;
 		}
@@ -424,38 +446,38 @@ function _gutenberg_register_default_connector_settings(): void {
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			);
-		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
-			$settings[ $auth['username_setting_name'] ]             = array(
-				'type'              => 'string',
+		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$settings[ $auth['setting_name'] ] = array(
+				'type'              => 'object',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
-					__( '%s Username', 'gutenberg' ),
+					__( '%s Credentials', 'gutenberg' ),
 					$connector_data['name']
 				),
 				'description'       => sprintf(
 					/* translators: %s: Connector name. */
-					__( 'Username for the %s connector.', 'gutenberg' ),
+					__( 'Application password credentials for the %s connector.', 'gutenberg' ),
 					$connector_data['name']
 				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
-			);
-			$settings[ $auth['application_password_setting_name'] ] = array(
-				'type'              => 'string',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s Application Password', 'gutenberg' ),
-					$connector_data['name']
+				'default'           => array(
+					'username' => '',
+					'password' => '',
 				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'Application password for the %s connector.', 'gutenberg' ),
-					$connector_data['name']
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'username' => array(
+								'type' => 'string',
+							),
+							'password' => array(
+								'type' => 'string',
+							),
+						),
+						'additionalProperties' => false,
+					),
 				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => '_gutenberg_sanitize_application_password_credentials',
 			);
 		}
 
@@ -568,15 +590,14 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 				$auth_out['isConnected'] = 'none' !== $auth_out['keySource'];
 			}
 		} elseif ( 'application_password' === $auth['method'] ) {
-			$username_setting_name             = $auth['username_setting_name'] ?? '';
-			$application_password_setting_name = $auth['application_password_setting_name'] ?? '';
-			$username                          = get_option( $username_setting_name, '' );
-			$application_password              = get_option( $application_password_setting_name, '' );
+			$setting_name = $auth['setting_name'] ?? '';
+			$credentials  = get_option( $setting_name, array() );
+			$username     = is_array( $credentials ) ? ( $credentials['username'] ?? '' ) : '';
+			$password     = is_array( $credentials ) ? ( $credentials['password'] ?? '' ) : '';
 
-			$auth_out['usernameSettingName']            = $username_setting_name;
-			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
-			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
-			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;
+			$auth_out['settingName']    = $setting_name;
+			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
+			$auth_out['isConnected']    = is_string( $username ) && '' !== $username && is_string( $password ) && '' !== $password;
 		}
 
 		$connector_out = array(

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -269,6 +269,17 @@ function _gutenberg_mask_api_key( string $key ): string {
 }
 
 /**
+ * Masks an application password without revealing any characters.
+ *
+ * @access private
+ *
+ * @return string The masked application password.
+ */
+function _gutenberg_mask_application_password(): string {
+	return str_repeat( "\u{2022}", 16 );
+}
+
+/**
  * Checks whether an API key is valid for a given provider.
  *
  * @access private
@@ -345,7 +356,7 @@ function _gutenberg_connectors_rest_settings_dispatch( WP_REST_Response $respons
 		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
 			$setting_name = $auth['application_password_setting_name'];
 			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = _gutenberg_mask_api_key( $data[ $setting_name ] );
+				$data[ $setting_name ] = _gutenberg_mask_application_password();
 			}
 			continue;
 		}

--- a/lib/compat/wordpress-7.0/default-connectors.php
+++ b/lib/compat/wordpress-7.0/default-connectors.php
@@ -424,7 +424,7 @@ function _gutenberg_register_default_connector_settings(): void {
 				'sanitize_callback' => 'sanitize_text_field',
 			);
 		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
-			$settings[ $auth['username_setting_name'] ] = array(
+			$settings[ $auth['username_setting_name'] ]             = array(
 				'type'              => 'string',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
@@ -572,7 +572,7 @@ function _gutenberg_get_connector_script_module_data( array $data ): array {
 			$username                          = get_option( $username_setting_name, '' );
 			$application_password              = get_option( $application_password_setting_name, '' );
 
-			$auth_out['usernameSettingName']             = $username_setting_name;
+			$auth_out['usernameSettingName']            = $username_setting_name;
 			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
 			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
 			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -302,7 +302,10 @@ export function ApplicationPasswordConnectorSettings( {
 		setSaveError( null );
 		setIsSaving( true );
 		try {
-			await onSave?.( { username, applicationPassword } );
+			await onSave?.( {
+				username: username.trim(),
+				applicationPassword,
+			} );
 		} catch ( error ) {
 			setSaveError(
 				error instanceof Error
@@ -386,7 +389,9 @@ export function ApplicationPasswordConnectorSettings( {
 						__next40pxDefaultSize
 						variant="primary"
 						disabled={
-							! username || ! applicationPassword || isSaving
+							! username.trim() ||
+							! applicationPassword ||
+							isSaving
 						}
 						accessibleWhenDisabled
 						isBusy={ isSaving }

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -254,6 +254,7 @@ export interface ApplicationPasswordConnectorSettingsProps {
 	helpUrl?: string;
 	helpLabel?: string;
 	readOnly?: boolean;
+	keySource?: ApiKeySource;
 }
 
 /**
@@ -266,6 +267,7 @@ export interface ApplicationPasswordConnectorSettingsProps {
  * @param props.helpUrl         - URL where users can create an application password.
  * @param props.helpLabel       - Custom label for the help link.
  * @param props.readOnly        - Whether the form is in read-only mode.
+ * @param props.keySource       - The source of the credentials: 'env', 'constant', 'database', or 'none'.
  */
 export function ApplicationPasswordConnectorSettings( {
 	onSave,
@@ -274,6 +276,7 @@ export function ApplicationPasswordConnectorSettings( {
 	helpUrl,
 	helpLabel,
 	readOnly = false,
+	keySource,
 }: ApplicationPasswordConnectorSettingsProps ) {
 	const [ username, setUsername ] = useState( initialUsername );
 	const [ applicationPassword, setApplicationPassword ] = useState( '' );
@@ -318,7 +321,15 @@ export function ApplicationPasswordConnectorSettings( {
 	};
 
 	let applicationPasswordHelp: ReactNode = help;
-	if ( readOnly ) {
+	if ( keySource === 'env' ) {
+		applicationPasswordHelp = __(
+			'These credentials are configured using an environment variable.'
+		);
+	} else if ( keySource === 'constant' ) {
+		applicationPasswordHelp = __(
+			'These credentials are configured as a constant.'
+		);
+	} else if ( readOnly ) {
 		applicationPasswordHelp = __(
 			'Your application password is stored securely.'
 		);

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -69,7 +69,17 @@ export function ConnectorItem( {
 export type { ApiKeySource } from './types';
 
 function getHelpLinkLabel( helpUrl?: string, helpLabel?: string ) {
-	return helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
+	if ( helpLabel ) {
+		return helpLabel;
+	}
+	if ( ! helpUrl ) {
+		return undefined;
+	}
+	try {
+		return new URL( helpUrl ).hostname;
+	} catch {
+		return helpUrl;
+	}
 }
 
 function createConnectorHelpLink(
@@ -204,7 +214,7 @@ export interface DefaultConnectorSettingsProps {
  * @param props.onRemove     - Callback invoked when the user removes the connector.
  * @param props.initialValue - Initial value for the API key field.
  * @param props.helpUrl      - URL to documentation for obtaining an API key.
- * @param props.helpLabel    - Custom label for the help link. Defaults to the URL without protocol.
+ * @param props.helpLabel    - Custom label for the help link. Defaults to the URL's hostname.
  * @param props.readOnly     - Whether the form is in read-only mode.
  * @param props.keySource    - The source of the API key: 'env', 'constant', 'database', or 'none'.
  */
@@ -321,7 +331,7 @@ export interface ApplicationPasswordConnectorSettingsProps {
  * @param props.onRemove        - Callback invoked when the credentials are removed.
  * @param props.initialUsername - Initial value for the username field.
  * @param props.helpUrl         - URL where users can create an application password.
- * @param props.helpLabel       - Custom label for the help link.
+ * @param props.helpLabel       - Custom label for the help link. Defaults to the URL's hostname.
  * @param props.readOnly        - Whether the form is in read-only mode.
  * @param props.keySource       - The source of the credentials: 'env', 'constant', 'database', or 'none'.
  */

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -314,7 +314,7 @@ export function ApplicationPasswordConnectorSettings( {
 		}
 	};
 
-	let applicationPasswordHelp = help;
+	let applicationPasswordHelp: ReactNode = help;
 	if ( readOnly ) {
 		applicationPasswordHelp = __(
 			'Your application password is stored securely.'

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -311,19 +311,21 @@ export interface ApplicationPasswordConnectorSettingsProps {
 	helpLabel?: string;
 	readOnly?: boolean;
 	keySource?: ApiKeySource;
+	externalCredentialsMalformed?: boolean;
 }
 
 /**
  * Default settings form for application password connectors.
  *
- * @param props                 - Component props.
- * @param props.onSave          - Callback invoked with the username and application password.
- * @param props.onRemove        - Callback invoked when the credentials are removed.
- * @param props.initialUsername - Initial value for the username field.
- * @param props.helpUrl         - URL where users can create an application password.
- * @param props.helpLabel       - Custom label for the help link.
- * @param props.readOnly        - Whether the form is in read-only mode.
- * @param props.keySource       - The source of the credentials: 'env', 'constant', 'database', or 'none'.
+ * @param props                              - Component props.
+ * @param props.onSave                       - Callback invoked with the username and application password.
+ * @param props.onRemove                     - Callback invoked when the credentials are removed.
+ * @param props.initialUsername              - Initial value for the username field.
+ * @param props.helpUrl                      - URL where users can create an application password.
+ * @param props.helpLabel                    - Custom label for the help link.
+ * @param props.readOnly                     - Whether the form is in read-only mode.
+ * @param props.keySource                    - The source of the credentials: 'env', 'constant', 'database', or 'none'.
+ * @param props.externalCredentialsMalformed - Whether externally configured credentials failed to parse.
  */
 export function ApplicationPasswordConnectorSettings( {
 	onSave,
@@ -333,6 +335,7 @@ export function ApplicationPasswordConnectorSettings( {
 	helpLabel,
 	readOnly = false,
 	keySource,
+	externalCredentialsMalformed = false,
 }: ApplicationPasswordConnectorSettingsProps ) {
 	const [ username, setUsername ] = useState( initialUsername );
 	const [ applicationPassword, setApplicationPassword ] = useState( '' );
@@ -350,7 +353,15 @@ export function ApplicationPasswordConnectorSettings( {
 	);
 
 	let applicationPasswordHelp: ReactNode = help;
-	if ( keySource === 'env' ) {
+	if ( externalCredentialsMalformed ) {
+		applicationPasswordHelp = (
+			<span role="alert" className="connector-settings__error">
+				{ __(
+					'The configured credentials are malformed. Expected format: username:password.'
+				) }
+			</span>
+		);
+	} else if ( keySource === 'env' ) {
 		applicationPasswordHelp = __(
 			'These credentials are configured using an environment variable.'
 		);
@@ -388,7 +399,11 @@ export function ApplicationPasswordConnectorSettings( {
 			/>
 			<TextControl
 				label={ __( 'Application password' ) }
-				value={ readOnly ? '••••••••••••••••' : applicationPassword }
+				value={
+					readOnly && ! externalCredentialsMalformed
+						? '••••••••••••••••'
+						: applicationPassword
+				}
 				onChange={ ( value ) => {
 					if ( ! readOnly ) {
 						setSaveError( null );

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -68,6 +68,124 @@ export function ConnectorItem( {
 
 export type { ApiKeySource } from './types';
 
+function getHelpLinkLabel( helpUrl?: string, helpLabel?: string ) {
+	return helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
+}
+
+function createConnectorHelpLink(
+	helpUrl: string | undefined,
+	helpLabel: string | undefined,
+	message: string
+) {
+	if ( ! helpUrl ) {
+		return undefined;
+	}
+
+	return createInterpolateElement( sprintf( message, '<a></a>' ), {
+		a: (
+			<ExternalLink href={ helpUrl }>
+				{ getHelpLinkLabel( helpUrl, helpLabel ) }
+			</ExternalLink>
+		),
+	} );
+}
+
+function useConnectorSettingsSave< TValue >(
+	onSave: ( ( value: TValue ) => void | Promise< void > ) | undefined,
+	fallbackErrorMessage: string
+) {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ saveError, setSaveError ] = useState< string | null >( null );
+
+	const handleSave = async ( value: TValue ) => {
+		setSaveError( null );
+		setIsSaving( true );
+		try {
+			await onSave?.( value );
+		} catch ( error ) {
+			setSaveError(
+				error instanceof Error ? error.message : fallbackErrorMessage
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return {
+		isSaving,
+		saveError,
+		setSaveError,
+		handleSave,
+	};
+}
+
+function ConnectorSettingsFrame( {
+	readOnly,
+	children,
+}: {
+	readOnly: boolean;
+	children: ReactNode;
+} ) {
+	return (
+		<VStack
+			spacing={ 4 }
+			className="connector-settings"
+			style={
+				readOnly
+					? {
+							'--wp-components-color-background': '#f0f0f0',
+					  }
+					: undefined
+			}
+		>
+			{ children }
+		</VStack>
+	);
+}
+
+function ConnectorSettingsFooter( {
+	readOnly,
+	onRemove,
+	canSave,
+	isSaving,
+	onSave,
+}: {
+	readOnly: boolean;
+	onRemove?: () => void;
+	canSave: boolean;
+	isSaving: boolean;
+	onSave: () => void;
+} ) {
+	if ( readOnly ) {
+		if ( ! onRemove ) {
+			return null;
+		}
+
+		return (
+			<HStack justify="flex-start">
+				<Button variant="link" isDestructive onClick={ onRemove }>
+					{ __( 'Remove and replace' ) }
+				</Button>
+			</HStack>
+		);
+	}
+
+	return (
+		<HStack justify="flex-start">
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				disabled={ ! canSave || isSaving }
+				accessibleWhenDisabled
+				isBusy={ isSaving }
+				onClick={ onSave }
+			>
+				{ __( 'Save' ) }
+			</Button>
+		</HStack>
+	);
+}
+
 export interface DefaultConnectorSettingsProps {
 	onSave?: ( apiKey: string ) => void | Promise< void >;
 	onRemove?: () => void;
@@ -100,27 +218,20 @@ export function DefaultConnectorSettings( {
 	keySource,
 }: DefaultConnectorSettingsProps ) {
 	const [ apiKey, setApiKey ] = useState( initialValue );
-	const [ isSaving, setIsSaving ] = useState( false );
-	const [ saveError, setSaveError ] = useState< string | null >( null );
+	const { isSaving, saveError, setSaveError, handleSave } =
+		useConnectorSettingsSave(
+			onSave,
+			__(
+				'It was not possible to connect to the provider using this key.'
+			)
+		);
 
-	const helpLinkLabel = helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
-
-	const helpLink = helpUrl
-		? createInterpolateElement(
-				sprintf(
-					/* translators: %s: Link to provider settings. */
-					__( 'Get your API key at %s' ),
-					'<a></a>'
-				),
-				{
-					a: (
-						<ExternalLink href={ helpUrl }>
-							{ helpLinkLabel }
-						</ExternalLink>
-					),
-				}
-		  )
-		: undefined;
+	const helpLink = createConnectorHelpLink(
+		helpUrl,
+		helpLabel,
+		/* translators: %s: Link to provider settings. */
+		__( 'Get your API key at %s' )
+	);
 
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
@@ -138,21 +249,13 @@ export function DefaultConnectorSettings( {
 		}
 		if ( readOnly ) {
 			return helpUrl
-				? createInterpolateElement(
-						sprintf(
-							/* translators: %s: Link to provider settings. */
-							__(
-								'Your API key is stored securely. You can manage it at %s'
-							),
-							'<a></a>'
-						),
-						{
-							a: (
-								<ExternalLink href={ helpUrl }>
-									{ helpLinkLabel }
-								</ExternalLink>
-							),
-						}
+				? createConnectorHelpLink(
+						helpUrl,
+						helpLabel,
+						/* translators: %s: Link to provider settings. */
+						__(
+							'Your API key is stored securely. You can manage it at %s'
+						)
 				  )
 				: __( 'Your API key is stored securely.' );
 		}
@@ -166,36 +269,8 @@ export function DefaultConnectorSettings( {
 		return helpLink;
 	};
 
-	const handleSave = async () => {
-		setSaveError( null );
-		setIsSaving( true );
-		try {
-			await onSave?.( apiKey );
-		} catch ( error ) {
-			setSaveError(
-				error instanceof Error
-					? error.message
-					: __(
-							'It was not possible to connect to the provider using this key.'
-					  )
-			);
-		} finally {
-			setIsSaving( false );
-		}
-	};
-
 	return (
-		<VStack
-			spacing={ 4 }
-			className="connector-settings"
-			style={
-				readOnly
-					? {
-							'--wp-components-color-background': '#f0f0f0',
-					  }
-					: undefined
-			}
-		>
+		<ConnectorSettingsFrame readOnly={ readOnly }>
 			<TextControl
 				label={ __( 'API Key' ) }
 				value={ apiKey }
@@ -210,33 +285,14 @@ export function DefaultConnectorSettings( {
 				autoComplete="off"
 				help={ getHelp() }
 			/>
-			{ readOnly ? (
-				onRemove && (
-					<HStack justify="flex-start">
-						<Button
-							variant="link"
-							isDestructive
-							onClick={ onRemove }
-						>
-							{ __( 'Remove and replace' ) }
-						</Button>
-					</HStack>
-				)
-			) : (
-				<HStack justify="flex-start">
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						disabled={ ! apiKey || isSaving }
-						accessibleWhenDisabled
-						isBusy={ isSaving }
-						onClick={ handleSave }
-					>
-						{ __( 'Save' ) }
-					</Button>
-				</HStack>
-			) }
-		</VStack>
+			<ConnectorSettingsFooter
+				readOnly={ readOnly }
+				onRemove={ onRemove }
+				canSave={ !! apiKey }
+				isSaving={ isSaving }
+				onSave={ () => handleSave( apiKey ) }
+			/>
+		</ConnectorSettingsFrame>
 	);
 }
 
@@ -280,45 +336,18 @@ export function ApplicationPasswordConnectorSettings( {
 }: ApplicationPasswordConnectorSettingsProps ) {
 	const [ username, setUsername ] = useState( initialUsername );
 	const [ applicationPassword, setApplicationPassword ] = useState( '' );
-	const [ isSaving, setIsSaving ] = useState( false );
-	const [ saveError, setSaveError ] = useState< string | null >( null );
+	const { isSaving, saveError, setSaveError, handleSave } =
+		useConnectorSettingsSave< ApplicationPasswordCredentials >(
+			onSave,
+			__( 'It was not possible to save these credentials.' )
+		);
 
-	const helpLinkLabel = helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
-	const help = helpUrl
-		? createInterpolateElement(
-				sprintf(
-					/* translators: %s: Link to the remote site's application passwords screen. */
-					__( 'Create an application password at %s' ),
-					'<a></a>'
-				),
-				{
-					a: (
-						<ExternalLink href={ helpUrl }>
-							{ helpLinkLabel }
-						</ExternalLink>
-					),
-				}
-		  )
-		: undefined;
-
-	const handleSave = async () => {
-		setSaveError( null );
-		setIsSaving( true );
-		try {
-			await onSave?.( {
-				username: username.trim(),
-				applicationPassword,
-			} );
-		} catch ( error ) {
-			setSaveError(
-				error instanceof Error
-					? error.message
-					: __( 'It was not possible to save these credentials.' )
-			);
-		} finally {
-			setIsSaving( false );
-		}
-	};
+	const help = createConnectorHelpLink(
+		helpUrl,
+		helpLabel,
+		/* translators: %s: Link to the remote site's application passwords screen. */
+		__( 'Create an application password at %s' )
+	);
 
 	let applicationPasswordHelp: ReactNode = help;
 	if ( keySource === 'env' ) {
@@ -343,17 +372,7 @@ export function ApplicationPasswordConnectorSettings( {
 	}
 
 	return (
-		<VStack
-			spacing={ 4 }
-			className="connector-settings"
-			style={
-				readOnly
-					? {
-							'--wp-components-color-background': '#f0f0f0',
-					  }
-					: undefined
-			}
-		>
+		<ConnectorSettingsFrame readOnly={ readOnly }>
 			<TextControl
 				label={ __( 'Username' ) }
 				value={ username }
@@ -382,36 +401,18 @@ export function ApplicationPasswordConnectorSettings( {
 				autoComplete="new-password"
 				help={ applicationPasswordHelp }
 			/>
-			{ readOnly ? (
-				onRemove && (
-					<HStack justify="flex-start">
-						<Button
-							variant="link"
-							isDestructive
-							onClick={ onRemove }
-						>
-							{ __( 'Remove and replace' ) }
-						</Button>
-					</HStack>
-				)
-			) : (
-				<HStack justify="flex-start">
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						disabled={
-							! username.trim() ||
-							! applicationPassword ||
-							isSaving
-						}
-						accessibleWhenDisabled
-						isBusy={ isSaving }
-						onClick={ handleSave }
-					>
-						{ __( 'Save' ) }
-					</Button>
-				</HStack>
-			) }
-		</VStack>
+			<ConnectorSettingsFooter
+				readOnly={ readOnly }
+				onRemove={ onRemove }
+				canSave={ !! username.trim() && !! applicationPassword }
+				isSaving={ isSaving }
+				onSave={ () =>
+					handleSave( {
+						username: username.trim(),
+						applicationPassword,
+					} )
+				}
+			/>
+		</ConnectorSettingsFrame>
 	);
 }

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -311,21 +311,19 @@ export interface ApplicationPasswordConnectorSettingsProps {
 	helpLabel?: string;
 	readOnly?: boolean;
 	keySource?: ApiKeySource;
-	externalCredentialsMalformed?: boolean;
 }
 
 /**
  * Default settings form for application password connectors.
  *
- * @param props                              - Component props.
- * @param props.onSave                       - Callback invoked with the username and application password.
- * @param props.onRemove                     - Callback invoked when the credentials are removed.
- * @param props.initialUsername              - Initial value for the username field.
- * @param props.helpUrl                      - URL where users can create an application password.
- * @param props.helpLabel                    - Custom label for the help link.
- * @param props.readOnly                     - Whether the form is in read-only mode.
- * @param props.keySource                    - The source of the credentials: 'env', 'constant', 'database', or 'none'.
- * @param props.externalCredentialsMalformed - Whether externally configured credentials failed to parse.
+ * @param props                 - Component props.
+ * @param props.onSave          - Callback invoked with the username and application password.
+ * @param props.onRemove        - Callback invoked when the credentials are removed.
+ * @param props.initialUsername - Initial value for the username field.
+ * @param props.helpUrl         - URL where users can create an application password.
+ * @param props.helpLabel       - Custom label for the help link.
+ * @param props.readOnly        - Whether the form is in read-only mode.
+ * @param props.keySource       - The source of the credentials: 'env', 'constant', 'database', or 'none'.
  */
 export function ApplicationPasswordConnectorSettings( {
 	onSave,
@@ -335,7 +333,6 @@ export function ApplicationPasswordConnectorSettings( {
 	helpLabel,
 	readOnly = false,
 	keySource,
-	externalCredentialsMalformed = false,
 }: ApplicationPasswordConnectorSettingsProps ) {
 	const [ username, setUsername ] = useState( initialUsername );
 	const [ applicationPassword, setApplicationPassword ] = useState( '' );
@@ -353,15 +350,7 @@ export function ApplicationPasswordConnectorSettings( {
 	);
 
 	let applicationPasswordHelp: ReactNode = help;
-	if ( externalCredentialsMalformed ) {
-		applicationPasswordHelp = (
-			<span role="alert" className="connector-settings__error">
-				{ __(
-					'The configured credentials are malformed. Expected format: username:password.'
-				) }
-			</span>
-		);
-	} else if ( keySource === 'env' ) {
+	if ( keySource === 'env' ) {
 		applicationPasswordHelp = __(
 			'These credentials are configured using an environment variable.'
 		);
@@ -399,11 +388,7 @@ export function ApplicationPasswordConnectorSettings( {
 			/>
 			<TextControl
 				label={ __( 'Application password' ) }
-				value={
-					readOnly && ! externalCredentialsMalformed
-						? '••••••••••••••••'
-						: applicationPassword
-				}
+				value={ readOnly ? '••••••••••••••••' : applicationPassword }
 				onChange={ ( value ) => {
 					if ( ! readOnly ) {
 						setSaveError( null );

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -12,7 +12,7 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { createInterpolateElement, useId, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, type TransformedText } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -68,6 +68,11 @@ export function ConnectorItem( {
 
 export type { ApiKeySource } from './types';
 
+type ConnectorHelpMessage =
+	| `${ string }%s${ string }`
+	| TransformedText< `${ string }%s${ string }` >;
+type ConnectorHelpInterpolatedMessage = `${ string }<a></a>${ string }`;
+
 function getHelpLinkLabel( helpUrl?: string, helpLabel?: string ) {
 	if ( helpLabel ) {
 		return helpLabel;
@@ -85,19 +90,22 @@ function getHelpLinkLabel( helpUrl?: string, helpLabel?: string ) {
 function createConnectorHelpLink(
 	helpUrl: string | undefined,
 	helpLabel: string | undefined,
-	message: string
+	message: ConnectorHelpMessage
 ) {
 	if ( ! helpUrl ) {
 		return undefined;
 	}
 
-	return createInterpolateElement( sprintf( message, '<a></a>' ), {
-		a: (
-			<ExternalLink href={ helpUrl }>
-				{ getHelpLinkLabel( helpUrl, helpLabel ) }
-			</ExternalLink>
-		),
-	} );
+	return createInterpolateElement(
+		sprintf( message, '<a></a>' ) as ConnectorHelpInterpolatedMessage,
+		{
+			a: (
+				<ExternalLink href={ helpUrl }>
+					{ getHelpLinkLabel( helpUrl, helpLabel ) }
+				</ExternalLink>
+			),
+		}
+	);
 }
 
 function useConnectorSettingsSave< TValue >(

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -341,7 +341,6 @@ export function ApplicationPasswordConnectorSettings( {
 			}
 		>
 			<TextControl
-				__next40pxDefaultSize
 				label={ __( 'Username' ) }
 				value={ username }
 				onChange={ ( value ) => {
@@ -355,7 +354,6 @@ export function ApplicationPasswordConnectorSettings( {
 				autoComplete="username"
 			/>
 			<TextControl
-				__next40pxDefaultSize
 				label={ __( 'Application password' ) }
 				value={ readOnly ? '••••••••••••••••' : applicationPassword }
 				onChange={ ( value ) => {

--- a/packages/connectors/src/connector-item.tsx
+++ b/packages/connectors/src/connector-item.tsx
@@ -239,3 +239,165 @@ export function DefaultConnectorSettings( {
 		</VStack>
 	);
 }
+
+export interface ApplicationPasswordCredentials {
+	username: string;
+	applicationPassword: string;
+}
+
+export interface ApplicationPasswordConnectorSettingsProps {
+	onSave?: (
+		credentials: ApplicationPasswordCredentials
+	) => void | Promise< void >;
+	onRemove?: () => void;
+	initialUsername?: string;
+	helpUrl?: string;
+	helpLabel?: string;
+	readOnly?: boolean;
+}
+
+/**
+ * Default settings form for application password connectors.
+ *
+ * @param props                 - Component props.
+ * @param props.onSave          - Callback invoked with the username and application password.
+ * @param props.onRemove        - Callback invoked when the credentials are removed.
+ * @param props.initialUsername - Initial value for the username field.
+ * @param props.helpUrl         - URL where users can create an application password.
+ * @param props.helpLabel       - Custom label for the help link.
+ * @param props.readOnly        - Whether the form is in read-only mode.
+ */
+export function ApplicationPasswordConnectorSettings( {
+	onSave,
+	onRemove,
+	initialUsername = '',
+	helpUrl,
+	helpLabel,
+	readOnly = false,
+}: ApplicationPasswordConnectorSettingsProps ) {
+	const [ username, setUsername ] = useState( initialUsername );
+	const [ applicationPassword, setApplicationPassword ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ saveError, setSaveError ] = useState< string | null >( null );
+
+	const helpLinkLabel = helpLabel || helpUrl?.replace( /^https?:\/\//, '' );
+	const help = helpUrl
+		? createInterpolateElement(
+				sprintf(
+					/* translators: %s: Link to the remote site's application passwords screen. */
+					__( 'Create an application password at %s' ),
+					'<a></a>'
+				),
+				{
+					a: (
+						<ExternalLink href={ helpUrl }>
+							{ helpLinkLabel }
+						</ExternalLink>
+					),
+				}
+		  )
+		: undefined;
+
+	const handleSave = async () => {
+		setSaveError( null );
+		setIsSaving( true );
+		try {
+			await onSave?.( { username, applicationPassword } );
+		} catch ( error ) {
+			setSaveError(
+				error instanceof Error
+					? error.message
+					: __( 'It was not possible to save these credentials.' )
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	let applicationPasswordHelp = help;
+	if ( readOnly ) {
+		applicationPasswordHelp = __(
+			'Your application password is stored securely.'
+		);
+	}
+	if ( saveError ) {
+		applicationPasswordHelp = (
+			<span role="alert" className="connector-settings__error">
+				{ saveError }
+			</span>
+		);
+	}
+
+	return (
+		<VStack
+			spacing={ 4 }
+			className="connector-settings"
+			style={
+				readOnly
+					? {
+							'--wp-components-color-background': '#f0f0f0',
+					  }
+					: undefined
+			}
+		>
+			<TextControl
+				__next40pxDefaultSize
+				label={ __( 'Username' ) }
+				value={ username }
+				onChange={ ( value ) => {
+					if ( ! readOnly ) {
+						setSaveError( null );
+						setUsername( value );
+					}
+				} }
+				placeholder={ __( 'Enter your username' ) }
+				disabled={ readOnly || isSaving }
+				autoComplete="username"
+			/>
+			<TextControl
+				__next40pxDefaultSize
+				label={ __( 'Application password' ) }
+				value={ readOnly ? '••••••••••••••••' : applicationPassword }
+				onChange={ ( value ) => {
+					if ( ! readOnly ) {
+						setSaveError( null );
+						setApplicationPassword( value );
+					}
+				} }
+				type="password"
+				placeholder={ __( 'Enter your application password' ) }
+				disabled={ readOnly || isSaving }
+				autoComplete="new-password"
+				help={ applicationPasswordHelp }
+			/>
+			{ readOnly ? (
+				onRemove && (
+					<HStack justify="flex-start">
+						<Button
+							variant="link"
+							isDestructive
+							onClick={ onRemove }
+						>
+							{ __( 'Remove and replace' ) }
+						</Button>
+					</HStack>
+				)
+			) : (
+				<HStack justify="flex-start">
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						disabled={
+							! username || ! applicationPassword || isSaving
+						}
+						accessibleWhenDisabled
+						isBusy={ isSaving }
+						onClick={ handleSave }
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</HStack>
+			) }
+		</VStack>
+	);
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -5,6 +5,7 @@ export {
 export {
 	ConnectorItem as __experimentalConnectorItem,
 	DefaultConnectorSettings as __experimentalDefaultConnectorSettings,
+	ApplicationPasswordConnectorSettings as __experimentalApplicationPasswordConnectorSettings,
 } from './connector-item';
 export type { ApiKeySource as __experimentalApiKeySource } from './types';
 export type { ConnectorConfig, ConnectorRenderProps } from './types';

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -15,8 +15,7 @@ export type ConnectorAuthentication =
 	  }
 	| {
 			method: 'application_password';
-			usernameSettingName: string;
-			applicationPasswordSettingName: string;
+			settingName: string;
 			credentialsUrl: string | null;
 			isConnected?: boolean;
 	  }

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -13,6 +13,13 @@ export type ConnectorAuthentication =
 			keySource?: ApiKeySource;
 			isConnected?: boolean;
 	  }
+	| {
+			method: 'application_password';
+			usernameSettingName: string;
+			applicationPasswordSettingName: string;
+			credentialsUrl: string | null;
+			isConnected?: boolean;
+	  }
 	| { method: 'none' };
 
 export interface ConnectorPlugin {

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -17,6 +17,7 @@ export type ConnectorAuthentication =
 			method: 'application_password';
 			settingName: string;
 			credentialsUrl: string | null;
+			keySource?: ApiKeySource;
 			isConnected?: boolean;
 	  }
 	| { method: 'none' };

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -9,8 +9,7 @@
  * @package gutenberg-test-connectors-application-password
  */
 
-const GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING             = 'connectors_content_source_test_remote_wordpress_username';
-const GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING = 'connectors_content_source_test_remote_wordpress_application_password';
+const GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING = 'connectors_content_source_test_remote_wordpress_credentials';
 
 add_action(
 	'wp_connectors_init',
@@ -22,10 +21,9 @@ add_action(
 				'description'    => 'Connect to example.com as a remote WordPress site.',
 				'type'           => 'content_source',
 				'authentication' => array(
-					'method'                            => 'application_password',
-					'credentials_url'                   => 'https://example.com/wp-admin/profile.php',
-					'username_setting_name'             => GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING,
-					'application_password_setting_name' => GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING,
+					'method'          => 'application_password',
+					'credentials_url' => 'https://example.com/wp-admin/profile.php',
+					'setting_name'    => GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING,
 				),
 			)
 		);
@@ -58,7 +56,6 @@ add_action(
 register_deactivation_hook(
 	__FILE__,
 	static function () {
-		delete_option( GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING );
-		delete_option( GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING );
+		delete_option( GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING );
 	}
 );

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -50,6 +50,29 @@ add_action(
 				},
 			)
 		);
+
+		// Exposes the raw stored credentials so tests can assert what was
+		// persisted, bypassing the masking applied to /wp/v2/settings.
+		register_rest_route(
+			'gutenberg-test-connectors/v1',
+			'/application-password-credentials',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => static function () {
+					$credentials = get_option(
+						GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING,
+						array()
+					);
+					return array(
+						'username' => is_array( $credentials ) && isset( $credentials['username'] ) ? $credentials['username'] : '',
+						'password' => is_array( $credentials ) && isset( $credentials['password'] ) ? $credentials['password'] : '',
+					);
+				},
+				'permission_callback' => static function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
 	}
 );
 

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -10,6 +10,9 @@
  */
 
 const GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING = 'connectors_content_source_test_remote_wordpress_credentials';
+const GUTENBERG_TEST_CONNECTOR_ENV_VAR_NAME        = 'GUTENBERG_TEST_CONNECTOR_REMOTE_CREDENTIALS';
+
+putenv( GUTENBERG_TEST_CONNECTOR_ENV_VAR_NAME . '=env-remote-user:abcd efgh ijkl mnop 1234' );
 
 add_action(
 	'wp_connectors_init',
@@ -24,6 +27,19 @@ add_action(
 					'method'          => 'application_password',
 					'credentials_url' => 'https://example.com/wp-admin/profile.php',
 					'setting_name'    => GUTENBERG_TEST_CONNECTOR_CREDENTIALS_SETTING,
+				),
+			)
+		);
+
+		$registry->register(
+			'test-env-configured-wordpress',
+			array(
+				'name'           => 'Test Env Configured WordPress',
+				'description'    => 'Connects using environment-variable credentials.',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'       => 'application_password',
+					'env_var_name' => GUTENBERG_TEST_CONNECTOR_ENV_VAR_NAME,
 				),
 			)
 		);

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -19,7 +19,7 @@ add_action(
 			'test-remote-wordpress',
 			array(
 				'name'           => 'Test Remote WordPress',
-				'description'    => 'Connect to a remote WordPress site for E2E testing.',
+				'description'    => 'Connect to example.com as a remote WordPress site.',
 				'type'           => 'content_source',
 				'authentication' => array(
 					'method'                            => 'application_password',

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Application Password Connector
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * Registers an application password connector for E2E testing.
+ *
+ * @package gutenberg-test-connectors-application-password
+ */
+
+const GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING = 'connectors_content_source_test_remote_wordpress_username';
+const GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING = 'connectors_content_source_test_remote_wordpress_application_password';
+
+add_action(
+	'wp_connectors_init',
+	static function ( WP_Connector_Registry $registry ) {
+		$registry->register(
+			'test-remote-wordpress',
+			array(
+				'name'           => 'Test Remote WordPress',
+				'description'    => 'Connect to a remote WordPress site for E2E testing.',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'                            => 'application_password',
+					'credentials_url'                   => 'https://example.com/wp-admin/profile.php',
+					'username_setting_name'             => GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING,
+					'application_password_setting_name' => GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING,
+				),
+			)
+		);
+	}
+);
+
+register_deactivation_hook(
+	__FILE__,
+	static function () {
+		delete_option( GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING );
+		delete_option( GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING );
+	}
+);

--- a/packages/e2e-tests/plugins/connectors-application-password.php
+++ b/packages/e2e-tests/plugins/connectors-application-password.php
@@ -9,7 +9,7 @@
  * @package gutenberg-test-connectors-application-password
  */
 
-const GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING = 'connectors_content_source_test_remote_wordpress_username';
+const GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING             = 'connectors_content_source_test_remote_wordpress_username';
 const GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING = 'connectors_content_source_test_remote_wordpress_application_password';
 
 add_action(
@@ -27,6 +27,29 @@ add_action(
 					'username_setting_name'             => GUTENBERG_TEST_CONNECTOR_USERNAME_SETTING,
 					'application_password_setting_name' => GUTENBERG_TEST_CONNECTOR_APPLICATION_PASSWORD_SETTING,
 				),
+			)
+		);
+	}
+);
+
+add_action(
+	'rest_api_init',
+	static function () {
+		register_rest_route(
+			'gutenberg-test-connectors/v1',
+			'/application-password',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => static function () {
+					return array(
+						'is_registered' => wp_is_connector_registered(
+							'test-remote-wordpress'
+						),
+					);
+				},
+				'permission_callback' => static function () {
+					return current_user_can( 'manage_options' );
+				},
 			)
 		);
 	}

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -12,10 +12,8 @@ import {
 	type ConnectorConfig,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
-import { store as coreStore } from '@wordpress/core-data';
-import { select, useDispatch, useSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { Badge, Link } from '@wordpress/ui';
 import { unlock } from '@wordpress/routes-lock-unlock';
 
@@ -308,26 +306,6 @@ function ApplicationPasswordConnector( {
 	const helpLabel = getHelpLabel( helpUrl );
 	const pluginSlug = getPluginSlug( plugin?.file );
 
-	const { currentUsername, hasResolvedSettings } = useSelect(
-		( registrySelect ) => {
-			const { getEntityRecord, hasFinishedResolution } =
-				registrySelect( coreStore );
-			const siteSettings = getEntityRecord( 'root', 'site' ) as
-				| Record< string, { username?: string; password?: string } >
-				| undefined;
-			return {
-				currentUsername: siteSettings?.[ settingName ]?.username ?? '',
-				// The settings form seeds its state on mount, so wait for the
-				// site settings to resolve before rendering it.
-				hasResolvedSettings: hasFinishedResolution( 'getEntityRecord', [
-					'root',
-					'site',
-				] ),
-			};
-		},
-		[ settingName ]
-	);
-
 	const {
 		pluginStatus,
 		canInstallPlugins,
@@ -336,10 +314,13 @@ function ApplicationPasswordConnector( {
 		setIsExpanded,
 		isBusy,
 		isConnected,
-		setIsConnected,
+		currentUsername,
+		hasResolvedSettings,
 		keySource,
 		handleButtonClick,
 		getButtonLabel,
+		saveCredentials,
+		removeCredentials,
 	} = useConnectorPlugin( {
 		file: plugin?.file,
 		settingName,
@@ -352,98 +333,10 @@ function ApplicationPasswordConnector( {
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
 
-	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } =
-		useDispatch( noticesStore );
 	const actionButtonRef = useRef< HTMLButtonElement >( null );
 	const showUnavailableBadge =
 		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
 		( pluginStatus === 'inactive' && canActivatePlugins === false );
-
-	const saveCredentials = async ( {
-		username,
-		applicationPassword,
-	}: {
-		username: string;
-		applicationPassword: string;
-	} ) => {
-		const updatedRecord = await saveEntityRecord(
-			'root',
-			'site',
-			{
-				[ settingName ]: {
-					username,
-					password: applicationPassword,
-				},
-			},
-			{ throwOnError: true }
-		);
-		const record = updatedRecord as
-			| Record< string, { username?: string; password?: string } >
-			| undefined;
-		const credentials = record?.[ settingName ];
-		// The server sanitizes the username (trimming/collapsing whitespace),
-		// so only verify that both credentials were persisted, not equality.
-		if ( ! credentials?.username || ! credentials?.password ) {
-			throw new Error(
-				__( 'It was not possible to save these credentials.' )
-			);
-		}
-
-		setIsConnected( true );
-		createSuccessNotice(
-			sprintf(
-				/* translators: %s: Name of the connector. */
-				__( '%s connected successfully.' ),
-				name
-			),
-			{
-				id: 'connector-connect-success',
-				type: 'snackbar',
-			}
-		);
-	};
-
-	const removeCredentials = async () => {
-		try {
-			await saveEntityRecord(
-				'root',
-				'site',
-				{
-					[ settingName ]: {
-						username: '',
-						password: '',
-					},
-				},
-				{ throwOnError: true }
-			);
-			setIsConnected( false );
-			createSuccessNotice(
-				sprintf(
-					/* translators: %s: Name of the connector. */
-					__( '%s disconnected.' ),
-					name
-				),
-				{
-					id: 'connector-disconnect-success',
-					type: 'snackbar',
-				}
-			);
-		} catch ( error ) {
-			createErrorNotice(
-				sprintf(
-					/* translators: %s: Name of the connector. */
-					__( 'Failed to disconnect %s.' ),
-					name
-				),
-				{
-					id: 'connector-disconnect-error',
-					type: 'snackbar',
-				}
-			);
-			throw error;
-		}
-	};
 
 	return (
 		<ConnectorItem

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -335,10 +335,6 @@ function ApplicationPasswordConnector( {
 	} );
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
-	// The server claims the env/constant source even when the value fails to
-	// parse as `username:password`, in which case it reports not connected.
-	const hasMalformedExternalCredentials =
-		isExternallyConfigured && ! isConnected;
 
 	const actionButtonRef = useRef< HTMLButtonElement >( null );
 	const showUnavailableBadge =
@@ -373,8 +369,7 @@ function ApplicationPasswordConnector( {
 					<ApplicationPasswordConnectorSettings
 						key={ isConnected ? 'connected' : 'setup' }
 						initialUsername={
-							isExternallyConfigured &&
-							! hasMalformedExternalCredentials
+							isExternallyConfigured
 								? '••••••••••••••••'
 								: currentUsername
 						}
@@ -382,9 +377,6 @@ function ApplicationPasswordConnector( {
 						helpLabel={ helpLabel }
 						readOnly={ isConnected || isExternallyConfigured }
 						keySource={ keySource }
-						externalCredentialsMalformed={
-							hasMalformedExternalCredentials
-						}
 						onRemove={
 							isExternallyConfigured
 								? undefined

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -215,6 +215,7 @@ function ApiKeyConnector( {
 		isBusy,
 		isConnected,
 		currentApiKey,
+		hasResolvedSettings,
 		keySource,
 		handleButtonClick,
 		getButtonLabel,
@@ -259,33 +260,35 @@ function ApiKeyConnector( {
 				/>
 			}
 		>
-			{ isExpanded && pluginStatus === 'active' && (
-				<DefaultConnectorSettings
-					key={ isConnected ? 'connected' : 'setup' }
-					initialValue={
-						isExternallyConfigured
-							? '••••••••••••••••'
-							: currentApiKey
-					}
-					helpUrl={ helpUrl }
-					helpLabel={ helpLabel }
-					readOnly={ isConnected || isExternallyConfigured }
-					keySource={ keySource }
-					onRemove={
-						isExternallyConfigured
-							? undefined
-							: async () => {
-									await removeApiKey();
-									actionButtonRef.current?.focus();
-							  }
-					}
-					onSave={ async ( apiKey: string ) => {
-						await saveApiKey( apiKey );
-						setIsExpanded( false );
-						actionButtonRef.current?.focus();
-					} }
-				/>
-			) }
+			{ isExpanded &&
+				pluginStatus === 'active' &&
+				hasResolvedSettings && (
+					<DefaultConnectorSettings
+						key={ isConnected ? 'connected' : 'setup' }
+						initialValue={
+							isExternallyConfigured
+								? '••••••••••••••••'
+								: currentApiKey
+						}
+						helpUrl={ helpUrl }
+						helpLabel={ helpLabel }
+						readOnly={ isConnected || isExternallyConfigured }
+						keySource={ keySource }
+						onRemove={
+							isExternallyConfigured
+								? undefined
+								: async () => {
+										await removeApiKey();
+										actionButtonRef.current?.focus();
+								  }
+						}
+						onSave={ async ( apiKey: string ) => {
+							await saveApiKey( apiKey );
+							setIsExpanded( false );
+							actionButtonRef.current?.focus();
+						} }
+					/>
+				) }
 		</ConnectorItem>
 	);
 }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -22,7 +22,7 @@ import { unlock } from '@wordpress/routes-lock-unlock';
 /**
  * Internal dependencies
  */
-import { useConnectorPlugin } from './use-connector-plugin';
+import { useConnectorPlugin, type PluginStatus } from './use-connector-plugin';
 import {
 	OpenAILogo,
 	ClaudeLogo,
@@ -126,6 +126,59 @@ const PluginDirectoryLink = ( { slug }: { slug: string } ) => (
 
 const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;
 
+interface ConnectorActionAreaProps {
+	isConnected: boolean;
+	showUnavailableBadge: boolean;
+	pluginSlug?: string;
+	isExpanded: boolean;
+	isBusy: boolean;
+	pluginStatus: PluginStatus;
+	actionButtonRef: {
+		current: HTMLButtonElement | null;
+	};
+	handleButtonClick: () => void;
+	getButtonLabel: () => string;
+}
+
+function ConnectorActionArea( {
+	isConnected,
+	showUnavailableBadge,
+	pluginSlug,
+	isExpanded,
+	isBusy,
+	pluginStatus,
+	actionButtonRef,
+	handleButtonClick,
+	getButtonLabel,
+}: ConnectorActionAreaProps ) {
+	return (
+		<HStack spacing={ 3 } expanded={ false }>
+			{ isConnected && <ConnectedBadge /> }
+			{ showUnavailableBadge &&
+				( pluginSlug ? (
+					<PluginDirectoryLink slug={ pluginSlug } />
+				) : (
+					<UnavailableActionBadge />
+				) ) }
+			{ ! showUnavailableBadge && (
+				<Button
+					ref={ actionButtonRef }
+					variant={
+						isExpanded || isConnected ? 'tertiary' : 'secondary'
+					}
+					size="compact"
+					onClick={ handleButtonClick }
+					disabled={ pluginStatus === 'checking' || isBusy }
+					isBusy={ isBusy }
+					accessibleWhenDisabled
+				>
+					{ getButtonLabel() }
+				</Button>
+			) }
+		</HStack>
+	);
+}
+
 function getPluginSlug( pluginFile?: string ) {
 	const pluginBasename = pluginFile?.replace( /\.php$/, '' );
 	return pluginBasename?.includes( '/' )
@@ -183,7 +236,6 @@ function ApiKeyConnector( {
 	const showUnavailableBadge =
 		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
 		( pluginStatus === 'inactive' && canActivatePlugins === false );
-	const showActionButton = ! showUnavailableBadge;
 
 	const actionButtonRef = useRef< HTMLButtonElement >( null );
 
@@ -196,32 +248,17 @@ function ApiKeyConnector( {
 			name={ name }
 			description={ description }
 			actionArea={
-				<HStack spacing={ 3 } expanded={ false }>
-					{ isConnected && <ConnectedBadge /> }
-					{ showUnavailableBadge &&
-						( pluginSlug ? (
-							<PluginDirectoryLink slug={ pluginSlug } />
-						) : (
-							<UnavailableActionBadge />
-						) ) }
-					{ showActionButton && (
-						<Button
-							ref={ actionButtonRef }
-							variant={
-								isExpanded || isConnected
-									? 'tertiary'
-									: 'secondary'
-							}
-							size="compact"
-							onClick={ handleButtonClick }
-							disabled={ pluginStatus === 'checking' || isBusy }
-							isBusy={ isBusy }
-							accessibleWhenDisabled
-						>
-							{ getButtonLabel() }
-						</Button>
-					) }
-				</HStack>
+				<ConnectorActionArea
+					isConnected={ isConnected }
+					showUnavailableBadge={ showUnavailableBadge }
+					pluginSlug={ pluginSlug }
+					isExpanded={ isExpanded }
+					isBusy={ isBusy }
+					pluginStatus={ pluginStatus }
+					actionButtonRef={ actionButtonRef }
+					handleButtonClick={ handleButtonClick }
+					getButtonLabel={ getButtonLabel }
+				/>
 			}
 		>
 			{ isExpanded && pluginStatus === 'active' && (
@@ -401,32 +438,17 @@ function ApplicationPasswordConnector( {
 			name={ name }
 			description={ description }
 			actionArea={
-				<HStack spacing={ 3 } expanded={ false }>
-					{ isConnected && <ConnectedBadge /> }
-					{ showUnavailableBadge &&
-						( pluginSlug ? (
-							<PluginDirectoryLink slug={ pluginSlug } />
-						) : (
-							<UnavailableActionBadge />
-						) ) }
-					{ ! showUnavailableBadge && (
-						<Button
-							ref={ actionButtonRef }
-							variant={
-								isExpanded || isConnected
-									? 'tertiary'
-									: 'secondary'
-							}
-							size="compact"
-							onClick={ handleButtonClick }
-							disabled={ pluginStatus === 'checking' || isBusy }
-							isBusy={ isBusy }
-							accessibleWhenDisabled
-						>
-							{ getButtonLabel() }
-						</Button>
-					) }
-				</HStack>
+				<ConnectorActionArea
+					isConnected={ isConnected }
+					showUnavailableBadge={ showUnavailableBadge }
+					pluginSlug={ pluginSlug }
+					isExpanded={ isExpanded }
+					isBusy={ isBusy }
+					pluginStatus={ pluginStatus }
+					actionButtonRef={ actionButtonRef }
+					handleButtonClick={ handleButtonClick }
+					getButtonLabel={ getButtonLabel }
+				/>
 			}
 		>
 			{ isExpanded && pluginStatus === 'active' && (

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -184,14 +184,6 @@ function getPluginSlug( pluginFile?: string ) {
 		: pluginBasename;
 }
 
-function getHelpLabel( helpUrl?: string ) {
-	try {
-		return helpUrl ? new URL( helpUrl ).hostname : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
 function ApiKeyConnector( {
 	name,
 	description,
@@ -203,7 +195,6 @@ function ApiKeyConnector( {
 		authentication?.method === 'api_key' ? authentication : undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const helpLabel = getHelpLabel( helpUrl );
 	const pluginSlug = getPluginSlug( plugin?.file );
 
 	const {
@@ -271,7 +262,6 @@ function ApiKeyConnector( {
 								: currentApiKey
 						}
 						helpUrl={ helpUrl }
-						helpLabel={ helpLabel }
 						readOnly={ isConnected || isExternallyConfigured }
 						keySource={ keySource }
 						onRemove={
@@ -306,7 +296,6 @@ function ApplicationPasswordConnector( {
 			: undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const helpLabel = getHelpLabel( helpUrl );
 	const pluginSlug = getPluginSlug( plugin?.file );
 
 	const {
@@ -374,7 +363,6 @@ function ApplicationPasswordConnector( {
 								: currentUsername
 						}
 						helpUrl={ helpUrl }
-						helpLabel={ helpLabel }
 						readOnly={ isConnected || isExternallyConfigured }
 						keySource={ keySource }
 						onRemove={

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -337,6 +337,7 @@ function ApplicationPasswordConnector( {
 		isBusy,
 		isConnected,
 		setIsConnected,
+		keySource,
 		handleButtonClick,
 		getButtonLabel,
 	} = useConnectorPlugin( {
@@ -345,8 +346,11 @@ function ApplicationPasswordConnector( {
 		connectorName: name,
 		isInstalled: plugin?.isInstalled,
 		isActivated: plugin?.isActivated,
+		keySource: auth?.keySource,
 		initialIsConnected: auth?.isConnected,
 	} );
+	const isExternallyConfigured =
+		keySource === 'env' || keySource === 'constant';
 
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
@@ -468,14 +472,23 @@ function ApplicationPasswordConnector( {
 				hasResolvedSettings && (
 					<ApplicationPasswordConnectorSettings
 						key={ isConnected ? 'connected' : 'setup' }
-						initialUsername={ currentUsername }
+						initialUsername={
+							isExternallyConfigured
+								? '••••••••••••••••'
+								: currentUsername
+						}
 						helpUrl={ helpUrl }
 						helpLabel={ helpLabel }
-						readOnly={ isConnected }
-						onRemove={ async () => {
-							await removeCredentials();
-							actionButtonRef.current?.focus();
-						} }
+						readOnly={ isConnected || isExternallyConfigured }
+						keySource={ keySource }
+						onRemove={
+							isExternallyConfigured
+								? undefined
+								: async () => {
+										await removeCredentials();
+										actionButtonRef.current?.focus();
+								  }
+						}
 						onSave={ async ( credentials ) => {
 							await saveCredentials( credentials );
 							setIsExpanded( false );

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -152,19 +152,8 @@ function ApiKeyConnector( {
 		authentication?.method === 'api_key' ? authentication : undefined;
 	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
-	const pluginFile = plugin?.file?.replace( /\.php$/, '' );
-	const pluginSlug = pluginFile?.includes( '/' )
-		? pluginFile.split( '/' )[ 0 ]
-		: pluginFile;
-
-	let helpLabel: string | undefined;
-	try {
-		if ( helpUrl ) {
-			helpLabel = new URL( helpUrl ).hostname;
-		}
-	} catch {
-		// Invalid URL — leave helpLabel undefined.
-	}
+	const helpLabel = getHelpLabel( helpUrl );
+	const pluginSlug = getPluginSlug( plugin?.file );
 
 	const {
 		pluginStatus,

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -303,9 +303,7 @@ function ApplicationPasswordConnector( {
 		authentication?.method === 'application_password'
 			? authentication
 			: undefined;
-	const usernameSettingName = auth?.usernameSettingName ?? '';
-	const applicationPasswordSettingName =
-		auth?.applicationPasswordSettingName ?? '';
+	const settingName = auth?.settingName ?? '';
 	const helpUrl = auth?.credentialsUrl ?? undefined;
 	const helpLabel = getHelpLabel( helpUrl );
 	const pluginSlug = getPluginSlug( plugin?.file );
@@ -315,10 +313,12 @@ function ApplicationPasswordConnector( {
 			const siteSettings = registrySelect( coreStore ).getEntityRecord(
 				'root',
 				'site'
-			) as Record< string, string > | undefined;
-			return siteSettings?.[ usernameSettingName ] ?? '';
+			) as
+				| Record< string, { username?: string; password?: string } >
+				| undefined;
+			return siteSettings?.[ settingName ]?.username ?? '';
 		},
-		[ usernameSettingName ]
+		[ settingName ]
 	);
 
 	const {
@@ -334,8 +334,7 @@ function ApplicationPasswordConnector( {
 		getButtonLabel,
 	} = useConnectorPlugin( {
 		file: plugin?.file,
-		settingName: usernameSettingName,
-		additionalSettingName: applicationPasswordSettingName,
+		settingName,
 		connectorName: name,
 		isInstalled: plugin?.isInstalled,
 		isActivated: plugin?.isActivated,
@@ -361,16 +360,18 @@ function ApplicationPasswordConnector( {
 			'root',
 			'site',
 			{
-				[ usernameSettingName ]: username,
-				[ applicationPasswordSettingName ]: applicationPassword,
+				[ settingName ]: {
+					username,
+					password: applicationPassword,
+				},
 			},
 			{ throwOnError: true }
 		);
-		const record = updatedRecord as Record< string, string > | undefined;
-		if (
-			record?.[ usernameSettingName ] !== username ||
-			! record?.[ applicationPasswordSettingName ]
-		) {
+		const record = updatedRecord as
+			| Record< string, { username?: string; password?: string } >
+			| undefined;
+		const credentials = record?.[ settingName ];
+		if ( credentials?.username !== username || ! credentials?.password ) {
 			throw new Error(
 				__( 'It was not possible to save these credentials.' )
 			);
@@ -396,8 +397,10 @@ function ApplicationPasswordConnector( {
 				'root',
 				'site',
 				{
-					[ usernameSettingName ]: '',
-					[ applicationPasswordSettingName ]: '',
+					[ settingName ]: {
+						username: '',
+						password: '',
+					},
 				},
 				{ throwOnError: true }
 			);

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -308,15 +308,22 @@ function ApplicationPasswordConnector( {
 	const helpLabel = getHelpLabel( helpUrl );
 	const pluginSlug = getPluginSlug( plugin?.file );
 
-	const currentUsername = useSelect(
+	const { currentUsername, hasResolvedSettings } = useSelect(
 		( registrySelect ) => {
-			const siteSettings = registrySelect( coreStore ).getEntityRecord(
-				'root',
-				'site'
-			) as
+			const { getEntityRecord, hasFinishedResolution } =
+				registrySelect( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' ) as
 				| Record< string, { username?: string; password?: string } >
 				| undefined;
-			return siteSettings?.[ settingName ]?.username ?? '';
+			return {
+				currentUsername: siteSettings?.[ settingName ]?.username ?? '',
+				// The settings form seeds its state on mount, so wait for the
+				// site settings to resolve before rendering it.
+				hasResolvedSettings: hasFinishedResolution( 'getEntityRecord', [
+					'root',
+					'site',
+				] ),
+			};
 		},
 		[ settingName ]
 	);
@@ -456,24 +463,26 @@ function ApplicationPasswordConnector( {
 				/>
 			}
 		>
-			{ isExpanded && pluginStatus === 'active' && (
-				<ApplicationPasswordConnectorSettings
-					key={ isConnected ? 'connected' : 'setup' }
-					initialUsername={ currentUsername }
-					helpUrl={ helpUrl }
-					helpLabel={ helpLabel }
-					readOnly={ isConnected }
-					onRemove={ async () => {
-						await removeCredentials();
-						actionButtonRef.current?.focus();
-					} }
-					onSave={ async ( credentials ) => {
-						await saveCredentials( credentials );
-						setIsExpanded( false );
-						actionButtonRef.current?.focus();
-					} }
-				/>
-			) }
+			{ isExpanded &&
+				pluginStatus === 'active' &&
+				hasResolvedSettings && (
+					<ApplicationPasswordConnectorSettings
+						key={ isConnected ? 'connected' : 'setup' }
+						initialUsername={ currentUsername }
+						helpUrl={ helpUrl }
+						helpLabel={ helpLabel }
+						readOnly={ isConnected }
+						onRemove={ async () => {
+							await removeCredentials();
+							actionButtonRef.current?.focus();
+						} }
+						onSave={ async ( credentials ) => {
+							await saveCredentials( credentials );
+							setIsExpanded( false );
+							actionButtonRef.current?.focus();
+						} }
+					/>
+				) }
 		</ConnectorItem>
 	);
 }

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -371,7 +371,9 @@ function ApplicationPasswordConnector( {
 			| Record< string, { username?: string; password?: string } >
 			| undefined;
 		const credentials = record?.[ settingName ];
-		if ( credentials?.username !== username || ! credentials?.password ) {
+		// The server sanitizes the username (trimming/collapsing whitespace),
+		// so only verify that both credentials were persisted, not equality.
+		if ( ! credentials?.username || ! credentials?.password ) {
 			throw new Error(
 				__( 'It was not possible to save these credentials.' )
 			);

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -332,6 +332,10 @@ function ApplicationPasswordConnector( {
 	} );
 	const isExternallyConfigured =
 		keySource === 'env' || keySource === 'constant';
+	// The server claims the env/constant source even when the value fails to
+	// parse as `username:password`, in which case it reports not connected.
+	const hasMalformedExternalCredentials =
+		isExternallyConfigured && ! isConnected;
 
 	const actionButtonRef = useRef< HTMLButtonElement >( null );
 	const showUnavailableBadge =
@@ -366,7 +370,8 @@ function ApplicationPasswordConnector( {
 					<ApplicationPasswordConnectorSettings
 						key={ isConnected ? 'connected' : 'setup' }
 						initialUsername={
-							isExternallyConfigured
+							isExternallyConfigured &&
+							! hasMalformedExternalCredentials
 								? '••••••••••••••••'
 								: currentUsername
 						}
@@ -374,6 +379,9 @@ function ApplicationPasswordConnector( {
 						helpLabel={ helpLabel }
 						readOnly={ isConnected || isExternallyConfigured }
 						keySource={ keySource }
+						externalCredentialsMalformed={
+							hasMalformedExternalCredentials
+						}
 						onRemove={
 							isExternallyConfigured
 								? undefined

--- a/routes/connectors-home/default-connectors.tsx
+++ b/routes/connectors-home/default-connectors.tsx
@@ -7,12 +7,15 @@ import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 	__experimentalDefaultConnectorSettings as DefaultConnectorSettings,
+	__experimentalApplicationPasswordConnectorSettings as ApplicationPasswordConnectorSettings,
 	privateApis as connectorsPrivateApis,
 	type ConnectorConfig,
 	type ConnectorRenderProps,
 } from '@wordpress/connectors';
-import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { Badge, Link } from '@wordpress/ui';
 import { unlock } from '@wordpress/routes-lock-unlock';
 
@@ -122,6 +125,21 @@ const PluginDirectoryLink = ( { slug }: { slug: string } ) => (
 );
 
 const UnavailableActionBadge = () => <Badge>{ __( 'Not available' ) }</Badge>;
+
+function getPluginSlug( pluginFile?: string ) {
+	const pluginBasename = pluginFile?.replace( /\.php$/, '' );
+	return pluginBasename?.includes( '/' )
+		? pluginBasename.split( '/' )[ 0 ]
+		: pluginBasename;
+}
+
+function getHelpLabel( helpUrl?: string ) {
+	try {
+		return helpUrl ? new URL( helpUrl ).hostname : undefined;
+	} catch {
+		return undefined;
+	}
+}
 
 function ApiKeyConnector( {
 	name,
@@ -248,6 +266,202 @@ function ApiKeyConnector( {
 	);
 }
 
+function ApplicationPasswordConnector( {
+	name,
+	description,
+	logo,
+	authentication,
+	plugin,
+}: ConnectorRenderProps ) {
+	const auth =
+		authentication?.method === 'application_password'
+			? authentication
+			: undefined;
+	const usernameSettingName = auth?.usernameSettingName ?? '';
+	const applicationPasswordSettingName =
+		auth?.applicationPasswordSettingName ?? '';
+	const helpUrl = auth?.credentialsUrl ?? undefined;
+	const helpLabel = getHelpLabel( helpUrl );
+	const pluginSlug = getPluginSlug( plugin?.file );
+
+	const currentUsername = useSelect(
+		( registrySelect ) => {
+			const siteSettings = registrySelect( coreStore ).getEntityRecord(
+				'root',
+				'site'
+			) as Record< string, string > | undefined;
+			return siteSettings?.[ usernameSettingName ] ?? '';
+		},
+		[ usernameSettingName ]
+	);
+
+	const {
+		pluginStatus,
+		canInstallPlugins,
+		canActivatePlugins,
+		isExpanded,
+		setIsExpanded,
+		isBusy,
+		isConnected,
+		setIsConnected,
+		handleButtonClick,
+		getButtonLabel,
+	} = useConnectorPlugin( {
+		file: plugin?.file,
+		settingName: usernameSettingName,
+		additionalSettingName: applicationPasswordSettingName,
+		connectorName: name,
+		isInstalled: plugin?.isInstalled,
+		isActivated: plugin?.isActivated,
+		initialIsConnected: auth?.isConnected,
+	} );
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+	const actionButtonRef = useRef< HTMLButtonElement >( null );
+	const showUnavailableBadge =
+		( pluginStatus === 'not-installed' && canInstallPlugins === false ) ||
+		( pluginStatus === 'inactive' && canActivatePlugins === false );
+
+	const saveCredentials = async ( {
+		username,
+		applicationPassword,
+	}: {
+		username: string;
+		applicationPassword: string;
+	} ) => {
+		const updatedRecord = await saveEntityRecord(
+			'root',
+			'site',
+			{
+				[ usernameSettingName ]: username,
+				[ applicationPasswordSettingName ]: applicationPassword,
+			},
+			{ throwOnError: true }
+		);
+		const record = updatedRecord as Record< string, string > | undefined;
+		if (
+			record?.[ usernameSettingName ] !== username ||
+			! record?.[ applicationPasswordSettingName ]
+		) {
+			throw new Error(
+				__( 'It was not possible to save these credentials.' )
+			);
+		}
+
+		setIsConnected( true );
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: Name of the connector. */
+				__( '%s connected successfully.' ),
+				name
+			),
+			{
+				id: 'connector-connect-success',
+				type: 'snackbar',
+			}
+		);
+	};
+
+	const removeCredentials = async () => {
+		try {
+			await saveEntityRecord(
+				'root',
+				'site',
+				{
+					[ usernameSettingName ]: '',
+					[ applicationPasswordSettingName ]: '',
+				},
+				{ throwOnError: true }
+			);
+			setIsConnected( false );
+			createSuccessNotice(
+				sprintf(
+					/* translators: %s: Name of the connector. */
+					__( '%s disconnected.' ),
+					name
+				),
+				{
+					id: 'connector-disconnect-success',
+					type: 'snackbar',
+				}
+			);
+		} catch ( error ) {
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: Name of the connector. */
+					__( 'Failed to disconnect %s.' ),
+					name
+				),
+				{
+					id: 'connector-disconnect-error',
+					type: 'snackbar',
+				}
+			);
+			throw error;
+		}
+	};
+
+	return (
+		<ConnectorItem
+			className={
+				pluginSlug ? `connector-item--${ pluginSlug }` : undefined
+			}
+			logo={ logo }
+			name={ name }
+			description={ description }
+			actionArea={
+				<HStack spacing={ 3 } expanded={ false }>
+					{ isConnected && <ConnectedBadge /> }
+					{ showUnavailableBadge &&
+						( pluginSlug ? (
+							<PluginDirectoryLink slug={ pluginSlug } />
+						) : (
+							<UnavailableActionBadge />
+						) ) }
+					{ ! showUnavailableBadge && (
+						<Button
+							ref={ actionButtonRef }
+							variant={
+								isExpanded || isConnected
+									? 'tertiary'
+									: 'secondary'
+							}
+							size="compact"
+							onClick={ handleButtonClick }
+							disabled={ pluginStatus === 'checking' || isBusy }
+							isBusy={ isBusy }
+							accessibleWhenDisabled
+						>
+							{ getButtonLabel() }
+						</Button>
+					) }
+				</HStack>
+			}
+		>
+			{ isExpanded && pluginStatus === 'active' && (
+				<ApplicationPasswordConnectorSettings
+					key={ isConnected ? 'connected' : 'setup' }
+					initialUsername={ currentUsername }
+					helpUrl={ helpUrl }
+					helpLabel={ helpLabel }
+					readOnly={ isConnected }
+					onRemove={ async () => {
+						await removeCredentials();
+						actionButtonRef.current?.focus();
+					} }
+					onSave={ async ( credentials ) => {
+						await saveCredentials( credentials );
+						setIsExpanded( false );
+						actionButtonRef.current?.focus();
+					} }
+				/>
+			) }
+		</ConnectorItem>
+	);
+}
+
 // Register connectors from server-provided connector data.
 export function registerDefaultConnectors() {
 	const connectors = getConnectorData();
@@ -281,6 +495,11 @@ export function registerDefaultConnectors() {
 		);
 		if ( authentication.method === 'api_key' && ! existing?.render ) {
 			args.render = ApiKeyConnector;
+		} else if (
+			authentication.method === 'application_password' &&
+			! existing?.render
+		) {
+			args.render = ApplicationPasswordConnector;
 		}
 
 		registerConnector( connectorName, args );

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -14,6 +14,7 @@ export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 interface UseConnectorPluginOptions {
 	file?: string;
 	settingName: string;
+	additionalSettingName?: string;
 	connectorName: string;
 	isInstalled?: boolean;
 	isActivated?: boolean;
@@ -29,6 +30,7 @@ interface UseConnectorPluginReturn {
 	setIsExpanded: ( expanded: boolean ) => void;
 	isBusy: boolean;
 	isConnected: boolean;
+	setIsConnected: ( connected: boolean ) => void;
 	currentApiKey: string;
 	keySource: ApiKeySource;
 	handleButtonClick: () => void;
@@ -40,6 +42,7 @@ interface UseConnectorPluginReturn {
 export function useConnectorPlugin( {
 	file: pluginFileFromServer,
 	settingName,
+	additionalSettingName,
 	connectorName,
 	isInstalled,
 	isActivated,
@@ -63,6 +66,7 @@ export function useConnectorPlugin( {
 		derivedPluginStatus,
 		canManagePlugins,
 		currentApiKey,
+		hasStoredCredentials,
 		canInstallPlugins,
 	} = useSelect(
 		( select ) => {
@@ -71,6 +75,13 @@ export function useConnectorPlugin( {
 				| Record< string, string >
 				| undefined;
 			const apiKey = siteSettings?.[ settingName ] ?? '';
+			const additionalSettingValue = additionalSettingName
+				? siteSettings?.[ additionalSettingName ] ?? ''
+				: undefined;
+			const credentialsExist =
+				!! apiKey &&
+				( additionalSettingValue === undefined ||
+					!! additionalSettingValue );
 
 			const canCreate = !! store.canUser( 'create', {
 				kind: 'root',
@@ -88,6 +99,7 @@ export function useConnectorPlugin( {
 						: 'checking' ) as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
 					currentApiKey: apiKey,
+					hasStoredCredentials: credentialsExist,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -108,6 +120,7 @@ export function useConnectorPlugin( {
 					derivedPluginStatus: 'checking' as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
 					currentApiKey: apiKey,
+					hasStoredCredentials: credentialsExist,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -124,6 +137,7 @@ export function useConnectorPlugin( {
 						: 'inactive' ) as PluginStatus,
 					canManagePlugins: true,
 					currentApiKey: apiKey,
+					hasStoredCredentials: credentialsExist,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -141,10 +155,18 @@ export function useConnectorPlugin( {
 				derivedPluginStatus: status,
 				canManagePlugins: false,
 				currentApiKey: apiKey,
+				hasStoredCredentials: credentialsExist,
 				canInstallPlugins: canCreate,
 			};
 		},
-		[ pluginBasename, settingName, isInstalled, isActivated ]
+		[
+			pluginFileFromServer,
+			pluginBasename,
+			settingName,
+			additionalSettingName,
+			isInstalled,
+			isActivated,
+		]
 	);
 
 	const pluginStatus = pluginStatusOverride ?? derivedPluginStatus;
@@ -154,9 +176,9 @@ export function useConnectorPlugin( {
 
 	const isConnected =
 		( pluginStatus === 'active' && connectedState ) ||
-		// After install/activate, if settings re-fetch reveals an existing key,
+		// After install/activate, if settings re-fetch reveals stored credentials,
 		// update connected state (mirrors what the server would report on page load).
-		( pluginStatusOverride === 'active' && !! currentApiKey );
+		( pluginStatusOverride === 'active' && hasStoredCredentials );
 
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
@@ -388,6 +410,7 @@ export function useConnectorPlugin( {
 		setIsExpanded,
 		isBusy,
 		isConnected,
+		setIsConnected: setConnectedState,
 		currentApiKey,
 		keySource,
 		handleButtonClick,

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -11,6 +11,13 @@ import type { __experimentalApiKeySource as ApiKeySource } from '@wordpress/conn
 
 export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 
+type ApplicationPasswordSettingValue = {
+	username: string;
+	password: string;
+};
+
+type ConnectorSettingValue = string | ApplicationPasswordSettingValue;
+
 interface UseConnectorPluginOptions {
 	file?: string;
 	settingName: string;
@@ -29,13 +36,19 @@ interface UseConnectorPluginReturn {
 	setIsExpanded: ( expanded: boolean ) => void;
 	isBusy: boolean;
 	isConnected: boolean;
-	setIsConnected: ( connected: boolean ) => void;
 	currentApiKey: string;
+	currentUsername: string;
+	hasResolvedSettings: boolean;
 	keySource: ApiKeySource;
 	handleButtonClick: () => void;
 	getButtonLabel: () => string;
 	saveApiKey: ( apiKey: string ) => Promise< void >;
 	removeApiKey: () => Promise< void >;
+	saveCredentials: ( credentials: {
+		username: string;
+		applicationPassword: string;
+	} ) => Promise< void >;
+	removeCredentials: () => Promise< void >;
 }
 
 export function useConnectorPlugin( {
@@ -64,7 +77,9 @@ export function useConnectorPlugin( {
 		derivedPluginStatus,
 		canManagePlugins,
 		currentApiKey,
+		currentUsername,
 		hasStoredCredentials,
+		hasResolvedSettings,
 		canInstallPlugins,
 	} = useSelect(
 		( select ) => {
@@ -81,10 +96,18 @@ export function useConnectorPlugin( {
 				| undefined;
 			const settingValue = siteSettings?.[ settingName ];
 			const apiKey = typeof settingValue === 'string' ? settingValue : '';
-			const credentialsExist =
+			const credentials =
 				typeof settingValue === 'object' && settingValue !== null
-					? !! settingValue.username && !! settingValue.password
+					? settingValue
+					: undefined;
+			const credentialsExist =
+				credentials !== undefined
+					? !! credentials.username && !! credentials.password
 					: !! apiKey;
+			const settingsResolved = store.hasFinishedResolution(
+				'getEntityRecord',
+				[ 'root', 'site' ]
+			);
 
 			const canCreate = !! store.canUser( 'create', {
 				kind: 'root',
@@ -102,7 +125,9 @@ export function useConnectorPlugin( {
 						: 'checking' ) as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
 					currentApiKey: apiKey,
+					currentUsername: credentials?.username ?? '',
 					hasStoredCredentials: credentialsExist,
+					hasResolvedSettings: settingsResolved,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -123,7 +148,9 @@ export function useConnectorPlugin( {
 					derivedPluginStatus: 'checking' as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
 					currentApiKey: apiKey,
+					currentUsername: credentials?.username ?? '',
 					hasStoredCredentials: credentialsExist,
+					hasResolvedSettings: settingsResolved,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -140,7 +167,9 @@ export function useConnectorPlugin( {
 						: 'inactive' ) as PluginStatus,
 					canManagePlugins: true,
 					currentApiKey: apiKey,
+					currentUsername: credentials?.username ?? '',
 					hasStoredCredentials: credentialsExist,
+					hasResolvedSettings: settingsResolved,
 					canInstallPlugins: canCreate,
 				};
 			}
@@ -158,7 +187,9 @@ export function useConnectorPlugin( {
 				derivedPluginStatus: status,
 				canManagePlugins: false,
 				currentApiKey: apiKey,
+				currentUsername: credentials?.username ?? '',
 				hasStoredCredentials: credentialsExist,
+				hasResolvedSettings: settingsResolved,
 				canInstallPlugins: canCreate,
 			};
 		},
@@ -185,6 +216,56 @@ export function useConnectorPlugin( {
 	const { saveEntityRecord, invalidateResolution } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+
+	const saveConnectorSetting = ( value: ConnectorSettingValue ) =>
+		saveEntityRecord(
+			'root',
+			'site',
+			{ [ settingName ]: value },
+			{ throwOnError: true }
+		);
+
+	const createConnectedNotice = () => {
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: Name of the connector (e.g. "OpenAI"). */
+				__( '%s connected successfully.' ),
+				connectorName
+			),
+			{
+				id: 'connector-connect-success',
+				type: 'snackbar',
+			}
+		);
+	};
+
+	const createDisconnectedNotice = () => {
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: Name of the connector (e.g. "OpenAI"). */
+				__( '%s disconnected.' ),
+				connectorName
+			),
+			{
+				id: 'connector-disconnect-success',
+				type: 'snackbar',
+			}
+		);
+	};
+
+	const createDisconnectErrorNotice = () => {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: Name of the connector (e.g. "OpenAI"). */
+				__( 'Failed to disconnect %s.' ),
+				connectorName
+			),
+			{
+				id: 'connector-disconnect-error',
+				type: 'snackbar',
+			}
+		);
+	};
 
 	const installPlugin = async () => {
 		if ( ! pluginSlug ) {
@@ -320,12 +401,7 @@ export function useConnectorPlugin( {
 	const saveApiKey = async ( apiKey: string ) => {
 		const previousApiKey = currentApiKey;
 		try {
-			const updatedRecord = await saveEntityRecord(
-				'root',
-				'site',
-				{ [ settingName ]: apiKey },
-				{ throwOnError: true }
-			);
+			const updatedRecord = await saveConnectorSetting( apiKey );
 
 			// The server rejects invalid keys in two ways:
 			// 1. Returns the previous (unchanged) value
@@ -345,17 +421,7 @@ export function useConnectorPlugin( {
 			}
 
 			setConnectedState( true );
-			createSuccessNotice(
-				sprintf(
-					/* translators: %s: Name of the connector (e.g. "OpenAI"). */
-					__( '%s connected successfully.' ),
-					connectorName
-				),
-				{
-					id: 'connector-connect-success',
-					type: 'snackbar',
-				}
-			);
+			createConnectedNotice();
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to save API key:', error );
@@ -365,41 +431,67 @@ export function useConnectorPlugin( {
 		}
 	};
 
+	const saveCredentials = async ( {
+		username,
+		applicationPassword,
+	}: {
+		username: string;
+		applicationPassword: string;
+	} ) => {
+		try {
+			const updatedRecord = await saveConnectorSetting( {
+				username,
+				password: applicationPassword,
+			} );
+			const record = updatedRecord as
+				| Record< string, { username?: string; password?: string } >
+				| undefined;
+			const credentials = record?.[ settingName ];
+			// The server sanitizes the username, so verify persistence rather
+			// than exact equality.
+			if ( ! credentials?.username || ! credentials?.password ) {
+				throw new Error(
+					__( 'It was not possible to save these credentials.' )
+				);
+			}
+
+			setConnectedState( true );
+			createConnectedNotice();
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to save credentials:', error );
+			// The error is rendered with role="alert" in the UI,
+			// which already announces it to screen readers.
+			throw error;
+		}
+	};
+
 	const removeApiKey = async () => {
 		try {
-			await saveEntityRecord(
-				'root',
-				'site',
-				{ [ settingName ]: '' },
-				{ throwOnError: true }
-			);
+			await saveConnectorSetting( '' );
 			// Store auto-updates; currentApiKey reactively becomes ''.
 			setConnectedState( false );
-			createSuccessNotice(
-				sprintf(
-					/* translators: %s: Name of the connector (e.g. "OpenAI"). */
-					__( '%s disconnected.' ),
-					connectorName
-				),
-				{
-					id: 'connector-disconnect-success',
-					type: 'snackbar',
-				}
-			);
+			createDisconnectedNotice();
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to remove API key:', error );
-			createErrorNotice(
-				sprintf(
-					/* translators: %s: Name of the connector (e.g. "OpenAI"). */
-					__( 'Failed to disconnect %s.' ),
-					connectorName
-				),
-				{
-					id: 'connector-disconnect-error',
-					type: 'snackbar',
-				}
-			);
+			createDisconnectErrorNotice();
+			throw error;
+		}
+	};
+
+	const removeCredentials = async () => {
+		try {
+			await saveConnectorSetting( {
+				username: '',
+				password: '',
+			} );
+			setConnectedState( false );
+			createDisconnectedNotice();
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to remove credentials:', error );
+			createDisconnectErrorNotice();
 			throw error;
 		}
 	};
@@ -412,12 +504,15 @@ export function useConnectorPlugin( {
 		setIsExpanded,
 		isBusy,
 		isConnected,
-		setIsConnected: setConnectedState,
 		currentApiKey,
+		currentUsername,
+		hasResolvedSettings,
 		keySource,
 		handleButtonClick,
 		getButtonLabel,
 		saveApiKey,
 		removeApiKey,
+		saveCredentials,
+		removeCredentials,
 	};
 }

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -14,7 +14,6 @@ export type PluginStatus = 'checking' | 'not-installed' | 'inactive' | 'active';
 interface UseConnectorPluginOptions {
 	file?: string;
 	settingName: string;
-	additionalSettingName?: string;
 	connectorName: string;
 	isInstalled?: boolean;
 	isActivated?: boolean;
@@ -42,7 +41,6 @@ interface UseConnectorPluginReturn {
 export function useConnectorPlugin( {
 	file: pluginFileFromServer,
 	settingName,
-	additionalSettingName,
 	connectorName,
 	isInstalled,
 	isActivated,
@@ -72,16 +70,21 @@ export function useConnectorPlugin( {
 		( select ) => {
 			const store = select( coreStore );
 			const siteSettings = store.getEntityRecord( 'root', 'site' ) as
-				| Record< string, string >
+				| Record<
+						string,
+						| string
+						| {
+								username?: string;
+								password?: string;
+						  }
+				  >
 				| undefined;
-			const apiKey = siteSettings?.[ settingName ] ?? '';
-			const additionalSettingValue = additionalSettingName
-				? siteSettings?.[ additionalSettingName ] ?? ''
-				: undefined;
+			const settingValue = siteSettings?.[ settingName ];
+			const apiKey = typeof settingValue === 'string' ? settingValue : '';
 			const credentialsExist =
-				!! apiKey &&
-				( additionalSettingValue === undefined ||
-					!! additionalSettingValue );
+				typeof settingValue === 'object' && settingValue !== null
+					? !! settingValue.username && !! settingValue.password
+					: !! apiKey;
 
 			const canCreate = !! store.canUser( 'create', {
 				kind: 'root',
@@ -163,7 +166,6 @@ export function useConnectorPlugin( {
 			pluginFileFromServer,
 			pluginBasename,
 			settingName,
-			additionalSettingName,
 			isInstalled,
 			isActivated,
 		]

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -114,21 +114,21 @@ export function useConnectorPlugin( {
 				name: 'plugin',
 			} );
 
+			const common = {
+				currentApiKey: apiKey,
+				currentUsername: credentials?.username ?? '',
+				hasStoredCredentials: credentialsExist,
+				hasResolvedSettings: settingsResolved,
+				canInstallPlugins: canCreate,
+			};
+
 			if ( ! pluginFileFromServer ) {
-				const hasLoaded = store.hasFinishedResolution(
-					'getEntityRecord',
-					[ 'root', 'site' ]
-				);
 				return {
-					derivedPluginStatus: ( hasLoaded
+					...common,
+					derivedPluginStatus: ( settingsResolved
 						? 'active'
 						: 'checking' ) as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
-					currentApiKey: apiKey,
-					currentUsername: credentials?.username ?? '',
-					hasStoredCredentials: credentialsExist,
-					hasResolvedSettings: settingsResolved,
-					canInstallPlugins: canCreate,
 				};
 			}
 
@@ -145,13 +145,9 @@ export function useConnectorPlugin( {
 
 			if ( ! hasFinished ) {
 				return {
+					...common,
 					derivedPluginStatus: 'checking' as PluginStatus,
 					canManagePlugins: undefined as boolean | undefined,
-					currentApiKey: apiKey,
-					currentUsername: credentials?.username ?? '',
-					hasStoredCredentials: credentialsExist,
-					hasResolvedSettings: settingsResolved,
-					canInstallPlugins: canCreate,
 				};
 			}
 
@@ -162,15 +158,11 @@ export function useConnectorPlugin( {
 					plugin.status === 'active' ||
 					plugin.status === 'network-active';
 				return {
+					...common,
 					derivedPluginStatus: ( isPluginActive
 						? 'active'
 						: 'inactive' ) as PluginStatus,
 					canManagePlugins: true,
-					currentApiKey: apiKey,
-					currentUsername: credentials?.username ?? '',
-					hasStoredCredentials: credentialsExist,
-					hasResolvedSettings: settingsResolved,
-					canInstallPlugins: canCreate,
 				};
 			}
 
@@ -184,13 +176,9 @@ export function useConnectorPlugin( {
 				status = 'inactive';
 			}
 			return {
+				...common,
 				derivedPluginStatus: status,
 				canManagePlugins: false,
-				currentApiKey: apiKey,
-				currentUsername: credentials?.username ?? '',
-				hasStoredCredentials: credentialsExist,
-				hasResolvedSettings: settingsResolved,
-				canInstallPlugins: canCreate,
 			};
 		},
 		[

--- a/routes/connectors-home/use-connector-plugin.ts
+++ b/routes/connectors-home/use-connector-plugin.ts
@@ -476,7 +476,6 @@ export function useConnectorPlugin( {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to remove API key:', error );
 			createDisconnectErrorNotice();
-			throw error;
 		}
 	};
 
@@ -492,7 +491,6 @@ export function useConnectorPlugin( {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to remove credentials:', error );
 			createDisconnectErrorNotice();
-			throw error;
 		}
 	};
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -634,11 +634,8 @@ test.describe( 'Connectors', () => {
 				path: '/wp/v2/settings',
 			} );
 			expect( settings[ USERNAME_SETTING ] ).toBe( 'remote-user' );
-			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).not.toBe(
-				APPLICATION_PASSWORD
-			);
-			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).toMatch(
-				/1234$/
+			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).toBe(
+				'\u2022'.repeat( 16 )
 			);
 
 			await admin.visitAdminPage(

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -655,7 +655,7 @@ test.describe( 'Connectors', () => {
 			).toHaveValue( 'remote-user' );
 			await expect(
 				reloadedCard.getByLabel( 'Application password' )
-			).not.toHaveValue( APPLICATION_PASSWORD );
+			).toHaveValue( '•'.repeat( 16 ) );
 			await reloadedCard
 				.getByRole( 'button', { name: 'Remove and replace' } )
 				.click();

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -675,6 +675,47 @@ test.describe( 'Connectors', () => {
 				password: '',
 			} );
 		} );
+
+		test( 'should keep the stored password when a masked settings response is saved back', async ( {
+			requestUtils,
+		} ) => {
+			await requestUtils.rest( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: {
+					[ CREDENTIALS_SETTING ]: {
+						username: 'remote-user',
+						password: APPLICATION_PASSWORD,
+					},
+				},
+			} );
+
+			// Read the settings back; the REST API masks the password.
+			const settings = await requestUtils.rest( {
+				path: '/wp/v2/settings',
+			} );
+			expect( settings[ CREDENTIALS_SETTING ].password ).toBe(
+				'\u2022'.repeat( 16 )
+			);
+
+			// Save the masked response back, as a read-modify-write client
+			// would, and confirm the stored password is not overwritten.
+			await requestUtils.rest( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: {
+					[ CREDENTIALS_SETTING ]: settings[ CREDENTIALS_SETTING ],
+				},
+			} );
+
+			const storedCredentials = await requestUtils.rest( {
+				path: '/gutenberg-test-connectors/v1/application-password-credentials',
+			} );
+			expect( storedCredentials ).toEqual( {
+				username: 'remote-user',
+				password: APPLICATION_PASSWORD,
+			} );
+		} );
 	} );
 
 	test.describe( 'JS extensibility', () => {

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -552,6 +552,115 @@ test.describe( 'Connectors', () => {
 		} );
 	} );
 
+	test.describe( 'Application password setup flow', () => {
+		const PLUGIN_SLUG = 'gutenberg-test-connectors-application-password';
+		const USERNAME_SETTING =
+			'connectors_content_source_test_remote_wordpress_username';
+		const APPLICATION_PASSWORD_SETTING =
+			'connectors_content_source_test_remote_wordpress_application_password';
+		const APPLICATION_PASSWORD = 'abcd efgh ijkl mnop 1234';
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin( PLUGIN_SLUG );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.rest( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: {
+					[ USERNAME_SETTING ]: '',
+					[ APPLICATION_PASSWORD_SETTING ]: '',
+				},
+			} );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin( PLUGIN_SLUG );
+		} );
+
+		test( 'should save, mask, reload, and remove both credentials', async ( {
+			page,
+			admin,
+			requestUtils,
+		} ) => {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+
+			const card = getConnectorCardByName(
+				page,
+				'Test Remote WordPress'
+			);
+			await card.getByRole( 'button', { name: 'Set up' } ).click();
+
+			const usernameInput = card.getByRole( 'textbox', {
+				name: 'Username',
+			} );
+			const passwordInput = card.getByLabel( 'Application password' );
+			const saveButton = card.getByRole( 'button', { name: 'Save' } );
+
+			await expect( saveButton ).toBeDisabled();
+			await usernameInput.fill( 'remote-user' );
+			await passwordInput.fill( APPLICATION_PASSWORD );
+			await expect( saveButton ).toBeEnabled();
+			await expect(
+				card.getByRole( 'link', {
+					name: 'example.com',
+				} )
+			).toHaveAttribute(
+				'href',
+				'https://example.com/wp-admin/profile.php'
+			);
+			await saveButton.click();
+
+			await expect(
+				card.getByText( 'Connected', { exact: true } )
+			).toBeVisible();
+			const editButton = card.getByRole( 'button', { name: 'Edit' } );
+			await expect( editButton ).toBeFocused();
+
+			const settings = await requestUtils.rest( {
+				path: '/wp/v2/settings',
+			} );
+			expect( settings[ USERNAME_SETTING ] ).toBe( 'remote-user' );
+			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).not.toBe(
+				APPLICATION_PASSWORD
+			);
+			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).toMatch(
+				/1234$/
+			);
+
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+			const reloadedCard = getConnectorCardByName(
+				page,
+				'Test Remote WordPress'
+			);
+			await reloadedCard.getByRole( 'button', { name: 'Edit' } ).click();
+
+			await expect(
+				reloadedCard.getByRole( 'textbox', { name: 'Username' } )
+			).toHaveValue( 'remote-user' );
+			await expect(
+				reloadedCard.getByLabel( 'Application password' )
+			).not.toHaveValue( APPLICATION_PASSWORD );
+			await reloadedCard
+				.getByRole( 'button', { name: 'Remove and replace' } )
+				.click();
+
+			await expect(
+				reloadedCard.getByText( 'Connected', { exact: true } )
+			).toBeHidden();
+			await expect(
+				reloadedCard.getByRole( 'textbox', { name: 'Username' } )
+			).toHaveValue( '' );
+		} );
+	} );
+
 	test.describe( 'JS extensibility', () => {
 		const PLUGIN_SLUG = 'gutenberg-test-connectors-js-extensibility';
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -716,6 +716,42 @@ test.describe( 'Connectors', () => {
 				password: APPLICATION_PASSWORD,
 			} );
 		} );
+
+		test( 'should show an environment-configured connector as connected and read-only', async ( {
+			page,
+			admin,
+		} ) => {
+			await admin.visitAdminPage(
+				SETTINGS_PAGE_PATH,
+				CONNECTORS_PAGE_QUERY
+			);
+
+			const card = getConnectorCardByName(
+				page,
+				'Test Env Configured WordPress'
+			);
+			await expect(
+				card.getByText( 'Connected', { exact: true } )
+			).toBeVisible();
+			await card.getByRole( 'button', { name: 'Edit' } ).click();
+
+			const usernameInput = card.getByRole( 'textbox', {
+				name: 'Username',
+			} );
+			await expect( usernameInput ).toBeDisabled();
+			await expect( usernameInput ).toHaveValue( '•'.repeat( 16 ) );
+			await expect(
+				card.getByLabel( 'Application password' )
+			).toBeDisabled();
+			await expect(
+				card.getByText(
+					'These credentials are configured using an environment variable.'
+				)
+			).toBeVisible();
+			await expect(
+				card.getByRole( 'button', { name: 'Remove and replace' } )
+			).toBeHidden();
+		} );
 	} );
 
 	test.describe( 'JS extensibility', () => {

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -554,10 +554,8 @@ test.describe( 'Connectors', () => {
 
 	test.describe( 'Application password setup flow', () => {
 		const PLUGIN_SLUG = 'gutenberg-test-application-password-connector';
-		const USERNAME_SETTING =
-			'connectors_content_source_test_remote_wordpress_username';
-		const APPLICATION_PASSWORD_SETTING =
-			'connectors_content_source_test_remote_wordpress_application_password';
+		const CREDENTIALS_SETTING =
+			'connectors_content_source_test_remote_wordpress_credentials';
 		const APPLICATION_PASSWORD = 'abcd efgh ijkl mnop 1234';
 
 		test.beforeAll( async ( { requestUtils } ) => {
@@ -578,8 +576,10 @@ test.describe( 'Connectors', () => {
 				path: '/wp/v2/settings',
 				method: 'POST',
 				data: {
-					[ USERNAME_SETTING ]: '',
-					[ APPLICATION_PASSWORD_SETTING ]: '',
+					[ CREDENTIALS_SETTING ]: {
+						username: '',
+						password: '',
+					},
 				},
 			} );
 		} );
@@ -633,8 +633,10 @@ test.describe( 'Connectors', () => {
 			const settings = await requestUtils.rest( {
 				path: '/wp/v2/settings',
 			} );
-			expect( settings[ USERNAME_SETTING ] ).toBe( 'remote-user' );
-			expect( settings[ APPLICATION_PASSWORD_SETTING ] ).toBe(
+			expect( settings[ CREDENTIALS_SETTING ].username ).toBe(
+				'remote-user'
+			);
+			expect( settings[ CREDENTIALS_SETTING ].password ).toBe(
 				'\u2022'.repeat( 16 )
 			);
 
@@ -668,10 +670,10 @@ test.describe( 'Connectors', () => {
 			const clearedSettings = await requestUtils.rest( {
 				path: '/wp/v2/settings',
 			} );
-			expect( clearedSettings[ USERNAME_SETTING ] ).toBe( '' );
-			expect( clearedSettings[ APPLICATION_PASSWORD_SETTING ] ).toBe(
-				''
-			);
+			expect( clearedSettings[ CREDENTIALS_SETTING ] ).toEqual( {
+				username: '',
+				password: '',
+			} );
 		} );
 	} );
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -667,6 +667,14 @@ test.describe( 'Connectors', () => {
 			await expect(
 				reloadedCard.getByRole( 'textbox', { name: 'Username' } )
 			).toHaveValue( '' );
+
+			const clearedSettings = await requestUtils.rest( {
+				path: '/wp/v2/settings',
+			} );
+			expect( clearedSettings[ USERNAME_SETTING ] ).toBe( '' );
+			expect( clearedSettings[ APPLICATION_PASSWORD_SETTING ] ).toBe(
+				''
+			);
 		} );
 	} );
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -553,7 +553,7 @@ test.describe( 'Connectors', () => {
 	} );
 
 	test.describe( 'Application password setup flow', () => {
-		const PLUGIN_SLUG = 'gutenberg-test-connectors-application-password';
+		const PLUGIN_SLUG = 'gutenberg-test-application-password-connector';
 		const USERNAME_SETTING =
 			'connectors_content_source_test_remote_wordpress_username';
 		const APPLICATION_PASSWORD_SETTING =

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -562,6 +562,15 @@ test.describe( 'Connectors', () => {
 
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activatePlugin( PLUGIN_SLUG );
+			const status = await requestUtils.rest( {
+				path: '/gutenberg-test-connectors/v1/application-password',
+			} );
+			// The companion Core change can land independently of this UI.
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! status.is_registered,
+				'Requires application_password support in WordPress Core.'
+			);
 		} );
 
 		test.afterEach( async ( { requestUtils } ) => {


### PR DESCRIPTION
## What?
- Adds a default username/application-password connector form and authentication type.
- Mirrors the Core API in Gutenberg's WordPress 7.0 connector compatibility layer.
- Adds a real PHP connector fixture and browser coverage for save, masking, reload, and removal.
- Skips only the new browser suite when the companion Core API is unavailable, allowing the PRs to land independently.

## Testing
- npm run build -- --skip-themes
- Targeted strict ESLint and PHPCS
- Full connector browser suite: 19 passed against the companion Core checkout
- Focused application-password browser flow: 1 passed after the independent-landing guard

Cross-repository command:
WP_ENV_CORE=/path/to/wordpress-develop/src WP_ENV_HOME=/tmp/gutenberg-application-password-wp-env WP_ENV_PORT=8891 WP_BASE_URL=http://localhost:8891 npm run test:e2e -- specs/admin/connectors.spec.js --project=chromium

## Screenshot
![Application password connector setup](https://raw.githubusercontent.com/WordPress/gutenberg/c6b5f4b8ad4/.github/pr-screenshots/79403/connectors-application-password.png)

Companion Core PR: https://github.com/WordPress/wordpress-develop/pull/12264
Related: https://github.com/WordPress/gutenberg/issues/78647
