### PR TITLE
UI: Update @base-ui/react to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2234,13 +2234,13 @@
 			}
 		},
 		"node_modules/@base-ui/react": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
-			"integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.2.9",
+				"@base-ui/utils": "0.3.1",
 				"@floating-ui/react-dom": "^2.1.8",
 				"@floating-ui/utils": "^0.2.11",
 				"use-sync-external-store": "^1.6.0"
@@ -2285,14 +2285,14 @@
 			}
 		},
 		"node_modules/@base-ui/utils": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
-			"integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
 				"@floating-ui/utils": "^0.2.11",
-				"reselect": "^5.1.1",
+				"reselect": "^5.2.0",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
@@ -40260,9 +40260,9 @@
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
 		},
 		"node_modules/reselect": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"license": "MIT"
 		},
 		"node_modules/resize-observer-polyfill": {
@@ -53802,7 +53802,7 @@
 			"version": "0.16.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.5.0",
+				"@base-ui/react": "^1.6.0",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Internal
 
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
+-   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0).
 
 ## 0.15.1 (2026-06-16)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).
+
 ## 0.16.0 (2026-06-24)
 
 ### Breaking Changes
@@ -31,7 +35,6 @@
 ### Internal
 
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
--   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0).
 
 ## 0.15.1 (2026-06-16)
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@base-ui/react": "^1.5.0",
+		"@base-ui/react": "^1.6.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION
## What?

Updates `@base-ui/react` in `@wordpress/ui` from `^1.5.0` to `^1.6.0`.

This also updates the resolved transitive packages required by Base UI:

- `@base-ui/utils`: `0.2.9` → `0.3.1`
- `reselect`: `5.1.1` → `5.2.0`

## Why?

`1.6.0` is the current npm `latest` release and includes upstream accessibility, focus-management, positioning, validation, and interaction fixes across Base UI primitives.

## How?

- Updated `packages/ui/package.json`.
- Refreshed `package-lock.json` with only the Base UI-related resolution changes.
- Added a `packages/ui/CHANGELOG.md` entry.

<details>
<summary>Release note impact report</summary>

Source reviewed: https://github.com/mui/base-ui/releases/tag/v1.6.0 and https://github.com/mui/base-ui/blob/master/CHANGELOG.md#v160.

Version check:

- Current resolved version: `@base-ui/react@1.5.0`.
- Target version: `@base-ui/react@1.6.0`.
- npm `latest`: `1.6.0`.

Impact by upstream release-note area:

