### PR TITLE
Jest: Mock CSS module class names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21305,6 +21305,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
 			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"license": "MIT",
 			"dependencies": {
 				"camel-case": "^4.1.2",
 				"capital-case": "^1.0.4",
@@ -51499,7 +51500,8 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/jest-console": "file:../jest-console",
-				"babel-jest": "^29.7.0"
+				"babel-jest": "^29.7.0",
+				"change-case": "^4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -176,14 +176,14 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                     data-wp-component="VStack"
                   >
                     <span
-                      class="truncate components-truncate components-color-palette__custom-color-name emotion-14 emotion-5"
+                      class="style-truncate components-truncate components-color-palette__custom-color-name emotion-14 emotion-5"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >
                       red
                     </span>
                     <span
-                      class="truncate components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex emotion-14 emotion-5"
+                      class="style-truncate components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex emotion-14 emotion-5"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -176,14 +176,14 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                     data-wp-component="VStack"
                   >
                     <span
-                      class="components-truncate components-color-palette__custom-color-name emotion-14 emotion-5"
+                      class="truncate components-truncate components-color-palette__custom-color-name emotion-14 emotion-5"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >
                       red
                     </span>
                     <span
-                      class="components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex emotion-14 emotion-5"
+                      class="truncate components-truncate components-color-palette__custom-color-value components-color-palette__custom-color-value--is-hex emotion-14 emotion-5"
                       data-wp-c16t="true"
                       data-wp-component="Truncate"
                     >

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Documentation
 
--   Document the safe `clsx` pattern for conditional CSS Module classes ([#79490](https://github.com/WordPress/gutenberg/pull/79490)).
+-   Document `clsx` object syntax for conditional CSS Module classes ([#79490](https://github.com/WordPress/gutenberg/pull/79490), [#79535](https://github.com/WordPress/gutenberg/pull/79535)).
 
 ### Bug Fixes
 

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -418,7 +418,7 @@ On the component's main named export, add a JSDoc comment that includes the main
 
 All new components should be styled using SCSS Modules.
 
-Place component-local styles in a `style.module.scss` file next to the component, import the module from JavaScript or TypeScript, and compose class names with `clsx`. Preserve existing public `components-*` class names where consumers may rely on them. For dynamic values, prefer inline CSS custom properties consumed by the SCSS module. For variants and state, prefer conditional module classes composed with `clsx`. When a conditional class comes from a CSS module, use `condition && styles.className` instead of a computed object key (`{ [ styles.className ]: condition }`), because CSS modules are mocked as empty objects in Jest tests, which result in a literal `undefined` class.
+Place component-local styles in a `style.module.scss` file next to the component, import the module from JavaScript or TypeScript, and compose class names with `clsx`. Preserve existing public `components-*` class names where consumers may rely on them. For dynamic values, prefer inline CSS custom properties consumed by the SCSS module. For variants and state, prefer conditional module classes composed with `clsx` object syntax, e.g. `{ [ styles.className ]: condition }`.
 
 Legacy components may still use Emotion while they are being migrated, but new Emotion usage should not be added.
 
@@ -446,8 +446,10 @@ function MyComponent( { __nextHasNoOuterMargins = false, className } ) {
 				'components-my-component',
 				styles.root,
 				className,
-				! __nextHasNoOuterMargins &&
-					styles.deprecatedOuterMargins
+				{
+					[ styles.deprecatedOuterMargins ]:
+						! __nextHasNoOuterMargins,
+				}
 			) }
 		/>
 	);

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -171,8 +171,8 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="surface components-surface components-card css-1hgll2p-PolymorphicDiv-Card-boxShadowless-rounded e19lxcc00"
-+     class="surface components-surface components-card css-11ld97d-PolymorphicDiv-Card-rounded e19lxcc00"
+-     class="style-surface components-surface components-card css-1hgll2p-PolymorphicDiv-Card-boxShadowless-rounded e19lxcc00"
++     class="style-surface components-surface components-card css-11ld97d-PolymorphicDiv-Card-rounded e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -374,7 +374,7 @@ exports[`Card Card component should render correctly 1`] = `
 
 <div>
   <div
-    class="surface components-surface components-card emotion-0 emotion-1"
+    class="style-surface components-surface components-card emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Card"
   >
@@ -404,7 +404,7 @@ exports[`Card Card component should render correctly 1`] = `
       </div>
       <hr
         aria-orientation="horizontal"
-        class="divider components-divider emotion-10 emotion-11 components-card__divider components-card-divider"
+        class="style-divider components-divider emotion-10 emotion-11 components-card__divider components-card-divider"
         data-wp-c16t="true"
         data-wp-component="CardDivider"
         role="separator"
@@ -543,7 +543,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 
 <div>
   <div
-    class="surface components-surface components-card emotion-0 emotion-1"
+    class="style-surface components-surface components-card emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Card"
   >

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -171,8 +171,8 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="components-surface components-card css-1hgll2p-PolymorphicDiv-Card-boxShadowless-rounded e19lxcc00"
-+     class="components-surface components-card css-11ld97d-PolymorphicDiv-Card-rounded e19lxcc00"
+-     class="surface components-surface components-card css-1hgll2p-PolymorphicDiv-Card-boxShadowless-rounded e19lxcc00"
++     class="surface components-surface components-card css-11ld97d-PolymorphicDiv-Card-rounded e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -374,7 +374,7 @@ exports[`Card Card component should render correctly 1`] = `
 
 <div>
   <div
-    class="components-surface components-card emotion-0 emotion-1"
+    class="surface components-surface components-card emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Card"
   >
@@ -404,7 +404,7 @@ exports[`Card Card component should render correctly 1`] = `
       </div>
       <hr
         aria-orientation="horizontal"
-        class="components-divider emotion-10 emotion-11 components-card__divider components-card-divider"
+        class="divider components-divider emotion-10 emotion-11 components-card__divider components-card-divider"
         data-wp-c16t="true"
         data-wp-component="CardDivider"
         role="separator"
@@ -543,7 +543,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 
 <div>
   <div
-    class="components-surface components-card emotion-0 emotion-1"
+    class="surface components-surface components-card emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Card"
   >

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -163,6 +163,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
               target="_blank"
             >
               <span
+                class="visually-hidden"
                 data-visually-hidden=""
               >
                 (opens in a new tab)

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -163,7 +163,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
               target="_blank"
             >
               <span
-                class="visually-hidden"
+                class="style-visually-hidden"
                 data-visually-hidden=""
               >
                 (opens in a new tab)

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Mock CSS Module class names with kebab-case values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
+-   Mock CSS Module class names with identity values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
 
 ## 12.49.0 (2026-06-24)
 

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Mock CSS Module class names with prefixed values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
+-   Mock CSS Module class names with prefixed kebab-case values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
 
 ## 12.49.0 (2026-06-24)
 

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Mock CSS Module class names with kebab-case values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
+
 ## 12.49.0 (2026-06-24)
 
 ## 12.48.1 (2026-06-16)

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Mock CSS Module class names with identity values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
+-   Mock CSS Module class names with prefixed values in unit tests ([#79535](https://github.com/WordPress/gutenberg/pull/79535)).
 
 ## 12.49.0 (2026-06-24)
 

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -32,7 +32,8 @@
 	"main": "index.js",
 	"dependencies": {
 		"@wordpress/jest-console": "file:../jest-console",
-		"babel-jest": "^29.7.0"
+		"babel-jest": "^29.7.0",
+		"change-case": "^4.1.2"
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7",

--- a/packages/jest-preset-default/scripts/style-mock.js
+++ b/packages/jest-preset-default/scripts/style-mock.js
@@ -1,1 +1,25 @@
-module.exports = {};
+function toKebabCase( value ) {
+	return String( value )
+		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
+		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
+		.toLowerCase();
+}
+
+const styles = new Proxy(
+	{},
+	{
+		get( target, property ) {
+			if ( property === '__esModule' ) {
+				return false;
+			}
+
+			if ( typeof property === 'symbol' ) {
+				return target[ property ];
+			}
+
+			return toKebabCase( property );
+		},
+	}
+);
+
+module.exports = styles;

--- a/packages/jest-preset-default/scripts/style-mock.js
+++ b/packages/jest-preset-default/scripts/style-mock.js
@@ -1,16 +1,14 @@
+const cssClass = ( property ) => `style-${ property }`;
+
 const styles = new Proxy(
 	{},
 	{
 		get( target, property ) {
-			if ( property === '__esModule' ) {
-				return false;
+			if ( typeof property === 'string' && property !== '__esModule' ) {
+				return cssClass( property );
 			}
 
-			if ( typeof property === 'symbol' ) {
-				return target[ property ];
-			}
-
-			return property;
+			return Reflect.get( target, property );
 		},
 	}
 );

--- a/packages/jest-preset-default/scripts/style-mock.js
+++ b/packages/jest-preset-default/scripts/style-mock.js
@@ -1,8 +1,4 @@
-const kebabCase = ( property ) =>
-	property
-		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
-		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
-		.toLowerCase();
+const { paramCase: kebabCase } = require( 'change-case' );
 
 const cssClass = ( property ) => `style-${ kebabCase( property ) }`;
 

--- a/packages/jest-preset-default/scripts/style-mock.js
+++ b/packages/jest-preset-default/scripts/style-mock.js
@@ -1,4 +1,10 @@
-const cssClass = ( property ) => `style-${ property }`;
+const kebabCase = ( property ) =>
+	property
+		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
+		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
+		.toLowerCase();
+
+const cssClass = ( property ) => `style-${ kebabCase( property ) }`;
 
 const styles = new Proxy(
 	{},

--- a/packages/jest-preset-default/scripts/style-mock.js
+++ b/packages/jest-preset-default/scripts/style-mock.js
@@ -1,10 +1,3 @@
-function toKebabCase( value ) {
-	return String( value )
-		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
-		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
-		.toLowerCase();
-}
-
 const styles = new Proxy(
 	{},
 	{
@@ -17,7 +10,7 @@ const styles = new Proxy(
 				return target[ property ];
 			}
 
-			return toKebabCase( property );
+			return property;
 		},
 	}
 );

--- a/packages/jest-preset-default/scripts/test/style-mock.js
+++ b/packages/jest-preset-default/scripts/test/style-mock.js
@@ -1,10 +1,10 @@
 const styles = require( '../style-mock' );
 
 describe( 'style mock', () => {
-	it( 'returns kebab-case class names for CSS Module properties', () => {
+	it( 'returns identity class names for CSS Module properties', () => {
 		expect( styles.root ).toBe( 'root' );
-		expect( styles.className ).toBe( 'class-name' );
-		expect( styles.singleLineClamp ).toBe( 'single-line-clamp' );
+		expect( styles.className ).toBe( 'className' );
+		expect( styles.singleLineClamp ).toBe( 'singleLineClamp' );
 		expect( styles[ 'already-kebab' ] ).toBe( 'already-kebab' );
 	} );
 

--- a/packages/jest-preset-default/scripts/test/style-mock.js
+++ b/packages/jest-preset-default/scripts/test/style-mock.js
@@ -8,6 +8,19 @@ describe( 'style mock', () => {
 		expect( styles[ 'already-kebab' ] ).toBe( 'already-kebab' );
 	} );
 
+	it( 'does not emit an undefined class when used as an object key', () => {
+		const classes = {
+			[ styles.conditionalClass ]: true,
+		};
+
+		expect(
+			Object.keys( classes ).filter(
+				( className ) => classes[ className ]
+			)
+		).toEqual( [ 'conditionalClass' ] );
+		expect( classes ).not.toHaveProperty( 'undefined' );
+	} );
+
 	it( 'does not mark the CommonJS mock as an ES module', () => {
 		expect( styles.__esModule ).toBe( false );
 	} );

--- a/packages/jest-preset-default/scripts/test/style-mock.js
+++ b/packages/jest-preset-default/scripts/test/style-mock.js
@@ -1,0 +1,18 @@
+const styles = require( '../style-mock' );
+
+describe( 'style mock', () => {
+	it( 'returns kebab-case class names for CSS Module properties', () => {
+		expect( styles.root ).toBe( 'root' );
+		expect( styles.className ).toBe( 'class-name' );
+		expect( styles.singleLineClamp ).toBe( 'single-line-clamp' );
+		expect( styles[ 'already-kebab' ] ).toBe( 'already-kebab' );
+	} );
+
+	it( 'does not mark the CommonJS mock as an ES module', () => {
+		expect( styles.__esModule ).toBe( false );
+	} );
+
+	it( 'ignores symbol property access', () => {
+		expect( styles[ Symbol.toStringTag ] ).toBeUndefined();
+	} );
+} );

--- a/packages/jest-preset-default/scripts/test/style-mock.js
+++ b/packages/jest-preset-default/scripts/test/style-mock.js
@@ -1,28 +1,23 @@
+const clsx = require( 'clsx' );
 const styles = require( '../style-mock' );
 
 describe( 'style mock', () => {
-	it( 'returns identity class names for CSS Module properties', () => {
-		expect( styles.root ).toBe( 'root' );
-		expect( styles.className ).toBe( 'className' );
-		expect( styles.singleLineClamp ).toBe( 'singleLineClamp' );
-		expect( styles[ 'already-kebab' ] ).toBe( 'already-kebab' );
+	it( 'returns prefixed class names for CSS Module properties', () => {
+		expect( styles.root ).toBe( 'style-root' );
+		expect( styles.className ).toBe( 'style-className' );
 	} );
 
-	it( 'does not emit an undefined class when used as an object key', () => {
-		const classes = {
+	it( 'does not emit an undefined class when used with clsx object syntax', () => {
+		const classes = clsx( {
 			[ styles.conditionalClass ]: true,
-		};
+		} );
 
-		expect(
-			Object.keys( classes ).filter(
-				( className ) => classes[ className ]
-			)
-		).toEqual( [ 'conditionalClass' ] );
-		expect( classes ).not.toHaveProperty( 'undefined' );
+		expect( classes ).toBe( 'style-conditionalClass' );
+		expect( classes ).not.toContain( 'undefined' );
 	} );
 
 	it( 'does not mark the CommonJS mock as an ES module', () => {
-		expect( styles.__esModule ).toBe( false );
+		expect( styles.__esModule ).toBeUndefined();
 	} );
 
 	it( 'ignores symbol property access', () => {

--- a/packages/jest-preset-default/test/style-mock.js
+++ b/packages/jest-preset-default/test/style-mock.js
@@ -1,5 +1,5 @@
 const clsx = require( 'clsx' );
-const styles = require( '../style-mock' );
+const styles = require( '../scripts/style-mock' );
 
 describe( 'style mock', () => {
 	it( 'returns prefixed class names for CSS Module properties', () => {

--- a/packages/jest-preset-default/test/style-mock.js
+++ b/packages/jest-preset-default/test/style-mock.js
@@ -2,9 +2,12 @@ const clsx = require( 'clsx' );
 const styles = require( '../scripts/style-mock' );
 
 describe( 'style mock', () => {
-	it( 'returns prefixed class names for CSS Module properties', () => {
+	it( 'returns prefixed kebab-case class names for CSS Module properties', () => {
 		expect( styles.root ).toBe( 'style-root' );
-		expect( styles.className ).toBe( 'style-className' );
+		expect( styles.className ).toBe( 'style-class-name' );
+		expect( styles.singleLineClamp ).toBe( 'style-single-line-clamp' );
+		expect( styles.Content ).toBe( 'style-content' );
+		expect( styles[ 'already-kebab' ] ).toBe( 'style-already-kebab' );
 	} );
 
 	it( 'does not emit an undefined class when used with clsx object syntax', () => {
@@ -12,7 +15,7 @@ describe( 'style mock', () => {
 			[ styles.conditionalClass ]: true,
 		} );
 
-		expect( classes ).toBe( 'style-conditionalClass' );
+		expect( classes ).toBe( 'style-conditional-class' );
 		expect( classes ).not.toContain( 'undefined' );
 	} );
 

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -450,6 +450,8 @@ describe( 'Popover', () => {
 			expect(
 				await screen.findByText( 'Unstyled content' )
 			).toBeVisible();
+			const unstyledPopup = unstyledRef.current;
+			expect( unstyledPopup ).not.toBeNull();
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Open styled' } )
@@ -458,7 +460,7 @@ describe( 'Popover', () => {
 
 			const styledClasses = Array.from( styledPopup.classList );
 			for ( const cls of styledClasses ) {
-				expect( unstyledRef.current! ).not.toHaveClass( cls );
+				expect( unstyledPopup! ).not.toHaveClass( cls );
 			}
 		} );
 	} );


### PR DESCRIPTION
## What?
Follow up to #79490.

Updates the CSS Module class guidance in `packages/components/CONTRIBUTING.md` to recommend `clsx` object syntax for conditional module classes.

## Why?
The previous guidance avoided object syntax because Jest mocked CSS Module imports as empty objects, which could produce a literal `undefined` class. As suggested in https://github.com/WordPress/gutenberg/pull/79490#issuecomment-4798777972, that is better fixed in Jest instead of discouraging the normal `clsx` pattern.

## How?
- Changes the default Jest CSS/SCSS mock to return prefixed kebab-case class names for accessed properties, using `change-case` for the kebab-case conversion.
- Adds unit coverage for CSS Module property access and `clsx` object syntax.
- Updates the components contributing guide prose and example to use `clsx` object syntax.
- Adds package changelog entries for `@wordpress/components` and `@wordpress/jest-preset-default`.

## Testing Instructions
1. Run `npm run lint:md:docs -- packages/components/CONTRIBUTING.md`.
2. Run `npm run lint:js -- packages/jest-preset-default/scripts/style-mock.js packages/jest-preset-default/test/style-mock.js packages/ui/src/popover/test/index.test.tsx`.
3. Run `npm run lint:pkg-json -- packages/jest-preset-default/package.json`.
4. Run `npm run lint:lockfile`.
5. Run `npm run lint:deps`.
6. Run `npm run test:unit -- packages/block-editor/src/components/color-palette/test/control.js packages/editor/src/components/post-publish-panel/test/index.js packages/components/src/card/test/index.tsx packages/ui/src/popover/test/index.test.tsx packages/jest-preset-default/test/style-mock.js`.

### Testing Instructions for Keyboard
Not applicable; documentation and test infrastructure only.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Created with assistance from ChatGPT/Codex and reviewed before opening this PR.
