### PR TITLE
Use `/* */` block style for translator comments

### DIFF
--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -109,7 +109,7 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
-						// translators: %s is the name of any user-provided key
+						/* translators: %s is the name of any user-provided key */
 						__( 'Invalid icon property: "%s".', 'gutenberg' ),
 						$key
 					),

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -109,7 +109,7 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
-						/* translators: %s is the name of any user-provided key */
+						/* translators: %s is the name of any user-provided key. */
 						__( 'Invalid icon property: "%s".', 'gutenberg' ),
 						$key
 					),

--- a/lib/compat/wordpress-7.0/class-wp-icons-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-icons-registry.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 					_doing_it_wrong(
 						__METHOD__,
 						sprintf(
-							/* translators: %s is the name of any user-provided key */
+							/* translators: %s is the name of any user-provided key. */
 							__( 'Invalid icon property: "%s".', 'gutenberg' ),
 							$key
 						),

--- a/lib/compat/wordpress-7.0/class-wp-icons-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-icons-registry.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 					_doing_it_wrong(
 						__METHOD__,
 						sprintf(
-							// translators: %s is the name of any user-provided key
+							/* translators: %s is the name of any user-provided key */
 							__( 'Invalid icon property: "%s".', 'gutenberg' ),
 							$key
 						),

--- a/lib/compat/wordpress-7.0/class-wp-rest-icons-controller.php
+++ b/lib/compat/wordpress-7.0/class-wp-rest-icons-controller.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
 				return new WP_Error(
 					'rest_icon_not_found',
 					sprintf(
-						/* translators: %s is the name of any user-provided name */
+						/* translators: %s is the name of any user-provided name. */
 						__( 'Icon not found: "%s".', 'gutenberg' ),
 						$name
 					),

--- a/lib/compat/wordpress-7.0/class-wp-rest-icons-controller.php
+++ b/lib/compat/wordpress-7.0/class-wp-rest-icons-controller.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
 				return new WP_Error(
 					'rest_icon_not_found',
 					sprintf(
-						// translators: %s is the name of any user-provided name
+						/* translators: %s is the name of any user-provided name */
 						__( 'Icon not found: "%s".', 'gutenberg' ),
 						$name
 					),

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -64,7 +64,7 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 				/* translators: %s is the Author name. */
 				$label = 'aria-label="' . esc_attr( sprintf( __( '(%s author archive, opens in a new tab)' ), $author_name ) ) . '"';
 			}
-			/* translators: 1: Author archive link. 2: Link target. %3$s Aria label. %4$s Avatar image. */
+			/* translators: 1: Author archive link, 2: Link target, 3: Aria label, 4: Avatar image. */
 			$avatar_block = sprintf( '<a href="%1$s" target="%2$s" %3$s class="wp-block-avatar__link">%4$s</a>', esc_url( get_author_posts_url( $author_id ) ), esc_attr( $attributes['linkTarget'] ), $label, $avatar_block );
 		}
 		return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $avatar_block );

--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -46,7 +46,7 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 		}
 
 		$author_name = get_the_author_meta( 'display_name', $author_id );
-		// translators: %s: Author name.
+		/* translators: %s: Author name. */
 		$alt          = sprintf( __( '%s Avatar' ), $author_name );
 		$avatar_block = get_avatar(
 			$author_id,
@@ -61,10 +61,10 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 			$label = '';
 			if ( '_blank' === $attributes['linkTarget'] ) {
-				// translators: %s is the Author name.
+				/* translators: %s is the Author name. */
 				$label = 'aria-label="' . esc_attr( sprintf( __( '(%s author archive, opens in a new tab)' ), $author_name ) ) . '"';
 			}
-			// translators: 1: Author archive link. 2: Link target. %3$s Aria label. %4$s Avatar image.
+			/* translators: 1: Author archive link. 2: Link target. %3$s Aria label. %4$s Avatar image. */
 			$avatar_block = sprintf( '<a href="%1$s" target="%2$s" %3$s class="wp-block-avatar__link">%4$s</a>', esc_url( get_author_posts_url( $author_id ) ), esc_attr( $attributes['linkTarget'] ), $label, $avatar_block );
 		}
 		return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $avatar_block );
