### PR TITLE
devops: separate environments for jest date tests

### DIFF
--- a/bin/unit-test-date.sh
+++ b/bin/unit-test-date.sh
@@ -11,7 +11,13 @@ locales=(en_US ja_JP)
 
 for timezone in "${timezones[@]}"; do
     for locale in "${locales[@]}"; do
-        TZ=$timezone LANG=$locale npm run test:unit -- packages/date "$@" &
+	# Use FK_ENV_* variables to define a dedicated Flakiness.io test
+	# environment.
+	# See https://docs.flakiness.io/ci/configuring-environments/
+        TZ=$timezone LANG=$locale \
+            FK_ENV_TZ=$timezone FK_ENV_LANG=$locale \
+            FLAKINESS_OUTPUT_DIR="flakiness-report-$timezone-$locale" \
+            npm run test:unit -- packages/date "$@" &
         pids+=($!)
         pidsTimezones+=($timezone)
         pidsLocales+=($locale)


### PR DESCRIPTION
This patch uses `FK_ENV_*` variables to specialize testing environment.
Flakiness.io will then build a dedicated history for each testing
environment, making it easier to debug & track.

Drive-by: specify a unique `FLAKINESS_OUTPUT_DIR` so that multiple
parallel jest runs do not clash.
