### PR TITLE
SearchControl: Complete __next40pxDefaultSize cleanup

### DIFF
--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -58,9 +58,9 @@ function SuffixItem( {
 
 function UnforwardedSearchControl(
 	{
+		// Prevent passing legacy props to internal component.
 		__nextHasNoMarginBottom: _,
 		__next40pxDefaultSize: _next40pxDefaultSize,
-		// Prevent passing legacy props to internal component
 		className,
 		onChange,
 		value,

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -59,7 +59,8 @@ function SuffixItem( {
 function UnforwardedSearchControl(
 	{
 		__nextHasNoMarginBottom: _,
-		__next40pxDefaultSize: _next40pxDefaultSize, // Prevent passing legacy props to internal component
+		__next40pxDefaultSize: _next40pxDefaultSize,
+		// Prevent passing legacy props to internal component
 		className,
 		onChange,
 		value,

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -58,7 +58,8 @@ function SuffixItem( {
 
 function UnforwardedSearchControl(
 	{
-		__nextHasNoMarginBottom: _, // Prevent passing to internal component
+		__nextHasNoMarginBottom: _,
+		__next40pxDefaultSize: _next40pxDefaultSize, // Prevent passing legacy props to internal component
 		className,
 		onChange,
 		value,

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -5,10 +5,13 @@ import type { InputControlProps } from '../input-control/types';
 
 export type SearchControlProps = Pick< InputControlProps, 'help' | 'value' > & {
 	/**
-	 * @deprecated This is now the default.
+	 * Start opting into the larger default height that will become the
+	 * default size in a future version.
+	 *
+	 * @deprecated Default behavior since WP 6.7. Prop can be safely removed.
 	 * @ignore
 	 */
-	__next40pxDefaultSize?: InputControlProps[ '__next40pxDefaultSize' ];
+	__next40pxDefaultSize?: boolean;
 	/**
 	 * Start opting into the new margin-free styles that will become the default in a future version.
 	 *

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -5,13 +5,10 @@ import type { InputControlProps } from '../input-control/types';
 
 export type SearchControlProps = Pick< InputControlProps, 'help' | 'value' > & {
 	/**
-	 * Start opting into the larger default height that will become the
-	 * default size in a future version.
-	 *
-	 * @deprecated Default behavior since WP 6.7. Prop can be safely removed.
+	 * @deprecated This is now the default.
 	 * @ignore
 	 */
-	__next40pxDefaultSize?: boolean;
+	__next40pxDefaultSize?: InputControlProps[ '__next40pxDefaultSize' ];
 	/**
 	 * Start opting into the new margin-free styles that will become the default in a future version.
 	 *

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -417,7 +417,6 @@ export function HierarchicalTermSelector( { slug } ) {
 		<Flex direction="column" gap="4">
 			{ showFilter && ! loading && (
 				<SearchControl
-					__next40pxDefaultSize
 					label={ filterLabel }
 					placeholder={ filterLabel }
 					value={ filterValue }

--- a/storybook/stories/icons/library.story.tsx
+++ b/storybook/stories/icons/library.story.tsx
@@ -123,7 +123,6 @@ const LibraryExample = ( {
 			<VStack spacing={ 8 }>
 				<HStack justify="flex-start" alignment="end" spacing={ 8 } wrap>
 					<SearchControl
-						__next40pxDefaultSize
 						label="Icon name"
 						hideLabelFromVision={ false }
 						value={ filter }

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -176,6 +176,7 @@ const restrictedSyntax = [
 		'FocalPointPicker',
 		'FontSizePicker',
 		'QueryControls',
+		'SearchControl',
 		'TextControl',
 	].map( ( componentName ) => ( {
 		selector: `JSXElement[openingElement.name.name="${ componentName }"] JSXAttribute[name.name="__next40pxDefaultSize"]`,


### PR DESCRIPTION
## What?

Follow up to #65751

`SearchControl` already unconditionally renders 40px child controls. This PR finishes the remaining bookkeeping: runtime prop stripping and ESLint.

## Why?

The public `__next40pxDefaultSize` prop was deprecated in WP 6.7 and has been a noop since the component hardcodes it on the embedded `InputControl`. This aligns lint rules with that reality and prevents the prop from leaking onto `InputControl` via `...restProps`.

## How?

- Destructure `__next40pxDefaultSize` in `SearchControl` so it is not spread onto `InputControl`.
- Add a restricted-syntax rule to forbid passing `__next40pxDefaultSize` to `SearchControl`.

No runtime behavior change.

## Testing Instructions

1. Open Storybook to **Components / SearchControl** and smoke test the default story.
2. Open the block inserter search field and confirm the search input still renders at 40px height.
3. Confirm no console warnings are logged.