### PR TITLE
Clarify Core-specific steps when bumping support

### DIFF
--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -86,7 +86,7 @@ The new reference commit hash that is chosen needs to meet the following require
 
 ### Update `wordpress-develop`
 
-When releasing a plugin update that changes the minimum required version of WordPress, the end-to-end test GitHub Action workflow in Core SVN will need to be updated in any branch losing support. Otherwise, the first run of that workflow on that branch following the release will fail.
+When releasing a plugin update that changes the minimum required version of WordPress, the end-to-end test GitHub Actions workflow in Core SVN will need to be updated for any branch losing support. Otherwise, the first run of that workflow on that branch following the release will fail.
 
 A plugin version can be pinned in the workflow by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
 

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -84,9 +84,11 @@ The new reference commit hash that is chosen needs to meet the following require
  - Be compatible with the new WP version used in the "Tested up to" flag.
  - Is already tracked on "codevitals.run" for all existing metrics.
 
-When releasing a plugin update with changes to the minimum WordPress version requirements, the end-to-end test GitHub Action workflow in Core SVN will need to be updated for any branch losing support. Otherwise the first run of that workflow on that branch following the release will fail.
+### Update `wordpress-develop`
 
-The version of the plugin used in the workflow can be pinned by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
+When releasing a plugin update that changes the minimum required version of WordPress, the end-to-end test GitHub Action workflow in Core SVN will need to be updated in any branch losing support. Otherwise, the first run of that workflow on that branch following the release will fail.
+
+A plugin version can be pinned in the workflow by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
 
 **Note:** Always use the final release including bug fixes (ie. `x.y.2` or `x.y.3`). If the final release is not yet known, create a [Trac ticket](https://core.trac.wordpress.org/ticket/62488) so it's not forgotten.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This makes the note about changes required in https://github.com/WordPress/wordpress-develop required following a bump of the minimum required version of WordPress for the plugin.

## Why?
#79196 recently raised the minimum required version of WordPress from 6.8 to 6.9. The change to `wordpress-develop` was missed even though the section containing the relevant note was referenced.

## How?
This adds a new heading to make the step harder to miss.

## Use of AI Tools

None.