### PR TITLE
Tab List: Fix render inline formatting on frontend

### DIFF
--- a/packages/block-library/src/tab-list/block.json
+++ b/packages/block-library/src/tab-list/block.json
@@ -16,8 +16,9 @@
 			"selector": "button",
 			"query": {
 				"label": {
-					"type": "string",
-					"source": "html"
+					"type": "rich-text",
+					"source": "rich-text",
+					"role": "content"
 				}
 			},
 			"default": []

--- a/packages/block-library/src/tab-list/save.js
+++ b/packages/block-library/src/tab-list/save.js
@@ -7,12 +7,12 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
+	RichText,
 	useBlockProps,
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 } from '@wordpress/block-editor';
-import { safeHTML } from '@wordpress/dom';
 
 export default function save( { attributes } ) {
 	const { tabs } = attributes;
@@ -35,15 +35,14 @@ export default function save( { attributes } ) {
 	return (
 		<div { ...blockProps }>
 			{ tabs.map( ( tab, index ) => (
-				<button
+				<RichText.Content
 					key={ index }
 					className={ buttonClassName || undefined }
 					style={ buttonStyle }
+					tagName="button"
+					value={ tab.label }
 					type="button"
 					role="tab"
-					dangerouslySetInnerHTML={ {
-						__html: safeHTML( tab.label ) || '',
-					} }
 				/>
 			) ) }
 		</div>

--- a/packages/block-library/src/tab-list/save.js
+++ b/packages/block-library/src/tab-list/save.js
@@ -12,6 +12,7 @@ import {
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 } from '@wordpress/block-editor';
+import { safeHTML } from '@wordpress/dom';
 
 export default function save( { attributes } ) {
 	const { tabs } = attributes;
@@ -40,9 +41,10 @@ export default function save( { attributes } ) {
 					style={ buttonStyle }
 					type="button"
 					role="tab"
-				>
-					{ tab.label }
-				</button>
+					dangerouslySetInnerHTML={ {
+						__html: safeHTML( tab.label ) || '',
+					} }
+				/>
 			) ) }
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #79536
Inline formatting like bold, italic, etc., applied to a tab label now renders correctly on the frontend instead of showing raw HTML tags as text.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When adding any decoration to the tab name like bold, itallic etc or a new line `<br>` it looks perfect in the editor, but on the frontend, the tags are showing as a string.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Inline formatting: `save.js` switched from `{ tab.label }` to RichText.Content to display the tab label with 'button'
 tagName.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page in the editor.
2. Insert a Tabs block.
3. Click into a tab label (e.g., "Tab 1").
5. In any tab label, apply Bold formatting to some text.
6. Save the post and view it on the frontend.
7. Verify the tab label text appears bold; no `<strong>` tag should be visible as text.
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/bfdc7878-68d1-478f-9451-b9d22a3fe730




## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Yes
Claude Code - For getting references and creating a skeleton of a fix.