### PR TITLE
devops: configure e2e report auto-upload for flakiness.io dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 yarn.lock
 /artifacts
 /test/e2e/artifacts
+/test/e2e/flakiness-report
 /perf-envs
 /composer.lock
 

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -28,7 +28,10 @@ const config = defineConfig( {
 				[ 'github' ],
 				[ './config/flaky-tests-reporter.ts' ],
 				[ 'blob' ],
-				[ '@flakiness/playwright' ],
+				[
+					'@flakiness/playwright',
+					{ flakinessProject: 'WordPress/gutenberg' },
+				],
 		  ]
 		: 'list',
 	workers: 1,


### PR DESCRIPTION
The configuration was supposed to be added as part of
https://github.com/WordPress/gutenberg/pull/79173, but I got confused
with indentation and forgot about it.

Drive-by: add `flakiness-report` folder to gitignore. The folder holds
the last generated report after every run.

References https://github.com/WordPress/gutenberg/issues/78605
