### PR TITLE
theme: Protect design tokens CSS import

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
+
 ## 0.16.0 (2026-06-24)
 
 ### Breaking Changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -77,7 +77,9 @@
 	},
 	"wpScript": true,
 	"types": "build-types",
-	"sideEffects": false,
+	"sideEffects": [
+		"src/prebuilt/css/design-tokens.css"
+	],
 	"dependencies": {
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION
## What?
Follow up to #77462 (P1).

Marks the published `@wordpress/theme/design-tokens.css` source file as side-effectful in `packages/theme/package.json`.

## Why?
The documented CSS import exists for its emitted global CSS. With `sideEffects: false`, downstream bundlers that honor package metadata can treat the import as tree-shakeable and remove it.

## How?
Replaces the package-wide `sideEffects: false` value with an explicit allowlist containing `src/prebuilt/css/design-tokens.css`, the file targeted by the public `./design-tokens.css` export.

## Testing Instructions
1. Run `npm run lint:pkg-json`.
2. Run `npm --cache /private/tmp/codex-npm-cache pack ./packages/theme --dry-run --json`.
3. Run `npm --cache /private/tmp/codex-npm-cache pack ./packages/theme --pack-destination /private/tmp` and confirm the packed manifest includes `"sideEffects": [ "src/prebuilt/css/design-tokens.css" ]`.

### Testing Instructions for Keyboard
Not applicable; this is package metadata only and does not change UI behavior.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
OpenAI Codex was used to implement the package metadata change and run verification commands.