### PR TITLE
Block Library: Remove redundant parentheses around assignments

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -73,7 +73,7 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
 		$colors['css_classes']
 	);
 
-	$style_attribute = ( $colors['inline_styles'] );
+	$style_attribute = $colors['inline_styles'];
 	$classes[]       = 'wp-block-navigation-item';
 
 	if ( is_front_page() ) {

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -309,7 +309,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		$colors['css_classes']
 	);
 
-	$style_attribute = ( $colors['inline_styles'] );
+	$style_attribute = $colors['inline_styles'];
 	$css_classes     = trim( implode( ' ', $classes ) );
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -16,7 +16,7 @@
  */
 function render_block_core_tag_cloud( $attributes ) {
 	$smallest_font_size = $attributes['smallestFontSize'];
-	$unit               = ( preg_match( '/^[0-9.]+(?P<unit>[a-z%]+)$/i', $smallest_font_size, $m ) ? $m['unit'] : 'pt' );
+	$unit               = preg_match( '/^[0-9.]+(?P<unit>[a-z%]+)$/i', $smallest_font_size, $m ) ? $m['unit'] : 'pt';
 
 	$args      = array(
 		'echo'       => false,


### PR DESCRIPTION
## What?

Removes unnecessary parentheses that wrapped the right-hand side of assignment expressions in three block render functions:

- `home-link/index.php` — `$style_attribute` assignment
- `page-list/index.php` — `$style_attribute` assignment
- `tag-cloud/index.php` — `$unit` ternary assignment

## Why?

The parentheses had no functional effect and only added visual noise. Removing them makes the assignments easier to read and aligns with the style used elsewhere in the codebase.

## How?

Stripped the surrounding `( ... )` from each assignment's value.

## Testing Instructions

This is a pure cleanup with no behavior change.