### PR TITLE
Code Modernization: Use str_starts_with() in WP_Theme_JSON and WP_Duotone

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -989,7 +989,7 @@ class WP_Duotone_Gutenberg {
 
 		$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
 		foreach ( $inner_classnames as $classname ) {
-			if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
+			if ( str_starts_with( $classname, 'wp-duotone' ) ) {
 				$tags->remove_class( $classname );
 				$tags->seek( 'wrapper-div' );
 				$tags->add_class( $classname );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -5318,7 +5318,7 @@ class WP_Theme_JSON_Gutenberg {
 		$prefix_len = strlen( $prefix );
 		$token_in   = '|';
 		$token_out  = '--';
-		if ( 0 === strpos( $value, $prefix ) ) {
+		if ( str_starts_with( $value, $prefix ) ) {
 			$unwrapped_name = str_replace(
 				$token_in,
 				$token_out,
@@ -5342,7 +5342,7 @@ class WP_Theme_JSON_Gutenberg {
 		$prefix = 'var:';
 
 		foreach ( $tree as $key => $data ) {
-			if ( is_string( $data ) && 0 === strpos( $data, $prefix ) ) {
+			if ( is_string( $data ) && str_starts_with( $data, $prefix ) ) {
 				$tree[ $key ] = self::convert_custom_properties( $data );
 			} elseif ( is_array( $data ) ) {
 				$tree[ $key ] = self::resolve_custom_css_format( $data );


### PR DESCRIPTION
## What?
Refactor: Replace `strpos()` with `str_starts_with()` for improved consistency.

## Why?
These changes are already merged into Core:

- https://github.com/WordPress/wordpress-develop/commit/6c22d69a47d99fc19cc935dcb69472b010521466
- https://github.com/WordPress/wordpress-develop/commit/fdbd29eaba67e30d13ac8a72fe550b2f8fc03e46
