### PR TITLE
Commands: Suggest pattern editing toggle for selected patterns

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -41,6 +41,38 @@ import { modalName as patternRenameModalName } from '../pattern-rename-modal';
 import { modalName as patternDuplicateModalName } from '../pattern-duplicate-modal';
 import isTemplateRevertable from '../../store/utils/is-template-revertable';
 
+function getTogglePatternEditingCommand( {
+	disableContentOnlyForPatternsAndTemplateParts,
+	stopEditingContentOnlySection,
+	updateEditorSettings,
+} ) {
+	return {
+		name: 'core/toggle-pattern-editing',
+		label: disableContentOnlyForPatternsAndTemplateParts
+			? __( 'Disable editing all patterns' )
+			: __( 'Enable editing all patterns' ),
+		icon: symbol,
+		category: 'command',
+		callback: ( { close } ) => {
+			const disableContentOnly =
+				! disableContentOnlyForPatternsAndTemplateParts;
+			stopEditingContentOnlySection();
+			updateEditorSettings( {
+				disableContentOnlyForUnsyncedPatterns: disableContentOnly,
+				disableContentOnlyForTemplateParts: disableContentOnly,
+			} );
+			close();
+		},
+	};
+}
+
+function isPatternOrTemplatePartBlock( blockName, attributes ) {
+	return (
+		!! attributes?.metadata?.patternName ||
+		blockName === 'core/template-part'
+	);
+}
+
 const getEditorCommandLoader = () =>
 	function useEditorCommandLoader() {
 		const {
@@ -191,24 +223,13 @@ const getEditorCommandLoader = () =>
 			},
 		} );
 
