### PR TITLE
Automated Testing: Use three-dot diff comparison for changelog checks

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -55,7 +55,7 @@ jobs:
                   # The workflow's `paths:` filter triggers on the union of all
                   # tracked packages, so this matrix entry may run on a PR that
                   # doesn't touch its package. Short-circuit if that's the case.
-                  relevant_changes=$(git diff --name-only "$BASE_SHA" HEAD -- "${PACKAGE_PATH}/" \
+                  relevant_changes=$(git diff --name-only "$BASE_SHA"...HEAD -- "${PACKAGE_PATH}/" \
                       | grep -Ev "^${PACKAGE_PATH}/src/(.+/)?(stories|test)/" || true)
 
                   if [ -z "$relevant_changes" ]; then
@@ -75,7 +75,7 @@ jobs:
                   optional_check_notice="This isn't a required check, so if you think your changes are small enough that they don't warrant a CHANGELOG entry, please go ahead and merge without one."
 
                   # Fail if the PR doesn't touch the changelog
-                  if git diff --quiet "$BASE_SHA" HEAD -- "$changelog_path"; then
+                  if git diff --quiet "$BASE_SHA"...HEAD -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
                     echo
                     echo "${optional_check_notice}"

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -14,6 +14,8 @@ const rootProviderCountByDocument = new WeakMap< Document, number >();
  * Context provider that generates a theme from a set of seed color values and
  * configuration, producing a set of design token overrides as CSS custom
  * properties.
+ *
+ * Sample failure.
  */
 export const ThemeProvider = ( {
 	children,

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -14,8 +14,6 @@ const rootProviderCountByDocument = new WeakMap< Document, number >();
  * Context provider that generates a theme from a set of seed color values and
  * configuration, producing a set of design token overrides as CSS custom
  * properties.
- *
- * Sample failure.
  */
 export const ThemeProvider = ( {
 	children,


### PR DESCRIPTION
## What?

Fixes an issue where the "Check Package Changelogs" CI check may produce false positives.

Related: https://github.com/WordPress/gutenberg/pull/79460#issuecomment-4783373376

## Why?

Our tests should be accurate to reflect their expected requirements, lest false positive cause confusion or decrease trust in the tests.

## How?

Before these changes, the changelog check was effectively doing `git diff $BASE_SHA HEAD`, which is a "two dot" operation ([ref](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-gitdiffoptionscommitcommit--path)).

For pull request changes, three-dot notation should be used, and is consistent with how GitHub presents pull request changes:

> [Since the three-dot comparison compares with the merge base, it is focusing on "what a pull request introduces."](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons)

For the false positive flagged in #79460, you can see the specific difference in behavior with how the PR's last commit compares against _trunk as it exists at the point of the check being run_:

- Two dot: https://github.com/WordPress/gutenberg/compare/12358ae0038..0c286d33e8b (includes `packages/theme` changes which is what triggered the test failure)
- Three dot: https://github.com/WordPress/gutenberg/compare/12358ae0038...0c286d33e8b (does not include `packages/theme` changes)

## Testing Instructions

Observe that the sample failure commit triggers test failure for "Check changelog" test.

## Use of AI Tools

Used Cursor + Composer for research, changes were applied myself.