### PR TITLE
Components: Add missing descriptions for design system components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Documentation
 
 -   `Menu`: Fix `overriden` typo to `overridden` in `CheckboxItemProps` and `RadioItemProps`. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
+-   Add component documentation for `ColorPicker`, `CustomSelectControl`, `Navigator`, `NumberControl`, `ResizableBox`, and `Slot` components ([#79460](https://github.com/WordPress/gutenberg/pull/79460)).
 
 ### Code Quality
 

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -247,6 +247,10 @@ const UnconnectedColorPicker = (
 	);
 };
 
+/**
+ * ColorPicker lets users select a color from a visual color surface, or by
+ * by editing its hex, RGB, or HSL values.
+ */
 export const ColorPicker = contextConnect(
 	UnconnectedColorPicker,
 	'ColorPicker'

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -249,7 +249,7 @@ const UnconnectedColorPicker = (
 
 /**
  * ColorPicker lets users select a color from a visual color surface, or by
- * by editing its hex, RGB, or HSL values.
+ * editing its hex, RGB, or HSL values.
  */
 export const ColorPicker = contextConnect(
 	UnconnectedColorPicker,

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -248,7 +248,7 @@ const UnconnectedColorPicker = (
 };
 
 /**
- * ColorPicker lets users select a color from a visual color surface, or by
+ * `ColorPicker` lets users select a color from a visual color surface, or by
  * editing its hex, RGB, or HSL values.
  */
 export const ColorPicker = contextConnect(

--- a/packages/components/src/color-picker/stories/index.story.tsx
+++ b/packages/components/src/color-picker/stories/index.story.tsx
@@ -12,6 +12,11 @@ import { ColorPicker } from '../component';
 const meta: Meta< typeof ColorPicker > = {
 	tags: [ 'manifest' ],
 	component: ColorPicker,
+	// Temporary: Due to an upstream bug, render the root explicitly so the
+	// components manifest extractor can resolve props from the JSX.
+	//
+	// See: https://github.com/storybookjs/storybook/issues/34877
+	render: ( args ) => <ColorPicker { ...args } />,
 	title: 'Components/Selection & Input/Color/ColorPicker',
 	id: 'components-colorpicker',
 	argTypes: {

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -53,9 +53,9 @@ function getDescribedBy( currentName: string, describedBy?: string ) {
 }
 
 /**
- * CustomSelectControl is a dropdown for selecting a single option from a list,
- * with support for custom styling. Use it instead of the `SelectControl` when
- * options need richer markup (e.g. per-option styles or hints).
+ * `CustomSelectControl` is a dropdown for selecting a single option from a
+ * list, with support for custom styling. Use it instead of the `SelectControl`
+ * when options need richer markup (e.g. per-option styles or hints).
  */
 function CustomSelectControl< T extends CustomSelectOption >(
 	props: CustomSelectProps< T >

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -52,6 +52,11 @@ function getDescribedBy( currentName: string, describedBy?: string ) {
 	return sprintf( __( 'Currently selected: %s' ), currentName );
 }
 
+/**
+ * CustomSelectControl is a dropdown for selecting a single option from a list,
+ * with support for custom styling. Use it instead of the `SelectControl` when
+ * options need richer markup (e.g. per-option styles or hints).
+ */
 function CustomSelectControl< T extends CustomSelectOption >(
 	props: CustomSelectProps< T >
 ) {

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -19,6 +19,11 @@ const meta: Meta< typeof Navigator > = {
 		Button: Navigator.Button,
 		BackButton: Navigator.BackButton,
 	},
+	// Temporary: Due to an upstream bug, render the root explicitly so the
+	// components manifest extractor can resolve props from the JSX.
+	//
+	// See: https://github.com/storybookjs/storybook/issues/34877
+	render: ( args ) => <Navigator { ...args } />,
 	title: 'Components/Navigation/Navigator',
 	id: 'components-navigator',
 	argTypes: {

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -277,7 +277,7 @@ function UnforwardedNumberControl(
 }
 
 /**
- * NumberControl lets users enter and adjust a numeric value.
+ * `NumberControl` lets users enter and adjust a numeric value.
  */
 export const NumberControl = forwardRef( UnforwardedNumberControl );
 NumberControl.displayName = 'NumberControl';

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -277,7 +277,8 @@ function UnforwardedNumberControl(
 }
 
 /**
- * `NumberControl` lets users enter and adjust a numeric value.
+ * `NumberControl` is a text input control that lets users enter and adjust a
+ * numeric value.
  */
 export const NumberControl = forwardRef( UnforwardedNumberControl );
 NumberControl.displayName = 'NumberControl';

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -276,6 +276,9 @@ function UnforwardedNumberControl(
 	);
 }
 
+/**
+ * NumberControl lets users enter and adjust a numeric value.
+ */
 export const NumberControl = forwardRef( UnforwardedNumberControl );
 NumberControl.displayName = 'NumberControl';
 

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -132,6 +132,10 @@ function UnforwardedResizableBox(
 	);
 }
 
+/**
+ * ResizableBox wraps content in a container with draggable handles, letting
+ * users interactively resize it along one or more edges or corners.
+ */
 export const ResizableBox = forwardRef( UnforwardedResizableBox );
 ResizableBox.displayName = 'ResizableBox';
 

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -133,7 +133,7 @@ function UnforwardedResizableBox(
 }
 
 /**
- * ResizableBox wraps content in a container with draggable handles, letting
+ * `ResizableBox` wraps content in a container with draggable handles, letting
  * users interactively resize it along one or more edges or corners.
  */
 export const ResizableBox = forwardRef( UnforwardedResizableBox );

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -31,7 +31,7 @@ import type {
 export { Fill };
 
 /**
- * Slot marks a location where content rendered by matching `Fill` components
+ * `Slot` marks a location where content rendered by matching `Fill` components
  * elsewhere will appear. Use it to allow a component to define UI areas that
  * can be extended from other parts of the application.
  */

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -30,6 +30,11 @@ import type {
 
 export { Fill };
 
+/**
+ * Slot marks a location where content rendered by matching `Fill` components
+ * elsewhere will appear. Use it to allow a component to define UI areas that
+ * can be extended from other parts of the application.
+ */
 export const Slot = forwardRef(
 	(
 		props: SlotComponentProps &

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 ### Documentation
 
-- Fix `overriden` typo to `overridden` in README. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
+-   Fix `overriden` typo to `overridden` in README. ([#79331](https://github.com/WordPress/gutenberg/pull/79331))
+-   Add component documentation for `DataViews`, `DataViewsPicker`, and `DataForm` components ([#79460](https://github.com/WordPress/gutenberg/pull/79460)).
 
 ### Internal
 

--- a/packages/dataviews/src/dataform/index.tsx
+++ b/packages/dataviews/src/dataform/index.tsx
@@ -13,9 +13,9 @@ import { DataFormLayout } from '../components/dataform-layouts/data-form-layout'
 import normalizeForm from '../components/dataform-layouts/normalize-form';
 
 /**
- * DataForm renders an auto-generated form for viewing and editing the fields of
- * a data item, driven by a fields and form layout configuration. Use it to edit
- * items of a dataset, often alongside `DataViews`.
+ * `DataForm` renders an auto-generated form for viewing and editing the fields
+ * of a data item, driven by a fields and form layout configuration. Use it to
+ * edit items of a dataset, often alongside `DataViews`.
  */
 export default function DataForm< Item >( {
 	data,

--- a/packages/dataviews/src/dataform/index.tsx
+++ b/packages/dataviews/src/dataform/index.tsx
@@ -12,6 +12,11 @@ import { DataFormProvider } from '../components/dataform-context';
 import { DataFormLayout } from '../components/dataform-layouts/data-form-layout';
 import normalizeForm from '../components/dataform-layouts/normalize-form';
 
+/**
+ * DataForm renders an auto-generated form for viewing and editing the fields of
+ * a data item, driven by a fields and form layout configuration. Use it to edit
+ * items of a dataset, often alongside `DataViews`.
+ */
 export default function DataForm< Item >( {
 	data,
 	form,

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -270,7 +270,7 @@ function DataViewsPicker< Item >( {
 }
 
 /**
- * DataViewsPicker renders a dataset allowing users to select one or multiple
+ * `DataViewsPicker` renders a dataset allowing users to select one or multiple
  * items. It shares the layouts, search, and filtering of `DataViews` but is
  * geared toward choosing items rather than managing them.
  */

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -269,6 +269,11 @@ function DataViewsPicker< Item >( {
 	);
 }
 
+/**
+ * DataViewsPicker renders a dataset allowing users to select one or multiple
+ * items. It shares the layouts, search, and filtering of `DataViews` but is
+ * geared toward choosing items rather than managing them.
+ */
 // Populate the DataViews sub components
 const DataViewsPickerSubComponents =
 	DataViewsPicker as typeof DataViewsPicker & {

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -311,7 +311,7 @@ function DataViews< Item >( {
 }
 
 /**
- * DataViews renders a dataset using configurable layouts (table, grid, list)
+ * `DataViews` renders a dataset using configurable layouts (table, grid, list)
  * with built-in search, filtering, sorting, pagination, and actions. Use it to
  * display and manage a collection of records.
  */

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -310,6 +310,11 @@ function DataViews< Item >( {
 	);
 }
 
+/**
+ * DataViews renders a dataset using configurable layouts (table, grid, list)
+ * with built-in search, filtering, sorting, pagination, and actions. Use it to
+ * display and manage a collection of records.
+ */
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	BulkActionToolbar: typeof BulkActionsFooter;

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -24,6 +24,11 @@ const meta = {
 	tags: [ 'manifest' ],
 	title: 'DataViews/DataViews',
 	component: DataViews,
+	// Temporary: Due to an upstream bug, render the root explicitly so the
+	// components manifest extractor can resolve props from the JSX.
+	//
+	// See: https://github.com/storybookjs/storybook/issues/34877
+	render: ( args ) => <DataViews { ...args } />,
 	args: {
 		containerHeight: 'auto',
 	},

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -557,7 +557,7 @@ export default dedupePlugins( [
 	// component always receives props and returns a React element, and its
 	// props should be documented through its TypeScript props types.
 	{
-		files: [ '**/*.tsx' ],
+		files: [ '**/@(storybook|stories)/**', '**/*.tsx' ],
 		rules: {
 			'jsdoc/require-param': 'off',
 		},

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -557,12 +557,7 @@ export default dedupePlugins( [
 	// component always receives props and returns a React element, and its
 	// props should be documented through its TypeScript props types.
 	{
-		files: [
-			'**/@(storybook|stories)/**',
-			'packages/components/src/**/*.tsx',
-			'packages/theme/src/**/*.tsx',
-			'packages/ui/src/**/*.tsx',
-		],
+		files: [ '**/*.tsx' ],
 		rules: {
 			'jsdoc/require-param': 'off',
 		},


### PR DESCRIPTION
## What?

Adds JSDoc descriptions for all components which are surfaced as design system components through the Storybook manifest file, which in turn are used by the `@wordpress/design-system-mcp` package.

In doing so, it also fixes missing component props for three components: ColorPicker, DataViews, and Navigator.

## Why?

Descriptions are useful in order to understand what a component does and whether it's usage is applicable to a given use-case. 

With AI agent workflows leveraging the `@wordpress/design-system-mcp`, descriptions are a particularly important part of the agent workflow, since an AI agent is [instructed](https://github.com/WordPress/gutenberg/blob/8d6753830067140240d9337a631746cf4ee72baf/packages/design-system-mcp/src/index.ts#L15) to get a list of components via the `get_components` tools before diving into individual component details with `get_component_details`. Since the only information surfaced on `get_components` listing is the component name and description, the description is a pivotal detail to cue an agent to retrieve more information if it would understand it to be relevant for a given request.

## How?

Adds missing JSDoc documentation to components.

For a few of these, I had to employ the same workaround as in #77382 to ensure that the docgen tool correctly parses these components, via inline `render` configuration in the component stories. This should be temporary and [may already be resolved upstream](https://github.com/WordPress/gutenberg/pull/77382#issuecomment-4770996707). Worth noting that this fixes a preexisting issue with these components props not being surfaced in the manifest (see "3/66 prop type errors" on [live components HTML manifest](https://wordpress.github.io/gutenberg/manifests/components.html)).

## Testing Instructions

Verify that built Storybook manifest parses all components successfully and all components have descriptions:

1. Run `npm run storybook:build`
2. Run `open storybook/build/manifests/components.html`
3. Observe "66 components okay" (compare to "3/66 prop type errors" on [live components HTML manifest](https://wordpress.github.io/gutenberg/manifests/components.html))
4. Observe every listed component has a description (compare to [live components HTML manifest](https://wordpress.github.io/gutenberg/manifests/components.html) missing descriptions for affected components like ColorPicker, DataViews, etc.)

Verify that descriptions appear in live Storybook site:

1. Run `npm run storybook:dev`
2. In the launched Storybook site at http://localhost:50240/, navigate to a Storybook page for one of the affected components (e.g. ColorPicker)
3. Observe that the Storybook shows a description

## Screenshots or screencast <!-- if applicable -->

<img width="1557" height="1173" alt="Screenshot 2026-06-23 at 4 29 18 PM" src="https://github.com/user-attachments/assets/8c6aa0da-b66c-434d-b2bf-df0b0c0bbd1a" />

## Use of AI Tools

Assessment and initial implementation (including descriptions themselves) with Claude Opus 4.8. Manual review and edits of most of the descriptions for readability and conciseness.