### PR TITLE
Media Fields: Ensure the current post is always included in the initial options

### DIFF
--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -90,13 +90,16 @@ export default function MediaAttachedToEdit( {
 			{}
 		);
 		setSearchResults( results );
-		const mappedSuggestions = results.map( ( result ) => {
+		const suggestions = results.map( ( result ) => {
 			return {
 				label: result.title,
 				value: result.id.toString(),
 			};
 		} );
-		setOptions( mappedSuggestions );
+		const includeCurrent =
+			! filterValue &&
+			suggestions.findIndex( ( s ) => s.value === value ) === -1;
+		setOptions( suggestions.concat( includeCurrent ? defaultPost : [] ) );
 		setIsLoading( false );
 	};
 


### PR DESCRIPTION
## What?
This is a follow-up to #74432.

PR updates the logic for generating the initial suggestion for "Attached to" entities and ensures the current post is included.  This matches the behavior of similar controls (Post Author, Page Parent) in the app.

## Testing Instructions
1. Open a post or page.
2. Add an image block and select media.
3. Open the crop media modal and navigate to details.
4. Click on the "Attached to" field.
5. Confirm that the currently suggested post shows up in the initial list.
6. Search for the post with a different name. Confirm that the post is no longer visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/4b94c5ec-dd35-4d24-a3db-211345f58694

**After**

https://github.com/user-attachments/assets/37fef0b3-f1d7-4d04-9dbe-18a2bf7b4fa0

## Use of AI Tools

None.