### PR TITLE
BoxControl: Respect a supplied placeholder via inputProps

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 -   `SandBox`: Fix the viewport-unit (`vh`, `vw`, etc.) stripping so user-supplied HTML using these units in `width`/`height` no longer triggers a runaway resize loop in the preview ([#78677](https://github.com/WordPress/gutenberg/pull/78677)).
+-   `BoxControl`: Respect a consumer-supplied `placeholder` passed via `inputProps`, falling back to it when there is no mixed-value placeholder ([#79466](https://github.com/WordPress/gutenberg/pull/79466)).
 
 ### Internal
 

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -87,6 +87,7 @@ export default function BoxInputControl( {
 	min = 0,
 	presets,
 	presetKey,
+	placeholder: placeholderProp,
 	...props
 }: BoxControlInputControlProps ) {
 	const defaultValuesToModify = getSidesToModify( side, sides );
@@ -217,7 +218,7 @@ export default function BoxInputControl( {
 							onUnitChange={ handleOnUnitChange }
 							onFocus={ handleOnFocus }
 							label={ LABELS[ side ] }
-							placeholder={ mixedPlaceholder }
+							placeholder={ mixedPlaceholder ?? placeholderProp }
 							hideLabelFromVision
 						/>
 					</Tooltip>

--- a/packages/components/src/box-control/test/index.tsx
+++ b/packages/components/src/box-control/test/index.tsx
@@ -474,4 +474,18 @@ describe( 'BoxControl', () => {
 			} );
 		} );
 	} );
+
+	describe( 'Placeholder', () => {
+		it( 'applies a consumer-supplied placeholder passed via inputProps', () => {
+			render(
+				<UncontrolledBoxControl
+					inputProps={ { placeholder: 'Inherited' } }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'textbox', { name: 'All sides' } )
+			).toHaveAttribute( 'placeholder', 'Inherited' );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Make `BoxControl` respect a `placeholder` passed through `inputProps`.

## Why?

`BoxInputControl` set the inner input's `placeholder` to its internal "Mixed" value, applied after the `inputProps` spread. So a `placeholder` passed via `inputProps` was overridden and dropped whenever the sides were not mixed. A consumer had no way to show a placeholder, for example an inherited or default value.

The ability to correctly set a placeholder value is required by https://github.com/WordPress/gutenberg/pull/77894

## How?

Pull `placeholder` out of `inputProps` and fall back to it when there is no mixed-value placeholder: `placeholder={ mixedPlaceholder ?? placeholderProp }`. "Mixed" still takes precedence when sides differ.

No public API change, since `inputProps` already accepts `placeholder`. No current core consumer passes it, so this only enables new usage.

## Testing Instructions

1. Box control unit tests should still pass: `npm run test:unit packages/components/src/box-control`
2. Optional manual check: render a `BoxControl` with `inputProps={ { placeholder: 'Inherited' } }` and no value set. Each empty input shows "Inherited" instead of being blank.

## Screenshots or screencast

N/A