### PR TITLE
Abilities: Support URI schema format

### DIFF
--- a/packages/abilities/src/tests/validation.test.ts
+++ b/packages/abilities/src/tests/validation.test.ts
@@ -249,6 +249,16 @@ describe( 'validateValueFromSchema', () => {
 				' is not a valid hostname.'
 			);
 		} );
+
+		it( 'should validate URI format', () => {
+			const schema = { type: 'string', format: 'uri' };
+			expect(
+				validateValueFromSchema( 'https://example.com/path', schema )
+			).toBe( true );
+			expect( validateValueFromSchema( 'not a uri', schema ) ).toBe(
+				' is not a valid URI.'
+			);
+		} );
 	} );
 
 	describe( 'pattern validation', () => {

--- a/packages/abilities/src/validation.ts
+++ b/packages/abilities/src/validation.ts
@@ -28,7 +28,15 @@ const ajv = new Ajv( {
 	allowUnionTypes: true, // Allow anyOf without explicit type
 } );
 
-addFormats( ajv, [ 'date-time', 'email', 'hostname', 'ipv4', 'ipv6', 'uuid' ] );
+addFormats( ajv, [
+	'date-time',
+	'email',
+	'hostname',
+	'ipv4',
+	'ipv6',
+	'uri',
+	'uuid',
+] );
 
 /**
  * Formats AJV errors into a simple error message.
@@ -78,6 +86,7 @@ function formatAjvError( ajvError: any, param: string ): string {
 				ipv4: `${ fullParam } is not a valid IP address.`,
 				ipv6: `${ fullParam } is not a valid IP address.`,
 				hostname: `${ fullParam } is not a valid hostname.`,
+				uri: `${ fullParam } is not a valid URI.`,
 			};
 			return formatMessages[ format ] || `Invalid ${ format }.`;
 


### PR DESCRIPTION
## What?
- Registers the JSON Schema `uri` format in the @wordpress/abilities client-side AJV validator.
- Adds regression coverage for valid and invalid URI values.

## Why?
Ability schemas may need to mirror Core REST fields that use `format: 'uri'`. Before this change, those schemas failed during client-side schema compilation with an unknown format error.

## Testing
- npm run test:unit -- packages/abilities/src/tests/validation.test.ts
- npm run lint:js -- packages/abilities/src/validation.ts packages/abilities/src/tests/validation.test.ts
- git diff --check HEAD
