### PR TITLE
Button: Fix corner artifacts by using background-clip: border-box

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `IconButton`: Restore the default tooltip delay on hover ([#79505](https://github.com/WordPress/gutenberg/pull/79505)).
+-   `Button`: Fix corner artifacts by using `background-clip: border-box` ([#79524](https://github.com/WordPress/gutenberg/pull/79524))
 
 ### Internal
 

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -53,7 +53,7 @@
 			border-color: var(--wp-ui-button-border-color);
 			border-radius: var(--wpds-border-radius-sm);
 			background-color: var(--wp-ui-button-background-color);
-			background-clip: padding-box;
+			background-clip: border-box;
 			font-family: var(--wpds-typography-font-family-body);
 			font-size: var(--wp-ui-button-font-size);
 			font-weight: var(--wp-ui-button-font-weight);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #79501
Fixes corner artifacts (halo/double-edge effect) visible when hovering buttons at high zoom or on high-density displays

## Why?
The Button component used `background-clip: padding-box`, which causes the browser to antialias the border's inner edge and the background's outer edge as two separate paint operations. At high zoom or on Retina/HiDPI displays, these independent antialias curves don't perfectly align, creating a faint stepped/halo artifact around the rounded corners. This affects all button variants (solid, outline, minimal) 

## How?
Changed `background-clip` from `padding-box` to `border-box`. With border-box, the background fills the entire border area in a single paint operation, eliminating the separate antialiased boundary between the border and background. 

## Testing Instructions
1. Open Storybook (npm run storybook:dev) and navigate to Design System > Components > IconButton.
2. Use the Storybook zoom control (top-right toolbar) to set zoom to 800%.
3. Hover over the button in any story (Default, Outline, Minimal, Neutral, Neutral Outline, Minimal Neutral Small).
4. Confirm the hover state renders as a single clean, rounded rectangle with no visible secondary edge or halo around the corners.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between be

fore and after the change. -->

|Before|After|
|-|-|
|<img width="350" height="346" alt="Screenshot 2026-06-28 at 10 16 58 PM" src="https://github.com/user-attachments/assets/c4c2d889-f011-421f-b551-301c76851822" />|<img width="363" height="356" alt="Screenshot 2026-06-28 at 10 21 16 PM" src="https://github.com/user-attachments/assets/1f69f5c7-6ee6-4b56-8902-a89c620a24fc" />|





