### PR TITLE
UI: Use isomorphic layout effects for SSR

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+-   Avoid React SSR warnings from layout effects in `@wordpress/ui` hooks and stories ([#79458](https://github.com/WordPress/gutenberg/pull/79458)).
 -   `Popover`: Disable popup transitions when Base UI marks animations as instant ([#79432](https://github.com/WordPress/gutenberg/pull/79432)).
 -   `Button`: Fix `loading` state in forced colors mode ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).
 -   `Button`: Fix `loading` prop affecting `unstyled` variant ([#78820](https://github.com/WordPress/gutenberg/pull/78820)).

--- a/packages/ui/src/popover/stories/utils.tsx
+++ b/packages/ui/src/popover/stories/utils.tsx
@@ -2,11 +2,10 @@ import {
 	createPortal,
 	forwardRef,
 	useCallback,
-	useLayoutEffect,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
+import { useIsomorphicLayoutEffect, useMergeRefs } from '@wordpress/compose';
 import type { RefCallback } from 'react';
 
 /**
@@ -23,7 +22,7 @@ export function useMeasure< TRef extends HTMLElement >() {
 		height: 0,
 	} );
 
-	useLayoutEffect( () => {
+	useIsomorphicLayoutEffect( () => {
 		if ( ! element ) {
 			return;
 		}

--- a/packages/ui/src/utils/use-overlay-scroll-state-attributes.ts
+++ b/packages/ui/src/utils/use-overlay-scroll-state-attributes.ts
@@ -1,5 +1,6 @@
 import type { UIEvent, UIEventHandler } from 'react';
-import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
+import { useIsomorphicLayoutEffect } from '@wordpress/compose';
+import { useCallback, useState } from '@wordpress/element';
 
 export const SCROLL_CONTAINER_ATTR = 'data-wp-ui-overlay-scroll-container';
 const SCROLLED_FROM_TOP_ATTR = 'data-wp-ui-overlay-scrolled-from-top';
@@ -198,7 +199,7 @@ export function useOverlayScrollStateAttributes<
 		setNode( el );
 	}, [] );
 
-	useLayoutEffect( () => {
+	useIsomorphicLayoutEffect( () => {
 		if ( ! node ) {
 			return;
 		}


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/78678#discussion_r3461834612.

## What?

Refactors the remaining raw `useLayoutEffect` calls found while scanning `@wordpress/ui` and `@wordpress/theme` to use `useIsomorphicLayoutEffect` from `@wordpress/compose` where a layout effect is still needed.

In the current `trunk` checkout, the remaining executable calls were in `@wordpress/ui`:

- `useOverlayScrollStateAttributes`
- the Popover Storybook `useMeasure` utility

`@wordpress/theme` no longer has raw `useLayoutEffect` calls on `trunk`.

## Why?

React warns when `useLayoutEffect` is used during server rendering. `useIsomorphicLayoutEffect` keeps the browser behavior as a layout effect while falling back to `useEffect` in SSR environments.

## How?

- Import `useIsomorphicLayoutEffect` from `@wordpress/compose`.
- Replace the raw `useLayoutEffect` calls in the UI hook and story utility.
- Add an `@wordpress/ui` changelog entry.

## Testing Instructions

1. `npm run lint:js -- packages/ui/src/utils/use-overlay-scroll-state-attributes.ts packages/ui/src/popover/stories/utils.tsx`
2. `npm run test:unit -- packages/ui/src/dialog/test packages/ui/src/drawer/test packages/ui/src/alert-dialog/test`

### Testing Instructions for Keyboard

No UI-facing changes.

## Screenshots or screencast

N/A - no visual changes intended.

## Use of AI Tools

Created with Codex.