### PR TITLE
BorderBoxControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -279,7 +279,6 @@ export default function BorderPanel( {
 						popoverPlacement="left-start"
 						value={ border }
 						__experimentalIsRenderedInSidebar
-						size="__unstable-large"
 						hideLabelFromVision={ ! hasShadowControl }
 						label={ __( 'Border' ) }
 					/>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
--   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed ([#79386](https://github.com/WordPress/gutenberg/pull/79386), [#79419](https://github.com/WordPress/gutenberg/pull/79419)):
+-   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed ([#79386](https://github.com/WordPress/gutenberg/pull/79386), [#79419](https://github.com/WordPress/gutenberg/pull/79419), [#79420](https://github.com/WordPress/gutenberg/pull/79420)):
+    -   `BorderBoxControl`
     -   `BoxControl`
     -   `TextControl`
 

--- a/packages/components/src/border-box-control/border-box-control-linked-button/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control-linked-button/hook.ts
@@ -16,17 +16,16 @@ import type { LinkedButtonProps } from '../types';
 export function useBorderBoxControlLinkedButton(
 	props: WordPressComponentProps< LinkedButtonProps, 'button' >
 ) {
-	const {
-		className,
-		size = 'default',
-		...otherProps
-	} = useContextSystem( props, 'BorderBoxControlLinkedButton' );
+	const { className, ...otherProps } = useContextSystem(
+		props,
+		'BorderBoxControlLinkedButton'
+	);
 
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.borderBoxControlLinkedButton( size ), className );
-	}, [ className, cx, size ] );
+		return cx( styles.borderBoxControlLinkedButton, className );
+	}, [ className, cx ] );
 
 	return { ...otherProps, className: classes };
 }

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -67,7 +67,6 @@ const BorderBoxControlSplitControls = (
 		isCompact: true,
 		__experimentalIsRenderedInSidebar,
 		size,
-		__shouldNotWarnDeprecated36pxSize: true,
 	};
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
@@ -76,9 +75,9 @@ const BorderBoxControlSplitControls = (
 		<Grid { ...otherProps } ref={ mergedRef } gap={ 3 }>
 			<BorderBoxControlVisualizer value={ value } size={ size } />
 
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
 			<BorderControl
+				__next40pxDefaultSize
+				__shouldNotWarnDeprecated36pxSize
 				className={ centeredClassName }
 				hideLabelFromVision
 				label={ __( 'Top border' ) }
@@ -87,9 +86,9 @@ const BorderBoxControlSplitControls = (
 				value={ value?.top }
 				{ ...sharedBorderControlProps }
 			/>
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
 			<BorderControl
+				__next40pxDefaultSize
+				__shouldNotWarnDeprecated36pxSize
 				hideLabelFromVision
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
@@ -97,9 +96,9 @@ const BorderBoxControlSplitControls = (
 				value={ value?.left }
 				{ ...sharedBorderControlProps }
 			/>
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
 			<BorderControl
+				__next40pxDefaultSize
+				__shouldNotWarnDeprecated36pxSize
 				className={ rightAlignedClassName }
 				hideLabelFromVision
 				label={ __( 'Right border' ) }
@@ -108,9 +107,9 @@ const BorderBoxControlSplitControls = (
 				value={ value?.right }
 				{ ...sharedBorderControlProps }
 			/>
-			{ /* Disable reason: BorderControl's size is being controlled via the `size` prop by the parent component  */ }
-			{ /* eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop */ }
 			<BorderControl
+				__next40pxDefaultSize
+				__shouldNotWarnDeprecated36pxSize
 				className={ centeredClassName }
 				hideLabelFromVision
 				label={ __( 'Bottom border' ) }

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -32,7 +32,6 @@ const BorderBoxControlSplitControls = (
 		popoverPlacement,
 		popoverOffset,
 		rightAlignedClassName,
-		size = 'default',
 		value,
 		__experimentalIsRenderedInSidebar,
 		...otherProps
@@ -66,18 +65,16 @@ const BorderBoxControlSplitControls = (
 		enableStyle,
 		isCompact: true,
 		__experimentalIsRenderedInSidebar,
-		size,
 	};
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
 
 	return (
 		<Grid { ...otherProps } ref={ mergedRef } gap={ 3 }>
-			<BorderBoxControlVisualizer value={ value } size={ size } />
+			<BorderBoxControlVisualizer value={ value } />
 
 			<BorderControl
-				__next40pxDefaultSize
-				__shouldNotWarnDeprecated36pxSize
+				size="__unstable-large"
 				className={ centeredClassName }
 				hideLabelFromVision
 				label={ __( 'Top border' ) }
@@ -87,8 +84,7 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
-				__next40pxDefaultSize
-				__shouldNotWarnDeprecated36pxSize
+				size="__unstable-large"
 				hideLabelFromVision
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
@@ -97,8 +93,7 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
-				__next40pxDefaultSize
-				__shouldNotWarnDeprecated36pxSize
+				size="__unstable-large"
 				className={ rightAlignedClassName }
 				hideLabelFromVision
 				label={ __( 'Right border' ) }
@@ -108,8 +103,7 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
-				__next40pxDefaultSize
-				__shouldNotWarnDeprecated36pxSize
+				size="__unstable-large"
 				className={ centeredClassName }
 				hideLabelFromVision
 				label={ __( 'Bottom border' ) }

--- a/packages/components/src/border-box-control/border-box-control-split-controls/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/hook.ts
@@ -21,7 +21,6 @@ export function useBorderBoxControlSplitControls(
 		colors = [],
 		enableAlpha = false,
 		enableStyle = true,
-		size = 'default',
 		__experimentalIsRenderedInSidebar = false,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControlSplitControls' );
@@ -29,8 +28,8 @@ export function useBorderBoxControlSplitControls(
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.borderBoxControlSplitControls( size ), className );
-	}, [ cx, className, size ] );
+		return cx( styles.borderBoxControlSplitControls, className );
+	}, [ cx, className ] );
 
 	const centeredClassName = useMemo( () => {
 		return cx( styles.centeredBorderControl, className );
@@ -48,7 +47,6 @@ export function useBorderBoxControlSplitControls(
 		enableAlpha,
 		enableStyle,
 		rightAlignedClassName,
-		size,
 		__experimentalIsRenderedInSidebar,
 	};
 }

--- a/packages/components/src/border-box-control/border-box-control-visualizer/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control-visualizer/hook.ts
@@ -16,21 +16,16 @@ import type { VisualizerProps } from '../types';
 export function useBorderBoxControlVisualizer(
 	props: WordPressComponentProps< VisualizerProps, 'div' >
 ) {
-	const {
-		className,
-		value,
-		size = 'default',
-		...otherProps
-	} = useContextSystem( props, 'BorderBoxControlVisualizer' );
+	const { className, value, ...otherProps } = useContextSystem(
+		props,
+		'BorderBoxControlVisualizer'
+	);
 
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx(
-			styles.borderBoxControlVisualizer( value, size ),
-			className
-		);
-	}, [ cx, className, value, size ] );
+		return cx( styles.borderBoxControlVisualizer( value ), className );
+	}, [ cx, className, value ] );
 
 	return { ...otherProps, className: classes, value };
 }

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -136,14 +136,6 @@ The space between the popover and the control wrapper.
 
 -   Required: No
 
-### `size`: `string`
-
-Size of the control.
-
--   Required: No
--   Default: `default`
--   Allowed values: `default`, `__unstable-large`
-
 ### `value`: `Object`
 
 An object representing the current border configuration.

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -47,7 +47,6 @@ const MyBorderBoxControl = () => {
 
 	return (
 		<BorderBoxControl
-			__next40pxDefaultSize
 			colors={ colors }
 			label={ __( 'Borders' ) }
 			onChange={ onChange }
@@ -166,10 +165,3 @@ const splitBorders = {
 ```
 
 -   Required: No
-
-### `__next40pxDefaultSize`: `boolean`
-
-Start opting into the larger default height that will become the default size in a future version.
-
--   Required: No
--   Default: `false`

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -59,7 +59,6 @@ const UnconnectedBorderBoxControl = (
 		onSplitChange,
 		popoverPlacement,
 		popoverOffset,
-		size,
 		splitValue,
 		toggleLinked,
 		wrapperClassName,
@@ -112,15 +111,11 @@ const UnconnectedBorderBoxControl = (
 						shouldSanitizeBorder={ false } // This component will handle that.
 						value={ linkedValue }
 						withSlider
-						width={
-							size === '__unstable-large' ? '116px' : '110px'
-						}
+						width="116px"
+						size="__unstable-large"
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						__next40pxDefaultSize
-						__shouldNotWarnDeprecated36pxSize
-						size={ size }
 					/>
 				) : (
 					<BorderBoxControlSplitControls
@@ -135,13 +130,11 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
-						size={ size }
 					/>
 				) }
 				<BorderBoxControlLinkedButton
 					onClick={ toggleLinked }
 					isLinked={ isLinked }
-					size={ size }
 				/>
 			</View>
 		</View>

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -118,6 +118,7 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
+						__next40pxDefaultSize
 						__shouldNotWarnDeprecated36pxSize
 						size={ size }
 					/>
@@ -176,7 +177,6 @@ const UnconnectedBorderBoxControl = (
  *
  * 	return (
  * 		<BorderBoxControl
- * 			__next40pxDefaultSize
  * 			colors={ colors }
  * 			label={ __( 'Borders' ) }
  * 			onChange={ onChange }

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -32,13 +32,10 @@ export function useBorderBoxControl(
 		onChange,
 		enableAlpha = false,
 		enableStyle = true,
-		size = 'default',
 		value,
 		__experimentalIsRenderedInSidebar = false,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControl' );
-
-	const computedSize = size === 'default' ? '__unstable-large' : size;
 
 	const mixedBorders = hasMixedBorders( value );
 	const splitBorders = hasSplitBorders( value );
@@ -135,7 +132,6 @@ export function useBorderBoxControl(
 		onSplitChange,
 		toggleLinked,
 		linkedValue,
-		size: computedSize,
 		splitValue,
 		wrapperClassName,
 		__experimentalIsRenderedInSidebar,

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -34,6 +34,9 @@ export function useBorderBoxControl(
 		enableStyle = true,
 		value,
 		__experimentalIsRenderedInSidebar = false,
+		// Deprecated props, no longer used.
+		size: _size,
+		__next40pxDefaultSize: _next40pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControl' );
 

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -19,7 +19,6 @@ import {
 import type { WordPressComponentProps } from '../../context';
 import { useContextSystem } from '../../context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { maybeWarnDeprecated36pxSize } from '../../utils/deprecated-36px-size';
 
 import type { Border } from '../../border-control/types';
 import type { Borders, BorderSide, BorderBoxControlProps } from '../types';
@@ -36,18 +35,10 @@ export function useBorderBoxControl(
 		size = 'default',
 		value,
 		__experimentalIsRenderedInSidebar = false,
-		__next40pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControl' );
 
-	maybeWarnDeprecated36pxSize( {
-		componentName: 'BorderBoxControl',
-		__next40pxDefaultSize,
-		size,
-	} );
-
-	const computedSize =
-		size === 'default' && __next40pxDefaultSize ? '__unstable-large' : size;
+	const computedSize = size === 'default' ? '__unstable-large' : size;
 
 	const mixedBorders = hasMixedBorders( value );
 	const splitBorders = hasSplitBorders( value );

--- a/packages/components/src/border-box-control/stories/index.story.tsx
+++ b/packages/components/src/border-box-control/stories/index.story.tsx
@@ -57,7 +57,6 @@ const Template: StoryFn< typeof BorderBoxControl > = ( props ) => {
 	return (
 		<>
 			<BorderBoxControl
-				__next40pxDefaultSize
 				{ ...otherProps }
 				onChange={ onChangeMerged }
 				value={ borders }
@@ -90,5 +89,4 @@ Default.args = {
 	colors,
 	label: 'Borders',
 	enableStyle: true,
-	__next40pxDefaultSize: true,
 };

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -22,16 +22,12 @@ export const wrapper = css`
 	position: relative;
 `;
 
-export const borderBoxControlLinkedButton = (
-	size?: 'default' | '__unstable-large'
-) => {
-	return css`
-		position: absolute;
-		top: ${ size === '__unstable-large' ? '8px' : '3px' };
-		${ rtl( { right: 0 } )() }
-		line-height: 0;
-	`;
-};
+export const borderBoxControlLinkedButton = css`
+	position: absolute;
+	top: 8px;
+	${ rtl( { right: 0 } )() }
+	line-height: 0;
+`;
 
 const borderBoxStyleWithFallback = ( border?: Border ) => {
 	const {
@@ -48,33 +44,25 @@ const borderBoxStyleWithFallback = ( border?: Border ) => {
 	return `${ color } ${ borderStyle } ${ clampedWidth }`;
 };
 
-export const borderBoxControlVisualizer = (
-	borders?: Borders,
-	size?: 'default' | '__unstable-large'
-) => {
-	return css`
-		position: absolute;
-		top: ${ size === '__unstable-large' ? '20px' : '15px' };
-		right: ${ size === '__unstable-large' ? '39px' : '29px' };
-		bottom: ${ size === '__unstable-large' ? '20px' : '15px' };
-		left: ${ size === '__unstable-large' ? '39px' : '29px' };
-		border-top: ${ borderBoxStyleWithFallback( borders?.top ) };
-		border-bottom: ${ borderBoxStyleWithFallback( borders?.bottom ) };
-		${ rtl( {
-			borderLeft: borderBoxStyleWithFallback( borders?.left ),
-		} )() }
-		${ rtl( {
-			borderRight: borderBoxStyleWithFallback( borders?.right ),
-		} )() }
-	`;
-};
+export const borderBoxControlVisualizer = ( borders?: Borders ) => css`
+	position: absolute;
+	top: 20px;
+	right: 39px;
+	bottom: 20px;
+	left: 39px;
+	border-top: ${ borderBoxStyleWithFallback( borders?.top ) };
+	border-bottom: ${ borderBoxStyleWithFallback( borders?.bottom ) };
+	${ rtl( {
+		borderLeft: borderBoxStyleWithFallback( borders?.left ),
+	} )() }
+	${ rtl( {
+		borderRight: borderBoxStyleWithFallback( borders?.right ),
+	} )() }
+`;
 
-export const borderBoxControlSplitControls = (
-	size?: 'default' | '__unstable-large'
-) => css`
+export const borderBoxControlSplitControls = css`
 	position: relative;
 	flex: 1;
-	width: ${ size === '__unstable-large' ? undefined : '80%' };
 `;
 
 export const centeredBorderControl = css`

--- a/packages/components/src/border-box-control/test/index.tsx
+++ b/packages/components/src/border-box-control/test/index.tsx
@@ -53,9 +53,7 @@ const colorPickerRegex = /Border color picker/;
 function TestBorderBoxControl(
 	restProps: ComponentProps< typeof BorderBoxControl >
 ) {
-	return (
-		<BorderBoxControl __next40pxDefaultSize { ...props } { ...restProps } />
-	);
+	return <BorderBoxControl { ...props } { ...restProps } />;
 }
 
 describe( 'BorderBoxControl', () => {

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -20,9 +20,22 @@ export type AnyBorder = Border | Borders | undefined;
 export type BorderProp = keyof Border;
 export type BorderSide = keyof Borders;
 
+export type BorderSide = keyof Borders;
+
+type DeprecatedBorderBoxControlProps = {
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+	 * @ignore
+	 */
+	__next40pxDefaultSize?: boolean;
+};
+
 export type BorderBoxControlProps = ColorProps &
 	LabelProps &
-	Pick< BorderControlProps, 'enableStyle' | 'size' > & {
+	Pick< BorderControlProps, 'enableStyle' | 'size' > &
+	DeprecatedBorderBoxControlProps & {
 		/**
 		 * A callback function invoked when any border value is changed. The value
 		 * received may be a "flat" border object, one that has properties defining
@@ -45,12 +58,6 @@ export type BorderBoxControlProps = ColorProps &
 		 * properties but for each side; `top`, `right`, `bottom`, and `left`.
 		 */
 		value: AnyBorder;
-		/**
-		 * Start opting into the larger default height that will become the default size in a future version.
-		 *
-		 * @default false
-		 */
-		__next40pxDefaultSize?: boolean;
 	};
 
 export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -22,7 +22,7 @@ export type BorderSide = keyof Borders;
 
 export type BorderBoxControlProps = ColorProps &
 	LabelProps &
-	Pick< BorderControlProps, 'enableStyle' | 'size' > & {
+	Pick< BorderControlProps, 'enableStyle' > & {
 		/**
 		 * A callback function invoked when any border value is changed. The value
 		 * received may be a "flat" border object, one that has properties defining
@@ -54,7 +54,7 @@ export type BorderBoxControlProps = ColorProps &
 		__next40pxDefaultSize?: boolean;
 	};
 
-export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {
+export type LinkedButtonProps = {
 	/**
 	 * This prop allows the `LinkedButton` to reflect whether the parent
 	 * `BorderBoxControl` is currently displaying "linked" or "unlinked"
@@ -69,7 +69,7 @@ export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {
 	onClick: () => void;
 };
 
-export type VisualizerProps = Pick< BorderBoxControlProps, 'size' > & {
+export type VisualizerProps = {
 	/**
 	 * An object representing the current border configuration. It contains
 	 * properties for each side, with each side an object reflecting the border
@@ -79,7 +79,7 @@ export type VisualizerProps = Pick< BorderBoxControlProps, 'size' > & {
 };
 
 export type SplitControlsProps = ColorProps &
-	Pick< BorderBoxControlProps, 'enableStyle' | 'size' > & {
+	Pick< BorderBoxControlProps, 'enableStyle' > & {
 		/**
 		 * A callback that is invoked whenever an individual side's border has
 		 * changed.

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -20,22 +20,9 @@ export type AnyBorder = Border | Borders | undefined;
 export type BorderProp = keyof Border;
 export type BorderSide = keyof Borders;
 
-export type BorderSide = keyof Borders;
-
-type DeprecatedBorderBoxControlProps = {
-	/**
-	 * Start opting into the larger default height that will become the default size in a future version.
-	 *
-	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
-	 * @ignore
-	 */
-	__next40pxDefaultSize?: boolean;
-};
-
 export type BorderBoxControlProps = ColorProps &
 	LabelProps &
-	Pick< BorderControlProps, 'enableStyle' | 'size' > &
-	DeprecatedBorderBoxControlProps & {
+	Pick< BorderControlProps, 'enableStyle' | 'size' > & {
 		/**
 		 * A callback function invoked when any border value is changed. The value
 		 * received may be a "flat" border object, one that has properties defining
@@ -58,6 +45,13 @@ export type BorderBoxControlProps = ColorProps &
 		 * properties but for each side; `top`, `right`, `bottom`, and `left`.
 		 */
 		value: AnyBorder;
+		/**
+		 * Start opting into the larger default height that will become the default size in a future version.
+		 *
+		 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+		 * @ignore
+		 */
+		__next40pxDefaultSize?: boolean;
 	};
 
 export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -48,7 +48,6 @@ export type BorderBoxControlProps = ColorProps &
 		/**
 		 * Size of the control.
 		 *
-		 * @default 'default'
 		 * @deprecated This prop no longer has any effect.
 		 * @ignore
 		 */

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -46,6 +46,14 @@ export type BorderBoxControlProps = ColorProps &
 		 */
 		value: AnyBorder;
 		/**
+		 * Size of the control.
+		 *
+		 * @default 'default'
+		 * @deprecated This prop no longer has any effect.
+		 * @ignore
+		 */
+		size?: 'default' | '__unstable-large';
+		/**
 		 * Start opting into the larger default height that will become the default size in a future version.
 		 *
 		 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -8,7 +8,6 @@ This is a temporary rule to help migrate components to the new default size. Onc
 
 The following components are checked by this rule:
 
--   BorderBoxControl
 -   BorderControl
 -   Button
 -   ComboboxControl

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -110,7 +110,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 		{
 			code: `
 				import {
-					BorderBoxControl,
 					BorderControl,
 					ComboboxControl,
 					CustomSelectControl,
@@ -128,7 +127,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					UnitControl,
 				} from '@wordpress/components';
 				<>
-					<BorderBoxControl __next40pxDefaultSize />
 					<BorderControl __next40pxDefaultSize />
 					<ComboboxControl __next40pxDefaultSize />
 					<CustomSelectControl __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -12,7 +12,6 @@ const { hasTruthyJsxAttribute } = require( '../utils' );
  * These can be exempted if they have a non-default `size` prop.
  */
 const COMPONENTS_REQUIRING_40PX = new Set( [
-	'BorderBoxControl',
 	'BorderControl',
 	'Button',
 	'ClipboardButton',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -159,10 +159,12 @@ const restrictedSyntax = [
 		selector: 'JSXAttribute[name.name="__nextHasNoMarginBottom"]',
 		message: 'The `__nextHasNoMarginBottom` prop is no longer needed.',
 	},
-	...[ 'BoxControl', 'TextControl' ].map( ( componentName ) => ( {
-		selector: `JSXElement[openingElement.name.name="${ componentName }"] JSXAttribute[name.name="__next40pxDefaultSize"]`,
-		message: `The \`__next40pxDefaultSize\` prop is no longer needed on \`${ componentName }\`.`,
-	} ) ),
+	...[ 'BorderBoxControl', 'BoxControl', 'TextControl' ].map(
+		( componentName ) => ( {
+			selector: `JSXElement[openingElement.name.name="${ componentName }"] JSXAttribute[name.name="__next40pxDefaultSize"]`,
+			message: `The \`__next40pxDefaultSize\` prop is no longer needed on \`${ componentName }\`.`,
+		} )
+	),
 	{
 		selector:
 			'CallExpression[callee.name="withDispatch"] > :function > BlockStatement > :not(VariableDeclaration,ReturnStatement)',


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the deprecated `__next40pxDefaultSize` prop from `BorderBoxControl`, making the 40px default size the permanent default.

## Why?

The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.1.

## How?

- Remove `__next40pxDefaultSize` from the `BorderBoxControl` public API and remove `maybeWarnDeprecated36pxSize`.
- Always map `size="default"` to `__unstable-large`.
- Keep passing `__next40pxDefaultSize` internally to embedded `BorderControl` until that component is hard-deprecated.
- Remove all monorepo usages of the prop on `BorderBoxControl`.
- Remove `BorderBoxControl` from the `components-no-missing-40px-size-prop` ESLint rule and add a restricted-syntax rule for passing the prop to `BorderBoxControl`.

## Testing Instructions

1. Open Storybook to **Components / BorderBoxControl** and smoke test the default story.
2. Toggle linked/unlinked sides and change border values.
3. Confirm controls render at 40px height without the prop, and no console warning should be logged.