### PR TITLE
Playlist: Simplify block track state

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -637,7 +637,7 @@ Embed a simple playlist.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding)
--	**Attributes:** caption, currentTrack, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
+-	**Attributes:** caption, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
 
 ## Playlist track
 
@@ -648,7 +648,7 @@ Playlist track.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Parent:** core/playlist
 -	**Supports:** interactivity (clientNavigation), ~~html~~, ~~reusable~~
--	**Attributes:** album, artist, blob, id, image, length, src, title, type, uniqueId
+-	**Attributes:** album, artist, blob, id, image, length, src, title, type
 
 ## Author (deprecated)
 

--- a/packages/block-library/src/playlist-track/README.md
+++ b/packages/block-library/src/playlist-track/README.md
@@ -24,7 +24,6 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 |-----------|------|---------|-------------|
 | `blob` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `local` |
 | `id` | `number` | — | — |
-| `uniqueId` | `string` | — | — |
 | `src` | `string` | — | — |
 | `type` | `string` | `"audio"` | — |
 | `album` | `string` | — | — |
@@ -49,7 +48,6 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 **Uses context:**
 
 - `showArtists`
-- `currentTrack`
 
 ## Block Markup
 

--- a/packages/block-library/src/playlist-track/block.json
+++ b/packages/block-library/src/playlist-track/block.json
@@ -9,7 +9,7 @@
 	"description": "Playlist track.",
 	"keywords": [ "music", "sound" ],
 	"textdomain": "default",
