### PR TITLE
Comments Block: Add blockGap, layout support, and default padding controls

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -244,7 +244,7 @@ An advanced block that allows displaying post comments using different visual co
 
 -	**Name:** [core/comments](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-comments/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
--	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), layout (allowSizingOnChildren), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** legacy, tagName
 
 ## Comments Pagination

--- a/packages/block-library/src/comments/README.md
+++ b/packages/block-library/src/comments/README.md
@@ -31,9 +31,12 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):
   - `margin`: `true`
   - `padding`: `true`
+  - `blockGap`: `true`
 - [`typography`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography):
   - [`fontSize`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-fontsize): `true`
   - [`lineHeight`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-lineheight): `true`
+- [`layout`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout):
+  - [`allowSizingOnChildren`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowsizingonchildren): `true`
 
 ## Context
 

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -32,7 +32,12 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"padding": true,
+				"blockGap": true
+			}
 		},
 		"typography": {
 			"fontSize": true,
@@ -58,6 +63,9 @@
 				"width": true,
 				"style": true
 			}
+		},
+		"layout": {
+			"allowSizingOnChildren": true
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",

--- a/packages/block-library/src/comments/deprecated.js
+++ b/packages/block-library/src/comments/deprecated.js
@@ -1,10 +1,78 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
-// v1: Deprecate the initial version of the block which was called "Comments
-// Query Loop" instead of "Comments".
+const v2 = {
+	attributes: {
+		tagName: {
+			type: 'string',
+			default: 'div',
+		},
+		legacy: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	apiVersion: 3,
+	supports: {
+		anchor: true,
+		align: [ 'wide', 'full' ],
+		html: false,
+		color: {
+			gradients: true,
+			heading: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	save( { attributes: { tagName: Tag, legacy } } ) {
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+
+		// The legacy version is dynamic (i.e. PHP rendered) and doesn't allow inner
+		// blocks, so nothing is saved in that case.
+		return legacy ? null : <Tag { ...innerBlocksProps } />;
+	},
+};
+
 const v1 = {
 	attributes: {
 		tagName: {
@@ -50,4 +118,4 @@ const v1 = {
 	},
 };
 
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/comments/edit/index.js
+++ b/packages/block-library/src/comments/edit/index.js
@@ -12,11 +12,12 @@ import TEMPLATE from './template';
 
 export default function CommentsEdit( props ) {
 	const { attributes, setAttributes, clientId } = props;
-	const { tagName: TagName, legacy } = attributes;
+	const { tagName: TagName, legacy, layout } = attributes;
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
+		layout,
 	} );
 
 	if ( legacy ) {


### PR DESCRIPTION
## What?
Closes #71975

Adds `blockGap`, `layout` (inner blocks use content width), and default padding controls to the `core/comments` block, bringing it to parity with `core/group` as a layout container.

## Why?
The `core/comments` block is a container that holds several comment-related inner blocks, but unlike `core/group` it was missing:

- `blockGap` support, no way to control spacing between inner blocks
- `layout` support, no "Inner blocks use content width" option
- Default UI controls for `padding`, padding existed as a support but wasn't enabled by default in the sidebar

This made `core/comments` a second-class container compared to `core/group`, limiting layout flexibility for theme authors and site editors.

## Testing Instructions
1. Open a post or page in the site editor or block editor.
2. Insert a **Comments** block.
3. Open the block inspector sidebar.

**blockGap:**
4. Under **Dimensions**, confirm a **Block spacing** (blockGap) control is now visible and enabled by default.
5. Adjust the value, verify the spacing between inner comment blocks updates accordingly in the editor and on the frontend.

**Default padding:**
6. Under **Dimensions**, confirm the **Padding** control is visible and enabled by default (no need to click the "+" to add it).
7. Set a padding value and verify it applies correctly.

**Inner blocks use content width (layout):**
8. Under **Layout** in the sidebar, confirm the "Inner blocks use content width" toggle is present.
9. Enable it, verify inner blocks respect constrained/wide/full-width sizing.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/9c83efab-c433-439c-be01-a5bb5b431351

