### PR TITLE
Divider: Restore lower border specificity

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 -   Document the safe `clsx` pattern for conditional CSS Module classes ([#79490](https://github.com/WordPress/gutenberg/pull/79490)).
 
+### Bug Fixes
+
+-   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
+
 ### Internal
 
 -   `Surface`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#79445](https://github.com/WordPress/gutenberg/pull/79445)).

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -7,7 +7,7 @@
 	margin-block-start: var(--wp-components-divider-margin-start, 0);
 	margin-block-end: var(--wp-components-divider-margin-end, 0);
 
-	&[aria-orientation="vertical"] {
+	&:where([aria-orientation="vertical"]) {
 		display: inline;
 		border-block-end: 0;
 		border-inline-end: 1px solid currentColor;

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -1,20 +1,20 @@
 .divider {
 	border: 0;
 	margin: 0;
-	border-block-end: 1px solid currentColor;
-	block-size: 0;
-	inline-size: auto;
-	margin-block-start: var(--wp-components-divider-margin-start, 0);
-	margin-block-end: var(--wp-components-divider-margin-end, 0);
 
-	&:where([aria-orientation="vertical"]) {
+	&:where([aria-orientation="horizontal"]) {
+		border-block-end: 1px solid currentColor;
+		block-size: 0;
+		inline-size: auto;
+		margin-block-start: var(--wp-components-divider-margin-start, 0);
+		margin-block-end: var(--wp-components-divider-margin-end, 0);
+	}
+
+	&[aria-orientation="vertical"] {
 		display: inline;
-		border-block-end: 0;
 		border-inline-end: 1px solid currentColor;
 		block-size: auto;
 		inline-size: 0;
-		margin-block-start: 0;
-		margin-block-end: 0;
 		margin-inline-start: var(--wp-components-divider-margin-start, 0);
 		margin-inline-end: var(--wp-components-divider-margin-end, 0);
 	}

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -1,20 +1,20 @@
 .divider {
 	border: 0;
 	margin: 0;
-
-	&[aria-orientation="horizontal"] {
-		border-block-end: 1px solid currentColor;
-		block-size: 0;
-		inline-size: auto;
-		margin-block-start: var(--wp-components-divider-margin-start, 0);
-		margin-block-end: var(--wp-components-divider-margin-end, 0);
-	}
+	border-block-end: 1px solid currentColor;
+	block-size: 0;
+	inline-size: auto;
+	margin-block-start: var(--wp-components-divider-margin-start, 0);
+	margin-block-end: var(--wp-components-divider-margin-end, 0);
 
 	&[aria-orientation="vertical"] {
 		display: inline;
+		border-block-end: 0;
 		border-inline-end: 1px solid currentColor;
 		block-size: auto;
 		inline-size: 0;
+		margin-block-start: 0;
+		margin-block-end: 0;
 		margin-inline-start: var(--wp-components-divider-margin-start, 0);
 		margin-inline-end: var(--wp-components-divider-margin-end, 0);
 	}

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -1,11 +1,16 @@
 .divider {
-	border: 0;
+	// Keep style/color on the base selector so legacy border color overrides win.
+	// Use explicit width longhands to avoid optimizer issues with border shorthands.
+	border-block-start-width: 0;
+	border-block-end-width: 0;
+	border-inline-start-width: 0;
+	border-inline-end-width: 0;
+	border-style: solid;
+	border-color: currentColor;
 	margin: 0;
 
-	// Keep the horizontal selector at the pre-#79444 specificity so existing custom
-	// border color overrides continue to win.
-	&:where([aria-orientation="horizontal"]) {
-		border-block-end: 1px solid currentColor;
+	&[aria-orientation="horizontal"] {
+		border-block-end-width: 1px;
 		block-size: 0;
 		inline-size: auto;
 		margin-block-start: var(--wp-components-divider-margin-start, 0);
@@ -14,7 +19,7 @@
 
 	&[aria-orientation="vertical"] {
 		display: inline;
-		border-inline-end: 1px solid currentColor;
+		border-inline-end-width: 1px;
 		block-size: auto;
 		inline-size: 0;
 		margin-inline-start: var(--wp-components-divider-margin-start, 0);

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -2,6 +2,8 @@
 	border: 0;
 	margin: 0;
 
+	// Keep the horizontal selector at the pre-#79444 specificity so existing custom
+	// border color overrides continue to win.
 	&:where([aria-orientation="horizontal"]) {
 		border-block-end: 1px solid currentColor;
 		block-size: 0;

--- a/packages/components/src/divider/style.module.scss
+++ b/packages/components/src/divider/style.module.scss
@@ -1,25 +1,20 @@
 .divider {
-	// Keep style/color on the base selector so legacy border color overrides win.
-	// Use explicit width longhands to avoid optimizer issues with border shorthands.
-	border-block-start-width: 0;
-	border-block-end-width: 0;
-	border-inline-start-width: 0;
-	border-inline-end-width: 0;
-	border-style: solid;
-	border-color: currentColor;
+	border: 0;
 	margin: 0;
 
-	&[aria-orientation="horizontal"] {
-		border-block-end-width: 1px;
+	// Keep the orientation selectors at the pre-#79444 specificity so existing
+	// border overrides continue to win.
+	&:where([aria-orientation="horizontal"]) {
+		border-block-end: 1px solid currentColor;
 		block-size: 0;
 		inline-size: auto;
 		margin-block-start: var(--wp-components-divider-margin-start, 0);
 		margin-block-end: var(--wp-components-divider-margin-end, 0);
 	}
 
-	&[aria-orientation="vertical"] {
+	&:where([aria-orientation="vertical"]) {
 		display: inline;
-		border-inline-end-width: 1px;
+		border-inline-end: 1px solid currentColor;
 		block-size: auto;
 		inline-size: 0;
 		margin-inline-start: var(--wp-components-divider-margin-start, 0);


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/79444#issuecomment-4798247128

## What?
Restores `Divider` custom border overrides after the #79444 SCSS Module migration.

## Why?
The migration moved divider border declarations into orientation selectors such as `.divider[aria-orientation="horizontal"]`. That made the default border styles more specific than legacy `hr` overrides, such as complementary-area rules that set a full border shorthand.

## How?
Keeps the separate horizontal and vertical orientation blocks from trunk, but wraps both orientation selectors in `:where()`.

This preserves the orientation-specific CSS structure while removing the additional attribute-selector specificity, so existing border overrides can continue to win.

## Testing Instructions
1. Start Storybook with `npm run storybook:dev`.
2. Open `Components / Divider`.
3. Confirm the horizontal Divider still renders.
4. Confirm the vertical Divider still renders.
5. In a complementary area or equivalent wrapper that styles `hr` with a custom border shorthand, confirm the custom border style wins over the Divider default border style.

### Testing Instructions for Keyboard
No keyboard-specific behavior changed. `Divider` remains a non-interactive separator.

## Screenshots or screencast
N/A: CSS specificity regression fix only.

## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex and reviewed before publishing.
