### PR TITLE
View config endpoint: bring back changes from core

### DIFF
--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -58,11 +58,21 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check(
-		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$request
-	) {
-		if ( ! current_user_can( 'edit_posts' ) ) {
+	public function get_items_permissions_check( $request ) {
+		$kind = $request->get_param( 'kind' );
+		$name = $request->get_param( 'name' );
+
+		$capability = $this->get_required_capability( $kind, $name );
+
+		if ( null === $capability ) {
+			return new WP_Error(
+				'rest_view_config_invalid_entity',
+				__( 'Invalid entity kind or name.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( $capability ) ) {
 			return new WP_Error(
 				'rest_cannot_read',
 				__( 'Sorry, you are not allowed to read view config.', 'gutenberg' ),
@@ -71,6 +81,48 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Resolves the capability required to read the view config for an entity.
+	 *
+	 * Known kinds map to the capability that gates managing that entity's list:
+	 * post types use their own `edit_posts` capability (which honors custom
+	 * `capability_type` registrations), taxonomies use `manage_terms`, and
+	 * root-level entities use `manage_options`. A post type or taxonomy that is
+	 * not registered, or not exposed to the REST API, resolves to `null` so the
+	 * request is treated as referencing an unknown entity.
+	 *
+	 * Any other kind falls back to `edit_posts`. This keeps entities registered
+	 * through the `get_entity_view_config_{$kind}_{$name}` filter readable behind
+	 * a baseline capability.
+	 *
+	 * @param string $kind The entity kind (e.g. `postType`).
+	 * @param string $name The entity name (e.g. `page`).
+	 * @return string|null Capability required to read the config, or null if the
+	 *                     entity is not registered.
+	 */
+	protected function get_required_capability( $kind, $name ) {
+		switch ( $kind ) {
+			case 'postType':
+				$post_type = get_post_type_object( $name );
+				if ( $post_type && $post_type->show_in_rest ) {
+					return $post_type->cap->edit_posts;
+				}
+				return null;
+
+			case 'taxonomy':
+				$taxonomy = get_taxonomy( $name );
+				if ( $taxonomy && $taxonomy->show_in_rest ) {
+					return $taxonomy->cap->manage_terms;
+				}
+				return null;
+
+			case 'root':
+				return 'manage_options';
+		}
+
+		return 'edit_posts';
 	}
 
 	/**
@@ -84,35 +136,91 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$name = $request->get_param( 'name' );
 
 		$config = gutenberg_get_entity_view_config( $kind, $name );
-
-		/*
-		 * The schema types these as objects, but PHP encodes empty arrays as
-		 * JSON arrays ([]). Cast the object-typed values that may be empty so
-		 * they serialize as JSON objects ({}) and match the schema.
-		 */
-		$default_view = $config['default_view'];
-		if ( isset( $default_view['layout'] ) ) {
-			$default_view['layout'] = (object) $default_view['layout'];
-		}
-
-		$default_layouts = $config['default_layouts'];
-		foreach ( $default_layouts as $view_type => $layout ) {
-			if ( isset( $layout['layout'] ) ) {
-				$layout['layout'] = (object) $layout['layout'];
-			}
-			$default_layouts[ $view_type ] = (object) $layout;
-		}
+		$schema = $this->get_item_schema();
 
 		$response = array(
 			'kind'            => $kind,
 			'name'            => $name,
-			'default_view'    => $default_view,
-			'default_layouts' => $default_layouts,
-			'view_list'       => $config['view_list'],
-			'form'            => (object) $config['form'],
+			'default_view'    => $this->cast_empty_objects( $config['default_view'], $schema['properties']['default_view'] ),
+			'default_layouts' => $this->cast_empty_objects( $config['default_layouts'], $schema['properties']['default_layouts'] ),
+			'view_list'       => $this->cast_empty_objects( $config['view_list'], $schema['properties']['view_list'] ),
+			'form'            => $this->cast_empty_objects( $config['form'], $schema['properties']['form'] ),
 		);
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Recursively casts empty arrays to objects where the schema types them as
+	 * objects.
+	 *
+	 * PHP cannot distinguish an empty associative array from an empty list, so
+	 * `json_encode()` always serializes `array()` as a JSON array (`[]`). The
+	 * REST schema, however, types several values as objects, which must encode
+	 * as `{}`. This walks the value against its schema and casts any empty,
+	 * object-typed array to an object. Non-empty associative arrays already
+	 * encode as objects, so they are left as arrays and only recursed into to
+	 * fix any nested empty objects.
+	 *
+	 * Union schemas (`oneOf`/`anyOf`) are handled only for the empty-array case:
+	 * an empty value is cast to an object when any branch allows an object. Such
+	 * values are not recursed into, which is sufficient for the form schema
+	 * where they never contain empty nested objects.
+	 *
+	 * @param mixed $value  The value to normalize.
+	 * @param array $schema The schema node describing the value.
+	 * @return mixed The normalized value, with empty object-typed arrays cast to objects.
+	 */
+	protected function cast_empty_objects( $value, $schema ) {
+		if ( ! is_array( $value ) || ! is_array( $schema ) ) {
+			return $value;
+		}
+
+		if ( isset( $schema['oneOf'] ) || isset( $schema['anyOf'] ) ) {
+			$branches = isset( $schema['oneOf'] ) ? $schema['oneOf'] : $schema['anyOf'];
+			if ( array() === $value ) {
+				foreach ( $branches as $branch ) {
+					if ( is_array( $branch ) && in_array( 'object', (array) ( isset( $branch['type'] ) ? $branch['type'] : array() ), true ) ) {
+						return (object) array();
+					}
+				}
+			}
+			return $value;
+		}
+
+		$types = (array) ( isset( $schema['type'] ) ? $schema['type'] : array() );
+
+		if ( in_array( 'array', $types, true ) && isset( $schema['items'] ) ) {
+			foreach ( $value as $index => $item ) {
+				$value[ $index ] = $this->cast_empty_objects( $item, $schema['items'] );
+			}
+			return $value;
+		}
+
+		if ( in_array( 'object', $types, true ) ) {
+			if ( isset( $schema['properties'] ) ) {
+				foreach ( $schema['properties'] as $property => $property_schema ) {
+					if ( array_key_exists( $property, $value ) ) {
+						$value[ $property ] = $this->cast_empty_objects( $value[ $property ], $property_schema );
+					}
+				}
+			}
+			if ( isset( $schema['additionalProperties'] ) && is_array( $schema['additionalProperties'] ) ) {
+				foreach ( $value as $key => $item ) {
+					if ( isset( $schema['properties'][ $key ] ) ) {
+						continue;
+					}
+					$value[ $key ] = $this->cast_empty_objects( $item, $schema['additionalProperties'] );
+				}
+			}
+
+			// Empty object-typed arrays must serialize as {} to match the schema.
+			if ( array() === $value ) {
+				return (object) array();
+			}
+		}
+
+		return $value;
 	}
 
 	/**
@@ -262,7 +370,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema properties for the base view configuration.
 	 */
-	private function get_view_base_schema() {
+	protected function get_view_base_schema() {
 		return array(
 			'search'                => array(
 				'type' => 'string',
@@ -371,7 +479,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a column style object.
 	 */
-	private function get_column_style_schema() {
+	protected function get_column_style_schema() {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
@@ -397,7 +505,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a table layout object.
 	 */
-	private function get_table_layout_schema() {
+	protected function get_table_layout_schema() {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
@@ -421,7 +529,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a list layout object.
 	 */
-	private function get_list_layout_schema() {
+	protected function get_list_layout_schema() {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
@@ -442,7 +550,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a combined layout object.
 	 */
-	private function get_combined_layout_schema() {
+	protected function get_combined_layout_schema() {
 		return array(
 			'type'       => 'object',
 			'properties' => array_merge(
@@ -458,7 +566,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a grid layout object.
 	 */
-	private function get_grid_layout_schema() {
+	protected function get_grid_layout_schema() {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
@@ -487,7 +595,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a form layout object.
 	 */
-	private function get_form_layout_schema() {
+	protected function get_form_layout_schema() {
 		return array(
 			'oneOf' => array(
 				// RegularLayout.
@@ -647,7 +755,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema for a form field.
 	 */
-	private function get_form_field_schema() {
+	protected function get_form_field_schema() {
 		return array(
 			'oneOf' => array(
 				array( 'type' => 'string' ),
@@ -688,7 +796,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 	 *
 	 * @return array Schema properties for the form configuration.
 	 */
-	private function get_form_schema() {
+	protected function get_form_schema() {
 		return array(
 			'layout' => $this->get_form_layout_schema(),
 			'fields' => array(

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -14,7 +14,14 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	const ROUTE = '/wp/v2/view-config';
 
 	/**
-	 * Editor user id (has `edit_posts`).
+	 * Administrator user id (has `edit_theme_options` and `manage_options`).
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Editor user id (has `edit_posts` and `manage_categories`, lacks `manage_options`).
 	 *
 	 * @var int
 	 */
@@ -33,6 +40,7 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	 * @param WP_UnitTest_Factory $factory Factory instance.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 	}
@@ -41,6 +49,7 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	 * Deletes shared users.
 	 */
 	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 	}
@@ -114,6 +123,126 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Post type config is gated by that post type's own `edit_posts` capability,
+	 * honoring custom capability registrations.
+	 *
+	 * `wp_template_part` maps `edit_posts` to `edit_theme_options`, which editors
+	 * lack but administrators have.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_uses_post_type_specific_capability() {
+		wp_set_current_user( self::$editor_id );
+		$this->assertErrorResponse(
+			'rest_cannot_read',
+			$this->dispatch_request( 'postType', 'wp_template_part' ),
+			403
+		);
+
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame(
+			200,
+			$this->dispatch_request( 'postType', 'wp_template_part' )->get_status()
+		);
+	}
+
+	/**
+	 * An unregistered post type is treated as an unknown entity (404).
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_unknown_post_type_is_not_found() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_request( 'postType', 'does_not_exist' );
+
+		$this->assertErrorResponse( 'rest_view_config_invalid_entity', $response, 404 );
+	}
+
+	/**
+	 * Taxonomy config is gated by the taxonomy's `manage_terms` capability.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_uses_taxonomy_capability() {
+		// Editors have `manage_categories` (the `manage_terms` cap for `category`).
+		wp_set_current_user( self::$editor_id );
+		$this->assertSame(
+			200,
+			$this->dispatch_request( 'taxonomy', 'category' )->get_status()
+		);
+
+		// Subscribers do not.
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertErrorResponse(
+			'rest_cannot_read',
+			$this->dispatch_request( 'taxonomy', 'category' ),
+			403
+		);
+	}
+
+	/**
+	 * An unregistered taxonomy is treated as an unknown entity (404).
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_unknown_taxonomy_is_not_found() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_request( 'taxonomy', 'does_not_exist' );
+
+		$this->assertErrorResponse( 'rest_view_config_invalid_entity', $response, 404 );
+	}
+
+	/**
+	 * Root-level config requires `manage_options`.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_root_requires_manage_options() {
+		// Editors lack `manage_options`.
+		wp_set_current_user( self::$editor_id );
+		$this->assertErrorResponse(
+			'rest_cannot_read',
+			$this->dispatch_request( 'root', 'site' ),
+			403
+		);
+
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame(
+			200,
+			$this->dispatch_request( 'root', 'site' )->get_status()
+		);
+	}
+
+	/**
+	 * Unknown kinds fall back to the baseline `edit_posts` capability so that
+	 * entities registered through the view config filter remain readable.
+	 *
+	 * @covers ::get_items_permissions_check
+	 * @covers ::get_required_capability
+	 */
+	public function test_get_items_unknown_kind_falls_back_to_edit_posts() {
+		wp_set_current_user( self::$editor_id );
+		$this->assertSame(
+			200,
+			$this->dispatch_request( 'custom_kind', 'custom_name' )->get_status()
+		);
+
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertErrorResponse(
+			'rest_cannot_read',
+			$this->dispatch_request( 'custom_kind', 'custom_name' ),
+			403
+		);
+	}
+
+	/**
 	 * Both `kind` and `name` are required.
 	 *
 	 * @covers ::register_routes
@@ -174,7 +303,8 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	 * @covers ::get_items
 	 */
 	public function test_empty_object_fields_serialize_as_json_objects() {
-		wp_set_current_user( self::$editor_id );
+		// Admin: reading wp_template_part config requires `edit_theme_options`.
+		wp_set_current_user( self::$admin_id );
 
 		// An entity with no provider yields empty default_layouts entries and form.
 		$decoded = json_decode( wp_json_encode( $this->dispatch_request( 'custom_kind', 'custom_name' )->get_data() ) );
@@ -189,6 +319,44 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 
 		$this->assertIsObject( $decoded->default_view->layout );
 		$this->assertIsObject( $decoded->default_layouts->grid->layout );
+	}
+
+	/**
+	 * Empty object-typed values nested inside a `view_list` item's `view`
+	 * override serialize as JSON objects ({}), not arrays ([]).
+	 *
+	 * The `view.layout` (and its `styles` map) are typed as objects by the
+	 * schema but are not produced by core data, so this exercises the
+	 * schema-driven cast against a value supplied through the documented
+	 * `get_entity_view_config_{$kind}_{$name}` filter.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_empty_objects_inside_view_list_view_serialize_as_json_objects() {
+		wp_set_current_user( self::$editor_id );
+
+		$filter = static function ( $config ) {
+			$config['view_list'][] = array(
+				'title' => 'Custom',
+				'slug'  => 'custom',
+				'view'  => array(
+					'type'   => 'table',
+					'layout' => array(
+						'styles' => array(),
+					),
+				),
+			);
+			return $config;
+		};
+		add_filter( 'get_entity_view_config_custom_kind_custom_name', $filter );
+
+		$decoded = json_decode( wp_json_encode( $this->dispatch_request( 'custom_kind', 'custom_name' )->get_data() ) );
+
+		remove_filter( 'get_entity_view_config_custom_kind_custom_name', $filter );
+
+		$view = end( $decoded->view_list );
+		$this->assertIsObject( $view->view->layout );
+		$this->assertIsObject( $view->view->layout->styles );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Brings back changes done in the core backport PR and merged at https://github.com/WordPress/wordpress-develop/commit/36cc6e9c061601f5a3ebb8969a9696a75ef198e9

## Why?

To make the gutenberg version of these files identical.

## How?

Changes in the REST Endpoint:

- no private functions, all are protected
- security model improved
- normalization based on schema

## Testing Instructions

Smoke test by visiting the Site Editor's Page, Templates, and Patterns screens. Verify the DataViews/DataForm work as before.