### PR TITLE
Select tab panel when caret moves into tab

### DIFF
--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -150,14 +150,9 @@ function Edit( {
 							className={ buttonClassName || undefined }
 							style={ buttonStyle }
 							tabIndex={ -1 }
-							onClick={ ( event ) => {
-								event.preventDefault();
-								selectTabPanel( index );
-							} }
-							// Activate the matching panel when the caret moves
-							// into this tab's label via the keyboard, mirroring
-							// the click behavior. `onFocus` bubbles from the
-							// inner RichText editable.
+							// Activate the matching panel whenever this tab
+							// receives focus — whether from a click or the caret
+							// moving into the label via the keyboard.
 							onFocus={ () => {
 								selectTabPanel( index );
 							} }

--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -61,7 +61,7 @@ function Edit( {
 	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
 
-	const handleTabClick = useCallback(
+	const selectTabPanel = useCallback(
 		( tabIndex ) => {
 			if ( tabsClientId && tabIndex !== effectiveActiveIndex ) {
 				__unstableMarkNextChangeAsNotPersistent();
@@ -152,7 +152,14 @@ function Edit( {
 							tabIndex={ -1 }
 							onClick={ ( event ) => {
 								event.preventDefault();
-								handleTabClick( index );
+								selectTabPanel( index );
+							} }
+							// Activate the matching panel when the caret moves
+							// into this tab's label via the keyboard, mirroring
+							// the click behavior. `onFocus` bubbles from the
+							// inner RichText editable.
+							onFocus={ () => {
+								selectTabPanel( index );
 							} }
 						>
 							<RichText


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates the Tabs block so that moving the caret into a tab's label in the editor activates that tab's panel, matching the existing click behavior.

## Why?
In the editor, the active tab panel only switched when you **clicked** a tab. Moving the caret into a different tab label with the keyboard left the previously selected panel showing — you had to click in the editor to update which panel was visible. This is inconsistent and breaks keyboard-only editing of tabs.

## How?
All tab labels live as `RichText` fields inside a single `core/tab-list` block, so moving the caret between labels with the keyboard never changes the selected block and never fired the existing click/selection handlers that update the active panel.

In `tab-list/edit.js`:
- Renamed `handleTabClick` to `selectTabPanel`, since it sets the active panel regardless of how it's triggered.
- Replaced the `onClick` handler with an `onFocus` handler on each tab button that calls `selectTabPanel( index )`. React's `onFocus` bubbles (via `focusin`) from the inner `RichText` editable, so focus landing in a tab label activates the matching panel.

`selectTabPanel` already no-ops when the target tab is already active and marks the change as non-persistent (kept out of undo history), so the added `onFocus` is safe alongside the click path.

## Testing Instructions
1. Add a Tabs block to a post with at least two tabs, each with distinct panel content.
2. Click into the first tab's label — confirm the first panel is shown.
3. Without clicking the editor canvas, move the caret into the second tab's label (see keyboard steps below).
4. Confirm the second tab's panel becomes the visible/active panel as soon as the caret enters its label.

### Testing Instructions for Keyboard
1. Add a Tabs block with two or more tabs.
2. Place the caret in the first tab's label and edit its text.
3. Use the arrow keys to move the caret from the first tab label into the next tab label.
4. Confirm the panel updates to the newly focused tab without needing a mouse click.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

I used Claude Code to investigate the cause and draft the change. 