### PR TITLE
Icons: ship required icons for admin bar and menu with public: false

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 -   Redraw a further 141 icons as stroke-based for variable stroke-width support, following the convention introduced in [#78808](https://github.com/WordPress/gutenberg/pull/78808), and refine the already stroke-based `image` drawing. Most retain their original footprint; the table icons, `capturePhoto` and `image` are slightly smaller by design. ([#82540](https://github.com/WordPress/gutenberg/pull/82540))
 -   `manifest.json`: The `public` property is now a tri-state. Omitting it keeps an icon in the JS library only; `true` ships it to WordPress Core and exposes it through the icons REST API, making it selectable in the Icon block; `false` ships it and registers it in the `core` collection for server-side use via `wp_get_icon()`, while hiding it from the REST API and the Icon block. ([#82634](https://github.com/WordPress/gutenberg/pull/82634))
--   The `wordpress` icon now ships to WordPress Core as a non-public icon: it is registered in the `core` collection and stays available to server-side code via `wp_get_icon( 'core/wordpress' )`, but is not exposed through the icons REST API and is not selectable in the Icon block. ([#82634](https://github.com/WordPress/gutenberg/pull/82634))
+-   The `brush`, `dashboard`, `link`, `media`, `page`, `pin`, `plugins`, `sites`, `tool`, `update` and `wordpress` icons now ship to WordPress Core as non-public icons: they are registered in the `core` collection and stay available to server-side code via `wp_get_icon()`, but are not exposed through the icons REST API and are not selectable in the Icon block. ([#82634](https://github.com/WordPress/gutenberg/pull/82634), [#79451](https://github.com/WordPress/gutenberg/pull/79451))
 
 ### Bug Fixes
 

--- a/packages/icons/src/manifest.json
+++ b/packages/icons/src/manifest.json
@@ -181,7 +181,8 @@
 	{
 		"slug": "brush",
 		"label": "Brush",
-		"filePath": "library/brush.svg"
+		"filePath": "library/brush.svg",
+		"public": true
 	},
 	{
 		"slug": "bug",
@@ -491,7 +492,8 @@
 	{
 		"slug": "dashboard",
 		"label": "Dashboard",
-		"filePath": "library/dashboard.svg"
+		"filePath": "library/dashboard.svg",
+		"public": true
 	},
 	{
 		"slug": "desktop",
@@ -695,7 +697,8 @@
 	{
 		"slug": "grid",
 		"label": "Grid",
-		"filePath": "library/grid.svg"
+		"filePath": "library/grid.svg",
+		"public": true
 	},
 	{
 		"slug": "group",
@@ -918,7 +921,8 @@
 	{
 		"slug": "link",
 		"label": "Link",
-		"filePath": "library/link.svg"
+		"filePath": "library/link.svg",
+		"public": true
 	},
 	{
 		"slug": "link-off",
@@ -979,7 +983,8 @@
 	{
 		"slug": "media",
 		"label": "Media",
-		"filePath": "library/media.svg"
+		"filePath": "library/media.svg",
+		"public": true
 	},
 	{
 		"slug": "media-and-text",
@@ -1064,7 +1069,8 @@
 	{
 		"slug": "page",
 		"label": "Page",
-		"filePath": "library/page.svg"
+		"filePath": "library/page.svg",
+		"public": true
 	},
 	{
 		"slug": "page-break",
@@ -1128,7 +1134,8 @@
 	{
 		"slug": "plugins",
 		"label": "Plugins",
-		"filePath": "library/plugins.svg"
+		"filePath": "library/plugins.svg",
+		"public": true
 	},
 	{
 		"slug": "play",
@@ -1170,7 +1177,8 @@
 	{
 		"slug": "post",
 		"label": "Post",
-		"filePath": "library/post.svg"
+		"filePath": "library/post.svg",
+		"public": true
 	},
 	{
 		"slug": "post-author",
@@ -1688,7 +1696,8 @@
 	{
 		"slug": "tool",
 		"label": "Tool",
-		"filePath": "library/tool.svg"
+		"filePath": "library/tool.svg",
+		"public": true
 	},
 	{
 		"slug": "trash",
@@ -1733,7 +1742,8 @@
 	{
 		"slug": "update",
 		"label": "Update",
-		"filePath": "library/update.svg"
+		"filePath": "library/update.svg",
+		"public": true
 	},
 	{
 		"slug": "upload",
@@ -1765,6 +1775,7 @@
 	{
 		"slug": "wordpress",
 		"label": "WordPress",
-		"filePath": "library/wordpress.svg"
+		"filePath": "library/wordpress.svg",
+		"public": true
 	}
 ]

--- a/packages/icons/src/manifest.json
+++ b/packages/icons/src/manifest.json
@@ -181,7 +181,8 @@
 	{
 		"slug": "brush",
 		"label": "Brush",
-		"filePath": "library/brush.svg"
+		"filePath": "library/brush.svg",
+		"public": false
 	},
 	{
 		"slug": "bug",
@@ -491,7 +492,8 @@
 	{
 		"slug": "dashboard",
 		"label": "Dashboard",
-		"filePath": "library/dashboard.svg"
+		"filePath": "library/dashboard.svg",
+		"public": false
 	},
 	{
 		"slug": "desktop",
@@ -923,7 +925,8 @@
 	{
 		"slug": "link",
 		"label": "Link",
-		"filePath": "library/link.svg"
+		"filePath": "library/link.svg",
+		"public": false
 	},
 	{
 		"slug": "link-off",
@@ -984,7 +987,8 @@
 	{
 		"slug": "media",
 		"label": "Media",
-		"filePath": "library/media.svg"
+		"filePath": "library/media.svg",
+		"public": false
 	},
 	{
 		"slug": "media-and-text",
@@ -1069,7 +1073,8 @@
 	{
 		"slug": "page",
 		"label": "Page",
-		"filePath": "library/page.svg"
+		"filePath": "library/page.svg",
+		"public": false
 	},
 	{
 		"slug": "page-break",
@@ -1123,7 +1128,8 @@
 	{
 		"slug": "pin",
 		"label": "Pin",
-		"filePath": "library/pin.svg"
+		"filePath": "library/pin.svg",
+		"public": false
 	},
 	{
 		"slug": "pin-small",
@@ -1133,7 +1139,8 @@
 	{
 		"slug": "plugins",
 		"label": "Plugins",
-		"filePath": "library/plugins.svg"
+		"filePath": "library/plugins.svg",
+		"public": false
 	},
 	{
 		"slug": "play",
@@ -1507,7 +1514,8 @@
 	{
 		"slug": "sites",
 		"label": "Sites",
-		"filePath": "library/sites.svg"
+		"filePath": "library/sites.svg",
+		"public": false
 	},
 	{
 		"slug": "square",
@@ -1713,7 +1721,8 @@
 	{
 		"slug": "tool",
 		"label": "Tool",
-		"filePath": "library/tool.svg"
+		"filePath": "library/tool.svg",
+		"public": false
 	},
 	{
 		"slug": "trash",
@@ -1758,7 +1767,8 @@
 	{
 		"slug": "update",
 		"label": "Update",
-		"filePath": "library/update.svg"
+		"filePath": "library/update.svg",
+		"public": false
 	},
 	{
 		"slug": "upload",

--- a/packages/icons/src/manifest.php
+++ b/packages/icons/src/manifest.php
@@ -61,6 +61,10 @@ return array(
 		'label'    => _x( 'Block Table', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/block-table.svg',
 	),
+	'brush'               => array(
+		'label'    => _x( 'Brush', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/brush.svg',
+	),
 	'calendar'            => array(
 		'label'    => _x( 'Calendar', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/calendar.svg',
@@ -141,6 +145,10 @@ return array(
 		'label'    => _x( 'Create', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/create.svg',
 	),
+	'dashboard'           => array(
+		'label'    => _x( 'Dashboard', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/dashboard.svg',
+	),
 	'desktop'             => array(
 		'label'    => _x( 'Desktop', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/desktop.svg',
@@ -177,6 +185,10 @@ return array(
 		'label'    => _x( 'Gallery', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/gallery.svg',
 	),
+	'grid'                => array(
+		'label'    => _x( 'Grid', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/grid.svg',
+	),
 	'group'               => array(
 		'label'    => _x( 'Group', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/group.svg',
@@ -209,9 +221,17 @@ return array(
 		'label'    => _x( 'Language', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/language.svg',
 	),
+	'link'                => array(
+		'label'    => _x( 'Link', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/link.svg',
+	),
 	'map-marker'          => array(
 		'label'    => _x( 'Map Marker', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/map-marker.svg',
+	),
+	'media'               => array(
+		'label'    => _x( 'Media', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/media.svg',
 	),
 	'menu'                => array(
 		'label'    => _x( 'Menu', 'icon label', 'gutenberg' ),
@@ -233,6 +253,10 @@ return array(
 		'label'    => _x( 'Next', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/next.svg',
 	),
+	'page'                => array(
+		'label'    => _x( 'Page', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/page.svg',
+	),
 	'paragraph'           => array(
 		'label'    => _x( 'Paragraph', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/paragraph.svg',
@@ -249,6 +273,10 @@ return array(
 		'label'    => _x( 'People', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/people.svg',
 	),
+	'plugins'             => array(
+		'label'    => _x( 'Plugins', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/plugins.svg',
+	),
 	'plus'                => array(
 		'label'    => _x( 'Plus', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/plus.svg',
@@ -256,6 +284,10 @@ return array(
 	'plus-circle'         => array(
 		'label'    => _x( 'Plus Circle', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/plus-circle.svg',
+	),
+	'post'                => array(
+		'label'    => _x( 'Post', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/post.svg',
 	),
 	'previous'            => array(
 		'label'    => _x( 'Previous', 'icon label', 'gutenberg' ),
@@ -349,6 +381,14 @@ return array(
 		'label'    => _x( 'Tip', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/tip.svg',
 	),
+	'tool'                => array(
+		'label'    => _x( 'Tool', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/tool.svg',
+	),
+	'update'              => array(
+		'label'    => _x( 'Update', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/update.svg',
+	),
 	'upload'              => array(
 		'label'    => _x( 'Upload', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/upload.svg',
@@ -356,5 +396,9 @@ return array(
 	'verse'               => array(
 		'label'    => _x( 'Verse', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/verse.svg',
+	),
+	'wordpress'           => array(
+		'label'    => _x( 'WordPress', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/wordpress.svg',
 	),
 );

--- a/packages/icons/src/manifest.php
+++ b/packages/icons/src/manifest.php
@@ -61,6 +61,11 @@ return array(
 		'label'    => _x( 'Block Table', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/block-table.svg',
 	),
+	'brush'               => array(
+		'label'    => _x( 'Brush', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/brush.svg',
+		'public'   => false,
+	),
 	'calendar'            => array(
 		'label'    => _x( 'Calendar', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/calendar.svg',
@@ -141,6 +146,11 @@ return array(
 		'label'    => _x( 'Create', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/create.svg',
 	),
+	'dashboard'           => array(
+		'label'    => _x( 'Dashboard', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/dashboard.svg',
+		'public'   => false,
+	),
 	'desktop'             => array(
 		'label'    => _x( 'Desktop', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/desktop.svg',
@@ -209,9 +219,19 @@ return array(
 		'label'    => _x( 'Language', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/language.svg',
 	),
+	'link'                => array(
+		'label'    => _x( 'Link', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/link.svg',
+		'public'   => false,
+	),
 	'map-marker'          => array(
 		'label'    => _x( 'Map Marker', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/map-marker.svg',
+	),
+	'media'               => array(
+		'label'    => _x( 'Media', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/media.svg',
+		'public'   => false,
 	),
 	'menu'                => array(
 		'label'    => _x( 'Menu', 'icon label', 'gutenberg' ),
@@ -233,6 +253,11 @@ return array(
 		'label'    => _x( 'Next', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/next.svg',
 	),
+	'page'                => array(
+		'label'    => _x( 'Page', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/page.svg',
+		'public'   => false,
+	),
 	'paragraph'           => array(
 		'label'    => _x( 'Paragraph', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/paragraph.svg',
@@ -248,6 +273,16 @@ return array(
 	'people'              => array(
 		'label'    => _x( 'People', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/people.svg',
+	),
+	'pin'                 => array(
+		'label'    => _x( 'Pin', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/pin.svg',
+		'public'   => false,
+	),
+	'plugins'             => array(
+		'label'    => _x( 'Plugins', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/plugins.svg',
+		'public'   => false,
 	),
 	'plus'                => array(
 		'label'    => _x( 'Plus', 'icon label', 'gutenberg' ),
@@ -305,6 +340,11 @@ return array(
 		'label'    => _x( 'Shuffle', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/shuffle.svg',
 	),
+	'sites'               => array(
+		'label'    => _x( 'Sites', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/sites.svg',
+		'public'   => false,
+	),
 	'star-empty'          => array(
 		'label'    => _x( 'Star Empty', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/star-empty.svg',
@@ -348,6 +388,16 @@ return array(
 	'tip'                 => array(
 		'label'    => _x( 'Tip', 'icon label', 'gutenberg' ),
 		'filePath' => 'library/tip.svg',
+	),
+	'tool'                => array(
+		'label'    => _x( 'Tool', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/tool.svg',
+		'public'   => false,
+	),
+	'update'              => array(
+		'label'    => _x( 'Update', 'icon label', 'gutenberg' ),
+		'filePath' => 'library/update.svg',
+		'public'   => false,
 	),
 	'upload'              => array(
 		'label'    => _x( 'Upload', 'icon label', 'gutenberg' ),


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/82723
Related to: https://github.com/WordPress/wordpress-develop/pull/12270

## What?

Make the following icons available to `wp_get_icon()` by adding `public: false` to the manifest.

1. `brush`
2. `dashboard`
3. `link`
4. `media`
5. `page`
6. `pin`
7. `plugins`
8. `sites`
9. `tool`
10. `update`

## Why?

The above icons are needed as the replacement for the old dashicons in the admin UI.

## Testing Instructions

It's way easier to test with https://github.com/WordPress/wordpress-develop/pull/12270. Open the following Playground link, which test both that Core PR and this Gutenberg PR:

https://playground.wordpress.net/?core-pr=12270&gutenberg-pr=79451

Then:

1. Verify you can see the new icons above (including `core/wordpress`):

<img width="566" height="512" alt="image" src="https://github.com/user-attachments/assets/e74a2236-bba6-4bcb-be0c-d799d3b850fa" />


2. Go to Editor, add an Icon block, verify you cannot search the above icons:

<img width="1128" height="414" alt="image" src="https://github.com/user-attachments/assets/3aa5a4a6-db38-4a77-ba31-265b1cb55a09" />


## Use of AI Tools

I used Claude Opus to generate the changes, then I also double checked it.