### PR TITLE
Add custom meta field sorting & filtering in Query loop block

### DIFF
--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -48,3 +48,235 @@ function gutenberg_override_attachments_rest_controller( $args, $post_type ) {
 	return $args;
 }
 add_filter( 'register_post_type_args', 'gutenberg_override_attachments_rest_controller', 10, 2 );
+
+/**
+ * Registers the meta-query collection params on a single post-type endpoint.
+ *
+ * @param array $params The current collection params for the endpoint.
+ * @return array Modified params array.
+ */
+function gutenberg_add_meta_query_collection_params( $params ) {
+	/*
+	* Using `meta_key` can result in slow queries on sites with large amounts of post meta.
+	* However, it is a necessary evil for ordering by custom field values.
+	*/
+	$params['meta_key'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'description'       => __( 'Custom meta field key to sort or filter by.', 'gutenberg' ),
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_key',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['meta_type'] = array(
+		'description'       => __( 'Data type of the meta field value, used for correct comparison.', 'gutenberg' ),
+		'type'              => 'string',
+		'enum'              => array( 'CHAR', 'NUMERIC', 'DATE', 'DATETIME', 'DECIMAL', 'SIGNED', 'TIME', 'UNSIGNED' ),
+		'default'           => 'CHAR',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['date_range'] = array(
+		'description'       => __( 'Preset date-range filter applied against the meta field.', 'gutenberg' ),
+		'type'              => 'string',
+		'enum'              => array( '', 'future', 'past', 'today', 'custom' ),
+		'default'           => '',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['meta_date_start'] = array(
+		'description'       => __( 'Start date for custom date range filter.', 'gutenberg' ),
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['meta_date_end'] = array(
+		'description'       => __( 'End date for custom date range filter.', 'gutenberg' ),
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['meta_value_filter'] = array(
+		'description'       => __( 'Value to compare the meta field against.', 'gutenberg' ),
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	$params['meta_compare'] = array(
+		'description'       => __( 'Operator to use for the meta field comparison.', 'gutenberg' ),
+		'type'              => 'string',
+		'enum'              => array( '=', '!=', '>', '<', 'LIKE' ),
+		'default'           => '=',
+		'sanitize_callback' => 'sanitize_text_field',
+		'validate_callback' => 'rest_validate_request_arg',
+	);
+
+	if ( isset( $params['orderby'] ) && isset( $params['orderby']['enum'] ) ) {
+		if ( ! in_array( 'meta_value', $params['orderby']['enum'], true ) ) {
+			$params['orderby']['enum'][] = 'meta_value';
+		}
+		if ( ! in_array( 'meta_value_num', $params['orderby']['enum'], true ) ) {
+			$params['orderby']['enum'][] = 'meta_value_num';
+		}
+	}
+
+	return $params;
+}
+
+/**
+ * Applies meta key ordering and filtering to the WP_Query arguments for REST API requests.
+ *
+ * Parses the meta-related collection parameters provided by the Query Loop block
+ * and translates them into native `WP_Query` and `WP_Meta_Query` arguments.
+ * Supports meta value sorting, preset and custom date-range filtering, and generic
+ * text/numeric filtering. Includes the `query_loop_meta_clause` filter to allow
+ * third-party plugins to intercept and modify the generated meta clause.
+ * Mirrors the frontend rendering logic to ensure the Editor preview matches the frontend.
+ *
+ * @since 23.4.0
+ *
+ * @param array           $args    WP_Query arguments array being built.
+ * @param WP_REST_Request $request Full details about the REST request.
+ * @param string          $post_type The post type slug current being queried.
+ * @return array Returns the modified WP_Query arguments.
+ */
+function gutenberg_apply_meta_query_rest_args( $args, $request, $post_type = 'post' ) {
+	$meta_key          = $request->get_param( 'meta_key' );
+	$meta_type         = $request->get_param( 'meta_type' );
+	$date_range        = $request->get_param( 'date_range' );
+	$start_date        = $request->get_param( 'meta_date_start' );
+	$end_date          = $request->get_param( 'meta_date_end' );
+	$meta_value_filter = $request->get_param( 'meta_value_filter' );
+	$order_by          = $args['orderby'] ?? '';
+
+	if ( ! $meta_type ) {
+		$meta_type = 'CHAR';
+	}
+
+	$meta_compare_raw = $request->get_param( 'meta_compare' ) ? $request->get_param( 'meta_compare' ) : '=';
+	$meta_compare     = html_entity_decode( $meta_compare_raw );
+	if ( ! in_array( $meta_compare, array( '=', '!=', '>', '<', 'LIKE' ), true ) ) {
+		$meta_compare = '=';
+	}
+
+	if ( empty( $meta_key ) || is_protected_meta( $meta_key, $post_type ) ) {
+		return $args;
+	}
+
+	$meta_order_types = array( 'meta_value', 'meta_value_num' );
+	if ( in_array( $order_by, $meta_order_types, true ) ) {
+		/*
+		 * Using `meta_key` can result in slow queries on sites with large amounts of post meta.
+		 * However, it is a necessary evil for ordering by custom field values.
+		 */
+		$args['meta_key']  = $meta_key; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		$args['meta_type'] = $meta_type;
+
+		if ( 'DATE' === $meta_type ) {
+			$args['orderby'] = 'meta_value';
+		}
+	}
+
+	$meta_clause = null;
+
+	if ( ! empty( $date_range ) ) {
+		$today = current_time( 'Y-m-d' );
+
+		if ( 'custom' === $date_range ) {
+			if ( $start_date && $end_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => array( $start_date, $end_date ),
+					'compare' => 'BETWEEN',
+					'type'    => $meta_type,
+				);
+			} elseif ( $start_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $start_date,
+					'compare' => '>=',
+					'type'    => $meta_type,
+				);
+			} elseif ( $end_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $end_date,
+					'compare' => '<=',
+					'type'    => $meta_type,
+				);
+			}
+		} else {
+			$compare_map = array(
+				'future' => '>=',
+				'past'   => '<',
+				'today'  => '=',
+			);
+
+			if ( isset( $compare_map[ $date_range ] ) ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $today,
+					'compare' => $compare_map[ $date_range ],
+					'type'    => $meta_type,
+				);
+			}
+		}
+	} elseif ( null !== $meta_value_filter && '' !== $meta_value_filter ) {
+		$meta_clause = array(
+			'key'     => $meta_key,
+			'value'   => $meta_value_filter,
+			'compare' => $meta_compare,
+			'type'    => $meta_type,
+		);
+	}
+	if ( $meta_clause ) {
+		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $meta_key, $date_range, $meta_type, $start_date, $end_date );
+
+		if ( $meta_clause && is_array( $meta_clause ) ) {
+			/*
+			 * Using `meta_query` can result in slow queries on sites with large amounts of post meta.
+			 * However, it is a necessary evil for filtering by custom field values.
+			 */
+			if ( ! empty( $args['meta_query'] ) ) {
+				$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					$args['meta_query'],
+					$meta_clause,
+				);
+			} else {
+				$args['meta_query'] = array( $meta_clause ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			}
+		}
+	}
+
+	return $args;
+}
+
+/**
+ * Registers the meta-query params and query filter on every public REST-
+ * enabled post type during `rest_api_init`.
+ */
+function gutenberg_register_meta_query_rest_params() {
+	$post_types = get_post_types( array( 'show_in_rest' => true ) );
+
+	foreach ( $post_types as $post_type ) {
+		add_filter(
+			"rest_{$post_type}_collection_params",
+			'gutenberg_add_meta_query_collection_params'
+		);
+
+		add_filter(
+			"rest_{$post_type}_query",
+			function ( $args, $request ) use ( $post_type ) {
+				return gutenberg_apply_meta_query_rest_args( $args, $request, $post_type );
+			},
+			10,
+			2
+		);
+	}
+}
+add_action( 'rest_api_init', 'gutenberg_register_meta_query_rest_params' );