-		commands.push( {
-			name: 'core/toggle-pattern-editing',
-			label: disableContentOnlyForPatternsAndTemplateParts
-				? __( 'Disable editing all patterns' )
-				: __( 'Enable editing all patterns' ),
-			icon: symbol,
-			category: 'command',
-			callback: ( { close } ) => {
-				const disableContentOnly =
-					! disableContentOnlyForPatternsAndTemplateParts;
-				stopEditingContentOnlySection();
-				updateEditorSettings( {
-					disableContentOnlyForUnsyncedPatterns: disableContentOnly,
-					disableContentOnlyForTemplateParts: disableContentOnly,
-				} );
-				close();
-			},
-		} );
+		commands.push(
+			getTogglePatternEditingCommand( {
+				disableContentOnlyForPatternsAndTemplateParts,
+				stopEditingContentOnlySection,
+				updateEditorSettings,
+			} )
+		);
 
 		if ( allowSwitchEditorMode ) {
 			commands.push( {
@@ -321,6 +342,69 @@ const getEditorCommandLoader = () =>
 		return {
 			commands,
 			isLoading: false,
+		};
+	};
+
+const getPatternEditingContextualCommands = () =>
+	function usePatternEditingContextualCommands( { search } ) {
+		const {
+			disableContentOnlyForPatternsAndTemplateParts,
+			hasPatternOrTemplatePartSelection,
+			isPreviewMode,
+		} = useSelect( ( select ) => {
+			const {
+				getBlockAttributes,
+				getBlockName,
+				getBlockParents,
+				getSelectedBlockClientId,
+				getSelectedBlockClientIds,
+				getSettings,
+			} = select( blockEditorStore );
+			const { getEditorSettings } = select( editorStore );
+			const editorSettings = getEditorSettings();
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const clientIdsToCheck =
+				selectedBlockClientId && selectedBlockClientIds.length === 1
+					? [
+							selectedBlockClientId,
+							...getBlockParents( selectedBlockClientId, true ),
+					  ]
+					: [];
+
+			return {
+				disableContentOnlyForPatternsAndTemplateParts:
+					!! editorSettings.disableContentOnlyForUnsyncedPatterns &&
+					!! editorSettings.disableContentOnlyForTemplateParts,
+				hasPatternOrTemplatePartSelection: clientIdsToCheck.some(
+					( clientId ) =>
+						isPatternOrTemplatePartBlock(
+							getBlockName( clientId ),
+							getBlockAttributes( clientId )
+						)
+				),
+				isPreviewMode: getSettings().isPreviewMode,
+			};
+		}, [] );
+		const { updateEditorSettings } = useDispatch( editorStore );
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const { stopEditingContentOnlySection } = unlock(
+			useDispatch( blockEditorStore )
+		);
+
+		if ( search || ! hasPatternOrTemplatePartSelection || isPreviewMode ) {
+			return { isLoading: false, commands: [] };
+		}
+
+		return {
+			isLoading: false,
+			commands: [
+				getTogglePatternEditingCommand( {
+					disableContentOnlyForPatternsAndTemplateParts,
+					stopEditingContentOnlySection,
+					updateEditorSettings,
+				} ),
+			],
 		};
 	};
 
@@ -512,6 +596,12 @@ export default function useCommands() {
 		name: 'core/editor/contextual-commands',
 		hook: getEditedEntityContextualCommands(),
 		context: 'entity-edit',
+	} );
+
+	useCommandLoader( {
+		name: 'core/editor/pattern-editing-contextual-commands',
+		hook: getPatternEditingContextualCommands(),
+		context: 'block-selection-edit',
 	} );
 
 	useCommandLoader( {

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -41,6 +41,17 @@ import { modalName as patternRenameModalName } from '../pattern-rename-modal';
 import { modalName as patternDuplicateModalName } from '../pattern-duplicate-modal';
 import isTemplateRevertable from '../../store/utils/is-template-revertable';
 
+/**
+ * Returns the command that toggles content-only editing for patterns and template parts.
+ * The command is registered both globally for search and contextually for block
+ * selection, so keeping it in one place ensures the label and callback stay aligned.
+ *
+ * @param {Object}   options                                               Command options.
+ * @param {boolean}  options.disableContentOnlyForPatternsAndTemplateParts Whether content-only editing is disabled for patterns and template parts.
+ * @param {Function} options.stopEditingContentOnlySection                 Stops editing the current content-only section before changing the setting.
+ * @param {Function} options.updateEditorSettings                          Updates the editor settings.
+ * @return {Object} The command configuration.
+ */
 function getTogglePatternEditingCommand( {
 	disableContentOnlyForPatternsAndTemplateParts,
 	stopEditingContentOnlySection,
@@ -392,6 +403,8 @@ const getPatternEditingContextualCommands = () =>
 			useDispatch( blockEditorStore )
 		);
 
+		// Keep the disable command available after full pattern editing is enabled,
+		// even when the current selection is no longer inside a pattern or template part.
 		if (
 			search ||
 			( ! hasPatternOrTemplatePartSelection &&

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -392,7 +392,12 @@ const getPatternEditingContextualCommands = () =>
 			useDispatch( blockEditorStore )
 		);
 
-		if ( search || ! hasPatternOrTemplatePartSelection || isPreviewMode ) {
+		if (
+			search ||
+			( ! hasPatternOrTemplatePartSelection &&
+				! disableContentOnlyForPatternsAndTemplateParts ) ||
+			isPreviewMode
+		) {
 			return { isLoading: false, commands: [] };
 		}
 

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -538,6 +538,7 @@ test.describe( 'Unsynced pattern', () => {
 				name: 'Enable editing all patterns',
 			} )
 			.click();
+		await expect( commandSuggestions ).toBeHidden();
 		await page.evaluate( () => {
 			window.wp.data
 				.dispatch( 'core/preferences' )

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -509,10 +509,14 @@ test.describe( 'Unsynced pattern', () => {
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>Pattern content</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:group -->` );
+<!-- /wp:group -->
+<!-- wp:paragraph -->
+<p>Outside paragraph</p>
+<!-- /wp:paragraph -->` );
 
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Pattern content' } )
 			.click();
 
 		await pageUtils.pressKeys( 'primary+k' );
@@ -526,6 +530,33 @@ test.describe( 'Unsynced pattern', () => {
 		await expect(
 			commandSuggestions.getByRole( 'option', {
 				name: 'Enable editing all patterns',
+			} )
+		).toBeVisible();
+
+		await commandSuggestions
+			.getByRole( 'option', {
+				name: 'Enable editing all patterns',
+			} )
+			.click();
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/commands', 'recentlyUsed', [] );
+		} );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Outside paragraph' } )
+			.click();
+
+		await pageUtils.pressKeys( 'primary+k' );
+
+		await expect( commandSuggestions.getByText( 'Recent' ) ).toBeHidden();
+		await expect(
+			commandSuggestions.getByText( 'Suggestions' )
+		).toBeVisible();
+		await expect(
+			commandSuggestions.getByRole( 'option', {
+				name: 'Disable editing all patterns',
 			} )
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -500,6 +500,36 @@ test.describe( 'Unsynced pattern', () => {
 		await expect( blockHeading ).toHaveAccessibleName( 'Header Group' );
 	} );
 
+	test( 'shows the full pattern editing command suggestion when a pattern content block is selected', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.setContent( `<!-- wp:group {"metadata":{"patternName":"theme/header-wrapper","name":"Header"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Pattern content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+
+		await pageUtils.pressKeys( 'primary+k' );
+		const commandSuggestions = page.getByRole( 'listbox', {
+			name: 'Command suggestions',
+		} );
+
+		await expect(
+			commandSuggestions.getByText( 'Suggestions' )
+		).toBeVisible();
+		await expect(
+			commandSuggestions.getByRole( 'option', {
+				name: 'Enable editing all patterns',
+			} )
+		).toBeVisible();
+	} );
+
 	test( 'shows the source block in the inspector when full pattern editing is enabled', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/78383

Adds the pattern/template part editing toggle command to command palette Suggestions when it is contextually relevant.

## Why?

The command is useful when working with patterns and template parts, but it was only discoverable through search. This makes the toggle available from Suggestions when selecting a pattern, template part, or their content blocks.

When full pattern editing is already enabled, the command remains available as `Disable editing all patterns` even if a normal block is selected, so users have a reliable way to exit that global mode without depending on Recent commands.

## How?

- Reuses the existing `core/toggle-pattern-editing` command.
- Adds an editor-level contextual command loader for `block-selection-edit`.
- Shows the command when:
  - the selected block or one of its ancestors is an unsynced pattern or template part, or
  - full pattern/template part editing is already enabled.
- Adds E2E coverage for enabling edit-all-patterns from a pattern child, then showing the disable command after selecting an outside paragraph.

## Testing Instructions

Not necessary, but if you want to clear "Recent commands" run this in your console:

```js
wp.data
	.dispatch( 'core/preferences' )
	.set( 'core/commands', 'recentlyUsed', [] );
```

1. Add an unsynced pattern and an outside paragraph.
2. Select a block inside the pattern.
3. Open the command palette.
4. Confirm `Enable editing all patterns` appears under Suggestions.
5. Run the command.
6. Select the outside paragraph.
7. Open the command palette again.
8. Confirm `Disable editing all patterns` appears under Suggestions.


https://github.com/user-attachments/assets/42b0bc9a-3ce4-4c79-b30a-e97d7b8058a9


