### PR TITLE
ui/IconButton: Restore default tooltip delay

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `IconButton`: Restore the default tooltip delay on hover ([#79505](https://github.com/WordPress/gutenberg/pull/79505)).
+
 ### Internal
 
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -9,6 +9,9 @@ import { type IconButtonProps } from './types';
 /**
  * An icon-only button with automatic tooltip and optimized styling.
  * Inherits all Button props while providing icon-specific enhancements.
+ *
+ * When rendering a group of `IconButton`s, wrap them in a `Tooltip.Provider`
+ * to coordinate tooltip delays across the group.
  */
 export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 	function IconButton(
@@ -30,42 +33,36 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 		const classes = clsx( styles[ 'icon-button' ], className );
 
 		return (
-			<Tooltip.Provider>
-				<Tooltip.Root>
-					<Tooltip.Trigger
-						ref={ ref }
-						disabled={ disabled && ! focusableWhenDisabled }
-						render={
-							<Button
-								{ ...restProps }
-								size={ size }
-								aria-label={ label }
-								aria-keyshortcuts={ shortcut?.ariaKeyShortcut }
-								disabled={ disabled }
-								focusableWhenDisabled={ focusableWhenDisabled }
-							/>
-						}
-						className={ classes }
-					>
-						<Icon
-							icon={ icon }
-							size={ 24 }
-							className={ styles.icon }
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					ref={ ref }
+					disabled={ disabled && ! focusableWhenDisabled }
+					render={
+						<Button
+							{ ...restProps }
+							size={ size }
+							aria-label={ label }
+							aria-keyshortcuts={ shortcut?.ariaKeyShortcut }
+							disabled={ disabled }
+							focusableWhenDisabled={ focusableWhenDisabled }
 						/>
-					</Tooltip.Trigger>
-					<Tooltip.Popup positioner={ positioner }>
-						{ label }
-						{ shortcut && (
-							<>
-								{ ' ' }
-								<span aria-hidden="true">
-									{ shortcut.displayShortcut }
-								</span>
-							</>
-						) }
-					</Tooltip.Popup>
-				</Tooltip.Root>
-			</Tooltip.Provider>
+					}
+					className={ classes }
+				>
+					<Icon icon={ icon } size={ 24 } className={ styles.icon } />
+				</Tooltip.Trigger>
+				<Tooltip.Popup positioner={ positioner }>
+					{ label }
+					{ shortcut && (
+						<>
+							{ ' ' }
+							<span aria-hidden="true">
+								{ shortcut.displayShortcut }
+							</span>
+						</>
+					) }
+				</Tooltip.Popup>
+			</Tooltip.Root>
 		);
 	}
 );

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -30,7 +30,7 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 		const classes = clsx( styles[ 'icon-button' ], className );
 
 		return (
-			<Tooltip.Provider delay={ 0 }>
+			<Tooltip.Provider>
 				<Tooltip.Root>
 					<Tooltip.Trigger
 						ref={ ref }

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -87,21 +87,23 @@ export const Disabled: Story = {
 export const WithDifferentIcons: Story = {
 	...Default,
 	render: ( args ) => (
-		<div
-			style={ {
-				display: 'flex',
-				gap: '1rem',
-				alignItems: 'center',
-				flexWrap: 'wrap',
-			} }
-		>
-			<IconButton { ...args } icon={ wordpress } label="WordPress" />
-			<IconButton { ...args } icon={ plus } label="Add" />
-			<IconButton { ...args } icon={ pencil } label="Edit" />
-			<IconButton { ...args } icon={ trash } label="Delete" />
-			<IconButton { ...args } icon={ download } label="Download" />
-			<IconButton { ...args } icon={ upload } label="Upload" />
-		</div>
+		<Tooltip.Provider>
+			<div
+				style={ {
+					display: 'flex',
+					gap: '1rem',
+					alignItems: 'center',
+					flexWrap: 'wrap',
+				} }
+			>
+				<IconButton { ...args } icon={ wordpress } label="WordPress" />
+				<IconButton { ...args } icon={ plus } label="Add" />
+				<IconButton { ...args } icon={ pencil } label="Edit" />
+				<IconButton { ...args } icon={ trash } label="Delete" />
+				<IconButton { ...args } icon={ download } label="Download" />
+				<IconButton { ...args } icon={ upload } label="Upload" />
+			</div>
+		</Tooltip.Provider>
 	),
 };
 

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from '@testing-library/react';
+import { act, render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import { IconButton } from '../index';
@@ -34,6 +34,48 @@ describe( 'IconButton', () => {
 	} );
 
 	describe( 'tooltip with disabled state', () => {
+		it( 'uses the default tooltip delay on hover', async () => {
+			jest.useFakeTimers();
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
+			try {
+				render( <IconButton label="Save" icon={ <svg /> } /> );
+
+				const button = screen.getByRole( 'button', { name: 'Save' } );
+				await user.hover( button );
+
+				expect( screen.queryByText( 'Save' ) ).not.toBeInTheDocument();
+
+				act( () => {
+					jest.advanceTimersByTime( 600 );
+				} );
+
+				await waitFor( () => {
+					expect( screen.getByText( 'Save' ) ).toBeVisible();
+				} );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'shows tooltip immediately on keyboard focus', async () => {
+			const user = userEvent.setup();
+
+			render( <IconButton label="Save" icon={ <svg /> } /> );
+
+			await user.tab();
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Save' ) ).toBeVisible();
+			} );
+			expect( screen.getByText( 'Save' ) ).toHaveAttribute(
+				'data-instant',
+				'focus'
+			);
+		} );
+
 		it( 'does not show tooltip when truly disabled', async () => {
 			const user = userEvent.setup();
 

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
 import { IconButton } from '../index';
@@ -34,48 +34,6 @@ describe( 'IconButton', () => {
 	} );
 
 	describe( 'tooltip with disabled state', () => {
-		it( 'uses the default tooltip delay on hover', async () => {
-			jest.useFakeTimers();
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
-
-			try {
-				render( <IconButton label="Save" icon={ <svg /> } /> );
-
-				const button = screen.getByRole( 'button', { name: 'Save' } );
-				await user.hover( button );
-
-				expect( screen.queryByText( 'Save' ) ).not.toBeInTheDocument();
-
-				act( () => {
-					jest.advanceTimersByTime( 600 );
-				} );
-
-				await waitFor( () => {
-					expect( screen.getByText( 'Save' ) ).toBeVisible();
-				} );
-			} finally {
-				jest.useRealTimers();
-			}
-		} );
-
-		it( 'shows tooltip immediately on keyboard focus', async () => {
-			const user = userEvent.setup();
-
-			render( <IconButton label="Save" icon={ <svg /> } /> );
-
-			await user.tab();
-
-			await waitFor( () => {
-				expect( screen.getByText( 'Save' ) ).toBeVisible();
-			} );
-			expect( screen.getByText( 'Save' ) ).toHaveAttribute(
-				'data-instant',
-				'focus'
-			);
-		} );
-
 		it( 'does not show tooltip when truly disabled', async () => {
 			const user = userEvent.setup();
 


### PR DESCRIPTION
## What?
Closes #79461

Restores the default tooltip delay for `@wordpress/ui` `IconButton` hover tooltips.

## Why?
`IconButton` wrapped each tooltip in a local `Tooltip.Provider` with `delay={ 0 }`, so tooltips appeared immediately on hover. In dense control surfaces this is noisy and can obscure nearby UI while users move across buttons.

## How?
Removes `IconButton`'s local `Tooltip.Provider`, so the tooltip uses the default delay behavior unless a consumer wraps a group of controls in their own provider.

Adds component docs and updates the grouped icon button story to show wrapping multiple `IconButton`s in `Tooltip.Provider`, which keeps grouped tooltip behavior under consumer control.

## Testing Instructions
1. Run `npm run test:unit packages/ui/src/icon-button/test/index.test.tsx -- --runInBand`.
2. Run `npm run lint:js -- packages/ui/src/icon-button/icon-button.tsx packages/ui/src/icon-button/stories/index.story.tsx packages/ui/src/icon-button/test/index.test.tsx`.
3. Run `npx tsgo --build packages/ui/tsconfig.json`.

### Testing Instructions for Keyboard
1. Open the `IconButton` Storybook examples.
2. Press Tab until an `IconButton` receives focus.
3. Confirm the tooltip appears when the button receives keyboard focus.

## Screenshots or screencast
N/A

## Use of AI Tools
Used Codex to implement the change, address review feedback, and run verification.
