### PR TITLE
Playlist block: Workaround: Prevent escaping of HTML entities in attributes

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -249,7 +249,19 @@ const PlaylistTrackEdit = ( {
 							value={ title }
 							placeholder={ __( 'Add title' ) }
 							onChange={ ( value ) => {
-								setAttributes( { title: value } );
+								// Calling `stripHTML` here is WRONG. This is
+								// done so that HTML entities may be rendered
+								// literally ('&amp;' -> '&'). However, the
+								// fundamental problem is that attributes
+								// `title` and `artist` are defined as of type
+								// `string` when they most likely should be
+								// `rich-text`. But declaring their types as
+								// `rich-text` will set off PHP notices in both
+								// editor and frontend until this REST
+								// validation issue is fixed:
+								//
+								// https://github.com/WordPress/gutenberg/issues/72180
+								setAttributes( { title: stripHTML( value ) } );
 							} }
 							allowedFormats={ [] }
 							withoutInteractiveFormatting
@@ -261,7 +273,23 @@ const PlaylistTrackEdit = ( {
 								value={ artist }
 								placeholder={ __( 'Add artist' ) }
 								onChange={ ( value ) =>
-									setAttributes( { artist: value } )
+									setAttributes( {
+										// Calling `stripHTML` here is WRONG.
+										// This is done so that HTML entities
+										// may be rendered literally ('&amp;'
+										// -> '&'). However, the fundamental
+										// problem is that attributes `title`
+										// and `artist` are defined as of type
+										// `string` when they most likely
+										// should be `rich-text`. But declaring
+										// their types as `rich-text` will set
+										// off PHP notices in both editor and
+										// frontend until this REST validation
+										// issue is fixed:
+										//
+										// https://github.com/WordPress/gutenberg/issues/72180
+										artist: stripHTML( value ),
+									} )
 								}
 								allowedFormats={ [] }
 								withoutInteractiveFormatting


### PR DESCRIPTION
## What?

See visual comparison below. Inputting characters like `&` in the editable area for a playlist track's title or artist results in a `&amp;` being rendered in the waveform player. This PR fixes that.

Before | After
-|-
<img alt="playlist-htmlentities-before" src="https://github.com/user-attachments/assets/28da4f14-2f4c-4246-96a6-233fca408137" /> | <img alt="playlist-htmlentities-after" src="https://github.com/user-attachments/assets/880e1528-be5d-4a9f-8176-1a9b6c938a02" />

## How?

As a workaround, by passing the values through `stripHTML` as they come out of `RichText` and are passed to `setAttributes`.

The fundamental problem is that Playlist Track's `title` and `artist` attributes are defined as of type `string` when they most likely should be `rich-text` if they are to be edited via the `RichText` component. _But declaring their types as `rich-text` will set off PHP notices in both editor and frontend until this REST validation issue is fixed: See #72180_

Other than the proper fix (see linked issue), there may be better workarounds than this. Using the `PlainText` component makes more sense semantically, but requires fixing the styling of the editable area.