### PR TITLE
Playlist: Use media control icons

### DIFF
--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -13,6 +13,7 @@ import '@testing-library/jest-dom';
 import {
 	createWaveformContainer,
 	styleSvgIcons,
+	setupPlayButtonIcons,
 	setupPlayButtonAccessibility,
 	logPlayError,
 } from '../waveform-utils';
@@ -198,6 +199,113 @@ describe( 'Waveform utilities', () => {
 			styleSvgIcons( container, '#ffff00' );
 
 			expect( path ).toHaveStyle( { fill: '#000000' } );
+		} );
+	} );
+
+	describe( 'setupPlayButtonIcons', () => {
+		const playIconPath = 'm8 18 9-6-9-6z';
+		const pauseIconPath = 'M10 17.5H7v-11h3zm7 0h-3v-11h3z';
+
+		it( 'should set the WordPress play icon initially', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			setupPlayButtonIcons( container, '#000000' );
+
+			expect( playBtn.querySelector( 'path' ) ).toHaveAttribute(
+				'd',
+				playIconPath
+			);
+		} );
+
+		it( 'should change to the WordPress pause icon on play', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			setupPlayButtonIcons( container, '#000000' );
+			container.dispatchEvent( new CustomEvent( 'waveformplayer:play' ) );
+
+			expect( playBtn.querySelector( 'path' ) ).toHaveAttribute(
+				'd',
+				pauseIconPath
+			);
+		} );
+
+		it( 'should change back to the WordPress play icon on pause', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			setupPlayButtonIcons( container, '#000000' );
+			container.dispatchEvent( new CustomEvent( 'waveformplayer:play' ) );
+			container.dispatchEvent(
+				new CustomEvent( 'waveformplayer:pause' )
+			);
+
+			expect( playBtn.querySelector( 'path' ) ).toHaveAttribute(
+				'd',
+				playIconPath
+			);
+		} );
+
+		it( 'should change back to the WordPress play icon on ended', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			setupPlayButtonIcons( container, '#000000' );
+			container.dispatchEvent( new CustomEvent( 'waveformplayer:play' ) );
+			container.dispatchEvent(
+				new CustomEvent( 'waveformplayer:ended' )
+			);
+
+			expect( playBtn.querySelector( 'path' ) ).toHaveAttribute(
+				'd',
+				playIconPath
+			);
+		} );
+
+		it( 'should style the WordPress icon with a contrasting fill', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			setupPlayButtonIcons( container, '#000000' );
+
+			expect( playBtn.querySelector( 'path' ) ).toHaveStyle( {
+				fill: '#ffffff',
+			} );
+		} );
+
+		it( 'should return cleanup function that removes listeners', () => {
+			const container = document.createElement( 'div' );
+			const playBtn = document.createElement( 'button' );
+			playBtn.className = 'waveform-btn';
+			container.appendChild( playBtn );
+
+			const cleanup = setupPlayButtonIcons( container, '#000000' );
+			cleanup();
+
+			container.dispatchEvent( new CustomEvent( 'waveformplayer:play' ) );
+			expect( playBtn.querySelector( 'path' ) ).toHaveAttribute(
+				'd',
+				playIconPath
+			);
+		} );
+
+		it( 'should do nothing when play button not found', () => {
+			const container = document.createElement( 'div' );
+
+			expect( () =>
+				setupPlayButtonIcons( container, '#000000' )
+			).not.toThrow();
 		} );
 	} );
 

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -14,6 +14,10 @@ import WaveformPlayerLib from '@arraypress/waveform-player';
  * Note: DEFAULT_WAVEFORM_HEIGHT should match $waveform-player-height in style.scss.
  */
 const DEFAULT_WAVEFORM_HEIGHT = 100;
+const PLAY_ICON_MARKUP =
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m8 18 9-6-9-6z"></path></svg>';
+const PAUSE_ICON_MARKUP =
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 17.5H7v-11h3zm7 0h-3v-11h3z"></path></svg>';
 
 /**
  * Get computed style for an element, using ownerDocument for iframe compatibility.
@@ -103,6 +107,39 @@ export function styleSvgIcons( container, buttonColor ) {
 	svgPaths.forEach( ( path ) => {
 		path.style.fill = iconColor;
 	} );
+}
+
+/**
+ * Set up the play button icon to use WordPress media control icons.
+ *
+ * @param {Element} container   - The waveform container element.
+ * @param {string}  buttonColor - The button background color (textColor).
+ */
+export function setupPlayButtonIcons( container, buttonColor ) {
+	const playBtn = container.querySelector( '.waveform-btn' );
+	if ( ! playBtn ) {
+		return;
+	}
+
+	const setIcon = ( iconMarkup ) => {
+		playBtn.innerHTML = iconMarkup;
+		styleSvgIcons( playBtn, buttonColor );
+	};
+
+	setIcon( PLAY_ICON_MARKUP );
+
+	const onPlay = () => setIcon( PAUSE_ICON_MARKUP );
+	const onPause = () => setIcon( PLAY_ICON_MARKUP );
+
+	container.addEventListener( 'waveformplayer:play', onPlay );
+	container.addEventListener( 'waveformplayer:pause', onPause );
+	container.addEventListener( 'waveformplayer:ended', onPause );
+
+	return () => {
+		container.removeEventListener( 'waveformplayer:play', onPlay );
+		container.removeEventListener( 'waveformplayer:pause', onPause );
+		container.removeEventListener( 'waveformplayer:ended', onPause );
+	};
 }
 
 /**
@@ -198,9 +235,13 @@ export function initWaveformPlayer(
 
 	// Set up event handlers.
 	let cleanupAccessibility;
+	let cleanupPlayButtonIcons;
 	const handlers = {
 		ready: () => {
-			styleSvgIcons( container, textColor );
+			cleanupPlayButtonIcons = setupPlayButtonIcons(
+				container,
+				textColor
+			);
 			cleanupAccessibility = setupPlayButtonAccessibility(
 				container,
 				labels
@@ -221,6 +262,7 @@ export function initWaveformPlayer(
 		container,
 		destroy: () => {
 			cleanupAccessibility?.();
+			cleanupPlayButtonIcons?.();
 			container.removeEventListener(
 				'waveformplayer:ready',
 				handlers.ready


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #78987.

Uses the new media-control icon artwork for the Playlist block waveform play/pause button.

## Why?
This keeps the Playlist block controls visually aligned with the shared WordPress media-control icons.

## How?
The waveform utility swaps the player library's generated button markup to the new play and pause SVGs while preserving contrast styling, labels, event cleanup, and editor/frontend reuse.

## Testing Instructions
- `npm run test:unit packages/block-library/src/utils/test/waveform-utils.js`
- `npm run lint:js -- packages/block-library/src/utils/waveform-utils.js packages/block-library/src/utils/test/waveform-utils.js`
- Insert a Playlist block and confirm the waveform button shows play, switches to pause during playback, and switches back when paused or ended.

### Testing Instructions for Keyboard
Tab to the playlist waveform button, press Enter or Space to play and pause, and confirm the icon and accessible label update.

## Screenshots or screencast
Not included.

## Use of AI Tools
OpenAI Codex helped implement and validate this change under human direction.
