### PR TITLE
Use Custom HTML block for freeform content behind an experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -63,6 +63,12 @@ function gutenberg_enable_block_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-experiments' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
 	}
+
+	// Use the Custom HTML block (instead of the Classic block) to handle
+	// non-block (freeform) content.
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-html-freeform-handler' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableHtmlFreeformHandler = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_block_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -34,6 +34,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Grid interactivity', 'gutenberg' ),
 					'description' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-html-freeform-handler',
+					'label'       => __( 'Custom HTML for freeform content', 'gutenberg' ),
+					'description' => __( 'Handles non-block (freeform) content with the Custom HTML block instead of the Classic block.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -385,7 +385,11 @@ export const registerCoreBlocks = (
 	}
 
 	setDefaultBlockName( paragraph.name );
-	if (
+	if ( window?.__experimentalEnableHtmlFreeformHandler ) {
+		// Experiment: handle non-block (freeform) content with the Custom HTML
+		// block instead of the Classic block.
+		setFreeformContentHandlerName( html.name );
+	} else if (
 		window.wp &&
 		window.wp.oldEditor &&
 		blocks.some( ( { name } ) => name === classic.name )


### PR DESCRIPTION
## What?

Adds a Gutenberg experiment that switches the **freeform content handler** — the block used to hold non-block (freeform) content that has no block delimiters — from the Classic block (`core/freeform`) to the Custom HTML block (`core/html`).

## Why?

Exploring whether `core/html` is a better default home for freeform content than the Classic block (`core/freeform`). Wrapping it as an opt-in experiment so the behavior change is gated and easy to evaluate.

Part of #78067.

## How?

- **`packages/block-library/src/index.js`** — In `registerCoreBlocks`, the freeform content handler now checks a new `window.__experimentalEnableHtmlFreeformHandler` global first; when set, it calls `setFreeformContentHandlerName( html.name )` instead of the Classic-block path.
- **`lib/experimental/editor-settings.php`** — Bridges the experiment toggle to that JS global (same pattern as the existing form/block experiments).
- **`lib/experimental/experiments/load.php`** — Registers the `gutenberg-html-freeform-handler` experiment in the **Blocks** group on the Experiments screen.

This reuses a known-good combination: the widgets editors (`edit-widgets`, `customize-widgets`) already use `setFreeformContentHandlerName( 'core/html' )`, and `core/html` is always registered, so no extra guard is needed.

## Testing Instructions

1. Build (`npm run build` or `npm start`).
2. Go to **Gutenberg → Experiments** and enable **"Custom HTML for freeform content"**.
3. Edit a post containing non-block / freeform content (e.g. seed raw HTML via the Code editor) and confirm it is handled by the **Custom HTML** block rather than the **Classic** block.
4. Disable the experiment and confirm the prior behavior (Classic block) is restored.

### Notes

- Default-off; behavior is unchanged unless the experiment is enabled.
- When enabled, the experiment switches to `core/html` unconditionally — including when `wp.oldEditor` is present — so the Classic-block fallback is disabled while the experiment is on.
