### PR TITLE
Media Fields: Avoid focus loss when detaching the current parent

### DIFF
--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -75,6 +75,7 @@ export default function MediaAttachedToEdit( {
 			post: 0,
 			_embedded: { ...data?._embedded, 'wp:attached-to': undefined },
 		} );
+		setValue( null );
 		setOptions( [] );
 	};
 
@@ -146,23 +147,22 @@ export default function MediaAttachedToEdit( {
 		}
 	};
 
-	const help = !! data.post
-		? createInterpolateElement(
-				__(
-					'Search for a post or page to attach this media to or <button>detach current</button>.'
-				),
-				{
-					button: (
-						<Button
-							__next40pxDefaultSize
-							onClick={ handleDetach }
-							variant="link"
-							accessibleWhenDisabled
-						/>
-					),
-				}
-		  )
-		: __( 'Search for a post or page to attach this media to.' );
+	const help = createInterpolateElement(
+		__(
+			'Search for a post or page to attach this media to or <button>detach current</button>.'
+		),
+		{
+			button: (
+				<Button
+					__next40pxDefaultSize
+					onClick={ handleDetach }
+					variant="link"
+					accessibleWhenDisabled
+					disabled={ ! value }
+				/>
+			),
+		}
+	);
 
 	return (
 		<ComboboxControl


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/74432.

PR tries to avoid focus loss when detaching the current parent from the media entity.

Hiding the action source after the click is bad for a11y and usually causes a loss of focus. I've updated the logic to disable the action button rather than swapping the entire help text.

## Testing Instructions
1. Open a post or page.
2. Add an image block and select media.
3. Open the crop media modal and navigate to details.
4. Click on the "Attached to" field.
5. Click on the "detach current" button in the help text.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/1a8ab7e7-a8dc-4307-9054-a486a18b384d

**After**

https://github.com/user-attachments/assets/08b4f5e7-0e22-4570-a211-7c1d19e17e88



## Use of AI Tools

None.