### PR TITLE
Pattern editing: use section block selector for pattern display identity

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/block-toolbar-icon.js
@@ -19,7 +19,6 @@ import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { store as blockEditorStore } from '../../store';
 import { hasPatternOverridesDefaultBinding } from '../../utils/block-bindings';
 import { unlock } from '../../lock-unlock';
-import { isIsolatedEditorKey } from '../../store/private-keys';
 
 function getBlockIconVariant( { select, clientIds } ) {
 	const {
@@ -30,14 +29,9 @@ function getBlockIconVariant( { select, clientIds } ) {
 		getTemplateLock,
 		getBlockEditingMode,
 		canEditBlock,
-		isWithinEditedContentOnlySection,
-		getSettings,
+		isSectionBlock,
 	} = unlock( select( blockEditorStore ) );
 	const { getBlockStyles } = select( blocksStore );
-	const settings = getSettings();
-	const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
-	const disableContentOnlyForUnsyncedPatterns =
-		!! settings?.disableContentOnlyForUnsyncedPatterns;
 
 	const hasTemplateLock = clientIds.some(
 		( id ) => getTemplateLock( id ) === 'contentOnly'
@@ -51,9 +45,7 @@ function getBlockIconVariant( { select, clientIds } ) {
 	const hasPatternNameInSelection = clientIds.some(
 		( id ) =>
 			!! getBlockAttributes( id )?.metadata?.patternName &&
-			! isWithinEditedContentOnlySection( id ) &&
-			! isIsolatedEditor &&
-			! disableContentOnlyForUnsyncedPatterns
+			isSectionBlock( id )
 	);
 	const hasPatternOverrides = clientIds.every( ( clientId ) =>
 		hasPatternOverridesDefaultBinding(
@@ -97,16 +89,9 @@ function getBlockIconVariant( { select, clientIds } ) {
 }
 
 function getBlockIcon( { select, clientIds } ) {
-	const {
-		getBlockName,
-		getBlockAttributes,
-		isWithinEditedContentOnlySection,
-		getSettings,
-	} = unlock( select( blockEditorStore ) );
-	const settings = getSettings();
-	const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
-	const disableContentOnlyForUnsyncedPatterns =
-		!! settings?.disableContentOnlyForUnsyncedPatterns;
+	const { getBlockName, getBlockAttributes, isSectionBlock } = unlock(
+		select( blockEditorStore )
+	);
 
 	const _isSingleBlock = clientIds.length === 1;
 	const firstClientId = clientIds[ 0 ];
@@ -115,9 +100,7 @@ function getBlockIcon( { select, clientIds } ) {
 	if (
 		_isSingleBlock &&
 		blockAttributes?.metadata?.patternName &&
-		! isWithinEditedContentOnlySection( firstClientId ) &&
-		! isIsolatedEditor &&
-		! disableContentOnlyForUnsyncedPatterns
+		isSectionBlock( firstClientId )
 	) {
 		return symbol;
 	}

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.js
@@ -13,7 +13,6 @@ import { paragraph } from '@wordpress/icons';
  * Internal dependencies
  */
 import BlockToolbarIcon from '../block-toolbar-icon';
-import { isIsolatedEditorKey } from '../../../store/private-keys';
 
 jest.mock( '@wordpress/blocks', () => {
 	const actualImplementation = jest.requireActual( '@wordpress/blocks' );
@@ -68,15 +67,13 @@ describe( 'BlockToolbarIcon', () => {
 		},
 		blockName = 'core/group',
 		getActiveBlockVariation = () => null,
-		settings = {},
-		isWithinEditedSection = false,
+		isSectionBlock = true,
 	} = {} ) => {
 		useSelect.mockImplementation( ( mapSelect ) =>
 			mapSelect( () => ( {
 				get: () => false,
 				getBlockName: () => blockName,
 				getBlockAttributes: () => attributes,
-				getSettings: () => settings,
 				getBlockParentsByBlockName: () => [],
 				canRemoveBlocks: () => true,
 				getTemplateLock: () => undefined,
@@ -84,7 +81,7 @@ describe( 'BlockToolbarIcon', () => {
 				canEditBlock: () => true,
 				getBlockStyles: () => [ {} ],
 				getActiveBlockVariation,
-				isWithinEditedContentOnlySection: () => isWithinEditedSection,
+				isSectionBlock: () => isSectionBlock,
 			} ) )
 		);
 	};
@@ -210,7 +207,7 @@ describe( 'BlockToolbarIcon', () => {
 		} );
 
 		it( 'should show the block switcher when the section is being edited', () => {
-			setupToolbarSelectors( { isWithinEditedSection: true } );
+			setupToolbarSelectors( { isSectionBlock: false } );
 
 			render( <BlockToolbarIcon { ...defaultProps } /> );
 
@@ -227,9 +224,7 @@ describe( 'BlockToolbarIcon', () => {
 						patternName: 'theme/header-wrapper',
 					},
 				},
-				settings: {
-					[ isIsolatedEditorKey ]: true,
-				},
+				isSectionBlock: false,
 			} );
 
 			render( <BlockToolbarIcon { ...defaultProps } /> );
@@ -244,9 +239,7 @@ describe( 'BlockToolbarIcon', () => {
 
 		it( 'should show the block switcher when content-only editing is disabled', () => {
 			setupToolbarSelectors( {
-				settings: {
-					disableContentOnlyForUnsyncedPatterns: true,
-				},
+				isSectionBlock: false,
 			} );
 
 			render( <BlockToolbarIcon { ...defaultProps } /> );
@@ -256,6 +249,19 @@ describe( 'BlockToolbarIcon', () => {
 			).toBeInTheDocument();
 			expect( screen.getByTestId( 'block-icon' ) ).toHaveTextContent(
 				'core/group-icon'
+			);
+		} );
+
+		it( 'should show the block icon for section blocks without pattern metadata', () => {
+			setupToolbarSelectors( {
+				attributes: {},
+				blockName: 'core/template-part',
+			} );
+
+			render( <BlockToolbarIcon { ...defaultProps } /> );
+
+			expect( screen.getByTestId( 'block-icon' ) ).toHaveTextContent(
+				'core/template-part-icon'
 			);
 		} );
 	} );

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -16,7 +16,6 @@ import { symbol } from '@wordpress/icons';
  */
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { isIsolatedEditorKey } from '../../store/private-keys';
 
 /** @typedef {import('@wordpress/blocks').WPIcon} WPIcon */
 
@@ -79,7 +78,6 @@ export default function useBlockDisplayInformation( clientId ) {
 				getBlockName,
 				getBlockAttributes,
 				__experimentalGetParsedPattern,
-				getSettings,
 			} = blockEditorSelect;
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
@@ -89,24 +87,12 @@ export default function useBlockDisplayInformation( clientId ) {
 				return null;
 			}
 			const attributes = getBlockAttributes( clientId );
-			const { isWithinEditedContentOnlySection } =
-				unlock( blockEditorSelect );
-			const settings = getSettings();
-			const isIsolatedEditor = !! settings?.[ isIsolatedEditorKey ];
-			const disableContentOnlyForUnsyncedPatterns =
-				!! settings?.disableContentOnlyForUnsyncedPatterns;
+			const { isSectionBlock } = unlock( blockEditorSelect );
 
 			// Check if this block is a pattern
 			const patternName = attributes?.metadata?.patternName;
-			const isEditedContentOnlySection =
-				isWithinEditedContentOnlySection( clientId );
 
-			if (
-				patternName &&
-				! isEditedContentOnlySection &&
-				! isIsolatedEditor &&
-				! disableContentOnlyForUnsyncedPatterns
-			) {
+			if ( patternName && isSectionBlock( clientId ) ) {
 				const pattern = __experimentalGetParsedPattern( patternName );
 				const positionLabel = getPositionTypeLabel( attributes );
 				return {

--- a/packages/block-editor/src/components/use-block-display-information/test/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/test/index.js
@@ -14,7 +14,6 @@ import { symbol } from '@wordpress/icons';
  * Internal dependencies
  */
 import useBlockDisplayInformation from '../';
-import { isIsolatedEditorKey } from '../../../store/private-keys';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 jest.mock( '../../../lock-unlock', () => ( {
@@ -26,6 +25,7 @@ jest.mock( '../../../lock-unlock', () => ( {
 } ) );
 
 const groupIcon = 'group-icon';
+const templatePartIcon = 'template-part-icon';
 
 function TestComponent( { onChange } ) {
 	const blockInformation = useBlockDisplayInformation( 'client-id' );
@@ -56,19 +56,17 @@ function setupUseSelect( {
 		description: 'Gather blocks in a layout container.',
 	},
 	getActiveBlockVariation = () => null,
-	settings = {},
-	isWithinEditedSection = false,
+	isSectionBlock = true,
 } = {} ) {
 	useSelect.mockImplementation( ( mapSelect ) =>
 		mapSelect( () => ( {
 			getBlockName: () => blockName,
 			getBlockAttributes: () => attributes,
-			getSettings: () => settings,
 			__experimentalGetParsedPattern: () => ( {
 				title: 'Hero pattern',
 				description: 'Pattern description.',
 			} ),
-			isWithinEditedContentOnlySection: () => isWithinEditedSection,
+			isSectionBlock: () => isSectionBlock,
 			getBlockType: () => blockType,
 			getActiveBlockVariation,
 		} ) )
@@ -97,7 +95,7 @@ describe( 'useBlockDisplayInformation', () => {
 	} );
 
 	it( 'displays block information for a pattern section that is being edited', () => {
-		setupUseSelect( { isWithinEditedSection: true } );
+		setupUseSelect( { isSectionBlock: false } );
 		const onChange = jest.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
@@ -120,9 +118,7 @@ describe( 'useBlockDisplayInformation', () => {
 					patternName: 'theme/header-wrapper',
 				},
 			},
-			settings: {
-				[ isIsolatedEditorKey ]: true,
-			},
+			isSectionBlock: false,
 		} );
 		const onChange = jest.fn();
 
@@ -140,9 +136,7 @@ describe( 'useBlockDisplayInformation', () => {
 
 	it( 'displays block information for a pattern wrapper when content-only editing is disabled', () => {
 		setupUseSelect( {
-			settings: {
-				disableContentOnlyForUnsyncedPatterns: true,
-			},
+			isSectionBlock: false,
 		} );
 		const onChange = jest.fn();
 
@@ -154,6 +148,30 @@ describe( 'useBlockDisplayInformation', () => {
 				icon: groupIcon,
 				description: 'Gather blocks in a layout container.',
 				name: 'Hero pattern',
+			} )
+		);
+	} );
+
+	it( 'displays block information for section blocks without pattern metadata', () => {
+		setupUseSelect( {
+			attributes: {},
+			blockName: 'core/template-part',
+			blockType: {
+				name: 'core/template-part',
+				title: 'Template Part',
+				icon: templatePartIcon,
+				description: 'A template part.',
+			},
+		} );
+		const onChange = jest.fn();
+
+		render( <TestComponent onChange={ onChange } /> );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				title: 'Template Part',
+				icon: templatePartIcon,
+				description: 'A template part.',
 			} )
 		);
 	} );


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/78383

Updates pattern display identity checks to use the shared `isSectionBlock` selector when deciding whether a block with `metadata.patternName` should be displayed as a Pattern.

## Why?

The previous checks duplicated part of the section-block logic locally across block display information and toolbar icon handling. Using `isSectionBlock` keeps these display rules aligned with the block editor’s existing source of truth for content-only pattern sections.

## How?

- Replaces duplicated checks for edited content-only sections, isolated editor state, and disabled content-only pattern editing with `patternName && isSectionBlock( clientId )`.
- Keeps the `patternName` guard so section blocks without pattern metadata continue to show their normal block identity.
- Updates unit tests for block display information and toolbar icons.

## Testing Instructions

1. Insert or select a content-only unsynced pattern.
2. Confirm the block card and toolbar show the Pattern identity before editing.
3. Click “Edit pattern”.
4. Confirm the block card and toolbar show the source block identity.
5. Confirm template parts or other section blocks without `metadata.patternName` still show their normal block identity.


https://github.com/user-attachments/assets/ca2c2756-6bba-4581-a6e6-30e6832ff477

