### PR TITLE
Style Engine: add CSS variables builder

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2473,7 +2473,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The new stylesheet.
 	 */
 	protected function get_css_variables( $nodes, $origins ) {
-		$css_rules = array();
+		$css_variables = new WP_Style_Engine_CSS_Variables_Gutenberg();
 		foreach ( $nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
 				continue;
@@ -2502,7 +2502,7 @@ class WP_Theme_JSON_Gutenberg {
 					continue;
 				}
 
-				$target = static::get_feature_selector( $feature_selectors, $preset_metadata['path'][0], $selector );
+				$target = static::get_css_variable_feature_selector( $feature_selectors, $preset_metadata['path'][0], $selector );
 
 				if ( ! isset( $vars_by_selector[ $target ] ) ) {
 					$vars_by_selector[ $target ] = array();
@@ -2517,20 +2517,21 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			// Theme vars always use the block's default selector.
-			foreach ( static::compute_theme_vars( $node ) as $theme_var ) {
-				$vars_by_selector[ $selector ][] = $theme_var;
-			}
+			$vars_by_selector[ $selector ] = array_merge(
+				$vars_by_selector[ $selector ],
+				WP_Style_Engine_CSS_Variables_Gutenberg::get_declarations_from_values(
+					$node['custom'] ?? array(),
+					array( 'prefix' => '--wp--custom--' )
+				)
+			);
 
 			foreach ( $vars_by_selector as $rule_selector => $declarations ) {
-				$css_rules[] = array(
-					'selector'     => $rule_selector,
-					'declarations' => $declarations,
-				);
+				$css_variables->add_declarations( $rule_selector, $declarations );
 			}
 		}
 
 		return WP_Style_Engine_Gutenberg::compile_css_rules(
-			$css_rules,
+			$css_variables->get_rules(),
 			array( 'sanitize' => false )
 		);
 	}
@@ -2548,7 +2549,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string                                      $default_selector  Fallback selector.
 	 * @return string The resolved selector.
 	 */
-	private static function get_feature_selector( array $feature_selectors, string $feature_key, string $default_selector ): string {
+	private static function get_css_variable_feature_selector( array $feature_selectors, string $feature_key, string $default_selector ): string {
 		if ( ! isset( $feature_selectors[ $feature_key ] ) ) {
 			return $default_selector;
 		}
@@ -2887,17 +2888,10 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The modified $declarations.
 	 */
 	protected static function compute_theme_vars( $settings ) {
-		$declarations  = array();
-		$custom_values = $settings['custom'] ?? array();
-		$css_vars      = static::flatten_tree( $custom_values );
-		foreach ( $css_vars as $key => $value ) {
-			$declarations[] = array(
-				'name'  => '--wp--custom--' . $key,
-				'value' => $value,
-			);
-		}
-
-		return $declarations;
+		return WP_Style_Engine_CSS_Variables_Gutenberg::get_declarations_from_values(
+			$settings['custom'] ?? array(),
+			array( 'prefix' => '--wp--custom--' )
+		);
 	}
 
 	/**
@@ -2938,25 +2932,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The flattened tree.
 	 */
 	protected static function flatten_tree( $tree, $prefix = '', $token = '--' ) {
-		$result = array();
-		foreach ( $tree as $property => $value ) {
-			$new_key = $prefix . str_replace(
-				'/',
-				'-',
-				strtolower( _wp_to_kebab_case( $property ) )
-			);
-
-			if ( is_array( $value ) ) {
-				$new_prefix        = $new_key . $token;
-				$flattened_subtree = static::flatten_tree( $value, $new_prefix, $token );
-				foreach ( $flattened_subtree as $subtree_key => $subtree_value ) {
-					$result[ $subtree_key ] = $subtree_value;
-				}
-			} else {
-				$result[ $new_key ] = $value;
-			}
-		}
-		return $result;
+		return WP_Style_Engine_CSS_Variables_Gutenberg::flatten_tree( $tree, $prefix, $token );
 	}
 
 	/**

--- a/lib/load.php
+++ b/lib/load.php
@@ -184,6 +184,7 @@ require __DIR__ . '/block-template-utils.php';
 if ( is_dir( __DIR__ . '/../build/scripts/style-engine' ) ) {
 	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
+	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-css-variables-gutenberg.php';
 	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';
 	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-processor-gutenberg.php';
 	require_once __DIR__ . '/../build/scripts/style-engine/class-wp-style-engine-gutenberg.php';

--- a/packages/style-engine/src/class-wp-style-engine-css-variables.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-variables.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Variables
+ *
+ * Builds CSS custom property declarations and rules.
+ *
+ * @package gutenberg
+ */
+
+if ( ! class_exists( 'WP_Style_Engine_CSS_Variables' ) ) {
+	/**
+	 * Builds CSS custom property declarations and rules.
+	 *
+	 * @access private
+	 */
+	class WP_Style_Engine_CSS_Variables {
+		/**
+		 * CSS variable declarations, grouped by selector.
+		 *
+		 * @var array
+		 */
+		protected $declarations_by_selector = array();
+
+		/**
+		 * Adds a CSS custom property declaration for a selector.
+		 *
+		 * @param string $selector CSS selector.
+		 * @param string $name     CSS custom property name.
+		 * @param mixed  $value    CSS custom property value.
+		 * @return WP_Style_Engine_CSS_Variables Returns the object to allow chaining methods.
+		 */
+		public function add_declaration( $selector, $name, $value ) {
+			if ( ! is_string( $selector ) || '' === $selector || ! is_string( $name ) || '' === $name ) {
+				return $this;
+			}
+
+			if ( ! isset( $this->declarations_by_selector[ $selector ] ) ) {
+				$this->declarations_by_selector[ $selector ] = array();
+			}
+
+			$this->declarations_by_selector[ $selector ][] = array(
+				'name'  => $name,
+				'value' => $value,
+			);
+
+			return $this;
+		}
+
+		/**
+		 * Adds CSS custom property declarations for a selector.
+		 *
+		 * The declarations can be an associative name/value map or an ordered list
+		 * of arrays with `name` and `value` keys.
+		 *
+		 * @param string $selector     CSS selector.
+		 * @param array  $declarations CSS custom property declarations.
+		 * @return WP_Style_Engine_CSS_Variables Returns the object to allow chaining methods.
+		 */
+		public function add_declarations( $selector, $declarations ) {
+			if ( empty( $declarations ) || ! is_array( $declarations ) ) {
+				return $this;
+			}
+
+			foreach ( $declarations as $name => $value ) {
+				if ( is_array( $value ) && array_key_exists( 'name', $value ) && array_key_exists( 'value', $value ) ) {
+					$name  = $value['name'];
+					$value = $value['value'];
+				}
+
+				$this->add_declaration( $selector, $name, $value );
+			}
+
+			return $this;
+		}
+
+		/**
+		 * Adds CSS custom property declarations generated from a nested value tree.
+		 *
+		 * @param string $selector CSS selector.
+		 * @param array  $values   Nested values.
+		 * @param array  $options  {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type string $prefix Prefix to prepend to each custom property name. Default empty string.
+		 *     @type string $token  Token to use between nested levels. Default '--'.
+		 * }
+		 * @return WP_Style_Engine_CSS_Variables Returns the object to allow chaining methods.
+		 */
+		public function add_declarations_from_values( $selector, $values, $options = array() ) {
+			$declarations = static::get_declarations_from_values( $values, $options );
+			return $this->add_declarations( $selector, $declarations );
+		}
+
+		/**
+		 * Returns CSS rules for the collected custom property declarations.
+		 *
+		 * @return array CSS rules.
+		 */
+		public function get_rules() {
+			$rules = array();
+
+			foreach ( $this->declarations_by_selector as $selector => $declarations ) {
+				if ( empty( $declarations ) ) {
+					continue;
+				}
+
+				$rules[] = array(
+					'selector'     => $selector,
+					'declarations' => $declarations,
+				);
+			}
+
+			return $rules;
+		}
+
+		/**
+		 * Returns CSS custom property declarations generated from a nested value tree.
+		 *
+		 * @param array $values  Nested values.
+		 * @param array $options {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type string $prefix Prefix to prepend to each custom property name. Default empty string.
+		 *     @type string $token  Token to use between nested levels. Default '--'.
+		 * }
+		 * @return array CSS custom property declarations.
+		 */
+		public static function get_declarations_from_values( $values, $options = array() ) {
+			if ( empty( $values ) || ! is_array( $values ) ) {
+				return array();
+			}
+
+			$options = wp_parse_args(
+				$options,
+				array(
+					'prefix' => '',
+					'token'  => '--',
+				)
+			);
+
+			$declarations = array();
+			$css_vars     = static::flatten_tree( $values, '', $options['token'] );
+
+			foreach ( $css_vars as $key => $value ) {
+				$declarations[] = array(
+					'name'  => $options['prefix'] . $key,
+					'value' => $value,
+				);
+			}
+
+			return $declarations;
+		}
+
+		/**
+		 * Given a tree, creates a flattened one by merging the keys and binding
+		 * the leaf values to the new keys.
+		 *
+		 * It also transforms camelCase names into kebab-case and substitutes `/`
+		 * with `-`.
+		 *
+		 * @param array  $tree   Input tree to process.
+		 * @param string $prefix Optional. Prefix to prepend to each variable. Default empty string.
+		 * @param string $token  Optional. Token to use between levels. Default '--'.
+		 * @return array The flattened tree.
+		 */
+		public static function flatten_tree( $tree, $prefix = '', $token = '--' ) {
+			$result = array();
+			foreach ( $tree as $property => $value ) {
+				$new_key = $prefix . str_replace(
+					'/',
+					'-',
+					strtolower( _wp_to_kebab_case( $property ) )
+				);
+
+				if ( is_array( $value ) ) {
+					$new_prefix        = $new_key . $token;
+					$flattened_subtree = static::flatten_tree( $value, $new_prefix, $token );
+					foreach ( $flattened_subtree as $subtree_key => $subtree_value ) {
+						$result[ $subtree_key ] = $subtree_value;
+					}
+				} else {
+					$result[ $new_key ] = $value;
+				}
+			}
+			return $result;
+		}
+	}
+}

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -1066,4 +1066,93 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '.first{color: red;color: blue;margin: 0;}.second{display: flex;}@media (min-width: 600px){.third{display: grid;}}', $compiled_css );
 	}
+
+	/**
+	 * Tests that CSS variable declarations can be generated from nested values.
+	 *
+	 * @covers WP_Style_Engine_CSS_Variables_Gutenberg::get_declarations_from_values
+	 */
+	public function test_css_variables_generates_declarations_from_nested_values() {
+		$declarations = WP_Style_Engine_CSS_Variables_Gutenberg::get_declarations_from_values(
+			array(
+				'lineHeight'   => array(
+					'small' => '1.2',
+				),
+				'spacing/unit' => 'rem',
+			),
+			array( 'prefix' => '--wp--custom--' )
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'name'  => '--wp--custom--line-height--small',
+					'value' => '1.2',
+				),
+				array(
+					'name'  => '--wp--custom--spacing-unit',
+					'value' => 'rem',
+				),
+			),
+			$declarations
+		);
+	}
+
+	/**
+	 * Tests that CSS variable rules preserve selector and declaration order.
+	 *
+	 * @covers WP_Style_Engine_CSS_Variables_Gutenberg
+	 */
+	public function test_css_variables_builds_selector_scoped_rules() {
+		$css_variables = new WP_Style_Engine_CSS_Variables_Gutenberg();
+
+		$css_variables
+			->add_declaration( ':root', '--wp--preset--color--primary', '#ffffff' )
+			->add_declarations_from_values(
+				':root',
+				array(
+					'lineHeight' => array(
+						'small' => '1.2',
+					),
+				),
+				array( 'prefix' => '--wp--custom--' )
+			)
+			->add_declarations(
+				'.wp-block-test',
+				array(
+					array(
+						'name'  => '--wp--preset--dimension--25',
+						'value' => '25%',
+					),
+				)
+			);
+
+		$this->assertSame(
+			array(
+				array(
+					'selector'     => ':root',
+					'declarations' => array(
+						array(
+							'name'  => '--wp--preset--color--primary',
+							'value' => '#ffffff',
+						),
+						array(
+							'name'  => '--wp--custom--line-height--small',
+							'value' => '1.2',
+						),
+					),
+				),
+				array(
+					'selector'     => '.wp-block-test',
+					'declarations' => array(
+						array(
+							'name'  => '--wp--preset--dimension--25',
+							'value' => '25%',
+						),
+					),
+				),
+			),
+			$css_variables->get_rules()
+		);
+	}
 }


