### PR TITLE
Fix Post Content selection jumping across template instances

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -13,6 +13,10 @@ import { SelectionContext } from './selection-context';
 
 const noop = () => {};
 
+// Undo can replace the selected block before every matching controlled list
+// restores selection, so remember which controller last held the selection.
+const lastSelectedControlledParentByRegistry = new WeakMap();
+
 /**
  * Clones a block and its inner blocks, building a bidirectional mapping
  * between external (original) and internal (cloned) client IDs.
@@ -93,6 +97,47 @@ function restoreSelectionIds( selectionState, mapping ) {
 }
 
 /**
+ * Find the nearest controlled inner block controller for a block.
+ * A block can be nested inside multiple controlled lists, so prefer
+ * the innermost parent.
+ *
+ * @param {string}   blockClientId            The block client ID.
+ * @param {Function} getBlockParents          Selector returning parent IDs.
+ * @param {Function} areInnerBlocksControlled Selector checking controlled blocks.
+ * @return {string|undefined}                  The nearest controlled parent client ID.
+ */
+function getNearestControlledParent(
+	blockClientId,
+	getBlockParents,
+	areInnerBlocksControlled
+) {
+	const parents = blockClientId ? getBlockParents( blockClientId ) : [];
+
+	for ( let i = parents.length - 1; i >= 0; i-- ) {
+		if ( areInnerBlocksControlled( parents[ i ] ) ) {
+			return parents[ i ];
+		}
+	}
+}
+
+function getLastSelectedControlledParent(
+	registry,
+	getBlockName,
+	areInnerBlocksControlled
+) {
+	const controlledParent =
+		lastSelectedControlledParentByRegistry.get( registry );
+
+	if (
+		controlledParent &&
+		getBlockName( controlledParent ) &&
+		areInnerBlocksControlled( controlledParent )
+	) {
+		return controlledParent;
+	}
+}
+
+/**
  * A function to call when the block value has been updated in the block-editor
  * store.
  *
@@ -158,8 +203,14 @@ export default function useBlockSync( {
 		setHasControlledInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
 	} = registry.dispatch( blockEditorStore );
-	const { getBlockName, getBlocks, getSelectionStart, getSelectionEnd } =
-		registry.select( blockEditorStore );
+	const {
+		areInnerBlocksControlled,
+		getBlockName,
+		getBlockParents,
+		getBlocks,
+		getSelectionStart,
+		getSelectionEnd,
+	} = registry.select( blockEditorStore );
 
 	const pendingChangesRef = useRef( { incoming: null, outgoing: [] } );
 	const subscribedRef = useRef( false );
@@ -200,6 +251,28 @@ export default function useBlockSync( {
 		const isOurs = clientId
 			? idMappingRef.current.externalToInternal.has( startClientId )
 			: !! getBlockName( startClientId );
+
+		if ( clientId && isOurs ) {
+			// Entity selections use external client IDs, so the same
+			// selection can look valid to multiple controlled block lists
+			// rendering the same entity. If the current editor selection is
+			// already inside another controller, do not steal it.
+			const selectedControllerId =
+				getNearestControlledParent(
+					getSelectionStart()?.clientId,
+					getBlockParents,
+					areInnerBlocksControlled
+				) ||
+				getLastSelectedControlledParent(
+					registry,
+					getBlockName,
+					areInnerBlocksControlled
+				);
+
+			if ( selectedControllerId && selectedControllerId !== clientId ) {
+				return;
+			}
+		}
 
 		if ( isOurs ) {
 			appliedSelectionRef.current = selection;
@@ -344,8 +417,6 @@ export default function useBlockSync( {
 			isLastBlockChangePersistent,
 			__unstableGetLastBlockChangeHistoryMode,
 			__unstableIsLastBlockChangeIgnored,
-			areInnerBlocksControlled,
-			getBlockParents,
 		} = registry.select( blockEditorStore );
 
 		let blocks = getBlocks( clientId );
@@ -404,6 +475,19 @@ export default function useBlockSync( {
 				newSelectionEnd !== prevSelectionEnd;
 
 			if ( selectionChanged ) {
+				const selectedControllerId = getNearestControlledParent(
+					newSelectionStart?.clientId,
+					getBlockParents,
+					areInnerBlocksControlled
+				);
+
+				if ( selectedControllerId ) {
+					lastSelectedControlledParentByRegistry.set(
+						registry,
+						selectedControllerId
+					);
+				}
+
 				prevSelectionStart = newSelectionStart;
 				prevSelectionEnd = newSelectionEnd;
 			}

--- a/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-content-focus-mode.spec.js
@@ -9,6 +9,22 @@ test.use( {
 	},
 } );
 
+const TEMPLATE_PART_CONTENT = [
+	'<!-- wp:post-title /-->',
+	'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+].join( '\n' );
+
+const SINGULAR_TEMPLATE_WITH_NESTED_POST_CONTENT = [
+	'<!-- wp:template-part {"slug":"header","tagName":"header","theme":"emptytheme"} /-->',
+	'<!-- wp:template-part {"slug":"content-area","theme":"emptytheme"} /-->',
+].join( '\n' );
+
+const SINGULAR_TEMPLATE_WITH_DUPLICATE_POST_CONTENT = [
+	'<!-- wp:template-part {"slug":"header","tagName":"header","theme":"emptytheme"} /-->',
+	'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+	'<!-- wp:template-part {"slug":"content-area","theme":"emptytheme"} /-->',
+].join( '\n' );
+
 // Post content focus mode (aka the 'Show template' option when editing a post or page).
 test.describe( 'Post Content focus mode', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
@@ -103,20 +119,14 @@ test.describe( 'Post Content focus mode', () => {
 			await requestUtils.createTemplate( 'wp_template_part', {
 				slug: 'content-area',
 				title: 'Content Area',
-				content: [
-					'<!-- wp:post-title /-->',
-					'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
-				].join( '\n' ),
+				content: TEMPLATE_PART_CONTENT,
 			} );
 
 			// Override the singular template so post-content is inside a template part.
 			await requestUtils.createTemplate( 'wp_template', {
 				slug: 'singular',
 				title: 'Singular',
-				content: [
-					'<!-- wp:template-part {"slug":"header","tagName":"header","theme":"emptytheme"} /-->',
-					'<!-- wp:template-part {"slug":"content-area","theme":"emptytheme"} /-->',
-				].join( '\n' ),
+				content: SINGULAR_TEMPLATE_WITH_NESTED_POST_CONTENT,
 			} );
 		} );
 
@@ -348,6 +358,84 @@ test.describe( 'Post Content focus mode', () => {
 					await postContentFocusMode.getTemplatePartInnerBlockNames()
 				).toEqual( expectedTemplatePart );
 			} );
+		} );
+
+		test( 'keeps selection in the edited Post Content instance after typing', async ( {
+			admin,
+			editor,
+			page,
+			pageUtils,
+			postContentFocusMode,
+			requestUtils,
+		} ) => {
+			await requestUtils.createTemplate( 'wp_template', {
+				slug: 'single',
+				title: 'Single',
+				content: SINGULAR_TEMPLATE_WITH_DUPLICATE_POST_CONTENT,
+			} );
+
+			await admin.createNewPost();
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Tracked paragraph' },
+			} );
+
+			await postContentFocusMode.enableShowTemplate();
+
+			const rootPostContent = await page.evaluate( () => {
+				const {
+					getBlocksByName,
+					getBlockOrder,
+					getBlockParents,
+					getBlockName,
+				} = window.wp.data.select( 'core/block-editor' );
+				const clientId = getBlocksByName( 'core/post-content' ).find(
+					( postContentClientId ) =>
+						! getBlockParents( postContentClientId ).some(
+							( parentClientId ) =>
+								getBlockName( parentClientId ) ===
+								'core/template-part'
+						)
+				);
+
+				return {
+					clientId,
+					innerBlockClientId: getBlockOrder( clientId )[ 0 ],
+				};
+			} );
+
+			await editor.canvas
+				.locator(
+					`[data-block="${ rootPostContent.innerBlockClientId }"]`
+				)
+				.click();
+			await page.keyboard.press( 'End' );
+			await page.keyboard.type( ' edited' );
+
+			const getSelectedPostContentClientId = () =>
+				page.evaluate( () => {
+					const {
+						getSelectedBlockClientId,
+						getBlockParents,
+						getBlockName,
+					} = window.wp.data.select( 'core/block-editor' );
+					return getBlockParents( getSelectedBlockClientId() ).find(
+						( parentClientId ) =>
+							getBlockName( parentClientId ) ===
+							'core/post-content'
+					);
+				} );
+
+			await expect
+				.poll( getSelectedPostContentClientId )
+				.toBe( rootPostContent.clientId );
+
+			await pageUtils.pressKeys( 'primary+z' );
+
+			await expect
+				.poll( getSelectedPostContentClientId )
+				.toBe( rootPostContent.clientId );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Noticed while testing https://github.com/WordPress/gutenberg/pull/79191#pullrequestreview-4550029709

Related to https://github.com/WordPress/gutenberg/issues/79096 (maybe)

This prevents a controlled inner block controller from restoring a shared post entity selection when the current editor selection already belongs to another controlled block list.

It also adds e2e regression coverage for Show template mode with one Post Content block at the template root and another nested inside a Template Part.

## Why?

When the same post content is rendered in more than one editable Post Content instance, each instance has different cloned block client IDs, but they map back to the same external post block IDs. That allowed an inactive Post Content instance to treat the saved entity selection as its own and move focus to its cloned block.

## Testing Instructions

1. Use a block theme.
2. Create a Template Part containing a Post Content block.
3. Create a Single post template containing:
   - one Post Content block at the template root
   - the Template Part that also contains Post Content
4. Create or edit a post with a paragraph.
5. Enable Show template.
6. Type in the paragraph in the root Post Content area.
7. Confirm the caret and selected block stay in the area you are editing instead of jumping to the matching paragraph inside the Template Part.
8. Press Ctrl+Z, or Cmd+Z on macOS.
9. Confirm the undo happens and the caret/selected block stay in the same Post Content instance


## Screenshots

### Before

https://github.com/user-attachments/assets/4b6488a2-9b87-4936-a137-41f1eafe839f

### After


https://github.com/user-attachments/assets/2c496c13-2f49-4c15-be7b-2e7cea3823d2