-	"usesContext": [ "showArtists", "currentTrack" ],
+	"usesContext": [ "showArtists" ],
 	"attributes": {
 		"blob": {
 			"type": "string",
@@ -17,9 +17,6 @@
 		},
 		"id": {
 			"type": "number"
-		},
-		"uniqueId": {
-			"type": "string"
 		},
 		"src": {
 			"type": "string"

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { v4 as uuid } from 'uuid';
-
-/**
  * WordPress dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-import { useRef, useState } from '@wordpress/element';
+import { useContext, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
@@ -35,25 +30,41 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
+import { PlaylistContext } from '../playlist/context';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const ALBUM_COVER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
-	// Note that 'id' is the media attachment ID, while 'uniqueId' is a unique identifier.
-	// This is to make sure that the same media can be used in more than one track.
-	const { id, uniqueId, src, album, artist, image, length, title } =
-		attributes;
+const PlaylistTrackEdit = ( {
+	attributes,
+	setAttributes,
+	context,
+	clientId,
+	isSelected,
+} ) => {
+	const { id, src, album, artist, image, length, title } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const showArtists = context?.showArtists;
-	const currentTrack = context?.currentTrack;
 	const imageButton = useRef();
 	const blockProps = useBlockProps();
+	const { currentTrackClientId, setCurrentTrackClientId } =
+		useContext( PlaylistContext );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
+
+	useEffect( () => {
+		if ( isSelected && currentTrackClientId !== clientId ) {
+			setCurrentTrackClientId( clientId );
+		}
+	}, [
+		isSelected,
+		clientId,
+		currentTrackClientId,
+		setCurrentTrackClientId,
+	] );
 
 	useUploadMediaFromBlobURL( {
 		src: temporaryURL,
@@ -69,7 +80,6 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 			setAttributes( {
 				blob: undefined,
 				id: undefined,
-				uniqueId: undefined,
 				artist: undefined,
 				album: undefined,
 				image: undefined,
@@ -89,7 +99,6 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 		setAttributes( {
 			blob: undefined,
 			id: media.id,
-			uniqueId: uuid(),
 			src: media.url,
 			artist:
 				media.artist ||
@@ -228,9 +237,9 @@ const PlaylistTrackEdit = ( { attributes, setAttributes, context } ) => {
 				{ !! temporaryURL && <Spinner /> }
 				<button
 					className="wp-block-playlist-track__button"
-					data-wp-context={ JSON.stringify( { uniqueId } ) }
+					onClick={ () => setCurrentTrackClientId( clientId ) }
 					aria-current={
-						currentTrack === uniqueId ? 'true' : 'false'
+						currentTrackClientId === clientId ? 'true' : 'false'
 					}
 				>
 					<span className="wp-block-playlist-track__content">

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -21,19 +21,12 @@ function render_block_core_playlist_track( $attributes ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
-	$unique_id = $attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
-	$artist    = $attributes['artist'] ?? '';
-	$length    = $attributes['length'] ?? '';
-	$title     = isset( $attributes['title'] ) && ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Unknown title' );
-
-	$context = wp_interactivity_data_wp_context(
-		array(
-			'uniqueId' => $unique_id,
-		)
-	);
+	$artist = $attributes['artist'] ?? '';
+	$length = $attributes['length'] ?? '';
+	$title  = isset( $attributes['title'] ) && ! empty( $attributes['title'] ) ? $attributes['title'] : __( 'Unknown title' );
 
 	$html  = '<li ' . $wrapper_attributes . '>';
-	$html .= '<button ' . $context . 'data-wp-on--click="actions.changeTrack" data-wp-bind--aria-current="state.isCurrentTrack" class="wp-block-playlist-track__button">';
+	$html .= '<button data-wp-on--click="actions.changeTrack" data-wp-bind--aria-current="state.isCurrentTrack" class="wp-block-playlist-track__button">';
 
 	$html .= '<span class="wp-block-playlist-track__content">';
 	if ( $title ) {

--- a/packages/block-library/src/playlist/README.md
+++ b/packages/block-library/src/playlist/README.md
@@ -22,7 +22,6 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 
 | Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
 |-----------|------|---------|-------------|
-| `currentTrack` | `string` | — | — |
 | `type` | `string` | `"audio"` | — |
 | `order` | `string` | `"asc"` | — |
 | `showTracklist` | `boolean` | `true` | — |
@@ -53,7 +52,6 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 **Provides context:**
 
 - `showArtists` → attribute `showArtists`
-- `currentTrack` → attribute `currentTrack`
 
 ## Block Styles
 

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -10,9 +10,6 @@
 	"textdomain": "default",
 	"allowedBlocks": [ "core/playlist-track" ],
 	"attributes": {
-		"currentTrack": {
-			"type": "string"
-		},
 		"type": {
 			"type": "string",
 			"default": "audio"
@@ -46,8 +43,7 @@
 		}
 	},
 	"providesContext": {
-		"showArtists": "showArtists",
-		"currentTrack": "currentTrack"
+		"showArtists": "showArtists"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/playlist/context.js
+++ b/packages/block-library/src/playlist/context.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export const PlaylistContext = createContext( {
+	currentTrackClientId: null,
+	setCurrentTrackClientId: () => {},
+} );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	MediaPlaceholder,
@@ -38,6 +37,7 @@ import { createBlock } from '@wordpress/blocks';
 import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
+import { PlaylistContext } from './context';
 import { getTrackAttributes } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
@@ -56,21 +56,19 @@ const PlaylistEdit = ( {
 		showImages,
 		showArtists,
 		showTrackLength,
-		currentTrack,
 	} = attributes;
 
 	// Extract the waveform style from the block style variation class.
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const [ currentTrackClientId, setCurrentTrackClientId ] = useState( null );
 
 	const { innerBlockTracks } = useSelect(
 		( select ) => {
@@ -82,61 +80,44 @@ const PlaylistEdit = ( {
 		[ clientId ]
 	);
 
-	// Ensure that each inner block has a unique ID,
-	// even if a track is duplicated.
-	useEffect( () => {
-		const seen = new Set();
-		let hasDuplicates = false;
-		const updatedBlocks = innerBlockTracks.map( ( block ) => {
-			if ( seen.has( block.attributes.uniqueId ) ) {
-				hasDuplicates = true;
-				return {
-					...block,
-					attributes: {
-						...block.attributes,
-						uniqueId: uuid(),
-					},
-				};
-			}
-			seen.add( block.attributes.uniqueId );
-			return block;
-		} );
-		if ( hasDuplicates ) {
-			replaceInnerBlocks( clientId, updatedBlocks );
-		}
-	}, [ innerBlockTracks, clientId, replaceInnerBlocks ] );
-
 	// Create a list of tracks from the inner blocks,
-	// but skip blocks that do not have a uniqueId attribute, such as the media placeholder.
-	const validTracks = innerBlockTracks.filter(
-		( block ) => !! block.attributes.uniqueId
+	// but skip blocks that do not have a source, such as the media placeholder.
+	const validTracks = useMemo(
+		() =>
+			innerBlockTracks.filter(
+				( block ) => !! block.attributes.src || !! block.attributes.blob
+			),
+		[ innerBlockTracks ]
 	);
-	const tracks = validTracks.map( ( block ) => block.attributes );
-	const firstTrackId = validTracks[ 0 ]?.attributes?.uniqueId;
+	const tracks = useMemo(
+		() =>
+			validTracks.map( ( block ) => ( {
+				...block.attributes,
+				clientId: block.clientId,
+			} ) ),
+		[ validTracks ]
+	);
 
-	// updateBlockAttributes is used to force updating the parent playlist block
-	// when the currentTrack changes. Using setAttributes directly does not update
-	// the currentTrack when multiple tracks are moved at the same time.
 	useEffect( () => {
-		if ( tracks.length === 0 ) {
-			// If there are no tracks but currentTrack is set, set it to null.
-			if ( currentTrack !== null ) {
-				updateBlockAttributes( clientId, { currentTrack: null } );
+		if ( validTracks.length === 0 ) {
+			if ( currentTrackClientId !== null ) {
+				setCurrentTrackClientId( null );
 			}
-		} else if (
-			// If the currentTrack is not the first track, update it to the first track.
-			firstTrackId &&
-			firstTrackId !== currentTrack
-		) {
-			updateBlockAttributes( clientId, { currentTrack: firstTrackId } );
+			return;
 		}
-	}, [
-		tracks,
-		currentTrack,
-		firstTrackId,
-		clientId,
-		updateBlockAttributes,
-	] );
+
+		const currentTrackExists = validTracks.some(
+			( block ) => block.clientId === currentTrackClientId
+		);
+		if ( ! currentTrackExists ) {
+			setCurrentTrackClientId( validTracks[ 0 ].clientId );
+		}
+	}, [ currentTrackClientId, setCurrentTrackClientId, validTracks ] );
+
+	const playlistContext = useMemo(
+		() => ( { currentTrackClientId, setCurrentTrackClientId } ),
+		[ currentTrackClientId, setCurrentTrackClientId ]
+	);
 
 	const onSelectTracks = useCallback(
 		( media ) => {
@@ -149,41 +130,32 @@ const PlaylistEdit = ( {
 			}
 
 			const trackList = media.map( getTrackAttributes );
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				currentTrack:
-					trackList.length > 0 ? trackList[ 0 ].uniqueId : null,
-			} );
 
 			const newBlocks = trackList.map( ( track ) =>
 				createBlock( 'core/playlist-track', track )
 			);
+			setCurrentTrackClientId( newBlocks[ 0 ]?.clientId ?? null );
 			// Replace the inner blocks with the new tracks.
 			replaceInnerBlocks( clientId, newBlocks );
 		},
-		[
-			__unstableMarkNextChangeAsNotPersistent,
-			setAttributes,
-			replaceInnerBlocks,
-			clientId,
-		]
+		[ replaceInnerBlocks, clientId, setCurrentTrackClientId ]
 	);
 
-	// Get current track data by finding the track with matching uniqueId.
-	const currentTrackData = tracks.find(
-		( track ) => track.uniqueId === currentTrack
-	);
+	// Get current track data by finding the track with matching client ID.
+	const currentTrackData =
+		tracks.find( ( track ) => track.clientId === currentTrackClientId ) ??
+		tracks[ 0 ];
 
 	// Handle track end - advance to next track or loop to first.
 	const onTrackEnded = useCallback( () => {
 		const currentIndex = tracks.findIndex(
-			( track ) => track.uniqueId === currentTrack
+			( track ) => track.clientId === currentTrackClientId
 		);
 		const nextTrack = tracks[ currentIndex + 1 ] || tracks[ 0 ];
-		if ( nextTrack?.uniqueId ) {
-			setAttributes( { currentTrack: nextTrack.uniqueId } );
+		if ( nextTrack?.clientId ) {
+			setCurrentTrackClientId( nextTrack.clientId );
 		}
-	}, [ currentTrack, tracks, setAttributes ] );
+	}, [ currentTrackClientId, setCurrentTrackClientId, tracks ] );
 
 	const onChangeOrder = useCallback(
 		( trackOrder ) => {
@@ -196,22 +168,18 @@ const PlaylistEdit = ( {
 				}
 				return titleB.localeCompare( titleA );
 			} );
-			const firstUniqueId = sortedBlocks[ 0 ]?.attributes?.uniqueId;
 			replaceInnerBlocks( clientId, sortedBlocks );
+			setCurrentTrackClientId( sortedBlocks[ 0 ]?.clientId ?? null );
 			setAttributes( {
 				order: trackOrder,
-				currentTrack:
-					firstUniqueId && firstUniqueId !== currentTrack
-						? firstUniqueId
-						: currentTrack,
 			} );
 		},
 		[
 			clientId,
-			currentTrack,
 			innerBlockTracks,
 			replaceInnerBlocks,
 			setAttributes,
+			setCurrentTrackClientId,
 		]
 	);
 
@@ -411,7 +379,9 @@ const PlaylistEdit = ( {
 								! showTrackLength,
 						} ) }
 					>
-						{ innerBlocksProps.children }
+						<PlaylistContext.Provider value={ playlistContext }>
+							{ innerBlocksProps.children }
+						</PlaylistContext.Provider>
 					</ol>
 				) }
 				<Caption

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -17,28 +17,23 @@
  * @return string Returns the Playlist.
  */
 function render_block_core_playlist( $attributes, $content, $block ) {
-	if ( empty( $attributes['currentTrack'] ) ) {
-		return '';
-	}
-
-	$current_media_id  = $attributes['currentTrack'];
-	$playlist_id       = wp_unique_id( 'playlist-' );
-	$playlist_tracks   = array();
-	$tracks_data       = array();
-	$current_unique_id = null;
+	$playlist_id     = wp_unique_id( 'playlist-' );
+	$playlist_tracks = array();
+	$tracks_data     = array();
 
 	// Parse inner blocks to extract track data.
 	// This approach avoids duplicating track data in the HTML output.
 	if ( ! empty( $block->inner_blocks ) ) {
 		foreach ( $block->inner_blocks as $inner_block ) {
 			if ( 'core/playlist-track' === $inner_block->name ) {
-				$inner_block->context['playlistId'] = $playlist_id;
+				$track_attributes = $inner_block->attributes;
 
-				$track_attributes  = $inner_block->attributes;
-				$unique_id         = $track_attributes['uniqueId'] ?? wp_unique_id( 'playlist-track-' );
-				$playlist_tracks[] = $unique_id;
+				if ( empty( $track_attributes['id'] ) ) {
+					continue;
+				}
 
-				$inner_block->attributes['uniqueId'] = $unique_id;
+				$track_id          = 'track-' . count( $playlist_tracks );
+				$playlist_tracks[] = $track_id;
 
 				// Extract track metadata from block attributes.
 				$title      = isset( $track_attributes['title'] ) && ! empty( $track_attributes['title'] ) ? $track_attributes['title'] : __( 'Unknown title' );
@@ -61,7 +56,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				// Data is passed to wp_interactivity_state() which JSON-encodes it,
 				// so we use wp_strip_all_tags() instead of esc_html() to prevent
 				// HTML injection without double-encoding. URLs still use esc_url().
-				$tracks_data[ $unique_id ] = array(
+				$tracks_data[ $track_id ] = array(
 					'url'       => esc_url( $url ),
 					'title'     => wp_strip_all_tags( $title ),
 					'artist'    => wp_strip_all_tags( $artist ),
@@ -69,18 +64,11 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 					'image'     => esc_url( $image ),
 					'ariaLabel' => wp_strip_all_tags( $aria_label ),
 				);
-
-				if ( $unique_id === $current_media_id ) {
-					$current_unique_id = $unique_id;
-				}
 			}
 		}
 	}
 
-	// If there are no tracks but there is a currentTrack set, do not render the block.
-	// This can happen for example if the currentTrack was not deleted correctly
-	// or if the block is manually edited in the code editor mode.
-	if ( empty( $playlist_tracks ) || ! in_array( $current_media_id, $playlist_tracks, true ) ) {
+	if ( empty( $playlist_tracks ) ) {
 		return '';
 	}
 
@@ -108,7 +96,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 		data-label-pause="' . $label_pause . '"
 	></div>';
 
-	// Add the HTML for the current track inside the figure.
+	// Add the waveform player container inside the figure.
 	$figure = null;
 	preg_match( '/<figure[^>]*>/', $content, $figure );
 	if ( ! empty( $figure[0] ) ) {
@@ -126,15 +114,38 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 
 	$processor->set_attribute(
 		'data-wp-context',
-		json_encode(
+		wp_json_encode(
 			array(
 				'playlistId'    => $playlist_id,
-				'currentId'     => $current_unique_id,
+				'currentId'     => $playlist_tracks[0],
 				'tracks'        => $playlist_tracks,
 				'waveformStyle' => $waveform_style,
 			)
 		)
 	);
+
+	// Track IDs are render-time only. Add them after inner blocks have rendered
+	// so track buttons can update the Interactivity API state without storing
+	// persistent unique IDs in post content.
+	$track_index = 0;
+	while ( $processor->next_tag( array( 'class_name' => 'wp-block-playlist-track__button' ) ) ) {
+		$track_id = $playlist_tracks[ $track_index ] ?? null;
+
+		if ( null === $track_id ) {
+			break;
+		}
+
+		$processor->set_attribute(
+			'data-wp-context',
+			wp_json_encode(
+				array(
+					'trackId' => $track_id,
+				)
+			)
+		);
+
+		++$track_index;
+	}
 
 	return $processor->get_updated_html();
 }

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -7,11 +7,6 @@
  */
 import { getTrackAttributes } from '../utils';
 
-// Mock uuid to return predictable values.
-jest.mock( 'uuid', () => ( {
-	v4: jest.fn( () => 'mock-uuid-1234' ),
-} ) );
-
 describe( 'Playlist block edit utilities', () => {
 	describe( 'getTrackAttributes', () => {
 		it( 'should transform media object to track attributes', () => {
@@ -29,7 +24,6 @@ describe( 'Playlist block edit utilities', () => {
 
 			expect( result ).toEqual( {
 				id: 123,
-				uniqueId: 'mock-uuid-1234',
 				src: 'https://example.com/song.mp3',
 				title: 'My Song',
 				artist: 'The Artist',

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { v4 as uuid } from 'uuid';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -17,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 export function getTrackAttributes( media ) {
 	return {
 		id: media.id || media.url, // Attachment ID or URL.
-		uniqueId: uuid(), // Unique ID for the track.
 		src: media.url,
 		title: media.title,
 		artist:

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -19,14 +19,14 @@ const { state } = store(
 		state: {
 			playlists: {},
 			get isCurrentTrack() {
-				const { currentId, uniqueId } = getContext();
-				return currentId === uniqueId;
+				const { currentId, trackId } = getContext();
+				return currentId === trackId;
 			},
 		},
 		actions: {
 			changeTrack() {
 				const context = getContext();
-				context.currentId = context.uniqueId;
+				context.currentId = context.trackId;
 			},
 		},
 		callbacks: {
@@ -109,7 +109,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 		onEnded: () => {
 			// Advance to next track (autoPlay handles playback).
 			const currentIndex = context.tracks.findIndex(
-				( uniqueId ) => uniqueId === context.currentId
+				( trackId ) => trackId === context.currentId
 			);
 			const nextTrack = context.tracks[ currentIndex + 1 ];
 			if ( nextTrack ) {

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -55,21 +55,20 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_returns_empty_when_current_track_is_missing() {
+	public function test_renders_when_current_track_is_missing() {
 		$markup = $this->build_playlist_markup(
 			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
 
 		$output = do_blocks( $markup );
-		$this->assertEmpty( trim( $output ) );
+		$this->assertStringContainsString( 'wp-block-playlist__waveform-player', $output );
 	}
 
 	/**
@@ -77,7 +76,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_returns_empty_when_no_inner_blocks() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' )
+			array()
 		);
 
 		$output = do_blocks( $markup );
@@ -87,21 +86,20 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_returns_empty_when_current_track_does_not_match_any_track() {
+	public function test_renders_when_current_track_does_not_match_any_track() {
 		$markup = $this->build_playlist_markup(
 			array( 'currentTrack' => 'nonexistent-track' ),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
 
 		$output = do_blocks( $markup );
-		$this->assertEmpty( trim( $output ) );
+		$this->assertStringContainsString( 'wp-block-playlist__waveform-player', $output );
 	}
 
 	/**
@@ -109,16 +107,15 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_renders_with_interactivity_attributes() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'artist'   => 'Artist One',
-					'album'    => 'Album One',
-					'src'      => 'http://example.com/song1.mp3',
-					'image'    => 'http://example.com/image1.jpg',
+					'id'     => 1,
+					'title'  => 'Song One',
+					'artist' => 'Artist One',
+					'album'  => 'Album One',
+					'src'    => 'http://example.com/song1.mp3',
+					'image'  => 'http://example.com/image1.jpg',
 				),
 			)
 		);
@@ -130,9 +127,9 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$this->assertSame( 'core/playlist', $p->get_attribute( 'data-wp-interactive' ) );
 
 		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
-		$this->assertSame( 'track-1', $context['currentId'] );
+		$this->assertSame( 'track-0', $context['currentId'] );
 		$this->assertIsArray( $context['tracks'] );
-		$this->assertContains( 'track-1', $context['tracks'] );
+		$this->assertContains( 'track-0', $context['tracks'] );
 		$this->assertArrayHasKey( 'playlistId', $context );
 	}
 
@@ -141,13 +138,12 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_renders_waveform_player_container() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -163,15 +159,13 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	public function test_waveform_style_extracted_from_single_word_style_class() {
 		$markup = $this->build_playlist_markup(
 			array(
-				'currentTrack' => 'track-1',
-				'className'    => 'is-style-mirror',
+				'className' => 'is-style-mirror',
 			),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -194,15 +188,13 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	public function test_waveform_style_extracted_from_hyphenated_style_class() {
 		$markup = $this->build_playlist_markup(
 			array(
-				'currentTrack' => 'track-1',
-				'className'    => 'is-style-thin-line',
+				'className' => 'is-style-thin-line',
 			),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -220,24 +212,22 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_track_data_in_interactivity_state() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'artist'   => 'Artist One',
-					'album'    => 'Album One',
-					'src'      => 'http://example.com/song1.mp3',
-					'image'    => 'http://example.com/image1.jpg',
+					'id'     => 1,
+					'title'  => 'Song One',
+					'artist' => 'Artist One',
+					'album'  => 'Album One',
+					'src'    => 'http://example.com/song1.mp3',
+					'image'  => 'http://example.com/image1.jpg',
 				),
 				array(
-					'id'       => 2,
-					'uniqueId' => 'track-2',
-					'title'    => 'Song Two',
-					'artist'   => 'Artist Two',
-					'album'    => 'Album Two',
-					'src'      => 'http://example.com/song2.mp3',
+					'id'     => 2,
+					'title'  => 'Song Two',
+					'artist' => 'Artist Two',
+					'album'  => 'Album Two',
+					'src'    => 'http://example.com/song2.mp3',
 				),
 			)
 		);
@@ -251,17 +241,17 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$playlist = reset( $playlists );
 		$tracks   = $playlist['tracks'];
+		$this->assertArrayHasKey( 'track-0', $tracks );
 		$this->assertArrayHasKey( 'track-1', $tracks );
-		$this->assertArrayHasKey( 'track-2', $tracks );
 
-		$this->assertSame( 'http://example.com/song1.mp3', $tracks['track-1']['url'] );
-		$this->assertSame( 'Song One', $tracks['track-1']['title'] );
-		$this->assertSame( 'Artist One', $tracks['track-1']['artist'] );
-		$this->assertSame( 'Album One', $tracks['track-1']['album'] );
-		$this->assertSame( 'http://example.com/image1.jpg', $tracks['track-1']['image'] );
+		$this->assertSame( 'http://example.com/song1.mp3', $tracks['track-0']['url'] );
+		$this->assertSame( 'Song One', $tracks['track-0']['title'] );
+		$this->assertSame( 'Artist One', $tracks['track-0']['artist'] );
+		$this->assertSame( 'Album One', $tracks['track-0']['album'] );
+		$this->assertSame( 'http://example.com/image1.jpg', $tracks['track-0']['image'] );
 
-		$this->assertSame( 'http://example.com/song2.mp3', $tracks['track-2']['url'] );
-		$this->assertSame( 'Song Two', $tracks['track-2']['title'] );
+		$this->assertSame( 'http://example.com/song2.mp3', $tracks['track-1']['url'] );
+		$this->assertSame( 'Song Two', $tracks['track-1']['title'] );
 	}
 
 	/**
@@ -269,15 +259,14 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_aria_label_with_title_artist_and_album() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'artist'   => 'Artist One',
-					'album'    => 'Album One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'     => 1,
+					'title'  => 'Song One',
+					'artist' => 'Artist One',
+					'album'  => 'Album One',
+					'src'    => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -286,7 +275,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$state    = wp_interactivity_state( 'core/playlist' );
 		$playlist = reset( $state['playlists'] );
-		$track    = $playlist['tracks']['track-1'];
+		$track    = $playlist['tracks']['track-0'];
 
 		$this->assertSame(
 			'Song One by Artist One from the album Album One',
@@ -299,13 +288,12 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_aria_label_falls_back_to_title_when_artist_or_album_missing() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -314,7 +302,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$state    = wp_interactivity_state( 'core/playlist' );
 		$playlist = reset( $state['playlists'] );
-		$track    = $playlist['tracks']['track-1'];
+		$track    = $playlist['tracks']['track-0'];
 
 		$this->assertSame( 'Song One', $track['ariaLabel'] );
 	}
@@ -324,12 +312,11 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_title_defaults_to_unknown_when_not_set() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'  => 1,
+					'src' => 'http://example.com/song1.mp3',
 				),
 			)
 		);
@@ -338,7 +325,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$state    = wp_interactivity_state( 'core/playlist' );
 		$playlist = reset( $state['playlists'] );
-		$track    = $playlist['tracks']['track-1'];
+		$track    = $playlist['tracks']['track-0'];
 
 		$this->assertSame( 'Unknown title', $track['title'] );
 	}
@@ -348,25 +335,22 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 */
 	public function test_renders_multiple_tracks_in_context() {
 		$markup = $this->build_playlist_markup(
-			array( 'currentTrack' => 'track-1' ),
+			array(),
 			array(
 				array(
-					'id'       => 1,
-					'uniqueId' => 'track-1',
-					'title'    => 'Song One',
-					'src'      => 'http://example.com/song1.mp3',
+					'id'    => 1,
+					'title' => 'Song One',
+					'src'   => 'http://example.com/song1.mp3',
 				),
 				array(
-					'id'       => 2,
-					'uniqueId' => 'track-2',
-					'title'    => 'Song Two',
-					'src'      => 'http://example.com/song2.mp3',
+					'id'    => 2,
+					'title' => 'Song Two',
+					'src'   => 'http://example.com/song2.mp3',
 				),
 				array(
-					'id'       => 3,
-					'uniqueId' => 'track-3',
-					'title'    => 'Song Three',
-					'src'      => 'http://example.com/song3.mp3',
+					'id'    => 3,
+					'title' => 'Song Three',
+					'src'   => 'http://example.com/song3.mp3',
 				),
 			)
 		);
@@ -377,6 +361,6 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
 		$this->assertCount( 3, $context['tracks'] );
-		$this->assertSame( array( 'track-1', 'track-2', 'track-3' ), $context['tracks'] );
+		$this->assertSame( array( 'track-0', 'track-1', 'track-2' ), $context['tracks'] );
 	}
 }


### PR DESCRIPTION
## What?

Closes #79412.

Simplifies Playlist block state by removing the persisted `currentTrack` attribute and Playlist Track `uniqueId` attribute.

## Why?

The Playlist block can start from the first rendered track, so persisting editor interaction state adds unnecessary synchronization work.

## How?

Editor track selection now lives in React context keyed by inner block `clientId`, while server rendering assigns per-render track IDs and initializes Interactivity API context to the first track.

## Testing Instructions

1. Insert a Playlist block with multiple audio tracks.
2. Select different tracks in the editor and confirm the waveform/current styling follows selection.
3. Save and view the post, then confirm the front end starts on the first track, changes tracks, and advances when playback ends.

### Testing Instructions for Keyboard

Use Tab and Shift+Tab to focus playlist track buttons, then Enter or Space to change tracks and confirm the current track updates.

## Screenshots or screencast

N/A

## Use of AI Tools

Prepared with OpenAI Codex and reviewed before submission.
