### PR TITLE
Components: restore shared stylelint cursor rule

### DIFF
--- a/packages/components/.stylelintrc.mjs
+++ b/packages/components/.stylelintrc.mjs
@@ -1,14 +1,31 @@
+import baseConfig from '@wordpress/stylelint-tools/config';
+
+const [ disallowedValues, disallowedValueMessages ] =
+	baseConfig.rules[ 'declaration-property-value-disallowed-list' ];
+
 /** @type {import('stylelint').Config} */
 export default {
 	extends: '@wordpress/stylelint-tools/config',
 	rules: {
 		'declaration-property-value-disallowed-list': [
 			{
-				'/.*/': [ '/--wp-admin-theme-/', '/--wp-components-color-/' ],
+				...disallowedValues,
+				'/.*/': [
+					...disallowedValues[ '/.*/' ],
+					'/--wp-admin-theme-/',
+					'/--wp-components-color-/',
+				],
 			},
 			{
-				message:
-					'To support component theming and ensure proper fallbacks, use Sass variables from packages/components/src/utils/theme-variables.scss instead.',
+				message: ( property, value ) => {
+					if (
+						/--wp-admin-theme-/.test( value ) ||
+						/--wp-components-color-/.test( value )
+					) {
+						return 'To support component theming and ensure proper fallbacks, use Sass variables from packages/components/src/utils/theme-variables.scss instead.';
+					}
+					return disallowedValueMessages.message( property, value );
+				},
 			},
 		],
 	},


### PR DESCRIPTION
## What?

Fixes the `@wordpress/components` stylelint config so it merges with the shared `declaration-property-value-disallowed-list` rule instead of replacing it entirely.

## Why?

The package-level `.stylelintrc.mjs` was overriding the shared rule with only the `--wp-admin-theme-*` and `--wp-components-color-*` checks. That dropped the shared `cursor: pointer` disallowed value and its guidance to use `var( --wpds-cursor-control )` for interactive non-link controls.

## How?

Import the shared config and spread its existing `declaration-property-value-disallowed-list` values before appending the components-specific patterns. Delegate to the shared custom message for non-theme-variable violations.

## Testing Instructions

1. Check out this branch.
2. Add a temporary SCSS file under `packages/components/src/` with a deliberate violation, for example:

```scss
.test-cursor-rule-violation {
	cursor: pointer;
}
```

Other things that should continue to error as before:

```css
color: var(--wp-admin-theme-color);
background-color: var(--wp-components-color-background);
```