### PR TITLE
DataViews: Fix infinite-scroll jump on async page loads

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
-- DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer no longer mounts mid-load (resizing the scroll container) when there are no bulk actions to show. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
+- DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer's visibility no longer depends on the loading state, so it no longer mounts mid-load (resizing the scroll container). [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
 ## 17.1.0 (2026-07-01)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
-- DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads asynchronously, which made the list jump upward as each page settled. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
+- DataViews: Fix infinite scroll when pages load asynchronously: the list no longer jumps while a page loads, no longer stalls at the bottom, and the scroll position no longer bounces as the loading spinner appears and disappears. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
 ## 17.1.0 (2026-07-01)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
-- DataViews: Fix infinite scroll when pages load asynchronously: the list no longer jumps while a page loads, no longer stalls at the bottom, and the scroll position no longer bounces as the loading spinner appears and disappears. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
+- DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer no longer mounts mid-load (resizing the scroll container) when there are no bulk actions to show. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
 ## 17.1.0 (2026-07-01)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads asynchronously, which made the list jump upward as each page settled. [#79546](https://github.com/WordPress/gutenberg/pull/79546)
+
 ## 17.1.0 (2026-07-01)
 
 ## 17.0.0 (2026-06-24)

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -13,7 +13,9 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import DataViewsContext from '../dataviews-context';
-import DataViewsPagination from '../dataviews-pagination';
+import DataViewsPagination, {
+	hasPaginationControls,
+} from '../dataviews-pagination';
 import {
 	BulkActionsFooter,
 	useSomeItemHasAPossibleBulkAction,
@@ -41,41 +43,33 @@ export default function DataViewsFooter() {
 		useSomeItemHasAPossibleBulkAction( actions, data ) &&
 		[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type );
 
-	// Skip the footer for infinite scroll without bulk actions: it has nothing
-	// to show, and mounting it on each load resized the scroll container and
-	// jumped the list.
-	if ( view.infiniteScrollEnabled && ! hasBulkActions ) {
+	const hasPagination = hasPaginationControls( view, {
+		totalItems,
+		totalPages,
+	} );
+
+	if ( ! totalItems || ( ! hasBulkActions && ! hasPagination ) ) {
 		return null;
 	}
 
-	if (
-		! isRefreshing &&
-		( ! totalItems ||
-			! totalPages ||
-			( totalPages <= 1 && ! hasBulkActions ) )
-	) {
-		return null;
-	}
 	return (
-		( !! totalItems || isRefreshing ) && (
-			<div
-				className="dataviews-footer"
-				// @ts-ignore
-				inert={ isRefreshing ? 'true' : undefined }
+		<div
+			className="dataviews-footer"
+			// @ts-ignore
+			inert={ isRefreshing ? 'true' : undefined }
+		>
+			<Stack
+				direction="row"
+				justify="end"
+				align="center"
+				className={ clsx( 'dataviews-footer__content', {
+					'is-refreshing': isDelayedRefreshing,
+				} ) }
+				gap="sm"
 			>
-				<Stack
-					direction="row"
-					justify="end"
-					align="center"
-					className={ clsx( 'dataviews-footer__content', {
-						'is-refreshing': isDelayedRefreshing,
-					} ) }
-					gap="sm"
-				>
-					{ hasBulkActions && <BulkActionsFooter /> }
-					<DataViewsPagination />
-				</Stack>
-			</div>
-		)
+				{ hasBulkActions && <BulkActionsFooter /> }
+				<DataViewsPagination />
+			</Stack>
+		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -41,6 +41,13 @@ export default function DataViewsFooter() {
 		useSomeItemHasAPossibleBulkAction( actions, data ) &&
 		[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type );
 
+	// Skip the footer for infinite scroll without bulk actions: it has nothing
+	// to show, and mounting it on each load resized the scroll container and
+	// jumped the list.
+	if ( view.infiniteScrollEnabled && ! hasBulkActions ) {
+		return null;
+	}
+
 	if (
 		! isRefreshing &&
 		( ! totalItems ||

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -394,6 +394,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list' );
 	const isDelayedLoading = useDelayedLoading( !! isLoading );
+	const { paginationInfo } = useContext( DataViewsContext );
 
 	const selectedItem = data?.findLast( ( item ) =>
 		selection.includes( getItemId( item ) )
@@ -535,6 +536,11 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const dataByGroup =
 		hasData && groupField ? getDataByGroup( data, groupField ) : null;
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
+	// Whether the server still has rows beyond the current window.
+	const hasMoreToLoad =
+		isInfiniteScroll &&
+		( view.startPosition ?? 1 ) + ( view.perPage ?? 0 ) <
+			paginationInfo.totalItems;
 	if ( ! hasData ) {
 		return (
 			<div
@@ -663,8 +669,14 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					);
 				} ) }
 			</Composite>
-			{ isInfiniteScroll && isLoading && (
-				<p className="dataviews-loading-more">
+			{ ( hasMoreToLoad || ( isInfiniteScroll && isLoading ) ) && (
+				// Keep the spinner mounted until everything is loaded so its
+				// height stays reserved and the scroll position doesn't bounce as
+				// loading starts/stops. Hidden (and silent to a11y) while idle.
+				<p
+					className="dataviews-loading-more"
+					aria-hidden={ ! isLoading }
+				>
 					<Spinner />
 				</p>
 			) }

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -536,8 +536,8 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const dataByGroup =
 		hasData && groupField ? getDataByGroup( data, groupField ) : null;
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
-	// Whether the server still has rows beyond the current window.
-	const hasMoreToLoad =
+	// Whether the server has more rows beyond the current window.
+	const hasMoreItems =
 		isInfiniteScroll &&
 		( view.startPosition ?? 1 ) + ( view.perPage ?? 0 ) <
 			paginationInfo.totalItems;
@@ -669,10 +669,10 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					);
 				} ) }
 			</Composite>
-			{ ( hasMoreToLoad || ( isInfiniteScroll && isLoading ) ) && (
-				// Keep the spinner mounted until everything is loaded so its
-				// height stays reserved and the scroll position doesn't bounce as
-				// loading starts/stops. Hidden (and silent to a11y) while idle.
+			{ ( hasMoreItems || ( isInfiniteScroll && isLoading ) ) && (
+				// Keep the spinner's height reserved while loading more so the
+				// scroll position doesn't bounce. Hidden, and silent to a11y,
+				// while idle.
 				<p
 					className="dataviews-loading-more"
 					aria-hidden={ ! isLoading }

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -11,18 +11,28 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import DataViewsContext from '../dataviews-context';
+import type { View } from '../../types';
+
+export function hasPaginationControls(
+	view: View,
+	paginationInfo: { totalItems: number; totalPages: number }
+): boolean {
+	return (
+		! view.infiniteScrollEnabled &&
+		paginationInfo.totalItems > 0 &&
+		paginationInfo.totalPages > 1
+	);
+}
 
 export function DataViewsPagination() {
-	const {
-		view,
-		onChangeView,
-		paginationInfo: { totalItems = 0, totalPages },
-	} = useContext( DataViewsContext );
+	const { view, onChangeView, paginationInfo } =
+		useContext( DataViewsContext );
 
-	if ( ! totalItems || ! totalPages || view.infiniteScrollEnabled ) {
+	if ( ! hasPaginationControls( view, paginationInfo ) ) {
 		return null;
 	}
 
+	const { totalPages } = paginationInfo;
 	const currentPage = view.page ?? 1;
 	const pageSelectOptions = Array.from( Array( totalPages ) ).map(
 		( _, i ) => {
@@ -44,84 +54,78 @@ export function DataViewsPagination() {
 	);
 
 	return (
-		!! totalItems &&
-		totalPages !== 1 && (
+		<Stack
+			direction="row"
+			className="dataviews-pagination"
+			justify="end"
+			align="center"
+			gap="xl"
+		>
 			<Stack
 				direction="row"
-				className="dataviews-pagination"
-				justify="end"
+				justify="flex-start"
 				align="center"
-				gap="xl"
+				gap="xs"
+				className="dataviews-pagination__page-select"
 			>
-				<Stack
-					direction="row"
-					justify="flex-start"
-					align="center"
-					gap="xs"
-					className="dataviews-pagination__page-select"
-				>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: 1: Current page number, 2: Total number of pages.
-							_x(
-								'<div>Page</div>%1$s<div>of %2$d</div>',
-								'paging'
-							),
-							'<CurrentPage />',
-							totalPages
+				{ createInterpolateElement(
+					sprintf(
+						// translators: 1: Current page number, 2: Total number of pages.
+						_x( '<div>Page</div>%1$s<div>of %2$d</div>', 'paging' ),
+						'<CurrentPage />',
+						totalPages
+					),
+					{
+						div: <div aria-hidden />,
+						// @ts-expect-error — Tag injected via sprintf argument, not visible in format string.
+						CurrentPage: (
+							<SelectControl
+								aria-label={ __( 'Current page' ) }
+								value={ currentPage.toString() }
+								options={ pageSelectOptions }
+								onChange={ ( newValue ) => {
+									onChangeView( {
+										...view,
+										page: +newValue,
+									} );
+								} }
+								size="small"
+								variant="minimal"
+							/>
 						),
-						{
-							div: <div aria-hidden />,
-							// @ts-expect-error — Tag injected via sprintf argument, not visible in format string.
-							CurrentPage: (
-								<SelectControl
-									aria-label={ __( 'Current page' ) }
-									value={ currentPage.toString() }
-									options={ pageSelectOptions }
-									onChange={ ( newValue ) => {
-										onChangeView( {
-											...view,
-											page: +newValue,
-										} );
-									} }
-									size="small"
-									variant="minimal"
-								/>
-							),
-						}
-					) }
-				</Stack>
-				<Stack direction="row" gap="xs" align="center">
-					<Button
-						onClick={ () =>
-							onChangeView( {
-								...view,
-								page: currentPage - 1,
-							} )
-						}
-						disabled={ currentPage === 1 }
-						accessibleWhenDisabled
-						label={ __( 'Previous page' ) }
-						icon={ isRTL() ? next : previous }
-						showTooltip
-						size="compact"
-						tooltipPosition="top"
-					/>
-					<Button
-						onClick={ () =>
-							onChangeView( { ...view, page: currentPage + 1 } )
-						}
-						disabled={ currentPage >= totalPages }
-						accessibleWhenDisabled
-						label={ __( 'Next page' ) }
-						icon={ isRTL() ? previous : next }
-						showTooltip
-						size="compact"
-						tooltipPosition="top"
-					/>
-				</Stack>
+					}
+				) }
 			</Stack>
-		)
+			<Stack direction="row" gap="xs" align="center">
+				<Button
+					onClick={ () =>
+						onChangeView( {
+							...view,
+							page: currentPage - 1,
+						} )
+					}
+					disabled={ currentPage === 1 }
+					accessibleWhenDisabled
+					label={ __( 'Previous page' ) }
+					icon={ isRTL() ? next : previous }
+					showTooltip
+					size="compact"
+					tooltipPosition="top"
+				/>
+				<Button
+					onClick={ () =>
+						onChangeView( { ...view, page: currentPage + 1 } )
+					}
+					disabled={ currentPage >= totalPages }
+					accessibleWhenDisabled
+					label={ __( 'Next page' ) }
+					icon={ isRTL() ? previous : next }
+					showTooltip
+					size="compact"
+					tooltipPosition="top"
+				/>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -1,0 +1,179 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViews from '../index';
+import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../constants';
+import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
+import type { View } from '../../types';
+import { actions, data as fixtureData, fields } from './fixtures';
+
+// The fixtures only contain ~50 rows; repeat them (with unique ids) so there
+// are enough rows to page through several times.
+const data = Array.from( { length: 8 }, ( _, batch ) =>
+	fixtureData.map( ( item ) => ( {
+		...item,
+		id: item.id + batch * 1000,
+		name: {
+			...item.name,
+			title: `${ item.name.title } #${ batch + 1 }`,
+		},
+	} ) )
+).flat();
+
+const PAGE = 20;
+// Simulated per-page network latency. The jump only reproduces while the user
+// keeps scrolling *during* this window, so it is deliberately long enough to
+// scroll within — both by hand and from the `play` function.
+const LOAD_DELAY_MS = 1000;
+
+/**
+ * Reproduces a real-world infinite-scroll consumer (e.g. a notifications list)
+ * that the static `InfiniteScroll` story does not: pages are revealed one at a
+ * time *asynchronously* and `isLoading` toggles for each page.
+ *
+ * The bug: the scroll handler captures a scroll-anchor the instant it advances
+ * the window, but the anchor is only restored on a later render gated on
+ * `isLoading`. When pages load over the network the user keeps scrolling in that
+ * gap, and the restoration can't tell that user-driven movement from a
+ * content-driven shift — so it "corrects" it, snapping the list back to where
+ * the anchor sat at capture time and undoing the scrolling done while loading.
+ *
+ * Scroll down continuously (the HUD shows the live `scrollTop`): on `trunk` the
+ * number jerks back upward as each page settles; with the fix it keeps climbing.
+ * The `play` function in `index.story.tsx` reproduces and asserts this without
+ * relying on hand-timed scrolling.
+ */
+const AsyncInfiniteScroll = () => {
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_LIST,
+		search: '',
+		startPosition: 1,
+		perPage: PAGE,
+		filters: [],
+		fields: [ 'satellites' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+		infiniteScrollEnabled: true,
+	} );
+
+	// A "server" that reveals rows one page at a time, asynchronously, keeping
+	// two pages buffered ahead of the scroll window. The buffer is what gives the
+	// user rows to scroll into while the next page is still loading — i.e. the
+	// async gap the anchor restoration mishandles.
+	const [ loadedCount, setLoadedCount ] = useState( PAGE );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const loadingRef = useRef( false );
+
+	const loadedData = useMemo(
+		() => data.slice( 0, loadedCount ),
+		[ loadedCount ]
+	);
+	const { data: shownData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( loadedData, view, fields ),
+		[ loadedData, view ]
+	);
+
+	const startPosition = view.startPosition ?? 1;
+	useEffect( () => {
+		if (
+			startPosition + PAGE * 2 <= loadedCount ||
+			loadingRef.current ||
+			loadedCount >= data.length
+		) {
+			return undefined;
+		}
+		loadingRef.current = true;
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setLoadedCount( ( count ) =>
+				Math.min( count + PAGE, data.length )
+			);
+			setIsLoading( false );
+			loadingRef.current = false;
+		}, LOAD_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ startPosition, loadedCount ] );
+
+	// Live scroll-position read-out so the jump is observable as a number, not
+	// just a flicker. The scrollable element is the internal
+	// `.dataviews-layout__container`; scroll events don't bubble but do fire in
+	// the capture phase, so we can observe it from the wrapper.
+	const wrapperRef = useRef< HTMLDivElement >( null );
+	const [ scrollTop, setScrollTop ] = useState( 0 );
+	useEffect( () => {
+		const wrapper = wrapperRef.current;
+		if ( ! wrapper ) {
+			return undefined;
+		}
+		const onScroll = ( event: Event ) => {
+			const target = event.target as HTMLElement;
+			if (
+				target?.classList?.contains( 'dataviews-layout__container' )
+			) {
+				setScrollTop( Math.round( target.scrollTop ) );
+			}
+		};
+		wrapper.addEventListener( 'scroll', onScroll, true );
+		return () => wrapper.removeEventListener( 'scroll', onScroll, true );
+	}, [] );
+
+	return (
+		<div
+			ref={ wrapperRef }
+			data-testid="async-infinite-scroll"
+			data-loading={ isLoading ? 'true' : 'false' }
+			data-loaded-count={ loadedCount }
+			style={ { position: 'relative' } }
+		>
+			<style>{ `
+			.dataviews-wrapper {
+				height: 600px;
+				overflow: auto;
+			}
+		` }</style>
+			<div
+				aria-hidden="true"
+				style={ {
+					position: 'absolute',
+					top: 8,
+					right: 8,
+					zIndex: 10,
+					padding: '6px 10px',
+					borderRadius: 4,
+					font: '12px/1.5 monospace',
+					whiteSpace: 'pre',
+					background: isLoading ? '#b32d2e' : '#1e1e1e',
+					color: '#fff',
+					pointerEvents: 'none',
+				} }
+			>
+				{ `scrollTop: ${ scrollTop }px\n${
+					isLoading ? 'loading next page…' : 'idle'
+				}\nloaded: ${ loadedCount } / ${ data.length }` }
+			</div>
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ shownData }
+				view={ view }
+				fields={ fields }
+				onChangeView={ setView }
+				isLoading={ isLoading }
+				actions={ actions }
+				defaultLayouts={ {
+					[ LAYOUT_TABLE ]: true,
+					[ LAYOUT_GRID ]: true,
+					[ LAYOUT_LIST ]: true,
+				} }
+			/>
+		</div>
+	);
+};
+
+export default AsyncInfiniteScroll;

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -26,27 +26,18 @@ const data = Array.from( { length: 8 }, ( _, batch ) =>
 ).flat();
 
 const PAGE = 20;
-// Simulated per-page network latency. The jump only reproduces while the user
-// keeps scrolling *during* this window, so it is deliberately long enough to
-// scroll within — both by hand and from the `play` function.
-const LOAD_DELAY_MS = 1000;
+// Simulated per-page network latency.
+const LOAD_DELAY_MS = 800;
 
 /**
- * Reproduces a real-world infinite-scroll consumer (e.g. a notifications list)
- * that the static `InfiniteScroll` story does not: pages are revealed one at a
- * time *asynchronously* and `isLoading` toggles for each page.
+ * A realistic network-backed infinite-scroll consumer (e.g. the experimental
+ * media modal): there is no prefetch buffer. The hook drives pagination by
+ * advancing `view.startPosition`; the consumer fetches exactly the window it was
+ * asked for, toggling `isLoading` while that request is in flight, and reports
+ * the *true* server total so the hook knows more remains.
  *
- * The bug: the scroll handler captures a scroll-anchor the instant it advances
- * the window, but the anchor is only restored on a later render gated on
- * `isLoading`. When pages load over the network the user keeps scrolling in that
- * gap, and the restoration can't tell that user-driven movement from a
- * content-driven shift — so it "corrects" it, snapping the list back to where
- * the anchor sat at capture time and undoing the scrolling done while loading.
- *
- * Scroll down continuously (the HUD shows the live `scrollTop`): on `trunk` the
- * number jerks back upward as each page settles; with the fix it keeps climbing.
- * The `play` function in `index.story.tsx` reproduces and asserts this without
- * relying on hand-timed scrolling.
+ * Use the HUD (top-right) to watch `scrollTop` / `scrollHeight` / `isLoading`
+ * while reproducing.
  */
 const AsyncInfiniteScroll = () => {
 	const [ view, setView ] = useState< View >( {
@@ -62,13 +53,27 @@ const AsyncInfiniteScroll = () => {
 		infiniteScrollEnabled: true,
 	} );
 
-	// A "server" that reveals rows one page at a time, asynchronously, keeping
-	// two pages buffered ahead of the scroll window. The buffer is what gives the
-	// user rows to scroll into while the next page is still loading — i.e. the
-	// async gap the anchor restoration mishandles.
+	// The "server": how many rows have been delivered so far, and whether a
+	// request for the current window is in flight.
 	const [ loadedCount, setLoadedCount ] = useState( PAGE );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const loadingRef = useRef( false );
+
+	const startPosition = view.startPosition ?? 1;
+	const perPage = view.perPage ?? PAGE;
+	// Rows required to fill the window the hook is currently asking for.
+	const needed = Math.min( startPosition - 1 + perPage, data.length );
+
+	useEffect( () => {
+		if ( needed <= loadedCount ) {
+			return undefined;
+		}
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setLoadedCount( needed );
+			setIsLoading( false );
+		}, LOAD_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ needed, loadedCount ] );
 
 	const loadedData = useMemo(
 		() => data.slice( 0, loadedCount ),
@@ -78,34 +83,22 @@ const AsyncInfiniteScroll = () => {
 		() => filterSortAndPaginate( loadedData, view, fields ),
 		[ loadedData, view ]
 	);
+	// Report the true server total (not just what's loaded) so infinite scroll
+	// keeps requesting until the dataset is exhausted.
+	const serverPaginationInfo = useMemo(
+		() => ( { ...paginationInfo, totalItems: data.length } ),
+		[ paginationInfo ]
+	);
 
-	const startPosition = view.startPosition ?? 1;
-	useEffect( () => {
-		if (
-			startPosition + PAGE * 2 <= loadedCount ||
-			loadingRef.current ||
-			loadedCount >= data.length
-		) {
-			return undefined;
-		}
-		loadingRef.current = true;
-		setIsLoading( true );
-		const timer = setTimeout( () => {
-			setLoadedCount( ( count ) =>
-				Math.min( count + PAGE, data.length )
-			);
-			setIsLoading( false );
-			loadingRef.current = false;
-		}, LOAD_DELAY_MS );
-		return () => clearTimeout( timer );
-	}, [ startPosition, loadedCount ] );
-
-	// Live scroll-position read-out so the jump is observable as a number, not
-	// just a flicker. The scrollable element is the internal
+	// Live scroll-position read-out. The scrollable element is the internal
 	// `.dataviews-layout__container`; scroll events don't bubble but do fire in
 	// the capture phase, so we can observe it from the wrapper.
 	const wrapperRef = useRef< HTMLDivElement >( null );
-	const [ scrollTop, setScrollTop ] = useState( 0 );
+	const [ metrics, setMetrics ] = useState( {
+		scrollTop: 0,
+		scrollHeight: 0,
+		clientHeight: 0,
+	} );
 	useEffect( () => {
 		const wrapper = wrapperRef.current;
 		if ( ! wrapper ) {
@@ -116,12 +109,19 @@ const AsyncInfiniteScroll = () => {
 			if (
 				target?.classList?.contains( 'dataviews-layout__container' )
 			) {
-				setScrollTop( Math.round( target.scrollTop ) );
+				setMetrics( {
+					scrollTop: Math.round( target.scrollTop ),
+					scrollHeight: Math.round( target.scrollHeight ),
+					clientHeight: Math.round( target.clientHeight ),
+				} );
 			}
 		};
 		wrapper.addEventListener( 'scroll', onScroll, true );
 		return () => wrapper.removeEventListener( 'scroll', onScroll, true );
 	}, [] );
+
+	const distanceToBottom =
+		metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop;
 
 	return (
 		<div
@@ -153,13 +153,19 @@ const AsyncInfiniteScroll = () => {
 					pointerEvents: 'none',
 				} }
 			>
-				{ `scrollTop: ${ scrollTop }px\n${
-					isLoading ? 'loading next page…' : 'idle'
-				}\nloaded: ${ loadedCount } / ${ data.length }` }
+				{ `${
+					isLoading ? 'loading…' : 'idle'
+				}\nloaded: ${ loadedCount } / ${
+					data.length
+				}\nstartPosition: ${ startPosition }\nscrollTop: ${
+					metrics.scrollTop
+				}\nscrollHeight: ${
+					metrics.scrollHeight
+				}\nto bottom: ${ distanceToBottom }px` }
 			</div>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
-				paginationInfo={ paginationInfo }
+				paginationInfo={ serverPaginationInfo }
 				data={ shownData }
 				view={ view }
 				fields={ fields }

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,14 +30,9 @@ const PAGE = 20;
 const LOAD_DELAY_MS = 800;
 
 /**
- * A realistic network-backed infinite-scroll consumer (e.g. the experimental
- * media modal): there is no prefetch buffer. The hook drives pagination by
- * advancing `view.startPosition`; the consumer fetches exactly the window it was
- * asked for, toggling `isLoading` while that request is in flight, and reports
- * the *true* server total so the hook knows more remains.
- *
- * Use the HUD (top-right) to watch `scrollTop` / `scrollHeight` / `isLoading`
- * while reproducing.
+ * A realistic network-backed infinite-scroll consumer: the hook advances
+ * `view.startPosition`, and the consumer fetches that window asynchronously
+ * (toggling `isLoading`) while reporting the true server total.
  */
 const AsyncInfiniteScroll = () => {
 	const [ view, setView ] = useState< View >( {
@@ -90,79 +85,14 @@ const AsyncInfiniteScroll = () => {
 		[ paginationInfo ]
 	);
 
-	// Live scroll-position read-out. The scrollable element is the internal
-	// `.dataviews-layout__container`; scroll events don't bubble but do fire in
-	// the capture phase, so we can observe it from the wrapper.
-	const wrapperRef = useRef< HTMLDivElement >( null );
-	const [ metrics, setMetrics ] = useState( {
-		scrollTop: 0,
-		scrollHeight: 0,
-		clientHeight: 0,
-	} );
-	useEffect( () => {
-		const wrapper = wrapperRef.current;
-		if ( ! wrapper ) {
-			return undefined;
-		}
-		const onScroll = ( event: Event ) => {
-			const target = event.target as HTMLElement;
-			if (
-				target?.classList?.contains( 'dataviews-layout__container' )
-			) {
-				setMetrics( {
-					scrollTop: Math.round( target.scrollTop ),
-					scrollHeight: Math.round( target.scrollHeight ),
-					clientHeight: Math.round( target.clientHeight ),
-				} );
-			}
-		};
-		wrapper.addEventListener( 'scroll', onScroll, true );
-		return () => wrapper.removeEventListener( 'scroll', onScroll, true );
-	}, [] );
-
-	const distanceToBottom =
-		metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop;
-
 	return (
-		<div
-			ref={ wrapperRef }
-			data-testid="async-infinite-scroll"
-			data-loading={ isLoading ? 'true' : 'false' }
-			data-loaded-count={ loadedCount }
-			style={ { position: 'relative' } }
-		>
+		<div style={ { height: '100%' } }>
 			<style>{ `
 			.dataviews-wrapper {
-				height: 600px;
+				height: 100%;
 				overflow: auto;
 			}
 		` }</style>
-			<div
-				aria-hidden="true"
-				style={ {
-					position: 'absolute',
-					top: 8,
-					right: 8,
-					zIndex: 10,
-					padding: '6px 10px',
-					borderRadius: 4,
-					font: '12px/1.5 monospace',
-					whiteSpace: 'pre',
-					background: isLoading ? '#b32d2e' : '#1e1e1e',
-					color: '#fff',
-					pointerEvents: 'none',
-				} }
-			>
-				{ `${
-					isLoading ? 'loading…' : 'idle'
-				}\nloaded: ${ loadedCount } / ${
-					data.length
-				}\nstartPosition: ${ startPosition }\nscrollTop: ${
-					metrics.scrollTop
-				}\nscrollHeight: ${
-					metrics.scrollHeight
-				}\nto bottom: ${ distanceToBottom }px` }
-			</div>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
 				paginationInfo={ serverPaginationInfo }

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -287,14 +287,14 @@ export const InfiniteScroll = {
 
 /**
  * Infinite scroll where pages load asynchronously (with `isLoading`), like a
- * real network-backed consumer that fetches one window at a time. Use it to
- * reproduce the scroll-position jump and the load stall manually; see the HUD
- * in the story for live scroll metrics.
+ * real network-backed consumer that fetches one window at a time. Reproduces
+ * the scroll-position jump that the synchronous story does not.
  */
 export const AsyncInfiniteScroll = {
 	render: AsyncInfiniteScrollComponent,
 	parameters: {
-		containerHeight: '600px',
+		// Fill the viewport so the list bottom is the window bottom.
+		containerHeight: 'calc(100vh - 2rem)',
 	},
 	argTypes: {
 		containerHeight: {

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta } from '@storybook/react-vite';
+import { expect, waitFor } from 'storybook/test';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import LayoutGridComponent from './layout-grid';
 import LayoutListComponent from './layout-list';
 import LayoutCustomComponent from './layout-custom';
 import InfiniteScrollComponent from './infinite-scroll';
+import AsyncInfiniteScrollComponent from './async-infinite-scroll';
 import WithCardComponent from './with-card';
 import FreeCompositionComponent from './free-composition';
 import MinimalUIComponent from './minimal-ui';
@@ -281,5 +283,86 @@ export const InfiniteScroll = {
 				disable: true,
 			},
 		},
+	},
+};
+
+/**
+ * Infinite scroll where pages load asynchronously (with `isLoading`), like a
+ * real network-backed consumer. The `play` function reproduces the scroll-anchor
+ * jump deterministically: it advances the window, keeps scrolling *while the
+ * page is still loading*, and asserts the list does not snap back up when the
+ * page settles. It fails against the buggy `trunk` hook and passes with the fix.
+ */
+export const AsyncInfiniteScroll = {
+	render: AsyncInfiniteScrollComponent,
+	parameters: {
+		containerHeight: '600px',
+	},
+	argTypes: {
+		containerHeight: {
+			control: false,
+			table: {
+				disable: true,
+			},
+		},
+	},
+	play: async ( { canvasElement }: { canvasElement: HTMLElement } ) => {
+		const getContainer = () =>
+			canvasElement.querySelector< HTMLElement >(
+				'.dataviews-layout__container'
+			);
+		const isLoading = () =>
+			canvasElement
+				.querySelector( '[data-testid="async-infinite-scroll"]' )
+				?.getAttribute( 'data-loading' ) === 'true';
+
+		// Wait for the first page to render.
+		const container = await waitFor( () => {
+			const el = getContainer();
+			expect( el ).toBeTruthy();
+			expect(
+				el!.querySelectorAll( '[aria-posinset]' ).length
+			).toBeGreaterThan( 5 );
+			return el!;
+		} );
+
+		// Reproduce the scenario a few times to page well into the list: advance
+		// the window (revealing buffered rows and starting an async fetch), keep
+		// scrolling while the fetch is in flight, then assert the list stayed put
+		// once it settled.
+		for ( let i = 0; i < 3; i++ ) {
+			// 1) Scroll to the bottom: advances the window and captures the
+			//    scroll-anchor.
+			container.scrollTop = container.scrollHeight;
+
+			// 2) Wait until a fetch is actually in flight (so rows have been
+			//    revealed and there is room to keep scrolling).
+			await waitFor( () => expect( isLoading() ).toBe( true ), {
+				timeout: 4000,
+			} );
+
+			// 3) The user keeps scrolling down into the freshly revealed rows
+			//    while the fetch is still pending — this is the movement the
+			//    buggy restoration used to undo.
+			container.scrollTop = container.scrollHeight;
+			const scrolledTo = container.scrollTop;
+			expect( scrolledTo ).toBeGreaterThan( 0 );
+
+			// 4) Let the fetch settle; the anchor-restoration layout effect runs
+			//    here.
+			await waitFor( () => expect( isLoading() ).toBe( false ), {
+				timeout: 4000,
+			} );
+
+			// 5) The viewport must stay where the user left it. On `trunk` the
+			//    restoration snaps `scrollTop` back toward its capture-time value,
+			//    yanking the list upward; the small tolerance absorbs sub-pixel
+			//    rounding only.
+			await waitFor( () =>
+				expect( container.scrollTop ).toBeGreaterThanOrEqual(
+					scrolledTo - 24
+				)
+			);
+		}
 	},
 };

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { Meta } from '@storybook/react-vite';
-import { expect, waitFor } from 'storybook/test';
 
 /**
  * Internal dependencies
@@ -288,10 +287,9 @@ export const InfiniteScroll = {
 
 /**
  * Infinite scroll where pages load asynchronously (with `isLoading`), like a
- * real network-backed consumer. The `play` function reproduces the scroll-anchor
- * jump deterministically: it advances the window, keeps scrolling *while the
- * page is still loading*, and asserts the list does not snap back up when the
- * page settles. It fails against the buggy `trunk` hook and passes with the fix.
+ * real network-backed consumer that fetches one window at a time. Use it to
+ * reproduce the scroll-position jump and the load stall manually; see the HUD
+ * in the story for live scroll metrics.
  */
 export const AsyncInfiniteScroll = {
 	render: AsyncInfiniteScrollComponent,
@@ -305,64 +303,5 @@ export const AsyncInfiniteScroll = {
 				disable: true,
 			},
 		},
-	},
-	play: async ( { canvasElement }: { canvasElement: HTMLElement } ) => {
-		const getContainer = () =>
-			canvasElement.querySelector< HTMLElement >(
-				'.dataviews-layout__container'
-			);
-		const isLoading = () =>
-			canvasElement
-				.querySelector( '[data-testid="async-infinite-scroll"]' )
-				?.getAttribute( 'data-loading' ) === 'true';
-
-		// Wait for the first page to render.
-		const container = await waitFor( () => {
-			const el = getContainer();
-			expect( el ).toBeTruthy();
-			expect(
-				el!.querySelectorAll( '[aria-posinset]' ).length
-			).toBeGreaterThan( 5 );
-			return el!;
-		} );
-
-		// Reproduce the scenario a few times to page well into the list: advance
-		// the window (revealing buffered rows and starting an async fetch), keep
-		// scrolling while the fetch is in flight, then assert the list stayed put
-		// once it settled.
-		for ( let i = 0; i < 3; i++ ) {
-			// 1) Scroll to the bottom: advances the window and captures the
-			//    scroll-anchor.
-			container.scrollTop = container.scrollHeight;
-
-			// 2) Wait until a fetch is actually in flight (so rows have been
-			//    revealed and there is room to keep scrolling).
-			await waitFor( () => expect( isLoading() ).toBe( true ), {
-				timeout: 4000,
-			} );
-
-			// 3) The user keeps scrolling down into the freshly revealed rows
-			//    while the fetch is still pending — this is the movement the
-			//    buggy restoration used to undo.
-			container.scrollTop = container.scrollHeight;
-			const scrolledTo = container.scrollTop;
-			expect( scrolledTo ).toBeGreaterThan( 0 );
-
-			// 4) Let the fetch settle; the anchor-restoration layout effect runs
-			//    here.
-			await waitFor( () => expect( isLoading() ).toBe( false ), {
-				timeout: 4000,
-			} );
-
-			// 5) The viewport must stay where the user left it. On `trunk` the
-			//    restoration snaps `scrollTop` back toward its capture-time value,
-			//    yanking the list upward; the small tolerance absorbs sub-pixel
-			//    rounding only.
-			await waitFor( () =>
-				expect( container.scrollTop ).toBeGreaterThanOrEqual(
-					scrolledTo - 24
-				)
-			);
-		}
 	},
 };

--- a/packages/dataviews/src/dataviews/style.scss
+++ b/packages/dataviews/src/dataviews/style.scss
@@ -69,6 +69,11 @@
 
 .dataviews-loading-more {
 	text-align: center;
+
+	// Hidden but keeps its box so the reserved height stays constant.
+	&[aria-hidden="true"] {
+		visibility: hidden;
+	}
 }
 
 @container (max-width: 430px) {

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -28,6 +28,7 @@ function captureAnchorElement(
 	anchorElementRef: React.MutableRefObject< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >,
 	direction: 'up' | 'down'
@@ -61,6 +62,7 @@ function captureAnchorElement(
 	anchorElementRef.current = {
 		posinset,
 		viewportOffset: anchorRect.top - containerRect.top,
+		scrollTop: container.scrollTop,
 		direction,
 	};
 	return true;
@@ -95,6 +97,7 @@ export function useInfiniteScroll( {
 	const anchorElementRef = useRef< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >( null );
 	const viewRef = useRef( view );
@@ -174,8 +177,16 @@ export function useInfiniteScroll( {
 			const anchorRect = anchorElement.getBoundingClientRect();
 			const currentOffset = anchorRect.top - containerRect.top;
 
-			// Calculate how much the anchor has moved and adjust scroll to compensate
-			const scrollAdjustment = currentOffset - anchor.viewportOffset;
+			// Compensate only for the content-driven shift, not for any scrolling
+			// the user did between capture (in the throttled scroll handler) and
+			// this restoration (which is gated on `isLoading`). When pages load
+			// asynchronously the user keeps scrolling in that gap; adding back the
+			// intervening scroll delta prevents the list from snapping back to the
+			// capture-time position and undoing that scroll.
+			const scrollAdjustment =
+				currentOffset -
+				anchor.viewportOffset +
+				( container.scrollTop - anchor.scrollTop );
 
 			if ( Math.abs( scrollAdjustment ) > 1 ) {
 				container.scrollTop += scrollAdjustment;

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -177,12 +177,9 @@ export function useInfiniteScroll( {
 			const anchorRect = anchorElement.getBoundingClientRect();
 			const currentOffset = anchorRect.top - containerRect.top;
 
-			// Compensate only for the content-driven shift, not for any scrolling
-			// the user did between capture (in the throttled scroll handler) and
-			// this restoration (which is gated on `isLoading`). When pages load
-			// asynchronously the user keeps scrolling in that gap; adding back the
-			// intervening scroll delta prevents the list from snapping back to the
-			// capture-time position and undoing that scroll.
+			// Compensate only for the content shift, not for scrolling the user
+			// did during an async load. Adding back the scroll delta since capture
+			// keeps the list from snapping back to the capture-time position.
 			const scrollAdjustment =
 				currentOffset -
 				anchor.viewportOffset +


### PR DESCRIPTION
## What?

Fixes the DataViews infinite-scroll (List layout) list jumping while pages load asynchronously. Adds a realistic network-backed story to reproduce it.

## Why?

For any consumer that loads pages over the network, scrolling down to load more made the list jump. There are two independent causes:

1. **Scroll-anchor restoration discarded the user's scrolling.** The anchor is captured when the window advances but only restored after the load finishes. If the user keeps scrolling in that gap, the restoration snapped the list back to the capture-time position — undoing that scrolling (a ~hundreds-of-pixels jump).
2. **The footer resized the scroll container mid-load.** `DataViewsFooter` renders only while "refreshing" (`isLoading`). For infinite scroll there's no pagination, so it had nothing to show, yet it mounted on every load — a sticky, `flex-shrink: 0` bar that shrank the scroll viewport by its height and reflowed the list.

The existing synchronous story never hit either: it resolves data immediately and never sets a loading state.

## How?

- **Anchor restoration:** also store `scrollTop` at capture and add back the scroll delta since then, so the restoration compensates only the content-driven shift, not the user's own scrolling. When the user doesn't scroll during a load, the added term is zero — behaviour is unchanged in that case.
- **Footer:** for infinite scroll, don't render the footer when there are no bulk actions to show (the in-list spinner already indicates loading). This keeps the scroll container a constant size across loads.
- **In-list spinner:** reserve its space while more items remain (`hasMoreItems`) so it doesn't change height as loading toggles, and drop it once everything is loaded.

## Considerations

Scroll anchoring depends on real layout/scroll, which jsdom does not simulate, so this is verified through the Storybook story in a real browser rather than a unit test. Both causes were isolated by reverting each fix independently and confirming the jump returns.

Row unloading (`useData`'s `IntersectionObserver` buffer) is intentionally **not** wired into the List layout here: unloading shifts the array-relative `aria-posinset` the anchor relies on, which reintroduces the snap-back. Bounding the DOM for very large lists is a separate concern.

## Testing Instructions

1. `npm run storybook:dev`
2. Open **DataViews → DataViews → Async Infinite Scroll** (each page loads with simulated latency).
3. Scroll down through several pages, and keep scrolling *while* a page is loading.
4. Expected: the list does not jump as each page settles.
5. To see the original bug, check out either `packages/dataviews/src/hooks/use-infinite-scroll.ts` or `packages/dataviews/src/components/dataviews-footer/index.tsx` from trunk and repeat.

### Testing Instructions for Keyboard

Not a markup/interaction change. The list can still be scrolled with the keyboard (focus a row, then `Page Down` / arrow keys); the same behaviour applies.

## Screenshots or screencast

|Before|After|
|-|-|
|List jumps as each async page settles|Scroll position stays put|

## Use of AI Tools

This change was authored with the assistance of AI tooling (Claude Code), and verified in Storybook (the two causes were isolated by independent A/B reverts).
