### PR TITLE
Enhance ValidatedInputControl to delay email validation until blur

### DIFF
--- a/packages/components/src/validated-form-controls/components/input-control.tsx
+++ b/packages/components/src/validated-form-controls/components/input-control.tsx
@@ -16,6 +16,7 @@ const UnforwardedValidatedInputControl = (
 		required,
 		customValidity,
 		markWhenOptional,
+		revalidateOn,
 		...restProps
 	}: Omit<
 		React.ComponentProps< typeof InputControl >,
@@ -27,11 +28,15 @@ const UnforwardedValidatedInputControl = (
 	const validityTargetRef = useRef< HTMLInputElement >( null );
 	const mergedRefs = useMergeRefs( [ forwardedRef, validityTargetRef ] );
 
+	const _revalidateOn =
+		revalidateOn ?? ( restProps.type === 'email' ? 'blur' : 'change' );
+
 	return (
 		<ControlWithError
 			required={ required }
 			markWhenOptional={ markWhenOptional }
 			customValidity={ customValidity }
+			revalidateOn={ _revalidateOn }
 			getValidityTarget={ () => validityTargetRef.current }
 		>
 			<InputControl

--- a/packages/components/src/validated-form-controls/components/types.ts
+++ b/packages/components/src/validated-form-controls/components/types.ts
@@ -26,4 +26,13 @@ export type ValidatedControlProps = {
 		type: 'validating' | 'valid' | 'invalid';
 		message: string;
 	};
+	/**
+	 * When to revalidate the control.
+	 *
+	 * - `change` (default): Revalidate whenever the user inputs data.
+	 * - `blur`: Revalidate only when the user finishes interacting with the control and focuses away.
+	 *
+	 * @default 'change'
+	 */
+	revalidateOn?: 'change' | 'blur';
 };

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -65,6 +65,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		required,
 		markWhenOptional,
 		customValidity,
+		revalidateOn = 'change',
 		getValidityTarget,
 		children,
 	}: {
@@ -77,6 +78,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		 */
 		markWhenOptional?: boolean;
 		customValidity?: ValidatedControlProps[ 'customValidity' ];
+		revalidateOn?: ValidatedControlProps[ 'revalidateOn' ];
 		/**
 		 * A function that returns the actual element on which the validity data should be applied.
 		 */
@@ -309,6 +311,15 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 					markWhenOptional
 				),
 				required,
+				onChange: ( ...args: any[] ) => {
+					if ( revalidateOn === 'blur' ) {
+						setShowMessage( false );
+						setIsTouched( false );
+					}
+					if ( children.props.onChange ) {
+						children.props.onChange( ...args );
+					}
+				},
 			} ) }
 			<div aria-live="polite">{ visibleMessage }</div>
 		</div>

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -27,6 +27,10 @@ export type DataFormValidatedTextControlProps< Item > =
 		 * Optional suffix element to display after the input.
 		 */
 		suffix?: React.ReactElement;
+		/**
+		 * When to revalidate the control.
+		 */
+		revalidateOn?: 'change' | 'blur';
 	};
 
 export default function ValidatedText< Item >( {
@@ -39,6 +43,7 @@ export default function ValidatedText< Item >( {
 	prefix,
 	suffix,
 	validity,
+	revalidateOn,
 }: DataFormValidatedTextControlProps< Item > ) {
 	const { label, placeholder, description, getValue, setValue, isValid } =
 		field;
@@ -61,6 +66,7 @@ export default function ValidatedText< Item >( {
 			required={ !! isValid.required }
 			markWhenOptional={ markWhenOptional }
 			customValidity={ getCustomValidity( isValid, validity ) }
+			revalidateOn={ revalidateOn }
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/79515 <!-- Replace with the actual issue number if different -->

This PR adds a `revalidateOn` prop to `ValidatedInputControl` and defaults it to `'blur'` for `email` input types, preventing noisy validation errors from displaying while the user is actively typing. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, validated email fields display error messages (e.g., "Please include an @ in the email address") continuously while a user is typing a new email address. This creates a noisy and premature validation UX because partial email addresses are expected to be invalid while being typed. 

Aligning with form design best practices (NNG, Baymard, GOV.UK), this change ensures we don't present inline validation errors before the user has finished entering their information.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Added a `revalidateOn?: 'change' | 'blur'` property to `ValidatedControlProps` and surfaced it through `ValidatedInputControl` and DataViews' `ValidatedText`.
2. In `ValidatedInputControl`, the `revalidateOn` property defaults to `'blur'` if the field `type === 'email'`.
3. In `ControlWithError`, we intercept the child component's `onChange` event via `cloneElement` to temporarily hide existing validation error messages and unset the `isTouched` state whenever `revalidateOn` is `'blur'` and the user interacts with the input. The existing `onBlur` behavior correctly handles the re-validation once focus is lost. Intercepting `onChange` within React prevents synthetic event batching issues that happen if we use native `addEventListener('input')`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Run `npm run storybook:dev`.
2. Open **Components / Selection & Input / Validated Form Controls / ValidatedInputControl**.
3. Set the `type` control to `email`.
4. Make sure `required` is enabled.
5. Focus the empty field, then blur it to see the initial validation error.
6. Focus the field again and start typing an email address. 
7. **Verify** that the validation error hides immediately when you begin typing.
8. **Verify** that it checks validity again and presents the proper error state once you blur the field.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Navigate to the Storybook field using the `Tab` key.
2. `Tab` away while empty to trigger the error.
3. `Shift + Tab` back into the field and type a letter. The error should visually clear and announce correctly based on standard Aria live region behaviors.
4. `Tab` away with an invalid partial email and confirm the error message returns.

## Use of AI Tools

This PR was authored with the assistance of an Gemini 3.1 Pro using Google Antigravity. It was used to find the relevant files and ensure nothing else breaks.  
