### PR TITLE
Audio: Apply `inert` directly instead of wrapping in `Disabled`

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { isBlobURL } from '@wordpress/blob';
 import {
-	Disabled,
 	SelectControl,
 	Spinner,
 	ToggleControl,
@@ -250,14 +249,11 @@ function AudioEdit( {
 				</ToolsPanel>
 			</InspectorControls>
 			<figure { ...blockProps }>
-				{ /*
-				Disable the audio tag if the block is not selected
-				so the user clicking on it won't play the
-				file or change the position slider when the controls are enabled.
-				*/ }
-				<Disabled isDisabled={ ! isSingleSelected }>
-					<audio controls="controls" src={ src ?? temporaryURL } />
-				</Disabled>
+				<audio
+					controls="controls"
+					inert={ ! isSingleSelected ? 'true' : undefined }
+					src={ src ?? temporaryURL }
+				/>
 				{ !! temporaryURL && <Spinner /> }
 				<Caption
 					attributes={ attributes }


### PR DESCRIPTION
## What?
The Audio block's edit component wrapped the `<audio>` in a `Disabled` component to prevent playback when the block isn't selected. The only behavior needed here is `inert`, so apply it directly to the `<audio>` element instead.

This mirrors the same change made for the Video block in #79371.

Benefits:
- Removes an extra DOM node, so editor markup matches the frontend (`save`) output: `<figure> -> <audio>`.
- Drops the `Disabled` dependency and its unused styles/context for this block.

## Testing Instructions
1. Open a post or page.
2. Add the Audio block and select an audio file.
3. With controls enabled and the block deselected, clicking the audio
should not play it or focus the controls.

### Testing Instructions for Keyboard
Same.
