### PR TITLE
Theme: Document ramp memoization contract

### DIFF
--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -23,8 +23,9 @@ import type { ThemeProviderProps } from './types';
 
 type Entry = [ string, string ];
 
-// `buildAccentRamp` caches by both arguments, so `getCachedBgRamp` must keep
-// equivalent background seeds on the same ramp reference for accent cache hits.
+// `buildAccentRamp` includes the `bgRamp` object reference in its cache key.
+// Memoizing the background ramp first lets the same background seed reuse the
+// same object reference, so accent ramps can be reused across renders.
 const getCachedBgRamp = memoize( buildBgRamp, { maxSize: 10 } );
 const getCachedAccentRamp = memoize( buildAccentRamp, { maxSize: 10 } );
 

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -23,9 +23,8 @@ import type { ThemeProviderProps } from './types';
 
 type Entry = [ string, string ];
 
-// `buildAccentRamp` includes the `bgRamp` object reference in its cache key.
-// Memoizing the background ramp first lets the same background seed reuse the
-// same object reference, so accent ramps can be reused across renders.
+// `getCachedAccentRamp` includes the `bgRamp` object reference in its cache key.
+// Without memoizing background ramps, accent ramp memoization would not work at all.
 const getCachedBgRamp = memoize( buildBgRamp, { maxSize: 10 } );
 const getCachedAccentRamp = memoize( buildAccentRamp, { maxSize: 10 } );
 

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -23,6 +23,8 @@ import type { ThemeProviderProps } from './types';
 
 type Entry = [ string, string ];
 
+// `buildAccentRamp` caches by both arguments, so `getCachedBgRamp` must keep
+// equivalent background seeds on the same ramp reference for accent cache hits.
 const getCachedBgRamp = memoize( buildBgRamp, { maxSize: 10 } );
 const getCachedAccentRamp = memoize( buildAccentRamp, { maxSize: 10 } );
 


### PR DESCRIPTION
## What?
Follow-up to #77462.

Documents the memoization contract between `getCachedBgRamp` and `getCachedAccentRamp` in `useThemeProviderStyles`.

## Why?
`buildAccentRamp` caches by both its seed and background ramp arguments. Keeping the background ramp memoized ensures equivalent background seeds reuse the same ramp reference, so accent ramp cache hits remain stable.

## How?
Adds a short comment next to the paired memoized ramp builders in `packages/theme/src/use-theme-provider-styles.ts`.

## Testing Instructions
1. Run `npm run lint:js -- packages/theme/src/use-theme-provider-styles.ts`.
2. Run `npx tsgo --build packages/theme/tsconfig.json`.

### Testing Instructions for Keyboard
Not applicable; this is an internal source comment change with no UI behavior.

## Screenshots or screencast
Not applicable; no visual changes.

## Use of AI Tools
This PR was prepared with OpenAI Codex. I reviewed the generated change and verification output.