### PR TITLE
Patterns: Add a missing gap to 'Enable overrides' modal

### DIFF
--- a/packages/patterns/src/components/allow-overrides-modal.js
+++ b/packages/patterns/src/components/allow-overrides-modal.js
@@ -69,7 +69,7 @@ export function AllowOverridesModal( {
 						placeholder={ placeholder }
 						onChange={ setEditedBlockName }
 					/>
-					<Stack justify="end">
+					<Stack gap="sm" justify="end">
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
@@ -77,7 +77,6 @@ export function AllowOverridesModal( {
 						>
 							{ __( 'Cancel' ) }
 						</Button>
-
 						<Button
 							__next40pxDefaultSize
 							aria-disabled={ ! isNameValid }


### PR DESCRIPTION
## What?
I missed a spot in #79233. PR fixes the missing gap for modal controls to match the existing design.

## Testing Instructions
Confirm that the gap is correctly applied.
