### PR TITLE
Color popover: move contrast warning notice to the bottom

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -88,15 +88,15 @@ function ColorGradientControlInner( {
 		// The `ColorPalette` must stay at a stable position in the tree whether
 		// or not a notice is present. Wrapping it in a `VStack` only when a
 		// notice appears remounts it, which resets the custom color picker back
-		// to the swatch view mid-edit. Keep `ColorPalette` last and toggle only
-		// the notice ahead of it; the notice's own bottom margin provides the
-		// spacing the wrapper used to.
+		// to the swatch view mid-edit. Keep `ColorPalette` first and toggle only
+		// the trailing notice after it, so the palette holds a stable index and
+		// the notice sits at the bottom of the popover.
 		[ TAB_IDS.color ]: (
 			<>
+				{ colorPalette }
 				{ noticeProps && (
 					<Notice isDismissible={ false } { ...noticeProps } />
 				) }
-				{ colorPalette }
 			</>
 		),
 		[ TAB_IDS.gradient ]: (

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -68,9 +68,9 @@ $swatch-gap: 12px;
 	background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 }
 
-// Space the in-popover contrast notice away from the color palette below it.
+// Space the in-popover contrast notice away from the color palette above it.
 .block-editor-panel-color-gradient-settings__contrast-notice {
-	margin-bottom: $grid-unit-20;
+	margin-top: $grid-unit-20;
 }
 
 /**


### PR DESCRIPTION
## What?
Follow up to #77279.

Moves the contrast warning notice inside the color picker popover from the top to the bottom, below the color palette.

## Why?
The recent relocation of the text and background color controls (#77279) renders the contrast warning at the top of the color popover, above the palette. When the selection changes the notice appears, disappears, or changes height, which shifts the palette below it and makes the controls jump under the pointer.

This addresses the feedback raised in https://github.com/WordPress/gutenberg/pull/77279#issuecomment-4766430016, which suggested placing the notice at the bottom of the popover so the palette stays put.

## How?
In `ColorGradientControl`, the color tab now renders the `ColorPalette` first and the notice after it, so the warning sits at the bottom of the popover. The palette keeps a stable position in the tree whether or not the notice is present, so toggling the notice does not remount the picker (which would reset the custom color view mid-edit
  ). The notice's spacing is changed from a bottom margin to a top margin to match the new order.

The notice stays scoped to the color tab, so the gradient tab is unaffected, and no copy or contrast logic changes.

## Testing Instructions
1. Open a post and add a Paragraph block with some text.
2. In the block inspector, open the Typography panel and the text color control.
3. Set a text color with poor contrast against the background (for example black text on a black background).
4. Confirm the warning notice now appears at the bottom of the popover, below the palette.
5. Change the selection between sufficient and insufficient contrast and confirm the palette does not jump.
6. Repeat for the background color control in the Background panel.

## Screenshots

| Before | After |
|---|---|
| <img width="574" height="511" alt="Screenshot 2026-06-24 at 6 35 45 pm" src="https://github.com/user-attachments/assets/113870b6-2bea-4aa9-9a44-a1aad41a48b1" /> | <img width="568" height="541" alt="Screenshot 2026-06-24 at 6 35 17 pm" src="https://github.com/user-attachments/assets/3ace46e9-5c04-497e-a4ee-92c1505c3ef9" /> |