### PR TITLE
Storybook: Include playground stories and MDX in CI smoke tests

### DIFF
--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -36,7 +36,7 @@ const stories = [
 	'../packages/ui/src/**/stories/*.mdx',
 	'../packages/ui/src/**/stories/*.story.@(ts|tsx)',
 	'../packages/admin-ui/src/**/stories/*.story.@(ts|tsx)',
-].filter( Boolean );
+];
 
 const config: StorybookConfig = {
 	core: {

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -13,13 +13,8 @@ import dsTokenFallbacksJs from '@wordpress/theme/vite-plugins/vite-ds-token-fall
 const { NODE_ENV = 'development' } = process.env;
 
 const stories = [
-	// Smoke tests ensure that the stories are rendered without any errors, but
-	// we don't need to test everything:
-	// - `.mdx` documentation is generally plain text and unlikely to break.
-	// - Playground stories are complex renderings of many components, which is
-	//   both slow and redundant with individual component stories.
-	NODE_ENV === 'test' ? '' : './stories/playground/**/*.story.@(jsx|tsx)',
-	NODE_ENV === 'test' ? '' : './stories/**/*.mdx',
+	'./stories/playground/**/*.story.@(jsx|tsx)',
+	'./stories/**/*.mdx',
 	'./stories/design-system/**/*.story.@(ts|tsx)',
 	'../packages/block-editor/src/**/stories/*.story.@(js|jsx|tsx|mdx)',
 	'../packages/editor/src/**/stories/*.story.@(js|jsx|tsx|mdx)',


### PR DESCRIPTION
## What?

Stop excluding playground stories and top-level Storybook MDX files from the CI smoke test build (`NODE_ENV=test`).

## Why?

The smoke test workflow (`storybook-check.yml`) runs with `NODE_ENV=test`, while the GitHub Pages deploy uses `NODE_ENV=production`. The conditionals in `storybook/main.ts` meant CI only built a subset of stories, so production-only build failures could slip through. This gap recently caused a merged PR to pass CI while breaking the Storybook Pages deploy.

Benchmarking locally shows the exclusions save only ~1 second of storybook build time (~1.5%), so the coverage trade-off is likely not worthwhile, even on CI.

The `NODE_ENV === 'test'` story exclusions date back to the Storybook 5.3 era (#19599), where they were used for Storyshots. They were carried forward through later Storybook upgrades (#53520, #74396) without a documented rationale tied to current CI.

#69679 added the smoke test workflow but did not introduce these conditionals or set `NODE_ENV` in CI. Until #74626 wired up `NODE_ENV: test` in `storybook-check.yml`, the exclusions were likely not even taking effect in CI. #74626 narrowed them from all `./stories/**` files to playground stories and top-level MDX, and added the comment about speed and redundancy during review. That PR was primarily about enabling the components manifest.

## How?

Always include `./stories/playground/**/*.story.@(jsx|tsx)` and `./stories/**/*.mdx` in the stories glob list.

> [!NOTE]
> You may be asking, should we stop doing `NODE_ENV=test` for the CI run then? My conclusion is no, because the main difference remaining between `test` and `production` is minification, and that indeed does contribute a non-negligible amount of time (~8s).

## Testing Instructions

1. Confirm CI "Storybook build and Smoke Tests" passes on this PR.
2. Optionally compare build times: `NODE_ENV=test npm run storybook:build` before and after.