### PR TITLE
Image block: Simplify metadata syncing logic by removing chained get entity calls

### DIFF
--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -45,8 +45,7 @@ jest.mock( '../../lock-unlock', () => ( {
 
 function createRegistry( {
 	getEditedEntityRecord = () => false,
-	getEntityRecord = () => undefined,
-	resolveGetEntityRecord = getEntityRecord,
+	resolveGetEntityRecord = () => undefined,
 } = {} ) {
 	const actions = {
 		invalidateResolution: jest.fn(),
@@ -54,7 +53,6 @@ function createRegistry( {
 	return {
 		select: jest.fn( () => ( {
 			getEditedEntityRecord,
-			getEntityRecord,
 		} ) ),
 		dispatch: jest.fn( () => actions ),
 		resolveSelect: jest.fn( () => ( {
@@ -169,11 +167,8 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: 'Original caption',
 			},
 			registryOptions: {
-				getEntityRecord: () => originalAttachment,
-				resolveGetEntityRecord: ( kind, name, attachmentId, query ) =>
-					query?.context === 'edit'
-						? updatedAttachment
-						: originalAttachment,
+				getEditedEntityRecord: () => originalAttachment,
+				resolveGetEntityRecord: () => updatedAttachment,
 			},
 		} );
 
@@ -181,13 +176,15 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			alt: 'Updated alt',
 			caption: 'Updated caption',
 		} );
-		expect( registry.actions.invalidateResolution ).toHaveBeenCalledWith(
-			'getEntityRecord',
-			[ 'postType', 'attachment', 1 ]
+		// A single, query-less resolution is invalidated: the hook reads,
+		// resolves, and invalidates the attachment through the entity's default
+		// (edit) context rather than an explicitly-keyed query.
+		expect( registry.actions.invalidateResolution ).toHaveBeenCalledTimes(
+			1
 		);
 		expect( registry.actions.invalidateResolution ).toHaveBeenCalledWith(
 			'getEntityRecord',
-			[ 'postType', 'attachment', 1, { context: 'edit' } ]
+			[ 'postType', 'attachment', 1 ]
 		);
 	} );
 
@@ -220,8 +217,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			1,
 			'postType',
 			'attachment',
-			1,
-			{ context: 'edit' }
+			1
 		);
 		expect( openMediaEditorModal ).toHaveBeenCalledWith( {
 			id: 1,
@@ -263,8 +259,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			1,
 			'postType',
 			'attachment',
-			1,
-			{ context: 'edit' }
+			1
 		);
 		expect( openMediaEditorModal ).toHaveBeenCalledWith( {
 			id: 1,
@@ -299,7 +294,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: undefined,
 			},
 			registryOptions: {
-				getEntityRecord: () => ( {
+				getEditedEntityRecord: () => ( {
 					id: 1,
 					alt_text: '',
 					caption: {
@@ -314,8 +309,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			1,
 			'postType',
 			'attachment',
-			1,
-			{ context: 'edit' }
+			1
 		);
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			caption: 'Updated attachment caption',
@@ -341,7 +335,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: '',
 			},
 			registryOptions: {
-				getEntityRecord: ( kind, name, attachmentId ) =>
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
 					attachmentId === 1 ? originalAttachment : undefined,
 				resolveGetEntityRecord: ( kind, name, attachmentId ) =>
 					attachmentId === 2 ? updatedAttachment : undefined,
@@ -371,7 +365,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		};
 		const deferredAttachment = createDeferred();
 		const registry = createRegistry( {
-			getEntityRecord: ( kind, name, attachmentId ) =>
+			getEditedEntityRecord: ( kind, name, attachmentId ) =>
 				attachmentId === 1 ? originalAttachment : undefined,
 			resolveGetEntityRecord: ( kind, name, attachmentId ) =>
 				attachmentId === 2 ? deferredAttachment.promise : undefined,
@@ -437,7 +431,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: '',
 			},
 			registryOptions: {
-				getEntityRecord: ( kind, name, attachmentId ) =>
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
 					attachmentId === 1
 						? originalAttachment
 						: {
@@ -469,7 +463,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: undefined,
 			},
 			registryOptions: {
-				getEntityRecord: () => ( {
+				getEditedEntityRecord: () => ( {
 					id: 1,
 					alt_text: '',
 					caption: { raw: 'Existing caption' },
@@ -526,7 +520,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: undefined,
 			},
 			registryOptions: {
-				getEntityRecord: () => ( {
+				getEditedEntityRecord: () => ( {
 					id: 1,
 					alt_text: 'Original alt',
 					caption: { raw: 'Existing caption' },
@@ -556,7 +550,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				caption: { toString: () => '' },
 			},
 			registryOptions: {
-				getEntityRecord: () => ( {
+				getEditedEntityRecord: () => ( {
 					id: 1,
 					alt_text: 'Original alt',
 					caption: { raw: 'Existing caption' },
@@ -603,7 +597,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		};
 		const deferredAttachment = createDeferred();
 		const registry = createRegistry( {
-			getEntityRecord: () => ( {
+			getEditedEntityRecord: () => ( {
 				id: 1,
 				alt_text: '',
 				caption: { raw: '' },

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -104,9 +104,6 @@ export function getSyncedImageBlockAttributes(
 }
 
 const { openMediaEditorModalKey } = unlock( blockEditorPrivateApis );
-// Caption sync needs `caption.raw`; view/default attachment records can contain
-// only rendered caption data or be tied to an in-flight stale resolution.
-const ATTACHMENT_EDIT_QUERY = { context: 'edit' };
 
 function getAttachmentFallbackForEmptyBlockMetadata( { alt, caption } ) {
 	const attachment = {};
@@ -177,25 +174,23 @@ export function useOpenImageMediaEditorModal( {
 		};
 	}, [ alt, caption, id, url ] );
 
+	// Reads the cached attachment record. The `attachment` postType entity
+	// fetches with `context: 'edit'` by default, so `getEditedEntityRecord`
+	// returns the edit-context record — carrying `caption` as `{ raw }` and a
+	// usable `alt_text` — without us specifying a context. It is resolver-
+	// backed, so on a cold cache this also kicks off the fetch and returns a
+	// falsy value synchronously; that resolution shares its cache key with the
+	// `resolveAttachmentRecord` call below (both keyed on the no-query
+	// `getEntityRecord`), so the two dedupe into a single request.
 	const getCachedAttachmentRecord = useCallback(
-		( attachmentId ) => {
-			const { getEditedEntityRecord, getEntityRecord } =
-				registry.select( coreStore );
-			return (
-				getEditedEntityRecord(
+		( attachmentId ) =>
+			registry
+				.select( coreStore )
+				.getEditedEntityRecord(
 					'postType',
 					'attachment',
 					attachmentId
-				) ||
-				getEntityRecord(
-					'postType',
-					'attachment',
-					attachmentId,
-					ATTACHMENT_EDIT_QUERY
-				) ||
-				getEntityRecord( 'postType', 'attachment', attachmentId )
-			);
-		},
+				),
 		[ registry ]
 	);
 
@@ -204,18 +199,10 @@ export function useOpenImageMediaEditorModal( {
 			const resolveSelect = registry.resolveSelect( coreStore );
 
 			try {
-				return (
-					( await resolveSelect.getEntityRecord(
-						'postType',
-						'attachment',
-						attachmentId,
-						ATTACHMENT_EDIT_QUERY
-					) ) ||
-					( await resolveSelect.getEntityRecord(
-						'postType',
-						'attachment',
-						attachmentId
-					) )
+				return await resolveSelect.getEntityRecord(
+					'postType',
+					'attachment',
+					attachmentId
 				);
 			} catch {
 				return undefined;
@@ -226,20 +213,15 @@ export function useOpenImageMediaEditorModal( {
 
 	const resolveFreshAttachmentRecord = useCallback(
 		async ( attachmentId ) => {
-			// Bust cached records so resolveAttachmentRecord fetches the
-			// server state that reflects the media editor's saved changes.
+			// Invalidate the cached resolution so resolveAttachmentRecord
+			// re-fetches the server state that reflects the media editor's
+			// saved changes.
 			const { invalidateResolution } = registry.dispatch( coreStore );
 
 			invalidateResolution( 'getEntityRecord', [
 				'postType',
 				'attachment',
 				attachmentId,
-			] );
-			invalidateResolution( 'getEntityRecord', [
-				'postType',
-				'attachment',
-				attachmentId,
-				ATTACHMENT_EDIT_QUERY,
 			] );
 			return resolveAttachmentRecord( attachmentId );
 		},
@@ -321,10 +303,10 @@ export function useOpenImageMediaEditorModal( {
 		}
 
 		// Snapshot the attachment's current metadata before the user makes
-		// any changes so handleMediaUpdate can compare against it later.
-		// Prefer a freshly resolved edit-context record for accuracy; fall
-		// back to whatever is in the cache, or a minimal object derived from
-		// the block's own attributes when nothing is cached yet.
+		// any changes so handleMediaUpdate can compare against it later. Use
+		// the cached record when it's already present; only resolve when
+		// nothing is cached yet, then fall back to a minimal object derived
+		// from the block's own attributes.
 		const cachedAttachmentRecord = getCachedAttachmentRecord( id );
 		const fallbackAttachmentRecord =
 			getAttachmentFallbackForEmptyBlockMetadata(


### PR DESCRIPTION
## What?

Follows:

* #78139 

This PR tries out an idea from @Mamaduka to simplify the `getCachedAttachmentRecord` behaviour in the image block's metadata syncing logic. This is the part of the Image block that attempts to sync alt text and caption edits that occur in the media editor modal back to the image block when a user has not made their own changes to these fields at the block level.

## Why?

The approach I used originally was naive and an attempt to grab any of the records that had been cached, but had the unintended consequence of firing off additional API requests. It turns out that was unnecessary, and I could have been using _just_ the `getEditedEntityRecord`. When we're editing an image we know we'll have access to the edited entity record, so it should be safe for us to just rely on this one.

That also means we should only need to perform one call to `resolveSelect.getEntityRecord` and `invalidateResolution( 'getEntityRecord'`, too.

The result of this PR should be that we have _fewer_ requests, that is no more duplicate `?context=edit&_locale=user` requests. It seems to be working okay for me 🤞 

## How?

* <kbd>Delete</kbd> the chained and additional get, resolve, and invalidate calls, and see if the syncing behaviour holds up. It seems to!

## Testing Instructions

* In a post or page, upload an image to an image block.
* Click on the Crop icon in the block toolbar.
* In the Details tab, give the image a caption and some alt text.
* Save.
* Note that the caption and alt text should be updated in the image block.
* Open the media editor modal again.
* Make further updates and save.
* They should be synced to the block.
* Now, update the Image block's values for Caption or alt text directly.
* Then, open the media editor modal and make changes to these fields, and save.
* The values should _not_ be synced as what's in post content differed from what's in the REST API response from the media item

In the above, try reloading the editor at various points to see if it all holds up across fresh page loads.

## Use of AI Tools

Claude Code to make the change, interrogate the ideas, verify the comments, update tests, and to walk through the logic of the resolvers and invalidation. It might have been quicker to do it manually 😅 