### PR TITLE
feat: Update validation for title and content in the dashboard widget

### DIFF
--- a/widgets/quick-draft/render.tsx
+++ b/widgets/quick-draft/render.tsx
@@ -122,7 +122,7 @@ export default function QuickDraft() {
 				id: 'title',
 				type: 'text',
 				label: __( 'Title' ),
-				isValid: { required: true, minLength: 3 },
+				isValid: { required: false },
 				hideLabelFromVision: true,
 				help: __( 'Enter a title for your post.' ),
 			},
@@ -130,7 +130,7 @@ export default function QuickDraft() {
 				id: 'content',
 				type: 'text',
 				label: __( 'Content' ),
-				isValid: { required: true, minLength: 10 },
+				isValid: { required: false },
 				Edit: QuickDraftContentField,
 				help: __( 'Enter the content for your post.' ),
 			},
@@ -140,7 +140,10 @@ export default function QuickDraft() {
 
 	const { validity, isValid } = useFormValidity( data, fields, FORM );
 
-	const canSave = isValid && ! isSaving;
+	const hasMeaningfulInput =
+		data.title.trim().length > 0 || data.content.trim().length > 0;
+
+	const canSave = isValid && hasMeaningfulInput && ! isSaving;
 
 	const saveDraftPost = async () => {
 		if ( ! canSave ) {
@@ -149,15 +152,18 @@ export default function QuickDraft() {
 
 		setIsSaving( true );
 
+		const trimmedTitle = data.title.trim();
+		const trimmedContent = data.content.trim();
+
 		try {
 			const saved = await saveEntityRecord( 'postType', 'post', {
-				title: data.title,
-				content: textToParagraphBlocks( data.content ),
+				title: trimmedTitle,
+				content: textToParagraphBlocks( trimmedContent ),
 				status: 'draft',
 			} );
 			const newId = ( saved as { id?: number } | null )?.id;
 			if ( typeof newId === 'number' ) {
-				setCreatedPost( { id: newId, title: data.title } );
+				setCreatedPost( { id: newId, title: trimmedTitle } );
 			}
 			setData( INITIAL_DATA );
 		} finally {


### PR DESCRIPTION
## What? Why?
Closes https://github.com/WordPress/gutenberg/issues/79526

Fixes the Quick Draft dashboard widget to allow saving a draft when only one of title or content is filled in.

The widget was incorrectly requiring both fields to be non-empty. WordPress has always allowed drafts with an empty title or empty content only a post with both fields empty should be blocked.

## Testing Instructions
1. Enable the Dashboard experiment: **WP Admin → Gutenberg → Experiments**.
2. Go to Dashboard(Beta)
3. Add New Widget (Customize - > Add Widget -> Quick Draft)
4. Leave both fields empty → Save button is disabled.
5. Enter spaces only in both fields → Save button is disabled. 
6. Enter a title, leave content empty → Save succeeds. 
7. Leave title empty, enter content → Save succeeds. 
8. Fill both fields → Save succeeds. 

Check for the below scenarios 
1. Title - Not Empty Content - Not Empty (Should allow to save)
2. Title - Empty Content - Not Empty (Should allow to save)
3. Title - Not Empty Content - Empty (Should allow to save)
4. Title - Empty Content - Empty (Should NOT allow to save)

## Screencast

https://github.com/user-attachments/assets/fed03e9b-fa70-4e92-8b60-0c4a00e59fbf