| Upstream area | Release notes | Gutenberg impact |
| --- | --- | --- |
| General changes | Correct inaccurate prop JSDoc. | Documentation/types-only upstream correction. Our wrappers derive many prop types from Base UI, but no local API change is needed. |
| General changes | Update hook value when store/arguments change. | Relevant to wrapped stateful primitives (`Select`, `Autocomplete`, `Combobox`, `Tabs`, overlays). Focused `packages/ui/src` tests passed; no local workaround found. |
| General changes | Restore viewport morphing after reopening kept-mounted popups. | Potentially relevant to kept-mounted popup/positioner primitives. Our overlay wrappers do not implement viewport morphing themselves; no code change needed. |
| General changes | Fix pseudo-element bounds in dev mode. | Upstream dev-mode positioning/measurement fix. No Gutenberg-specific code uses these internals directly. |
| Accordion | Fix trigger behavior bugs. | We do not wrap `@base-ui/react/accordion`. `CollapsibleCard` is our local accordion-like pattern, but not built on Base UI Accordion. |
| Accordion | Remove `region` role from `Accordion.Root`. | No direct usage. Checked against the WAI-ARIA APG Accordion Pattern: panel `region` is optional and should be avoided when it creates landmark proliferation. No local change needed. |
| Accordion | Align keyboard navigation with APG. | No direct Accordion usage. Keyboard-related coverage for our actual wrappers passed. |
| Alert Dialog | Fix programmatic focus return. | Relevant: `AlertDialog.Popup` forwards `finalFocus` and uses our `useDeprioritizedInitialFocus`. Existing alert-dialog tests passed; no local workaround found. |
| Autocomplete | Keep ArrowLeft/ArrowRight on input caret in grid mode. | We wrap Autocomplete but do not use grid mode in package code. No change needed. |
| Autocomplete | Document `open` requirement for `inline`. | Relevant to our inline autocomplete story, which already sets `inline: true` and `open: true`. No change needed. |
| Avatar | Fix image status edge cases. | No `Avatar` wrapper or direct usage. |
| Checkbox | Fix parent group cancellation/indeterminate state; ignore disabled Field `data-focused`; fix extra `validate` calls. | No `Checkbox` wrapper or direct usage. |
| Checkbox Group | Fix parent group cancellation/indeterminate state; parent checkbox custom validation; multiple required checkbox validation; forward group IDs. | No `CheckboxGroup` wrapper or direct usage. |
| Collapsible | Fix trigger and panel state bugs. | Relevant: we wrap `Collapsible.Root`, `Trigger`, and `Panel`. Existing collapsible and collapsible-card tests passed; no local workaround found. |
| Combobox | Fix chip context error. | Relevant: our Combobox exposes chips. Existing combobox tests passed. |
| Combobox | Keep ArrowLeft/ArrowRight on input caret in grid mode. | We do not use grid mode. No change needed. |
| Combobox | Avoid re-rendering every item on each keystroke. | Upstream performance improvement for our Combobox wrapper; no local code change needed. |
| Combobox | Fix autofill and selected state edge cases. | Relevant to our object-value/searchable Combobox use. Existing tests passed. |
| Combobox | Document `open` requirement for `inline`. | Our inline combobox story already sets `inline: true` and `open: true`. No change needed. |
| Dialog | Fix confirmation return focus; programmatic focus return; positioning/viewport edge cases; non-modal focus-out close and tabindex management. | Relevant: `Dialog.Popup` forwards `initialFocus`/`finalFocus`, modal mode, and positioner behavior through Base UI. Existing dialog tests passed; no local workaround found. |
| Drawer | Fix confirmation return focus; improve swipe drag performance; native swipe gesture driving; add virtual keyboard provider; commit swipe on primary-button release. | Relevant: our Drawer wraps Base UI Drawer and has local scroll/swipe integration. Existing drawer tests passed; no obsolete local workaround found. |
| Field | Fix form validation bugs; reflect disabled `Field.Item` state in `Field.Label` and `Field.Description`; fix `valueMissing` revalidation; fix validation bugs. | Relevant: our form field primitives wrap Base UI Field. Existing field tests passed; disabled-state styling already uses Base UI data attributes. |
| Fieldset | Fix disabled fieldset form bugs. | Relevant: our fieldset primitives wrap Base UI Fieldset. Existing fieldset tests passed. |
| Form | Fix form validation bugs. | We do not expose Base UI Form directly. Effects may flow through Field/Fieldset/Input/Select primitives; related tests passed. |
| Menu | Fix submenu trigger interactions; submenu hover delay; controlled hover leave close; positioning/viewport edge cases. | We do not ship a `Menu` wrapper yet. One AlertDialog story imports Base UI Menu directly as an example; no package API change needed. |
| Menubar | Fix vertical menu focus behavior. | No `Menubar` wrapper or direct usage. |
| Meter | Sync value text with indicator. | No `Meter` wrapper or direct usage. |
| Navigation Menu | Preserve controlled exit transition; fix interaction/value/styling-hook bugs. | No `NavigationMenu` wrapper or direct usage. |
| Number Field | Clipboard paste, committed value, keyboard stepping, Intl rounding, locale cache, numeric precision, and input/scrub fixes. | No `NumberField` wrapper or direct usage. |
| OTP Field | Breaking change: namespace export renamed `OTPFieldPreview` → `OTPField`; password-manager bubble fix. | No `OTPField` wrapper or imports, so the breaking change does not affect Gutenberg. |
| Popover | Fix controlled hover leave close; programmatic focus return; positioning/viewport edge cases; non-modal focus-out close and tabindex management. | Relevant: our Popover wrapper forwards focus and positioning through Base UI. Existing popover tests passed; no local workaround found. |
| Preview Card | Controlled hover leave close; positioning/viewport; inline preview anchoring; close on active trigger unmount. | No `PreviewCard` wrapper or direct usage. |
| Radio Group | Forward group IDs; Space selection; disabled selected form submission; honor canceled value changes. | No `RadioGroup` wrapper or direct usage. |
| Scroll Area | Fix overflow/scrolling state; add scrolling state to Thumb. | No `ScrollArea` wrapper or direct usage. |
| Select | Fix autofill/selected state; dirty state in multiple mode; skip disabled items in typeahead and fix multiple-mode serialization. | Relevant: our Select wrapper supports object values and popup items. Existing select tests passed; no local code change needed. |
| Slider | Extra validation calls; interaction edge cases; touchend listener leak. | No `Slider` wrapper or direct usage. |
| Switch | Fix extra `validate` calls. | No `Switch` wrapper or direct usage. |
| Tabs | Fix state edge cases; fix suspended panel activation. | Relevant: our Tabs wrapper previously changed tests for Base UI `1.5.0` automatic selection behavior. Existing tabs tests passed with no assertion changes. |
| Toast | Fix timer and limit edge cases. | No `Toast` wrapper or direct usage. |
| Toggle | Fix grouped cancellation and JSDoc. | No `Toggle` wrapper or direct usage. |
| Toggle Group | Fix grouped cancellation and JSDoc; remove invalid `aria-orientation` from `role="group"`; fix disabled state and roving focus bugs. | No `ToggleGroup` wrapper or direct usage. The `aria-orientation` note is consistent with WAI-ARIA 1.2 role-specific supported/prohibited state guidance, but it does not affect our package. |
| Toolbar | Do not forward `disabled` to default toolbar button; disabled state and roving focus fixes. | No `Toolbar` wrapper or direct usage. |
| Tooltip | Fix positioning/viewport edge cases; provider delay group lifecycle; reset `preventUnmountOnClose` on reopen; close when active trigger unmounts. | Relevant: our Tooltip wrapper forwards provider, popup, portal, trigger, and positioner behavior. Existing tooltip tests passed; no local code change needed. |

No local compatibility changes were required after reviewing the release notes against current `packages/ui` imports, wrappers, tests, stories, and Base UI-related comments/workarounds.

</details>

## Testing Instructions

1. `npm install` doesn't modify the lock file
2. Unit tests, lint checks and TS complication pass without errors
8. Run `npm audit --omit=dev --json` and confirm no new Base UI-specific advisory is introduced.

Smoke test `@wordpress/ui` components, in particular the ones directly affected by the update (see collapsed section above).

## Use of AI Tools

This PR was prepared with assistance from OpenAI Codex. I reviewed the release notes, generated diff, and verification results.