### PR TITLE
Components: add Emotion migration guardrails

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Internal
 
 -   `ResizableBox`: Make the `children` prop optional ([#79370](https://github.com/WordPress/gutenberg/pull/79370)).
+-   Add documentation and lint guardrails for the ongoing Emotion migration ([#79442](https://github.com/WordPress/gutenberg/pull/79442)).
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
 -   Point the legacy `--wp-components-*` color fallbacks at the design system tokens (`--wpds-*` / `--wp-admin-theme-color*`), so component styles get sensible defaults from the prebuilt token stylesheet without a runtime `<ThemeProvider>` ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 -   `withFallbackStyles`: Refactor from a class component to a function component with hooks ([#78837](https://github.com/WordPress/gutenberg/pull/78837)).

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -416,9 +416,11 @@ On the component's main named export, add a JSDoc comment that includes the main
 
 ## Styling
 
-All new component should be styled using [Emotion](https://emotion.sh/docs/introduction).
+All new components should be styled using SCSS Modules.
 
-Note: Instead of using Emotion's standard `cx` function, the custom [`useCx` hook](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/utils/hooks/use-cx.ts) should be used instead.
+Place component-local styles in a `style.module.scss` file next to the component, import the module from JavaScript or TypeScript, and compose class names with `clsx`. Preserve existing public `components-*` class names where consumers may rely on them. For dynamic values, prefer inline CSS custom properties consumed by the SCSS module. For variants and state, prefer `data-*` attributes or explicit module classes.
+
+Legacy components may still use Emotion while they are being migrated, but new Emotion usage should not be added.
 
 ### Deprecating styles
 
@@ -426,10 +428,11 @@ Changing the styles of a non-experimental component must be done with care. To p
 
 ```jsx
 // component.tsx
+import clsx from 'clsx';
 import deprecated from '@wordpress/deprecated';
-import { Wrapper } from './styles.ts';
+import styles from './style.module.scss';
 
-function MyComponent( { __nextHasNoOuterMargins = false } ) {
+function MyComponent( { __nextHasNoOuterMargins = false, className } ) {
 	if ( ! __nextHasNoOuterMargins ) {
 		deprecated( 'Outer margin styles for wp.components.MyComponent', {
 			since: '6.0',
@@ -437,27 +440,32 @@ function MyComponent( { __nextHasNoOuterMargins = false } ) {
 			hint: 'Set the `__nextHasNoOuterMargins` prop to true to start opting into the new styles, which will become the default in a future version.',
 		} );
 	}
-	return <Wrapper __nextHasNoOuterMargins={ __nextHasNoOuterMargins } />;
+	return (
+		<div
+			className={ clsx(
+				'components-my-component',
+				styles.root,
+				className
+			) }
+			data-has-no-outer-margins={
+				__nextHasNoOuterMargins ? true : undefined
+			}
+		/>
+	);
 }
 ```
 
 Styles should be structured so the deprecated styles are cleanly encapsulated, and can be easily removed when the deprecation version arrives.
 
-```js
-// styles.ts
-const deprecatedMargins = ( { __nextHasNoOuterMargins } ) => {
-	if ( ! __nextHasNoOuterMargins ) {
-		return css`
-			margin: 8px;
-		`;
-	}
-};
-
-export const Wrapper = styled.div`
+```scss
+// style.module.scss
+.root {
 	margin: 0;
 
-	${ deprecatedMargins }
-`;
+	&:not([data-has-no-outer-margins]) {
+		margin: 8px;
+	}
+}
 ```
 
 Once deprecated, code examples in docs/stories should include the opt-in prop set to `true` so that new consumers are encouraged to adopt it from the start.

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -191,10 +191,10 @@ function useExampleComponent(
 	);
 
 	// Any other reusable rendering logic (e.g. computing className, state, event listeners...)
-	const cx = useCx();
-	const classes = useMemo(
-		() => cx( styles.example, isVisible && styles.visible, className ),
-		[ className, isVisible ]
+	const classes = clsx(
+		styles.example,
+		isVisible && styles.visible,
+		className
 	);
 
 	return {
@@ -418,7 +418,7 @@ On the component's main named export, add a JSDoc comment that includes the main
 
 All new components should be styled using SCSS Modules.
 
-Place component-local styles in a `style.module.scss` file next to the component, import the module from JavaScript or TypeScript, and compose class names with `clsx`. Preserve existing public `components-*` class names where consumers may rely on them. For dynamic values, prefer inline CSS custom properties consumed by the SCSS module. For variants and state, prefer `data-*` attributes or explicit module classes.
+Place component-local styles in a `style.module.scss` file next to the component, import the module from JavaScript or TypeScript, and compose class names with `clsx`. Preserve existing public `components-*` class names where consumers may rely on them. For dynamic values, prefer inline CSS custom properties consumed by the SCSS module. For variants and state, prefer conditional module classes composed with `clsx`.
 
 Legacy components may still use Emotion while they are being migrated, but new Emotion usage should not be added.
 
@@ -445,11 +445,10 @@ function MyComponent( { __nextHasNoOuterMargins = false, className } ) {
 			className={ clsx(
 				'components-my-component',
 				styles.root,
+				! __nextHasNoOuterMargins &&
+					styles.deprecatedOuterMargins,
 				className
 			) }
-			data-has-no-outer-margins={
-				__nextHasNoOuterMargins ? true : undefined
-			}
 		/>
 	);
 }
@@ -461,10 +460,10 @@ Styles should be structured so the deprecated styles are cleanly encapsulated, a
 // style.module.scss
 .root {
 	margin: 0;
+}
 
-	&:not([data-has-no-outer-margins]) {
-		margin: 8px;
-	}
+.deprecatedOuterMargins {
+	margin: 8px;
 }
 ```
 
@@ -691,7 +690,7 @@ component-name/
 ├── hook.ts
 ├── index.ts
 ├── README.md
-├── styles.ts
+├── style.module.scss
 └── types.ts
 ```
 
@@ -704,13 +703,13 @@ component-family-name/
 │   ├── component.tsx
 │   ├── hook.ts
 │   ├── README.md
-│   └── styles.ts
+│   └── style.module.scss
 ├── sub-component-name/
 │   ├── index.ts
 │   ├── component.tsx
 │   ├── hook.ts
 │   ├── README.md
-│   └── styles.ts
+│   └── style.module.scss
 ├── stories
 │   └── index.js
 ├── test
@@ -750,7 +749,7 @@ This second approach involves creating a new, separate version (ie. export) of t
 
 If possible, the legacy version of the component should be rewritten so that it uses the same underlying implementation of the new version, with an extra API "translation" layer to adapt the legacy API surface to the new API surface, e.g:
 
-```
+```tsx
 // legacy-component/index.tsx
 
 function LegacyComponent( props ) {

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -128,19 +128,6 @@ const restrictedImports = [
 	},
 ];
 
-const componentsEmotionImports = [
-	'@emotion/cache',
-	'@emotion/css',
-	'@emotion/react',
-	'@emotion/serialize',
-	'@emotion/styled',
-	'@emotion/utils',
-].map( ( name ) => ( {
-	name,
-	message:
-		'Do not add new Emotion usage in `@wordpress/components`. Use SCSS Modules for component-local styles instead.',
-} ) );
-
 const componentsEmotionImportPatterns = [
 	{
 		group: [ '@emotion/**' ],
@@ -149,89 +136,12 @@ const componentsEmotionImportPatterns = [
 	},
 ];
 
-const componentsEmotionMigrationAllowlist = [
-	'packages/components/src/base-control/styles/base-control-styles.ts',
-	'packages/components/src/border-box-control/styles.ts',
-	'packages/components/src/border-control/styles.ts',
-	'packages/components/src/box-control/styles/box-control-icon-styles.ts',
-	'packages/components/src/box-control/styles/box-control-styles.ts',
-	'packages/components/src/card/card/component.tsx',
-	'packages/components/src/card/get-padding-by-size.ts',
-	'packages/components/src/card/styles.ts',
-	'packages/components/src/color-palette/styles.ts',
-	'packages/components/src/color-picker/styles.ts',
-	'packages/components/src/combobox-control/styles.ts',
-	'packages/components/src/confirm-dialog/styles.ts',
-	'packages/components/src/context/test/context-system-provider.js',
-	'packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.tsx',
-	'packages/components/src/custom-select-control-v2/styles.ts',
-	'packages/components/src/date-time/date-picker/styles.ts',
-	'packages/components/src/date-time/date-time/styles.ts',
-	'packages/components/src/date-time/time-picker/styles.ts',
-	'packages/components/src/disabled/styles/disabled-styles.tsx',
-	'packages/components/src/divider/styles.ts',
-	'packages/components/src/dropdown/styles.ts',
-	'packages/components/src/elevation/hook.ts',
-	'packages/components/src/elevation/styles.ts',
-	'packages/components/src/flex/flex-item/hook.ts',
-	'packages/components/src/flex/flex/hook.ts',
-	'packages/components/src/flex/styles.ts',
-	'packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts',
-	'packages/components/src/focal-point-picker/styles/focal-point-style.ts',
-	'packages/components/src/font-size-picker/styles.ts',
-	'packages/components/src/form-token-field/styles.ts',
-	'packages/components/src/grid/hook.ts',
-	'packages/components/src/input-control/styles/input-control-styles.tsx',
-	'packages/components/src/item-group/styles.ts',
-	'packages/components/src/menu/stories/index.story.tsx',
-	'packages/components/src/menu/styles.ts',
-	'packages/components/src/navigator/styles.ts',
-	'packages/components/src/number-control/styles/number-control-styles.ts',
-	'packages/components/src/palette-edit/styles.ts',
-	'packages/components/src/progress-bar/styles.ts',
-	'packages/components/src/range-control/styles/range-control-styles.ts',
-	'packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.ts',
-	'packages/components/src/scrollable/styles.ts',
-	'packages/components/src/search-control/styles.ts',
-	'packages/components/src/select-control/styles/select-control-styles.ts',
-	'packages/components/src/spacer/hook.ts',
-	'packages/components/src/spinner/styles.ts',
-	'packages/components/src/style-provider/index.tsx',
-	'packages/components/src/surface/styles.ts',
-	'packages/components/src/tabs/styles.ts',
-	'packages/components/src/text/hook.ts',
-	'packages/components/src/text/styles.ts',
-	'packages/components/src/textarea-control/styles/textarea-control-styles.ts',
-	'packages/components/src/theme/styles.ts',
-	'packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts',
-	'packages/components/src/toggle-group-control/toggle-group-control/styles.ts',
-	'packages/components/src/tools-panel/stories/index.story.tsx',
-	'packages/components/src/tools-panel/styles.ts',
-	'packages/components/src/truncate/hook.ts',
-	'packages/components/src/truncate/styles.ts',
-	'packages/components/src/unit-control/styles/unit-control-styles.ts',
-	'packages/components/src/utils/base-label.ts',
-	'packages/components/src/utils/box-sizing.ts',
-	'packages/components/src/utils/hooks/emotion.d.ts',
-	'packages/components/src/utils/hooks/test/use-cx.js',
-	'packages/components/src/utils/hooks/use-cx.ts',
-	'packages/components/src/utils/rtl.js',
-	'packages/components/src/view/component.tsx',
-	'packages/components/src/z-stack/styles.ts',
-];
-
 const componentsSourceRestrictedImports = [
 	...restrictedImports.filter(
 		( { name } ) =>
-			! [
-				'@ariakit/react',
-				'framer-motion',
-				...componentsEmotionImports.map(
-					( { name: emotionPackage } ) => emotionPackage
-				),
-			].includes( name )
+			! [ '@ariakit/react', 'framer-motion' ].includes( name ) &&
+			! name.startsWith( '@emotion/' )
 	),
-	...componentsEmotionImports,
 ];
 
 // Common `no-restricted-imports` configuration for `@wordpress/ui` paths,
@@ -783,7 +693,6 @@ export default dedupePlugins( [
 	// Emotion styles are migrated incrementally.
 	{
 		files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
-		ignores: componentsEmotionMigrationAllowlist,
 		rules: {
 			'no-restricted-imports': [
 				'error',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -128,22 +128,6 @@ const restrictedImports = [
 	},
 ];
 
-const componentsEmotionImportPatterns = [
-	{
-		group: [ '@emotion/**' ],
-		message:
-			'Do not add new Emotion usage in `@wordpress/components`. Use SCSS Modules for component-local styles instead.',
-	},
-];
-
-const componentsSourceRestrictedImports = [
-	...restrictedImports.filter(
-		( { name } ) =>
-			! [ '@ariakit/react', 'framer-motion' ].includes( name ) &&
-			! name.startsWith( '@emotion/' )
-	),
-];
-
 // Common `no-restricted-imports` configuration for `@wordpress/ui` paths,
 // which occur across multiple override configs. The exclusion here allows
 // Base UI to be imported directly in `@wordpress/ui`, which is the intended
@@ -679,8 +663,13 @@ export default dedupePlugins( [
 			'no-restricted-imports': [
 				'error',
 				{
-					paths: componentsSourceRestrictedImports,
-					patterns: componentsEmotionImportPatterns,
+					paths: restrictedImports.filter(
+						( { name } ) =>
+							! [ '@ariakit/react', 'framer-motion' ].includes(
+								name
+							) && ! name.startsWith( '@emotion/' )
+					),
+					patterns: [ '@emotion/**' ],
 				},
 			],
 		},

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -671,28 +671,10 @@ export default dedupePlugins( [
 		},
 	},
 
-	// Override: Components src — allow ariakit and framer-motion imports.
+	// Override: Components src — allow ariakit/framer-motion imports and
+	// prevent new Emotion usage while existing styles are migrated.
 	{
 		files: [ 'packages/components/src/**' ],
-		rules: {
-			'no-restricted-imports': [
-				'error',
-				{
-					paths: restrictedImports.filter(
-						( { name } ) =>
-							! [ '@ariakit/react', 'framer-motion' ].includes(
-								name
-							)
-					),
-				},
-			],
-		},
-	},
-
-	// Override: Components src — prevent new Emotion usage while existing
-	// Emotion styles are migrated incrementally.
-	{
-		files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
 		rules: {
 			'no-restricted-imports': [
 				'error',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -141,6 +141,14 @@ const componentsEmotionImports = [
 		'Do not add new Emotion usage in `@wordpress/components`. Use SCSS Modules for component-local styles instead.',
 } ) );
 
+const componentsEmotionImportPatterns = [
+	{
+		group: [ '@emotion/**' ],
+		message:
+			'Do not add new Emotion usage in `@wordpress/components`. Use SCSS Modules for component-local styles instead.',
+	},
+];
+
 const componentsEmotionMigrationAllowlist = [
 	'packages/components/src/base-control/styles/base-control-styles.ts',
 	'packages/components/src/border-box-control/styles.ts',
@@ -781,6 +789,7 @@ export default dedupePlugins( [
 				'error',
 				{
 					paths: componentsSourceRestrictedImports,
+					patterns: componentsEmotionImportPatterns,
 				},
 			],
 		},

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -128,6 +128,104 @@ const restrictedImports = [
 	},
 ];
 
+const componentsEmotionImports = [
+	'@emotion/cache',
+	'@emotion/css',
+	'@emotion/react',
+	'@emotion/serialize',
+	'@emotion/styled',
+	'@emotion/utils',
+].map( ( name ) => ( {
+	name,
+	message:
+		'Do not add new Emotion usage in `@wordpress/components`. Use SCSS Modules for component-local styles instead.',
+} ) );
+
+const componentsEmotionMigrationAllowlist = [
+	'packages/components/src/base-control/styles/base-control-styles.ts',
+	'packages/components/src/border-box-control/styles.ts',
+	'packages/components/src/border-control/styles.ts',
+	'packages/components/src/box-control/styles/box-control-icon-styles.ts',
+	'packages/components/src/box-control/styles/box-control-styles.ts',
+	'packages/components/src/card/card/component.tsx',
+	'packages/components/src/card/get-padding-by-size.ts',
+	'packages/components/src/card/styles.ts',
+	'packages/components/src/color-palette/styles.ts',
+	'packages/components/src/color-picker/styles.ts',
+	'packages/components/src/combobox-control/styles.ts',
+	'packages/components/src/confirm-dialog/styles.ts',
+	'packages/components/src/context/test/context-system-provider.js',
+	'packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.tsx',
+	'packages/components/src/custom-select-control-v2/styles.ts',
+	'packages/components/src/date-time/date-picker/styles.ts',
+	'packages/components/src/date-time/date-time/styles.ts',
+	'packages/components/src/date-time/time-picker/styles.ts',
+	'packages/components/src/disabled/styles/disabled-styles.tsx',
+	'packages/components/src/divider/styles.ts',
+	'packages/components/src/dropdown/styles.ts',
+	'packages/components/src/elevation/hook.ts',
+	'packages/components/src/elevation/styles.ts',
+	'packages/components/src/flex/flex-item/hook.ts',
+	'packages/components/src/flex/flex/hook.ts',
+	'packages/components/src/flex/styles.ts',
+	'packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts',
+	'packages/components/src/focal-point-picker/styles/focal-point-style.ts',
+	'packages/components/src/font-size-picker/styles.ts',
+	'packages/components/src/form-token-field/styles.ts',
+	'packages/components/src/grid/hook.ts',
+	'packages/components/src/input-control/styles/input-control-styles.tsx',
+	'packages/components/src/item-group/styles.ts',
+	'packages/components/src/menu/stories/index.story.tsx',
+	'packages/components/src/menu/styles.ts',
+	'packages/components/src/navigator/styles.ts',
+	'packages/components/src/number-control/styles/number-control-styles.ts',
+	'packages/components/src/palette-edit/styles.ts',
+	'packages/components/src/progress-bar/styles.ts',
+	'packages/components/src/range-control/styles/range-control-styles.ts',
+	'packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.ts',
+	'packages/components/src/scrollable/styles.ts',
+	'packages/components/src/search-control/styles.ts',
+	'packages/components/src/select-control/styles/select-control-styles.ts',
+	'packages/components/src/spacer/hook.ts',
+	'packages/components/src/spinner/styles.ts',
+	'packages/components/src/style-provider/index.tsx',
+	'packages/components/src/surface/styles.ts',
+	'packages/components/src/tabs/styles.ts',
+	'packages/components/src/text/hook.ts',
+	'packages/components/src/text/styles.ts',
+	'packages/components/src/textarea-control/styles/textarea-control-styles.ts',
+	'packages/components/src/theme/styles.ts',
+	'packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts',
+	'packages/components/src/toggle-group-control/toggle-group-control/styles.ts',
+	'packages/components/src/tools-panel/stories/index.story.tsx',
+	'packages/components/src/tools-panel/styles.ts',
+	'packages/components/src/truncate/hook.ts',
+	'packages/components/src/truncate/styles.ts',
+	'packages/components/src/unit-control/styles/unit-control-styles.ts',
+	'packages/components/src/utils/base-label.ts',
+	'packages/components/src/utils/box-sizing.ts',
+	'packages/components/src/utils/hooks/emotion.d.ts',
+	'packages/components/src/utils/hooks/test/use-cx.js',
+	'packages/components/src/utils/hooks/use-cx.ts',
+	'packages/components/src/utils/rtl.js',
+	'packages/components/src/view/component.tsx',
+	'packages/components/src/z-stack/styles.ts',
+];
+
+const componentsSourceRestrictedImports = [
+	...restrictedImports.filter(
+		( { name } ) =>
+			! [
+				'@ariakit/react',
+				'framer-motion',
+				...componentsEmotionImports.map(
+					( { name: emotionPackage } ) => emotionPackage
+				),
+			].includes( name )
+	),
+	...componentsEmotionImports,
+];
+
 // Common `no-restricted-imports` configuration for `@wordpress/ui` paths,
 // which occur across multiple override configs. The exclusion here allows
 // Base UI to be imported directly in `@wordpress/ui`, which is the intended
@@ -668,6 +766,21 @@ export default dedupePlugins( [
 								name
 							)
 					),
+				},
+			],
+		},
+	},
+
+	// Override: Components src — prevent new Emotion usage while existing
+	// Emotion styles are migrated incrementally.
+	{
+		files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
+		ignores: componentsEmotionMigrationAllowlist,
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					paths: componentsSourceRestrictedImports,
 				},
 			],
 		},

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -627,6 +627,71 @@
 			"count": 1
 		}
 	},
+	"packages/components/src/base-control/styles/base-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/border-box-control/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/border-control/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/box-control/styles/box-control-icon-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/box-control/styles/box-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/card/card/component.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/card/get-padding-by-size.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/card/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/color-palette/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/color-picker/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/combobox-control/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/confirm-dialog/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/context/test/context-system-provider.js": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx": {
 		"react-hooks/refs": {
 			"count": 1
@@ -637,8 +702,88 @@
 			"count": 1
 		}
 	},
+	"packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/custom-select-control-v2/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/date-time/date-picker/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/date-time/date-time/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/date-time/time-picker/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/disabled/styles/disabled-styles.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/divider/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
 	"packages/components/src/draggable/index.tsx": {
 		"react-hooks/refs": {
+			"count": 1
+		}
+	},
+	"packages/components/src/dropdown/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/elevation/hook.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/elevation/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/flex/flex-item/hook.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/flex/flex/hook.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/flex/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/focal-point-picker/styles/focal-point-style.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/font-size-picker/styles.ts": {
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -647,14 +792,59 @@
 			"count": 1
 		}
 	},
+	"packages/components/src/form-token-field/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/grid/hook.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/components/src/input-control/input-field.tsx": {
 		"react-hooks/immutability": {
 			"count": 2
 		}
 	},
+	"packages/components/src/input-control/styles/input-control-styles.tsx": {
+		"no-restricted-imports": {
+			"count": 3
+		}
+	},
+	"packages/components/src/item-group/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/menu/stories/index.story.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/menu/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/navigator/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/components/src/number-control/index.tsx": {
 		"react-hooks/refs": {
 			"count": 2
+		}
+	},
+	"packages/components/src/number-control/styles/number-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/palette-edit/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/components/src/panel/body.tsx": {
@@ -667,6 +857,11 @@
 			"count": 1
 		}
 	},
+	"packages/components/src/progress-bar/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
 	"packages/components/src/range-control/index.tsx": {
 		"react-hooks/immutability": {
 			"count": 3
@@ -675,8 +870,88 @@
 			"count": 4
 		}
 	},
+	"packages/components/src/range-control/styles/range-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/scrollable/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/search-control/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/select-control/styles/select-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
 	"packages/components/src/slot-fill/slot.tsx": {
 		"react-hooks/refs": {
+			"count": 1
+		}
+	},
+	"packages/components/src/spacer/hook.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/spinner/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/style-provider/index.tsx": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/surface/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/tabs/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/text/hook.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/text/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/textarea-control/styles/textarea-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/theme/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/toggle-group-control/toggle-group-control/styles.ts": {
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -690,6 +965,16 @@
 			"count": 1
 		}
 	},
+	"packages/components/src/tools-panel/stories/index.story.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/tools-panel/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
 	"packages/components/src/tools-panel/tools-panel/hook.ts": {
 		"react-hooks/refs": {
 			"count": 2
@@ -698,6 +983,61 @@
 	"packages/components/src/tree-grid/cell.tsx": {
 		"react-hooks/refs": {
 			"count": 1
+		}
+	},
+	"packages/components/src/truncate/hook.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/truncate/styles.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/unit-control/styles/unit-control-styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
+		}
+	},
+	"packages/components/src/utils/base-label.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/utils/box-sizing.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/utils/hooks/emotion.d.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/utils/hooks/test/use-cx.js": {
+		"no-restricted-imports": {
+			"count": 3
+		}
+	},
+	"packages/components/src/utils/hooks/use-cx.ts": {
+		"no-restricted-imports": {
+			"count": 4
+		}
+	},
+	"packages/components/src/utils/rtl.js": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/view/component.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/z-stack/styles.ts": {
+		"no-restricted-imports": {
+			"count": 2
 		}
 	},
 	"packages/compose/src/hooks/use-dialog/index.ts": {


### PR DESCRIPTION
## What?

Part of #66806.

Adds the first set of docs and lint guardrails for migrating `@wordpress/components` away from Emotion.

## Why?
New component styles should use the existing SCSS Modules pattern while the current Emotion usage is migrated incrementally. This prevents the migration backlog from growing.

## How?
- Updates `packages/components/CONTRIBUTING.md` to recommend SCSS Modules and `clsx` for new component-local styles.
- Documents CSS custom properties for dynamic values and conditional CSS Module classes for variants/state.
- Replaces the Emotion-based deprecation styling example with a SCSS Modules example.
- Adds a `packages/components/src` import guard that blocks new `@emotion/*` imports while temporarily allowlisting current Emotion files.

## Testing Instructions
1. Run `npm run lint:md:docs -- packages/components/CONTRIBUTING.md`.
2. Run `npm run lint:js -- tools/eslint/config.mjs`.
3. Run `npm run lint:js -- packages/components/src --pass-on-unpruned-suppressions`.
4. Optionally add a new `@emotion/react` import to a non-allowlisted file under `packages/components/src` and confirm linting reports it.

### Testing Instructions for Keyboard
Not applicable; this PR only changes documentation and lint rules.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Drafted with assistance from ChatGPT/Codex. The changes were reviewed before opening this PR.
