### PR TITLE
Tabs: Fix dirty editor state on mount caused by tab-list sync

### DIFF
--- a/packages/block-library/src/tabs/use-tab-list-items-sync.js
+++ b/packages/block-library/src/tabs/use-tab-list-items-sync.js
@@ -1,9 +1,14 @@
 /**
+ * External dependencies
+ */
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
+
+/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Keep the tab-list block's `tabs` attribute in sync with the tab-panel blocks.
@@ -19,8 +24,7 @@ import { useEffect, useRef } from '@wordpress/element';
 export default function useTabListItemsSync( { tabPanels, tabListClientId } ) {
 	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-
-	const prevTabsRef = useRef( null );
+	const { getBlockAttributes } = useSelect( blockEditorStore );
 
 	useEffect( () => {
 		if ( ! tabListClientId ) {
@@ -31,18 +35,18 @@ export default function useTabListItemsSync( { tabPanels, tabListClientId } ) {
 			label: tab.attributes.label || '',
 		} ) );
 
-		// Only update if tabs actually changed to avoid unnecessary re-renders.
-		const serialized = JSON.stringify( newTabs );
-		if ( serialized === prevTabsRef.current ) {
+		// Skip the update when the stored tabs already match the derived ones.
+		const currentTabs = getBlockAttributes( tabListClientId )?.tabs ?? [];
+		if ( fastDeepEqual( newTabs, currentTabs ) ) {
 			return;
 		}
-		prevTabsRef.current = serialized;
 
 		__unstableMarkNextChangeAsNotPersistent();
 		updateBlockAttributes( tabListClientId, { tabs: newTabs } );
 	}, [
 		tabPanels,
 		tabListClientId,
+		getBlockAttributes,
 		updateBlockAttributes,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );


### PR DESCRIPTION
## What?
Part of #73230.
Related #78989.

PR updates tab list sync effect to avoid making the post dirty when block mounts. Note: this was only affected environments with React StrictMode enabled.

Fix fetches current tabs from the store and uses them for comparison. I've also replaced JSON string comparison with `fastDeepEqual`.

## Why
`useTabListItemsSync` wrote the tab-list `tabs` attribute on every mount (`prevTabsRef` started `null`), even when the stored value already matched the panel labels. The write is marked non-persistent, but `__unstableMarkNextChangeAsNotPersistent` is a single global one-shot flag. Under React StrictMode, the effect double-fires and interleaves with other mount-time dispatches, so the marker gets consumed elsewhere, and this update lands as a persistent change, dirtying the post on load.

## Testing Instructions
1. With React StrictMode enabled.
2. Open a post.
3. Insert the Tabs blocks.
4. Save the post.
5. Reload the editor.
6. Freshly saved post shouldn't become dirty.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
