### PR TITLE
Try generating block element selectors only when element styles exist

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1354,21 +1354,18 @@ class WP_Theme_JSON_Gutenberg {
 	 *     {
 	 *       'core/paragraph': {
 	 *         'selector': 'p',
-	 *         'elements': {
-	 *           'link' => 'link selector',
-	 *           'etc'  => 'element selector'
-	 *         }
 	 *       },
 	 *       'core/heading': {
 	 *         'selector': 'h1',
-	 *         'elements': {}
 	 *       },
 	 *       'core/image': {
 	 *         'selector': '.wp-block-image',
 	 *         'duotone': 'img',
-	 *         'elements': {}
 	 *       }
 	 *     }
+	 *
+	 * Block element selectors are generated lazily for block style nodes that
+	 * contain element styles.
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Added `duotone` key with CSS selector.
@@ -1412,11 +1409,6 @@ class WP_Theme_JSON_Gutenberg {
 
 			static::$blocks_metadata[ $block_name ]['selector']  = $root_selector;
 			static::$blocks_metadata[ $block_name ]['selectors'] = static::get_block_selectors( $block_type, $root_selector );
-
-			$elements = static::get_block_element_selectors( $root_selector );
-			if ( ! empty( $elements ) ) {
-				static::$blocks_metadata[ $block_name ]['elements'] = $elements;
-			}
 
 			// The block may or may not have a duotone selector.
 			$duotone_selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
@@ -3139,6 +3131,43 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Determines whether a block style node contains element styles.
+	 *
+	 * @param array $node               A theme.json block styles node.
+	 * @param bool  $include_variations Whether variation nodes will be included.
+	 * @return bool Whether the block node contains element styles.
+	 */
+	private static function block_node_has_element_styles( $node, $include_variations = false ) {
+		if ( isset( $node['elements'] ) ) {
+			return true;
+		}
+
+		foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+			if ( isset( $node[ $breakpoint ]['elements'] ) ) {
+				return true;
+			}
+		}
+
+		if ( ! $include_variations || ! isset( $node['variations'] ) ) {
+			return false;
+		}
+
+		foreach ( $node['variations'] as $variation_node ) {
+			if ( isset( $variation_node['elements'] ) ) {
+				return true;
+			}
+
+			foreach ( array_keys( static::RESPONSIVE_BREAKPOINTS ) as $breakpoint ) {
+				if ( isset( $variation_node[ $breakpoint ]['elements'] ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * An internal method to get the block nodes from a theme.json file.
 	 *
 	 * @since 6.1.0
@@ -3202,10 +3231,18 @@ class WP_Theme_JSON_Gutenberg {
 					$feature_selectors = $selectors[ $name ]['selectors'];
 				}
 
+				$block_elements = $selectors[ $name ]['elements'] ?? array();
+				if ( empty( $block_elements ) && null !== $selector && static::block_node_has_element_styles( $node, $include_variations ) ) {
+					$block_elements = static::get_block_element_selectors( $selector );
+					if ( isset( static::$blocks_metadata[ $name ] ) && $selector === static::$blocks_metadata[ $name ]['selector'] ) {
+						static::$blocks_metadata[ $name ]['elements'] = $block_elements;
+					}
+				}
+
 				$variation_selectors = array();
 
 				if ( $include_variations && isset( $node['variations'] ) ) {
-					foreach ( $node['variations'] as $variation => $node ) {
+					foreach ( $node['variations'] as $variation => $variation_node ) {
 						$variation_selectors[] = array(
 							'name'     => $variation,
 							'path'     => array( 'styles', 'blocks', $name, 'variations', $variation ),
@@ -3219,7 +3256,7 @@ class WP_Theme_JSON_Gutenberg {
 					'path'       => $node_path,
 					'selector'   => $selector,
 					'selectors'  => $feature_selectors,
-					'elements'   => $selectors[ $name ]['elements'] ?? array(),
+					'elements'   => $block_elements,
 					'duotone'    => $duotone_selector,
 					'variations' => $variation_selectors,
 					'css'        => $selector,
@@ -3236,7 +3273,7 @@ class WP_Theme_JSON_Gutenberg {
 							'media_query' => static::RESPONSIVE_BREAKPOINTS[ $breakpoint ],
 							'selector'    => $selector,
 							'selectors'   => $feature_selectors,
-							'elements'    => $selectors[ $name ]['elements'] ?? array(),
+							'elements'    => $block_elements,
 							'variations'  => $variation_selectors,
 							'css'         => $selector,
 						);
@@ -3283,7 +3320,7 @@ class WP_Theme_JSON_Gutenberg {
 								'path'       => array( 'styles', 'blocks', $name, $pseudo_selector ),
 								'selector'   => static::append_to_selector( $selector, $pseudo_selector ),
 								'selectors'  => $pseudo_feature_selectors,
-								'elements'   => $selectors[ $name ]['elements'] ?? array(),
+								'elements'   => $block_elements,
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => static::append_to_selector( $selector, $pseudo_selector ),
@@ -3301,7 +3338,7 @@ class WP_Theme_JSON_Gutenberg {
 									'media_query' => static::RESPONSIVE_BREAKPOINTS[ $breakpoint ],
 									'selector'    => static::append_to_selector( $selector, $pseudo_selector ),
 									'selectors'   => $pseudo_feature_selectors,
-									'elements'    => $selectors[ $name ]['elements'] ?? array(),
+									'elements'    => $block_elements,
 									'variations'  => $variation_selectors,
 									'css'         => static::append_to_selector( $selector, $pseudo_selector ),
 								);
@@ -3323,7 +3360,7 @@ class WP_Theme_JSON_Gutenberg {
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),
 								'selector'   => $custom_css_selector,
 								'selectors'  => $feature_selectors,
-								'elements'   => $selectors[ $name ]['elements'] ?? array(),
+								'elements'   => $block_elements,
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => $custom_css_selector,
@@ -3339,7 +3376,7 @@ class WP_Theme_JSON_Gutenberg {
 											'path'       => array( 'styles', 'blocks', $name, $custom_state, $pseudo ),
 											'selector'   => $compound_css_selector,
 											'selectors'  => $feature_selectors,
-											'elements'   => $selectors[ $name ]['elements'] ?? array(),
+											'elements'   => $block_elements,
 											'duotone'    => $duotone_selector,
 											'variations' => $variation_selectors,
 											'css'        => $compound_css_selector,
@@ -3361,7 +3398,7 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$element_selector = $selectors[ $name ]['elements'][ $element ];
+					$element_selector = $block_elements[ $element ];
 
 					$nodes[] = array(
 						'path'     => $element_path,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -106,9 +106,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * Resets the block metadata cache for WP_Theme_JSON_Gutenberg.
 	 */
 	private function reset_blocks_metadata() {
-		$property = new ReflectionProperty( WP_Theme_JSON_Gutenberg::class, 'blocks_metadata' );
-		$property->setAccessible( true );
-		$property->setValue( null, array() );
+		$reset = Closure::bind(
+			static function () {
+				WP_Theme_JSON_Gutenberg::$blocks_metadata = array();
+			},
+			null,
+			WP_Theme_JSON_Gutenberg::class
+		);
+
+		$reset();
 	}
 
 	/**
@@ -117,9 +123,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * @return array Block metadata.
 	 */
 	private function get_blocks_metadata() {
-		$property = new ReflectionProperty( WP_Theme_JSON_Gutenberg::class, 'blocks_metadata' );
-		$property->setAccessible( true );
-		return $property->getValue();
+		$get = Closure::bind(
+			static function () {
+				return WP_Theme_JSON_Gutenberg::$blocks_metadata;
+			},
+			null,
+			WP_Theme_JSON_Gutenberg::class
+		);
+
+		return $get();
 	}
 
 	public function test_get_settings() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -102,6 +102,26 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Resets the block metadata cache for WP_Theme_JSON_Gutenberg.
+	 */
+	private function reset_blocks_metadata() {
+		$property = new ReflectionProperty( WP_Theme_JSON_Gutenberg::class, 'blocks_metadata' );
+		$property->setAccessible( true );
+		$property->setValue( null, array() );
+	}
+
+	/**
+	 * Returns the block metadata cache for WP_Theme_JSON_Gutenberg.
+	 *
+	 * @return array Block metadata.
+	 */
+	private function get_blocks_metadata() {
+		$property = new ReflectionProperty( WP_Theme_JSON_Gutenberg::class, 'blocks_metadata' );
+		$property->setAccessible( true );
+		return $property->getValue();
+	}
+
 	public function test_get_settings() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
@@ -626,6 +646,60 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameCSS( $styles, $theme_json->get_stylesheet( array( 'styles' ) ) );
 		$this->assertSameCSS( $presets, $theme_json->get_stylesheet( array( 'presets' ) ) );
 		$this->assertSameCSS( $all, $theme_json->get_stylesheet() );
+	}
+
+	public function test_get_stylesheet_generates_block_element_selectors_lazily() {
+		$this->reset_blocks_metadata();
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'color' => array(
+								'text' => 'black',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+
+		$blocks_metadata = $this->get_blocks_metadata();
+
+		$this->assertArrayHasKey( 'core/group', $blocks_metadata );
+		$this->assertArrayNotHasKey( 'elements', $blocks_metadata['core/group'] );
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => 'red',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+
+		$this->assertSameCSS( ':root :where(.wp-block-group a:where(:not(.wp-element-button))){color: red;}', $actual );
+
+		$blocks_metadata = $this->get_blocks_metadata();
+
+		$this->assertArrayHasKey( 'elements', $blocks_metadata['core/group'] );
+		$this->assertArrayHasKey( 'link', $blocks_metadata['core/group']['elements'] );
 	}
 
 	public function test_get_styles_for_block_support_for_shorthand_and_longhand_values() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

The description of #76556 states that "For one site I was using to test with I found that there were over 4,000 calls to prepend_to_selector() just to bootstrap WordPress". That sounds like a lot for a function that's only called inside `get_block_element_selectors` so I looked into it. Turns out we're generating element selectors for every single block that's registered (not even only the blocks on the page that loads), whether it has element styles or not. We shouldn't need to do that. 

This PR introduces a check for the existence of element styles, or nested element styles inside breakpoints or style variations for each block, so that we can generate the selectors only for the blocks that need them.

This is not intended as a replacement for #76556, but as a further optimisation.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that element styles are still being applied correctly to blocks, their viewport state styles and their style variations.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Used codex/gpt 5.5 to validate my initial assessment and make changes based on it. Human reviewed by myself.