### PR TITLE
Guidelines: Use str_starts_with() in is_block_meta_key()

### DIFF
--- a/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
+++ b/lib/experimental/guidelines/class-gutenberg-guidelines-post-type.php
@@ -306,7 +306,7 @@ class Gutenberg_Guidelines_Post_Type {
 	 * @return bool True if it's a block guideline meta key.
 	 */
 	public static function is_block_meta_key( string $meta_key ): bool {
-		return strpos( $meta_key, self::BLOCK_META_PREFIX ) === 0;
+		return str_starts_with( $meta_key, self::BLOCK_META_PREFIX );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Replaces the `strpos( $meta_key, self::BLOCK_META_PREFIX ) === 0` check in `Gutenberg_Guidelines_Post_Type::is_block_meta_key()` with the native `str_starts_with()` function.

## Why?

`str_starts_with()` expresses the intent ("does this key start with the block meta prefix?") more directly than the `strpos( … ) === 0` idiom, which is easy to misread.

## Testing Instructions

### Testing Instructions for Keyboard

N/A — this PR contains no user interface changes.

## Screenshots or screencast

N/A — no visual changes.

## Use of AI Tools
