### PR TITLE
Focus first tab when adding Tabs block

### DIFF
--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -117,13 +117,7 @@ function Edit( {
 			} );
 		};
 
-		if ( tabsList.length > prevCount ) {
-			// Tab added — focus the last (newly added) button.
-			focusButtonAt( tabsList.length - 1 );
-		} else {
-			// Tab removed — focus the new active button.
-			focusButtonAt( effectiveActiveIndex );
-		}
+		focusButtonAt( effectiveActiveIndex );
 	}, [ tabsList.length, effectiveActiveIndex ] );
 
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses a but mentioned in https://github.com/WordPress/gutenberg/issues/73230#issuecomment-4786609172

When inserting a Tabs block, focus landed on the second tab title instead of the first.

The tab-list block focuses a tab button whenever the tab count changes, and it decided which button to focus from the count delta: a growing count was treated as a user “Add tab” action and focused the last button. But on insertion the tab panels are populated from the block template (0 → 2), so this misfired and focus jumped to the last/second tab.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's unexpected to focus the second tab when adding a tabs block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Focus the active tab (effectiveActiveIndex) in all cases instead of branching on the count delta:

- Add tab already moves the active index to the newly added tab, so focus still follows the new tab.
- Remove tab already relied on the active index — unchanged.
- Insert / initial template population never sets editorActiveTabIndex, so the active index stays at 0 and focus correctly lands on the first tab (this also fixes the case where panels populate in staged updates).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a Tabs block (it inserts with two tabs)  →  cursor/focus should be in the first tab’s title, not the second.
- Click Add tab → focus should move to the newly added tab.
- Click Remove tab → focus should move to the new active tab (no focus lost to the toolbar/canvas).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Follow the above, using Enter keypress

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools
Claude Opus 4.8 helped with all parts of this
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
