### PR TITLE
Popover: Align transition state styles

### DIFF
--- a/packages/ui/src/popover/style.module.css
+++ b/packages/ui/src/popover/style.module.css
@@ -116,10 +116,11 @@
 			z-index: var(--wp-ui-popover-z-index, initial);
 			/* TODO: Replace with a WPDS overlay/scrim token when one exists. */
 			background-color: rgba(0, 0, 0, 0.15);
-			opacity: 0;
+			opacity: 1;
 
-			&[data-open]:not([data-starting-style]):not([data-ending-style]) {
-				opacity: 1;
+			&[data-starting-style],
+			&[data-ending-style] {
+				opacity: 0;
 			}
 
 			@media not (prefers-reduced-motion) {

--- a/packages/ui/src/utils/css/dropdown-motion.module.css
+++ b/packages/ui/src/utils/css/dropdown-motion.module.css
@@ -25,24 +25,32 @@
 				will-change: transform, opacity;
 			}
 
-			opacity: 0;
+			opacity: 1;
+			transform: translate(0);
 
-			&[data-side="bottom"] {
+			&[data-starting-style],
+			&[data-ending-style] {
+				opacity: 0;
+			}
+
+			&[data-side="bottom"][data-starting-style],
+			&[data-side="bottom"][data-ending-style] {
 				transform: translateY(calc(-1 * var(--wp-ui-dropdown-slide-distance)));
 			}
-			&[data-side="top"] {
+
+			&[data-side="top"][data-starting-style],
+			&[data-side="top"][data-ending-style] {
 				transform: translateY(var(--wp-ui-dropdown-slide-distance));
 			}
-			&[data-side="left"] {
+
+			&[data-side="left"][data-starting-style],
+			&[data-side="left"][data-ending-style] {
 				transform: translateX(var(--wp-ui-dropdown-slide-distance));
 			}
-			&[data-side="right"] {
-				transform: translateX(calc(-1 * var(--wp-ui-dropdown-slide-distance)));
-			}
 
-			&[data-open]:not([data-starting-style]) {
-				opacity: 1;
-				transform: translate(0);
+			&[data-side="right"][data-starting-style],
+			&[data-side="right"][data-ending-style] {
+				transform: translateX(calc(-1 * var(--wp-ui-dropdown-slide-distance)));
 			}
 		}
 	}


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/78885#discussion_r3357710771

## What?

Align the Popover/dropdown transition CSS with the state pattern used by Dialog-like overlays.

## Why?

The previous dropdown motion utility and Popover backdrop styles modeled the hidden state as the default and opted into the visible state with `data-open` selectors. The follow-up from #78885 asked to unify that approach with the rest of the overlay styles.

## How?

- Makes the shared dropdown motion utility use the visible resting state by default.
- Moves the fade/offset state to `data-starting-style` and `data-ending-style` selectors.
- Applies the same state shape to Popover's backdrop opacity.

## Testing Instructions

1. Run `npm run lint:css -- packages/ui/src/popover/style.module.css packages/ui/src/utils/css/dropdown-motion.module.css`.
2. Run `npm run test:unit -- packages/ui/src/popover/test/index.test.tsx`.
3. Open the Popover Storybook stories and verify styled Popover instances still open and close with the same motion.

### Testing Instructions for Keyboard

1. Open a Popover story.
2. Use Tab to focus the trigger.
3. Press Enter or Space to open the popover.
4. Press Escape and verify the popover closes and focus returns as expected.

## Screenshots or screencast

Not applicable; no intended visual change.

## Use of AI Tools

Created with assistance from OpenAI Codex. The changes and tests were reviewed before opening this PR.