### PR TITLE
Theme: Add Sass fallback helper root entrypoint

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -4,7 +4,7 @@
 
 @use "sass:color";
 @use "sass:math";
-@use "@wordpress/theme/src/prebuilt/scss/design-token-fallbacks" as wpds;
+@use "@wordpress/theme/design-token-fallbacks" as wpds;
 @use "./variables";
 @use "./colors";
 @use "./breakpoints";

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -314,13 +314,13 @@ An alternative to loading the [design tokens stylesheet](#outside-wordpress), us
 
 You do not need this helper if you already load the design tokens stylesheet or use fallback injection via the build plugins or `@wordpress/build`. In those cases, write bare `var(--wpds-*)` references in your source.
 
-The `@wordpress/theme/design-token-fallbacks` export provides a generated `wpds-var()` function that wraps token references with the same fallback map used by the build plugins — for example, `wpds.wpds-var('--wpds-color-fg-content-neutral')` compiles to `var(--wpds-color-fg-content-neutral, #1e1e1e)`.
+The `@wordpress/theme/design-token-fallbacks` export provides a generated `wpds-var()` function that wraps token references with the same fallback map used by the build plugins. For example, `wpds.wpds-var('--wpds-color-foreground-content-neutral')` compiles to `var(--wpds-color-foreground-content-neutral, #1e1e1e)`.
 
 ```scss
 @use '@wordpress/theme/design-token-fallbacks' as wpds;
 
 .example {
-	color: wpds.wpds-var( '--wpds-color-fg-content-neutral' );
+	color: wpds.wpds-var( '--wpds-color-foreground-content-neutral' );
 }
 ```
 
@@ -330,11 +330,7 @@ When using Sass with [`NodePackageImporter`](https://sass-lang.com/documentation
 @use 'pkg:@wordpress/theme/design-token-fallbacks' as wpds;
 ```
 
-For Sass setups that resolve packages from `node_modules` with a load path, use:
-
-```scss
-@use '@wordpress/theme/src/prebuilt/scss/design-token-fallbacks' as wpds;
-```
+The same `@wordpress/theme/design-token-fallbacks` import also supports Sass setups that resolve packages from `node_modules` with a load path.
 
 ## Contributing to this package
 

--- a/packages/theme/design-token-fallbacks.scss
+++ b/packages/theme/design-token-fallbacks.scss
@@ -1,0 +1,1 @@
+@forward "./src/prebuilt/scss/design-token-fallbacks";

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -40,9 +40,7 @@
 		},
 		"./design-tokens.css": "./src/prebuilt/css/design-tokens.css",
 		"./design-token-fallbacks": {
-			"sass": "./design-token-fallbacks.scss",
-			"style": "./design-token-fallbacks.scss",
-			"default": "./design-token-fallbacks.scss"
+			"sass": "./design-token-fallbacks.scss"
 		},
 		"./design-tokens.js": {
 			"types": "./build-types/prebuilt/js/design-tokens.d.ts",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -27,6 +27,7 @@
 		"build",
 		"build-module",
 		"build-types",
+		"design-token-fallbacks.scss",
 		"*.md"
 	],
 	"main": "build/index.cjs",
@@ -38,7 +39,11 @@
 			"default": "./build/index.cjs"
 		},
 		"./design-tokens.css": "./src/prebuilt/css/design-tokens.css",
-		"./design-token-fallbacks": "./src/prebuilt/scss/design-token-fallbacks.scss",
+		"./design-token-fallbacks": {
+			"sass": "./design-token-fallbacks.scss",
+			"style": "./design-token-fallbacks.scss",
+			"default": "./design-token-fallbacks.scss"
+		},
 		"./design-tokens.js": {
 			"types": "./build-types/prebuilt/js/design-tokens.d.ts",
 			"import": "./build-module/prebuilt/js/design-tokens.mjs",

--- a/packages/theme/src/prebuilt/scss/design-token-fallbacks.scss
+++ b/packages/theme/src/prebuilt/scss/design-token-fallbacks.scss
@@ -129,7 +129,6 @@ $fallbacks: (
 	'--wpds-color-stroke-surface-warning': '#e1bc7c',
 	'--wpds-color-stroke-surface-warning-strong': '#926300',
 	'--wpds-cursor-control': 'pointer',
-	'--wpds-dimension-base': '4px',
 	'--wpds-dimension-gap-2xl': '32px',
 	'--wpds-dimension-gap-3xl': '40px',
 	'--wpds-dimension-gap-lg': '16px',


### PR DESCRIPTION
## What?

Stacked on #79470

Adds a package-root Sass shim for `@wordpress/theme/design-token-fallbacks` and points the package export at that stable entry point.

## Why?

The Sass fallback helper needs to work in both package-export-aware build tools and older Sass setups that resolve packages from `node_modules` with a load path. Exporting or documenting a generated `src/prebuilt` path would make package internals part of the public API.

This should unblock us to reinstall the changes that we reverted in #79429.

## How?

Adds `packages/theme/design-token-fallbacks.scss` as a public shim that forwards to the generated helper. The package export now points to that shim with Sass/style/default conditions, and the docs use the same public `@wordpress/theme/design-token-fallbacks` import for both package importer and load-path Sass setups.


## Testing Instructions

1. Run `npm run storybook:build`.
2. Confirm the build completes successfully.