### PR TITLE
Classic Block: Remove conversion from `BlockInvalidWarning`

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -20,7 +20,7 @@ const blockToBlocks = ( block ) =>
 	} );
 
 export default function BlockInvalidWarning( { clientId } ) {
-	const { block, canInsertHTMLBlock, canInsertClassicBlock } = useSelect(
+	const { block, canInsertHTMLBlock } = useSelect(
 		( select ) => {
 			const { canInsertBlockType, getBlock, getBlockRootClientId } =
 				select( blockEditorStore );
@@ -31,10 +31,6 @@ export default function BlockInvalidWarning( { clientId } ) {
 				block: getBlock( clientId ),
 				canInsertHTMLBlock: canInsertBlockType(
 					'core/html',
-					rootClientId
-				),
-				canInsertClassicBlock: canInsertBlockType(
-					'core/freeform',
 					rootClientId
 				),
 			};
@@ -48,12 +44,6 @@ export default function BlockInvalidWarning( { clientId } ) {
 
 	const convert = useMemo(
 		() => ( {
-			toClassic() {
-				const classicBlock = createBlock( 'core/freeform', {
-					content: block.originalContent,
-				} );
-				return replaceBlock( block.clientId, classicBlock );
-			},
 			toHTML() {
 				const htmlBlock = createBlock( 'core/html', {
 					content: block.originalContent,
@@ -88,12 +78,8 @@ export default function BlockInvalidWarning( { clientId } ) {
 					title: __( 'Convert to HTML' ),
 					onClick: convert.toHTML,
 				},
-				canInsertClassicBlock && {
-					title: __( 'Convert to Classic Block' ),
-					onClick: convert.toClassic,
-				},
 			].filter( Boolean ),
-		[ canInsertHTMLBlock, canInsertClassicBlock, convert ]
+		[ canInsertHTMLBlock, convert ]
 	);
 
 	return (


### PR DESCRIPTION
## What?

Removes the **Convert to Classic Block** option from the invalid block warning (`BlockInvalidWarning`).

## Why?

The classic (`core/freeform`) block is being de-emphasized and is hidden from the modern inserter. Offering "Convert to Classic Block" as a resolution for an invalid block steers users toward a legacy block we no longer want to promote. The remaining options — **Attempt recovery**, **Resolve**, and **Convert to HTML** — cover the relevant recovery paths.

Part of #78067.

## How?

In `packages/block-editor/src/components/block-list/block-invalid-warning.js`:

- Drop the `canInsertClassicBlock` selector (the `canInsertBlockType( 'core/freeform', … )` check).
- Remove the `convert.toClassic()` converter that created a `core/freeform` block.
- Remove the "Convert to Classic Block" entry from `secondaryActions`.
- Update both `useSelect` and `useMemo` dependency arrays accordingly.

## Testing Instructions

1. Open the editor for a new post.
2. Open the **Code editor** (Options menu → Code editor) and paste a block with tampered/invalid markup, e.g.:
   ```html
   <!-- wp:paragraph -->
   <p>Hello <strong>world</strong></p>
   <div>unexpected extra markup</div>
   <!-- /wp:paragraph -->
   ```
3. Switch back to the **Visual editor**. The block shows "Block contains unexpected or invalid content."
4. Open the warning's secondary actions.
5. **Expected:** You see **Resolve** and **Convert to HTML**, but **no "Convert to Classic Block"** option.

### Testing Instructions for Keyboard

Same

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="664" height="204" alt="Screenshot 2026-06-24 at 20 08 09" src="https://github.com/user-attachments/assets/f3e418a2-4bb7-43ee-b024-59e8d772f775" /> | <img width="669" height="206" alt="Screenshot 2026-06-24 at 20 04 38" src="https://github.com/user-attachments/assets/34800dd9-c71b-4811-9d4f-ca644e76ce50" />|




## Use of AI Tools

This PR was authored with assistance from Claude Code. All code was reviewed by the author before submission.
