### PR TITLE
LetterSpacingControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   The `__next40pxDefaultSize` prop is now true by default on `__experimentalLetterSpacingControl`. The prop can be safely removed.
+-   The `__next40pxDefaultSize` prop is now true by default on `__experimentalLetterSpacingControl`. The prop can be safely removed ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
-    -   `__experimentalLetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
+    -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
--   The `__next40pxDefaultSize` prop is now true by default on `__experimentalLetterSpacingControl`. The prop can be safely removed ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
+-   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
+    -   `__experimentalLetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `__next40pxDefaultSize` prop is now true by default on `__experimentalLetterSpacingControl`. The prop can be safely removed.
+
 ### Deprecations
 
 -   Soft-deprecate the `__experimentalImageEditor` component. The Media Editor modal is now the default crop experience for core blocks ([#78654](https://github.com/WordPress/gutenberg/pull/78654)).

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -678,7 +678,6 @@ export default function TypographyPanel( {
 					<LetterSpacingControl
 						value={ letterSpacing }
 						onChange={ setLetterSpacing }
-						size="__unstable-large"
 						__unstableInputWidth="auto"
 					/>
 				</ToolsPanelItem>

--- a/packages/block-editor/src/components/letter-spacing-control/README.md
+++ b/packages/block-editor/src/components/letter-spacing-control/README.md
@@ -19,7 +19,6 @@ const MyLetterSpacingControl = () => (
 		value={ value }
 		onChange={ onChange }
 		__unstableInputWidth="auto"
-		__next40pxDefaultSize
 	/>
 );
 ```
@@ -45,13 +44,6 @@ A callback function invoked when the value is changed.
 -   **Default:** `undefined`
 
 Input width to pass through to inner UnitControl. Should be a valid CSS value.
-
-#### `__next40pxDefaultSize`
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Start opting into the larger default height that will become the default size in a future version.
 
 ## Related components
 

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -5,7 +5,6 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -18,6 +17,9 @@ import { useSettings } from '../../components/use-settings';
  *
  * @param {Object}                  props                       Component props.
  * @param {boolean}                 props.__next40pxDefaultSize Start opting into the larger default height that will become the default size in a future version.
+ *
+ * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+ * @ignore
  * @param {string}                  props.value                 Currently selected letter-spacing.
  * @param {Function}                props.onChange              Handles change in letter-spacing selection.
  * @param {string|number|undefined} props.__unstableInputWidth  Input width to pass through to inner UnitControl. Should be a valid CSS value.
@@ -25,7 +27,7 @@ import { useSettings } from '../../components/use-settings';
  * @return {Element} Letter-spacing control.
  */
 export default function LetterSpacingControl( {
-	__next40pxDefaultSize = false,
+	__next40pxDefaultSize: _next40pxDefaultSize,
 	value,
 	onChange,
 	__unstableInputWidth = '60px',
@@ -37,23 +39,9 @@ export default function LetterSpacingControl( {
 		defaultValues: { px: 2, em: 0.2, rem: 0.2 },
 	} );
 
-	if (
-		! __next40pxDefaultSize &&
-		( otherProps.size === undefined || otherProps.size === 'default' )
-	) {
-		deprecated(
-			`36px default size for wp.blockEditor.__experimentalLetterSpacingControl`,
-			{
-				since: '6.8',
-				version: '7.1',
-				hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
-			}
-		);
-	}
-
 	return (
 		<UnitControl
-			__next40pxDefaultSize={ __next40pxDefaultSize }
+			__next40pxDefaultSize
 			__shouldNotWarnDeprecated36pxSize
 			{ ...otherProps }
 			label={ __( 'Letter spacing' ) }

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -15,18 +15,16 @@ import { useSettings } from '../../components/use-settings';
 /**
  * Control for letter-spacing.
  *
- * @param {Object}                  props                       Component props.
- * @param {boolean}                 props.__next40pxDefaultSize Start opting into the larger default height that will become the default size in a future version.
- *
- * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
- * @ignore
- * @param {string}                  props.value                 Currently selected letter-spacing.
- * @param {Function}                props.onChange              Handles change in letter-spacing selection.
- * @param {string|number|undefined} props.__unstableInputWidth  Input width to pass through to inner UnitControl. Should be a valid CSS value.
+ * @param {Object}                  props                         Component props.
+ * @param {boolean}                 [props.__next40pxDefaultSize] Start opting into the larger default height that will become the default size in a future version.
+ * @param {string}                  props.value                   Currently selected letter-spacing.
+ * @param {Function}                props.onChange                Handles change in letter-spacing selection.
+ * @param {string|number|undefined} props.__unstableInputWidth    Input width to pass through to inner UnitControl. Should be a valid CSS value.
  *
  * @return {Element} Letter-spacing control.
  */
 export default function LetterSpacingControl( {
+	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
 	__next40pxDefaultSize: _next40pxDefaultSize,
 	value,
 	onChange,

--- a/packages/block-editor/src/components/letter-spacing-control/stories/index.story.jsx
+++ b/packages/block-editor/src/components/letter-spacing-control/stories/index.story.jsx
@@ -46,24 +46,12 @@ const meta = {
 				defaultValue: { summary: '60px' },
 			},
 		},
-		__next40pxDefaultSize: {
-			control: 'boolean',
-			description:
-				'Start opting into the larger default height that will become the default size in a future version.',
-			table: {
-				type: { summary: 'boolean' },
-				defaultValue: { summary: 'false' },
-			},
-		},
 	},
 };
 
 export default meta;
 
 export const Default = {
-	args: {
-		__next40pxDefaultSize: true,
-	},
 	render: function Template( { onChange, ...args } ) {
 		const [ value, setValue ] = useState( '' );
 		return (

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -17,7 +17,6 @@ The following components are checked by this rule:
 -   FormFileUpload (special case - see below)
 -   FormTokenField
 -   InputControl
--   LetterSpacingControl
 -   LineHeightControl
 -   NumberControl
 -   RangeControl

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -117,7 +117,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					FontFamilyControl,
 					FormTokenField,
 					InputControl,
-					LetterSpacingControl,
 					LineHeightControl,
 					NumberControl,
 					RangeControl,
@@ -133,7 +132,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					<FontFamilyControl __next40pxDefaultSize />
 					<FormTokenField __next40pxDefaultSize />
 					<InputControl __next40pxDefaultSize />
-					<LetterSpacingControl __next40pxDefaultSize />
 					<LineHeightControl __next40pxDefaultSize />
 					<NumberControl __next40pxDefaultSize />
 					<RangeControl __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -22,7 +22,6 @@ const COMPONENTS_REQUIRING_40PX = new Set( [
 	'FormTokenField',
 	'IconButton',
 	'InputControl',
-	'LetterSpacingControl',
 	'LineHeightControl',
 	'NumberControl',
 	'Radio',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -174,6 +174,7 @@ const restrictedSyntax = [
 		'BoxControl',
 		'FocalPointPicker',
 		'FontSizePicker',
+		'LetterSpacingControl',
 		'QueryControls',
 		'TextControl',
 	].map( ( componentName ) => ( {


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the deprecated `__next40pxDefaultSize` prop from `__experimentalLetterSpacingControl` (`LetterSpacingControl`), making the 40px default size the permanent default.

## Why?

The soft deprecation was introduced in WP 6.8 with a 36px console warning when the prop was not set. Block Editor typography wrappers are being updated before the primitives they embed.

## How?

- Remove `__next40pxDefaultSize` from the `LetterSpacingControl` runtime API and remove the 36px soft-deprecation warning.
- Keep a `@deprecated` `@ignore` JSDoc stub for external callers (per #46741).
- Keep passing `__next40pxDefaultSize` internally to the embedded `UnitControl` until that primitive is hard-deprecated.
- Update README and Storybook.
- Remove `LetterSpacingControl` from the `components-no-missing-40px-size-prop` ESLint rule and add a restricted-syntax rule for passing the prop to `LetterSpacingControl`.

## Testing Instructions

1. Open Storybook to **BlockEditor / LetterSpacingControl** and smoke test the default story.
2. In the editor, select a block with typography controls (e.g. Paragraph) and confirm Letter spacing in the Typography panel renders at 40px height.
3. Confirm letter-spacing changes still work.
4. Confirm no console warnings are logged.