### PR TITLE
Edit Post: Refactor MetaBoxesSection to use data hooks

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -10,7 +10,7 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import MetaBoxesSection from './meta-boxes-section';
+import { MetaBoxesSection } from './meta-boxes-section';
 
 const { PreferenceToggleControl } = unlock( preferencesPrivateApis );
 const { PreferencesModal } = unlock( editorPrivateApis );

--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { privateApis as preferencesPrivateApis } from '@wordpress/preferences';
 
@@ -16,11 +16,18 @@ import { unlock } from '../../lock-unlock';
 
 const { PreferencesModalSection } = unlock( preferencesPrivateApis );
 
-export function MetaBoxesSection( {
-	areCustomFieldsRegistered,
-	metaBoxes,
-	...sectionProps
-} ) {
+export function MetaBoxesSection( sectionProps ) {
+	const { areCustomFieldsRegistered, metaBoxes } = useSelect( ( select ) => {
+		const { getEditorSettings } = select( editorStore );
+		const { getAllMetaBoxes } = select( editPostStore );
+
+		return {
+			areCustomFieldsRegistered:
+				getEditorSettings().enableCustomFields !== undefined,
+			metaBoxes: getAllMetaBoxes(),
+		};
+	}, [] );
+
 	// The 'Custom Fields' meta box is a special case that we handle separately.
 	const thirdPartyMetaBoxes = metaBoxes.filter(
 		( { id } ) => id !== 'postcustom'
@@ -45,15 +52,3 @@ export function MetaBoxesSection( {
 		</PreferencesModalSection>
 	);
 }
-
-export default withSelect( ( select ) => {
-	const { getEditorSettings } = select( editorStore );
-	const { getAllMetaBoxes } = select( editPostStore );
-
-	return {
-		// This setting should not live in the block editor's store.
-		areCustomFieldsRegistered:
-			getEditorSettings().enableCustomFields !== undefined,
-		metaBoxes: getAllMetaBoxes(),
-	};
-} )( MetaBoxesSection );

--- a/packages/edit-post/src/components/preferences-modal/test/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/test/meta-boxes-section.js
@@ -4,67 +4,95 @@
 import { render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect, select as realSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
  * Internal dependencies
  */
 import { MetaBoxesSection } from '../meta-boxes-section';
+import { store as editPostStore } from '../../../store';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+// Override only the selectors the section reads, while delegating the rest
+// (used by the rendered child options) to the real registry.
+function setupUseSelect( { areCustomFieldsRegistered, metaBoxes } ) {
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( ( store ) => {
+			if ( store === editorStore ) {
+				return {
+					...realSelect( store ),
+					getEditorSettings: () => ( {
+						enableCustomFields: areCustomFieldsRegistered
+							? false
+							: undefined,
+					} ),
+				};
+			}
+			if ( store === editPostStore ) {
+				return {
+					...realSelect( store ),
+					getAllMetaBoxes: () => metaBoxes,
+				};
+			}
+			return realSelect( store );
+		} )
+	);
+}
 
 describe( 'MetaBoxesSection', () => {
 	it( 'does not render if there are no options', () => {
-		render(
-			<MetaBoxesSection
-				areCustomFieldsRegistered={ false }
-				metaBoxes={ [
-					{ id: 'postcustom', title: 'This should not render' },
-				] }
-			/>
-		);
+		setupUseSelect( {
+			areCustomFieldsRegistered: false,
+			metaBoxes: [
+				{ id: 'postcustom', title: 'This should not render' },
+			],
+		} );
+		render( <MetaBoxesSection /> );
 		expect( screen.queryByRole( 'group' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders a Custom Fields option', () => {
-		render(
-			<MetaBoxesSection
-				title="Advanced panels"
-				areCustomFieldsRegistered
-				metaBoxes={ [
-					{ id: 'postcustom', title: 'This should not render' },
-				] }
-			/>
-		);
+		setupUseSelect( {
+			areCustomFieldsRegistered: true,
+			metaBoxes: [
+				{ id: 'postcustom', title: 'This should not render' },
+			],
+		} );
+		render( <MetaBoxesSection title="Advanced panels" /> );
 		expect(
 			screen.getByRole( 'group', { name: 'Advanced panels' } )
 		).toMatchSnapshot();
 	} );
 
 	it( 'renders meta box options', () => {
-		render(
-			<MetaBoxesSection
-				title="Advanced panels"
-				areCustomFieldsRegistered={ false }
-				metaBoxes={ [
-					{ id: 'postcustom', title: 'This should not render' },
-					{ id: 'test1', title: 'Meta Box 1' },
-					{ id: 'test2', title: 'Meta Box 2' },
-				] }
-			/>
-		);
+		setupUseSelect( {
+			areCustomFieldsRegistered: false,
+			metaBoxes: [
+				{ id: 'postcustom', title: 'This should not render' },
+				{ id: 'test1', title: 'Meta Box 1' },
+				{ id: 'test2', title: 'Meta Box 2' },
+			],
+		} );
+		render( <MetaBoxesSection title="Advanced panels" /> );
 		expect(
 			screen.getByRole( 'group', { name: 'Advanced panels' } )
 		).toMatchSnapshot();
 	} );
 
 	it( 'renders a Custom Fields option and meta box options', () => {
-		render(
-			<MetaBoxesSection
-				title="Advanced panels"
-				areCustomFieldsRegistered
-				metaBoxes={ [
-					{ id: 'postcustom', title: 'This should not render' },
-					{ id: 'test1', title: 'Meta Box 1' },
-					{ id: 'test2', title: 'Meta Box 2' },
-				] }
-			/>
-		);
+		setupUseSelect( {
+			areCustomFieldsRegistered: true,
+			metaBoxes: [
+				{ id: 'postcustom', title: 'This should not render' },
+				{ id: 'test1', title: 'Meta Box 1' },
+				{ id: 'test2', title: 'Meta Box 2' },
+			],
+		} );
+		render( <MetaBoxesSection title="Advanced panels" /> );
 		expect(
 			screen.getByRole( 'group', { name: 'Advanced panels' } )
 		).toMatchSnapshot();


### PR DESCRIPTION
## What?
Refactors MetaBoxesSection from the legacy withSelect HoC to the useSelect hook, and collapses the file to a single named export (dropping the now-redundant default export). Updates the consumer and unit tests accordingly. No behavior change.

## Testing Instructions
Smoke test metaboxes preferences, which I think also has e2e test coverage.

## Use of AI Tools

Assisted By Claude.