### PR TITLE
Try adding alignment controls to grid layout

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -841,14 +841,14 @@ For the `flex` layout type only, determines display of sizing controls (Fit/Grow
 -   Type: `boolean`
 -   Default value: `true`
 
-For the `flex` layout type only, determines display of the vertical alignment control in the block toolbar.
+For the `flex` layout type, determines display of the vertical alignment control in the block toolbar and block sidebar. For the `grid` layout type, determines display of the vertical alignment control in the block sidebar.
 
 ### layout.allowJustification
 
 -   Type: `boolean`
 -   Default value: `true`
 
-For the `flex` layout type, determines display of the justification control in the block toolbar and block sidebar. For the `constrained` layout type, determines display of justification control in the block sidebar.
+For the `flex` layout type, determines display of the justification control in the block toolbar and block sidebar. For the `grid` and `constrained` layout types, determines display of the justification control in the block sidebar.
 
 ### layout.allowOrientation
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -762,6 +762,20 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'grid' === $layout_type ) {
+		$justify_items_options = array(
+			'left'    => 'start',
+			'center'  => 'center',
+			'right'   => 'end',
+			'stretch' => 'stretch',
+		);
+
+		$alignment_options = array(
+			'top'     => 'start',
+			'center'  => 'center',
+			'bottom'  => 'end',
+			'stretch' => 'stretch',
+		);
+
 		/*
 		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
 		 * is the relevant one for computation of responsive grid columns.
@@ -809,8 +823,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$should_output_grid_columns = true;
 		}
 
-		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['rowCount'] );
-		$grid_declarations       = array();
+		$should_output_grid_rows          = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['rowCount'] );
+		$should_output_grid_justification = null === $viewport_overrides || $has_viewport_property_override( 'justifyContent' );
+		$should_output_grid_alignment     = null === $viewport_overrides || $has_viewport_property_override( 'verticalAlignment' );
+		$grid_declarations                = array();
 
 		if ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
 			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout_for_styles['columnCount'] . ' - 1))) /' . $layout_for_styles['columnCount'] . ')';
@@ -829,16 +845,24 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					$grid_declarations['container-type'] = 'inline-size';
 				}
 			}
-			$layout_styles[] = array(
-				'selector'     => $selector,
-				'declarations' => $grid_declarations,
-			);
 		}
 
 		if ( $should_output_grid_rows ) {
+			$grid_declarations['grid-template-rows'] = 'repeat(' . $layout_for_styles['rowCount'] . ', minmax(1rem, auto))';
+		}
+
+		if ( $should_output_grid_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_items_options ) ) {
+			$grid_declarations['justify-items'] = $justify_items_options[ $layout_for_styles['justifyContent'] ];
+		}
+
+		if ( $should_output_grid_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $alignment_options ) ) {
+			$grid_declarations['align-items'] = $alignment_options[ $layout_for_styles['verticalAlignment'] ];
+		}
+
+		if ( ! empty( $grid_declarations ) ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout_for_styles['rowCount'] . ', minmax(1rem, auto))' ),
+				'declarations' => $grid_declarations,
 			);
 		}
 

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -9,17 +9,24 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import BlockPopoverCover from '../block-popover/cover';
-import { getComputedCSS, getGridTracks, getClosestTrack } from './utils';
+import {
+	getGridContentClientRect,
+	getGridItemAreaClientRect,
+	getGridOffsetRect,
+	getGridRect,
+} from './utils';
 
 export function GridItemResizer( {
 	clientId,
 	bounds,
+	layout,
 	onChange,
 	parentLayout,
 } ) {
 	const blockElement = useBlockElement( clientId );
 	const rootBlockElement = blockElement?.parentElement;
-	const { isManualPlacement } = parentLayout;
+	const { isManualPlacement, justifyContent, verticalAlignment } =
+		parentLayout;
 
 	if ( ! blockElement || ! rootBlockElement ) {
 		return null;
@@ -31,11 +38,14 @@ export function GridItemResizer( {
 			bounds={ bounds }
 			blockElement={ blockElement }
 			rootBlockElement={ rootBlockElement }
+			layout={ layout }
 			onChange={ onChange }
 			isManualGrid={
 				isManualPlacement &&
 				window.__experimentalEnableGridInteractivity
 			}
+			justifyContent={ justifyContent }
+			verticalAlignment={ verticalAlignment }
 		/>
 	);
 }
@@ -45,8 +55,11 @@ function GridItemResizerInner( {
 	bounds,
 	blockElement,
 	rootBlockElement,
+	layout,
 	onChange,
 	isManualGrid,
+	justifyContent,
+	verticalAlignment,
 } ) {
 	const [ resizeDirection, setResizeDirection ] = useState( null );
 	const [ enableSide, setEnableSide ] = useState( {
@@ -55,20 +68,32 @@ function GridItemResizerInner( {
 		left: false,
 		right: false,
 	} );
+	const [ gridAreaStyles, setGridAreaStyles ] = useState( {} );
 
 	useEffect( () => {
-		const observer = new window.ResizeObserver( () => {
+		const updateGridArea = () => {
+			const gridItemAreaClientRect =
+				getGridItemAreaClientRect( blockElement );
 			const blockClientRect = blockElement.getBoundingClientRect();
-			const rootBlockClientRect =
-				rootBlockElement.getBoundingClientRect();
+			const gridContentClientRect =
+				getGridContentClientRect( rootBlockElement );
 
-			const topAvailable = blockClientRect.top > rootBlockClientRect.top;
+			setGridAreaStyles( {
+				width: gridItemAreaClientRect.width,
+				height: gridItemAreaClientRect.height,
+				transform: `translate(${
+					gridItemAreaClientRect.left - blockClientRect.left
+				}px, ${ gridItemAreaClientRect.top - blockClientRect.top }px)`,
+			} );
+
+			const topAvailable =
+				gridItemAreaClientRect.top > gridContentClientRect.top;
 			const bottomAvailable =
-				blockClientRect.bottom < rootBlockClientRect.bottom;
+				gridItemAreaClientRect.bottom < gridContentClientRect.bottom;
 			const leftAvailable =
-				blockClientRect.left > rootBlockClientRect.left;
+				gridItemAreaClientRect.left > gridContentClientRect.left;
 			const rightAvailable =
-				blockClientRect.right < rootBlockClientRect.right;
+				gridItemAreaClientRect.right < gridContentClientRect.right;
 
 			setEnableSide( {
 				top: !! isManualGrid
@@ -80,10 +105,27 @@ function GridItemResizerInner( {
 					: ! rightAvailable && leftAvailable,
 				right: rightAvailable,
 			} );
+		};
+
+		updateGridArea();
+
+		const observer = new window.ResizeObserver( () => {
+			updateGridArea();
 		} );
-		observer.observe( blockElement );
+		observer.observe( blockElement, { box: 'border-box' } );
+		observer.observe( rootBlockElement, { box: 'border-box' } );
 		return () => observer.disconnect();
-	}, [ blockElement, rootBlockElement, isManualGrid ] );
+	}, [
+		blockElement,
+		rootBlockElement,
+		isManualGrid,
+		justifyContent,
+		verticalAlignment,
+		layout?.columnStart,
+		layout?.rowStart,
+		layout?.columnSpan,
+		layout?.rowSpan,
+	] );
 
 	const justification = {
 		right: 'left',
@@ -96,6 +138,7 @@ function GridItemResizerInner( {
 	};
 
 	const styles = {
+		...gridAreaStyles,
 		display: 'flex',
 		justifyContent: 'center',
 		alignItems: 'center',
@@ -150,47 +193,19 @@ function GridItemResizerInner( {
 					setResizeDirection( direction );
 				} }
 				onResizeStop={ ( event, direction, boxElement ) => {
-					const columnGap = parseFloat(
-						getComputedCSS( rootBlockElement, 'column-gap' )
+					const rect = getGridOffsetRect(
+						rootBlockElement,
+						boxElement.getBoundingClientRect()
 					);
-					const rowGap = parseFloat(
-						getComputedCSS( rootBlockElement, 'row-gap' )
-					);
-					const gridColumnTracks = getGridTracks(
-						getComputedCSS(
-							rootBlockElement,
-							'grid-template-columns'
-						),
-						columnGap
-					);
-					const gridRowTracks = getGridTracks(
-						getComputedCSS(
-							rootBlockElement,
-							'grid-template-rows'
-						),
-						rowGap
-					);
-					const rect = new window.DOMRect(
-						blockElement.offsetLeft + boxElement.offsetLeft,
-						blockElement.offsetTop + boxElement.offsetTop,
-						boxElement.offsetWidth,
-						boxElement.offsetHeight
-					);
-					const columnStart =
-						getClosestTrack( gridColumnTracks, rect.left ) + 1;
-					const rowStart =
-						getClosestTrack( gridRowTracks, rect.top ) + 1;
-					const columnEnd =
-						getClosestTrack( gridColumnTracks, rect.right, 'end' ) +
-						1;
-					const rowEnd =
-						getClosestTrack( gridRowTracks, rect.bottom, 'end' ) +
-						1;
+					const gridRect = getGridRect( rootBlockElement, rect );
+
 					onChange( {
-						columnSpan: columnEnd - columnStart + 1,
-						rowSpan: rowEnd - rowStart + 1,
-						columnStart: isManualGrid ? columnStart : undefined,
-						rowStart: isManualGrid ? rowStart : undefined,
+						columnSpan: gridRect.columnSpan,
+						rowSpan: gridRect.rowSpan,
+						columnStart: isManualGrid
+							? gridRect.columnStart
+							: undefined,
+						rowStart: isManualGrid ? gridRect.rowStart : undefined,
 					} );
 				} }
 			/>

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -3,11 +3,12 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
-.block-editor-grid-visualizer {
+.components-popover.block-editor-block-popover.block-editor-grid-visualizer {
 	// Specificity to override the z-index and pointer-events set by .components-popover.
 	&.block-editor-grid-visualizer.block-editor-grid-visualizer {
 		z-index: z-index(".block-editor-grid-visualizer");
 
+		.components-popover__content,
 		.components-popover__content * {
 			pointer-events: none;
 		}
@@ -80,26 +81,27 @@
 	min-height: $grid-unit-10;
 }
 
-.block-editor-grid-item-resizer {
+.components-popover.block-editor-block-popover.block-editor-grid-item-resizer {
 	// Specificity to override the z-index and pointer-events set by .components-popover.
 	&.block-editor-grid-item-resizer.block-editor-grid-item-resizer {
 		z-index: z-index(".block-editor-grid-visualizer");
 
+		.components-popover__content,
 		.components-popover__content * {
 			pointer-events: none;
+		}
+
+		.block-editor-grid-item-resizer__box .components-resizable-box__handle {
+			// Specificity to override the pointer-events set by this popover.
+			&.components-resizable-box__handle.components-resizable-box__handle {
+				pointer-events: all;
+			}
 		}
 	}
 }
 
 .block-editor-grid-item-resizer__box {
 	border: $border-width solid var(--wp-admin-theme-color);
-
-	.components-resizable-box__handle {
-		// Specificity to override the pointer-events set by .components-popover.
-		&.components-resizable-box__handle.components-resizable-box__handle {
-			pointer-events: all;
-		}
-	}
 }
 
 .block-editor-grid-item-mover__move-button-container {
@@ -267,4 +269,3 @@
 		}
 	}
 }
-

--- a/packages/block-editor/src/components/grid/test/utils.js
+++ b/packages/block-editor/src/components/grid/test/utils.js
@@ -1,0 +1,171 @@
+/**
+ * Internal dependencies
+ */
+import { getGridItemAreaRect, getGridItemRect } from '../utils';
+
+function createGrid() {
+	const grid = document.createElement( 'div' );
+	const first = document.createElement( 'div' );
+	const second = document.createElement( 'div' );
+	const third = document.createElement( 'div' );
+
+	grid.append( first, second, third );
+	document.body.appendChild( grid );
+
+	return { grid, first, second, third };
+}
+
+function mockComputedStyles( styles ) {
+	jest.spyOn( window, 'getComputedStyle' ).mockImplementation(
+		( element ) => ( {
+			getPropertyValue: ( property ) =>
+				styles.get( element )?.[ property ] ?? '',
+		} )
+	);
+}
+
+function mockClientRect( element, { left, top, width, height } ) {
+	jest.spyOn( element, 'getBoundingClientRect' ).mockReturnValue(
+		new window.DOMRect( left, top, width, height )
+	);
+}
+
+describe( 'grid utils', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+		document.body.replaceChildren();
+	} );
+
+	it( 'gets the occupied grid rect for auto-placed items that visually render smaller than their grid area', () => {
+		const { grid, first, second, third } = createGrid();
+		mockComputedStyles(
+			new Map( [
+				[
+					grid,
+					{
+						'grid-template-columns': '100px 100px 100px',
+						'grid-template-rows': '50px 50px',
+						'column-gap': '10px',
+						'row-gap': '10px',
+						'justify-items': 'center',
+						'align-items': 'center',
+					},
+				],
+				[
+					first,
+					{
+						'grid-column-start': 'span 2',
+						'grid-column-end': 'auto',
+						'grid-row-start': 'auto',
+						'grid-row-end': 'auto',
+					},
+				],
+				[
+					second,
+					{
+						'grid-column-start': 'auto',
+						'grid-column-end': 'auto',
+						'grid-row-start': 'auto',
+						'grid-row-end': 'auto',
+					},
+				],
+				[
+					third,
+					{
+						'grid-column-start': 'span 2',
+						'grid-column-end': 'auto',
+						'grid-row-start': 'auto',
+						'grid-row-end': 'auto',
+					},
+				],
+			] )
+		);
+		mockClientRect( grid, {
+			left: 0,
+			top: 0,
+			width: 320,
+			height: 110,
+		} );
+		mockClientRect( first, {
+			left: 80,
+			top: 15,
+			width: 50,
+			height: 20,
+		} );
+		mockClientRect( second, {
+			left: 245,
+			top: 15,
+			width: 50,
+			height: 20,
+		} );
+		mockClientRect( third, {
+			left: 80,
+			top: 75,
+			width: 50,
+			height: 20,
+		} );
+
+		const firstGridRect = getGridItemRect( first );
+		const firstAreaRect = getGridItemAreaRect( first );
+		const secondGridRect = getGridItemRect( second );
+		const thirdGridRect = getGridItemRect( third );
+
+		expect( firstGridRect ).toMatchObject( {
+			columnStart: 1,
+			columnEnd: 2,
+			rowStart: 1,
+			rowEnd: 1,
+		} );
+		expect( firstAreaRect ).toMatchObject( {
+			left: 0,
+			top: 0,
+			width: 210,
+			height: 50,
+		} );
+		expect( secondGridRect ).toMatchObject( {
+			columnStart: 3,
+			columnEnd: 3,
+			rowStart: 1,
+			rowEnd: 1,
+		} );
+		expect( thirdGridRect ).toMatchObject( {
+			columnStart: 1,
+			columnEnd: 2,
+			rowStart: 2,
+			rowEnd: 2,
+		} );
+	} );
+
+	it( 'gets the occupied grid area for manually positioned items', () => {
+		const { grid, first } = createGrid();
+		mockComputedStyles(
+			new Map( [
+				[
+					grid,
+					{
+						'grid-template-columns': '100px 100px 100px',
+						'grid-template-rows': '50px 50px 50px',
+						'column-gap': '10px',
+						'row-gap': '10px',
+					},
+				],
+				[
+					first,
+					{
+						'grid-column-start': '2',
+						'grid-column-end': 'span 2',
+						'grid-row-start': '2',
+						'grid-row-end': 'span 2',
+					},
+				],
+			] )
+		);
+
+		expect( getGridItemAreaRect( first ) ).toMatchObject( {
+			left: 110,
+			top: 60,
+			width: 210,
+			height: 110,
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/grid/utils.js
+++ b/packages/block-editor/src/components/grid/utils.js
@@ -65,6 +65,19 @@ export function getComputedCSS( element, property ) {
 		.getPropertyValue( property );
 }
 
+function getNumericCSS( element, property ) {
+	return parseFloat( getComputedCSS( element, property ) ) || 0;
+}
+
+function createDOMRect( element, left, top, width, height ) {
+	return new element.ownerDocument.defaultView.DOMRect(
+		left,
+		top,
+		width,
+		height
+	);
+}
+
 /**
  * Given a grid-template-columns or grid-template-rows CSS property value, gets the start and end
  * position in pixels of each grid track.
@@ -81,9 +94,13 @@ export function getComputedCSS( element, property ) {
 export function getGridTracks( template, gap ) {
 	const tracks = [];
 	for ( const size of template.split( ' ' ) ) {
+		const parsedSize = parseFloat( size );
+		if ( Number.isNaN( parsedSize ) ) {
+			continue;
+		}
 		const previousTrack = tracks[ tracks.length - 1 ];
 		const start = previousTrack ? previousTrack.end + gap : 0;
-		const end = start + parseFloat( size );
+		const end = start + parsedSize;
 		tracks.push( { start, end } );
 	}
 	return tracks;
@@ -116,8 +133,8 @@ export function getClosestTrack( tracks, position, edge = 'start' ) {
 }
 
 export function getGridRect( gridElement, rect ) {
-	const columnGap = parseFloat( getComputedCSS( gridElement, 'column-gap' ) );
-	const rowGap = parseFloat( getComputedCSS( gridElement, 'row-gap' ) );
+	const columnGap = getNumericCSS( gridElement, 'column-gap' );
+	const rowGap = getNumericCSS( gridElement, 'row-gap' );
 	const gridColumnTracks = getGridTracks(
 		getComputedCSS( gridElement, 'grid-template-columns' ),
 		columnGap
@@ -139,15 +156,305 @@ export function getGridRect( gridElement, rect ) {
 	} );
 }
 
-export function getGridItemRect( gridItemElement ) {
+function parseGridLine( value ) {
+	const normalizedValue = value?.trim();
+	if ( ! normalizedValue || normalizedValue === 'auto' ) {
+		return {};
+	}
+
+	const spanMatch = normalizedValue.match( /^span\s+(\d+)$/ );
+	if ( spanMatch ) {
+		return { span: parseInt( spanMatch[ 1 ], 10 ) };
+	}
+
+	if ( /^-?\d+$/.test( normalizedValue ) ) {
+		return { line: parseInt( normalizedValue, 10 ) };
+	}
+
+	return {};
+}
+
+function getGridItemRectFromOffsets( gridItemElement ) {
 	return getGridRect(
 		gridItemElement.parentElement,
-		new window.DOMRect(
+		createDOMRect(
+			gridItemElement,
 			gridItemElement.offsetLeft,
 			gridItemElement.offsetTop,
 			gridItemElement.offsetWidth,
 			gridItemElement.offsetHeight
 		)
+	);
+}
+
+function resolveGridLine( line, trackCount ) {
+	if ( line === undefined ) {
+		return undefined;
+	}
+
+	return line < 0 ? trackCount + line + 2 : line;
+}
+
+function getAxisPlacement( startValue, endValue, trackCount ) {
+	const start = parseGridLine( startValue );
+	const end = parseGridLine( endValue );
+	const startLine = resolveGridLine( start.line, trackCount );
+	const endLine = resolveGridLine( end.line, trackCount );
+	const span = Math.min(
+		start.span ||
+			end.span ||
+			( startLine && endLine ? Math.max( 1, endLine - startLine ) : 1 ),
+		trackCount
+	);
+
+	return {
+		start:
+			startLine ??
+			( endLine ? Math.max( 1, endLine - span ) : undefined ),
+		span,
+	};
+}
+
+function getGridItemPlacement(
+	gridItemElement,
+	gridColumnCount,
+	gridRowCount
+) {
+	const column = getAxisPlacement(
+		getComputedCSS( gridItemElement, 'grid-column-start' ),
+		getComputedCSS( gridItemElement, 'grid-column-end' ),
+		gridColumnCount
+	);
+	const row = getAxisPlacement(
+		getComputedCSS( gridItemElement, 'grid-row-start' ),
+		getComputedCSS( gridItemElement, 'grid-row-end' ),
+		gridRowCount
+	);
+
+	return {
+		columnStart: column.start,
+		columnSpan: column.span,
+		rowStart: row.start,
+		rowSpan: row.span,
+	};
+}
+
+function normalizeAlignment( value ) {
+	const alignment = value?.trim();
+	if ( ! alignment || alignment === 'auto' || alignment === 'normal' ) {
+		return 'stretch';
+	}
+
+	const keyword = alignment.split( /\s+/ ).at( -1 );
+	if ( [ 'start', 'self-start', 'flex-start', 'left' ].includes( keyword ) ) {
+		return 'start';
+	}
+	if ( [ 'end', 'self-end', 'flex-end', 'right' ].includes( keyword ) ) {
+		return 'end';
+	}
+	if ( keyword === 'center' ) {
+		return 'center';
+	}
+
+	return 'stretch';
+}
+
+function getGridItemAlignment( gridItemElement, selfProperty, itemsProperty ) {
+	const selfAlignment = getComputedCSS( gridItemElement, selfProperty );
+	if ( selfAlignment?.trim() && selfAlignment.trim() !== 'auto' ) {
+		return normalizeAlignment( selfAlignment );
+	}
+
+	return normalizeAlignment(
+		getComputedCSS( gridItemElement.parentElement, itemsProperty )
+	);
+}
+
+function getTrackSpanStart( tracks, rectStart, rectEnd, span, alignment ) {
+	const lastStartIndex = Math.max( tracks.length - span, 0 );
+	let closestIndex = 0;
+	let closestDistance = Infinity;
+
+	for ( let index = 0; index <= lastStartIndex; index++ ) {
+		const start = tracks[ index ].start;
+		const end = tracks[ index + span - 1 ].end;
+		let distance;
+
+		if ( alignment === 'start' ) {
+			distance = Math.abs( start - rectStart );
+		} else if ( alignment === 'end' ) {
+			distance = Math.abs( end - rectEnd );
+		} else if ( alignment === 'center' ) {
+			distance = Math.abs(
+				( start + end ) / 2 - ( rectStart + rectEnd ) / 2
+			);
+		} else {
+			distance =
+				Math.abs( start - rectStart ) + Math.abs( end - rectEnd );
+		}
+
+		if ( distance < closestDistance ) {
+			closestDistance = distance;
+			closestIndex = index;
+		}
+	}
+
+	return closestIndex + 1;
+}
+
+export function getGridItemRect( gridItemElement ) {
+	const gridElement = gridItemElement.parentElement;
+	const gridColumnTracks = getGridTracks(
+		getComputedCSS( gridElement, 'grid-template-columns' ),
+		getNumericCSS( gridElement, 'column-gap' )
+	);
+	const gridRowTracks = getGridTracks(
+		getComputedCSS( gridElement, 'grid-template-rows' ),
+		getNumericCSS( gridElement, 'row-gap' )
+	);
+
+	if ( ! gridColumnTracks.length || ! gridRowTracks.length ) {
+		return getGridItemRectFromOffsets( gridItemElement );
+	}
+
+	const { columnStart, columnSpan, rowStart, rowSpan } = getGridItemPlacement(
+		gridItemElement,
+		gridColumnTracks.length,
+		gridRowTracks.length
+	);
+	const itemRect = getGridOffsetRect(
+		gridElement,
+		gridItemElement.getBoundingClientRect()
+	);
+
+	return new GridRect( {
+		columnStart:
+			columnStart ??
+			getTrackSpanStart(
+				gridColumnTracks,
+				itemRect.left,
+				itemRect.right,
+				columnSpan,
+				getGridItemAlignment(
+					gridItemElement,
+					'justify-self',
+					'justify-items'
+				)
+			),
+		rowStart:
+			rowStart ??
+			getTrackSpanStart(
+				gridRowTracks,
+				itemRect.top,
+				itemRect.bottom,
+				rowSpan,
+				getGridItemAlignment(
+					gridItemElement,
+					'align-self',
+					'align-items'
+				)
+			),
+		columnSpan,
+		rowSpan,
+	} );
+}
+
+export function getGridContentClientRect( gridElement ) {
+	const clientRect = gridElement.getBoundingClientRect();
+	const borderLeftWidth = getNumericCSS( gridElement, 'border-left-width' );
+	const borderRightWidth = getNumericCSS( gridElement, 'border-right-width' );
+	const borderTopWidth = getNumericCSS( gridElement, 'border-top-width' );
+	const borderBottomWidth = getNumericCSS(
+		gridElement,
+		'border-bottom-width'
+	);
+	const paddingLeft = getNumericCSS( gridElement, 'padding-left' );
+	const paddingRight = getNumericCSS( gridElement, 'padding-right' );
+	const paddingTop = getNumericCSS( gridElement, 'padding-top' );
+	const paddingBottom = getNumericCSS( gridElement, 'padding-bottom' );
+	const left = clientRect.left + borderLeftWidth + paddingLeft;
+	const top = clientRect.top + borderTopWidth + paddingTop;
+	const width =
+		clientRect.width -
+		borderLeftWidth -
+		borderRightWidth -
+		paddingLeft -
+		paddingRight;
+	const height =
+		clientRect.height -
+		borderTopWidth -
+		borderBottomWidth -
+		paddingTop -
+		paddingBottom;
+
+	return createDOMRect( gridElement, left, top, width, height );
+}
+
+export function getGridOffsetRect( gridElement, clientRect ) {
+	const gridContentClientRect = getGridContentClientRect( gridElement );
+
+	return createDOMRect(
+		gridElement,
+		clientRect.left - gridContentClientRect.left,
+		clientRect.top - gridContentClientRect.top,
+		clientRect.width,
+		clientRect.height
+	);
+}
+
+export function getGridItemAreaRect( gridItemElement ) {
+	const gridElement = gridItemElement.parentElement;
+	const columnGap = getNumericCSS( gridElement, 'column-gap' );
+	const rowGap = getNumericCSS( gridElement, 'row-gap' );
+	const gridColumnTracks = getGridTracks(
+		getComputedCSS( gridElement, 'grid-template-columns' ),
+		columnGap
+	);
+	const gridRowTracks = getGridTracks(
+		getComputedCSS( gridElement, 'grid-template-rows' ),
+		rowGap
+	);
+
+	if ( ! gridColumnTracks.length || ! gridRowTracks.length ) {
+		return createDOMRect(
+			gridElement,
+			gridItemElement.offsetLeft,
+			gridItemElement.offsetTop,
+			gridItemElement.offsetWidth,
+			gridItemElement.offsetHeight
+		);
+	}
+
+	const gridRect = getGridItemRect( gridItemElement );
+	const columnStartIndex = gridRect.columnStart - 1;
+	const columnEndIndex = Math.min(
+		gridRect.columnEnd - 1,
+		gridColumnTracks.length - 1
+	);
+	const rowStartIndex = gridRect.rowStart - 1;
+	const rowEndIndex = Math.min(
+		gridRect.rowEnd - 1,
+		gridRowTracks.length - 1
+	);
+	const left = gridColumnTracks[ columnStartIndex ]?.start ?? 0;
+	const right = gridColumnTracks[ columnEndIndex ]?.end ?? left;
+	const top = gridRowTracks[ rowStartIndex ]?.start ?? 0;
+	const bottom = gridRowTracks[ rowEndIndex ]?.end ?? top;
+
+	return createDOMRect( gridElement, left, top, right - left, bottom - top );
+}
+
+export function getGridItemAreaClientRect( gridItemElement ) {
+	const gridElement = gridItemElement.parentElement;
+	const gridContentClientRect = getGridContentClientRect( gridElement );
+	const gridItemAreaRect = getGridItemAreaRect( gridItemElement );
+
+	return createDOMRect(
+		gridElement,
+		gridContentClientRect.left + gridItemAreaRect.left,
+		gridContentClientRect.top + gridItemAreaRect.top,
+		gridItemAreaRect.width,
+		gridItemAreaRect.height
 	);
 }
 

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -495,6 +495,7 @@ function GridTools( {
 					clientId={ clientId }
 					// Don't allow resizing beyond the grid visualizer.
 					bounds={ resizerBounds }
+					layout={ style?.layout }
 					onChange={ updateLayout }
 					parentLayout={ parentLayout }
 				/>

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -1,8 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-
+import { __, _x } from '@wordpress/i18n';
+import {
+	justifyLeft,
+	justifyCenter,
+	justifyRight,
+	justifyStretch,
+	justifyTop,
+	justifyCenterVertical,
+	justifyBottom,
+	justifyStretchVertical,
+} from '@wordpress/icons';
 import {
 	BaseControl,
 	Flex,
@@ -11,6 +20,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -63,6 +73,68 @@ const units = [
 	{ value: 'em', label: 'em', default: 0 },
 ];
 
+const justifyItemsMap = {
+	left: 'start',
+	center: 'center',
+	right: 'end',
+	stretch: 'stretch',
+};
+
+const alignItemsMap = {
+	top: 'start',
+	center: 'center',
+	bottom: 'end',
+	stretch: 'stretch',
+};
+
+const defaultAlignment = 'stretch';
+
+const gridJustificationOptions = [
+	{
+		value: 'left',
+		icon: justifyLeft,
+		label: __( 'Justify items left' ),
+	},
+	{
+		value: 'center',
+		icon: justifyCenter,
+		label: __( 'Justify items center' ),
+	},
+	{
+		value: 'right',
+		icon: justifyRight,
+		label: __( 'Justify items right' ),
+	},
+	{
+		value: 'stretch',
+		icon: justifyStretch,
+		label: __( 'Stretch items' ),
+	},
+];
+
+const gridVerticalAlignmentOptions = [
+	{
+		value: 'top',
+		icon: justifyTop,
+		label: _x( 'Align top', 'Block vertical alignment setting' ),
+	},
+	{
+		value: 'center',
+		icon: justifyCenterVertical,
+		label: _x( 'Align middle', 'Block vertical alignment setting' ),
+	},
+	{
+		value: 'bottom',
+		icon: justifyBottom,
+		label: _x( 'Align bottom', 'Block vertical alignment setting' ),
+	},
+	{
+		value: 'stretch',
+		icon: justifyStretchVertical,
+		label: _x( 'Stretch to fill', 'Block vertical alignment setting' ),
+	},
+];
+
 export default {
 	name: 'grid',
 	label: __( 'Grid' ),
@@ -73,7 +145,11 @@ export default {
 		resetLayout = {},
 		clientId,
 	} ) {
-		const { allowSizingOnChildren = false } = layoutBlockSupport;
+		const {
+			allowJustification = true,
+			allowVerticalAlignment = true,
+			allowSizingOnChildren = false,
+		} = layoutBlockSupport;
 
 		// Always show both column and minimum width controls in Auto mode.
 		// Manual mode (with isManualPlacement) is only available behind the experiment flag.
@@ -92,6 +168,10 @@ export default {
 			hasLayoutValue( 'rowCount' );
 		const hasMinimumColumnWidthValue = () =>
 			hasLayoutValue( 'minimumColumnWidth' );
+		const hasJustificationValue = () =>
+			hasLayoutValue( 'justifyContent', defaultAlignment );
+		const hasVerticalAlignmentValue = () =>
+			hasLayoutValue( 'verticalAlignment', defaultAlignment );
 		const resetGridType = () =>
 			onChange(
 				cleanEmptyObject( {
@@ -114,6 +194,20 @@ export default {
 				cleanEmptyObject( {
 					...layout,
 					minimumColumnWidth: resetLayout?.minimumColumnWidth,
+				} )
+			);
+		const resetJustification = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					justifyContent: resetLayout?.justifyContent,
+				} )
+			);
+		const resetVerticalAlignment = () =>
+			onChange(
+				cleanEmptyObject( {
+					...layout,
+					verticalAlignment: resetLayout?.verticalAlignment,
 				} )
 			);
 
@@ -162,6 +256,32 @@ export default {
 						/>
 					</ToolsPanelItem>
 				) }
+				{ allowJustification && (
+					<ToolsPanelItem
+						label={ __( 'Justification' ) }
+						hasValue={ hasJustificationValue }
+						onDeselect={ resetJustification }
+						panelId={ clientId }
+					>
+						<GridLayoutJustifyItemsControl
+							layout={ layout }
+							onChange={ onChange }
+						/>
+					</ToolsPanelItem>
+				) }
+				{ allowVerticalAlignment && (
+					<ToolsPanelItem
+						label={ __( 'Alignment' ) }
+						hasValue={ hasVerticalAlignmentValue }
+						onDeselect={ resetVerticalAlignment }
+						panelId={ clientId }
+					>
+						<GridLayoutVerticalAlignmentControl
+							layout={ layout }
+							onChange={ onChange }
+						/>
+					</ToolsPanelItem>
+				) }
 			</>
 		);
 	},
@@ -189,6 +309,8 @@ export default {
 			columnCount = null,
 			rowCount = null,
 		} = effectiveLayout;
+		const justifyItems = justifyItemsMap[ effectiveLayout.justifyContent ];
+		const alignItems = alignItemsMap[ effectiveLayout.verticalAlignment ];
 
 		// Check that the grid layout attributes are of the correct type, so that we don't accidentally
 		// write code that stores a string attribute instead of a number.
@@ -241,6 +363,11 @@ export default {
 			( ! hasViewportOverrides || hasViewportOverride( 'rowCount' ) ) &&
 			columnCount &&
 			rowCount;
+		const shouldOutputGridJustification =
+			! hasViewportOverrides || hasViewportOverride( 'justifyContent' );
+		const shouldOutputGridAlignment =
+			! hasViewportOverrides ||
+			hasViewportOverride( 'verticalAlignment' );
 
 		if (
 			shouldOutputGridColumns &&
@@ -289,6 +416,14 @@ export default {
 			);
 		}
 
+		if ( shouldOutputGridJustification && justifyItems ) {
+			rules.push( `justify-items: ${ justifyItems }` );
+		}
+
+		if ( shouldOutputGridAlignment && alignItems ) {
+			rules.push( `align-items: ${ alignItems }` );
+		}
+
 		if ( rules.length ) {
 			output = `${ appendSelectors( selector ) } { ${ rules.join(
 				'; '
@@ -313,6 +448,68 @@ export default {
 		return [];
 	},
 };
+
+function GridLayoutJustifyItemsControl( { layout, onChange } ) {
+	const { justifyContent = defaultAlignment } = layout;
+	const onJustificationChange = ( value ) => {
+		onChange( {
+			...layout,
+			justifyContent: value,
+		} );
+	};
+
+	return (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			label={ __( 'Justification' ) }
+			onChange={ onJustificationChange }
+			value={ justifyContent }
+			className="block-editor-hooks__grid-layout-justification-controls"
+		>
+			{ gridJustificationOptions.map( ( { value, icon, label } ) => {
+				return (
+					<ToggleGroupControlOptionIcon
+						key={ value }
+						value={ value }
+						icon={ icon }
+						label={ label }
+					/>
+				);
+			} ) }
+		</ToggleGroupControl>
+	);
+}
+
+function GridLayoutVerticalAlignmentControl( { layout, onChange } ) {
+	const { verticalAlignment = defaultAlignment } = layout;
+	const onVerticalAlignmentChange = ( value ) => {
+		onChange( {
+			...layout,
+			verticalAlignment: value,
+		} );
+	};
+
+	return (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			label={ __( 'Alignment' ) }
+			onChange={ onVerticalAlignmentChange }
+			value={ verticalAlignment }
+			className="block-editor-hooks__grid-layout-vertical-alignment-controls"
+		>
+			{ gridVerticalAlignmentOptions.map( ( { value, icon, label } ) => {
+				return (
+					<ToggleGroupControlOptionIcon
+						key={ value }
+						value={ value }
+						icon={ icon }
+						label={ label }
+					/>
+				);
+			} ) }
+		</ToggleGroupControl>
+	);
+}
 
 // Enables setting minimum width of grid items.
 function GridLayoutMinimumWidthControl( { layout, onChange } ) {

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -1,7 +1,34 @@
 /**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import grid from '../grid';
+
+const GridLayoutInspectorControls = grid.inspectorControls;
+const PANEL_ID = 'test-panel';
+
+function renderInspectorControls( props = {} ) {
+	return render(
+		<ToolsPanel label="Layout" resetAll={ jest.fn() } panelId={ PANEL_ID }>
+			<GridLayoutInspectorControls
+				clientId={ PANEL_ID }
+				layout={ {} }
+				onChange={ jest.fn() }
+				{ ...props }
+			/>
+		</ToolsPanel>
+	);
+}
 
 describe( 'getLayoutStyle', () => {
 	it( 'should return only `grid-template-columns` and `container-type` properties if no non-default params are provided', () => {
@@ -45,5 +72,102 @@ describe( 'getLayoutStyle', () => {
 		} );
 
 		expect( result ).toBe( expected );
+	} );
+
+	it( 'should return grid item alignment properties', () => {
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(min(12rem, 100%), 1fr)); container-type: inline-size; justify-items: center; align-items: end; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { justifyContent: 'center', verticalAlignment: 'bottom' },
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: false,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
+
+	it( 'should return responsive grid item alignment overrides', () => {
+		const expected = `.my-container { justify-items: end; align-items: start; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { type: 'grid' },
+			viewportOverrides: {
+				justifyContent: 'right',
+				verticalAlignment: 'top',
+			},
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: false,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
+} );
+
+describe( 'GridLayoutInspectorControls', () => {
+	it( 'should not render justification and alignment controls by default', () => {
+		renderInspectorControls();
+
+		expect(
+			screen.queryByRole( 'radio', { name: 'Justify items center' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'radio', { name: 'Align bottom' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render justification and alignment controls when they have values', () => {
+		renderInspectorControls( {
+			layout: { justifyContent: 'center', verticalAlignment: 'bottom' },
+		} );
+
+		expect(
+			screen.getByRole( 'radio', { name: 'Justify items center' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'radio', { name: 'Align bottom' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should update justification and alignment values', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		renderInspectorControls( { onChange } );
+
+		await user.click(
+			screen.getByRole( 'button', { name: /Layout options/i } )
+		);
+		await user.click(
+			screen.getByRole( 'menuitemcheckbox', {
+				name: 'Show Justification',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: /Layout options/i } )
+		);
+		await user.click(
+			screen.getByRole( 'menuitemcheckbox', {
+				name: 'Show Alignment',
+			} )
+		);
+
+		await user.click(
+			screen.getByRole( 'radio', { name: 'Justify items center' } )
+		);
+		await user.click(
+			screen.getByRole( 'radio', { name: 'Align bottom' } )
+		);
+
+		expect( onChange ).toHaveBeenNthCalledWith( 1, {
+			justifyContent: 'center',
+		} );
+		expect( onChange ).toHaveBeenNthCalledWith( 2, {
+			verticalAlignment: 'bottom',
+		} );
 	} );
 } );

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -404,6 +404,17 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
 			),
+			'grid layout with item alignment'              => array(
+				'args'            => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
+						'type'              => 'grid',
+						'justifyContent'    => 'center',
+						'verticalAlignment' => 'bottom',
+					),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;justify-items:center;align-items:end;}',
+			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(
 					'selector'              => '.wp-block-group.wp-container-6',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


Addresses the first part of #62895 (grid parent controls only)

This got complicated because the grid item resize handles follow the item size, which changes if the grid's alignments are other than their default "stretch" value. In order to ensure they work well, we had to do a bunch of changes to the resizer logic. 

I've only half reviewed it and have run into a bug while testing where all the grid children become unselectable. 

I might not have time to work on this for 7.1, so I'm just leaving this here for now to pick up later.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add a Grid block with children to the page and try changing its justification/alignment. Test with children that have multi-column or multi-row spans.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Written with codex/gpt 5.5.