### PR TITLE
Components: migrate View away from Emotion

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -98,13 +98,6 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.emotion-18 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 <div>
   <div
     class="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -22,6 +22,9 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -36,11 +39,11 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-height: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   font-size: 11px;
   font-weight: 499;
   line-height: 1.4;
@@ -50,11 +53,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   padding: 0;
 }
 
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.emotion-10 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -69,15 +68,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.emotion-8>* {
-  min-height: 0;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.emotion-13 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -92,15 +83,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.emotion-10>* {
-  min-height: 0;
-}
-
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.emotion-16 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -115,8 +98,11 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.emotion-12>* {
-  min-height: 0;
+.emotion-18 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 <div>
@@ -130,7 +116,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
         class="block-editor-color-gradient-control__fieldset"
       >
         <div
-          class="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
+          class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack components-v-stack"
           data-wp-c16t="true"
           data-wp-component="VStack"
         >
@@ -139,7 +125,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               class="block-editor-color-gradient-control__color-indicator"
             >
               <span
-                class="components-base-control__label emotion-6 emotion-7"
+                class="components-base-control__label emotion-7 emotion-8"
               >
                 Test Color
               </span>
@@ -149,7 +135,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             class="block-editor-color-gradient-control__panel"
           >
             <div
-              class="components-flex components-h-stack components-v-stack emotion-8 emotion-5"
+              class="emotion-4 emotion-10 emotion-6 components-flex components-h-stack components-v-stack"
               data-wp-c16t="true"
               data-wp-component="VStack"
             >
@@ -158,7 +144,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                 tabindex="-1"
               >
                 <div
-                  class="components-flex components-h-stack components-v-stack components-color-palette__custom-color-wrapper emotion-10 emotion-5"
+                  class="emotion-4 emotion-13 emotion-6 components-flex components-h-stack components-v-stack components-color-palette__custom-color-wrapper"
                   data-wp-c16t="true"
                   data-wp-component="VStack"
                 >
@@ -171,19 +157,19 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                     type="button"
                   />
                   <div
-                    class="components-flex components-h-stack components-v-stack components-color-palette__custom-color-text-wrapper emotion-12 emotion-5"
+                    class="emotion-4 emotion-16 emotion-6 components-flex components-h-stack components-v-stack components-color-palette__custom-color-text-wrapper"
                     data-wp-c16t="true"
                     data-wp-component="VStack"
                   >
                     <span
-                      class="style-truncate components-truncate components-color-palette__custom-color-name emotion-14 emotion-5"
+                      class="style-truncate components-truncate components-color-palette__custom-color-name"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >
                       red
                     </span>
                     <span
-                      class="style-truncate components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex emotion-14 emotion-5"
+                      class="style-truncate components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -38,7 +38,7 @@
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   `Surface`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#79445](https://github.com/WordPress/gutenberg/pull/79445)).
 -   `Truncate`: Migrate styles from Emotion to SCSS Modules ([#79446](https://github.com/WordPress/gutenberg/pull/79446)).
--   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
+-   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior and style cascade order ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
 
 ## 36.0.0 (2026-06-24)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -62,6 +62,7 @@
 -   `ResizableBox`: Make the `children` prop optional ([#79370](https://github.com/WordPress/gutenberg/pull/79370)).
 -   Add documentation and lint guardrails for the ongoing Emotion migration ([#79442](https://github.com/WordPress/gutenberg/pull/79442)).
 -   `Divider`: Migrate styles from Emotion to SCSS Modules ([#79444](https://github.com/WordPress/gutenberg/pull/79444)).
+-   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
 -   Point the legacy `--wp-components-*` color fallbacks at the design system tokens (`--wpds-*` / `--wp-admin-theme-color*`), so component styles get sensible defaults from the prebuilt token stylesheet without a runtime `<ThemeProvider>` ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 -   `withFallbackStyles`: Refactor from a class component to a function component with hooks ([#78837](https://github.com/WordPress/gutenberg/pull/78837)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 -   `ExternalLink`: No longer sets the `rel` attribute by default. Consumers relying on the previous behavior should pass `rel` explicitly ([#79743](https://github.com/WordPress/gutenberg/pull/79743)).
 -   `View`: The legacy Emotion `css` prop no longer applies styles and is now accepted as a no-op for compatibility. Use `style` for inline styles or `className` for CSS-based styling instead ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
+-   Components that compose Emotion style fragments with `cx()` should pass source-order-dependent fragments in a single `css()` call. Passing separate fragments can change override order after the following components stopped rendering styles through Emotion:
+    -   `Truncate` ([#79446](https://github.com/WordPress/gutenberg/pull/79446))
+    -   `Divider` ([#79444](https://github.com/WordPress/gutenberg/pull/79444))
+    -   `Surface` ([#79445](https://github.com/WordPress/gutenberg/pull/79445))
+    -   `View` ([#79443](https://github.com/WordPress/gutenberg/pull/79443))
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
     -   `BorderBoxControl` ([#79420](https://github.com/WordPress/gutenberg/pull/79420))
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -38,6 +38,7 @@
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   `Surface`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#79445](https://github.com/WordPress/gutenberg/pull/79445)).
 -   `Truncate`: Migrate styles from Emotion to SCSS Modules ([#79446](https://github.com/WordPress/gutenberg/pull/79446)).
+-   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
 
 ## 36.0.0 (2026-06-24)
 
@@ -62,7 +63,6 @@
 -   `ResizableBox`: Make the `children` prop optional ([#79370](https://github.com/WordPress/gutenberg/pull/79370)).
 -   Add documentation and lint guardrails for the ongoing Emotion migration ([#79442](https://github.com/WordPress/gutenberg/pull/79442)).
 -   `Divider`: Migrate styles from Emotion to SCSS Modules ([#79444](https://github.com/WordPress/gutenberg/pull/79444)).
--   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
 -   Adopt `--wpds-dimension-size-*` design tokens [#79093](https://github.com/WordPress/gutenberg/pull/79093).
 -   Point the legacy `--wp-components-*` color fallbacks at the design system tokens (`--wpds-*` / `--wp-admin-theme-color*`), so component styles get sensible defaults from the prebuilt token stylesheet without a runtime `<ThemeProvider>` ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 -   `withFallbackStyles`: Refactor from a class component to a function component with hooks ([#78837](https://github.com/WordPress/gutenberg/pull/78837)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   `ExternalLink`: No longer sets the `rel` attribute by default. Consumers relying on the previous behavior should pass `rel` explicitly ([#79743](https://github.com/WordPress/gutenberg/pull/79743)).
+-   `View`: The legacy Emotion `css` prop no longer applies styles and is now accepted as a no-op for compatibility. Use `style` for inline styles or `className` for CSS-based styling instead ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
     -   `BorderBoxControl` ([#79420](https://github.com/WordPress/gutenberg/pull/79420))
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -130,10 +130,11 @@ export function useBorderControl(
 		wrapperWidth = '116px';
 	}
 	const innerWrapperClassName = useMemo( () => {
-		const widthStyle = !! wrapperWidth && styles.wrapperWidth;
-		const heightStyle = styles.wrapperHeight;
-
-		return cx( styles.innerWrapper(), widthStyle, heightStyle );
+		return cx(
+			styles.getInnerWrapperStyles( {
+				hasWidth: !! wrapperWidth,
+			} )
+		);
 	}, [ wrapperWidth, cx ] );
 
 	const sliderClassName = useMemo( () => {

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -53,16 +53,8 @@ export const wrapperHeight = css`
 	height: 40px;
 `;
 
-export function getInnerWrapperStyles( {
-	hasWidth,
-}: {
-	hasWidth: boolean;
-} ) {
-	return css(
-		innerWrapper(),
-		hasWidth && wrapperWidth,
-		wrapperHeight
-	);
+export function getInnerWrapperStyles( { hasWidth }: { hasWidth: boolean } ) {
+	return css( innerWrapper(), hasWidth && wrapperWidth, wrapperHeight );
 }
 
 export const borderControlDropdown = css`

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -53,6 +53,18 @@ export const wrapperHeight = css`
 	height: 40px;
 `;
 
+export function getInnerWrapperStyles( {
+	hasWidth,
+}: {
+	hasWidth: boolean;
+} ) {
+	return css(
+		innerWrapper(),
+		hasWidth && wrapperWidth,
+		wrapperHeight
+	);
+}
+
 export const borderControlDropdown = css`
 	background: #fff;
 

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -14,6 +14,8 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import { BorderControl } from '../';
+import * as styles from '../styles';
+import { useCx } from '../../utils/hooks/use-cx';
 
 const colors = [
 	{ name: 'Gray', color: '#f6f7f7' },
@@ -80,6 +82,19 @@ function TestBorderControl( restProps ) {
 	return <BorderControl { ...restProps } />;
 }
 
+const getGeneratedEmotionClassNames = ( element ) =>
+	Array.from( element.classList ).filter( ( className ) =>
+		/^(css|emotion)-/.test( className )
+	);
+
+function EmotionStyleTest( { styleFragment } ) {
+	const cx = useCx();
+
+	return (
+		<div data-testid="emotion-style" className={ cx( styleFragment ) } />
+	);
+}
+
 describe( 'BorderControl', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render standard border control', () => {
@@ -123,6 +138,22 @@ describe( 'BorderControl', () => {
 
 			const slider = getSliderInput();
 			expect( slider ).toBeInTheDocument();
+		} );
+
+		it( 'should compose inner wrapper width and height styles in a single generated class', () => {
+			render(
+				<EmotionStyleTest
+					styleFragment={ styles.getInnerWrapperStyles( {
+						hasWidth: true,
+					} ) }
+				/>
+			);
+
+			expect(
+				getGeneratedEmotionClassNames(
+					screen.getByTestId( 'emotion-style' )
+				)
+			).toHaveLength( 1 );
 		} );
 
 		it( 'should render placeholder in UnitControl', () => {

--- a/packages/components/src/card/card-footer/hook.ts
+++ b/packages/components/src/card/card-footer/hook.ts
@@ -11,7 +11,6 @@ import { useContextSystem } from '../../context';
 import * as styles from '../styles';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { FooterProps } from '../types';
-import { getPaddingBySize } from '../get-padding-by-size';
 
 export function useCardFooter(
 	props: WordPressComponentProps< FooterProps, 'div' >
@@ -27,21 +26,18 @@ export function useCardFooter(
 
 	const cx = useCx();
 
-	const classes = useMemo(
-		() =>
-			cx(
-				styles.Footer,
-				styles.borderRadius,
-				styles.borderColor,
-				getPaddingBySize( size ),
-				isBorderless && styles.borderless,
-				isShady && styles.shady,
-				// This classname is added for legacy compatibility reasons.
-				'components-card__footer',
-				className
-			),
-		[ className, cx, isBorderless, isShady, size ]
-	);
+	const classes = useMemo( () => {
+		return cx(
+			styles.getCardFooterStyles( {
+				isBorderless,
+				isShady,
+				size,
+			} ),
+			// This classname is added for legacy compatibility reasons.
+			'components-card__footer',
+			className
+		);
+	}, [ className, cx, isBorderless, isShady, size ] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/card/card-header/hook.ts
+++ b/packages/components/src/card/card-header/hook.ts
@@ -11,7 +11,6 @@ import { useContextSystem } from '../../context';
 import * as styles from '../styles';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { HeaderProps } from '../types';
-import { getPaddingBySize } from '../get-padding-by-size';
 
 export function useCardHeader(
 	props: WordPressComponentProps< HeaderProps, 'div' >
@@ -26,21 +25,18 @@ export function useCardHeader(
 
 	const cx = useCx();
 
-	const classes = useMemo(
-		() =>
-			cx(
-				styles.Header,
-				styles.borderRadius,
-				styles.borderColor,
-				getPaddingBySize( size ),
-				isBorderless && styles.borderless,
-				isShady && styles.shady,
-				// This classname is added for legacy compatibility reasons.
-				'components-card__header',
-				className
-			),
-		[ className, cx, isBorderless, isShady, size ]
-	);
+	const classes = useMemo( () => {
+		return cx(
+			styles.getCardHeaderStyles( {
+				isBorderless,
+				isShady,
+				size,
+			} ),
+			// This classname is added for legacy compatibility reasons.
+			'components-card__header',
+			className
+		);
+	}, [ className, cx, isBorderless, isShady, size ] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/card/card/hook.ts
+++ b/packages/components/src/card/card/hook.ts
@@ -57,9 +57,10 @@ export function useCard( props: CardProps ) {
 
 	const classes = useMemo( () => {
 		return cx(
-			styles.Card,
-			isBorderless && styles.boxShadowless,
-			isRounded && styles.rounded,
+			styles.getCardStyles( {
+				isBorderless,
+				isRounded,
+			} ),
 			className
 		);
 	}, [ className, cx, isBorderless, isRounded ] );

--- a/packages/components/src/card/styles.ts
+++ b/packages/components/src/card/styles.ts
@@ -7,6 +7,8 @@ import { css } from '@emotion/react';
  * Internal dependencies
  */
 import { COLORS, CONFIG } from '../utils';
+import { getPaddingBySize } from './get-padding-by-size';
+import type { FooterProps, HeaderProps, Props } from './types';
 
 // Since the border for `Card` is rendered via the `box-shadow` property
 // (as opposed to the `border` property), the value of the border radius needs
@@ -97,3 +99,50 @@ export const rounded = css`
 export const shady = css`
 	background-color: ${ COLORS.ui.backgroundDisabled };
 `;
+
+export function getCardStyles( {
+	isBorderless,
+	isRounded,
+}: Pick< Props, 'isBorderless' | 'isRounded' > ) {
+	const cardStyles = css(
+		Card,
+		isBorderless && boxShadowless,
+		isRounded && rounded
+	);
+
+	return cardStyles;
+}
+
+export function getCardHeaderStyles( {
+	isBorderless,
+	isShady,
+	size,
+}: Pick< HeaderProps, 'isBorderless' | 'isShady' | 'size' > ) {
+	const headerStyles = css(
+		Header,
+		borderRadius,
+		borderColor,
+		getPaddingBySize( size ),
+		isBorderless && borderless,
+		isShady && shady
+	);
+
+	return headerStyles;
+}
+
+export function getCardFooterStyles( {
+	isBorderless,
+	isShady,
+	size,
+}: Pick< FooterProps, 'isBorderless' | 'isShady' | 'size' > ) {
+	const footerStyles = css(
+		Footer,
+		borderRadius,
+		borderColor,
+		getPaddingBySize( size ),
+		isBorderless && borderless,
+		isShady && shady
+	);
+
+	return footerStyles;
+}

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -8,8 +8,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-card__body components-card-body css-1gg1viu-PolymorphicDiv-Body-borderRadius-medium e19lxcc00"
-+     class="components-scrollable components-card__body components-card-body css-9p6d97-PolymorphicDiv-Scrollable-scrollableScrollbar-scrollY-Body-borderRadius-medium e19lxcc00"
+-     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++     class="css-drdujb-Scrollable css-9laccq-scrollableScrollbar css-flie1-scrollY components-scrollable css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
       data-wp-c16t="true"
       data-wp-component="CardBody"
     >
@@ -25,8 +25,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-card__body components-card-body css-1gg1viu-PolymorphicDiv-Body-borderRadius-medium e19lxcc00"
-+     class="components-card__body components-card-body css-1jxruy0-PolymorphicDiv-Body-borderRadius-medium-shady e19lxcc00"
+-     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium css-1hzhpw5-shady components-card__body components-card-body"
       data-wp-c16t="true"
       data-wp-component="CardBody"
     >
@@ -42,8 +42,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-flex components-card__footer components-card-footer css-1s5uzde-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-medium e19lxcc00"
-+     class="components-flex components-card__footer components-card-footer css-1nz7z3h-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-medium-shady e19lxcc00"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
++     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium css-1hzhpw5-shady components-card__footer components-card-footer"
       data-wp-c16t="true"
       data-wp-component="CardFooter"
     >
@@ -59,8 +59,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-flex components-card__footer components-card-footer css-1s5uzde-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-medium e19lxcc00"
-+     class="components-flex components-card__footer components-card-footer css-11v2u4y-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-medium e19lxcc00"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
++     class="css-a57899-Flex css-qs9i8n-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
       data-wp-c16t="true"
       data-wp-component="CardFooter"
     >
@@ -76,8 +76,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-flex components-card__header components-card-header css-1hlwlpa-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-medium e19lxcc00"
-+     class="components-flex components-card__header components-card-header css-zom6gv-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-medium-shady e19lxcc00"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__header components-card-header"
++     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium css-1hzhpw5-shady components-card__header components-card-header"
       data-wp-c16t="true"
       data-wp-component="CardHeader"
     >
@@ -93,19 +93,19 @@ Snapshot Diff:
 @@ -6,18 +6,18 @@
     >
       <div
-        class="css-1yddrvs-PolymorphicDiv-Content e19lxcc00"
+        class="css-1ruapvy-Content"
       >
         <div
--         class="components-flex components-card__header components-card-header css-1hlwlpa-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-medium e19lxcc00"
-+         class="components-flex components-card__header components-card-header css-dxbfrz-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-large e19lxcc00"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="components-card__body components-card-body css-1gg1viu-PolymorphicDiv-Body-borderRadius-medium e19lxcc00"
-+         class="components-card__body components-card-body css-16631vj-PolymorphicDiv-Body-borderRadius-large e19lxcc00"
+-         class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
@@ -120,10 +120,12 @@ Snapshot Diff:
 
   Array [
     Object {
--     "border-radius": "calc(8px - 1px)",
       "box-shadow": "0 0 0 1px rgba(0, 0, 0, 0.1)",
       "outline": "none",
     },
+-   Object {
+-     "border-radius": "calc(8px - 1px)",
+-   },
   ]
 `;
 
@@ -135,27 +137,27 @@ Snapshot Diff:
 @@ -6,25 +6,25 @@
     >
       <div
-        class="css-1yddrvs-PolymorphicDiv-Content e19lxcc00"
+        class="css-1ruapvy-Content"
       >
         <div
--         class="components-flex components-card__header components-card-header css-1qrvb07-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-large-borderless e19lxcc00"
-+         class="components-flex components-card__header components-card-header css-nhtehb-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-small e19lxcc00"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="components-card__body components-card-body css-16631vj-PolymorphicDiv-Body-borderRadius-large e19lxcc00"
-+         class="components-card__body components-card-body css-1gg1viu-PolymorphicDiv-Body-borderRadius-medium e19lxcc00"
+-         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
++         class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
           Body
         </div>
         <div
--         class="components-flex components-card__footer components-card-footer css-ny5e27-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-large-borderless e19lxcc00"
-+         class="components-flex components-card__footer components-card-footer css-1isabr8-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-xSmallCardPadding e19lxcc00"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__footer components-card-footer"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-v01qju-xSmallCardPadding components-card__footer components-card-footer"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -171,33 +173,33 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="style-surface components-surface components-card css-1hgll2p-PolymorphicDiv-Card-boxShadowless-rounded e19lxcc00"
-+     class="style-surface components-surface components-card css-11ld97d-PolymorphicDiv-Card-rounded e19lxcc00"
+-     class="style-surface components-surface css-1jzuy0h-Card css-14zofrl-boxShadowless css-zqt9u2-rounded components-card"
++     class="style-surface components-surface css-1jzuy0h-Card css-zqt9u2-rounded components-card"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
       <div
-        class="css-1yddrvs-PolymorphicDiv-Content e19lxcc00"
+        class="css-1ruapvy-Content"
       >
         <div
--         class="components-flex components-card__header components-card-header css-1qrvb07-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-large-borderless e19lxcc00"
-+         class="components-flex components-card__header components-card-header css-nhtehb-PolymorphicDiv-Flex-base-ItemsRow-Header-borderRadius-borderColor-small e19lxcc00"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="components-card__body components-card-body css-16631vj-PolymorphicDiv-Body-borderRadius-large e19lxcc00"
-+         class="components-card__body components-card-body css-be2ezs-PolymorphicDiv-Body-borderRadius-small e19lxcc00"
+-         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
++         class="css-1klm29z-Body css-1qegus6-borderRadius css-5swhss-small components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
           Body
         </div>
         <div
--         class="components-flex components-card__footer components-card-footer css-ny5e27-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-large-borderless e19lxcc00"
-+         class="components-flex components-card__footer components-card-footer css-wpxcc4-PolymorphicDiv-Flex-base-ItemsRow-Footer-borderRadius-borderColor-small e19lxcc00"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__footer components-card-footer"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__footer components-card-footer"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -209,6 +211,9 @@ exports[`Card Card component should render correctly 1`] = `
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
+}
+
+.emotion-1 {
   border-radius: calc(8px - 1px);
 }
 
@@ -216,11 +221,14 @@ exports[`Card Card component should render correctly 1`] = `
   height: 100%;
 }
 
-.emotion-4 {
+.emotion-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -233,128 +241,83 @@ exports[`Card Card component should render correctly 1`] = `
   -webkit-justify-content: space-between;
   justify-content: space-between;
   width: 100%;
-  border-bottom: 1px solid;
-  box-sizing: border-box;
-  border-color: rgba(0, 0, 0, 0.1);
-  padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-4>* {
+.emotion-5>* {
   min-width: 0;
 }
 
-.emotion-4:last-child {
+.emotion-6 {
+  border-bottom: 1px solid;
+  box-sizing: border-box;
+}
+
+.emotion-6:last-child {
   border-bottom: none;
 }
 
-.emotion-4:first-of-type {
+.emotion-7:first-of-type {
   border-top-left-radius: calc(8px - 1px);
   border-top-right-radius: calc(8px - 1px);
 }
 
-.emotion-4:last-of-type {
+.emotion-7:last-of-type {
   border-bottom-left-radius: calc(8px - 1px);
   border-bottom-right-radius: calc(8px - 1px);
 }
 
-.emotion-6 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
+.emotion-8 {
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.emotion-9 {
   padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-6:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-6:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
 .emotion-10 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
+}
+
+.emotion-16 {
   box-sizing: border-box;
   display: block;
   width: 100%;
 }
 
-.emotion-11 {
-  border-color: rgba(0, 0, 0, 0.1);
-}
-
-.emotion-14 {
+.emotion-21 {
   box-sizing: border-box;
   overflow: hidden;
 }
 
-.emotion-14>img,
-.emotion-14>iframe {
+.emotion-21>img,
+.emotion-21>iframe {
   display: block;
   height: auto;
   max-width: 100%;
   width: 100%;
 }
 
-.emotion-14:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-14:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
+.emotion-26 {
   border-top: 1px solid;
   box-sizing: border-box;
-  border-color: rgba(0, 0, 0, 0.1);
-  padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-16>* {
-  min-width: 0;
-}
-
-.emotion-16:first-of-type {
+.emotion-26:first-of-type {
   border-top: none;
 }
 
-.emotion-16:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-16:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-18 {
+.emotion-30 {
   background: transparent;
   display: block;
   margin: 0!important;
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-31 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -362,14 +325,17 @@ exports[`Card Card component should render correctly 1`] = `
   left: 0;
   right: 0;
   top: 0;
-  border-radius: 8px;
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-18 {
+  .emotion-31 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
+}
+
+.emotion-32 {
+  border-radius: 8px;
 }
 
 <div>
@@ -379,24 +345,24 @@ exports[`Card Card component should render correctly 1`] = `
     data-wp-component="Card"
   >
     <div
-      class="emotion-2 emotion-1"
+      class="emotion-2"
     >
       <div
-        class="components-flex components-card__header components-card-header emotion-4 emotion-1"
+        class="emotion-3 emotion-4 emotion-5 components-flex emotion-6 emotion-7 emotion-8 emotion-9 components-card__header components-card-header"
         data-wp-c16t="true"
         data-wp-component="CardHeader"
       >
         Card Header
       </div>
       <div
-        class="components-card__body components-card-body emotion-6 emotion-1"
+        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
         Card Body 1
       </div>
       <div
-        class="components-card__body components-card-body emotion-6 emotion-1"
+        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -410,14 +376,14 @@ exports[`Card Card component should render correctly 1`] = `
         role="separator"
       />
       <div
-        class="components-card__body components-card-body emotion-6 emotion-1"
+        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
         Card Body 3
       </div>
       <div
-        class="components-card__media components-card-media emotion-14 emotion-1"
+        class="emotion-21 emotion-7 components-card__media components-card-media"
         data-wp-c16t="true"
         data-wp-component="CardMedia"
       >
@@ -427,7 +393,7 @@ exports[`Card Card component should render correctly 1`] = `
         />
       </div>
       <div
-        class="components-flex components-card__footer components-card-footer emotion-16 emotion-1"
+        class="emotion-3 emotion-4 emotion-5 components-flex emotion-26 emotion-7 emotion-8 emotion-9 components-card__footer components-card-footer"
         data-wp-c16t="true"
         data-wp-component="CardFooter"
       >
@@ -436,13 +402,13 @@ exports[`Card Card component should render correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="components-elevation emotion-18 emotion-1"
+      class="emotion-30 emotion-31 components-elevation emotion-32"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="components-elevation emotion-18 emotion-1"
+      class="emotion-30 emotion-31 components-elevation emotion-32"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
@@ -461,15 +427,15 @@ Snapshot Diff:
       </div>
       <div
         aria-hidden="true"
--       class="components-elevation css-1gw374p-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-+       class="components-elevation css-12og79l-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+-       class="css-1n58bsy-Elevation css-8r3vl0-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
++       class="css-1n58bsy-Elevation css-m0892f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />
       <div
         aria-hidden="true"
--       class="components-elevation css-1570405-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
-+       class="components-elevation css-12og79l-PolymorphicDiv-Elevation-sx-Base-sx-Base-elevationClassName e19lxcc00"
+-       class="css-1n58bsy-Elevation css-1pxaz5f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
++       class="css-1n58bsy-Elevation css-m0892f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />
@@ -486,6 +452,9 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
+}
+
+.emotion-1 {
   border-radius: calc(8px - 1px);
 }
 
@@ -493,13 +462,16 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   height: 100%;
 }
 
-.emotion-4 {
+.emotion-3 {
   background: transparent;
   display: block;
   margin: 0!important;
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-4 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -507,7 +479,6 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   left: 0;
   right: 0;
   top: 0;
-  border-radius: 8px;
 }
 
 @media not ( prefers-reduced-motion ) {
@@ -517,13 +488,11 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   }
 }
 
-.emotion-6 {
-  background: transparent;
-  display: block;
-  margin: 0!important;
-  pointer-events: none;
-  position: absolute;
-  will-change: box-shadow;
+.emotion-5 {
+  border-radius: 8px;
+}
+
+.emotion-7 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
@@ -531,11 +500,10 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   left: 0;
   right: 0;
   top: 0;
-  border-radius: 8px;
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-6 {
+  .emotion-7 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -548,19 +516,19 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
     data-wp-component="Card"
   >
     <div
-      class="emotion-2 emotion-1"
+      class="emotion-2"
     >
       Code is Poetry
     </div>
     <div
       aria-hidden="true"
-      class="components-elevation emotion-4 emotion-1"
+      class="emotion-3 emotion-4 components-elevation emotion-5"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="components-elevation emotion-6 emotion-1"
+      class="emotion-3 emotion-7 components-elevation emotion-5"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -334,9 +334,6 @@ exports[`Card Card component should render correctly 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-24 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -347,13 +344,13 @@ exports[`Card Card component should render correctly 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-.emotion-25 {
+.emotion-24 {
   border-radius: 8px;
 }
 
@@ -421,13 +418,13 @@ exports[`Card Card component should render correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="emotion-23 emotion-24 components-elevation emotion-25"
+      class="emotion-23 components-elevation emotion-24"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="emotion-23 emotion-24 components-elevation emotion-25"
+      class="emotion-23 components-elevation emotion-24"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
@@ -446,15 +443,15 @@ Snapshot Diff:
       </div>
       <div
         aria-hidden="true"
--       class="css-1n58bsy-Elevation css-8r3vl0-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
-+       class="css-1n58bsy-Elevation css-m0892f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
+-       class="css-jirgir-Elevation-sx-Base-sx-Base-elevationStyles components-elevation css-3cgmlt-elevationClassName"
++       class="css-pudyh0-Elevation-sx-Base-sx-Base-elevationStyles components-elevation css-3cgmlt-elevationClassName"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />
       <div
         aria-hidden="true"
--       class="css-1n58bsy-Elevation css-1pxaz5f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
-+       class="css-1n58bsy-Elevation css-m0892f-sx-Base-sx-Base components-elevation css-3cgmlt-elevationClassName"
+-       class="css-12yxda4-Elevation-sx-Base-sx-Base-elevationStyles components-elevation css-3cgmlt-elevationClassName"
++       class="css-pudyh0-Elevation-sx-Base-sx-Base-elevationStyles components-elevation css-3cgmlt-elevationClassName"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />
@@ -485,9 +482,6 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-3 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -498,17 +492,23 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-3 {
+  .emotion-2 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-.emotion-4 {
+.emotion-3 {
   border-radius: 8px;
 }
 
-.emotion-6 {
+.emotion-4 {
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
@@ -519,7 +519,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-6 {
+  .emotion-4 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -538,13 +538,13 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
     </div>
     <div
       aria-hidden="true"
-      class="emotion-2 emotion-3 components-elevation emotion-4"
+      class="emotion-2 components-elevation emotion-3"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="emotion-2 emotion-6 components-elevation emotion-4"
+      class="emotion-4 components-elevation emotion-3"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -8,8 +8,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
-+     class="css-drdujb-Scrollable css-9laccq-scrollableScrollbar css-flie1-scrollY components-scrollable css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
+-     class="css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++     class="css-drdujb-Scrollable css-9laccq-scrollableScrollbar css-flie1-scrollY components-scrollable css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium components-card__body components-card-body"
       data-wp-c16t="true"
       data-wp-component="CardBody"
     >
@@ -25,8 +25,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
-+     class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium css-1hzhpw5-shady components-card__body components-card-body"
+-     class="css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++     class="css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium css-1284mxe-shady components-card__body components-card-body"
       data-wp-c16t="true"
       data-wp-component="CardBody"
     >
@@ -42,8 +42,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
-+     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium css-1hzhpw5-shady components-card__footer components-card-footer"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-14ezg3c-Footer-borderRadius-borderColor-medium-footerStyles components-card__footer components-card-footer"
++     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-zu9yjw-Footer-borderRadius-borderColor-medium-shady-footerStyles components-card__footer components-card-footer"
       data-wp-c16t="true"
       data-wp-component="CardFooter"
     >
@@ -59,8 +59,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
-+     class="css-a57899-Flex css-qs9i8n-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__footer components-card-footer"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-14ezg3c-Footer-borderRadius-borderColor-medium-footerStyles components-card__footer components-card-footer"
++     class="css-a57899-Flex css-qs9i8n-base css-1ozeagb-ItemsRow components-flex css-14ezg3c-Footer-borderRadius-borderColor-medium-footerStyles components-card__footer components-card-footer"
       data-wp-c16t="true"
       data-wp-component="CardFooter"
     >
@@ -76,8 +76,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__header components-card-header"
-+     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium css-1hzhpw5-shady components-card__header components-card-header"
+-     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-knjbwb-Header-borderRadius-borderColor-medium-headerStyles components-card__header components-card-header"
++     class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1e8qxyk-Header-borderRadius-borderColor-medium-shady-headerStyles components-card__header components-card-header"
       data-wp-c16t="true"
       data-wp-component="CardHeader"
     >
@@ -96,16 +96,16 @@ Snapshot Diff:
         class="css-1ruapvy-Content"
       >
         <div
--         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-2ktc4y-medium components-card__header components-card-header"
-+         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large components-card__header components-card-header"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-knjbwb-Header-borderRadius-borderColor-medium-headerStyles components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1to91lo-Header-borderRadius-borderColor-large-headerStyles components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
-+         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
+-         class="css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium components-card__body components-card-body"
++         class="css-1klm29z-Body css-156bl4t-borderRadius css-1url6g9-large components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
@@ -120,12 +120,10 @@ Snapshot Diff:
 
   Array [
     Object {
+-     "border-radius": "calc(8px - 1px)",
       "box-shadow": "0 0 0 1px rgba(0, 0, 0, 0.1)",
       "outline": "none",
     },
--   Object {
--     "border-radius": "calc(8px - 1px)",
--   },
   ]
 `;
 
@@ -140,24 +138,24 @@ Snapshot Diff:
         class="css-1ruapvy-Content"
       >
         <div
--         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__header components-card-header"
-+         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__header components-card-header"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1knfgzz-Header-borderRadius-borderColor-large-borderless-headerStyles components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-utqozr-Header-borderRadius-borderColor-small-headerStyles components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
-+         class="css-1klm29z-Body css-1qegus6-borderRadius css-2ktc4y-medium components-card__body components-card-body"
+-         class="css-1klm29z-Body css-156bl4t-borderRadius css-1url6g9-large components-card__body components-card-body"
++         class="css-1klm29z-Body css-156bl4t-borderRadius css-2ktc4y-medium components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
           Body
         </div>
         <div
--         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__footer components-card-footer"
-+         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-v01qju-xSmallCardPadding components-card__footer components-card-footer"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-jtu0fc-Footer-borderRadius-borderColor-large-borderless-footerStyles components-card__footer components-card-footer"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-egj1bt-Footer-borderRadius-borderColor-xSmallCardPadding-footerStyles components-card__footer components-card-footer"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -173,8 +171,8 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="style-surface components-surface css-1jzuy0h-Card css-14zofrl-boxShadowless css-zqt9u2-rounded components-card"
-+     class="style-surface components-surface css-1jzuy0h-Card css-zqt9u2-rounded components-card"
+-     class="style-surface components-surface css-2wm9l0-Card-boxShadowless-rounded-cardStyles components-card"
++     class="style-surface components-surface css-9kgksu-Card-rounded-cardStyles components-card"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -182,24 +180,24 @@ Snapshot Diff:
         class="css-1ruapvy-Content"
       >
         <div
--         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__header components-card-header"
-+         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-euqiwd-Header css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__header components-card-header"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1knfgzz-Header-borderRadius-borderColor-large-borderless-headerStyles components-card__header components-card-header"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-utqozr-Header-borderRadius-borderColor-small-headerStyles components-card__header components-card-header"
           data-wp-c16t="true"
           data-wp-component="CardHeader"
         >
           Header
         </div>
         <div
--         class="css-1klm29z-Body css-1qegus6-borderRadius css-1url6g9-large components-card__body components-card-body"
-+         class="css-1klm29z-Body css-1qegus6-borderRadius css-5swhss-small components-card__body components-card-body"
+-         class="css-1klm29z-Body css-156bl4t-borderRadius css-1url6g9-large components-card__body components-card-body"
++         class="css-1klm29z-Body css-156bl4t-borderRadius css-5swhss-small components-card__body components-card-body"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
           Body
         </div>
         <div
--         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-1url6g9-large css-kyy9w8-borderless components-card__footer components-card-footer"
-+         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-1rianq6-Footer css-1qegus6-borderRadius css-172gaya-borderColor css-5swhss-small components-card__footer components-card-footer"
+-         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-jtu0fc-Footer-borderRadius-borderColor-large-borderless-footerStyles components-card__footer components-card-footer"
++         class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex css-zrnqar-Footer-borderRadius-borderColor-small-footerStyles components-card__footer components-card-footer"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -211,24 +209,21 @@ exports[`Card Card component should render correctly 1`] = `
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
-}
-
-.emotion-1 {
   border-radius: calc(8px - 1px);
 }
 
-.emotion-2 {
+.emotion-1 {
   height: 100%;
 }
 
-.emotion-3 {
+.emotion-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-4 {
+.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -243,17 +238,35 @@ exports[`Card Card component should render correctly 1`] = `
   width: 100%;
 }
 
-.emotion-5>* {
+.emotion-4>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-5 {
   border-bottom: 1px solid;
   box-sizing: border-box;
+  border-color: rgba(0, 0, 0, 0.1);
+  padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-6:last-child {
+.emotion-5:last-child {
   border-bottom: none;
+}
+
+.emotion-5:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-5:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
 }
 
 .emotion-7:first-of-type {
@@ -267,48 +280,54 @@ exports[`Card Card component should render correctly 1`] = `
 }
 
 .emotion-8 {
-  border-color: rgba(0, 0, 0, 0.1);
-}
-
-.emotion-9 {
   padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-10 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-}
-
-.emotion-16 {
+.emotion-12 {
   box-sizing: border-box;
   display: block;
   width: 100%;
 }
 
-.emotion-21 {
+.emotion-13 {
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.emotion-17 {
   box-sizing: border-box;
   overflow: hidden;
 }
 
-.emotion-21>img,
-.emotion-21>iframe {
+.emotion-17>img,
+.emotion-17>iframe {
   display: block;
   height: auto;
   max-width: 100%;
   width: 100%;
 }
 
-.emotion-26 {
+.emotion-22 {
   border-top: 1px solid;
   box-sizing: border-box;
+  border-color: rgba(0, 0, 0, 0.1);
+  padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-26:first-of-type {
+.emotion-22:first-of-type {
   border-top: none;
 }
 
-.emotion-30 {
+.emotion-22:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-22:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-23 {
   background: transparent;
   display: block;
   margin: 0!important;
@@ -317,7 +336,7 @@ exports[`Card Card component should render correctly 1`] = `
   will-change: box-shadow;
 }
 
-.emotion-31 {
+.emotion-24 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -328,41 +347,41 @@ exports[`Card Card component should render correctly 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-31 {
+  .emotion-24 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-.emotion-32 {
+.emotion-25 {
   border-radius: 8px;
 }
 
 <div>
   <div
-    class="style-surface components-surface components-card emotion-0 emotion-1"
+    class="style-surface components-surface emotion-0 components-card"
     data-wp-c16t="true"
     data-wp-component="Card"
   >
     <div
-      class="emotion-2"
+      class="emotion-1"
     >
       <div
-        class="emotion-3 emotion-4 emotion-5 components-flex emotion-6 emotion-7 emotion-8 emotion-9 components-card__header components-card-header"
+        class="emotion-2 emotion-3 emotion-4 components-flex emotion-5 components-card__header components-card-header"
         data-wp-c16t="true"
         data-wp-component="CardHeader"
       >
         Card Header
       </div>
       <div
-        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
+        class="emotion-6 emotion-7 emotion-8 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
         Card Body 1
       </div>
       <div
-        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
+        class="emotion-6 emotion-7 emotion-8 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -370,20 +389,20 @@ exports[`Card Card component should render correctly 1`] = `
       </div>
       <hr
         aria-orientation="horizontal"
-        class="style-divider components-divider emotion-10 emotion-11 components-card__divider components-card-divider"
+        class="style-divider components-divider emotion-12 emotion-13 components-card__divider components-card-divider"
         data-wp-c16t="true"
         data-wp-component="CardDivider"
         role="separator"
       />
       <div
-        class="emotion-10 emotion-7 emotion-9 components-card__body components-card-body"
+        class="emotion-6 emotion-7 emotion-8 components-card__body components-card-body"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
         Card Body 3
       </div>
       <div
-        class="emotion-21 emotion-7 components-card__media components-card-media"
+        class="emotion-17 emotion-7 components-card__media components-card-media"
         data-wp-c16t="true"
         data-wp-component="CardMedia"
       >
@@ -393,7 +412,7 @@ exports[`Card Card component should render correctly 1`] = `
         />
       </div>
       <div
-        class="emotion-3 emotion-4 emotion-5 components-flex emotion-26 emotion-7 emotion-8 emotion-9 components-card__footer components-card-footer"
+        class="emotion-2 emotion-3 emotion-4 components-flex emotion-22 components-card__footer components-card-footer"
         data-wp-c16t="true"
         data-wp-component="CardFooter"
       >
@@ -402,13 +421,13 @@ exports[`Card Card component should render correctly 1`] = `
     </div>
     <div
       aria-hidden="true"
-      class="emotion-30 emotion-31 components-elevation emotion-32"
+      class="emotion-23 emotion-24 components-elevation emotion-25"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="emotion-30 emotion-31 components-elevation emotion-32"
+      class="emotion-23 emotion-24 components-elevation emotion-25"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
@@ -452,17 +471,14 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
-}
-
-.emotion-1 {
   border-radius: calc(8px - 1px);
 }
 
-.emotion-2 {
+.emotion-1 {
   height: 100%;
 }
 
-.emotion-3 {
+.emotion-2 {
   background: transparent;
   display: block;
   margin: 0!important;
@@ -471,7 +487,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   will-change: box-shadow;
 }
 
-.emotion-4 {
+.emotion-3 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -482,17 +498,17 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-4 {
+  .emotion-3 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-.emotion-5 {
+.emotion-4 {
   border-radius: 8px;
 }
 
-.emotion-7 {
+.emotion-6 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
@@ -503,7 +519,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-7 {
+  .emotion-6 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -511,24 +527,24 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 
 <div>
   <div
-    class="style-surface components-surface components-card emotion-0 emotion-1"
+    class="style-surface components-surface emotion-0 components-card"
     data-wp-c16t="true"
     data-wp-component="Card"
   >
     <div
-      class="emotion-2"
+      class="emotion-1"
     >
       Code is Poetry
     </div>
     <div
       aria-hidden="true"
-      class="emotion-3 emotion-4 components-elevation emotion-5"
+      class="emotion-2 emotion-3 components-elevation emotion-4"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />
     <div
       aria-hidden="true"
-      class="emotion-3 emotion-7 components-elevation emotion-5"
+      class="emotion-2 emotion-6 components-elevation emotion-4"
       data-wp-c16t="true"
       data-wp-component="Elevation"
     />

--- a/packages/components/src/card/test/index.tsx
+++ b/packages/components/src/card/test/index.tsx
@@ -238,14 +238,20 @@ describe( 'Card', () => {
 					<EmotionStylePrimer styleFragment={ styles.borderless } />
 				);
 				render(
-					<CardHeader data-testid="card-header" isBorderless>
-						Header
-					</CardHeader>
+					<Card>
+						<CardHeader data-testid="card-header" isBorderless>
+							Header
+						</CardHeader>
+						<CardBody>Body</CardBody>
+					</Card>
 				);
 
 				expectComposedEmotionClassName(
 					screen.getByTestId( 'card-header' ),
 					[ 'Header', 'borderRadius', 'borderColor', 'borderless' ]
+				);
+				expect( screen.getByTestId( 'card-header' ) ).toHaveStyle(
+					'border: none'
 				);
 			} );
 		} );
@@ -274,14 +280,20 @@ describe( 'Card', () => {
 					<EmotionStylePrimer styleFragment={ styles.borderless } />
 				);
 				render(
-					<CardFooter data-testid="card-footer" isBorderless>
-						Footer
-					</CardFooter>
+					<Card>
+						<CardBody>Body</CardBody>
+						<CardFooter data-testid="card-footer" isBorderless>
+							Footer
+						</CardFooter>
+					</Card>
 				);
 
 				expectComposedEmotionClassName(
 					screen.getByTestId( 'card-footer' ),
 					[ 'Footer', 'borderRadius', 'borderColor', 'borderless' ]
+				);
+				expect( screen.getByTestId( 'card-footer' ) ).toHaveStyle(
+					'border: none'
 				);
 			} );
 		} );

--- a/packages/components/src/card/test/index.tsx
+++ b/packages/components/src/card/test/index.tsx
@@ -14,6 +14,39 @@ import {
 	CardHeader,
 	CardMedia,
 } from '../';
+import { useCx } from '../../utils/hooks/use-cx';
+import * as styles from '../styles';
+
+function EmotionStylePrimer( {
+	styleFragment,
+}: {
+	styleFragment: Parameters< ReturnType< typeof useCx > >[ 0 ];
+} ) {
+	const cx = useCx();
+
+	return <div className={ cx( styleFragment ) } />;
+}
+
+function expectComposedEmotionClassName(
+	element: HTMLElement,
+	styleLabels: string[]
+) {
+	const matchingClassNames = element.className
+		.split( /\s+/ )
+		.filter( ( className ) => className.startsWith( 'css-' ) )
+		.filter( ( className ) =>
+			styleLabels.some( ( styleLabel ) =>
+				className.includes( styleLabel )
+			)
+		);
+
+	expect( matchingClassNames ).toHaveLength( 1 );
+	for ( const styleLabel of styleLabels ) {
+		expect( matchingClassNames[ 0 ] ).toEqual(
+			expect.stringContaining( styleLabel )
+		);
+	}
+}
 
 describe( 'Card', () => {
 	describe( 'Card component', () => {
@@ -55,6 +88,22 @@ describe( 'Card', () => {
 			expect( screen.getByTestId( 'card-wrapper' ) ).toHaveStyle(
 				'box-shadow: none'
 			);
+		} );
+
+		it( 'should remove borders regardless of Emotion insertion order', () => {
+			render(
+				<EmotionStylePrimer styleFragment={ styles.boxShadowless } />
+			);
+			render(
+				<Card data-testid="card-wrapper" isBorderless>
+					Code is Poetry
+				</Card>
+			);
+
+			const card = screen.getByTestId( 'card-wrapper' );
+
+			expectComposedEmotionClassName( card, [ 'Card', 'boxShadowless' ] );
+			expect( window.getComputedStyle( card ).boxShadow ).toBe( 'none' );
 		} );
 
 		it( 'should add rounded border when the isRounded prop is true', () => {
@@ -181,6 +230,24 @@ describe( 'Card', () => {
 				);
 				expect( container ).toMatchDiffSnapshot( containerShady );
 			} );
+
+			it( 'should remove borders regardless of Emotion insertion order', () => {
+				expect.hasAssertions();
+
+				render(
+					<EmotionStylePrimer styleFragment={ styles.borderless } />
+				);
+				render(
+					<CardHeader data-testid="card-header" isBorderless>
+						Header
+					</CardHeader>
+				);
+
+				expectComposedEmotionClassName(
+					screen.getByTestId( 'card-header' ),
+					[ 'Header', 'borderRadius', 'borderColor', 'borderless' ]
+				);
+			} );
 		} );
 
 		describe( 'CardFooter', () => {
@@ -198,6 +265,24 @@ describe( 'Card', () => {
 					<CardFooter justify="flex-end">Footer</CardFooter>
 				);
 				expect( container ).toMatchDiffSnapshot( containerWithFlexEnd );
+			} );
+
+			it( 'should remove borders regardless of Emotion insertion order', () => {
+				expect.hasAssertions();
+
+				render(
+					<EmotionStylePrimer styleFragment={ styles.borderless } />
+				);
+				render(
+					<CardFooter data-testid="card-footer" isBorderless>
+						Footer
+					</CardFooter>
+				);
+
+				expectComposedEmotionClassName(
+					screen.getByTestId( 'card-footer' ),
+					[ 'Footer', 'borderRadius', 'borderColor', 'borderless' ]
+				);
 			} );
 		} );
 

--- a/packages/components/src/elevation/hook.ts
+++ b/packages/components/src/elevation/hook.ts
@@ -108,14 +108,15 @@ export function useElevation(
 			`;
 		}
 
-		return cx(
+		const elevationStyles = css(
 			styles.Elevation,
 			sx.Base,
 			sx.hover,
 			sx.focus,
-			sx.active,
-			className
+			sx.active
 		);
+
+		return cx( elevationStyles, className );
 	}, [
 		active,
 		borderRadius,

--- a/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
@@ -8,9 +8,6 @@ exports[`props should render active 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -21,23 +18,23 @@ exports[`props should render active 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-2 {
+*:hover>.emotion-0 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
-*:active>.emotion-3 {
+*:active>.emotion-0 {
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
 }
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -52,9 +49,6 @@ exports[`props should render correctly 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -65,7 +59,7 @@ exports[`props should render correctly 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -73,7 +67,7 @@ exports[`props should render correctly 1`] = `
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -88,9 +82,6 @@ exports[`props should render hover 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -101,19 +92,19 @@ exports[`props should render hover 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-2 {
+*:hover>.emotion-0 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 emotion-2 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -128,9 +119,6 @@ exports[`props should render isInteractive 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -141,23 +129,23 @@ exports[`props should render isInteractive 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-2 {
+*:hover>.emotion-0 {
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
 }
 
-*:active>.emotion-3 {
+*:active>.emotion-0 {
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
 }
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -172,9 +160,6 @@ exports[`props should render offset 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: -2px;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -185,23 +170,23 @@ exports[`props should render offset 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-2 {
+*:hover>.emotion-0 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
-*:active>.emotion-3 {
+*:active>.emotion-0 {
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
 }
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -216,9 +201,6 @@ exports[`props should render value 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
-}
-
-.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -229,7 +211,7 @@ exports[`props should render value 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-1 {
+  .emotion-0 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -237,7 +219,7 @@ exports[`props should render value 1`] = `
 
 <div
   aria-hidden="true"
-  class="emotion-0 emotion-1 components-elevation"
+  class="emotion-0 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"

--- a/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
@@ -8,6 +8,9 @@ exports[`props should render active 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -18,23 +21,23 @@ exports[`props should render active 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-0 {
+*:hover>.emotion-2 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
-*:active>.emotion-0 {
+*:active>.emotion-3 {
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
 }
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -49,6 +52,9 @@ exports[`props should render correctly 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -59,7 +65,7 @@ exports[`props should render correctly 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -67,7 +73,7 @@ exports[`props should render correctly 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -82,6 +88,9 @@ exports[`props should render hover 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -92,19 +101,19 @@ exports[`props should render hover 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-0 {
+*:hover>.emotion-2 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -119,6 +128,9 @@ exports[`props should render isInteractive 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
@@ -129,23 +141,23 @@ exports[`props should render isInteractive 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-0 {
+*:hover>.emotion-2 {
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
 }
 
-*:active>.emotion-0 {
+*:active>.emotion-3 {
   box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
 }
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -160,6 +172,9 @@ exports[`props should render offset 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: -2px;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -170,23 +185,23 @@ exports[`props should render offset 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
 }
 
-*:hover>.emotion-0 {
+*:hover>.emotion-2 {
   box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.7);
 }
 
-*:active>.emotion-0 {
+*:active>.emotion-3 {
   box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
 }
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 emotion-3 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"
@@ -201,6 +216,9 @@ exports[`props should render value 1`] = `
   pointer-events: none;
   position: absolute;
   will-change: box-shadow;
+}
+
+.emotion-1 {
   border-radius: inherit;
   bottom: 0;
   box-shadow: 0 7px 14px 0 rgba(0, 0, 0, 0.35);
@@ -211,7 +229,7 @@ exports[`props should render value 1`] = `
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-0 {
+  .emotion-1 {
     -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
     transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
   }
@@ -219,7 +237,7 @@ exports[`props should render value 1`] = `
 
 <div
   aria-hidden="true"
-  class="components-elevation emotion-0 emotion-1"
+  class="emotion-0 emotion-1 components-elevation"
   data-testid="elevation"
   data-wp-c16t="true"
   data-wp-component="Elevation"

--- a/packages/components/src/elevation/test/index.tsx
+++ b/packages/components/src/elevation/test/index.tsx
@@ -8,6 +8,11 @@ import { render, screen } from '@testing-library/react';
  */
 import { Elevation } from '..';
 
+const getGeneratedEmotionClassNames = ( element: HTMLElement ) =>
+	Array.from( element.classList ).filter( ( className ) =>
+		/^(css|emotion)-/.test( className )
+	);
+
 describe( 'props', () => {
 	test( 'should render correctly', () => {
 		render( <Elevation data-testid="elevation" /> );
@@ -60,5 +65,21 @@ describe( 'props', () => {
 		);
 
 		expect( screen.getByTestId( 'elevation' ) ).toMatchSnapshot();
+	} );
+
+	test( 'should compose interactive styles in a single generated class', () => {
+		render(
+			<Elevation
+				active={ 5 }
+				focus={ 9 }
+				hover={ 14 }
+				value={ 7 }
+				data-testid="elevation"
+			/>
+		);
+
+		expect(
+			getGeneratedEmotionClassNames( screen.getByTestId( 'elevation' ) )
+		).toHaveLength( 1 );
 	} );
 } );

--- a/packages/components/src/flex/flex-item/hook.ts
+++ b/packages/components/src/flex/flex-item/hook.ts
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 
 /**
@@ -24,24 +20,17 @@ export function useFlexItem(
 		...otherProps
 	} = useContextSystem( props, 'FlexItem' );
 
-	const sx: {
-		Base?: SerializedStyles;
-	} = {};
-
 	const contextDisplay = useFlexContext().flexItemDisplay;
 
-	sx.Base = css( {
+	const base = css( {
 		display: displayProp || contextDisplay,
 	} );
 
 	const cx = useCx();
 
-	const classes = cx(
-		styles.Item,
-		sx.Base,
-		isBlock && styles.block,
-		className
-	);
+	const itemStyles = css( styles.Item, base, isBlock && styles.block );
+
+	const classes = cx( itemStyles, className );
 
 	return {
 		...otherProps,

--- a/packages/components/src/flex/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/flex/test/__snapshots__/index.tsx.snap
@@ -5,27 +5,25 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -1,22 +1,18 @@
+@@ -1,20 +1,18 @@
   <div
-    class="components-flex css-4xxgm8-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+    class="css-a57899-Flex css-lmbxer-base css-1ozeagb-ItemsRow components-flex"
 -   data-testid="flex"
 +   data-testid="base-flex"
     data-wp-c16t="true"
     data-wp-component="Flex"
   >
     <div
-      class="components-flex-item css-11ygw1k-PolymorphicDiv-Item-sx-Base e19lxcc00"
+      class="css-14ac8g8-Item css-119tq0c-sx-Base components-flex-item"
       data-wp-c16t="true"
       data-wp-component="FlexItem"
     >
       Item
     </div>
--   <div
--     class="css-1ragr82-PolymorphicDiv e19lxcc00"
--   />
+-   <div />
 -   <div />
     <div
-      class="components-flex-item components-flex-block css-1gfd63q-PolymorphicDiv-Item-sx-Base-block e19lxcc00"
+      class="css-14ac8g8-Item css-119tq0c-sx-Base css-1ya6i3g-block components-flex-item components-flex-block"
       data-wp-c16t="true"
       data-wp-component="FlexBlock"
     >
@@ -36,8 +34,11 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -1,15 +1,15 @@
+@@ -1,18 +1,18 @@
   Array [
+    Object {
+      "display": "flex",
+    },
     Object {
 -     "-ms-flex-align": "flex-start",
 +     "-ms-flex-align": "center",
@@ -51,11 +52,11 @@ Snapshot Diff:
       "-webkit-justify-content": "space-between",
 -     "align-items": "flex-start",
 +     "align-items": "center",
-      "display": "flex",
       "flex-direction": "row",
       "gap": "calc(4px * 2)",
       "justify-content": "space-between",
       "width": "100%",
+    },
 `;
 
 exports[`props should render correctly 1`] = `
@@ -64,6 +65,9 @@ exports[`props should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -78,11 +82,11 @@ exports[`props should render correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-width: 0;
 }
 
-.emotion-2 {
+.emotion-3 {
   display: block;
   max-height: 100%;
   max-width: 100%;
@@ -90,32 +94,27 @@ exports[`props should render correctly 1`] = `
   min-width: 0;
 }
 
-.emotion-4 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
+.emotion-7 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
 <div
-  class="components-flex emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 components-flex"
   data-testid="base-flex"
   data-wp-c16t="true"
   data-wp-component="Flex"
 >
   <div
-    class="components-flex-item emotion-2 emotion-1"
+    class="emotion-3 emotion-4 components-flex-item"
     data-wp-c16t="true"
     data-wp-component="FlexItem"
   >
     Item
   </div>
   <div
-    class="components-flex-item components-flex-block emotion-4 emotion-1"
+    class="emotion-3 emotion-4 emotion-7 components-flex-item components-flex-block"
     data-wp-c16t="true"
     data-wp-component="FlexBlock"
   >
@@ -129,7 +128,9 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-  Array [
+@@ -3,18 +3,17 @@
+      "display": "flex",
+    },
     Object {
       "-ms-flex-align": "center",
       "-ms-flex-direction": "row",
@@ -142,7 +143,6 @@ Snapshot Diff:
 -     "-webkit-justify-content": "flex-start",
 +     "-webkit-justify-content": "space-between",
       "align-items": "center",
-      "display": "flex",
       "flex-direction": "row",
       "gap": "calc(4px * 2)",
 -     "justify-content": "flex-start",
@@ -154,25 +154,5 @@ Snapshot Diff:
 
 exports[`props should render spacing 1`] = `
 Snapshot Diff:
-- Received styles
-+ Base styles
-
-  Array [
-    Object {
--     "min-width": "0",
--   },
--   Object {
-      "-ms-flex": "1",
-      "-webkit-flex": "1",
-      "display": "block",
-      "flex": "1",
-      "max-height": "100%",
-      "max-width": "100%",
-      "min-height": "0",
-+     "min-width": "0",
-+   },
-+   Object {
-      "min-width": "0",
-    },
-  ]
+Compared values have no visual difference.
 `;

--- a/packages/components/src/flex/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/flex/test/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ Snapshot Diff:
     data-wp-component="Flex"
   >
     <div
-      class="css-14ac8g8-Item css-119tq0c-sx-Base components-flex-item"
+      class="css-1rk86jm-Item-base-itemStyles components-flex-item"
       data-wp-c16t="true"
       data-wp-component="FlexItem"
     >
@@ -23,7 +23,7 @@ Snapshot Diff:
 -   <div />
 -   <div />
     <div
-      class="css-14ac8g8-Item css-119tq0c-sx-Base css-1ya6i3g-block components-flex-item components-flex-block"
+      class="css-7ugsc8-Item-base-block-itemStyles components-flex-item components-flex-block"
       data-wp-c16t="true"
       data-wp-component="FlexBlock"
     >
@@ -94,7 +94,12 @@ exports[`props should render correctly 1`] = `
   min-width: 0;
 }
 
-.emotion-7 {
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -107,14 +112,14 @@ exports[`props should render correctly 1`] = `
   data-wp-component="Flex"
 >
   <div
-    class="emotion-3 emotion-4 components-flex-item"
+    class="emotion-3 components-flex-item"
     data-wp-c16t="true"
     data-wp-component="FlexItem"
   >
     Item
   </div>
   <div
-    class="emotion-3 emotion-4 emotion-7 components-flex-item components-flex-block"
+    class="emotion-4 components-flex-item components-flex-block"
     data-wp-c16t="true"
     data-wp-component="FlexBlock"
   >

--- a/packages/components/src/flex/test/index.tsx
+++ b/packages/components/src/flex/test/index.tsx
@@ -9,6 +9,11 @@ import { render, screen } from '@testing-library/react';
 import { View } from '../../view';
 import { Flex, FlexBlock, FlexItem } from '../';
 
+const getGeneratedEmotionClassNames = ( element: HTMLElement ) =>
+	Array.from( element.classList ).filter( ( className ) =>
+		/^(css|emotion)-/.test( className )
+	);
+
 describe( 'props', () => {
 	test( 'should render correctly', () => {
 		render(
@@ -106,5 +111,20 @@ describe( 'props', () => {
 		expect( screen.getByTestId( 'flex-block' ) ).toMatchStyleDiffSnapshot(
 			screen.getByTestId( 'flex-block-with-gap' )
 		);
+	} );
+
+	test( 'should compose flex item styles in a single generated class', () => {
+		render(
+			<Flex>
+				<FlexItem isBlock display="inline-flex" data-testid="item">
+					Item
+				</FlexItem>
+			</Flex>
+		);
+
+		const item = screen.getByTestId( 'item' );
+
+		expect( getGeneratedEmotionClassNames( item ) ).toHaveLength( 1 );
+		expect( item ).toHaveStyle( { display: 'inline-flex' } );
 	} );
 } );

--- a/packages/components/src/flex/test/index.tsx
+++ b/packages/components/src/flex/test/index.tsx
@@ -10,33 +10,6 @@ import { View } from '../../view';
 import { Flex, FlexBlock, FlexItem } from '../';
 
 describe( 'props', () => {
-	test( 'should apply base flex and flex-block layout styles', () => {
-		render(
-			<Flex data-testid="base-flex">
-				<FlexItem>Item</FlexItem>
-				<FlexBlock data-testid="flex-block">Item</FlexBlock>
-			</Flex>
-		);
-
-		const flexStyles = window.getComputedStyle(
-			screen.getByTestId( 'base-flex' )
-		);
-		const flexBlockStyles = window.getComputedStyle(
-			screen.getByTestId( 'flex-block' )
-		);
-
-		expect( flexStyles.alignItems ).toBe( 'center' );
-		expect( flexStyles.display ).toBe( 'flex' );
-		expect( flexStyles.gap ).toBe( 'calc(4px * 2)' );
-		expect( flexStyles.justifyContent ).toBe( 'space-between' );
-		expect( flexStyles.width ).toBe( '100%' );
-
-		expect( flexBlockStyles.display ).toBe( 'block' );
-		expect( flexBlockStyles.flex ).toBe( '1 1 0%' );
-		expect( flexBlockStyles.minHeight ).toBe( '0' );
-		expect( flexBlockStyles.minWidth ).toBe( '0' );
-	} );
-
 	test( 'should render correctly', () => {
 		render(
 			<Flex data-testid="base-flex">

--- a/packages/components/src/flex/test/index.tsx
+++ b/packages/components/src/flex/test/index.tsx
@@ -10,6 +10,33 @@ import { View } from '../../view';
 import { Flex, FlexBlock, FlexItem } from '../';
 
 describe( 'props', () => {
+	test( 'should apply base flex and flex-block layout styles', () => {
+		render(
+			<Flex data-testid="base-flex">
+				<FlexItem>Item</FlexItem>
+				<FlexBlock data-testid="flex-block">Item</FlexBlock>
+			</Flex>
+		);
+
+		const flexStyles = window.getComputedStyle(
+			screen.getByTestId( 'base-flex' )
+		);
+		const flexBlockStyles = window.getComputedStyle(
+			screen.getByTestId( 'flex-block' )
+		);
+
+		expect( flexStyles.alignItems ).toBe( 'center' );
+		expect( flexStyles.display ).toBe( 'flex' );
+		expect( flexStyles.gap ).toBe( 'calc(4px * 2)' );
+		expect( flexStyles.justifyContent ).toBe( 'space-between' );
+		expect( flexStyles.width ).toBe( '100%' );
+
+		expect( flexBlockStyles.display ).toBe( 'block' );
+		expect( flexBlockStyles.flex ).toBe( '1 1 0%' );
+		expect( flexBlockStyles.minHeight ).toBe( '0' );
+		expect( flexBlockStyles.minWidth ).toBe( '0' );
+	} );
+
 	test( 'should render correctly', () => {
 		render(
 			<Flex data-testid="base-flex">

--- a/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
@@ -6,6 +6,9 @@ exports[`props should render alignment 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -21,22 +24,18 @@ exports[`props should render alignment 1`] = `
   width: 100%;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-width: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack"
     data-wp-c16t="true"
     data-wp-component="HStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;
@@ -47,6 +46,9 @@ exports[`props should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -61,22 +63,18 @@ exports[`props should render correctly 1`] = `
   width: 100%;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-width: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack"
     data-wp-c16t="true"
     data-wp-component="HStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;
@@ -87,6 +85,9 @@ exports[`props should render spacing 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -101,22 +102,18 @@ exports[`props should render spacing 1`] = `
   width: 100%;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-width: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack"
     data-wp-c16t="true"
     data-wp-component="HStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;

--- a/packages/components/src/h-stack/test/index.tsx
+++ b/packages/components/src/h-stack/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,6 +10,24 @@ import { View } from '../../view';
 import { HStack } from '..';
 
 describe( 'props', () => {
+	test( 'should apply default horizontal stack styles', () => {
+		render(
+			<HStack data-testid="h-stack">
+				<View />
+				<View />
+			</HStack>
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'h-stack' )
+		);
+
+		expect( styles.alignItems ).toBe( 'center' );
+		expect( styles.display ).toBe( 'flex' );
+		expect( styles.gap ).toBe( 'calc(4px * 2)' );
+		expect( styles.justifyContent ).toBe( 'space-between' );
+	} );
+
 	test( 'should render correctly', () => {
 		const { container } = render(
 			<HStack>

--- a/packages/components/src/h-stack/test/index.tsx
+++ b/packages/components/src/h-stack/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,24 +10,6 @@ import { View } from '../../view';
 import { HStack } from '..';
 
 describe( 'props', () => {
-	test( 'should apply default horizontal stack styles', () => {
-		render(
-			<HStack data-testid="h-stack">
-				<View />
-				<View />
-			</HStack>
-		);
-
-		const styles = window.getComputedStyle(
-			screen.getByTestId( 'h-stack' )
-		);
-
-		expect( styles.alignItems ).toBe( 'center' );
-		expect( styles.display ).toBe( 'flex' );
-		expect( styles.gap ).toBe( 'calc(4px * 2)' );
-		expect( styles.justifyContent ).toBe( 'space-between' );
-	} );
-
 	test( 'should render correctly', () => {
 		const { container } = render(
 			<HStack>

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -6,20 +6,14 @@ exports[`props should render correctly 1`] = `
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
-}
-
-.emotion-1 {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
   font-size: calc(1.95 * 13px);
   font-weight: 600;
-}
-
-.emotion-2 {
   display: block;
 }
 
 <h2
-  class="components-truncate emotion-0 emotion-1 emotion-2 components-text components-heading"
+  class="components-truncate emotion-0 components-text components-heading"
   data-wp-c16t="true"
   data-wp-component="Heading"
 >
@@ -32,24 +26,18 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -4,13 +4,13 @@
+@@ -1,10 +1,10 @@
+  Array [
+    Object {
+      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
+      "display": "block",
+-     "font-size": "calc(1.25 * 13px)",
++     "font-size": "calc(1.95 * 13px)",
+      "font-weight": "600",
       "line-height": "1.4",
       "margin": "0",
       "text-wrap": "pretty",
     },
-    Object {
--     "display": "block",
--   },
--   Object {
-      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
-      "font-weight": "600",
-+   },
-+   Object {
-+     "display": "block",
-    },
-  ]
 `;
 
 exports[`props should render level as a string 1`] = `
@@ -57,22 +45,16 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -4,13 +4,13 @@
+@@ -1,10 +1,10 @@
+  Array [
+    Object {
+      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
+      "display": "block",
+-     "font-size": "calc(1.25 * 13px)",
++     "font-size": "calc(1.95 * 13px)",
+      "font-weight": "600",
       "line-height": "1.4",
       "margin": "0",
       "text-wrap": "pretty",
     },
-    Object {
--     "display": "block",
--   },
--   Object {
-      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
-      "font-weight": "600",
-+   },
-+   Object {
-+     "display": "block",
-    },
-  ]
 `;

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -6,14 +6,20 @@ exports[`props should render correctly 1`] = `
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
+}
+
+.emotion-1 {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
   font-size: calc(1.95 * 13px);
   font-weight: 600;
+}
+
+.emotion-2 {
   display: block;
 }
 
 <h2
-  class="components-truncate components-text components-heading emotion-0 emotion-1"
+  class="components-truncate emotion-0 emotion-1 emotion-2 components-text components-heading"
   data-wp-c16t="true"
   data-wp-component="Heading"
 >
@@ -26,18 +32,24 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -1,10 +1,10 @@
-  Array [
-    Object {
-      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
-      "display": "block",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
-      "font-weight": "600",
+@@ -4,13 +4,13 @@
       "line-height": "1.4",
       "margin": "0",
       "text-wrap": "pretty",
     },
+    Object {
+-     "display": "block",
+-   },
+-   Object {
+      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
+-     "font-size": "calc(1.25 * 13px)",
++     "font-size": "calc(1.95 * 13px)",
+      "font-weight": "600",
++   },
++   Object {
++     "display": "block",
+    },
+  ]
 `;
 
 exports[`props should render level as a string 1`] = `
@@ -45,16 +57,22 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -1,10 +1,10 @@
-  Array [
-    Object {
-      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
-      "display": "block",
--     "font-size": "calc(1.25 * 13px)",
-+     "font-size": "calc(1.95 * 13px)",
-      "font-weight": "600",
+@@ -4,13 +4,13 @@
       "line-height": "1.4",
       "margin": "0",
       "text-wrap": "pretty",
     },
+    Object {
+-     "display": "block",
+-   },
+-   Object {
+      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
+-     "font-size": "calc(1.25 * 13px)",
++     "font-size": "calc(1.95 * 13px)",
+      "font-weight": "600",
++   },
++   Object {
++     "display": "block",
+    },
+  ]
 `;

--- a/packages/components/src/heading/test/index.tsx
+++ b/packages/components/src/heading/test/index.tsx
@@ -14,6 +14,15 @@ describe( 'props', () => {
 		expect( screen.getByRole( 'heading' ) ).toMatchSnapshot();
 	} );
 
+	test( 'should apply default heading text styles', () => {
+		render( <Heading>Code is Poetry</Heading> );
+
+		const styles = window.getComputedStyle( screen.getByRole( 'heading' ) );
+
+		expect( styles.display ).toBe( 'block' );
+		expect( styles.fontWeight ).toBe( '600' );
+	} );
+
 	test( 'should render level as a number', () => {
 		render( <Heading>Code is Poetry</Heading> );
 		render( <Heading level={ 4 }>Code is Poetry</Heading> );

--- a/packages/components/src/heading/test/index.tsx
+++ b/packages/components/src/heading/test/index.tsx
@@ -14,15 +14,6 @@ describe( 'props', () => {
 		expect( screen.getByRole( 'heading' ) ).toMatchSnapshot();
 	} );
 
-	test( 'should apply default heading text styles', () => {
-		render( <Heading>Code is Poetry</Heading> );
-
-		const styles = window.getComputedStyle( screen.getByRole( 'heading' ) );
-
-		expect( styles.display ).toBe( 'block' );
-		expect( styles.fontWeight ).toBe( '600' );
-	} );
-
 	test( 'should render level as a number', () => {
 		render( <Heading>Code is Poetry</Heading> );
 		render( <Heading level={ 4 }>Code is Poetry</Heading> );

--- a/packages/components/src/item-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.js.snap
@@ -11,8 +11,8 @@ Snapshot Diff:
         role="listitem"
       >
         <div
--         class="components-item css-14dwj71-PolymorphicDiv-medium-item-spacedAround e19lxcc00"
-+         class="components-item css-avymxl-PolymorphicDiv-large-item-spacedAround e19lxcc00"
+-         class="css-17kujwd-medium css-1izz8ne-item css-166x88h-spacedAround components-item"
++         class="css-o0djae-large css-1izz8ne-item css-166x88h-spacedAround components-item"
           data-wp-c16t="true"
           data-wp-component="Item"
         >
@@ -24,8 +24,8 @@ Snapshot Diff:
         role="listitem"
       >
         <div
--         class="components-item css-14dwj71-PolymorphicDiv-medium-item-spacedAround e19lxcc00"
-+         class="components-item css-avymxl-PolymorphicDiv-large-item-spacedAround e19lxcc00"
+-         class="css-17kujwd-medium css-1izz8ne-item css-166x88h-spacedAround components-item"
++         class="css-o0djae-large css-1izz8ne-item css-166x88h-spacedAround components-item"
           data-wp-c16t="true"
           data-wp-component="Item"
         >
@@ -44,8 +44,8 @@ Snapshot Diff:
       role="listitem"
     >
       <div
--       class="components-item css-5pzc6i-PolymorphicDiv-medium-item e19lxcc00"
-+       class="components-item css-y16wpf-PolymorphicDiv-large-item e19lxcc00"
+-       class="css-17kujwd-medium css-1izz8ne-item components-item"
++       class="css-o0djae-large css-1izz8ne-item components-item"
         data-wp-c16t="true"
         data-wp-component="Item"
       >
@@ -68,34 +68,40 @@ exports[`ItemGroup ItemGroup component should render correctly 1`] = `
   border-bottom-right-radius: 2px;
 }
 
-.emotion-2 {
+.emotion-1 {
   width: 100%;
   display: block;
 }
 
-.emotion-3 {
+.emotion-2 {
   padding: calc((36px - calc(13px * 1.4) - 2px) / 2) 12px;
+}
+
+.emotion-3 {
   box-sizing: border-box;
   width: 100%;
   display: block;
   margin: 0;
   color: inherit;
+}
+
+.emotion-4 {
   border-radius: 2px;
 }
 
 <div>
   <div
-    class="components-item-group emotion-0 emotion-1"
+    class="emotion-0 components-item-group"
     data-wp-c16t="true"
     data-wp-component="ItemGroup"
     role="list"
   >
     <div
-      class="emotion-2"
+      class="emotion-1"
       role="listitem"
     >
       <div
-        class="components-item emotion-3 emotion-1"
+        class="emotion-2 emotion-3 emotion-4 components-item"
         data-wp-c16t="true"
         data-wp-component="Item"
       >
@@ -114,8 +120,8 @@ Snapshot Diff:
 @@ -1,18 +1,18 @@
   <div>
     <div
--     class="components-item-group css-7sdlfv-PolymorphicDiv-rounded e19lxcc00"
-+     class="components-item-group css-12ds22-PolymorphicDiv-separated-rounded e19lxcc00"
+-     class="css-1e6snp6-rounded components-item-group"
++     class="css-qr0sb5-separated css-1e6snp6-rounded components-item-group"
       data-wp-c16t="true"
       data-wp-component="ItemGroup"
       role="list"
@@ -125,8 +131,8 @@ Snapshot Diff:
         role="listitem"
       >
         <div
--         class="components-item css-14dwj71-PolymorphicDiv-medium-item-spacedAround e19lxcc00"
-+         class="components-item css-5pzc6i-PolymorphicDiv-medium-item e19lxcc00"
+-         class="css-17kujwd-medium css-1izz8ne-item css-166x88h-spacedAround components-item"
++         class="css-17kujwd-medium css-1izz8ne-item components-item"
           data-wp-c16t="true"
           data-wp-component="Item"
         >
@@ -142,8 +148,8 @@ Snapshot Diff:
 @@ -1,18 +1,18 @@
   <div>
     <div
--     class="components-item-group css-7sdlfv-PolymorphicDiv-rounded e19lxcc00"
-+     class="components-item-group css-z3k5b4-PolymorphicDiv-bordered-rounded e19lxcc00"
+-     class="css-1e6snp6-rounded components-item-group"
++     class="css-9rmwob-bordered css-1e6snp6-rounded components-item-group"
       data-wp-c16t="true"
       data-wp-component="ItemGroup"
       role="list"
@@ -153,8 +159,8 @@ Snapshot Diff:
         role="listitem"
       >
         <div
--         class="components-item css-14dwj71-PolymorphicDiv-medium-item-spacedAround e19lxcc00"
-+         class="components-item css-5pzc6i-PolymorphicDiv-medium-item e19lxcc00"
+-         class="css-17kujwd-medium css-1izz8ne-item css-166x88h-spacedAround components-item"
++         class="css-17kujwd-medium css-1izz8ne-item components-item"
           data-wp-c16t="true"
           data-wp-component="Item"
         >
@@ -170,8 +176,8 @@ Snapshot Diff:
 @@ -1,8 +1,8 @@
   <div>
     <div
--     class="components-item-group css-7sdlfv-PolymorphicDiv-rounded e19lxcc00"
-+     class="components-item-group css-1ragr82-PolymorphicDiv e19lxcc00"
+-     class="css-1e6snp6-rounded components-item-group"
++     class="components-item-group"
       data-wp-c16t="true"
       data-wp-component="ItemGroup"
       role="list"

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -48,6 +48,7 @@ exports[`Notice should match snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
+        fill="currentColor"
         focusable="false"
         height="24"
         viewBox="0 0 24 24"

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`Notice should match snapshot 1`] = `
     class="components-notice is-success"
   >
     <div
-      class="components-visually-hidden css-1ragr82-PolymorphicDiv emotion-0"
+      class="components-visually-hidden"
       data-visually-hidden=""
       data-wp-c16t="true"
       data-wp-component="VisuallyHidden"

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -48,7 +48,6 @@ exports[`Notice should match snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        fill="currentColor"
         focusable="false"
         height="24"
         viewBox="0 0 24 24"

--- a/packages/components/src/scrollable/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/scrollable/test/__snapshots__/index.tsx.snap
@@ -3,26 +3,24 @@
 exports[`props should render correctly 1`] = `
 .emotion-0 {
   height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 @media only screen and ( min-device-width: 40em ) {
-  .emotion-0::-webkit-scrollbar {
+  .emotion-1::-webkit-scrollbar {
     height: 12px;
     width: 12px;
   }
 
-  .emotion-0::-webkit-scrollbar-track {
+  .emotion-1::-webkit-scrollbar-track {
     background-color: transparent;
   }
 
-  .emotion-0::-webkit-scrollbar-track {
+  .emotion-1::-webkit-scrollbar-track {
     background: rgba(0, 0, 0, 0.04);
     border-radius: 8px;
   }
 
-  .emotion-0::-webkit-scrollbar-thumb {
+  .emotion-1::-webkit-scrollbar-thumb {
     -webkit-background-clip: padding-box;
     background-clip: padding-box;
     background-color: rgba(0, 0, 0, 0.2);
@@ -30,13 +28,18 @@ exports[`props should render correctly 1`] = `
     border-radius: 7px;
   }
 
-  .emotion-0:hover::-webkit-scrollbar-thumb {
+  .emotion-1:hover::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.5);
   }
 }
 
+.emotion-2 {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 <div
-  class="components-scrollable emotion-0 emotion-1"
+  class="emotion-0 emotion-1 emotion-2 components-scrollable"
   data-testid="scrollable"
   data-wp-c16t="true"
   data-wp-component="Scrollable"
@@ -50,12 +53,14 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-  Array [
+@@ -4,9 +4,6 @@
+    },
     Object {
-      "height": "100%",
       "overflow-x": "hidden",
       "overflow-y": "auto",
--     "scroll-behavior": "smooth",
     },
+-   Object {
+-     "scroll-behavior": "smooth",
+-   },
   ]
 `;

--- a/packages/components/src/scrollable/test/index.tsx
+++ b/packages/components/src/scrollable/test/index.tsx
@@ -19,22 +19,6 @@ describe( 'props', () => {
 		expect( screen.getByTestId( 'scrollable' ) ).toMatchSnapshot();
 	} );
 
-	test( 'should apply default scroll styles', () => {
-		render(
-			<Scrollable data-testid="scrollable">
-				WordPress.org - Code is Poetry
-			</Scrollable>
-		);
-
-		const styles = window.getComputedStyle(
-			screen.getByTestId( 'scrollable' )
-		);
-
-		expect( styles.height ).toBe( '100%' );
-		expect( styles.overflowX ).toBe( 'hidden' );
-		expect( styles.overflowY ).toBe( 'auto' );
-	} );
-
 	test( 'should render smoothScroll', () => {
 		render(
 			<Scrollable data-testid="scrollable">

--- a/packages/components/src/scrollable/test/index.tsx
+++ b/packages/components/src/scrollable/test/index.tsx
@@ -19,6 +19,22 @@ describe( 'props', () => {
 		expect( screen.getByTestId( 'scrollable' ) ).toMatchSnapshot();
 	} );
 
+	test( 'should apply default scroll styles', () => {
+		render(
+			<Scrollable data-testid="scrollable">
+				WordPress.org - Code is Poetry
+			</Scrollable>
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'scrollable' )
+		);
+
+		expect( styles.height ).toBe( '100%' );
+		expect( styles.overflowX ).toBe( 'hidden' );
+		expect( styles.overflowY ).toBe( 'auto' );
+	} );
+
 	test( 'should render smoothScroll', () => {
 		render(
 			<Scrollable data-testid="scrollable">

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -42,16 +42,12 @@ exports[`Slot bubblesVirtually true should subsume another slot by the same name
   <div
     data-position="first"
   >
-    <div
-      class="css-1ragr82-PolymorphicDiv emotion-0"
-    />
+    <div />
   </div>
   <div
     data-position="second"
   >
-    <div
-      class="css-1ragr82-PolymorphicDiv emotion-0"
-    >
+    <div>
       Content
     </div>
   </div>
@@ -66,9 +62,7 @@ exports[`Slot bubblesVirtually true should subsume another slot by the same name
   <div
     data-position="second"
   >
-    <div
-      class="css-1ragr82-PolymorphicDiv emotion-0"
-    >
+    <div>
       Content
     </div>
   </div>
@@ -207,9 +201,7 @@ exports[`Slot should render in expected order when fills unmounted 1`] = `
 exports[`Slot should warn without a Provider 1`] = `
 <div>
   <div>
-    <div
-      class="css-1ragr82-PolymorphicDiv emotion-0"
-    />
+    <div />
   </div>
 </div>
 `;

--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -40,7 +40,7 @@ export function useSpacer(
 
 	const cx = useCx();
 
-	const classes = cx(
+	const spacerStyles = css(
 		isDefined( margin ) &&
 			css`
 				margin: ${ space( margin ) };
@@ -100,9 +100,10 @@ export function useSpacer(
 		isDefined( paddingRight ) &&
 			rtl( {
 				paddingRight: space( paddingRight ),
-			} )(),
-		className
+			} )()
 	);
+
+	const classes = cx( spacerStyles, className );
 
 	return { ...otherProps, className: classes };
 }

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -7,10 +7,17 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin": "calc(4px * 10)",
--     "margin-bottom": "calc(4px * 1)",
--     "margin-left": "calc(4px * 3)",
 -     "margin-right": "calc(4px * 5)",
+-   },
+-   Object {
+-     "margin": "calc(4px * 10)",
+-   },
+-   Object {
+-     "margin-left": "calc(4px * 3)",
+-     "margin-right": "calc(4px * 3)",
+-   },
+-   Object {
+-     "margin-bottom": "calc(4px * 1)",
 +     "margin-bottom": "calc(4px * 2)",
     },
   ]
@@ -24,11 +31,20 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding": "calc(4px * 10)",
--     "padding-bottom": "calc(4px * 2)",
--     "padding-left": "calc(4px * 3)",
--     "padding-top": "calc(4px * 5)",
     },
+-   Object {
+-     "padding-top": "calc(4px * 5)",
+-   },
+-   Object {
+-     "padding": "calc(4px * 10)",
+-   },
+-   Object {
+-     "padding-bottom": "calc(4px * 2)",
+-     "padding-top": "calc(4px * 2)",
+-   },
+-   Object {
+-     "padding-left": "calc(4px * 3)",
+-   },
   ]
 `;
 
@@ -38,7 +54,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-spacer emotion-0 emotion-1"
+  class="emotion-0 components-spacer"
   data-testid="spacer"
   data-wp-c16t="true"
   data-wp-component="Spacer"
@@ -52,9 +68,11 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin": "calc(4px * 5)",
       "margin-bottom": "calc(4px * 2)",
     },
+-   Object {
+-     "margin": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -79,8 +97,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "margin-left": "calc(4px * 5)",
     },
+-   Object {
+-     "margin-left": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -92,8 +112,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "margin-right": "calc(4px * 5)",
     },
+-   Object {
+-     "margin-right": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -105,8 +127,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "margin-top": "calc(4px * 5)",
     },
+-   Object {
+-     "margin-top": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -118,9 +142,11 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
+    },
+-   Object {
 -     "margin-left": "calc(4px * 5)",
 -     "margin-right": "calc(4px * 5)",
-    },
+-   },
   ]
 `;
 
@@ -132,8 +158,11 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "margin-top": "calc(4px * 5)",
     },
+-   Object {
+-     "margin-bottom": "calc(4px * 5)",
+-     "margin-top": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -145,8 +174,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding": "calc(4px * 5)",
     },
+-   Object {
+-     "padding": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -158,8 +189,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding-bottom": "calc(4px * 5)",
     },
+-   Object {
+-     "padding-bottom": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -171,8 +204,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding-left": "calc(4px * 5)",
     },
+-   Object {
+-     "padding-left": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -184,8 +219,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding-right": "calc(4px * 5)",
     },
+-   Object {
+-     "padding-right": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -197,8 +234,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
--     "padding-top": "calc(4px * 5)",
     },
+-   Object {
+-     "padding-top": "calc(4px * 5)",
+-   },
   ]
 `;
 
@@ -210,9 +249,11 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
+    },
+-   Object {
 -     "padding-left": "calc(4px * 5)",
 -     "padding-right": "calc(4px * 5)",
-    },
+-   },
   ]
 `;
 
@@ -224,8 +265,10 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
+    },
+-   Object {
 -     "padding-bottom": "calc(4px * 5)",
 -     "padding-top": "calc(4px * 5)",
-    },
+-   },
   ]
 `;

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -7,9 +7,6 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin-right": "calc(4px * 5)",
--   },
--   Object {
 -     "margin": "calc(4px * 10)",
 -   },
 -   Object {
@@ -18,6 +15,9 @@ Snapshot Diff:
 -   },
 -   Object {
 -     "margin-bottom": "calc(4px * 1)",
+-   },
+-   Object {
+-     "margin-right": "calc(4px * 5)",
 +     "margin-bottom": "calc(4px * 2)",
     },
   ]
@@ -33,14 +33,14 @@ Snapshot Diff:
       "margin-bottom": "calc(4px * 2)",
     },
 -   Object {
--     "padding-top": "calc(4px * 5)",
--   },
--   Object {
 -     "padding": "calc(4px * 10)",
 -   },
 -   Object {
 -     "padding-bottom": "calc(4px * 2)",
 -     "padding-top": "calc(4px * 2)",
+-   },
+-   Object {
+-     "padding-top": "calc(4px * 5)",
 -   },
 -   Object {
 -     "padding-left": "calc(4px * 3)",
@@ -111,11 +111,11 @@ Snapshot Diff:
 
   Array [
     Object {
-      "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "margin-right": "calc(4px * 5)",
 -   },
+-   Object {
+      "margin-bottom": "calc(4px * 2)",
+    },
   ]
 `;
 

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -7,6 +7,9 @@ Snapshot Diff:
 
   Array [
     Object {
+-     "margin-right": "calc(4px * 5)",
+-   },
+-   Object {
 -     "margin": "calc(4px * 10)",
 -   },
 -   Object {
@@ -15,9 +18,6 @@ Snapshot Diff:
 -   },
 -   Object {
 -     "margin-bottom": "calc(4px * 1)",
--   },
--   Object {
--     "margin-right": "calc(4px * 5)",
 +     "margin-bottom": "calc(4px * 2)",
     },
   ]
@@ -33,14 +33,14 @@ Snapshot Diff:
       "margin-bottom": "calc(4px * 2)",
     },
 -   Object {
+-     "padding-top": "calc(4px * 5)",
+-   },
+-   Object {
 -     "padding": "calc(4px * 10)",
 -   },
 -   Object {
 -     "padding-bottom": "calc(4px * 2)",
 -     "padding-top": "calc(4px * 2)",
--   },
--   Object {
--     "padding-top": "calc(4px * 5)",
 -   },
 -   Object {
 -     "padding-left": "calc(4px * 3)",
@@ -111,11 +111,11 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin-right": "calc(4px * 5)",
--   },
--   Object {
       "margin-bottom": "calc(4px * 2)",
     },
+-   Object {
+-     "margin-right": "calc(4px * 5)",
+-   },
   ]
 `;
 

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -7,17 +7,10 @@ Snapshot Diff:
 
   Array [
     Object {
--     "margin-right": "calc(4px * 5)",
--   },
--   Object {
 -     "margin": "calc(4px * 10)",
--   },
--   Object {
--     "margin-left": "calc(4px * 3)",
--     "margin-right": "calc(4px * 3)",
--   },
--   Object {
 -     "margin-bottom": "calc(4px * 1)",
+-     "margin-left": "calc(4px * 3)",
+-     "margin-right": "calc(4px * 5)",
 +     "margin-bottom": "calc(4px * 2)",
     },
   ]
@@ -31,20 +24,11 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
--     "padding-top": "calc(4px * 5)",
--   },
--   Object {
 -     "padding": "calc(4px * 10)",
--   },
--   Object {
 -     "padding-bottom": "calc(4px * 2)",
--     "padding-top": "calc(4px * 2)",
--   },
--   Object {
 -     "padding-left": "calc(4px * 3)",
--   },
+-     "padding-top": "calc(4px * 5)",
+    },
   ]
 `;
 
@@ -68,11 +52,9 @@ Snapshot Diff:
 
   Array [
     Object {
+-     "margin": "calc(4px * 5)",
       "margin-bottom": "calc(4px * 2)",
     },
--   Object {
--     "margin": "calc(4px * 5)",
--   },
   ]
 `;
 
@@ -97,10 +79,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "margin-left": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -112,10 +92,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "margin-right": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -127,10 +105,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "margin-top": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -142,11 +118,9 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "margin-left": "calc(4px * 5)",
 -     "margin-right": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -158,11 +132,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
--     "margin-bottom": "calc(4px * 5)",
 -     "margin-top": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -174,10 +145,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -189,10 +158,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-bottom": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -204,10 +171,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-left": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -219,10 +184,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-right": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -234,10 +197,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-top": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -249,11 +210,9 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-left": "calc(4px * 5)",
 -     "padding-right": "calc(4px * 5)",
--   },
+    },
   ]
 `;
 
@@ -265,10 +224,8 @@ Snapshot Diff:
   Array [
     Object {
       "margin-bottom": "calc(4px * 2)",
-    },
--   Object {
 -     "padding-bottom": "calc(4px * 5)",
 -     "padding-top": "calc(4px * 5)",
--   },
+    },
   ]
 `;

--- a/packages/components/src/spacer/test/index.tsx
+++ b/packages/components/src/spacer/test/index.tsx
@@ -95,6 +95,20 @@ describe( 'props', () => {
 		).toMatchStyleDiffSnapshot( screen.getByTestId( 'spacer' ) );
 	} );
 
+	test( 'should preserve explicit margin props regardless of Emotion insertion order', () => {
+		render( <Spacer marginRight={ 5 } data-testid="primer" /> );
+		render(
+			<Spacer margin={ 10 } marginRight={ 5 } data-testid="target" />
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'target' )
+		);
+
+		expect( styles.marginRight ).toBe( 'calc(20px)' );
+		expect( styles.marginTop ).toBe( 'calc(40px)' );
+	} );
+
 	test( 'should render padding', () => {
 		render( <Spacer data-testid="spacer" /> );
 		render( <Spacer padding={ 5 } data-testid="customized-spacer" /> );
@@ -175,5 +189,19 @@ describe( 'props', () => {
 		expect(
 			screen.getByTestId( 'customized-spacer' )
 		).toMatchStyleDiffSnapshot( screen.getByTestId( 'spacer' ) );
+	} );
+
+	test( 'should preserve explicit padding props regardless of Emotion insertion order', () => {
+		render( <Spacer paddingRight={ 5 } data-testid="primer" /> );
+		render(
+			<Spacer padding={ 10 } paddingRight={ 5 } data-testid="target" />
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'target' )
+		);
+
+		expect( styles.paddingRight ).toBe( 'calc(20px)' );
+		expect( styles.paddingTop ).toBe( 'calc(40px)' );
 	} );
 } );

--- a/packages/components/src/spacer/test/index.tsx
+++ b/packages/components/src/spacer/test/index.tsx
@@ -9,6 +9,48 @@ import { render, screen } from '@testing-library/react';
 import { Spacer } from '../index';
 
 describe( 'props', () => {
+	test( 'should apply margin shorthand props with the expected cascade', () => {
+		render(
+			<Spacer
+				margin={ 10 }
+				marginX={ 3 }
+				marginRight={ 5 }
+				marginBottom={ 1 }
+				data-testid="customized-spacer"
+			/>
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'customized-spacer' )
+		);
+
+		expect( styles.marginTop ).toBe( 'calc(40px)' );
+		expect( styles.marginRight ).toBe( 'calc(20px)' );
+		expect( styles.marginBottom ).toBe( 'calc(4px)' );
+		expect( styles.marginLeft ).toBe( 'calc(12px)' );
+	} );
+
+	test( 'should apply padding shorthand props with the expected cascade', () => {
+		render(
+			<Spacer
+				padding={ 10 }
+				paddingY={ 2 }
+				paddingTop={ 5 }
+				paddingLeft={ 3 }
+				data-testid="customized-spacer"
+			/>
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'customized-spacer' )
+		);
+
+		expect( styles.paddingTop ).toBe( 'calc(20px)' );
+		expect( styles.paddingRight ).toBe( 'calc(40px)' );
+		expect( styles.paddingBottom ).toBe( 'calc(8px)' );
+		expect( styles.paddingLeft ).toBe( 'calc(12px)' );
+	} );
+
 	test( 'should render correctly', () => {
 		render( <Spacer data-testid="spacer" /> );
 

--- a/packages/components/src/spacer/test/index.tsx
+++ b/packages/components/src/spacer/test/index.tsx
@@ -9,48 +9,6 @@ import { render, screen } from '@testing-library/react';
 import { Spacer } from '../index';
 
 describe( 'props', () => {
-	test( 'should apply margin shorthand props with the expected cascade', () => {
-		render(
-			<Spacer
-				margin={ 10 }
-				marginX={ 3 }
-				marginRight={ 5 }
-				marginBottom={ 1 }
-				data-testid="customized-spacer"
-			/>
-		);
-
-		const styles = window.getComputedStyle(
-			screen.getByTestId( 'customized-spacer' )
-		);
-
-		expect( styles.marginTop ).toBe( 'calc(40px)' );
-		expect( styles.marginRight ).toBe( 'calc(20px)' );
-		expect( styles.marginBottom ).toBe( 'calc(4px)' );
-		expect( styles.marginLeft ).toBe( 'calc(12px)' );
-	} );
-
-	test( 'should apply padding shorthand props with the expected cascade', () => {
-		render(
-			<Spacer
-				padding={ 10 }
-				paddingY={ 2 }
-				paddingTop={ 5 }
-				paddingLeft={ 3 }
-				data-testid="customized-spacer"
-			/>
-		);
-
-		const styles = window.getComputedStyle(
-			screen.getByTestId( 'customized-spacer' )
-		);
-
-		expect( styles.paddingTop ).toBe( 'calc(20px)' );
-		expect( styles.paddingRight ).toBe( 'calc(40px)' );
-		expect( styles.paddingBottom ).toBe( 'calc(8px)' );
-		expect( styles.paddingLeft ).toBe( 'calc(12px)' );
-	} );
-
 	test( 'should render correctly', () => {
 		render( <Spacer data-testid="spacer" /> );
 

--- a/packages/components/src/text/README.md
+++ b/packages/components/src/text/README.md
@@ -171,7 +171,7 @@ function Example() {
 	const backgroundColor = 'blue';
 
 	return (
-		<View css={ { backgroundColor } }>
+		<View style={ { backgroundColor } }>
 			<Text optimizeReadabilityFor={ backgroundColor }>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 			</Text>

--- a/packages/components/src/text/hook.ts
+++ b/packages/components/src/text/hook.ts
@@ -3,6 +3,7 @@
  */
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type React from 'react';
 
 /**
  * WordPress dependencies
@@ -23,7 +24,6 @@ import { CONFIG, COLORS } from '../utils';
 import { getLineHeight } from './get-line-height';
 import { useCx } from '../utils/hooks/use-cx';
 import type { Props } from './types';
-import type React from 'react';
 
 /**
  * @param {import('../context').WordPressComponentProps<import('./types').Props, 'span'>} props
@@ -79,14 +79,12 @@ export default function useText(
 	const cx = useCx();
 
 	const classes = useMemo( () => {
-		const sx: Record< string, SerializedStyles | null > = {};
-
 		const lineHeight = getLineHeight(
 			adjustLineHeightForInnerControls,
 			lineHeightProp
 		);
 
-		sx.Base = css( {
+		const base = css( {
 			color,
 			display,
 			fontSize: getFontSize( size ),
@@ -96,32 +94,33 @@ export default function useText(
 			textAlign: align,
 		} );
 
-		sx.upperCase = css( { textTransform: 'uppercase' } );
+		const upperCaseStyles = css( { textTransform: 'uppercase' } );
 
-		sx.optimalTextColor = null;
+		let optimalTextColor: SerializedStyles | null = null;
 
 		if ( optimizeReadabilityFor ) {
 			const isOptimalTextColorDark =
 				getOptimalTextShade( optimizeReadabilityFor ) === 'dark';
 
 			// Should not use theme colors
-			sx.optimalTextColor = isOptimalTextColorDark
+			optimalTextColor = isOptimalTextColorDark
 				? css( { color: COLORS.gray[ 900 ] } )
 				: css( { color: COLORS.white } );
 		}
 
-		return cx(
+		const textStyles = css(
 			styles.Text,
-			sx.Base,
-			sx.optimalTextColor,
+			base,
+			optimalTextColor,
 			isDestructive && styles.destructive,
 			!! isHighlighter && styles.highlighterText,
 			isBlock && styles.block,
 			isCaption && styles.muted,
 			variant && styles[ variant ],
-			upperCase && sx.upperCase,
-			className
+			upperCase && upperCaseStyles
 		);
+
+		return cx( textStyles, className );
 	}, [
 		adjustLineHeightForInnerControls,
 		align,

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -5,14 +5,13 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -3,8 +3,9 @@
-      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
+@@ -6,7 +6,8 @@
+      "text-wrap": "pretty",
+    },
+    Object {
       "font-size": "calc((13 / 13) * 13px)",
       "font-weight": "normal",
-      "line-height": "1.4",
-      "margin": "0",
 +     "text-align": "center",
-      "text-wrap": "pretty",
     },
   ]
 `;
@@ -23,11 +22,14 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
+}
+
+.emotion-1 {
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
 
-.emotion-0 mark {
+.emotion-2 mark {
   background: #f0b849;
   border-radius: 2px;
   box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.05 ) inset,0 -1px 0 rgba( 0, 0, 0, 0.1 ) inset;
@@ -35,7 +37,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 
 <div>
   <span
-    class="components-truncate components-text emotion-0 emotion-1"
+    class="components-truncate emotion-0 emotion-1 emotion-2 components-text"
     data-wp-c16t="true"
     data-wp-component="Text"
     role="heading"
@@ -55,13 +57,16 @@ exports[`Text snapshot tests should render correctly 1`] = `
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
+}
+
+.emotion-1 {
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
 
 <div>
   <span
-    class="components-truncate components-text emotion-0 emotion-1"
+    class="components-truncate emotion-0 emotion-1 components-text"
     data-wp-c16t="true"
     data-wp-component="Text"
   >

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -5,13 +5,14 @@ Snapshot Diff:
 - Received styles
 + Base styles
 
-@@ -6,7 +6,8 @@
-      "text-wrap": "pretty",
-    },
-    Object {
+@@ -3,8 +3,9 @@
+      "color": "var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e))",
       "font-size": "calc((13 / 13) * 13px)",
       "font-weight": "normal",
+      "line-height": "1.4",
+      "margin": "0",
 +     "text-align": "center",
+      "text-wrap": "pretty",
     },
   ]
 `;
@@ -22,14 +23,11 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
-}
-
-.emotion-1 {
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
 
-.emotion-2 mark {
+.emotion-0 mark {
   background: #f0b849;
   border-radius: 2px;
   box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.05 ) inset,0 -1px 0 rgba( 0, 0, 0, 0.1 ) inset;
@@ -37,7 +35,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 
 <div>
   <span
-    class="components-truncate emotion-0 emotion-1 emotion-2 components-text"
+    class="components-truncate emotion-0 components-text"
     data-wp-c16t="true"
     data-wp-component="Text"
     role="heading"
@@ -57,16 +55,13 @@ exports[`Text snapshot tests should render correctly 1`] = `
   line-height: 1.4;
   margin: 0;
   text-wrap: pretty;
-}
-
-.emotion-1 {
   font-size: calc((13 / 13) * 13px);
   font-weight: normal;
 }
 
 <div>
   <span
-    class="components-truncate emotion-0 emotion-1 components-text"
+    class="components-truncate emotion-0 components-text"
     data-wp-c16t="true"
     data-wp-component="Text"
   >

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -106,6 +106,23 @@ describe( 'Text', () => {
 		} );
 	} );
 
+	test( 'should render variant color regardless of Emotion insertion order', () => {
+		render(
+			<>
+				<Text role="note" variant="muted">
+					Primer.
+				</Text>
+				<Text role="heading" color="orange" variant="muted">
+					Lorem ipsum.
+				</Text>
+			</>
+		);
+
+		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
+			color: COLORS.theme.gray[ 700 ],
+		} );
+	} );
+
 	test( 'should render display', () => {
 		render(
 			<Text role="heading" display="inline-flex">

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -49,6 +49,17 @@ describe( 'Text', () => {
 		} );
 	} );
 
+	test( 'should apply base typography styles', () => {
+		render( <Text role="note">Lorem ipsum.</Text> );
+
+		const styles = window.getComputedStyle( screen.getByRole( 'note' ) );
+
+		expect( styles.color ).toBe( COLORS.theme.foreground );
+		expect( styles.lineHeight ).toBe( '1.4' );
+		expect( styles.margin ).toBe( '0px' );
+		expect( styles.textWrap ).toBe( 'pretty' );
+	} );
+
 	test( 'should render custom size', () => {
 		render(
 			<Text role="heading" size={ 15 }>

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -49,17 +49,6 @@ describe( 'Text', () => {
 		} );
 	} );
 
-	test( 'should apply base typography styles', () => {
-		render( <Text role="note">Lorem ipsum.</Text> );
-
-		const styles = window.getComputedStyle( screen.getByRole( 'note' ) );
-
-		expect( styles.color ).toBe( COLORS.theme.foreground );
-		expect( styles.lineHeight ).toBe( '1.4' );
-		expect( styles.margin ).toBe( '0px' );
-		expect( styles.textWrap ).toBe( 'pretty' );
-	} );
-
 	test( 'should render custom size', () => {
 		render(
 			<Text role="heading" size={ 15 }>

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -274,6 +274,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             >
               <svg
                 aria-hidden="true"
+                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -308,6 +309,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             >
               <svg
                 aria-hidden="true"
+                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -848,6 +850,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             >
               <svg
                 aria-hidden="true"
+                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -882,6 +885,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             >
               <svg
                 aria-hidden="true"
+                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -81,7 +81,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   		);
 }
 
-.emotion-8 {
+.emotion-7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -94,7 +94,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -139,27 +139,27 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-10 {
+  .emotion-9 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10[disabled],
-.emotion-10[aria-disabled='true'] {
+.emotion-9[disabled],
+.emotion-9[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-10:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-9:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +168,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   line-height: 1;
 }
 
-.emotion-15 {
+.emotion-14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -211,23 +211,23 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-15 {
+  .emotion-14 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-15[disabled],
-.emotion-15[aria-disabled='true'] {
+.emotion-14[disabled],
+.emotion-14[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-15:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-14:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
@@ -246,19 +246,19 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
       </label>
       <div
         aria-label="Test Toggle Group Control"
-        class="components-toggle-group-control emotion-6 emotion-7"
+        class="emotion-6 components-toggle-group-control"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
         id="wp-components-base-control-19"
         role="radiogroup"
       >
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="true"
             aria-label="Uppercase"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-active-item="true"
             data-value="uppercase"
             data-wp-c16t="true"
@@ -270,7 +270,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             value="uppercase"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               <svg
                 aria-hidden="true"
@@ -289,12 +289,12 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
           </button>
         </div>
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="Lowercase"
-            class="emotion-15 components-toggle-group-control-option-base"
+            class="emotion-14 components-toggle-group-control-option-base"
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -305,7 +305,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             value="lowercase"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               <svg
                 aria-hidden="true"
@@ -416,7 +416,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   		);
 }
 
-.emotion-8 {
+.emotion-7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -429,7 +429,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -468,27 +468,27 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-10 {
+  .emotion-9 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10[disabled],
-.emotion-10[aria-disabled='true'] {
+.emotion-9[disabled],
+.emotion-9[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-10:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-9:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -512,19 +512,19 @@ exports[`ToggleGroupControl controlled should render correctly with text options
       </label>
       <div
         aria-label="Test Toggle Group Control"
-        class="components-toggle-group-control emotion-6 emotion-7"
+        class="emotion-6 components-toggle-group-control"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
         id="wp-components-base-control-18"
         role="radiogroup"
       >
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="R"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-value="rigas"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -535,19 +535,19 @@ exports[`ToggleGroupControl controlled should render correctly with text options
             value="rigas"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               R
             </div>
           </button>
         </div>
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="J"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-value="jack"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -558,7 +558,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
             value="jack"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               J
             </div>
@@ -657,7 +657,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   		);
 }
 
-.emotion-8 {
+.emotion-7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -670,7 +670,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -715,27 +715,27 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-10 {
+  .emotion-9 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10[disabled],
-.emotion-10[aria-disabled='true'] {
+.emotion-9[disabled],
+.emotion-9[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-10:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-9:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -744,7 +744,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   line-height: 1;
 }
 
-.emotion-15 {
+.emotion-14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -787,23 +787,23 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-15 {
+  .emotion-14 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-15[disabled],
-.emotion-15[aria-disabled='true'] {
+.emotion-14[disabled],
+.emotion-14[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-15:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-14:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
@@ -822,19 +822,19 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
       </label>
       <div
         aria-label="Test Toggle Group Control"
-        class="components-toggle-group-control emotion-6 emotion-7"
+        class="emotion-6 components-toggle-group-control"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
         id="wp-components-base-control-1"
         role="radiogroup"
       >
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="true"
             aria-label="Uppercase"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-active-item="true"
             data-value="uppercase"
             data-wp-c16t="true"
@@ -846,7 +846,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             value="uppercase"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               <svg
                 aria-hidden="true"
@@ -865,12 +865,12 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
           </button>
         </div>
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="Lowercase"
-            class="emotion-15 components-toggle-group-control-option-base"
+            class="emotion-14 components-toggle-group-control-option-base"
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -881,7 +881,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             value="lowercase"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               <svg
                 aria-hidden="true"
@@ -986,7 +986,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
   		);
 }
 
-.emotion-8 {
+.emotion-7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -999,7 +999,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1038,27 +1038,27 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-10 {
+  .emotion-9 {
     -webkit-transition: color 160ms linear,font-weight 60ms linear;
     transition: color 160ms linear,font-weight 60ms linear;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10[disabled],
-.emotion-10[aria-disabled='true'] {
+.emotion-9[disabled],
+.emotion-9[aria-disabled='true'] {
   opacity: 0.4;
   cursor: default;
 }
 
-.emotion-10:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
+.emotion-9:hover:not( [disabled] ):not( [aria-disabled='true'] ) {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1082,19 +1082,19 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
       </label>
       <div
         aria-label="Test Toggle Group Control"
-        class="components-toggle-group-control emotion-6 emotion-7"
+        class="emotion-6 components-toggle-group-control"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
         id="wp-components-base-control-0"
         role="radiogroup"
       >
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="R"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-value="rigas"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -1105,19 +1105,19 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
             value="rigas"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               R
             </div>
           </button>
         </div>
         <div
-          class="emotion-8 emotion-9"
+          class="emotion-7 emotion-8"
         >
           <button
             aria-checked="false"
             aria-label="J"
-            class="emotion-10 components-toggle-group-control-option-base"
+            class="emotion-9 components-toggle-group-control-option-base"
             data-value="jack"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -1128,7 +1128,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
             value="jack"
           >
             <div
-              class="emotion-11 emotion-12"
+              class="emotion-10 emotion-11"
             >
               J
             </div>

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -274,7 +274,6 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             >
               <svg
                 aria-hidden="true"
-                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -309,7 +308,6 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
             >
               <svg
                 aria-hidden="true"
-                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -850,7 +848,6 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             >
               <svg
                 aria-hidden="true"
-                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -885,7 +882,6 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
             >
               <svg
                 aria-hidden="true"
-                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -27,6 +27,11 @@ const hoverOutside = async () => {
 	await hover( document.body, { clientX: 10, clientY: 10 } );
 };
 
+const getGeneratedEmotionClassNames = ( element: HTMLElement ) =>
+	Array.from( element.classList ).filter( ( className ) =>
+		/^(css|emotion)-/.test( className )
+	);
+
 const ControlledToggleGroupControl = ( {
 	value: valueProp,
 	onChange,
@@ -630,4 +635,19 @@ describe.each( [
 			} );
 		} );
 	} );
+} );
+
+test( 'should compose block styles in a single generated class', () => {
+	render(
+		<ToggleGroupControl label="Test Toggle Group Control" isBlock>
+			{ options }
+		</ToggleGroupControl>
+	);
+
+	const control = screen.getByRole( 'radiogroup', {
+		name: 'Test Toggle Group Control',
+	} );
+
+	expect( getGeneratedEmotionClassNames( control ) ).toHaveLength( 1 );
+	expect( control ).toHaveStyle( { display: 'flex' } );
 } );

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -76,7 +76,6 @@ function UnconnectedToggleGroupControl(
 					isBlock,
 					isDeselectable,
 				} ),
-				isBlock && styles.block,
 				className
 			),
 		[ className, cx, isBlock, isDeselectable ]

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -9,6 +9,11 @@ import { css } from '@emotion/react';
 import { CONFIG, COLORS } from '../../utils';
 import type { ToggleGroupControlProps } from '../types';
 
+export const block = css`
+	display: flex;
+	width: 100%;
+`;
+
 export const toggleGroupControl = ( {
 	isBlock,
 	isDeselectable,
@@ -22,6 +27,7 @@ export const toggleGroupControl = ( {
 	position: relative;
 
 	${ ! isDeselectable && enclosingBorders( isBlock ) }
+	${ isBlock && block }
 
 	@media not ( prefers-reduced-motion ) {
 		&[data-indicator-animated]::before {
@@ -76,8 +82,3 @@ const enclosingBorders = ( isBlock: ToggleGroupControlProps[ 'isBlock' ] ) => {
 		}
 	`;
 };
-
-export const block = css`
-	display: flex;
-	width: 100%;
-`;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -62,6 +62,22 @@ export const ToolsPanelHiddenInnerWrapper = css`
 	}
 `;
 
+export function getToolsPanelStyles( {
+	columns,
+	hasInnerWrapper,
+	areAllOptionalControlsHidden,
+}: {
+	columns: number;
+	hasInnerWrapper: boolean;
+	areAllOptionalControlsHidden: boolean;
+} ) {
+	return css(
+		ToolsPanel( columns ),
+		hasInnerWrapper && ToolsPanelWithInnerWrapper( columns ),
+		areAllOptionalControlsHidden && ToolsPanelHiddenInnerWrapper
+	);
+}
+
 export const ToolsPanelHeader = css`
 	${ toolsPanelGrid.item.fullWidth }
 	gap: ${ space( 2 ) };

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -9,6 +9,8 @@ import userEvent from '@testing-library/user-event';
  */
 import { ToolsPanel, ToolsPanelContext, ToolsPanelItem } from '../';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
+import * as styles from '../styles';
+import { useCx } from '../../utils/hooks/use-cx';
 import type {
 	ToolsPanelContext as ToolsPanelContextType,
 	ResetAllFilter,
@@ -17,6 +19,25 @@ import type {
 const { Fill: ToolsPanelItems, Slot } = createSlotFill( 'ToolsPanelSlot' );
 const resetAll = jest.fn();
 const noop = () => undefined;
+
+type EmotionStyleFragment = Parameters< ReturnType< typeof useCx > >[ 0 ];
+
+const getGeneratedEmotionClassNames = ( element: HTMLElement ) =>
+	Array.from( element.classList ).filter( ( className ) =>
+		/^(css|emotion)-/.test( className )
+	);
+
+function EmotionStyleTest( {
+	styleFragment,
+}: {
+	styleFragment: EmotionStyleFragment;
+} ) {
+	const cx = useCx();
+
+	return (
+		<div data-testid="emotion-style" className={ cx( styleFragment ) } />
+	);
+}
 
 type ControlValue = boolean | undefined;
 
@@ -257,6 +278,24 @@ describe( 'ToolsPanel', () => {
 			const resetAllItem = await screen.findByRole( 'menuitem' );
 
 			expect( resetAllItem ).toBeInTheDocument();
+		} );
+
+		it( 'should compose inner wrapper visibility styles in a single generated class', () => {
+			render(
+				<EmotionStyleTest
+					styleFragment={ styles.getToolsPanelStyles( {
+						columns: 2,
+						hasInnerWrapper: true,
+						areAllOptionalControlsHidden: true,
+					} ) }
+				/>
+			);
+
+			expect(
+				getGeneratedEmotionClassNames(
+					screen.getByTestId( 'emotion-style' )
+				)
+			).toHaveLength( 1 );
 		} );
 
 		it( 'should render panel menu items correctly', async () => {

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -341,16 +341,12 @@ export function useToolsPanel(
 
 	const cx = useCx();
 	const classes = useMemo( () => {
-		const wrapperStyle =
-			hasInnerWrapper &&
-			styles.ToolsPanelWithInnerWrapper( DEFAULT_COLUMNS );
-		const emptyStyle =
-			areAllOptionalControlsHidden && styles.ToolsPanelHiddenInnerWrapper;
-
 		return cx(
-			styles.ToolsPanel( DEFAULT_COLUMNS ),
-			wrapperStyle,
-			emptyStyle,
+			styles.getToolsPanelStyles( {
+				columns: DEFAULT_COLUMNS,
+				hasInnerWrapper,
+				areAllOptionalControlsHidden,
+			} ),
 			className
 		);
 	}, [ areAllOptionalControlsHidden, className, cx, hasInnerWrapper ] );

--- a/packages/components/src/utils/hooks/use-cx.ts
+++ b/packages/components/src/utils/hooks/use-cx.ts
@@ -24,6 +24,10 @@ const isSerializedStyles = ( o: any ): o is SerializedStyles =>
  * `cx` normally knows how to handle. It also hooks into the Emotion
  * Cache, allowing `css` calls to work inside iframes.
  *
+ * Passing multiple `SerializedStyles` arguments emits multiple classes. When
+ * fragments rely on source-order overrides, compose them in a single `css()`
+ * call before passing them to `cx`.
+ *
  * ```jsx
  * import { css } from '@emotion/react';
  *

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -18,6 +18,8 @@ type PolymorphicElementProps< T extends React.ElementType > = Omit<
 type PolymorphicElementRef< T extends React.ElementType > =
 	React.ComponentPropsWithRef< T >[ 'ref' ];
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
 const knownIntrinsicElementProps = new Set( [
 	'children',
 	'className',
@@ -53,7 +55,10 @@ function isValidIntrinsicElementProp( prop: string, element: string ) {
 
 	const ownerDocument = globalThis.document;
 	if ( ownerDocument ) {
-		return prop in ownerDocument.createElement( element );
+		return (
+			prop in ownerDocument.createElement( element ) ||
+			prop in ownerDocument.createElementNS( SVG_NAMESPACE, element )
+		);
 	}
 
 	return prop === prop.toLowerCase();

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import type * as React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+type PolymorphicElementProps< T extends React.ElementType > = Omit<
+	React.ComponentPropsWithoutRef< T >,
+	'as'
+> & {
+	as?: T;
+};
+
+type PolymorphicElementRef< T extends React.ElementType > =
+	React.ComponentPropsWithRef< T >[ 'ref' ];
+
+function UnforwardedPolymorphicElement< T extends React.ElementType = 'div' >(
+	{ as, ...props }: PolymorphicElementProps< T >,
+	ref: PolymorphicElementRef< T >
+) {
+	const Element = as || 'div';
+
+	return <Element ref={ ref } { ...props } />;
+}
+
+/**
+ * Internal utility for components that need Emotion-compatible `as` behavior
+ * while rendering with plain React elements.
+ */
+export const PolymorphicElement = forwardRef(
+	UnforwardedPolymorphicElement
+) as < T extends React.ElementType = 'div' >(
+	props: PolymorphicElementProps< T > & {
+		ref?: PolymorphicElementRef< T >;
+	}
+) => React.ReactElement | null;

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -18,13 +18,69 @@ type PolymorphicElementProps< T extends React.ElementType > = Omit<
 type PolymorphicElementRef< T extends React.ElementType > =
 	React.ComponentPropsWithRef< T >[ 'ref' ];
 
-function UnforwardedPolymorphicElement< T extends React.ElementType = 'div' >(
-	{ as, ...props }: PolymorphicElementProps< T >,
-	ref: PolymorphicElementRef< T >
+const knownIntrinsicElementProps = new Set( [
+	'children',
+	'className',
+	'dangerouslySetInnerHTML',
+	'defaultChecked',
+	'defaultValue',
+	'htmlFor',
+	'id',
+	'readOnly',
+	'ref',
+	'role',
+	'style',
+	'suppressContentEditableWarning',
+	'suppressHydrationWarning',
+	'tabIndex',
+	'title',
+] );
+
+function isValidIntrinsicElementProp( prop: string, element: string ) {
+	if (
+		prop.startsWith( 'data-' ) ||
+		prop.startsWith( 'aria-' ) ||
+		( prop.charCodeAt( 0 ) === 111 &&
+			prop.charCodeAt( 1 ) === 110 &&
+			prop.charCodeAt( 2 ) < 91 )
+	) {
+		return true;
+	}
+
+	if ( knownIntrinsicElementProps.has( prop ) ) {
+		return true;
+	}
+
+	const ownerDocument = globalThis.document;
+	if ( ownerDocument ) {
+		return prop in ownerDocument.createElement( element );
+	}
+
+	return prop === prop.toLowerCase();
+}
+
+function filterIntrinsicElementProps(
+	props: PolymorphicElementProps< React.ElementType >,
+	element: string
+) {
+	return Object.fromEntries(
+		Object.entries( props ).filter( ( [ prop ] ) =>
+			isValidIntrinsicElementProp( prop, element )
+		)
+	);
+}
+
+function UnforwardedPolymorphicElement(
+	{ as, ...props }: PolymorphicElementProps< React.ElementType >,
+	ref: React.ForwardedRef< unknown >
 ) {
 	const Element = as || 'div';
+	const forwardedProps =
+		typeof Element === 'string'
+			? filterIntrinsicElementProps( props, Element )
+			: props;
 
-	return <Element ref={ ref } { ...props } />;
+	return <Element ref={ ref } { ...forwardedProps } />;
 }
 
 /**

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -21,6 +21,10 @@ type PolymorphicElementRef< T extends React.ElementType > =
 const customAttributeRegExp = /^(data|aria|x)-/i;
 const eventHandlerRegExp = /^on[A-Z]/;
 
+// Derived from @emotion/is-prop-valid's React prop allowlist, but split by
+// element type so SVG-only props are intentionally filtered from HTML elements.
+// The event-handler check is also deliberately stricter than Emotion's
+// charCode-based `on*` fallback.
 const svgElementNames = new Set(
 	`animate animateMotion animateTransform circle clipPath defs desc ellipse
 	feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -18,120 +18,97 @@ type PolymorphicElementProps< T extends React.ElementType > = Omit<
 type PolymorphicElementRef< T extends React.ElementType > =
 	React.ComponentPropsWithRef< T >[ 'ref' ];
 
-const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
-let cachedOwnerDocument: Document | undefined;
-const htmlElementCache = new Map< string, HTMLElement >();
-const svgElementCache = new Map< string, SVGElement >();
+const customAttributeRegExp = /^(data|aria|x)-/i;
+const eventHandlerRegExp = /^on[A-Z]/;
 
-const knownSvgElementProps = new Set( [
-	'clipPath',
-	'clipRule',
-	'cx',
-	'cy',
-	'd',
-	'fill',
-	'fillRule',
-	'focusable',
-	'height',
-	'pathLength',
-	'points',
-	'preserveAspectRatio',
-	'r',
-	'rx',
-	'ry',
-	'stroke',
-	'strokeLinecap',
-	'strokeLinejoin',
-	'strokeWidth',
-	'transform',
-	'viewBox',
-	'width',
-	'x',
-	'x1',
-	'x2',
-	'xlinkHref',
-	'xmlSpace',
-	'y',
-	'y1',
-	'y2',
-] );
+const svgElementNames = new Set(
+	`animate animateMotion animateTransform circle clipPath defs desc ellipse
+	feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix
+	feDiffuseLighting feDisplacementMap feDistantLight feDropShadow feFlood
+	feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage feMerge feMergeNode
+	feMorphology feOffset fePointLight feSpecularLighting feSpotLight feTile
+	feTurbulence filter foreignObject g image line linearGradient marker mask
+	metadata mpath path pattern polygon polyline radialGradient rect set stop svg
+	switch symbol text textPath tspan use view`.split( /\s+/ )
+);
 
-const knownIntrinsicElementProps = new Set( [
-	'children',
-	'className',
-	'dangerouslySetInnerHTML',
-	'defaultChecked',
-	'defaultValue',
-	'htmlFor',
-	'id',
-	'readOnly',
-	'ref',
-	'role',
-	'style',
-	'suppressContentEditableWarning',
-	'suppressHydrationWarning',
-	'tabIndex',
-	'title',
-] );
+const baseElementProps = new Set(
+	`children dangerouslySetInnerHTML key autoFocus defaultValue defaultChecked
+	innerHTML suppressContentEditableWarning suppressHydrationWarning valueLink
+	abbr accept acceptCharset accessKey action allow allowUserMedia
+	allowPaymentRequest allowFullScreen allowTransparency alt async autoComplete
+	autoPlay capture cellPadding cellSpacing challenge charSet checked cite classID
+	className cols colSpan content contentEditable contextMenu controls controlsList
+	coords crossOrigin data dateTime decoding default defer dir disabled
+	disablePictureInPicture disableRemotePlayback download draggable encType
+	enterKeyHint fetchpriority fetchPriority form formAction formEncType formMethod
+	formNoValidate formTarget frameBorder headers height hidden high href hrefLang
+	htmlFor httpEquiv id inputMode integrity is keyParams keyType kind label lang
+	list loading loop low marginHeight marginWidth max maxLength media mediaGroup
+	method min minLength multiple muted name nonce noValidate open optimum pattern
+	placeholder playsInline popover popoverTarget popoverTargetAction poster
+	preload profile radioGroup readOnly referrerPolicy rel required reversed role
+	rows rowSpan sandbox scope scoped scrolling seamless selected shape size sizes
+	slot span spellCheck src srcDoc srcLang srcSet start step style summary
+	tabIndex target title translate type useMap value width wmode wrap about
+	datatype inlist prefix property resource typeof vocab autoCapitalize
+	autoCorrect autoSave color incremental fallback inert itemProp itemScope
+	itemType itemID itemRef on option results security unselectable`.split( /\s+/ )
+);
 
-function getCachedIntrinsicElements( element: string ) {
-	const ownerDocument = globalThis.document;
-	if ( ! ownerDocument ) {
-		return;
-	}
+const svgElementProps = new Set(
+	`accentHeight accumulate additive alignmentBaseline allowReorder alphabetic
+	amplitude arabicForm ascent attributeName attributeType autoReverse azimuth
+	baseFrequency baselineShift baseProfile bbox begin bias by calcMode capHeight
+	clip clipPathUnits clipPath clipRule colorInterpolation
+	colorInterpolationFilters colorProfile colorRendering contentScriptType
+	contentStyleType cursor cx cy d decelerate descent diffuseConstant direction
+	display divisor dominantBaseline dur dx dy edgeMode elevation enableBackground
+	end exponent externalResourcesRequired fill fillOpacity fillRule filter
+	filterRes filterUnits floodColor floodOpacity focusable fontFamily fontSize
+	fontSizeAdjust fontStretch fontStyle fontVariant fontWeight format from fr fx
+	fy g1 g2 glyphName glyphOrientationHorizontal glyphOrientationVertical
+	glyphRef gradientTransform gradientUnits hanging horizAdvX horizOriginX
+	ideographic imageRendering in in2 intercept k k1 k2 k3 k4 kernelMatrix
+	kernelUnitLength kerning keyPoints keySplines keyTimes lengthAdjust
+	letterSpacing lightingColor limitingConeAngle local markerEnd markerMid
+	markerStart markerHeight markerUnits markerWidth mask maskContentUnits
+	maskUnits mathematical mode numOctaves offset opacity operator order orient
+	orientation origin overflow overlinePosition overlineThickness panose1
+	paintOrder pathLength patternContentUnits patternTransform patternUnits
+	pointerEvents points pointsAtX pointsAtY pointsAtZ preserveAlpha
+	preserveAspectRatio primitiveUnits r radius refX refY renderingIntent
+	repeatCount repeatDur requiredExtensions requiredFeatures restart result rotate
+	rx ry scale seed shapeRendering slope spacing specularConstant
+	specularExponent speed spreadMethod startOffset stdDeviation stemh stemv
+	stitchTiles stopColor stopOpacity strikethroughPosition strikethroughThickness
+	string stroke strokeDasharray strokeDashoffset strokeLinecap strokeLinejoin
+	strokeMiterlimit strokeOpacity strokeWidth surfaceScale systemLanguage
+	tableValues targetX targetY textAnchor textDecoration textRendering textLength
+	to transform u1 u2 underlinePosition underlineThickness unicode unicodeBidi
+	unicodeRange unitsPerEm vAlphabetic vHanging vIdeographic vMathematical values
+	vectorEffect version vertAdvY vertOriginX vertOriginY viewBox viewTarget
+	visibility widths wordSpacing writingMode x xHeight x1 x2 xChannelSelector
+	xlinkActuate xlinkArcrole xlinkHref xlinkRole xlinkShow xlinkTitle xlinkType
+	xmlBase xmlns xmlnsXlink xmlLang xmlSpace y y1 y2 yChannelSelector z
+	zoomAndPan`.split( /\s+/ )
+);
 
-	if ( ownerDocument !== cachedOwnerDocument ) {
-		cachedOwnerDocument = ownerDocument;
-		htmlElementCache.clear();
-		svgElementCache.clear();
-	}
-
-	let htmlElement = htmlElementCache.get( element );
-	if ( ! htmlElement ) {
-		htmlElement = ownerDocument.createElement( element );
-		htmlElementCache.set( element, htmlElement );
-	}
-
-	let svgElement = svgElementCache.get( element );
-	if ( ! svgElement ) {
-		svgElement = ownerDocument.createElementNS( SVG_NAMESPACE, element );
-		svgElementCache.set( element, svgElement );
-	}
-
-	return {
-		htmlElement,
-		svgElement,
-	};
-}
+const compatElementProps = new Set( [ 'autofocus', 'class', 'for' ] );
 
 function isValidIntrinsicElementProp( prop: string, element: string ) {
 	if (
-		prop.startsWith( 'data-' ) ||
-		prop.startsWith( 'aria-' ) ||
-		( prop.charCodeAt( 0 ) === 111 &&
-			prop.charCodeAt( 1 ) === 110 &&
-			prop.charCodeAt( 2 ) < 91 )
+		customAttributeRegExp.test( prop ) ||
+		eventHandlerRegExp.test( prop )
 	) {
 		return true;
 	}
 
-	if ( knownIntrinsicElementProps.has( prop ) ) {
+	if ( baseElementProps.has( prop ) || compatElementProps.has( prop ) ) {
 		return true;
 	}
 
-	if ( knownSvgElementProps.has( prop ) ) {
-		return true;
-	}
-
-	const cachedElements = getCachedIntrinsicElements( element );
-	if ( cachedElements ) {
-		return (
-			prop in cachedElements.htmlElement ||
-			prop in cachedElements.svgElement
-		);
-	}
-
-	return prop === prop.toLowerCase();
+	return svgElementNames.has( element ) && svgElementProps.has( prop );
 }
 
 function filterIntrinsicElementProps(

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -23,6 +23,39 @@ let cachedOwnerDocument: Document | undefined;
 const htmlElementCache = new Map< string, HTMLElement >();
 const svgElementCache = new Map< string, SVGElement >();
 
+const knownSvgElementProps = new Set( [
+	'clipPath',
+	'clipRule',
+	'cx',
+	'cy',
+	'd',
+	'fill',
+	'fillRule',
+	'focusable',
+	'height',
+	'pathLength',
+	'points',
+	'preserveAspectRatio',
+	'r',
+	'rx',
+	'ry',
+	'stroke',
+	'strokeLinecap',
+	'strokeLinejoin',
+	'strokeWidth',
+	'transform',
+	'viewBox',
+	'width',
+	'x',
+	'x1',
+	'x2',
+	'xlinkHref',
+	'xmlSpace',
+	'y',
+	'y1',
+	'y2',
+] );
+
 const knownIntrinsicElementProps = new Set( [
 	'children',
 	'className',
@@ -83,6 +116,10 @@ function isValidIntrinsicElementProp( prop: string, element: string ) {
 	}
 
 	if ( knownIntrinsicElementProps.has( prop ) ) {
+		return true;
+	}
+
+	if ( knownSvgElementProps.has( prop ) ) {
 		return true;
 	}
 

--- a/packages/components/src/utils/polymorphic-element.tsx
+++ b/packages/components/src/utils/polymorphic-element.tsx
@@ -19,6 +19,9 @@ type PolymorphicElementRef< T extends React.ElementType > =
 	React.ComponentPropsWithRef< T >[ 'ref' ];
 
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+let cachedOwnerDocument: Document | undefined;
+const htmlElementCache = new Map< string, HTMLElement >();
+const svgElementCache = new Map< string, SVGElement >();
 
 const knownIntrinsicElementProps = new Set( [
 	'children',
@@ -38,6 +41,36 @@ const knownIntrinsicElementProps = new Set( [
 	'title',
 ] );
 
+function getCachedIntrinsicElements( element: string ) {
+	const ownerDocument = globalThis.document;
+	if ( ! ownerDocument ) {
+		return;
+	}
+
+	if ( ownerDocument !== cachedOwnerDocument ) {
+		cachedOwnerDocument = ownerDocument;
+		htmlElementCache.clear();
+		svgElementCache.clear();
+	}
+
+	let htmlElement = htmlElementCache.get( element );
+	if ( ! htmlElement ) {
+		htmlElement = ownerDocument.createElement( element );
+		htmlElementCache.set( element, htmlElement );
+	}
+
+	let svgElement = svgElementCache.get( element );
+	if ( ! svgElement ) {
+		svgElement = ownerDocument.createElementNS( SVG_NAMESPACE, element );
+		svgElementCache.set( element, svgElement );
+	}
+
+	return {
+		htmlElement,
+		svgElement,
+	};
+}
+
 function isValidIntrinsicElementProp( prop: string, element: string ) {
 	if (
 		prop.startsWith( 'data-' ) ||
@@ -53,11 +86,11 @@ function isValidIntrinsicElementProp( prop: string, element: string ) {
 		return true;
 	}
 
-	const ownerDocument = globalThis.document;
-	if ( ownerDocument ) {
+	const cachedElements = getCachedIntrinsicElements( element );
+	if ( cachedElements ) {
 		return (
-			prop in ownerDocument.createElement( element ) ||
-			prop in ownerDocument.createElementNS( SVG_NAMESPACE, element )
+			prop in cachedElements.htmlElement ||
+			prop in cachedElements.svgElement
 		);
 	}
 

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -3,6 +3,7 @@
  */
 import styled from '@emotion/styled';
 import { render, screen } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
 
 /**
  * WordPress dependencies
@@ -68,6 +69,19 @@ describe.each( components )( '$name', ( { Component: RawComponent } ) => {
 		expect( element ).toHaveStyle( { color: 'rgb(255, 0, 0)' } );
 	} );
 
+	it( 'preserves standard props without relying on the DOM', () => {
+		const view = renderToString(
+			createElement( Component, {
+				as: 'form',
+				acceptCharset: 'utf-8',
+			} as Parameters< typeof Component >[ 0 ] & {
+				acceptCharset: string;
+			} )
+		);
+
+		expect( view ).toContain( 'accept-charset="utf-8"' );
+	} );
+
 	it( 'preserves SVG props for SVG intrinsic elements', () => {
 		render(
 			<Component
@@ -88,6 +102,21 @@ describe.each( components )( '$name', ( { Component: RawComponent } ) => {
 		expect( svg ).toHaveAttribute( 'stroke', 'none' );
 		expect( svg ).toHaveAttribute( 'stroke-width', '2' );
 		expect( svg ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+	} );
+
+	it( 'preserves SVG props without relying on the DOM', () => {
+		const view = renderToString(
+			<Component
+				as="svg"
+				fill="currentColor"
+				strokeWidth={ 2 }
+				viewBox="0 0 24 24"
+			/>
+		);
+
+		expect( view ).toContain( 'fill="currentColor"' );
+		expect( view ).toContain( 'stroke-width="2"' );
+		expect( view ).toContain( 'viewBox="0 0 24 24"' );
 	} );
 
 	it( 'preserves SVG props for non-SVG-root intrinsic elements', () => {
@@ -166,5 +195,43 @@ describe.each( components )( '$name', ( { Component: RawComponent } ) => {
 		);
 
 		expect( ref.current ).toBe( screen.getByTestId( 'button' ) );
+	} );
+} );
+
+describe( 'PolymorphicElement prop filtering', () => {
+	it( 'filters invalid on-prefixed props from intrinsic elements', () => {
+		render(
+			createElement( PolymorphicElement, {
+				'data-testid': 'element',
+				on1: 'invalid',
+				'on-foo': 'invalid',
+			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+				on1: string;
+				'on-foo': string;
+			} )
+		);
+
+		const element = screen.getByTestId( 'element' );
+
+		expect( element ).not.toHaveAttribute( 'on1' );
+		expect( element ).not.toHaveAttribute( 'on-foo' );
+	} );
+
+	it( 'filters SVG-only props from HTML intrinsic elements', () => {
+		render(
+			createElement( PolymorphicElement, {
+				'data-testid': 'element',
+				fill: 'currentColor',
+				strokeWidth: 2,
+			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+				fill: string;
+				strokeWidth: number;
+			} )
+		);
+
+		const element = screen.getByTestId( 'element' );
+
+		expect( element ).not.toHaveAttribute( 'fill' );
+		expect( element ).not.toHaveAttribute( 'stroke-width' );
 	} );
 } );

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -52,6 +52,41 @@ describe( 'PolymorphicElement', () => {
 		expect( element ).toHaveStyle( { color: 'rgb(255, 0, 0)' } );
 	} );
 
+	it( 'preserves SVG props for SVG intrinsic elements', () => {
+		render(
+			<PolymorphicElement
+				as="svg"
+				data-testid="svg"
+				preserveAspectRatio="xMidYMid meet"
+				viewBox="0 0 24 24"
+			/>
+		);
+
+		const svg = screen.getByTestId( 'svg' );
+
+		expect( svg ).toHaveAttribute( 'preserveAspectRatio', 'xMidYMid meet' );
+		expect( svg ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+	} );
+
+	it( 'filters invalid props from SVG intrinsic elements', () => {
+		render(
+			createElement( PolymorphicElement, {
+				as: 'svg',
+				'data-testid': 'svg',
+				labelPosition: 'top',
+				viewBox: '0 0 24 24',
+			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+				labelPosition: string;
+			} )
+		);
+
+		const svg = screen.getByTestId( 'svg' );
+
+		expect( svg ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+		expect( svg ).not.toHaveAttribute( 'labelPosition' );
+		expect( svg ).not.toHaveAttribute( 'labelposition' );
+	} );
+
 	it( 'passes custom props through to custom components', () => {
 		function CustomComponent( {
 			variant,

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -73,15 +73,41 @@ describe.each( components )( '$name', ( { Component: RawComponent } ) => {
 			<Component
 				as="svg"
 				data-testid="svg"
+				fill="currentColor"
 				preserveAspectRatio="xMidYMid meet"
+				stroke="none"
+				strokeWidth={ 2 }
 				viewBox="0 0 24 24"
 			/>
 		);
 
 		const svg = screen.getByTestId( 'svg' );
 
+		expect( svg ).toHaveAttribute( 'fill', 'currentColor' );
 		expect( svg ).toHaveAttribute( 'preserveAspectRatio', 'xMidYMid meet' );
+		expect( svg ).toHaveAttribute( 'stroke', 'none' );
+		expect( svg ).toHaveAttribute( 'stroke-width', '2' );
 		expect( svg ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+	} );
+
+	it( 'preserves SVG props for non-SVG-root intrinsic elements', () => {
+		render(
+			<svg>
+				<Component
+					as="path"
+					d="M0 0h24v24H0z"
+					data-testid="path"
+					fillRule="evenodd"
+					clipPath="url(#clip)"
+				/>
+			</svg>
+		);
+
+		const path = screen.getByTestId( 'path' );
+
+		expect( path ).toHaveAttribute( 'clip-path', 'url(#clip)' );
+		expect( path ).toHaveAttribute( 'd', 'M0 0h24v24H0z' );
+		expect( path ).toHaveAttribute( 'fill-rule', 'evenodd' );
 	} );
 
 	it( 'filters invalid props from SVG intrinsic elements', () => {

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import styled from '@emotion/styled';
 import { render, screen } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 
-/**
- * WordPress dependencies
- */
 import { createElement, createRef } from '@wordpress/element';
 
 /**

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement, createRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PolymorphicElement } from '../polymorphic-element';
+
+describe( 'PolymorphicElement', () => {
+	it( 'filters invalid props from intrinsic elements', () => {
+		render(
+			createElement( PolymorphicElement, {
+				as: 'label',
+				'data-testid': 'label',
+				htmlFor: 'field',
+				labelPosition: 'top',
+			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+				labelPosition: string;
+			} )
+		);
+
+		const label = screen.getByTestId( 'label' );
+
+		expect( label ).toHaveAttribute( 'for', 'field' );
+		expect( label ).not.toHaveAttribute( 'labelPosition' );
+		expect( label ).not.toHaveAttribute( 'labelposition' );
+	} );
+
+	it( 'preserves standard props for intrinsic elements', () => {
+		render(
+			<PolymorphicElement
+				aria-label="Notice"
+				className="custom-class"
+				data-testid="notice"
+				style={ { color: 'red' } }
+				title="Notice title"
+			/>
+		);
+
+		const element = screen.getByTestId( 'notice' );
+
+		expect( element ).toHaveAttribute( 'aria-label', 'Notice' );
+		expect( element ).toHaveAttribute( 'title', 'Notice title' );
+		expect( element ).toHaveClass( 'custom-class' );
+		expect( element ).toHaveStyle( { color: 'rgb(255, 0, 0)' } );
+	} );
+
+	it( 'passes custom props through to custom components', () => {
+		function CustomComponent( {
+			variant,
+			...props
+		}: JSX.IntrinsicElements[ 'section' ] & {
+			variant: string;
+		} ) {
+			return <section data-variant={ variant } { ...props } />;
+		}
+
+		render(
+			<PolymorphicElement
+				as={ CustomComponent }
+				data-testid="custom"
+				variant="primary"
+			/>
+		);
+
+		expect( screen.getByTestId( 'custom' ) ).toHaveAttribute(
+			'data-variant',
+			'primary'
+		);
+	} );
+
+	it( 'forwards refs to the rendered element', () => {
+		const ref = createRef< HTMLButtonElement >();
+
+		render(
+			<PolymorphicElement
+				as="button"
+				data-testid="button"
+				ref={ ref }
+				type="button"
+			/>
+		);
+
+		expect( ref.current ).toBe( screen.getByTestId( 'button' ) );
+	} );
+} );

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import styled from '@emotion/styled';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,15 +14,30 @@ import { createElement, createRef } from '@wordpress/element';
  */
 import { PolymorphicElement } from '../polymorphic-element';
 
-describe( 'PolymorphicElement', () => {
+const StyledDiv = styled.div``;
+
+const components = [
+	{
+		name: 'PolymorphicElement',
+		Component: PolymorphicElement,
+	},
+	{
+		name: 'styled.div',
+		Component: StyledDiv,
+	},
+] as const;
+
+describe.each( components )( '$name', ( { Component: RawComponent } ) => {
+	const Component = RawComponent as typeof PolymorphicElement;
+
 	it( 'filters invalid props from intrinsic elements', () => {
 		render(
-			createElement( PolymorphicElement, {
+			createElement( Component, {
 				as: 'label',
 				'data-testid': 'label',
 				htmlFor: 'field',
 				labelPosition: 'top',
-			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+			} as Parameters< typeof Component >[ 0 ] & {
 				labelPosition: string;
 			} )
 		);
@@ -35,7 +51,7 @@ describe( 'PolymorphicElement', () => {
 
 	it( 'preserves standard props for intrinsic elements', () => {
 		render(
-			<PolymorphicElement
+			<Component
 				aria-label="Notice"
 				className="custom-class"
 				data-testid="notice"
@@ -54,7 +70,7 @@ describe( 'PolymorphicElement', () => {
 
 	it( 'preserves SVG props for SVG intrinsic elements', () => {
 		render(
-			<PolymorphicElement
+			<Component
 				as="svg"
 				data-testid="svg"
 				preserveAspectRatio="xMidYMid meet"
@@ -70,12 +86,12 @@ describe( 'PolymorphicElement', () => {
 
 	it( 'filters invalid props from SVG intrinsic elements', () => {
 		render(
-			createElement( PolymorphicElement, {
+			createElement( Component, {
 				as: 'svg',
 				'data-testid': 'svg',
 				labelPosition: 'top',
 				viewBox: '0 0 24 24',
-			} as Parameters< typeof PolymorphicElement >[ 0 ] & {
+			} as Parameters< typeof Component >[ 0 ] & {
 				labelPosition: string;
 			} )
 		);
@@ -98,7 +114,7 @@ describe( 'PolymorphicElement', () => {
 		}
 
 		render(
-			<PolymorphicElement
+			<Component
 				as={ CustomComponent }
 				data-testid="custom"
 				variant="primary"
@@ -115,7 +131,7 @@ describe( 'PolymorphicElement', () => {
 		const ref = createRef< HTMLButtonElement >();
 
 		render(
-			<PolymorphicElement
+			<Component
 				as="button"
 				data-testid="button"
 				ref={ ref }

--- a/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
@@ -6,6 +6,9 @@ exports[`props should render alignment 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20,22 +23,18 @@ exports[`props should render alignment 1`] = `
   justify-content: center;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-height: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack components-v-stack"
     data-wp-c16t="true"
     data-wp-component="VStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;
@@ -46,6 +45,9 @@ exports[`props should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -60,22 +62,18 @@ exports[`props should render correctly 1`] = `
   justify-content: center;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-height: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack components-v-stack"
     data-wp-c16t="true"
     data-wp-component="VStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;
@@ -86,6 +84,9 @@ exports[`props should render spacing 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-1 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -100,22 +101,18 @@ exports[`props should render spacing 1`] = `
   justify-content: center;
 }
 
-.emotion-0>* {
+.emotion-2>* {
   min-height: 0;
 }
 
 <div>
   <div
-    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    class="emotion-0 emotion-1 emotion-2 components-flex components-h-stack components-v-stack"
     data-wp-c16t="true"
     data-wp-component="VStack"
   >
-    <div
-      class="emotion-2 emotion-1"
-    />
-    <div
-      class="emotion-2 emotion-1"
-    />
+    <div />
+    <div />
   </div>
 </div>
 `;

--- a/packages/components/src/v-stack/test/index.tsx
+++ b/packages/components/src/v-stack/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,6 +10,25 @@ import { View } from '../../view';
 import { VStack } from '..';
 
 describe( 'props', () => {
+	test( 'should apply default vertical stack styles', () => {
+		render(
+			<VStack data-testid="v-stack">
+				<View />
+				<View />
+			</VStack>
+		);
+
+		const styles = window.getComputedStyle(
+			screen.getByTestId( 'v-stack' )
+		);
+
+		expect( styles.alignItems ).toBe( 'stretch' );
+		expect( styles.display ).toBe( 'flex' );
+		expect( styles.flexDirection ).toBe( 'column' );
+		expect( styles.gap ).toBe( 'calc(4px * 2)' );
+		expect( styles.justifyContent ).toBe( 'center' );
+	} );
+
 	test( 'should render correctly', () => {
 		const { container } = render(
 			<VStack>

--- a/packages/components/src/v-stack/test/index.tsx
+++ b/packages/components/src/v-stack/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,25 +10,6 @@ import { View } from '../../view';
 import { VStack } from '..';
 
 describe( 'props', () => {
-	test( 'should apply default vertical stack styles', () => {
-		render(
-			<VStack data-testid="v-stack">
-				<View />
-				<View />
-			</VStack>
-		);
-
-		const styles = window.getComputedStyle(
-			screen.getByTestId( 'v-stack' )
-		);
-
-		expect( styles.alignItems ).toBe( 'stretch' );
-		expect( styles.display ).toBe( 'flex' );
-		expect( styles.flexDirection ).toBe( 'column' );
-		expect( styles.gap ).toBe( 'calc(4px * 2)' );
-		expect( styles.justifyContent ).toBe( 'center' );
-	} );
-
 	test( 'should render correctly', () => {
 		const { container } = render(
 			<VStack>

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -29,9 +29,3 @@ function Example() {
 **Type**: `string`,`E`
 
 Render the component as another React Component or HTML Element.
-
-### css
-
-**Type**: `InterpolatedCSS`
-
-Render custom CSS using the style system.

--- a/packages/components/src/view/component.tsx
+++ b/packages/components/src/view/component.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import styled from '@emotion/styled';
-
-/**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
@@ -12,14 +7,25 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../context';
+import { PolymorphicElement } from '../utils/polymorphic-element';
 
-const PolymorphicDiv = styled.div``;
+type ViewProps< T extends React.ElementType > = WordPressComponentProps<
+	{},
+	T
+> & {
+	/**
+	 * Legacy Emotion prop accepted by `View`. It is intentionally consumed here
+	 * so it does not leak to the rendered element after Emotion is removed.
+	 */
+	css?: unknown;
+};
 
 function UnforwardedView< T extends React.ElementType = 'div' >(
-	{ as, ...restProps }: WordPressComponentProps< {}, T >,
+	{ css: _css, ...restProps }: ViewProps< T >,
 	ref: React.ForwardedRef< any >
 ) {
-	return <PolymorphicDiv as={ as } ref={ ref } { ...restProps } />;
+	void _css;
+	return <PolymorphicElement ref={ ref } { ...restProps } />;
 }
 
 /**

--- a/packages/components/src/view/component.tsx
+++ b/packages/components/src/view/component.tsx
@@ -14,8 +14,8 @@ type ViewProps< T extends React.ElementType > = WordPressComponentProps<
 	T
 > & {
 	/**
-	 * Legacy Emotion prop accepted by `View` so it does not leak to the
-	 * rendered element.
+	 * Legacy Emotion prop accepted as a no-op by `View` so it does not leak to
+	 * the rendered element.
 	 *
 	 * @deprecated This prop no longer has any effect.
 	 * @ignore

--- a/packages/components/src/view/component.tsx
+++ b/packages/components/src/view/component.tsx
@@ -14,8 +14,11 @@ type ViewProps< T extends React.ElementType > = WordPressComponentProps<
 	T
 > & {
 	/**
-	 * Legacy Emotion prop accepted by `View`. It is intentionally consumed here
-	 * so it does not leak to the rendered element after Emotion is removed.
+	 * Legacy Emotion prop accepted by `View` so it does not leak to the
+	 * rendered element.
+	 *
+	 * @deprecated This prop no longer has any effect.
+	 * @ignore
 	 */
 	css?: unknown;
 };
@@ -24,6 +27,7 @@ function UnforwardedView< T extends React.ElementType = 'div' >(
 	{ css, ...restProps }: ViewProps< T >,
 	ref: React.ForwardedRef< any >
 ) {
+	void css;
 	return <PolymorphicElement ref={ ref } { ...restProps } />;
 }
 

--- a/packages/components/src/view/component.tsx
+++ b/packages/components/src/view/component.tsx
@@ -21,10 +21,9 @@ type ViewProps< T extends React.ElementType > = WordPressComponentProps<
 };
 
 function UnforwardedView< T extends React.ElementType = 'div' >(
-	{ css: _css, ...restProps }: ViewProps< T >,
+	{ css, ...restProps }: ViewProps< T >,
 	ref: React.ForwardedRef< any >
 ) {
-	void _css;
 	return <PolymorphicElement ref={ ref } { ...restProps } />;
 }
 

--- a/packages/components/src/view/test/__snapshots__/index.js.snap
+++ b/packages/components/src/view/test/__snapshots__/index.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`props should ignore legacy css prop styles (array) 1`] = `
+<div>
+  <p
+    data-testid="custom-css-array-view"
+  >
+    <span />
+  </p>
+</div>
+`;
+
+exports[`props should ignore legacy css prop styles (object) 1`] = `
+<div>
+  <p
+    data-testid="custom-css-object-view"
+  >
+    <span />
+  </p>
+</div>
+`;
+
+exports[`props should ignore legacy css prop styles (string) 1`] = `
+<div>
+  <p
+    data-testid="custom-css-string-view"
+  >
+    <span />
+  </p>
+</div>
+`;
+
 exports[`props should render as a custom component 1`] = `
 <div>
   <section
@@ -25,35 +55,5 @@ exports[`props should render correctly 1`] = `
   <div>
     <span />
   </div>
-</div>
-`;
-
-exports[`props should render with custom styles (Array) 1`] = `
-<div>
-  <p
-    data-testid="custom-css-array-view"
-  >
-    <span />
-  </p>
-</div>
-`;
-
-exports[`props should render with custom styles (object) 1`] = `
-<div>
-  <p
-    data-testid="custom-css-object-view"
-  >
-    <span />
-  </p>
-</div>
-`;
-
-exports[`props should render with custom styles (string) 1`] = `
-<div>
-  <p
-    data-testid="custom-css-string-view"
-  >
-    <span />
-  </p>
 </div>
 `;

--- a/packages/components/src/view/test/__snapshots__/index.js.snap
+++ b/packages/components/src/view/test/__snapshots__/index.js.snap
@@ -1,10 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`props should render as a custom component 1`] = `
+<div>
+  <section
+    class="custom-class"
+    data-custom-component="true"
+    data-testid="custom-view"
+  >
+    <span />
+  </section>
+</div>
+`;
+
 exports[`props should render as another element 1`] = `
 <div>
-  <p
-    class="css-1ragr82-PolymorphicDiv emotion-0"
-  >
+  <p>
     <span />
   </p>
 </div>
@@ -12,9 +22,7 @@ exports[`props should render as another element 1`] = `
 
 exports[`props should render correctly 1`] = `
 <div>
-  <div
-    class="css-1ragr82-PolymorphicDiv emotion-0"
-  >
+  <div>
     <span />
   </div>
 </div>
@@ -23,7 +31,7 @@ exports[`props should render correctly 1`] = `
 exports[`props should render with custom styles (Array) 1`] = `
 <div>
   <p
-    class="css-1ragr82-PolymorphicDiv emotion-0"
+    data-testid="custom-css-array-view"
   >
     <span />
   </p>
@@ -33,7 +41,7 @@ exports[`props should render with custom styles (Array) 1`] = `
 exports[`props should render with custom styles (object) 1`] = `
 <div>
   <p
-    class="css-1ragr82-PolymorphicDiv emotion-0"
+    data-testid="custom-css-object-view"
   >
     <span />
   </p>
@@ -43,7 +51,7 @@ exports[`props should render with custom styles (object) 1`] = `
 exports[`props should render with custom styles (string) 1`] = `
 <div>
   <p
-    class="css-1ragr82-PolymorphicDiv emotion-0"
+    data-testid="custom-css-string-view"
   >
     <span />
   </p>

--- a/packages/components/src/view/test/index.js
+++ b/packages/components/src/view/test/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,10 +32,33 @@ describe( 'props', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
+	test( 'should render as a custom component', () => {
+		const CustomComponent = forwardRef( ( props, ref ) => (
+			<section ref={ ref } data-custom-component { ...props } />
+		) );
+
+		const ref = jest.fn();
+		const { container } = render(
+			<View
+				as={ CustomComponent }
+				className="custom-class"
+				data-testid="custom-view"
+				ref={ ref }
+			>
+				<span />
+			</View>
+		);
+
+		const customView = screen.getByTestId( 'custom-view' );
+		expect( container ).toMatchSnapshot();
+		expect( ref ).toHaveBeenCalledWith( customView );
+	} );
+
 	test( 'should render with custom styles (string)', () => {
 		const { container } = render(
 			<View
 				as="p"
+				data-testid="custom-css-string-view"
 				css={ `
 					background: pink;
 				` }
@@ -39,12 +67,16 @@ describe( 'props', () => {
 			</View>
 		);
 		expect( container ).toMatchSnapshot();
+		expect(
+			screen.getByTestId( 'custom-css-string-view' )
+		).not.toHaveAttribute( 'css' );
 	} );
 
 	test( 'should render with custom styles (object)', () => {
 		const { container } = render(
 			<View
 				as="p"
+				data-testid="custom-css-object-view"
 				css={ {
 					background: 'pink',
 				} }
@@ -53,12 +85,16 @@ describe( 'props', () => {
 			</View>
 		);
 		expect( container ).toMatchSnapshot();
+		expect(
+			screen.getByTestId( 'custom-css-object-view' )
+		).not.toHaveAttribute( 'css' );
 	} );
 
 	test( 'should render with custom styles (Array)', () => {
 		const { container } = render(
 			<View
 				as="p"
+				data-testid="custom-css-array-view"
 				css={ [
 					{
 						background: 'pink',
@@ -70,5 +106,8 @@ describe( 'props', () => {
 			</View>
 		);
 		expect( container ).toMatchSnapshot();
+		expect(
+			screen.getByTestId( 'custom-css-array-view' )
+		).not.toHaveAttribute( 'css' );
 	} );
 } );

--- a/packages/components/src/view/test/index.js
+++ b/packages/components/src/view/test/index.js
@@ -71,7 +71,7 @@ describe( 'props', () => {
 		expect( svgView ).toHaveAttribute( 'viewBox', '0 0 24 24' );
 	} );
 
-	test( 'should render with custom styles (string)', () => {
+	test( 'should ignore legacy css prop styles (string)', () => {
 		const { container } = render(
 			<View
 				as="p"
@@ -89,7 +89,7 @@ describe( 'props', () => {
 		).not.toHaveAttribute( 'css' );
 	} );
 
-	test( 'should render with custom styles (object)', () => {
+	test( 'should ignore legacy css prop styles (object)', () => {
 		const { container } = render(
 			<View
 				as="p"
@@ -107,7 +107,7 @@ describe( 'props', () => {
 		).not.toHaveAttribute( 'css' );
 	} );
 
-	test( 'should render with custom styles (Array)', () => {
+	test( 'should ignore legacy css prop styles (array)', () => {
 		const { container } = render(
 			<View
 				as="p"

--- a/packages/components/src/view/test/index.js
+++ b/packages/components/src/view/test/index.js
@@ -54,6 +54,23 @@ describe( 'props', () => {
 		expect( ref ).toHaveBeenCalledWith( customView );
 	} );
 
+	test( 'should preserve SVG attributes', () => {
+		render(
+			<View
+				as="svg"
+				data-testid="svg-view"
+				fill="currentColor"
+				strokeWidth={ 2 }
+				viewBox="0 0 24 24"
+			/>
+		);
+
+		const svgView = screen.getByTestId( 'svg-view' );
+		expect( svgView ).toHaveAttribute( 'fill', 'currentColor' );
+		expect( svgView ).toHaveAttribute( 'stroke-width', '2' );
+		expect( svgView ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+	} );
+
 	test( 'should render with custom styles (string)', () => {
 		const { container } = render(
 			<View

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -22,6 +22,9 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -37,16 +40,19 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -63,7 +69,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
         class="components-base-control__field emotion-2 emotion-3"
       >
         <div
-          class="components-flex components-h-stack emotion-4 emotion-5"
+          class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
           data-wp-c16t="true"
           data-wp-component="HStack"
         >
@@ -83,7 +89,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
             />
           </span>
           <label
-            class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-3"
@@ -128,6 +134,9 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -143,16 +152,19 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -169,7 +181,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
         class="components-base-control__field emotion-2 emotion-3"
       >
         <div
-          class="components-flex components-h-stack emotion-4 emotion-5"
+          class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
           data-wp-c16t="true"
           data-wp-component="HStack"
         >
@@ -190,7 +202,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
             />
           </span>
           <label
-            class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-0"
@@ -224,6 +236,9 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -239,16 +254,19 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -265,7 +283,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
         class="components-base-control__field emotion-2 emotion-3"
       >
         <div
-          class="components-flex components-h-stack emotion-4 emotion-5"
+          class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
           data-wp-c16t="true"
           data-wp-component="HStack"
         >
@@ -286,7 +304,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
             />
           </span>
           <label
-            class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-2"
@@ -331,6 +349,9 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -346,16 +367,19 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -372,7 +396,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
         class="components-base-control__field emotion-2 emotion-3"
       >
         <div
-          class="components-flex components-h-stack emotion-4 emotion-5"
+          class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
           data-wp-c16t="true"
           data-wp-component="HStack"
         >
@@ -392,7 +416,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
             />
           </span>
           <label
-            class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-1"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -50,9 +50,6 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -89,7 +86,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
             />
           </span>
           <label
-            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+            class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-3"
@@ -162,9 +159,6 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -202,7 +196,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
             />
           </span>
           <label
-            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+            class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-0"
@@ -264,9 +258,6 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -304,7 +295,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
             />
           </span>
           <label
-            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+            class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-2"
@@ -377,9 +368,6 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -416,7 +404,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fiel
             />
           </span>
           <label
-            class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+            class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
             data-wp-c16t="true"
             data-wp-component="FlexBlock"
             for="inspector-toggle-control-1"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -50,9 +50,6 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -103,7 +100,7 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-0"
@@ -168,9 +165,6 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -221,7 +215,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-3"
@@ -263,7 +257,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-4"
@@ -305,7 +299,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-5"
@@ -370,9 +364,6 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-}
-
-.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -424,7 +415,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-1"
@@ -466,7 +457,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
               />
             </span>
             <label
-              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
+              class="emotion-7 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-2"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -22,6 +22,9 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -37,16 +40,19 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -77,7 +83,7 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -97,7 +103,7 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-0"
@@ -134,6 +140,9 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -149,16 +158,19 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -189,7 +201,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -209,7 +221,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-3"
@@ -230,7 +242,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -251,7 +263,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-4"
@@ -272,7 +284,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -293,7 +305,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-5"
@@ -330,6 +342,9 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -345,16 +360,19 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
   min-height: 0;
   min-width: 0;
+}
+
+.emotion-9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -385,7 +403,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -406,7 +424,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-1"
@@ -427,7 +445,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -448,7 +466,7 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
               />
             </span>
             <label
-              class="components-flex-item components-flex-block components-toggle-control__label emotion-6 emotion-5"
+              class="emotion-7 emotion-8 emotion-9 components-flex-item components-flex-block components-toggle-control__label"
               data-wp-c16t="true"
               data-wp-component="FlexBlock"
               for="inspector-toggle-control-2"

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -32,6 +32,9 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-11 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -47,7 +50,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   width: 100%;
 }
 
-.emotion-10>* {
+.emotion-12>* {
   min-width: 0;
 }
 
@@ -199,7 +202,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-10 emotion-11"
+            class="emotion-10 emotion-11 emotion-12 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -259,6 +262,9 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-11 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -274,7 +280,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   width: 100%;
 }
 
-.emotion-10>* {
+.emotion-12>* {
   min-width: 0;
 }
 
@@ -404,7 +410,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-10 emotion-11"
+            class="emotion-10 emotion-11 emotion-12 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -454,6 +460,9 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -469,7 +478,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
@@ -559,7 +568,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -609,6 +618,9 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-5 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -624,7 +636,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
   width: 100%;
 }
 
-.emotion-4>* {
+.emotion-6>* {
   min-width: 0;
 }
 
@@ -714,7 +726,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-4 emotion-5"
+            class="emotion-4 emotion-5 emotion-6 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -808,6 +820,9 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.emotion-11 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -823,7 +838,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
   width: 100%;
 }
 
-.emotion-10>* {
+.emotion-12>* {
   min-width: 0;
 }
 
@@ -893,7 +908,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
           class="components-base-control__field emotion-8 emotion-9"
         >
           <div
-            class="components-flex components-h-stack emotion-10 emotion-11"
+            class="emotion-10 emotion-11 emotion-12 components-flex components-h-stack"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -69,7 +69,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
       >
         <svg
           aria-hidden="true"
-          fill="currentColor"
           focusable="false"
           height="24"
           viewBox="0 0 24 24"
@@ -172,7 +171,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
               </span>
               <svg
                 aria-hidden="true"
-                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -299,7 +297,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
       >
         <svg
           aria-hidden="true"
-          fill="currentColor"
           focusable="false"
           height="24"
           viewBox="0 0 24 24"
@@ -532,7 +529,6 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
           <svg
             aria-hidden="true"
             class="components-site-icon"
-            fill="currentColor"
             focusable="false"
             height="36px"
             viewBox="-2 -2 24 24"
@@ -690,7 +686,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
           <svg
             aria-hidden="true"
             class="components-site-icon"
-            fill="currentColor"
             focusable="false"
             height="36px"
             viewBox="-2 -2 24 24"

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -69,6 +69,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
       >
         <svg
           aria-hidden="true"
+          fill="currentColor"
           focusable="false"
           height="24"
           viewBox="0 0 24 24"
@@ -171,6 +172,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
               </span>
               <svg
                 aria-hidden="true"
+                fill="currentColor"
                 focusable="false"
                 height="24"
                 viewBox="0 0 24 24"
@@ -297,6 +299,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
       >
         <svg
           aria-hidden="true"
+          fill="currentColor"
           focusable="false"
           height="24"
           viewBox="0 0 24 24"
@@ -529,6 +532,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
           <svg
             aria-hidden="true"
             class="components-site-icon"
+            fill="currentColor"
             focusable="false"
             height="36px"
             viewBox="-2 -2 24 24"
@@ -686,6 +690,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
           <svg
             aria-hidden="true"
             class="components-site-icon"
+            fill="currentColor"
             focusable="false"
             height="36px"
             viewBox="-2 -2 24 24"

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -952,6 +952,11 @@
 			"count": 2
 		}
 	},
+	"packages/components/src/utils/test/polymorphic-element.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/components/src/tree-grid/cell.tsx": {
 		"react-hooks/refs": {
 			"count": 1

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -736,7 +736,7 @@
 	},
 	"packages/components/src/flex/flex-item/hook.ts": {
 		"no-restricted-imports": {
-			"count": 2
+			"count": 1
 		}
 	},
 	"packages/components/src/flex/flex/hook.ts": {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -952,11 +952,6 @@
 			"count": 2
 		}
 	},
-	"packages/components/src/utils/test/polymorphic-element.tsx": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/components/src/tree-grid/cell.tsx": {
 		"react-hooks/refs": {
 			"count": 1
@@ -993,6 +988,11 @@
 		}
 	},
 	"packages/components/src/utils/rtl.js": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/components/src/utils/test/polymorphic-element.tsx": {
 		"no-restricted-imports": {
 			"count": 1
 		}

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -997,11 +997,6 @@
 			"count": 1
 		}
 	},
-	"packages/components/src/view/component.tsx": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/components/src/z-stack/styles.ts": {
 		"no-restricted-imports": {
 			"count": 2


### PR DESCRIPTION
## What?
Follow up to #66806.

Migrates `View` away from Emotion while preserving polymorphic `as` behavior, refs, valid DOM/SVG prop forwarding, and legacy `css` prop type compatibility.

## Why?
`View` is a core dependency for many components, so this validates a high-risk part of the broader Emotion migration without changing public rendered markup or `components-*` class names.

## How?
- Adds an internal `PolymorphicElement` utility for `as`, ref forwarding, and intrinsic prop filtering.
- Updates `View` to render through that utility instead of `@emotion/styled`.
- Keeps the legacy `css` prop typed and consumed as a no-op so it does not leak to the DOM.
- Preserves source-order cascade where affected components still compose Emotion styles through `useCx`.

<details>
<summary>Implementation notes</summary>

- The intrinsic prop allowlists are derived from `@emotion/is-prop-valid`, but split by element type so SVG-only props are filtered from HTML elements.
- Some snapshots change because Emotion-generated styles are merged differently or removed from `View`-rendered elements.
- The documented `View` `css` prop usage is removed from the README. The prop remains accepted for compatibility, but it no longer applies styles.

</details>

## Testing Instructions
1. Run `npm run lint:js` for the changed JS/TS files.
2. Run `npm run test:unit -- --runInBand`.
3. Run `./node_modules/.bin/tsgo --build packages/components/tsconfig.json`.
4. In the affected snapshots/tests, verify that `as`, refs, SVG attributes, public `components-*` classes, and computed style cascade behavior are preserved.

### Testing Instructions for Keyboard
Not applicable; this PR does not change keyboard interaction.

## Screenshots or screencast
Not applicable; this PR should not change UI rendering.

## Use of AI Tools
Drafted with assistance from ChatGPT/Codex. The changes went through several rounds of human review.

## ✍️ Developer note

A long-running migration has kickstarted in the `@wordpress/components` package, with the goal of refactoring all Emotion-based styles to SCSS modules.

Most consumers should not need to change anything, but there are two migration details for code that relied on Emotion-specific behavior:

- `View` still accepts the legacy `css` prop for type compatibility, but it is now a no-op. Use `style` for inline styles or `className` for CSS-based styling.
- When using `cx()` with Emotion `css()` fragments, compose source-order-dependent fragments into a single `css()` call before passing them to `cx()`. Passing separate fragments can change override order now that `View` no longer renders through Emotion.

Example:

```js
const classes = cx(
	css(
		baseStyles,
		condition && overrideStyles
	),
	className
);
```

This keeps shorthand/longhand overrides and nested-selector overrides in one generated class, preserving the intended cascade order.


The affected components are:

- `Divider`
- `Surface`
- `Truncate`
- `View`
- `Flex`
- `Spacer`

The list is expected to grow as the migration continues. Follow https://github.com/WordPress/gutenberg/issues/66806 for more details.