### PR TITLE
Theme: Add Sass fallback helper root entrypoint

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -314,13 +314,13 @@ An alternative to loading the [design tokens stylesheet](#outside-wordpress), us
 
 You do not need this helper if you already load the design tokens stylesheet or use fallback injection via the build plugins or `@wordpress/build`. In those cases, write bare `var(--wpds-*)` references in your source.
 
-The `@wordpress/theme/design-token-fallbacks` export provides a generated `wpds-var()` function that wraps token references with the same fallback map used by the build plugins — for example, `wpds.wpds-var('--wpds-color-fg-content-neutral')` compiles to `var(--wpds-color-fg-content-neutral, #1e1e1e)`.
+The `@wordpress/theme/design-token-fallbacks` export provides a generated `wpds-var()` function that wraps token references with the same fallback map used by the build plugins. For example, `wpds.wpds-var('--wpds-color-foreground-content-neutral')` compiles to `var(--wpds-color-foreground-content-neutral, #1e1e1e)`.
 
 ```scss
 @use '@wordpress/theme/design-token-fallbacks' as wpds;
 
 .example {
-	color: wpds.wpds-var( '--wpds-color-fg-content-neutral' );
+	color: wpds.wpds-var( '--wpds-color-foreground-content-neutral' );
 }
 ```
 
@@ -330,11 +330,7 @@ When using Sass with [`NodePackageImporter`](https://sass-lang.com/documentation
 @use 'pkg:@wordpress/theme/design-token-fallbacks' as wpds;
 ```
 
-For Sass setups that resolve packages from `node_modules` with a load path, use:
-
-```scss
-@use '@wordpress/theme/src/prebuilt/scss/design-token-fallbacks' as wpds;
-```
+The same `@wordpress/theme/design-token-fallbacks` import also supports Sass setups that resolve packages from `node_modules` with a load path.
 
 ## Contributing to this package
 

--- a/packages/theme/design-token-fallbacks.scss
+++ b/packages/theme/design-token-fallbacks.scss
@@ -1,0 +1,1 @@
+@forward "./src/prebuilt/scss/design-token-fallbacks";

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -39,6 +39,7 @@
 		},
 		"./design-tokens.css": "./src/prebuilt/css/design-tokens.css",
 		"./design-token-fallbacks": "./src/prebuilt/scss/design-token-fallbacks.scss",
+		"./src/prebuilt/scss/design-token-fallbacks": "./src/prebuilt/scss/design-token-fallbacks.scss",
 		"./design-tokens.js": {
 			"types": "./build-types/prebuilt/js/design-tokens.d.ts",
 			"import": "./build-module/prebuilt/js/design-tokens.mjs",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -27,6 +27,7 @@
 		"build",
 		"build-module",
 		"build-types",
+		"design-token-fallbacks.scss",
 		"*.md"
 	],
 	"main": "build/index.cjs",
@@ -38,8 +39,11 @@
 			"default": "./build/index.cjs"
 		},
 		"./design-tokens.css": "./src/prebuilt/css/design-tokens.css",
-		"./design-token-fallbacks": "./src/prebuilt/scss/design-token-fallbacks.scss",
-		"./src/prebuilt/scss/design-token-fallbacks": "./src/prebuilt/scss/design-token-fallbacks.scss",
+		"./design-token-fallbacks": {
+			"sass": "./design-token-fallbacks.scss",
+			"style": "./design-token-fallbacks.scss",
+			"default": "./design-token-fallbacks.scss"
+		},
 		"./design-tokens.js": {
 			"types": "./build-types/prebuilt/js/design-tokens.d.ts",
 			"import": "./build-module/prebuilt/js/design-tokens.mjs",


### PR DESCRIPTION
## What?

Adds a package-root Sass shim for `@wordpress/theme/design-token-fallbacks` and removes the generated-source `src/prebuilt` subpath export.

## Why?

The Sass fallback helper needs to work in both package-export-aware build tools and older Sass setups that resolve packages from `node_modules` with a load path. Exporting the generated `src/prebuilt` path works around one build failure, but it also makes generated package internals part of the public API.

## How?

Adds `packages/theme/design-token-fallbacks.scss` as a stable public shim that forwards to the generated helper. The package export now points to that shim with Sass/style/default conditions, and the docs use the same public `@wordpress/theme/design-token-fallbacks` import for both package importer and load-path Sass setups.

## Testing Instructions

1. Run `npm run storybook:build`.
2. Confirm the build completes successfully.