### PR TITLE
CODEOWNERS: add ownership for widget dashboard areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@
 /packages/edit-widgets                          @draganescu @adamziel @kevin940726
 /packages/customize-widgets
 /packages/widgets
+/packages/widget-primitives                     @retrofox
 
 # Full Site Editing
 /packages/edit-site
@@ -90,6 +91,8 @@
 /packages/dataviews                             @oandregal @gigitux @ntsekouras
 /packages/theme                                 @WordPress/gutenberg-components
 /packages/ui                                    @WordPress/gutenberg-components
+/packages/widget-dashboard                      @retrofox
+/packages/grid                                  @retrofox
 
 # Utilities
 /packages/a11y
@@ -127,6 +130,10 @@
 
 # wp-env
 /packages/env                                   @t-hamano
+
+# Widget Dashboard
+/routes/dashboard                               @retrofox
+/lib/experimental/dashboard-widgets             @retrofox
 
 # PHP
 /lib                                            @spacedmonkey


### PR DESCRIPTION
## Summary
As a main developer working on the experimental dashboard and related grid package:

- Add CODEOWNERS entry for `packages/widget-primitives`.
- Add CODEOWNERS entries for `packages/widget-dashboard` and `packages/grid`.
- Add CODEOWNERS entries for dashboard route and experimental dashboard widgets PHP area.

## Test plan
- [x] Confirm only `.github/CODEOWNERS` is changed in this PR.
- [x] Verify added paths match existing repository directories.
- [x] Verify all new entries map to `@retrofox`.