### PR TITLE
UI: Disable instant overlay popup transitions

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Bug Fixes
 
--   `Popover`, `Autocomplete`, `Combobox`: Disable popup transitions when Base UI marks animations as instant. ([#79432](https://github.com/WordPress/gutenberg/pull/79432)).
+-   `Popover`: Disable popup transitions when Base UI marks animations as instant ([#79432](https://github.com/WordPress/gutenberg/pull/79432)).
 -   `Button`: Fix `loading` state in forced colors mode ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).
 -   `Button`: Fix `loading` prop affecting `unstyled` variant ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+-   `Popover`, `Autocomplete`, `Combobox`: Disable popup transitions when Base UI marks animations as instant. ([#79432](https://github.com/WordPress/gutenberg/pull/79432)).
 -   `Button`: Fix `loading` state in forced colors mode ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).
 -   `Button`: Fix `loading` prop affecting `unstyled` variant ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).
 

--- a/packages/ui/src/utils/css/dropdown-motion.module.css
+++ b/packages/ui/src/utils/css/dropdown-motion.module.css
@@ -25,6 +25,10 @@
 				will-change: transform, opacity;
 			}
 
+			&[data-instant] {
+				transition: none;
+			}
+
 			opacity: 1;
 			transform: translate(0);
 


### PR DESCRIPTION
## What?

Disables the shared `@wordpress/ui` popup transition when Base UI marks a popup with `data-instant`.

## Why?

Base UI uses `data-instant` when popup motion should be skipped. The active runtime case in this package is `Popover.Popup` — for example keyboard open/close, dismiss/focus closes, and post-animation detached trigger changes.

Without this override, our shared dropdown motion styles still animate those instant states.

## How?

Adds `transition: none` to `[data-instant]` in `dropdown-motion.module.css`.

This directly fixes `Popover.Popup`. The same shared class is also used by Combobox/Autocomplete popups; Base UI documents `data-instant` for those, but I did not find a 1.5.0 source path that emits it today.

> [!Tip]
> @WordPress/gutenberg-components and @WordPress/gutenberg-design  , should we consider adding an animation to `Tooltip` too?

## Testing Instructions

1. Run `npm run lint:css -- packages/ui/src/utils/css/dropdown-motion.module.css`.
2. Open an `@wordpress/ui` Popover with the default popup surface.
3. Focus the trigger and press Enter or Space.
4. Inspect the popup and confirm `data-instant` is present.
5. Confirm the popup does not run the shared slide/fade transition while `data-instant` is present.
6. Press Escape and confirm focus returns to the trigger.

### Testing Instructions for Keyboard

Covered above.

## Screenshots or screencast

**Before: always animates**

https://github.com/user-attachments/assets/c209ab4c-1370-477e-9882-2f8f4ae5f8ef

**After: only animates on click, doesn't animate on key press**

https://github.com/user-attachments/assets/de638842-c9b1-4653-9275-0e1262cda91b


## Use of AI Tools

This PR was authored with assistance from OpenAI Codex. I reviewed the change and verification output.