### PR TITLE
Block Supports: Guard elements hover rendering against missing hover selector

### DIFF
--- a/backport-changelog/7.1/12312.md
+++ b/backport-changelog/7.1/12312.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12312
+
+* https://github.com/WordPress/gutenberg/pull/79511

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -193,7 +193,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 				)
 			);
 
-			if ( isset( $element_style_object[':hover'] ) && ! empty( $element_config['hover_selector'] ) ) {
+			if ( isset( $element_style_object[':hover'], $element_config['hover_selector'] ) ) {
 				gutenberg_style_engine_get_styles(
 					$element_style_object[':hover'],
 					array(

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -193,7 +193,7 @@ function gutenberg_render_elements_support_styles( $parsed_block ) {
 				)
 			);
 
-			if ( isset( $element_style_object[':hover'] ) ) {
+			if ( isset( $element_style_object[':hover'] ) && ! empty( $element_config['hover_selector'] ) ) {
 				gutenberg_style_engine_get_styles(
 					$element_style_object[':hover'],
 					array(

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -326,6 +326,21 @@ class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {
 				),
 				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-element-button, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-block-button__link' . $color_css_rules . '$/',
 			),
+			'button hover styles are skipped without a hover selector' => array(
+				'color_settings'  => array( 'button' => true ),
+				'elements_styles' => array(
+					'button' => array(
+						'color'  => $color_styles,
+						':hover' => array( 'color' => $color_styles ),
+					),
+				),
+				/*
+				 * Only the base button rule should be emitted. The button element
+				 * type has no `hover_selector`, so the `:hover` object must be
+				 * ignored rather than triggering an undefined array key warning.
+				 */
+				'expected_styles' => '/^.wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-element-button, .wp-elements-(?:[a-f0-9]{32}|[0-9]+) .wp-block-button__link' . $color_css_rules . '$/',
+			),
 			'link element styles are applied'            => array(
 				'color_settings'  => array( 'link' => true ),
 				'elements_styles' => array(


### PR DESCRIPTION
## What?
Related: https://github.com/WordPress/gutenberg/pull/77894

Only render `:hover` element styles for element types that actually define a hover selector.

## Why?
In `gutenberg_render_elements_support_styles()`, only the `link` element type defines a `hover_selector`. If a block's `style.elements` carries a `:hover` object for `button` or `heading`, the code reaches for `$element_config['hover_selector']` on a type that doesn't have it. That emits an "Undefined array key 'hover_selector'" warning and passes an empty selector to the style engine.

It's hard to reach through the default UI, but the attribute data can be persisted on a block directly, so the warning stands on its own.

## How?

- Updates the guard here in Gutenberg to match the approach already in WordPress core.
- Adds regression test to cover missing hover selectors while an element has hover styles.


## Testing Instructions
1. Updated `WP_Block_Supports_Elements_Test` should pass
