### PR TITLE
Classic Block: Port PHPUnit coverage for hiding it from the inserter

### DIFF
--- a/backport-changelog/7.1/11712.md
+++ b/backport-changelog/7.1/11712.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/11712
 
 * https://github.com/WordPress/gutenberg/pull/77911
 * https://github.com/WordPress/gutenberg/pull/78613
+* https://github.com/WordPress/gutenberg/pull/79434

--- a/lib/compat/wordpress-7.1/classic-block.php
+++ b/lib/compat/wordpress-7.1/classic-block.php
@@ -11,6 +11,7 @@ if ( ! function_exists( 'wp_declare_classic_block_necessary' ) ) {
 	 * Declares a flag that the Classic block is necessary for the current post.
 	 *
 	 * @since 7.1.0
+	 * @access private
 	 */
 	function wp_declare_classic_block_necessary(): void {
 		/**

--- a/phpunit/script-loader-test.php
+++ b/phpunit/script-loader-test.php
@@ -76,4 +76,71 @@ class WP_Script_Loader_Test extends WP_UnitTestCase {
 			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
 		);
 	}
+
+	/**
+	 * Tests that the Classic block is hidden from the inserter by default.
+	 *
+	 * @covers ::wp_declare_classic_block_necessary
+	 */
+	public function test_wp_declare_classic_block_necessary_does_nothing_by_default() {
+		wp_register_script( 'wp-block-library', 'https://example.org/wp-block-library.js' );
+
+		wp_declare_classic_block_necessary();
+
+		$this->assertFalse(
+			wp_scripts()->get_data( 'wp-block-library', 'before' ),
+			'No inline script should be enqueued when the filter is not used.'
+		);
+	}
+
+	/**
+	 * Tests that the Classic block can be opted into the inserter via the filter.
+	 *
+	 * @covers ::wp_declare_classic_block_necessary
+	 */
+	public function test_wp_declare_classic_block_necessary_enqueues_flag_when_filter_enabled() {
+		wp_register_script( 'wp-block-library', 'https://example.org/wp-block-library.js' );
+		add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
+
+		wp_declare_classic_block_necessary();
+
+		$before = wp_scripts()->get_data( 'wp-block-library', 'before' );
+		$this->assertIsArray(
+			$before,
+			'An inline script should be enqueued when the filter opts in.'
+		);
+		$this->assertContains(
+			'window.__needsClassicBlock = true;',
+			$before,
+			'The Classic block flag should be added to the wp-block-library inline scripts.'
+		);
+	}
+
+	/**
+	 * Tests that the current post is passed to the filter.
+	 *
+	 * @covers ::wp_declare_classic_block_necessary
+	 */
+	public function test_wp_declare_classic_block_necessary_passes_post_to_filter() {
+		wp_register_script( 'wp-block-library', 'https://example.org/wp-block-library.js' );
+
+		$post_id         = self::factory()->post->create();
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$filter_post = false;
+		add_filter(
+			'wp_classic_block_supports_inserter',
+			static function ( $supports_inserter, $post ) use ( &$filter_post ) {
+				$filter_post = $post;
+				return $supports_inserter;
+			},
+			10,
+			2
+		);
+
+		wp_declare_classic_block_necessary();
+
+		$this->assertInstanceOf( WP_Post::class, $filter_post, 'The post should be passed to the filter.' );
+		$this->assertSame( $post_id, $filter_post->ID, 'The current post should be passed to the filter.' );
+	}
 }


### PR DESCRIPTION
## What

Ports the PHPUnit coverage for `wp_declare_classic_block_necessary()` from the corresponding Core PR ([wordpress-develop#11712](https://github.com/WordPress/wordpress-develop/pull/11712)) into Gutenberg, so the two stay in sync.

- Adds 3 tests to `WP_Script_Loader_Test` covering the default (hidden) behavior, opting in via the `wp_classic_block_supports_inserter` filter, and the post being passed to the filter.
- Aligns the function docblock with the `@access private` tag from Core.

## Why

The function shipped in Gutenberg (#77911, #78613) without PHP test coverage, while Core PR https://github.com/WordPress/wordpress-develop/pull/11712 added tests for it. This brings that coverage back so the implementations stay aligned.

No behavior change.

## Testing Instructions

```
npm run test:unit:php:base -- --filter test_wp_declare_classic_block_necessary
```

All 3 tests should pass.

## Use of AI Tools

Opus 4.8
