### PR TITLE
DataFormPostSummary: fix different `useSelect` returned values 

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -174,15 +174,26 @@ function bindFieldToNamespace( field, namespace, isVisible = () => true ) {
 }
 
 export default function DataFormPostSummary( { onActionPerformed } ) {
-	const { postType, postId, isPostStatusRemoved } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId, isEditorPanelRemoved } =
-			select( editorStore );
-		return {
-			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
-			isPostStatusRemoved: isEditorPanelRemoved( 'post-status' ),
-		};
-	}, [] );
+	const { postType, postId, isPostStatusRemoved, availableTemplates } =
+		useSelect( ( select ) => {
+			const {
+				getCurrentPostType,
+				getCurrentPostId,
+				isEditorPanelRemoved,
+				getEditorSettings,
+			} = select( editorStore );
+			const _availableTemplates = select(
+				coreDataStore
+			).getCurrentTheme()?.is_block_theme
+				? null
+				: getEditorSettings().availableTemplates ?? null;
+			return {
+				postType: getCurrentPostType(),
+				postId: getCurrentPostId(),
+				isPostStatusRemoved: isEditorPanelRemoved( 'post-status' ),
+				availableTemplates: _availableTemplates,
+			};
+		}, [] );
 	const { form: formConfig } = useViewConfig( {
 		kind: 'postType',
 		name: postType,
@@ -241,14 +252,6 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 		},
 		[ postType ]
 	);
-
-	const availableTemplates = useSelect( ( select ) => {
-		if ( select( coreDataStore ).getCurrentTheme()?.is_block_theme ) {
-			return null;
-		}
-		const settings = select( editorStore ).getEditorSettings();
-		return settings.availableTemplates ?? null;
-	}, [] );
 
 	// Merge the supplementary data onto the record.
 	const data = useMemo( () => {

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { DataForm } from '@wordpress/dataviews';
 import { Stack } from '@wordpress/ui';
@@ -211,9 +211,8 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	// alongside the post record: read-only editor data that the post's own
 	// fields consume (e.g. the `template` field's `available_templates` in
 	// classic themes), and the records of other entities targeted by namespaced
-	// fields (keyed by `${ kind }_${ name }`) together with the id used to
-	// persist edits back to each one.
-	const { entityData, entityIds, availableTemplates } = useSelect(
+	// fields (keyed by `${ kind }_${ name }`).
+	const { entityData, availableTemplates } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, canUser, getCurrentTheme } =
 				select( coreDataStore );
@@ -224,7 +223,6 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 						.availableTemplates ?? {};
 
 			const extra = {};
-			const ids = {};
 
 			// Other entities the current post type needs merged into its form.
 			for ( const [ key, entity ] of Object.entries(
@@ -248,12 +246,10 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					entity.name,
 					id
 				);
-				ids[ key ] = id;
 			}
 
 			return {
 				entityData: extra,
-				entityIds: ids,
 				availableTemplates: _availableTemplates,
 			};
 		},
@@ -276,6 +272,7 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 	}, [ record, entityData, availableTemplates ] );
 
 	const { editEntityRecord } = useDispatch( coreDataStore );
+	const registry = useRegistry();
 
 	// Map of namespaced field id to the namespace key its entity is merged under.
 	const fieldNamespaces = useMemo( () => {
@@ -354,12 +351,13 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 		for ( const [ key, value ] of Object.entries( edits ) ) {
 			const entity = entities[ key ];
 			if ( entity ) {
-				editEntityRecord(
-					entity.kind,
-					entity.name,
-					entityIds[ key ],
-					value
-				);
+				// Resolve the id the same way it was resolved to read the
+				// record, so the save targets the right entity regardless of
+				// its key field (`undefined` for the `root/site` singleton).
+				const id = entity.getId
+					? entity.getId( registry.select )
+					: undefined;
+				editEntityRecord( entity.kind, entity.name, id, value );
 			} else {
 				baseEdits[ key ] = value;
 			}

--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -207,25 +207,14 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 
 	const templatePanelMode = usePostTemplatePanelMode();
 
-	// Assemble every piece of supplementary data merged into the form `data`
-	// alongside the post record: read-only editor data that the post's own
-	// fields consume (e.g. the `template` field's `available_templates` in
-	// classic themes), and the records of other entities targeted by namespaced
-	// fields (keyed by `${ kind }_${ name }`).
-	const { entityData, availableTemplates } = useSelect(
+	const entityRecords = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, canUser, getCurrentTheme } =
-				select( coreDataStore );
+			const { getEditedEntityRecord, canUser } = select( coreDataStore );
 
-			const _availableTemplates = getCurrentTheme()?.is_block_theme
-				? null
-				: select( editorStore ).getEditorSettings()
-						.availableTemplates ?? {};
-
-			const extra = {};
+			const records = {};
 
 			// Other entities the current post type needs merged into its form.
-			for ( const [ key, entity ] of Object.entries(
+			for ( const [ namespace, entity ] of Object.entries(
 				ENTITIES[ postType ] ?? {}
 			) ) {
 				if (
@@ -241,35 +230,37 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 				if ( entity.getId && ! id ) {
 					continue;
 				}
-				extra[ key ] = getEditedEntityRecord(
+				records[ namespace ] = getEditedEntityRecord(
 					entity.kind,
 					entity.name,
 					id
 				);
 			}
 
-			return {
-				entityData: extra,
-				availableTemplates: _availableTemplates,
-			};
+			return records;
 		},
 		[ postType ]
 	);
 
-	// Merge the supplementary data onto the record only when there is any.
+	const availableTemplates = useSelect( ( select ) => {
+		if ( select( coreDataStore ).getCurrentTheme()?.is_block_theme ) {
+			return null;
+		}
+		const settings = select( editorStore ).getEditorSettings();
+		return settings.availableTemplates ?? null;
+	}, [] );
+
+	// Merge the supplementary data onto the record.
 	const data = useMemo( () => {
 		if ( ! record ) {
 			return record;
 		}
-		const extra = { ...entityData };
+		const extra = { ...entityRecords };
 		if ( availableTemplates && Object.keys( availableTemplates ).length ) {
 			extra.available_templates = availableTemplates;
 		}
-		if ( ! Object.keys( extra ).length ) {
-			return record;
-		}
 		return { ...record, ...extra };
-	}, [ record, entityData, availableTemplates ] );
+	}, [ record, entityRecords, availableTemplates ] );
 
 	const { editEntityRecord } = useDispatch( coreDataStore );
 	const registry = useRegistry();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/76934

The linked PR introduced a warning for returning different values in `useSelect`: `Non-equal value keys: entityData, entityIds`. This PR solves that.

## Testing instructions
1. Enable the `Editor Inspector: Use DataForm` experiment.
2. Edit a post and open the summary panel and the dev tools
3. no `useSelect` warning should be shown and editing should work exactly as before

## Use of AI Tools
Opus 4.8 with direction, changes and review
