### PR TITLE
Experimental: Preserve editor panel visibility in the DataForm post summary

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -23,6 +23,102 @@ import revisionsField from '../../dataviews/fields/revisions';
 const EMPTY_FORM = { layout: { type: 'panel' }, fields: [] };
 const VIEW_CONFIG_FIELDS = [ 'form' ];
 
+/**
+ * Bridges the legacy editor-panel visibility controls onto the DataForm summary,
+ * returning the form with the hidden fields removed. The new inspector has no
+ * concept of the Preferences → Panels switches or of `removeEditorPanel`, so we
+ * reproduce their effect on the form.
+ *
+ * @param {Object} form The DataForm summary form configuration.
+ * @return {Object} The form with the hidden fields removed.
+ */
+function useInspectorPanelVisibility( form ) {
+	const {
+		isPostStatusRemoved,
+		featuredImagePanelEnabled,
+		excerptPanelEnabled,
+		discussionPanelEnabled,
+		pageAttributesPanelEnabled,
+	} = useSelect( ( select ) => {
+		const { isEditorPanelRemoved, isEditorPanelEnabled } =
+			select( editorStore );
+		return {
+			isPostStatusRemoved: isEditorPanelRemoved( 'post-status' ),
+			featuredImagePanelEnabled: isEditorPanelEnabled( 'featured-image' ),
+			excerptPanelEnabled: isEditorPanelEnabled( 'post-excerpt' ),
+			discussionPanelEnabled: isEditorPanelEnabled( 'discussion-panel' ),
+			pageAttributesPanelEnabled:
+				isEditorPanelEnabled( 'page-attributes' ),
+		};
+	}, [] );
+
+	const visibleForm = useMemo( () => {
+		if ( ! form.fields?.length ) {
+			return form;
+		}
+		const isFieldVisible = ( id ) => {
+			// `featured_media` and `excerpt` fields are tied to their own panel switches.
+			if ( id === 'featured_media' ) {
+				return featuredImagePanelEnabled;
+			}
+			if ( id === 'excerpt' ) {
+				return excerptPanelEnabled;
+			}
+			if ( id === 'post-content-info' ) {
+				return true; // This field was always present.
+			}
+			// `removeEditorPanel( 'post-status' )` hid the rest of the summary
+			// as a unit.
+			if ( isPostStatusRemoved ) {
+				return false;
+			}
+			// If `post-status` panel is not removed, its nested panels honor their own switch.
+			if ( id === 'discussion' ) {
+				return discussionPanelEnabled;
+			}
+			if ( id === 'parent' ) {
+				return pageAttributesPanelEnabled;
+			}
+			return true;
+		};
+		// Recurse into `children` so a panel-tied field is dropped wherever it
+		// sits in the form: the PHP view-config filter can nest such a field
+		// inside another field's group.
+		const filterFields = ( fields ) =>
+			fields.reduce( ( acc, field ) => {
+				const id = typeof field === 'string' ? field : field.id;
+				if ( ! isFieldVisible( id ) ) {
+					return acc;
+				}
+				if (
+					typeof field !== 'string' &&
+					Array.isArray( field.children )
+				) {
+					const children = filterFields( field.children );
+					// A group whose children were all removed would render as
+					// an empty panel, so drop it too.
+					if ( ! children.length ) {
+						return acc;
+					}
+					acc.push( { ...field, children } );
+					return acc;
+				}
+				acc.push( field );
+				return acc;
+			}, [] );
+		return { ...form, fields: filterFields( form.fields ) };
+	}, [
+		form,
+		isPostStatusRemoved,
+		featuredImagePanelEnabled,
+		excerptPanelEnabled,
+		discussionPanelEnabled,
+		pageAttributesPanelEnabled,
+	] );
+
+	return visibleForm;
+}
+
 // Some post types expose summary fields that edit entities other than the one
 // being edited. Keyed by the post type that needs them, the related records are
 // merged into the form data under a `${ kind }_${ name }` namespace key so that
@@ -90,11 +186,13 @@ function bindFieldToNamespace( field, namespace, isVisible = () => true ) {
 }
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+	const { postType, postId, isPostStatusRemoved } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId, isEditorPanelRemoved } =
+			select( editorStore );
 		return {
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
+			isPostStatusRemoved: isEditorPanelRemoved( 'post-status' ),
 		};
 	}, [] );
 	const { form: formConfig } = useViewConfig( {
@@ -102,7 +200,9 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 		name: postType,
 		fields: VIEW_CONFIG_FIELDS,
 	} );
