### PR TITLE
Pattern editing: show root block identity when editing pattern sections

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -19,6 +19,7 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { store as blockEditorStore } from '../../store';
 import { hasPatternOverridesDefaultBinding } from '../../utils/block-bindings';
 import { unlock } from '../../lock-unlock';
+import { isIsolatedEditorKey } from '../../store/private-keys';
 
 function getBlockIconVariant( { select, clientIds } ) {
 	const {
@@ -29,8 +30,11 @@ function getBlockIconVariant( { select, clientIds } ) {
 		getTemplateLock,
 		getBlockEditingMode,
 		canEditBlock,
+		isWithinEditedContentOnlySection,
+		getSettings,
 	} = unlock( select( blockEditorStore ) );
 	const { getBlockStyles } = select( blocksStore );
+	const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
 
 	const hasTemplateLock = clientIds.some(
 		( id ) => getTemplateLock( id ) === 'contentOnly'
@@ -42,7 +46,10 @@ function getBlockIconVariant( { select, clientIds } ) {
 	const hasBlockStyles =
 		isSingleBlock && !! getBlockStyles( blockName )?.length;
 	const hasPatternNameInSelection = clientIds.some(
-		( id ) => !! getBlockAttributes( id )?.metadata?.patternName
+		( id ) =>
+			!! getBlockAttributes( id )?.metadata?.patternName &&
+			! isWithinEditedContentOnlySection( id ) &&
+			! isIsolatedEditor
 	);
 	const hasPatternOverrides = clientIds.every( ( clientId ) =>
 		hasPatternOverridesDefaultBinding(
@@ -86,20 +93,29 @@ function getBlockIconVariant( { select, clientIds } ) {
 }
 
 function getBlockIcon( { select, clientIds } ) {
-	const { getBlockName, getBlockAttributes } = unlock(
-		select( blockEditorStore )
-	);
+	const {
+		getBlockName,
+		getBlockAttributes,
+		isWithinEditedContentOnlySection,
+		getSettings,
+	} = unlock( select( blockEditorStore ) );
+	const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
 
 	const _isSingleBlock = clientIds.length === 1;
 	const firstClientId = clientIds[ 0 ];
+
 	const blockAttributes = getBlockAttributes( firstClientId );
-	if ( _isSingleBlock && blockAttributes?.metadata?.patternName ) {
+	if (
+		_isSingleBlock &&
+		blockAttributes?.metadata?.patternName &&
+		! isWithinEditedContentOnlySection( firstClientId ) &&
+		! isIsolatedEditor
+	) {
 		return symbol;
 	}
 
 	const blockName = getBlockName( firstClientId );
 	const blockType = getBlockType( blockName );
-
 	if ( _isSingleBlock ) {
 		const { getActiveBlockVariation } = select( blocksStore );
 		const match = getActiveBlockVariation( blockName, blockAttributes );

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
@@ -13,10 +13,33 @@ import { paragraph } from '@wordpress/icons';
  * Internal dependencies
  */
 import BlockToolbarIcon from '../block-toolbar-icon';
+import { isIsolatedEditorKey } from '../../../store/private-keys';
 
+jest.mock( '@wordpress/blocks', () => {
+	const actualImplementation = jest.requireActual( '@wordpress/blocks' );
+	return {
+		...actualImplementation,
+		getBlockType: ( name ) => ( {
+			name,
+			title: name === 'core/template-part' ? 'Template Part' : 'Group',
+			icon: `${ name }-icon`,
+		} ),
+	};
+} );
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '../../../lock-unlock', () => ( {
+	lock: ( value ) => value,
+	unlock: ( value ) => ( {
+		registerPrivateActions: jest.fn(),
+		registerPrivateSelectors: jest.fn(),
+		...value,
+	} ),
+} ) );
 jest.mock( '../../block-title/use-block-display-title', () =>
 	jest.fn().mockReturnValue( 'Block Name' )
+);
+jest.mock( '../../block-icon', () =>
+	jest.fn( ( { icon } ) => <span data-testid="block-icon">{ icon }</span> )
 );
 jest.mock( '../../block-switcher', () =>
 	jest.fn( ( { children } ) => (
@@ -37,6 +60,34 @@ describe( 'BlockToolbarIcon', () => {
 	const defaultProps = {
 		clientIds: [ 'test-client-id' ],
 		isSynced: false,
+	};
+	const setupToolbarSelectors = ( {
+		attributes = {
+			metadata: {
+				patternName: 'theme/hero',
+			},
+		},
+		blockName = 'core/group',
+		getActiveBlockVariation = () => null,
+		settings = {},
+		isWithinEditedSection = false,
+	} = {} ) => {
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				get: () => false,
+				getBlockName: () => blockName,
+				getBlockAttributes: () => attributes,
+				getSettings: () => settings,
+				getBlockParentsByBlockName: () => [],
+				canRemoveBlocks: () => true,
+				getTemplateLock: () => undefined,
+				getBlockEditingMode: () => 'default',
+				canEditBlock: () => true,
+				getBlockStyles: () => [ {} ],
+				getActiveBlockVariation,
+				isWithinEditedContentOnlySection: () => isWithinEditedSection,
+			} ) )
+		);
 	};
 
 	beforeEach( () => {
@@ -140,6 +191,55 @@ describe( 'BlockToolbarIcon', () => {
 			expect( button ).toHaveAttribute(
 				'aria-label',
 				'Multiple blocks selected'
+			);
+		} );
+	} );
+
+	describe( 'pattern sections', () => {
+		it( 'should not show the block switcher before the section is being edited', () => {
+			setupToolbarSelectors();
+
+			render( <BlockToolbarIcon { ...defaultProps } /> );
+
+			expect(
+				screen.queryByTestId( 'block-switcher' )
+			).not.toBeInTheDocument();
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
+		} );
+
+		it( 'should show the block switcher when the section is being edited', () => {
+			setupToolbarSelectors( { isWithinEditedSection: true } );
+
+			render( <BlockToolbarIcon { ...defaultProps } /> );
+
+			expect(
+				screen.getByTestId( 'block-switcher' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should show the block icon for pattern wrappers in isolated editors', () => {
+			setupToolbarSelectors( {
+				attributes: {
+					metadata: {
+						name: 'Header',
+						patternName: 'theme/header-wrapper',
+					},
+				},
+				settings: {
+					[ isIsolatedEditorKey ]: true,
+				},
+			} );
+
+			render( <BlockToolbarIcon { ...defaultProps } /> );
+
+			expect(
+				screen.getByTestId( 'block-switcher' )
+			).toBeInTheDocument();
+			expect( screen.getByTestId( 'block-icon' ) ).toHaveTextContent(
+				'core/group-icon'
 			);
 		} );
 	} );

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
@@ -28,7 +28,6 @@ jest.mock( '@wordpress/blocks', () => {
 } );
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 jest.mock( '../../../lock-unlock', () => ( {
-	lock: ( value ) => value,
 	unlock: ( value ) => ( {
 		registerPrivateActions: jest.fn(),
 		registerPrivateSelectors: jest.fn(),

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -12,15 +12,8 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import {
-	Icon,
-	lockSmall as lock,
-	pinSmall,
-	unseen,
-	symbol,
-} from '@wordpress/icons';
+import { Icon, lockSmall as lock, pinSmall, unseen } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
-import { useSelect } from '@wordpress/data';
 
 import { Tooltip } from '@wordpress/ui';
 
@@ -33,7 +26,6 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
-import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
@@ -63,13 +55,6 @@ function ListViewBlockSelectButton(
 		context: 'list-view',
 	} );
 	const { isLocked } = useBlockLock( clientId );
-	const hasPatternName = useSelect(
-		( select ) => {
-			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
-			return !! getBlockAttributes( clientId )?.metadata?.patternName;
-		},
-		[ clientId ]
-	);
 
 	const shouldShowLockIcon = isLocked;
 	const isSticky = blockInformation?.positionType === 'sticky';
@@ -115,7 +100,7 @@ function ListViewBlockSelectButton(
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
 			<BlockIcon
-				icon={ hasPatternName ? symbol : blockInformation?.icon }
+				icon={ blockInformation?.icon }
 				showColors
 				context="list-view"
 			/>

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -15,6 +15,8 @@ import { symbol } from '@wordpress/icons';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+import { isIsolatedEditorKey } from '../../store/private-keys';
 
 /** @typedef {import('@wordpress/blocks').WPIcon} WPIcon */
 
@@ -72,11 +74,13 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! clientId ) {
 				return null;
 			}
+			const blockEditorSelect = select( blockEditorStore );
 			const {
 				getBlockName,
 				getBlockAttributes,
 				__experimentalGetParsedPattern,
-			} = select( blockEditorStore );
+				getSettings,
+			} = blockEditorSelect;
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const blockName = getBlockName( clientId );
@@ -85,11 +89,20 @@ export default function useBlockDisplayInformation( clientId ) {
 				return null;
 			}
 			const attributes = getBlockAttributes( clientId );
+			const { isWithinEditedContentOnlySection } =
+				unlock( blockEditorSelect );
+			const isIsolatedEditor = !! getSettings()?.[ isIsolatedEditorKey ];
 
 			// Check if this block is a pattern
 			const patternName = attributes?.metadata?.patternName;
+			const isEditedContentOnlySection =
+				isWithinEditedContentOnlySection( clientId );
 
-			if ( patternName ) {
+			if (
+				patternName &&
+				! isEditedContentOnlySection &&
+				! isIsolatedEditor
+			) {
 				const pattern = __experimentalGetParsedPattern( patternName );
 				const positionLabel = getPositionTypeLabel( attributes );
 				return {

--- a/packages/block-editor/src/components/use-block-display-information/test/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/test/index.js
@@ -1,0 +1,141 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { symbol } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import useBlockDisplayInformation from '../';
+import { isIsolatedEditorKey } from '../../../store/private-keys';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '../../../lock-unlock', () => ( {
+	lock: ( value ) => value,
+	unlock: ( value ) => ( {
+		registerPrivateActions: jest.fn(),
+		registerPrivateSelectors: jest.fn(),
+		...value,
+	} ),
+} ) );
+
+const groupIcon = 'group-icon';
+
+function TestComponent( { onChange } ) {
+	const blockInformation = useBlockDisplayInformation( 'client-id' );
+	useEffect( () => {
+		onChange( blockInformation );
+	}, [ blockInformation, onChange ] );
+	return null;
+}
+
+function setupUseSelect( {
+	attributes = {
+		anchor: 'hero',
+		metadata: {
+			name: 'Hero pattern',
+			patternName: 'theme/hero',
+		},
+		style: {
+			position: {
+				type: 'sticky',
+			},
+		},
+	},
+	blockName = 'core/group',
+	blockType = {
+		name: 'core/group',
+		title: 'Group',
+		icon: groupIcon,
+		description: 'Gather blocks in a layout container.',
+	},
+	getActiveBlockVariation = () => null,
+	settings = {},
+	isWithinEditedSection = false,
+} = {} ) {
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( () => ( {
+			getBlockName: () => blockName,
+			getBlockAttributes: () => attributes,
+			getSettings: () => settings,
+			__experimentalGetParsedPattern: () => ( {
+				title: 'Hero pattern',
+				description: 'Pattern description.',
+			} ),
+			isWithinEditedContentOnlySection: () => isWithinEditedSection,
+			getBlockType: () => blockType,
+			getActiveBlockVariation,
+		} ) )
+	);
+}
+
+describe( 'useBlockDisplayInformation', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'displays pattern information for a pattern section that is not being edited', () => {
+		setupUseSelect();
+		const onChange = jest.fn();
+
+		render( <TestComponent onChange={ onChange } /> );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'Pattern',
+				icon: symbol,
+				description: 'Pattern description.',
+				name: 'Hero pattern',
+			} )
+		);
+	} );
+
+	it( 'displays block information for a pattern section that is being edited', () => {
+		setupUseSelect( { isWithinEditedSection: true } );
+		const onChange = jest.fn();
+
+		render( <TestComponent onChange={ onChange } /> );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'Group',
+				icon: groupIcon,
+				description: 'Gather blocks in a layout container.',
+				name: 'Hero pattern',
+			} )
+		);
+	} );
+
+	it( 'displays block information for a pattern wrapper in an isolated editor', () => {
+		setupUseSelect( {
+			attributes: {
+				metadata: {
+					name: 'Header',
+					patternName: 'theme/header-wrapper',
+				},
+			},
+			settings: {
+				[ isIsolatedEditorKey ]: true,
+			},
+		} );
+		const onChange = jest.fn();
+
+		render( <TestComponent onChange={ onChange } /> );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'Group',
+				icon: groupIcon,
+				description: 'Gather blocks in a layout container.',
+				name: 'Header',
+			} )
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/use-block-display-information/test/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/test/index.js
@@ -18,7 +18,6 @@ import { isIsolatedEditorKey } from '../../../store/private-keys';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 jest.mock( '../../../lock-unlock', () => ( {
-	lock: ( value ) => value,
 	unlock: ( value ) => ( {
 		registerPrivateActions: jest.fn(),
 		registerPrivateSelectors: jest.fn(),


### PR DESCRIPTION
## What?

Resolves https://github.com/WordPress/gutenberg/issues/78903

Playing on @t-hamano's ideas in https://github.com/WordPress/gutenberg/issues/78903#issuecomment-4618383836

Updates pattern section display behavior so the real root block identity is shown when editing the section.

This affects:

- Inline “Edit pattern” mode for content-only patterns.
- Isolated editor views such as template parts opened through “Edit original”.

## Why?

When a pattern section is being edited, users need to know which wrapper block they are working with. Previously, the editor could continue showing the pattern symbol and a `Pattern` badge, for example `Header / Pattern`, even when the active editing context should expose the underlying root block.

## How?

- Keeps normal inserted patterns displayed as patterns before editing.
- Ignores pattern metadata while inside an edited content-only section.
- Ignores pattern metadata in isolated editor views.
- Lets list view use the shared block display information instead of forcing the pattern icon separately.

## Manual Test Steps

1. Insert a content-only section pattern whose root block is a Group, Cover, or another wrapper block.
2. Select the inserted pattern before editing it.
3. Confirm the inspector/list view still show the pattern icon, pattern name, and `Pattern` badge.
4. Click `Edit pattern`.
5. Confirm the inspector/list view/toolbar now show the root block icon and root block badge, such as `Group` or `Cover`, while preserving the section name.
6. In the Site Editor, select a template part such as Header and click `Edit original`.
7. In the isolated template part editor, select a wrapper block that came from a pattern.
8. Confirm it shows the wrapper block identity, for example `Header` with a `Group` badge, not `Header` with a `Pattern` badge.


https://github.com/user-attachments/assets/f1d7dffa-f9d8-437e-91c0-072687046993


