### PR TITLE
Icons: Add Storybook React Vite dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51288,6 +51288,9 @@
 				"@wordpress/primitives": "file:../primitives",
 				"change-case": "^4.1.2"
 			},
+			"devDependencies": {
+				"@storybook/react-vite": "^10.4.3"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,6 +47,9 @@
 		"@wordpress/primitives": "file:../primitives",
 		"change-case": "^4.1.2"
 	},
+	"devDependencies": {
+		"@storybook/react-vite": "^10.4.3"
+	},
 	"peerDependencies": {
 		"@types/react": "^18.3.27",
 		"react": "^18.0.0"


### PR DESCRIPTION
## What?

Adds `@storybook/react-vite` to `@wordpress/icons` devDependencies.

## Why?

Follow-up to https://github.com/WordPress/gutenberg/pull/79320#discussion_r3469832598. The icons package now contains Storybook stories that use the React Vite Storybook framework, matching sibling packages that already declare the same devDependency range.

## Testing Instructions

- Run `npm install`.
- Run `npm run lint:lockfile`.
- Run `npm run lint:pkg-json`.
- Run `npm run lint:deps`.
- Run `npm run --workspace @wordpress/icons build`.

## Notes

`npm audit --audit-level=high` still reports existing repository-wide advisories on the current dependency tree. This PR only adds a workspace devDependency edge to an already-resolved Storybook package and does not introduce a new resolved package version.