--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -160,8 +160,8 @@ function gutenberg_apply_meta_query_rest_args( $args, $request, $post_type = 'po
 		$meta_type = 'CHAR';
 	}
 
-	$meta_compare_raw = $request->get_param( 'meta_compare' ) ? $request->get_param( 'meta_compare' ) : '=';
-	$meta_compare     = html_entity_decode( $meta_compare_raw );
+	$meta_compare_raw          = $request->get_param( 'meta_compare' ) ? $request->get_param( 'meta_compare' ) : '=';
+	$meta_compare              = html_entity_decode( $meta_compare_raw );
 	$allowed_compare_operators = apply_filters(
 		'query_loop_allowed_meta_compare_operators',
 		array( '=', '!=', '>', '<', 'LIKE' )

--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -109,7 +109,10 @@ function gutenberg_add_meta_query_collection_params( $params ) {
 	$params['meta_compare'] = array(
 		'description'       => __( 'Operator to use for the meta field comparison.', 'gutenberg' ),
 		'type'              => 'string',
-		'enum'              => array( '=', '!=', '>', '<', 'LIKE' ),
+		'enum'              => apply_filters(
+			'query_loop_allowed_meta_compare_operators',
+			array( '=', '!=', '>', '<', 'LIKE' )
+		),
 		'default'           => '=',
 		'sanitize_callback' => 'sanitize_text_field',
 		'validate_callback' => 'rest_validate_request_arg',
@@ -159,15 +162,33 @@ function gutenberg_apply_meta_query_rest_args( $args, $request, $post_type = 'po
 
 	$meta_compare_raw = $request->get_param( 'meta_compare' ) ? $request->get_param( 'meta_compare' ) : '=';
 	$meta_compare     = html_entity_decode( $meta_compare_raw );
-	if ( ! in_array( $meta_compare, array( '=', '!=', '>', '<', 'LIKE' ), true ) ) {
+	$allowed_compare_operators = apply_filters(
+		'query_loop_allowed_meta_compare_operators',
+		array( '=', '!=', '>', '<', 'LIKE' )
+	);
+
+	if ( ! in_array( $meta_compare, $allowed_compare_operators, true ) ) {
 		$meta_compare = '=';
 	}
 
-	if ( empty( $meta_key ) || is_protected_meta( $meta_key, $post_type ) ) {
+	$is_meta_key_allowed = apply_filters(
+		'query_loop_is_meta_key_allowed',
+		! is_protected_meta( $meta_key, $post_type ),
+		$meta_key,
+		$post_type
+	);
+
+	if ( empty( $meta_key ) || ! $is_meta_key_allowed ) {
 		return $args;
 	}
 
-	$meta_order_types = array( 'meta_value', 'meta_value_num' );
+	$meta_order_types = apply_filters(
+		'query_loop_meta_order_types',
+		array( 'meta_value', 'meta_value_num' ),
+		$meta_key,
+		$meta_type
+	);
+
 	if ( in_array( $order_by, $meta_order_types, true ) ) {
 		/*
 		 * Using `meta_key` can result in slow queries on sites with large amounts of post meta.
@@ -181,60 +202,74 @@ function gutenberg_apply_meta_query_rest_args( $args, $request, $post_type = 'po
 		}
 	}
 
-	$meta_clause = null;
+	$meta_clause = apply_filters(
+		'query_loop_pre_build_meta_clause',
+		null,
+		$post_type,
+		$meta_key,
+		$meta_type,
+		$meta_compare,
+		$meta_value_filter,
+		$date_range,
+		$start_date,
+		$end_date
+	);
 
-	if ( ! empty( $date_range ) ) {
-		$today = current_time( 'Y-m-d' );
+	if ( null === $meta_clause ) {
+		if ( ! empty( $date_range ) ) {
+			$today = current_time( 'Y-m-d' );
 
-		if ( 'custom' === $date_range ) {
-			if ( $start_date && $end_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => array( $start_date, $end_date ),
-					'compare' => 'BETWEEN',
-					'type'    => $meta_type,
+			if ( 'custom' === $date_range ) {
+				if ( $start_date && $end_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => array( $start_date, $end_date ),
+						'compare' => 'BETWEEN',
+						'type'    => $meta_type,
+					);
+				} elseif ( $start_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $start_date,
+						'compare' => '>=',
+						'type'    => $meta_type,
+					);
+				} elseif ( $end_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $end_date,
+						'compare' => '<=',
+						'type'    => $meta_type,
+					);
+				}
+			} else {
+				$compare_map = array(
+					'future' => '>=',
+					'past'   => '<',
+					'today'  => '=',
 				);
-			} elseif ( $start_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $start_date,
-					'compare' => '>=',
-					'type'    => $meta_type,
-				);
-			} elseif ( $end_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $end_date,
-					'compare' => '<=',
-					'type'    => $meta_type,
-				);
+
+				if ( isset( $compare_map[ $date_range ] ) ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $today,
+						'compare' => $compare_map[ $date_range ],
+						'type'    => $meta_type,
+					);
+				}
 			}
-		} else {
-			$compare_map = array(
-				'future' => '>=',
-				'past'   => '<',
-				'today'  => '=',
+		} elseif ( null !== $meta_value_filter && '' !== $meta_value_filter ) {
+			$meta_clause = array(
+				'key'     => $meta_key,
+				'value'   => $meta_value_filter,
+				'compare' => $meta_compare,
+				'type'    => $meta_type,
 			);
-
-			if ( isset( $compare_map[ $date_range ] ) ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $today,
-					'compare' => $compare_map[ $date_range ],
-					'type'    => $meta_type,
-				);
-			}
 		}
-	} elseif ( null !== $meta_value_filter && '' !== $meta_value_filter ) {
-		$meta_clause = array(
-			'key'     => $meta_key,
-			'value'   => $meta_value_filter,
-			'compare' => $meta_compare,
-			'type'    => $meta_type,
-		);
 	}
+
 	if ( $meta_clause ) {
-		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $meta_key, $date_range, $meta_type, $start_date, $end_date );
+		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $post_type, $meta_key, $meta_type, $meta_compare, $meta_value_filter, $date_range, $start_date, $end_date );
 
 		if ( $meta_clause && is_array( $meta_clause ) ) {
 			/*
@@ -251,6 +286,7 @@ function gutenberg_apply_meta_query_rest_args( $args, $request, $post_type = 'po
 				$args['meta_query'] = array( $meta_clause ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			}
 		}
+		do_action( 'query_loop_meta_query_resolved', $meta_clause, $meta_key, $post_type );
 	}
 
 	return $args;

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -103,6 +103,13 @@ export default function PostTemplateEdit( {
 			parents,
 			pages,
 			format,
+			metaKey,
+			metaType,
+			dateRange,
+			metaValue,
+			metaCompare,
+			metaDateStart,
+			metaDateEnd,
 			// We gather extra query args to pass to the REST API call.
 			// This way extenders of Query Loop can add their own query args,
 			// and have accurate previews in the editor.
@@ -203,6 +210,23 @@ export default function PostTemplateEdit( {
 			if ( format?.length ) {
 				query.format = format;
 			}
+			if ( metaKey ) {
+				query.meta_key = metaKey;
+				query.meta_type = metaType || 'CHAR';
+			}
+			if ( dateRange ) {
+				query.date_range = dateRange;
+			}
+			if ( metaValue ) {
+				query.meta_value_filter = metaValue;
+				query.meta_compare = metaCompare;
+			}
+			if ( metaDateStart ) {
+				query.meta_date_start = metaDateStart;
+			}
+			if ( metaDateEnd ) {
+				query.meta_date_end = metaDateEnd;
+			}
 
 			/*
 			 * Handle cases where sticky is set to `exclude` or `only`.
@@ -267,6 +291,13 @@ export default function PostTemplateEdit( {
 			taxQuery,
 			parents,
 			format,
+			metaKey,
+			metaType,
+			metaValue,
+			metaCompare,
+			dateRange,
+			metaDateStart,
+			metaDateEnd,
 			restQueryArgs,
 			previewPostType,
 		]

--- a/packages/block-library/src/query/README.md
+++ b/packages/block-library/src/query/README.md
@@ -16,7 +16,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
 |-----------|------|---------|-------------|
 | `queryId` | `number` | — | — |
-| `query` | `object` | `{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[],"format":[]}` | — |
+| `query` | `object` | `{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[],"format":[],"metaKey":"","metaType":"CHAR","dateRange":"","metaValue":"","metaCompare":"=","metaDateStart":"","metaDateEnd":""}` | — |
 | `tagName` | `string` | `"div"` | — |
 | `namespace` | `string` | — | — |
 | `enhancedPagination` | `boolean` | `false` | — |

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -27,7 +27,14 @@
 				"inherit": true,
 				"taxQuery": null,
 				"parents": [],
-				"format": []
+				"format": [],
+				"metaKey": "",
+				"metaType": "CHAR",
+				"dateRange": "",
+				"metaValue": "",
+				"metaCompare": "=",
+				"metaDateStart": "",
+				"metaDateEnd": ""
 			}
 		},
 		"tagName": {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -29,6 +29,7 @@ import StickyControl from './sticky-control';
 import PerPageControl from './per-page-control';
 import OffsetControl from './offset-controls';
 import PagesControl from './pages-control';
+import MetaQueryControls from './meta-query-controls';
 import {
 	usePostTypes,
 	useIsPostTypeHierarchical,
@@ -55,6 +56,13 @@ export default function QueryInspectorControls( props ) {
 		taxQuery,
 		parents,
 		format,
+		metaKey = '',
+		metaType = 'CHAR',
+		metaDateStart,
+		metaDateEnd,
+		dateRange = '',
+		metaValue = '',
+		metaCompare = '=',
 	} = query;
 	const allowedControls = useAllowedControls( attributes );
 	const showSticky = postType === 'post';
@@ -119,7 +127,7 @@ export default function QueryInspectorControls( props ) {
 		}, 250 );
 	}, [ setQuery ] );
 
-	const orderByOptions = useOrderByOptions( postType );
+	const orderByOptions = useOrderByOptions( postType, metaKey, metaType );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
@@ -171,12 +179,15 @@ export default function QueryInspectorControls( props ) {
 		[ allowedControls, postTypeHasFormatSupport ]
 	);
 
+	const showMetaQueryControl =
+		! inherit && isControlAllowed( allowedControls, 'metaQuery' );
 	const showFiltersPanel =
 		showTaxControl ||
 		showAuthorControl ||
 		showSearchControl ||
 		showParentControl ||
-		showFormatControl;
+		showFormatControl ||
+		showMetaQueryControl;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const showPostCountControl = isControlAllowed(
@@ -386,6 +397,13 @@ export default function QueryInspectorControls( props ) {
 							search: '',
 							taxQuery: null,
 							format: [],
+							metaKey: '',
+							metaDateStart: '',
+							metaDateEnd: '',
+							metaValue: '',
+							metaCompare: '=',
+							metaType: 'CHAR',
+							dateRange: '',
 						} );
 						setQuerySearch( '' );
 					} }
@@ -464,6 +482,41 @@ export default function QueryInspectorControls( props ) {
 							<FormatControls
 								onChange={ setQuery }
 								query={ query }
+							/>
+						</ToolsPanelItem>
+					) }
+					{ showMetaQueryControl && (
+						<ToolsPanelItem
+							label={ __( 'Meta field' ) }
+							hasValue={ () => !! metaKey }
+							onDeselect={ () =>
+								setQuery( {
+									metaKey: '',
+									metaType: 'CHAR',
+									metaDateStart: '',
+									metaDateEnd: '',
+									dateRange: '',
+									metaValue: '',
+									metaCompare: '=',
+									...( [
+										'meta_value',
+										'meta_value_num',
+									].includes( orderBy ) && {
+										orderBy: 'date',
+										order: 'desc',
+									} ),
+								} )
+							}
+						>
+							<MetaQueryControls
+								metaKey={ metaKey }
+								metaType={ metaType }
+								metaDateStart={ metaDateStart }
+								metaDateEnd={ metaDateEnd }
+								dateRange={ dateRange }
+								metaValue={ metaValue }
+								metaCompare={ metaCompare }
+								onChange={ setQuery }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -516,6 +516,7 @@ export default function QueryInspectorControls( props ) {
 								dateRange={ dateRange }
 								metaValue={ metaValue }
 								metaCompare={ metaCompare }
+								postType={ postType }
 								onChange={ setQuery }
 							/>
 						</ToolsPanelItem>

--- a/packages/block-library/src/query/edit/inspector-controls/meta-query-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/meta-query-controls.js
@@ -4,6 +4,7 @@
 import { TextControl, SelectControl } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 const META_TYPE_OPTIONS = [
 	{ label: __( 'Text' ), value: 'CHAR' },
@@ -35,9 +36,81 @@ export default function MetaQueryControls( {
 	metaDateEnd,
 	metaValue,
 	metaCompare,
+	postType,
 	onChange,
 } ) {
 	const isDateType = metaType === 'DATE';
+
+	/**
+	 * Filters the list of available meta field "type" options shown in the
+	 * Query Loop inspector. Lets plugins register additional types (e.g.
+	 * `DATETIME`) for specialized CPTs. The corresponding server side
+	 * resolution must be registered via the `query_loop_pre_build_meta_clause`
+	 *  & `query_loop_meta_clause` PHP filters.
+	 *
+	 * @param {Array}  options  Default meta type options.
+	 * @param {string} postType The post type currently configured on the block.
+	 */
+	const metaTypeOptions = applyFilters(
+		'blockLibrary.query.metaTypeOptions',
+		META_TYPE_OPTIONS,
+		postType
+	);
+
+	/**
+	 * Filters the list of date range presets shown in the Query Loop
+	 * inspector. Lets plugins register custom presets (e.g. "This week",
+	 * "Next 30 days") for event style CPTs. The corresponding server side
+	 * resolution must be registered via the `query_loop_pre_build_meta_clause`
+	 *  & `query_loop_meta_clause` PHP filters.
+	 *
+	 * @param {Array}  options  Default date range options.
+	 * @param {string} postType The post type currently configured on the block.
+	 */
+	const dateRangeOptions = applyFilters(
+		'blockLibrary.query.dateRangeOptions',
+		DATE_RANGE_OPTIONS,
+		postType
+	);
+
+	/**
+	 * Filters the list of comparison operators shown for generic meta value
+	 * filtering. The corresponding server side resolution must be registered
+	 * via the `query_loop_allowed_meta_compare_operators`,
+	 * `query_loop_pre_build_meta_clause` & `query_loop_meta_clause` PHP filters.
+	 *
+	 * @param {Array}  options  Default compare operators.
+	 * @param {string} postType The post type currently configured on the block.
+	 */
+	const compareOptions = applyFilters(
+		'blockLibrary.query.metaCompareOptions',
+		COMPARE_OPTIONS,
+		postType
+	);
+
+	/**
+	 * Filters the controls rendered for the Meta field panel, after the
+	 * built in controls. Lets plugins render entirely custom UI for specific
+	 * post types.
+	 *
+	 * @param {Element|null} controls Defaults to `null`.
+	 * @param {Object}       props    The full set of props passed to MetaQueryControls.
+	 */
+	const customControls = applyFilters(
+		'blockLibrary.query.metaQueryControlsAfter',
+		null,
+		{
+			metaKey,
+			metaType,
+			dateRange,
+			metaDateStart,
+			metaDateEnd,
+			metaValue,
+			metaCompare,
+			postType,
+			onChange,
+		}
+	);
 
 	return (
 		<Stack gap="lg" direction="column">
@@ -67,7 +140,7 @@ export default function MetaQueryControls( {
 						__next40pxDefaultSize
 						label={ __( 'Field type' ) }
 						value={ metaType }
-						options={ META_TYPE_OPTIONS }
+						options={ metaTypeOptions }
 						onChange={ ( value ) =>
 							onChange( {
 								metaType: value,
@@ -87,7 +160,7 @@ export default function MetaQueryControls( {
 								__next40pxDefaultSize
 								label={ __( 'Date filter' ) }
 								value={ dateRange }
-								options={ DATE_RANGE_OPTIONS }
+								options={ dateRangeOptions }
 								onChange={ ( value ) =>
 									onChange( { dateRange: value } )
 								}
@@ -122,7 +195,7 @@ export default function MetaQueryControls( {
 								__next40pxDefaultSize
 								label={ __( 'Filter operator' ) }
 								value={ metaCompare }
-								options={ COMPARE_OPTIONS }
+								options={ compareOptions }
 								onChange={ ( value ) =>
 									onChange( { metaCompare: value } )
 								}
@@ -142,6 +215,7 @@ export default function MetaQueryControls( {
 					) }
 				</>
 			) }
+			{ customControls }
 		</Stack>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/meta-query-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/meta-query-controls.js
@@ -1,0 +1,147 @@
+/**
+ * WordPress dependencies
+ */
+import { TextControl, SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+
+const META_TYPE_OPTIONS = [
+	{ label: __( 'Text' ), value: 'CHAR' },
+	{ label: __( 'Number' ), value: 'NUMERIC' },
+	{ label: __( 'Date' ), value: 'DATE' },
+];
+
+const DATE_RANGE_OPTIONS = [
+	{ label: __( 'Any date' ), value: '' },
+	{ label: __( 'Upcoming (today and future)' ), value: 'future' },
+	{ label: __( 'Past events' ), value: 'past' },
+	{ label: __( 'Today only' ), value: 'today' },
+	{ label: __( 'Custom range' ), value: 'custom' },
+];
+
+const COMPARE_OPTIONS = [
+	{ label: __( 'Equals' ), value: '=' },
+	{ label: __( 'Not Equals' ), value: '!=' },
+	{ label: __( 'Contains' ), value: 'LIKE' },
+	{ label: __( 'Greater Than' ), value: '>' },
+	{ label: __( 'Less Than' ), value: '<' },
+];
+
+export default function MetaQueryControls( {
+	metaKey,
+	metaType,
+	dateRange,
+	metaDateStart,
+	metaDateEnd,
+	metaValue,
+	metaCompare,
+	onChange,
+} ) {
+	const isDateType = metaType === 'DATE';
+
+	return (
+		<Stack gap="lg" direction="column">
+			<TextControl
+				__next40pxDefaultSize
+				label={ __( 'Meta field key' ) }
+				help={ __( 'Enter the exact custom field key' ) }
+				value={ metaKey }
+				onChange={ ( value ) =>
+					onChange( {
+						metaKey: value,
+						...( ! value && {
+							metaType: 'CHAR',
+							dateRange: '',
+							metaDateStart: '',
+							metaDateEnd: '',
+							metaValue: '',
+							metaCompare: '=',
+						} ),
+					} )
+				}
+			/>
+
+			{ !! metaKey && (
+				<>
+					<SelectControl
+						__next40pxDefaultSize
+						label={ __( 'Field type' ) }
+						value={ metaType }
+						options={ META_TYPE_OPTIONS }
+						onChange={ ( value ) =>
+							onChange( {
+								metaType: value,
+								...( value !== 'DATE' && {
+									dateRange: '',
+									metaDateStart: '',
+									metaDateEnd: '',
+								} ),
+								...( value === 'DATE' && { metaValue: '' } ),
+							} )
+						}
+					/>
+
+					{ isDateType ? (
+						<Stack gap="lg" direction="column">
+							<SelectControl
+								__next40pxDefaultSize
+								label={ __( 'Date filter' ) }
+								value={ dateRange }
+								options={ DATE_RANGE_OPTIONS }
+								onChange={ ( value ) =>
+									onChange( { dateRange: value } )
+								}
+							/>
+
+							{ dateRange === 'custom' && (
+								<Stack gap="md" direction="column">
+									<TextControl
+										__next40pxDefaultSize
+										type="date"
+										label={ __( 'Start date' ) }
+										value={ metaDateStart }
+										onChange={ ( value ) =>
+											onChange( { metaDateStart: value } )
+										}
+									/>
+									<TextControl
+										__next40pxDefaultSize
+										type="date"
+										label={ __( 'End date' ) }
+										value={ metaDateEnd }
+										onChange={ ( value ) =>
+											onChange( { metaDateEnd: value } )
+										}
+									/>
+								</Stack>
+							) }
+						</Stack>
+					) : (
+						<Stack gap="lg" direction="column">
+							<SelectControl
+								__next40pxDefaultSize
+								label={ __( 'Filter operator' ) }
+								value={ metaCompare }
+								options={ COMPARE_OPTIONS }
+								onChange={ ( value ) =>
+									onChange( { metaCompare: value } )
+								}
+							/>
+							<TextControl
+								__next40pxDefaultSize
+								label={ __( 'Filter value' ) }
+								help={ __(
+									'Leave blank to only sort without filtering.'
+								) }
+								value={ metaValue }
+								onChange={ ( value ) =>
+									onChange( { metaValue: value } )
+								}
+							/>
+						</Stack>
+					) }
+				</>
+			) }
+		</Stack>
+	);
+}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -179,7 +179,7 @@ function block_core_query_apply_meta_query_vars( $query, $block ) {
 
 	$meta_compare_raw = isset( $query_context['metaCompare'] ) ? sanitize_text_field( $query_context['metaCompare'] ) : '=';
 	$meta_compare     = html_entity_decode( $meta_compare_raw );
-	
+
 	/**
 	 * Filters the list of operators allowed for generic meta value filtering.
 	 * This must stay in sync with any operators a plugin adds to the JS
@@ -350,9 +350,9 @@ function block_core_query_apply_meta_query_vars( $query, $block ) {
 		 *
 		 * @since 23.4.0
 		 *
-		 * @param array      $meta_clause  Return an array to overwrite core's logic. 
+		 * @param array      $meta_clause  Return an array to overwrite core's logic.
 		 * @param string     $post_type    The post type the query is running against.
-	 	 * @param string     $meta_key     The configured meta key.
+		 * @param string     $meta_key     The configured meta key.
 		 * @param string     $meta_type    The meta field's data type.
 		 * @param string     $meta_compare Generic filter compare operator.
 		 * @param string     $meta_value   Generic filter value (or '').

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -179,17 +179,72 @@ function block_core_query_apply_meta_query_vars( $query, $block ) {
 
 	$meta_compare_raw = isset( $query_context['metaCompare'] ) ? sanitize_text_field( $query_context['metaCompare'] ) : '=';
 	$meta_compare     = html_entity_decode( $meta_compare_raw );
-	if ( ! in_array( $meta_compare, array( '=', '!=', '>', '<', 'LIKE' ), true ) ) {
+	
+	/**
+	 * Filters the list of operators allowed for generic meta value filtering.
+	 * This must stay in sync with any operators a plugin adds to the JS
+	 * `blockLibrary.query.metaCompareOptions` filter, or they'll be silently
+	 * rejected here.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param string[] $allowed_operators Default: '=', '!=', '>', '<', 'LIKE'.
+	 */
+	$allowed_compare_operators = apply_filters(
+		'query_loop_allowed_meta_compare_operators',
+		array( '=', '!=', '>', '<', 'LIKE' )
+	);
+	if ( ! in_array( $meta_compare, $allowed_compare_operators, true ) ) {
 		$meta_compare = '=';
 	}
 
 	$order_by = $query['orderby'] ?? '';
 
-	if ( empty( $meta_key ) || is_protected_meta( $meta_key, $post_type ) ) {
+	/**
+	 * Filters whether a given meta key is allowed to be used for Query Loop
+	 * sorting/filtering on a given post type. Defaults to the core protected meta
+	 * check, but lets plugins allow list keys for their own CPTs (e.g. event
+	 * meta) or explicitly block additional keys.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param bool   $is_allowed Whether the meta key is allowed. Default based on `is_protected_meta()`.
+	 * @param string $meta_key   The meta key being requested.
+	 * @param string $post_type  The post type the query is running against.
+	 */
+	$is_meta_key_allowed = apply_filters(
+		'query_loop_is_meta_key_allowed',
+		! is_protected_meta( $meta_key, $post_type ),
+		$meta_key,
+		$post_type
+	);
+
+	if ( empty( $meta_key ) || ! $is_meta_key_allowed ) {
 		return $query;
 	}
 
-	$meta_order_types = array( 'meta_value', 'meta_value_num' );
+	/**
+	 * Filters the list of `orderby` values that should be treated as meta key
+	 * sorting (i.e. that trigger `meta_key`/`meta_type` to be set on the query).
+	 * Lets plugins register custom orderby values (e.g. `event_proximity`) that
+	 * should resolve against a meta key.
+	 * This must stay in sync with any `orderby value` a plugin adds to the JS
+	 * `blockLibrary.query.orderByOptions` filter, or they'll be silently
+	 * rejected here.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param string[] $meta_order_types Default: array( 'meta_value', 'meta_value_num' ).
+	 * @param string   $meta_key         The meta key configured on the block.
+	 * @param string   $meta_type        The meta field's data type.
+	 */
+	$meta_order_types = apply_filters(
+		'query_loop_meta_order_types',
+		array( 'meta_value', 'meta_value_num' ),
+		$meta_key,
+		$meta_type
+	);
+
 	if ( in_array( $order_by, $meta_order_types, true ) ) {
 		/*
 		* Using `meta_key` can result in slow queries on sites with large amounts of post meta.
@@ -203,61 +258,109 @@ function block_core_query_apply_meta_query_vars( $query, $block ) {
 		}
 	}
 
-	$meta_clause = null;
+	/**
+	 * Filters the meta clause before core attempts to build one from the
+	 * `dateRange`/`metaValue` attributes. Return a non null array to fully
+	 * override clause construction, useful for registering brand new date
+	 * presets (e.g. "this_week", "next_30_days") or entirely custom filtering
+	 * UIs for specialized CPTs like events.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param array|null $meta_clause  Null by default; return an array to overwrite core's logic.
+	 * @param string     $post_type    The post type the query is running against.
+	 * @param string     $meta_key     The configured meta key.
+	 * @param string     $meta_type    The meta field's data type.
+	 * @param string     $meta_compare Generic filter compare operator.
+	 * @param string     $meta_value   Generic filter value (or '').
+	 * @param string     $date_range   The configured date range preset (or '').
+	 * @param string     $start_date   Custom range start date (or '').
+	 * @param string     $end_date     Custom range end date (or '').
+	 */
+	$meta_clause = apply_filters(
+		'query_loop_pre_build_meta_clause',
+		null,
+		$post_type,
+		$meta_key,
+		$meta_type,
+		$meta_compare,
+		$meta_value,
+		$date_range,
+		$start_date,
+		$end_date
+	);
 
-	if ( ! empty( $date_range ) ) {
-		$today = current_time( 'Y-m-d' );
+	if ( null === $meta_clause ) {
+		if ( ! empty( $date_range ) ) {
+			$today = current_time( 'Y-m-d' );
 
-		if ( 'custom' === $date_range ) {
-			if ( $start_date && $end_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => array( $start_date, $end_date ),
-					'compare' => 'BETWEEN',
-					'type'    => $meta_type,
+			if ( 'custom' === $date_range ) {
+				if ( $start_date && $end_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => array( $start_date, $end_date ),
+						'compare' => 'BETWEEN',
+						'type'    => $meta_type,
+					);
+				} elseif ( $start_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $start_date,
+						'compare' => '>=',
+						'type'    => $meta_type,
+					);
+				} elseif ( $end_date ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $end_date,
+						'compare' => '<=',
+						'type'    => $meta_type,
+					);
+				}
+			} else {
+				$compare_map = array(
+					'future' => '>=',
+					'past'   => '<',
+					'today'  => '=',
 				);
-			} elseif ( $start_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $start_date,
-					'compare' => '>=',
-					'type'    => $meta_type,
-				);
-			} elseif ( $end_date ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $end_date,
-					'compare' => '<=',
-					'type'    => $meta_type,
-				);
+
+				if ( isset( $compare_map[ $date_range ] ) ) {
+					$meta_clause = array(
+						'key'     => $meta_key,
+						'value'   => $today,
+						'compare' => $compare_map[ $date_range ],
+						'type'    => $meta_type,
+					);
+				}
 			}
-		} else {
-			$compare_map = array(
-				'future' => '>=',
-				'past'   => '<',
-				'today'  => '=',
+		} elseif ( '' !== $meta_value ) {
+			$meta_clause = array(
+				'key'     => $meta_key,
+				'value'   => $meta_value,
+				'compare' => $meta_compare,
+				'type'    => $meta_type,
 			);
-
-			if ( isset( $compare_map[ $date_range ] ) ) {
-				$meta_clause = array(
-					'key'     => $meta_key,
-					'value'   => $today,
-					'compare' => $compare_map[ $date_range ],
-					'type'    => $meta_type,
-				);
-			}
 		}
-	} elseif ( '' !== $meta_value ) {
-		$meta_clause = array(
-			'key'     => $meta_key,
-			'value'   => $meta_value,
-			'compare' => $meta_compare,
-			'type'    => $meta_type,
-		);
 	}
 
 	if ( $meta_clause ) {
-		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $meta_key, $date_range, $meta_type, $start_date, $end_date );
+		/**
+		 * Filters the final meta clause before it's merged into the query's
+		 * `meta_query`.
+		 *
+		 * @since 23.4.0
+		 *
+		 * @param array      $meta_clause  Return an array to overwrite core's logic. 
+		 * @param string     $post_type    The post type the query is running against.
+	 	 * @param string     $meta_key     The configured meta key.
+		 * @param string     $meta_type    The meta field's data type.
+		 * @param string     $meta_compare Generic filter compare operator.
+		 * @param string     $meta_value   Generic filter value (or '').
+		 * @param string     $date_range   The configured date-range preset (or '').
+		 * @param string     $start_date   Custom range start date (or '').
+		 * @param string     $end_date     Custom range end date (or '').
+		 */
+		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $post_type, $meta_key, $meta_type, $meta_compare, $meta_value, $date_range, $start_date, $end_date );
 
 		if ( $meta_clause && is_array( $meta_clause ) ) {
 			if ( ! empty( $query['meta_query'] ) ) {
@@ -278,6 +381,19 @@ function block_core_query_apply_meta_query_vars( $query, $block ) {
 				$query['meta_query'] = array( $meta_clause ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			}
 		}
+
+		/**
+		 * Fires after a meta clause has been resolved and merged into the
+		 * Query Loop block's query. Useful for logging/debugging custom
+		 * sorting/filtering extensions.
+		 *
+		 * @since 23.4.0
+		 *
+		 * @param array    $meta_clause The resolved and filtered meta clause.
+		 * @param string   $meta_key    The configured meta key.
+		 * @param string   $post_type   The post type the query is running against.
+		 */
+		do_action( 'query_loop_meta_query_resolved', $meta_clause, $meta_key, $post_type );
 	}
 
 	return $query;

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -150,3 +150,136 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 }
 
 add_filter( 'render_block_data', 'block_core_query_disable_enhanced_pagination', 10, 1 );
+
+/**
+ * Applies meta key ordering and filtering to the Query Loop block's WP_Query arguments.
+ *
+ * Parses the `query` context attributes configured in the block's inspector controls
+ * and translates them into native `WP_Query` and `WP_Meta_Query` parameters.
+ * Supports meta value sorting, preset and custom date-range filtering, and generic
+ * text/numeric filtering. Includes the `query_loop_meta_clause` filter to allow
+ * third-party plugins to intercept and modify the generated meta clause.
+ *
+ * @since 23.4.0
+ *
+ * @param array    $query WP_Query arguments array being built.
+ * @param WP_Block $block The Query Loop block instance.
+ * @return array Returns the modified WP_Query arguments.
+ */
+function block_core_query_apply_meta_query_vars( $query, $block ) {
+	$query_context = $block->context['query'] ?? array();
+
+	$post_type  = isset( $query_context['postType'] ) ? sanitize_text_field( $query_context['postType'] ) : 'post';
+	$meta_key   = isset( $query_context['metaKey'] ) ? sanitize_key( $query_context['metaKey'] ) : '';
+	$meta_type  = isset( $query_context['metaType'] ) ? sanitize_text_field( $query_context['metaType'] ) : 'CHAR';
+	$date_range = isset( $query_context['dateRange'] ) ? sanitize_text_field( $query_context['dateRange'] ) : '';
+	$meta_value = isset( $query_context['metaValue'] ) ? sanitize_text_field( $query_context['metaValue'] ) : '';
+	$start_date = isset( $query_context['metaDateStart'] ) ? sanitize_text_field( $query_context['metaDateStart'] ) : '';
+	$end_date   = isset( $query_context['metaDateEnd'] ) ? sanitize_text_field( $query_context['metaDateEnd'] ) : '';
+
+	$meta_compare_raw = isset( $query_context['metaCompare'] ) ? sanitize_text_field( $query_context['metaCompare'] ) : '=';
+	$meta_compare     = html_entity_decode( $meta_compare_raw );
+	if ( ! in_array( $meta_compare, array( '=', '!=', '>', '<', 'LIKE' ), true ) ) {
+		$meta_compare = '=';
+	}
+
+	$order_by = $query['orderby'] ?? '';
+
+	if ( empty( $meta_key ) || is_protected_meta( $meta_key, $post_type ) ) {
+		return $query;
+	}
+
+	$meta_order_types = array( 'meta_value', 'meta_value_num' );
+	if ( in_array( $order_by, $meta_order_types, true ) ) {
+		/*
+		* Using `meta_key` can result in slow queries on sites with large amounts of post meta.
+		* However, it is a necessary evil for filtering by custom field values.
+		*/
+		$query['meta_key']  = $meta_key; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		$query['meta_type'] = $meta_type;
+
+		if ( 'DATE' === $meta_type ) {
+			$query['orderby'] = 'meta_value';
+		}
+	}
+
+	$meta_clause = null;
+
+	if ( ! empty( $date_range ) ) {
+		$today = current_time( 'Y-m-d' );
+
+		if ( 'custom' === $date_range ) {
+			if ( $start_date && $end_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => array( $start_date, $end_date ),
+					'compare' => 'BETWEEN',
+					'type'    => $meta_type,
+				);
+			} elseif ( $start_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $start_date,
+					'compare' => '>=',
+					'type'    => $meta_type,
+				);
+			} elseif ( $end_date ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $end_date,
+					'compare' => '<=',
+					'type'    => $meta_type,
+				);
+			}
+		} else {
+			$compare_map = array(
+				'future' => '>=',
+				'past'   => '<',
+				'today'  => '=',
+			);
+
+			if ( isset( $compare_map[ $date_range ] ) ) {
+				$meta_clause = array(
+					'key'     => $meta_key,
+					'value'   => $today,
+					'compare' => $compare_map[ $date_range ],
+					'type'    => $meta_type,
+				);
+			}
+		}
+	} elseif ( '' !== $meta_value ) {
+		$meta_clause = array(
+			'key'     => $meta_key,
+			'value'   => $meta_value,
+			'compare' => $meta_compare,
+			'type'    => $meta_type,
+		);
+	}
+
+	if ( $meta_clause ) {
+		$meta_clause = apply_filters( 'query_loop_meta_clause', $meta_clause, $meta_key, $date_range, $meta_type, $start_date, $end_date );
+
+		if ( $meta_clause && is_array( $meta_clause ) ) {
+			if ( ! empty( $query['meta_query'] ) ) {
+				/*
+				* Using `meta_query` can result in slow queries on sites with large amounts of post meta.
+				* However, it is a necessary evil for filtering by custom field values.
+				*/
+				$query['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					$query['meta_query'],
+					$meta_clause,
+				);
+			} else {
+				/*
+				* Using `meta_query` can result in slow queries on sites with large amounts of post meta.
+				* However, it is a necessary evil for filtering by custom field values.
+				*/
+				$query['meta_query'] = array( $meta_clause ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			}
+		}
+	}
+
+	return $query;
+}
+add_filter( 'query_loop_block_query_vars', 'block_core_query_apply_meta_query_vars', 10, 3 );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -12,6 +12,7 @@ import {
 	getBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { applyFilters } from '@wordpress/hooks';
 
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('@wordpress/components/build-types/query-controls/types').OrderByOption} OrderByOption */
@@ -270,8 +271,26 @@ export function useOrderByOptions( postType, metaKey = '', metaType = 'CHAR' ) {
 			}
 		}
 
-		return orderByOptions;
-	}, [ supportsCustomOrder, metaKey, metaType ] );
+		/**
+		 * Filters the list of order by options shown in the Query Loop inspector.
+		 * Lets plugins register custom sorting definitions (e.g. "Event proximity").
+		 * The corresponding server side resolution must be registered via the
+		 * `query_loop_meta_order_types`, `query_loop_pre_build_meta_clause`
+		 * & `query_loop_meta_clause` PHP filters.
+		 *
+		 * @param {Array}  options  Default order by options.
+		 * @param {string} postType The post type currently configured on the block.
+		 * @param {string} metaKey  The meta key currently configured on the block.
+		 * @param {string} metaType The data type of the meta field.
+		 */
+		return applyFilters(
+			'blockLibrary.query.orderByOptions',
+			orderByOptions,
+			postType,
+			metaKey,
+			metaType
+		);
+	}, [ supportsCustomOrder, metaKey, metaType, postType ] );
 }
 
 /**

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -192,9 +192,11 @@ export function useIsPostTypeHierarchical( postType ) {
  * List of avaiable options to order by.
  *
  * @param {string} postType The post type to check.
+ * @param {string} metaKey  Optional meta key; when provided, meta-value ordering options are appended to the list.
+ * @param {string} metaType The data type of the meta field.
  * @return {OrderByOption[]} List of order options.
  */
-export function useOrderByOptions( postType ) {
+export function useOrderByOptions( postType, metaKey = '', metaType = 'CHAR' ) {
 	const supportsCustomOrder = useSelect(
 		( select ) => {
 			const type = select( coreStore ).getPostType( postType );
@@ -240,8 +242,36 @@ export function useOrderByOptions( postType ) {
 			);
 		}
 
+		if ( metaKey ) {
+			const isNumericSorting = metaType !== 'CHAR';
+
+			if ( isNumericSorting ) {
+				orderByOptions.push(
+					{
+						label: __( 'Meta value (Ascending)' ),
+						value: 'meta_value_num/asc',
+					},
+					{
+						label: __( 'Meta value (Descending)' ),
+						value: 'meta_value_num/desc',
+					}
+				);
+			} else {
+				orderByOptions.push(
+					{
+						label: __( 'Meta value (A → Z)' ),
+						value: 'meta_value/asc',
+					},
+					{
+						label: __( 'Meta value (Z → A)' ),
+						value: 'meta_value/desc',
+					}
+				);
+			}
+		}
+
 		return orderByOptions;
-	}, [ supportsCustomOrder ] );
+	}, [ supportsCustomOrder, metaKey, metaType ] );
 }
 
 /**


### PR DESCRIPTION
## What?
Closes #72749

This pull request introduces advanced server-side and client-side sorting and filtering configuration controls for custom meta fields and custom date ranges directly within the Query Loop block settings.

## Why?
Users frequently need to query and arrange posts dynamically by custom field criteria, such as tracking event registration thresholds or upcoming event calendars, which was previously impossible without rolling custom theme code or heavy third-party plugins.

## How?
Expanded the Query Loop block schema and inspector controls to support custom meta field configurations, including dynamic date ranges and comparison operators.
Safely translates these block attributes into native WP_Meta_Query arguments across both frontend rendering and REST API endpoints while blocking protected metadata queries.
Ensures accurate editor previews by wiring the new parameters into the Post Template requests and exposes new PHP filters & actions for third-party query extensibility.

## Testing Instructions
1. Register a custom meta field for your post type or use a tool like ACF to create a custom text, number, or date field.
2. Open a new page or post and insert a Query Loop block.
3. Access the block sidebar settings panel and locate the new Meta Query configuration section.
4. Input your custom field key name, select the matching data type, and pick a custom evaluation condition.
5. Verify that changing options dynamically alters the block query list directly inside the Gutenberg editor canvas interface.
6. Publish the post and ensure that the public-facing webpage layout renders the identically filtered post collection perfectly.

## Screenshots or screencast
<img width="140" height="308" alt="image" src="https://github.com/user-attachments/assets/cef78911-64ae-4624-ba5e-c2b123f57ba1" />

## Use of AI Tools

This pull request was co-authored with Google Gemini AI to accelerate the restructuring of PHP database parameter mappings, and generate strict structural documentation summaries.