### PR DESCRIPTION
## What?

This is stacked on #79303.

This PR is part of a stack:

- https://github.com/WordPress/gutenberg/pull/79302 
- https://github.com/WordPress/gutenberg/pull/79303
- https://github.com/WordPress/gutenberg/pull/79463  (this PR) 

It adds a generic Style Engine CSS variables builder:

```php
WP_Style_Engine_CSS_Variables
```

The builder collects ordered CSS custom property declarations by selector and returns rule arrays that can be compiled by the Style Engine rule compiler added in #79303.

Theme JSON now uses this builder when generating CSS variable rules:

```text
Theme JSON data
  -> Theme JSON resolves preset metadata and feature selectors
  -> WP_Style_Engine_CSS_Variables collects custom property declarations by selector
  -> Style Engine compiles the stylesheet
```

## Why?

The previous PR established the Style Engine rule-list compiler. This PR adds the next reusable piece to the Style Engine instead of creating a Theme JSON-specific CSS variables helper.

Before this stack:

```text
Theme JSON computes declarations
Theme JSON groups by selector
Theme JSON concatenates CSS strings
```

After #79303:

```text
Theme JSON computes declarations
Theme JSON groups into rule arrays
Style Engine compiles the stylesheet
```

After this PR:

```text
Theme JSON handles Theme JSON-specific preset and selector resolution
Style Engine owns generic CSS custom property declaration/rule building
Style Engine compiles the stylesheet
```