@@ -88,7 +88,7 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] && isset( $comment->comment_author_url ) && '' !== $comment->comment_author_url ) {
 		$label = '';
 		if ( '_blank' === $attributes['linkTarget'] ) {
-			// translators: %s: Comment author name.
+			/* translators: %s: Comment author name. */
 			$label = 'aria-label="' . esc_attr( sprintf( __( '(%s website link, opens in a new tab)' ), $comment->comment_author ) ) . '"';
 		}
 		$avatar_block = sprintf( '<a href="%1$s" target="%2$s" %3$s class="wp-block-avatar__link">%4$s</a>', esc_url( $comment->comment_author_url ), esc_attr( $attributes['linkTarget'] ), $label, $avatar_block );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -34,7 +34,7 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
 		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
+			/* translators: Visible only in the front end, this warning takes the place of a faulty block. */
 			__( '[block rendering halted]' ) :
 			'';
 	}

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -29,7 +29,7 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
-		// translators: %s: human-readable time difference.
+		/* translators: %s: human-readable time difference. */
 		$formatted_date = sprintf( __( '%s ago' ), human_time_diff( get_comment_date( 'U', $comment ) ) );
 	} else {
 		$formatted_date = get_comment_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $comment );

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -50,7 +50,7 @@ function render_block_core_pattern( $attributes ) {
 		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
 		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block. %s represents a pattern's slug.
+			/* translators: Visible only in the front end, this warning takes the place of a faulty block. %s represents a pattern's slug. */
 			sprintf( __( '[block rendering halted for pattern "%s"]' ), $slug ) :
 			'';
 	}

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -30,7 +30,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
 		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
+			/* translators: Visible only in the front end, this warning takes the place of a faulty block. */
 			__( '[block rendering halted]' ) :
 			'';
 	}

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -61,10 +61,10 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
 		if ( $post_timestamp > time() ) {
-			// translators: %s: human-readable time difference.
+			/* translators: %s: human-readable time difference. */
 			$formatted_date = sprintf( __( '%s from now' ), human_time_diff( $post_timestamp ) );
 		} else {
-			// translators: %s: human-readable time difference.
+			/* translators: %s: human-readable time difference. */
 			$formatted_date = sprintf( __( '%s ago' ), human_time_diff( $post_timestamp ) );
 		}
 	} else {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 			$attr['alt'] = trim( strip_tags( $title ) );
 		} else {
 			$attr['alt'] = sprintf(
-				// translators: %d is the post ID.
+				/* translators: %d is the post ID. */
 				__( 'Untitled post %d' ),
 				$post_ID
 			);

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -62,7 +62,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 
 		case 'total-results':
 		default:
-			// translators: %d: number of results.
+			/* translators: %d: number of results. */
 			$output = sprintf( _n( '%d result found', '%d results found', $max_rows ), $max_rows );
 			break;
 	}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -129,7 +129,7 @@ function render_block_core_template_part( $attributes ) {
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {
 		return $is_debug ?
-			// translators: Visible only in the front end, this warning takes the place of a faulty block.
+			/* translators: Visible only in the front end, this warning takes the place of a faulty block. */
 			__( '[block rendering halted]' ) :
 			'';
 	}


### PR DESCRIPTION
Closes #79430

## What

Converts the remaining `// translators:` line comments in PHP to the `/* translators: */` block comment style that is the documented WordPress convention and used in the overwhelming majority of cases across the codebase.

16 occurrences across 12 files:

- `lib/class-wp-icons-registry-gutenberg.php`
- `lib/compat/wordpress-7.0/class-wp-icons-registry.php`
- `lib/compat/wordpress-7.0/class-wp-rest-icons-controller.php`
- `packages/block-library/src/avatar/index.php` (4)
- `packages/block-library/src/block/index.php`
- `packages/block-library/src/comment-date/index.php`
- `packages/block-library/src/pattern/index.php`
- `packages/block-library/src/post-content/index.php`
- `packages/block-library/src/post-date/index.php` (2)
- `packages/block-library/src/post-featured-image/index.php`
- `packages/block-library/src/query-total/index.php`
- `packages/block-library/src/template-part/index.php`

## Why

Coding-standards consistency. This complements WordPress core [Trac #65518](https://core.trac.wordpress.org/ticket/65518) / [wordpress-develop#12274](https://github.com/WordPress/wordpress-develop/pull/12274), which standardizes the core-authored files. The `packages/block-library/src/*/index.php` render files are maintained here and synced to core, so they are changed here first.

There is no functional impact — the `// translators:` style is still extracted correctly by `wp i18n make-pot` / `xgettext` when the comment sits directly above the gettext call; this just aligns the outliers with the block-comment convention.

## Testing instructions

- No behavior change. `php -l` passes on all touched files.
- Existing translator comments remain associated with their strings.