### PR TITLE
Add e2e coverage for pattern wrapper block identity

### DIFF
--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -463,6 +463,50 @@ test.describe( 'Unsynced pattern', () => {
 		).toBeVisible();
 	} );
 
+	test( 'shows the source block in the inspector when editing a pattern', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.setContent( `<!-- wp:group {"metadata":{"patternName":"theme/header-wrapper","name":"Header"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Pattern content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+		await listView
+			.getByRole( 'gridcell', { name: 'Header', exact: true } )
+			.click();
+
+		await editor.openDocumentSettingsSidebar();
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		const blockCard = editorSettings
+			.locator( '.block-editor-block-card' )
+			.first();
+		const blockCardName = blockCard.locator(
+			'.block-editor-block-card__name'
+		);
+		const blockCardBadge = blockCard.locator(
+			'.components-badge__content'
+		);
+
+		await expect( blockCardName ).toHaveText( 'Header' );
+		await expect( blockCardBadge ).toHaveText( 'Pattern' );
+
+		await editorSettings
+			.getByRole( 'button', { name: 'Edit pattern' } )
+			.click();
+
+		await expect( blockCardName ).toHaveText( 'Header' );
+		await expect( blockCardBadge ).toHaveText( 'Group' );
+	} );
+
 	test( 'detaches an unsynced pattern via the block options menu', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -486,25 +486,18 @@ test.describe( 'Unsynced pattern', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-		const blockCard = editorSettings
-			.locator( '.block-editor-block-card' )
+		const blockHeading = editorSettings
+			.getByRole( 'tabpanel', { name: 'Block' } )
+			.getByRole( 'heading' )
 			.first();
-		const blockCardName = blockCard.locator(
-			'.block-editor-block-card__name'
-		);
-		const blockCardBadge = blockCard.locator(
-			'.components-badge__content'
-		);
 
-		await expect( blockCardName ).toHaveText( 'Header' );
-		await expect( blockCardBadge ).toHaveText( 'Pattern' );
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Pattern' );
 
 		await editorSettings
 			.getByRole( 'button', { name: 'Edit pattern' } )
 			.click();
 
-		await expect( blockCardName ).toHaveText( 'Header' );
-		await expect( blockCardBadge ).toHaveText( 'Group' );
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
 	} );
 
 	test( 'detaches an unsynced pattern via the block options menu', async ( {

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -254,16 +254,12 @@ test.describe( 'Template Part', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-		const blockCard = editorSettings
-			.locator( '.block-editor-block-card' )
+		const blockHeading = editorSettings
+			.getByRole( 'tabpanel', { name: 'Block' } )
+			.getByRole( 'heading' )
 			.first();
 
-		await expect(
-			blockCard.locator( '.block-editor-block-card__name' )
-		).toHaveText( 'Header' );
-		await expect(
-			blockCard.locator( '.components-badge__content' )
-		).toHaveText( 'Group' );
+		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
 	} );
 
 	test( 'shows changes in a template when a template part it contains is modified', async ( {

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -221,6 +221,51 @@ test.describe( 'Template Part', () => {
 		await expect( templatePartWithParagraph ).toBeHidden();
 	} );
 
+	test( 'shows the source block for a pattern wrapper in focus mode', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const templatePart = await requestUtils.createTemplate(
+			'wp_template_part',
+			{
+				slug: 'pattern-header',
+				title: 'Pattern Header',
+				content: `<!-- wp:group {"metadata":{"patternName":"theme/header-wrapper","name":"Header"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Template part content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`,
+			}
+		);
+
+		await admin.visitSiteEditor( {
+			postId: templatePart.id,
+			postType: 'wp_template_part',
+			canvas: 'edit',
+		} );
+
+		await editor.selectBlocks(
+			editor.canvas.getByRole( 'document', { name: 'Block: Group' } )
+		);
+		await editor.openDocumentSettingsSidebar();
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		const blockCard = editorSettings
+			.locator( '.block-editor-block-card' )
+			.first();
+
+		await expect(
+			blockCard.locator( '.block-editor-block-card__name' )
+		).toHaveText( 'Header' );
+		await expect(
+			blockCard.locator( '.components-badge__content' )
+		).toHaveText( 'Group' );
+	} );
+
 	test( 'shows changes in a template when a template part it contains is modified', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What? Why?
Adds focused e2e coverage for pattern wrapper block identity after #79417.


## How?
- Verifies an unsynced pattern wrapper changes its block info card badge from `Pattern` to `Group` after clicking `Edit pattern`.
- Verifies a pattern wrapper inside an isolated template part editor shows `Header` with a `Group` badge instead of `Pattern`.

## Manual Testing

1. Open the post editor with a Group block that has `metadata.patternName` and `metadata.name: "Header"`.
2. Select the wrapper and confirm the block info card shows `Header` with a `Pattern` badge.
3. Click `Edit pattern`.
4. Confirm the same block info card shows `Header` with a `Group` badge.
5. Open a template part in focus mode containing the same wrapper.
6. Select the Group block and confirm the block info card shows `Header` with a `Group` badge.