## Notes

This keeps the boundary more reusable than a `WP_Theme_JSON_*` helper. Theme JSON still owns Theme JSON-specific concerns such as preset metadata, origins, and feature-selector routing. The Style Engine owns generic custom-property mechanics: nested value flattening, declaration collection, selector grouping, and ordered rule output.

Follow-ups can use the same direction for other producers: move generic mechanics into the Style Engine, while keeping Theme JSON-specific adapters thin.

## Manual Testing

1. Start the local environment:

   ```bash
   npm run wp-env start -- --auto-port
   ```

2. Open the frontend and inspect the generated global styles.

3. Confirm CSS custom properties still appear for root and block scopes, for example `--wp--preset--color--*`, `--wp--preset--font-size--*`, and `--wp--custom--*`.

4. In the Site Editor, change a global style preset usage such as color, typography, or spacing, save it, and reload the frontend.

5. Confirm the frontend still receives the expected global styles and block rendering has not lost preset variables.

## Testing

```bash
php -l packages/style-engine/src/class-wp-style-engine-css-variables.php
php -l build/scripts/style-engine/class-wp-style-engine-css-variables-gutenberg.php
php -l lib/class-wp-theme-json-gutenberg.php
php -l lib/load.php
php -l phpunit/style-engine/style-engine-test.php
php -l phpunit/class-wp-theme-json-test.php
vendor/bin/phpcbf packages/style-engine/src/class-wp-style-engine-css-variables.php build/scripts/style-engine/class-wp-style-engine-css-variables-gutenberg.php lib/class-wp-theme-json-gutenberg.php lib/load.php phpunit/style-engine/style-engine-test.php phpunit/class-wp-theme-json-test.php
vendor/bin/phpcs packages/style-engine/src/class-wp-style-engine-css-variables.php build/scripts/style-engine/class-wp-style-engine-css-variables-gutenberg.php lib/class-wp-theme-json-gutenberg.php lib/load.php phpunit/style-engine/style-engine-test.php phpunit/class-wp-theme-json-test.php
npm run test:unit:php:base -- --filter WP_Style_Engine_Test
npm run test:unit:php:base -- --filter "test_get_stylesheet|test_resolve_variables"
```

I also tried the full `WP_Theme_JSON_Gutenberg_Test` class locally before this adjustment, but the rebased base branch currently reproduces unrelated custom-state failures in this environment, so the validation above focuses on the CSS variable and stylesheet paths touched here.
