### PR TITLE
Global Styles Engine: fix variation element selector for multi-token block roots

### DIFF
--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1146,8 +1146,15 @@ export const getNodesWithStyles = (
 							) {
 								variationNodesToAdd.push( {
 									styles: elementStyles,
+									// Scope the element to only the block wrapper
+									// token (the first space-separated part of the
+									// variation selector). Using the full variation
+									// selector would produce a wrong descendant
+									// combinator for blocks like core/button whose
+									// root selector already ends in the element
+									// class (e.g. .wp-block-button__link).
 									selector: scopeSelector(
-										variationSelector,
+										variationSelector.split( ' ' )[ 0 ],
 										ELEMENTS[ element as ElementName ]
 									),
 									elementName: element,
@@ -1238,10 +1245,30 @@ export const getNodesWithStyles = (
 												variationBlockElement as ElementName
 											]
 										) {
+											// Scope the element to the inner block's
+											// wrapper token (first space-separated
+											// part of its selector) to avoid a wrong
+											// descendant combinator for multi-token
+											// block roots like core/button.
+											const innerBlockWrapper =
+												typeof blockSelectors !==
+													'string' &&
+												blockSelectors[
+													variationBlockName
+												]?.selector
+													? scopeSelector(
+															variationSelector,
+															blockSelectors[
+																variationBlockName
+															].selector.split(
+																' '
+															)[ 0 ]
+													  )
+													: variationBlockSelector;
 											variationNodesToAdd.push( {
 												styles: variationBlockElementStyles,
 												selector: scopeSelector(
-													variationBlockSelector,
+													innerBlockWrapper,
 													ELEMENTS[
 														variationBlockElement as ElementName
 													]

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1142,7 +1142,8 @@ export const getNodesWithStyles = (
 						).forEach( ( [ element, elementStyles ] ) => {
 							if (
 								elementStyles &&
-								ELEMENTS[ element as ElementName ]
+								ELEMENTS[ element as ElementName ] &&
+								variationSelector
 							) {
 								variationNodesToAdd.push( {
 									styles: elementStyles,

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -924,6 +924,73 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'should use a compound (not descendant) selector for variation element styles on multi-token block roots', () => {
+			// Regression test for https://github.com/WordPress/gutenberg/issues/79318.
+			// core/button root selector is '.wp-block-button .wp-block-button__link'.
+			// Both .wp-block-button__link and .wp-element-button are on the same <a>.
+			// Scoping the button element to the variation selector must NOT produce
+			// the descendant '.wp-block-button.is-style-tonal .wp-block-button__link .wp-element-button'
+			// — it must scope to just the block wrapper so elements stay adjacent.
+			const tree = {
+				styles: {
+					blocks: {
+						'core/button': {
+							variations: {
+								tonal: {
+									elements: {
+										button: {
+											color: {
+												background: '#f0f0f0',
+												text: '#111111',
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/button': {
+					selector: '.wp-block-button .wp-block-button__link',
+					styleVariationSelectors: {
+						tonal: '.wp-block-button.is-style-tonal .wp-block-button__link',
+					},
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				false,
+				false,
+				true,
+				true,
+				{
+					blockGap: false,
+					blockStyles: true,
+					layoutStyles: false,
+					marginReset: false,
+					presets: false,
+					rootPadding: false,
+					variationStyles: true,
+				}
+			);
+
+			// Selector must scope element to the block wrapper (.wp-block-button.is-style-tonal),
+			// not to the full variation selector, so the element is a direct descendant of the
+			// wrapper — not a descendant of .wp-block-button__link (which IS the same <a>).
+			expect( result ).toContain(
+				':root :where(.wp-block-button.is-style-tonal .wp-element-button)'
+			);
+			// The wrong form would have an extra .wp-block-button__link in the middle.
+			expect( result ).not.toContain(
+				'.wp-block-button.is-style-tonal .wp-block-button__link .wp-element-button'
+			);
+		} );
+
 		it( 'outputs variation responsive pseudo styles after default pseudo styles', () => {
 			const tree = {
 				styles: {


### PR DESCRIPTION
## What

Fixes #79318.

When a block style variation defines `elements.button` styles in a theme.json partial (e.g. a tonal button variation with custom colors), the Global Styles Engine generates a wrong **descendant** selector that never matches anything in the DOM:

\`\`\`css
/* ✕ Before — never matches */
:root :where(.wp-block-button.is-style-tonal .wp-block-button__link .wp-element-button) {
  background-color: #e0f2fe;
  color: #0369a1;
}
\`\`\`

The problem: `core/button`'s root selector is `.wp-block-button .wp-block-button__link` (two tokens). When the variation element path called `scopeSelector(variationSelector, ELEMENTS['button'])`, it used the **full** variation selector (`.wp-block-button.is-style-tonal .wp-block-button__link`) as the scope, producing a descendant combinator between `.wp-block-button__link` and `.wp-element-button`. But both classes live on the **same** `<a>` element — there is no `.wp-element-button` nested inside `.wp-block-button__link`.

## Fix

Scope element selectors to only the **first token** of the variation selector (the block wrapper, e.g. `.wp-block-button.is-style-tonal`) instead of the full variation selector:

\`\`\`css
/* ✓ After — correctly matches the <a> */
:root :where(
  .wp-block-button.is-style-tonal .wp-element-button,
  .wp-block-button.is-style-tonal .wp-block-button__link
) {
  background-color: #e0f2fe;
  color: #0369a1;
}
\`\`\`

The same fix is applied to the analogous path for **inner-block element styles** within a variation (e.g. a group variation that styles elements of an inner button block).

This brings the JS output into parity with `lib/class-wp-theme-json-gutenberg.php`, which already uses `get_block_style_variation_feature_selector` (compound) for the same path.

## Changes

- `packages/global-styles-engine/src/core/render.tsx` — two call sites changed:
  - Variation inner-element path: `scopeSelector(variationSelector, ...)` → `scopeSelector(variationSelector.split(' ')[0], ...)`
  - Variation inner-block element path: scopes to inner block's wrapper token rather than its full root selector

- `packages/global-styles-engine/src/test/render.test.ts` — regression test asserting the compound selector form for a `core/button` tonal variation with `elements.button` color styles. Fails before the fix, passes after.

## Testing

1. Register a block style variation for `core/button` and add `elements.button.color` styles in a theme.json partial or the Styles panel.
2. Add a Button block in the editor, apply the variation.
3. **Before:** variation colors do not apply (wrong selector). **After:** colors apply correctly.

Or run the unit test directly:

\`\`\`bash
npx jest packages/global-styles-engine/src/test/render.test.ts --no-coverage \
  -t "should use a compound (not descendant) selector"
\`\`\`

## Before / After

**Before** — tonal button variation colors not applied (wrong descendant selector):

<img width="1200" height="702" alt="79318-before" src="https://github.com/user-attachments/assets/a615eecf-d9a6-4d5a-a7f5-1c2f934fc37e" />


**After** — tonal button variation colors correctly applied:

<img width="1200" height="702" alt="79318-after" src="https://github.com/user-attachments/assets/686fc3e3-6bf9-4bee-a408-af3825477840" />
