### PR TITLE
test: actually pass TZ from the running script

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -30,8 +30,9 @@ const transpiledPackageNames = glob(
 	return relative.split( path.sep )[ 1 ];
 } );
 
-// Make sure the tests run in UTC timezone, regardless of the system timezone.
-process.env.TZ = 'UTC';
+// Make sure the tests run in UTC timezone, unless some other
+// timezone is set explicitly.
+process.env.TZ ??= 'UTC';
 
 module.exports = {
 	rootDir: '../../',


### PR DESCRIPTION
The `jest.config.js` force-defines timezone to `UTC`; however, the
date tests run a matrix to set timezone to different values:

https://github.com/WordPress/gutenberg/blob/a7fcec777038a55e00599eaceb4db25310f4a9c8/bin/unit-test-date.sh#L17

This patch makes sure that the date tests actually test in different
timezones.