-	const form = formConfig ?? EMPTY_FORM;
+	// Bridge the legacy editor-panel visibility (Preferences → Panels and
+	// programmatic panel removal) onto the form by dropping hidden fields.
+	const form = useInspectorPanelVisibility( formConfig ?? EMPTY_FORM );
 	const record = useSelect(
 		( select ) => {
 			if ( ! postType || ! postId ) {
@@ -313,7 +413,9 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					form={ form }
 					onChange={ onChange }
 				/>
-				<PostTrash onActionPerformed={ onActionPerformed } />
+				{ ! isPostStatusRemoved && (
+					<PostTrash onActionPerformed={ onActionPerformed } />
+				) }
 			</Stack>
 		</PostPanelSection>
 	);

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -35,20 +35,19 @@ const VIEW_CONFIG_FIELDS = [ 'form' ];
 function useInspectorPanelVisibility( form ) {
 	const {
 		isPostStatusRemoved,
-		featuredImagePanelEnabled,
-		excerptPanelEnabled,
-		discussionPanelEnabled,
-		pageAttributesPanelEnabled,
+		featuredImageEnabled,
+		excerptEnabled,
+		discussionEnabled,
+		pageAttributesEnabled,
 	} = useSelect( ( select ) => {
 		const { isEditorPanelRemoved, isEditorPanelEnabled } =
 			select( editorStore );
 		return {
 			isPostStatusRemoved: isEditorPanelRemoved( 'post-status' ),
-			featuredImagePanelEnabled: isEditorPanelEnabled( 'featured-image' ),
-			excerptPanelEnabled: isEditorPanelEnabled( 'post-excerpt' ),
-			discussionPanelEnabled: isEditorPanelEnabled( 'discussion-panel' ),
-			pageAttributesPanelEnabled:
-				isEditorPanelEnabled( 'page-attributes' ),
+			featuredImageEnabled: isEditorPanelEnabled( 'featured-image' ),
+			excerptEnabled: isEditorPanelEnabled( 'post-excerpt' ),
+			discussionEnabled: isEditorPanelEnabled( 'discussion-panel' ),
+			pageAttributesEnabled: isEditorPanelEnabled( 'page-attributes' ),
 		};
 	}, [] );
 
@@ -56,31 +55,20 @@ function useInspectorPanelVisibility( form ) {
 		if ( ! form.fields?.length ) {
 			return form;
 		}
-		const isFieldVisible = ( id ) => {
-			// `featured_media` and `excerpt` fields are tied to their own panel switches.
-			if ( id === 'featured_media' ) {
-				return featuredImagePanelEnabled;
-			}
-			if ( id === 'excerpt' ) {
-				return excerptPanelEnabled;
-			}
-			if ( id === 'post-content-info' ) {
-				return true; // This field was always present.
-			}
-			// `removeEditorPanel( 'post-status' )` hid the rest of the summary
-			// as a unit.
-			if ( isPostStatusRemoved ) {
-				return false;
-			}
-			// If `post-status` panel is not removed, its nested panels honor their own switch.
-			if ( id === 'discussion' ) {
-				return discussionPanelEnabled;
-			}
-			if ( id === 'parent' ) {
-				return pageAttributesPanelEnabled;
-			}
-			return true;
+		// `featured_media`/`excerpt` are their own top-level panels and
+		// `post-content-info` is always shown, so they survive. Everything else
+		// belongs to the `post-status` summary panel: `discussion`/`parent` honor
+		// their own switch, but every one of them is hidden while the `post-status`
+		// panel is removed.
+		const visibilityById = {
+			featured_media: featuredImageEnabled,
+			excerpt: excerptEnabled,
+			'post-content-info': true,
+			discussion: discussionEnabled && ! isPostStatusRemoved,
+			parent: pageAttributesEnabled && ! isPostStatusRemoved,
 		};
+		const isFieldVisible = ( id ) =>
+			id in visibilityById ? visibilityById[ id ] : ! isPostStatusRemoved;
 		// Recurse into `children` so a panel-tied field is dropped wherever it
 		// sits in the form: the PHP view-config filter can nest such a field
 		// inside another field's group.
@@ -110,10 +98,10 @@ function useInspectorPanelVisibility( form ) {
 	}, [
 		form,
 		isPostStatusRemoved,
-		featuredImagePanelEnabled,
-		excerptPanelEnabled,
-		discussionPanelEnabled,
-		pageAttributesPanelEnabled,
+		featuredImageEnabled,
+		excerptEnabled,
+		discussionEnabled,
+		pageAttributesEnabled,
 	] );
 
 	return visibleForm;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076

Under the `Editor Inspector: Use DataForm` experiment, the new DataForm-based post summary ignored the legacy editor-panel visibility system, so **Preferences → Panels** toggles and programmatic `removeEditorPanel( 'post-status' )` calls silently stopped working.


This PR bridges that legacy state onto the form, dropping hidden fields from the form config matching the classic summary's behavior.

## How

- `featured_media` and `excerpt` follow their own Preferences → Panels switch and survive `post-status` removal (as in classic).
- `post-content-info` always shows.
- `removeEditorPanel( 'post-status' )` hides the rest of the summary as a unit — the status block, the nested `discussion`/`page-attributes` fields (removal takes priority over their own switch), and any field added to the form later through the `get_entity_view_config_{kind}_{name}` filter.
- Filtering happens on the form config and recurses into `children`, so it also handles grouped fields and fields a view-config filter has nested elsewhere; emptied groups are pruned.
- The move-to-trash button is hidden when `post-status` is removed.




## Testing instructions
1. Enable the `Editor Inspector: Use DataForm` experiment.
2. Go to edit a post and open the preferences (through the options dialog - top right in screen)
3. Toggle some of the related items in `General/Document settings` (e.g. featured image)
4. Close the dialog and observe that the post summary respects the preferences updates
5. Repeat steps 2 to 4 for a page.

You should also test the programmatic removal of `post-status` panel with:
1. In the dev tools run `wp.data.dispatch('core/editor').removeEditorPanel('post-status')`. Observe that the removed fields match what is being removed in the classic post summary (experiment disabled).

## Videos

_Noting that I'm refreshing in the videos because I use different tabs to make them smaller. When you toggle a preference there is no need to refresh the page._

### Preferences for page


https://github.com/user-attachments/assets/ac23c885-8ea3-4d07-ab6f-a2d24d34f5bb

### Preferences for post

https://github.com/user-attachments/assets/9341cd1c-7007-4cc4-8a8d-4830b0ed0d52




### Remove `post status` panel


https://github.com/user-attachments/assets/449a6da8-a4c4-4957-b521-d0e19a4c820f



## Use of AI Tools
Opus 4.8 with direction, changes and review