### PR TITLE
Editor: Clarify the site-wide impact of 'Apply Globally'

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -57,11 +57,16 @@ function GlobalStylesDescription( { record } ) {
 		}
 	);
 	return globalStylesChanges.length ? (
-		<ul className="entities-saved-states__changes">
-			{ globalStylesChanges.map( ( change ) => (
-				<li key={ change }>{ change }</li>
-			) ) }
-		</ul>
+		<>
+			<PanelRow>
+				{ __( 'This will update site-wide styles for:' ) }
+			</PanelRow>
+			<ul className="entities-saved-states__changes">
+				{ globalStylesChanges.map( ( change ) => (
+					<li key={ change }>{ change }</li>
+				) ) }
+			</ul>
+		</>
 	) : null;
 }
 

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -57,16 +57,11 @@ function GlobalStylesDescription( { record } ) {
 		}
 	);
 	return globalStylesChanges.length ? (
-		<>
-			<PanelRow>
-				{ __( 'This will update site-wide styles for:' ) }
-			</PanelRow>
-			<ul className="entities-saved-states__changes">
-				{ globalStylesChanges.map( ( change ) => (
-					<li key={ change }>{ change }</li>
-				) ) }
-			</ul>
-		</>
+		<ul className="entities-saved-states__changes">
+			{ globalStylesChanges.map( ( change ) => (
+				<li key={ change }>{ change }</li>
+			) ) }
+		</ul>
 	) : null;
 }
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -9,7 +9,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { BaseControl, Button } from '@wordpress/components';
+import { BaseControl, Button, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY,
@@ -17,7 +17,7 @@ import {
 	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -252,6 +252,19 @@ function PushChangesToGlobalStylesControl( {
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const hasGlobalStylesEdits = useSelect( ( select ) => {
+		const {
+			__experimentalGetCurrentGlobalStylesId,
+			hasEditsForEntityRecord,
+		} = select( coreStore );
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+
+		return globalStylesId
+			? hasEditsForEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: false;
+	}, [] );
+
+	const [ hasAppliedGlobally, setHasAppliedGlobally ] = useState( false );
 
 	const pushChanges = useCallback( () => {
 		if ( changes.length === 0 ) {
@@ -290,6 +303,7 @@ function PushChangesToGlobalStylesControl( {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( newBlockAttributes );
 			setUserConfig( newUserConfig, { undoIgnore: true } );
+			setHasAppliedGlobally( true );
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: Title of the block e.g. 'Heading'.
@@ -307,6 +321,7 @@ function PushChangesToGlobalStylesControl( {
 								setUserConfig( userConfig, {
 									undoIgnore: true,
 								} );
+								setHasAppliedGlobally( false );
 							},
 						},
 					],
@@ -325,29 +340,46 @@ function PushChangesToGlobalStylesControl( {
 	] );
 
 	return (
-		<BaseControl
-			className="editor-push-changes-to-global-styles-control"
-			help={ sprintf(
-				// translators: %s: Title of the block e.g. 'Heading'.
-				__(
-					'Apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
-				),
-				getBlockType( name ).title
+		<>
+			{ hasAppliedGlobally && hasGlobalStylesEdits && (
+				<Notice
+					className="editor-push-changes-to-global-styles-notice"
+					status="info"
+					isDismissible={ false }
+				>
+					{ sprintf(
+						// translators: %s: Title of the block e.g. 'Heading'.
+						__(
+							'These styles will apply to all %s blocks across the site when you save.'
+						),
+						getBlockType( name ).title
+					) }
+				</Notice>
 			) }
-		>
-			<BaseControl.VisualLabel>
-				{ __( 'Styles' ) }
-			</BaseControl.VisualLabel>
-			<Button
-				__next40pxDefaultSize
-				variant="secondary"
-				accessibleWhenDisabled
-				disabled={ changes.length === 0 }
-				onClick={ pushChanges }
+			<BaseControl
+				className="editor-push-changes-to-global-styles-control"
+				help={ sprintf(
+					// translators: %s: Title of the block e.g. 'Heading'.
+					__(
+						'Apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
+					),
+					getBlockType( name ).title
+				) }
 			>
-				{ __( 'Apply globally' ) }
-			</Button>
-		</BaseControl>
+				<BaseControl.VisualLabel>
+					{ __( 'Styles' ) }
+				</BaseControl.VisualLabel>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					accessibleWhenDisabled
+					disabled={ changes.length === 0 }
+					onClick={ pushChanges }
+				>
+					{ __( 'Apply globally' ) }
+				</Button>
+			</BaseControl>
+		</>
 	);
 }
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -9,7 +9,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { BaseControl, Button, Notice } from '@wordpress/components';
+import { BaseControl, Button, Modal } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY,
@@ -246,25 +246,13 @@ function PushChangesToGlobalStylesControl( {
 	setAttributes,
 } ) {
 	const { user: userConfig, setUser: setUserConfig } = useGlobalStyles();
+	const [ isConfirmModalOpen, setIsConfirmModalOpen ] = useState( false );
 
 	const changes = useChangesToPush( name, attributes, userConfig );
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const hasGlobalStylesEdits = useSelect( ( select ) => {
-		const {
-			__experimentalGetCurrentGlobalStylesId,
-			hasEditsForEntityRecord,
-		} = select( coreStore );
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-
-		return globalStylesId
-			? hasEditsForEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: false;
-	}, [] );
-
-	const [ hasAppliedGlobally, setHasAppliedGlobally ] = useState( false );
 
 	const pushChanges = useCallback( () => {
 		if ( changes.length === 0 ) {
@@ -303,7 +291,6 @@ function PushChangesToGlobalStylesControl( {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( newBlockAttributes );
 			setUserConfig( newUserConfig, { undoIgnore: true } );
-			setHasAppliedGlobally( true );
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: Title of the block e.g. 'Heading'.
@@ -321,7 +308,6 @@ function PushChangesToGlobalStylesControl( {
 								setUserConfig( userConfig, {
 									undoIgnore: true,
 								} );
-								setHasAppliedGlobally( false );
 							},
 						},
 					],
@@ -339,23 +325,25 @@ function PushChangesToGlobalStylesControl( {
 		userConfig,
 	] );
 
+	const openConfirmModal = useCallback( () => {
+		if ( changes.length === 0 ) {
+			return;
+		}
+
+		setIsConfirmModalOpen( true );
+	}, [ changes.length ] );
+
+	const closeConfirmModal = useCallback( () => {
+		setIsConfirmModalOpen( false );
+	}, [] );
+
+	const confirmApplyGlobally = useCallback( () => {
+		setIsConfirmModalOpen( false );
+		pushChanges();
+	}, [ pushChanges ] );
+
 	return (
 		<>
-			{ hasAppliedGlobally && hasGlobalStylesEdits && (
-				<Notice
-					className="editor-push-changes-to-global-styles-notice"
-					status="info"
-					isDismissible={ false }
-				>
-					{ sprintf(
-						// translators: %s: Title of the block e.g. 'Heading'.
-						__(
-							'These styles will apply to all %s blocks across the site when you save.'
-						),
-						getBlockType( name ).title
-					) }
-				</Notice>
-			) }
 			<BaseControl
 				className="editor-push-changes-to-global-styles-control"
 				help={ sprintf(
@@ -374,11 +362,44 @@ function PushChangesToGlobalStylesControl( {
 					variant="secondary"
 					accessibleWhenDisabled
 					disabled={ changes.length === 0 }
-					onClick={ pushChanges }
+					onClick={ openConfirmModal }
 				>
 					{ __( 'Apply globally' ) }
 				</Button>
 			</BaseControl>
+			{ isConfirmModalOpen && (
+				<Modal
+					title={ __( 'Apply styles globally' ) }
+					onRequestClose={ closeConfirmModal }
+					size="medium"
+				>
+					<p>
+						{ sprintf(
+							// translators: %s: Title of the block e.g. 'Paragraph'.
+							__(
+								'Applying these styles globally will affect every %s block across all content. Do you want to continue?'
+							),
+							getBlockType( name ).title
+						) }
+					</p>
+					<div className="editor-push-changes-to-global-styles-modal-actions">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ closeConfirmModal }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ confirmApplyGlobally }
+						>
+							{ __( 'Apply' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
 		</>
 	);
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -3,6 +3,9 @@
 	width: 100%;
 }
 
-.editor-push-changes-to-global-styles-notice {
-	margin: 0 0 16px;
+.editor-push-changes-to-global-styles-modal-actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+	margin-top: 24px;
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -2,3 +2,7 @@
 	justify-content: center;
 	width: 100%;
 }
+
+.editor-push-changes-to-global-styles-notice {
+	margin: 0 0 16px;
+}

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -79,6 +79,12 @@ test.describe( 'Push to Global Styles button', () => {
 		// Press the Push button
 		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
 
+		// Confirm applying styles globally.
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Apply' } )
+			.click();
+
 		// Snackbar notification should appear
 		await expect(
 			page.getByRole( 'button', {


### PR DESCRIPTION
## What?

Closes #79343.

This PR updates the `Apply globally` flow to use a confirmation modal before applying block styles site-wide.

## Why?

Applying styles globally has a broad impact, so users should explicitly confirm this action at the moment they trigger it. This approach makes the site-wide consequences clearer while avoiding redundant messaging later in the save flow.

## How?

- Added a confirmation modal shown when `Apply globally` is clicked.
- Added explicit confirmation actions in the modal:
  - Cancel: dismisses without applying changes
  - Apply: proceeds with global style application
- Kept the existing Undo snackbar behavior after applying.
- Kept the existing Global Styles change listing behavior in the Save modal without adding additional explanatory copy.

## Testing Instructions

1. Open the editor in a block theme.
2. Select a block with supported style controls (for example Group).
3. Change a supported style (color, spacing, typography, or border).
4. Click Apply globally.
5. Confirm a modal appears asking for confirmation.
6. Click Cancel and verify no global style change is applied.
7. Click Apply globally again, then click Apply in the modal.
8. Verify the style is applied globally and snackbar appears with Undo.
9. Click Undo and confirm the applied global style reverts.

### Testing Instructions for Keyboard

1. Navigate to Apply globally via keyboard.
2. Press Enter or Space to open the confirmation modal.
3. Verify focus moves into the modal.
4. Use keyboard to activate Cancel and confirm it closes without applying.
5. Re-open modal and activate Apply using keyboard.
6. Verify global apply succeeds and Undo snackbar is reachable.

## Screenshots or screencast

Before:

- `Apply globally` relied on the existing save flow without an upfront confirmation step.


https://github.com/user-attachments/assets/e70f53ef-6dbc-4998-aac6-92a69e212483

After

- `Apply globally` opens a confirmation modal before applying site-wide changes.

<img width="2078" height="1016" alt="image" src="https://github.com/user-attachments/assets/aa475029-f258-4e3e-819a-4f5074f5d567" />

## Use of AI Tools

Used GitHub Copilot to help refine the implementation, copy, and PR description.
