### PR TITLE
Tools: Restrict layout effect imports in UI and theme

### DIFF
--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -128,14 +128,24 @@ const restrictedImports = [
 	},
 ];
 
+const useIsomorphicLayoutEffectRestrictedImport = {
+	name: '@wordpress/element',
+	importNames: [ 'useLayoutEffect' ],
+	message:
+		'Use `useIsomorphicLayoutEffect` from `@wordpress/compose` instead. It keeps layout effect behavior in the browser while avoiding SSR warnings.',
+};
+
 // Common `no-restricted-imports` configuration for `@wordpress/ui` paths,
 // which occur across multiple override configs. The exclusion here allows
 // Base UI to be imported directly in `@wordpress/ui`, which is the intended
 // abstraction layer for BaseUI components.
 const UI_RESTRICTED_IMPORTS = {
-	paths: restrictedImports.filter(
-		( { name } ) => name !== '@base-ui/react'
-	),
+	paths: [
+		...restrictedImports.filter(
+			( { name } ) => name !== '@base-ui/react'
+		),
+		useIsomorphicLayoutEffectRestrictedImport,
+	],
 	patterns: [],
 };
 
@@ -678,6 +688,22 @@ export default dedupePlugins( [
 		files: [ 'packages/ui/src/**' ],
 		rules: {
 			'no-restricted-imports': [ 'error', UI_RESTRICTED_IMPORTS ],
+		},
+	},
+
+	// Override: Theme src — use the SSR-safe layout effect hook.
+	{
+		files: [ 'packages/theme/src/**' ],
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					paths: [
+						...restrictedImports,
+						useIsomorphicLayoutEffectRestrictedImport,
+					],
+				},
+			],
 		},
 	},
 


### PR DESCRIPTION
Follow up to #79458.

## What?

Adds an ESLint guard so `@wordpress/ui` and `@wordpress/theme` do not import `useLayoutEffect` from `@wordpress/element`.

## Why?

These packages should use `useIsomorphicLayoutEffect` from `@wordpress/compose` to avoid SSR warnings.

## How?

Adds a shared `no-restricted-imports` entry and applies it to `packages/ui/src/**` and `packages/theme/src/**`.

No changelog: private lint config only.

## Testing Instructions

1. `npm run lint:js -- tools/eslint/config.mjs`
2. `npm run lint:js -- packages/ui/src packages/theme/src`
3. Verified synthetic invalid imports fail for both package paths.

### Testing Instructions for Keyboard

No UI-facing changes.

## Screenshots or screencast

N/A

## Use of AI Tools

Created with Codex and reviewed locally.