### PR TITLE
Style Engine: Preserve important gradient declarations

### DIFF
--- a/backport-changelog/7.1/12361.md
+++ b/backport-changelog/7.1/12361.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12361
+
+* https://github.com/WordPress/gutenberg/pull/79568

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -113,12 +113,13 @@ function gutenberg_get_state_declarations_with_background_resets( $declarations 
 
 	/*
 	 * When the state sets a solid background-color but no gradient of its own,
-	 * emit `background-image: unset !important` to clear any gradient (whether
-	 * stored as the `background` shorthand or as `background-image`) that was
-	 * applied to the default / normal state via an inline style attribute.
+	 * emit `background-image: unset` to clear any gradient (whether stored as
+	 * the `background` shorthand or as `background-image`) that was applied to
+	 * the default / normal state via an inline style attribute. The declaration
+	 * is marked important when the state rule is registered with the style engine.
 	 */
 	if ( $has_background_color && ! $has_background && ! $has_background_image ) {
-		$declarations['background-image'] = 'unset !important';
+		$declarations['background-image'] = 'unset';
 	}
 
 	return $declarations;
@@ -645,21 +646,35 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	 */
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
-		$declarations = $rule['declarations'];
-		foreach ( $declarations as $property => $value ) {
-			$declarations[ $property ] = is_string( $value ) && str_contains( $value, '!important' )
-				? $value
-				: $value . ' !important';
+		$declarations           = $rule['declarations'];
+		$important_declarations = gutenberg_get_state_declarations_with_background_resets( $declarations );
+		$selector               = gutenberg_build_state_selector(
+			".$unique_class",
+			$rule['selector'],
+			$rule['state']
+		);
+		$style_rule             = array(
+			'selector'     => $selector,
+			'declarations' => $important_declarations,
+			'important'    => true,
+		);
+		if ( ! empty( $rule['rules_group'] ) ) {
+			$style_rule['rules_group'] = $rule['rules_group'];
 		}
-		$declarations = gutenberg_get_state_declarations_with_fallback_border_styles( $declarations );
-		$declarations = gutenberg_get_state_declarations_with_background_resets( $declarations );
-		$style_rule   = array(
-			'selector'     => gutenberg_build_state_selector(
-				".$unique_class",
-				$rule['selector'],
-				$rule['state']
-			),
-			'declarations' => $declarations,
+		$style_rules[] = $style_rule;
+
+		$fallback_declarations = gutenberg_get_state_declarations_with_fallback_border_styles( $declarations );
+		foreach ( array_keys( $declarations ) as $property ) {
+			unset( $fallback_declarations[ $property ] );
+		}
+
+		if ( empty( $fallback_declarations ) ) {
+			continue;
+		}
+
+		$style_rule = array(
+			'selector'     => $selector,
+			'declarations' => $fallback_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
 			$style_rule['rules_group'] = $rule['rules_group'];

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -650,7 +650,13 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		$important_declaration_values = gutenberg_get_state_declarations_with_background_resets( $declarations );
 		$important_declarations       = new WP_Style_Engine_CSS_Declarations_Gutenberg();
 		foreach ( $important_declaration_values as $property => $value ) {
-			$important_declarations->add_declaration( $property, $value, true );
+			$important_declarations->add_declaration(
+				$property,
+				$value,
+				array(
+					'important' => true,
+				)
+			);
 		}
 		$selector   = gutenberg_build_state_selector(
 			".$unique_class",

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -646,17 +646,20 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 	 */
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
-		$declarations           = $rule['declarations'];
-		$important_declarations = gutenberg_get_state_declarations_with_background_resets( $declarations );
-		$selector               = gutenberg_build_state_selector(
+		$declarations                 = $rule['declarations'];
+		$important_declaration_values = gutenberg_get_state_declarations_with_background_resets( $declarations );
+		$important_declarations       = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+		foreach ( $important_declaration_values as $property => $value ) {
+			$important_declarations->add_declaration( $property, $value, true );
+		}
+		$selector   = gutenberg_build_state_selector(
 			".$unique_class",
 			$rule['selector'],
 			$rule['state']
 		);
-		$style_rule             = array(
+		$style_rule = array(
 			'selector'     => $selector,
 			'declarations' => $important_declarations,
-			'important'    => true,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
 			$style_rule['rules_group'] = $rule['rules_group'];

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -663,14 +663,14 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 			$rule['selector'],
 			$rule['state']
 		);
-		$style_rule = array(
+		$important_style_rule = array(
 			'selector'     => $selector,
 			'declarations' => $important_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
-			$style_rule['rules_group'] = $rule['rules_group'];
+			$important_style_rule['rules_group'] = $rule['rules_group'];
 		}
-		$style_rules[] = $style_rule;
+		$style_rules[] = $important_style_rule;
 
 		$fallback_declarations = gutenberg_get_state_declarations_with_fallback_border_styles( $declarations );
 		foreach ( array_keys( $declarations ) as $property ) {
@@ -681,14 +681,14 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 			continue;
 		}
 
-		$style_rule = array(
+		$fallback_style_rule = array(
 			'selector'     => $selector,
 			'declarations' => $fallback_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
-			$style_rule['rules_group'] = $rule['rules_group'];
+			$fallback_style_rule['rules_group'] = $rule['rules_group'];
 		}
-		$style_rules[] = $style_rule;
+		$style_rules[] = $fallback_style_rule;
 	}
 
 	gutenberg_style_engine_get_stylesheet_from_css_rules(

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -658,7 +658,7 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 				)
 			);
 		}
-		$selector   = gutenberg_build_state_selector(
+		$selector             = gutenberg_build_state_selector(
 			".$unique_class",
 			$rule['selector'],
 			$rule['state']

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -95,13 +95,12 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		 * Adds multiple declarations.
 		 *
 		 * @param array $declarations An array of declarations.
-		 * @param bool  $is_important Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 		 */
-		public function add_declarations( $declarations, $is_important = false ) {
+		public function add_declarations( $declarations ) {
 			foreach ( $declarations as $property => $value ) {
-				$this->add_declaration( $property, $value, $is_important );
+				$this->add_declaration( $property, $value );
 			}
 			return $this;
 		}

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -127,7 +127,25 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 			$filtered_value = wp_strip_all_tags( $value, true );
 
 			if ( '' !== $filtered_value ) {
-				return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+				$important_pattern = '/\s*!\s*important\s*$/i';
+				$has_important     = 1 === preg_match( $important_pattern, $filtered_value );
+
+				/*
+				 * Some safecss validators, such as gradients, expect the value to
+				 * end after the CSS function. Validate without !important and then
+				 * restore it when the result is still a single declaration.
+				 */
+				if ( $has_important ) {
+					$filtered_value = preg_replace( $important_pattern, '', $filtered_value );
+				}
+
+				$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+
+				if ( $has_important && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+					return "$filtered_declaration !important";
+				}
+
+				return $filtered_declaration;
 			}
 			return '';
 		}

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -177,7 +177,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 
 				$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 
-				if ( ! empty( $options['important'] ) && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+				// Only append !important in the presence of an option value and when sanitization returns a single declaration.
+				if ( true === $options['important'] && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
 					return "$filtered_declaration !important";
 				}
 

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -23,11 +23,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		protected $declarations = array();
 
 		/**
-		 * CSS properties whose declarations should be output with !important.
+		 * CSS declaration options keyed by property name.
 		 *
 		 * @var array
 		 */
-		protected $important_declarations = array();
+		protected $declaration_options = array();
 
 		/**
 		 * Constructor for this object.
@@ -78,12 +78,14 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 				)
 			);
 
+			$options = array_filter( $options );
+
 			// Adds the declaration property/value pair.
 			$this->declarations[ $property ] = $value;
-			if ( ! empty( $options['important'] ) ) {
-				$this->important_declarations[ $property ] = true;
+			if ( $options ) {
+				$this->declaration_options[ $property ] = $options;
 			} else {
-				unset( $this->important_declarations[ $property ] );
+				unset( $this->declaration_options[ $property ] );
 			}
 
 			return $this;
@@ -98,7 +100,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		 */
 		public function remove_declaration( $property ) {
 			unset( $this->declarations[ $property ] );
-			unset( $this->important_declarations[ $property ] );
+			unset( $this->declaration_options[ $property ] );
 			return $this;
 		}
 
@@ -140,12 +142,12 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		}
 
 		/**
-		 * Gets the important declarations array.
+		 * Gets declaration options keyed by property name.
 		 *
 		 * @return array
 		 */
-		public function get_important_declarations() {
-			return $this->important_declarations;
+		public function get_declaration_options() {
+			return $this->declaration_options;
 		}
 
 		/**
@@ -205,9 +207,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 					$property,
 					$value,
 					$spacer,
-					array(
-						'important' => ! empty( $this->important_declarations[ $property ] ),
-					)
+					$this->declaration_options[ $property ] ?? array()
 				);
 				if ( $filtered_declaration ) {
 					$declarations_output .= "{$indent}{$filtered_declaration};$suffix";

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -23,6 +23,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		protected $declarations = array();
 
 		/**
+		 * CSS properties whose declarations should be output with !important.
+		 *
+		 * @var array
+		 */
+		protected $important_declarations = array();
+
+		/**
 		 * Constructor for this object.
 		 *
 		 * If a `$declarations` array is passed, it will be used to populate
@@ -37,12 +44,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		/**
 		 * Adds a single declaration.
 		 *
-		 * @param string $property The CSS property.
-		 * @param string $value    The CSS value.
+		 * @param string $property     The CSS property.
+		 * @param string $value        The CSS value.
+		 * @param bool   $is_important Optional. Whether to output the declaration with !important. Default false.
 		 *
 		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 		 */
-		public function add_declaration( $property, $value ) {
+		public function add_declaration( $property, $value, $is_important = false ) {
 			// Sanitizes the property.
 			$property = $this->sanitize_property( $property );
 			// Bails early if the property is empty.
@@ -61,6 +69,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 
 			// Adds the declaration property/value pair.
 			$this->declarations[ $property ] = $value;
+			if ( $is_important ) {
+				$this->important_declarations[ $property ] = true;
+			} else {
+				unset( $this->important_declarations[ $property ] );
+			}
 
 			return $this;
 		}
@@ -74,6 +87,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		 */
 		public function remove_declaration( $property ) {
 			unset( $this->declarations[ $property ] );
+			unset( $this->important_declarations[ $property ] );
 			return $this;
 		}
 
@@ -81,12 +95,13 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		 * Adds multiple declarations.
 		 *
 		 * @param array $declarations An array of declarations.
+		 * @param bool  $is_important Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 		 */
-		public function add_declarations( $declarations ) {
+		public function add_declarations( $declarations, $is_important = false ) {
 			foreach ( $declarations as $property => $value ) {
-				$this->add_declaration( $property, $value );
+				$this->add_declaration( $property, $value, $is_important );
 			}
 			return $this;
 		}
@@ -115,33 +130,31 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		}
 
 		/**
+		 * Gets the important declarations array.
+		 *
+		 * @return array
+		 */
+		public function get_important_declarations() {
+			return $this->important_declarations;
+		}
+
+		/**
 		 * Filters a CSS property + value pair.
 		 *
-		 * @param string $property The CSS property.
-		 * @param string $value    The value to be filtered.
-		 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
+		 * @param string $property     The CSS property.
+		 * @param string $value        The value to be filtered.
+		 * @param string $spacer       The spacer between the colon and the value. Defaults to an empty string.
+		 * @param bool   $is_important Whether to output the declaration with !important.
 		 *
 		 * @return string The filtered declaration or an empty string.
 		 */
-		protected static function filter_declaration( $property, $value, $spacer = '' ) {
+		protected static function filter_declaration( $property, $value, $spacer = '', $is_important = false ) {
 			$filtered_value = wp_strip_all_tags( $value, true );
 
 			if ( '' !== $filtered_value ) {
-				$important_pattern = '/\s*!\s*important\s*$/i';
-				$has_important     = 1 === preg_match( $important_pattern, $filtered_value );
-
-				/*
-				 * Some safecss validators, such as gradients, expect the value to
-				 * end after the CSS function. Validate without !important and then
-				 * restore it when the result is still a single declaration.
-				 */
-				if ( $has_important ) {
-					$filtered_value = preg_replace( $important_pattern, '', $filtered_value );
-				}
-
 				$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 
-				if ( $has_important && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+				if ( $is_important && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
 					return "$filtered_declaration !important";
 				}
 
@@ -167,7 +180,8 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 			$spacer              = $should_prettify ? ' ' : '';
 
 			foreach ( $declarations_array as $property => $value ) {
-				$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
+				$is_important         = ! empty( $this->important_declarations[ $property ] );
+				$filtered_declaration = static::filter_declaration( $property, $value, $spacer, $is_important );
 				if ( $filtered_declaration ) {
 					$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 				}

--- a/packages/style-engine/src/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-declarations.php
@@ -44,13 +44,17 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		/**
 		 * Adds a single declaration.
 		 *
-		 * @param string $property     The CSS property.
-		 * @param string $value        The CSS value.
-		 * @param bool   $is_important Optional. Whether to output the declaration with !important. Default false.
+		 * @param string $property The CSS property.
+		 * @param string $value    The CSS value.
+		 * @param array  $options  {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $important Whether to output the declaration with !important. Default false.
+		 * }
 		 *
 		 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 		 */
-		public function add_declaration( $property, $value, $is_important = false ) {
+		public function add_declaration( $property, $value, $options = array() ) {
 			// Sanitizes the property.
 			$property = $this->sanitize_property( $property );
 			// Bails early if the property is empty.
@@ -67,9 +71,16 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 				return $this;
 			}
 
+			$options = wp_parse_args(
+				$options,
+				array(
+					'important' => false,
+				)
+			);
+
 			// Adds the declaration property/value pair.
 			$this->declarations[ $property ] = $value;
-			if ( $is_important ) {
+			if ( ! empty( $options['important'] ) ) {
 				$this->important_declarations[ $property ] = true;
 			} else {
 				unset( $this->important_declarations[ $property ] );
@@ -140,20 +151,31 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 		/**
 		 * Filters a CSS property + value pair.
 		 *
-		 * @param string $property     The CSS property.
-		 * @param string $value        The value to be filtered.
-		 * @param string $spacer       The spacer between the colon and the value. Defaults to an empty string.
-		 * @param bool   $is_important Whether to output the declaration with !important.
+		 * @param string $property The CSS property.
+		 * @param string $value    The value to be filtered.
+		 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
+		 * @param array  $options  {
+		 *     Optional. An array of options. Default empty array.
+		 *
+		 *     @type bool $important Whether to output the declaration with !important. Default false.
+		 * }
 		 *
 		 * @return string The filtered declaration or an empty string.
 		 */
-		protected static function filter_declaration( $property, $value, $spacer = '', $is_important = false ) {
+		protected static function filter_declaration( $property, $value, $spacer = '', $options = array() ) {
 			$filtered_value = wp_strip_all_tags( $value, true );
 
 			if ( '' !== $filtered_value ) {
+				$options = wp_parse_args(
+					$options,
+					array(
+						'important' => false,
+					)
+				);
+
 				$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 
-				if ( $is_important && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+				if ( ! empty( $options['important'] ) && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
 					return "$filtered_declaration !important";
 				}
 
@@ -179,8 +201,14 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 			$spacer              = $should_prettify ? ' ' : '';
 
 			foreach ( $declarations_array as $property => $value ) {
-				$is_important         = ! empty( $this->important_declarations[ $property ] );
-				$filtered_declaration = static::filter_declaration( $property, $value, $spacer, $is_important );
+				$filtered_declaration = static::filter_declaration(
+					$property,
+					$value,
+					$spacer,
+					array(
+						'important' => ! empty( $this->important_declarations[ $property ] ),
+					)
+				);
 				if ( $filtered_declaration ) {
 					$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 				}

--- a/packages/style-engine/src/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-rule.php
@@ -46,12 +46,11 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
 		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
 		 * @param string                                    $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 * @param bool                                      $is_important Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 */
-		public function __construct( $selector = '', $declarations = array(), $rules_group = '', $is_important = false ) {
+		public function __construct( $selector = '', $declarations = array(), $rules_group = '' ) {
 			$this->set_selector( $selector );
-			$this->add_declarations( $declarations, $is_important );
+			$this->add_declarations( $declarations );
 			$this->set_rules_group( $rules_group );
 		}
 
@@ -70,13 +69,12 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Sets the declarations.
 		 *
-		 * @param array|WP_Style_Engine_CSS_Declarations $declarations  An array of declarations (property => value pairs),
-		 *                                                              or a WP_Style_Engine_CSS_Declarations object.
-		 * @param bool                                    $is_important Optional. Whether to output the declarations with !important. Default false.
+		 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
+		 *                                                             or a WP_Style_Engine_CSS_Declarations object.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
-		public function add_declarations( $declarations, $is_important = false ) {
+		public function add_declarations( $declarations ) {
 			$is_declarations_object = ! is_array( $declarations );
 			$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
 			$important_declarations = $is_declarations_object ? $declarations->get_important_declarations() : array();
@@ -93,7 +91,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 				$this->declarations->add_declaration(
 					$property,
 					$value,
-					$is_important || ! empty( $important_declarations[ $property ] )
+					! empty( $important_declarations[ $property ] )
 				);
 			}
 

--- a/packages/style-engine/src/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-rule.php
@@ -46,11 +46,12 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
 		 *                                                                or a WP_Style_Engine_CSS_Declarations object.
 		 * @param string                                    $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param bool                                      $is_important Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 */
-		public function __construct( $selector = '', $declarations = array(), $rules_group = '' ) {
+		public function __construct( $selector = '', $declarations = array(), $rules_group = '', $is_important = false ) {
 			$this->set_selector( $selector );
-			$this->add_declarations( $declarations );
+			$this->add_declarations( $declarations, $is_important );
 			$this->set_rules_group( $rules_group );
 		}
 
@@ -69,23 +70,32 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		/**
 		 * Sets the declarations.
 		 *
-		 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
-		 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+		 * @param array|WP_Style_Engine_CSS_Declarations $declarations  An array of declarations (property => value pairs),
+		 *                                                              or a WP_Style_Engine_CSS_Declarations object.
+		 * @param bool                                    $is_important Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 		 */
-		public function add_declarations( $declarations ) {
+		public function add_declarations( $declarations, $is_important = false ) {
 			$is_declarations_object = ! is_array( $declarations );
 			$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
+			$important_declarations = $is_declarations_object ? $declarations->get_important_declarations() : array();
 
 			if ( null === $this->declarations ) {
 				if ( $is_declarations_object ) {
 					$this->declarations = $declarations;
 					return $this;
 				}
-				$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
+				$this->declarations = new WP_Style_Engine_CSS_Declarations();
 			}
-			$this->declarations->add_declarations( $declarations_array );
+
+			foreach ( $declarations_array as $property => $value ) {
+				$this->declarations->add_declaration(
+					$property,
+					$value,
+					$is_important || ! empty( $important_declarations[ $property ] )
+				);
+			}
 
 			return $this;
 		}

--- a/packages/style-engine/src/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-rule.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 		public function add_declarations( $declarations ) {
 			$is_declarations_object = ! is_array( $declarations );
 			$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
-			$important_declarations = $is_declarations_object ? $declarations->get_important_declarations() : array();
+			$declaration_options    = $is_declarations_object ? $declarations->get_declaration_options() : array();
 
 			if ( null === $this->declarations ) {
 				if ( $is_declarations_object ) {
@@ -91,9 +91,7 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 				$this->declarations->add_declaration(
 					$property,
 					$value,
-					array(
-						'important' => ! empty( $important_declarations[ $property ] ),
-					)
+					$declaration_options[ $property ] ?? array()
 				);
 			}
 

--- a/packages/style-engine/src/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/src/class-wp-style-engine-css-rule.php
@@ -91,7 +91,9 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
 				$this->declarations->add_declaration(
 					$property,
 					$value,
-					! empty( $important_declarations[ $property ] )
+					array(
+						'important' => ! empty( $important_declarations[ $property ] ),
+					)
 				);
 			}
 

--- a/packages/style-engine/src/class-wp-style-engine-processor.php
+++ b/packages/style-engine/src/class-wp-style-engine-processor.php
@@ -142,14 +142,20 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 			// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
 			$selectors_json = array();
 			foreach ( $this->css_rules as $rule ) {
-				$declarations           = $rule->get_declarations()->get_declarations();
-				$important_declarations = $rule->get_declarations()->get_important_declarations();
+				$declarations        = $rule->get_declarations()->get_declarations();
+				$declaration_options = $rule->get_declarations()->get_declaration_options();
 				ksort( $declarations );
-				ksort( $important_declarations );
+				ksort( $declaration_options );
+				foreach ( $declaration_options as $property => $options ) {
+					if ( is_array( $options ) ) {
+						ksort( $options );
+						$declaration_options[ $property ] = $options;
+					}
+				}
 				$selectors_json[ $rule->get_selector() ] = wp_json_encode(
 					array(
-						'declarations'           => $declarations,
-						'important_declarations' => $important_declarations,
+						'declarations'        => $declarations,
+						'declaration_options' => $declaration_options,
 					)
 				);
 			}

--- a/packages/style-engine/src/class-wp-style-engine-processor.php
+++ b/packages/style-engine/src/class-wp-style-engine-processor.php
@@ -145,6 +145,7 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 				$declarations        = $rule->get_declarations()->get_declarations();
 				$declaration_options = $rule->get_declarations()->get_declaration_options();
 				ksort( $declarations );
+				// Declaration options are keyed by property and are part of the rule identity.
 				ksort( $declaration_options );
 				foreach ( $declaration_options as $property => $options ) {
 					if ( is_array( $options ) ) {

--- a/packages/style-engine/src/class-wp-style-engine-processor.php
+++ b/packages/style-engine/src/class-wp-style-engine-processor.php
@@ -142,9 +142,16 @@ if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {
 			// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
 			$selectors_json = array();
 			foreach ( $this->css_rules as $rule ) {
-				$declarations = $rule->get_declarations()->get_declarations();
+				$declarations           = $rule->get_declarations()->get_declarations();
+				$important_declarations = $rule->get_declarations()->get_important_declarations();
 				ksort( $declarations );
-				$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
+				ksort( $important_declarations );
+				$selectors_json[ $rule->get_selector() ] = wp_json_encode(
+					array(
+						'declarations'           => $declarations,
+						'important_declarations' => $important_declarations,
+					)
+				);
 			}
 
 			// Combine selectors that have the same styles.

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -417,17 +417,17 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 *
 		 * @param string   $store_name       A valid store key.
 		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+		 * @param string[]|WP_Style_Engine_CSS_Declarations $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
+		 *                                                                     or a WP_Style_Engine_CSS_Declarations object.
 		 * @param string   $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
-		 * @param bool     $is_important      Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '', $is_important = false ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '' ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations, $is_important );
+			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations );
 		}
 
 		/**

--- a/packages/style-engine/src/class-wp-style-engine.php
+++ b/packages/style-engine/src/class-wp-style-engine.php
@@ -418,15 +418,16 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		 * @param string   $store_name       A valid store key.
 		 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 		 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-		 * @param string $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param string   $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+		 * @param bool     $is_important      Optional. Whether to output the declarations with !important. Default false.
 		 *
 		 * @return void.
 		 */
-		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '' ) {
+		public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '', $is_important = false ) {
 			if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
 				return;
 			}
-			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations );
+			static::get_store( $store_name )->add_rule( $css_selector, $rules_group )->add_declarations( $css_declarations, $is_important );
 		}
 
 		/**

--- a/packages/style-engine/src/style-engine.php
+++ b/packages/style-engine/src/style-engine.php
@@ -85,8 +85,8 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     @type array ...$0 {
  *         @type string   $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
  *         @type string   $selector     A CSS selector.
- *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
- *         @type bool     $important    Optional. Whether to output the declarations with !important. Default false.
+ *         @type string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
+ *                                                                       or a WP_Style_Engine_CSS_Declarations object.
  *     }
  * }
  * @param array $options {
@@ -114,17 +114,21 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 
 	$css_rule_objects = array();
 	foreach ( $css_rules as $css_rule ) {
-		if ( empty( $css_rule['selector'] ) || empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
+		$declarations = $css_rule['declarations'] ?? null;
+		if (
+			empty( $css_rule['selector'] ) ||
+			empty( $declarations ) ||
+			( ! is_array( $declarations ) && ! $declarations instanceof WP_Style_Engine_CSS_Declarations )
+		) {
 			continue;
 		}
 
-		$rules_group  = $css_rule['rules_group'] ?? null;
-		$is_important = ! empty( $css_rule['important'] );
+		$rules_group = $css_rule['rules_group'] ?? null;
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group, $is_important );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $declarations, $rules_group );
 		}
 
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group, $is_important );
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $declarations, $rules_group );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/packages/style-engine/src/style-engine.php
+++ b/packages/style-engine/src/style-engine.php
@@ -86,6 +86,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *         @type string   $rules_group  A parent CSS selector in the case of nested CSS, or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
  *         @type string   $selector     A CSS selector.
  *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ *         @type bool     $important    Optional. Whether to output the declarations with !important. Default false.
  *     }
  * }
  * @param array $options {
@@ -117,12 +118,13 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 			continue;
 		}
 
-		$rules_group = $css_rule['rules_group'] ?? null;
+		$rules_group  = $css_rule['rules_group'] ?? null;
+		$is_important = ! empty( $css_rule['important'] );
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group, $is_important );
 		}
 
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group );
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group, $is_important );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1010,6 +1010,43 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a responsive background gradient generates media-query scoped CSS.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_background_gradient_generates_media_query_scoped_css() {
+		$this->ensure_block_registered( 'core/group' );
+
+		$block_content = '<div class="wp-block-group">Hello</div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'@tablet' => array(
+						'background' => array(
+							'gradient' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		$this->assertMatchesRegularExpression(
+			'/^<div class="wp-block-group (wp-states-[a-f0-9]{8})">Hello<\/div>$/',
+			$actual
+		);
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (480px < width <= 782px){.' . $matches[0] . '{background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
 	 * Tests that responsive styles are routed through block feature selectors.
 	 *
 	 * @covers ::gutenberg_render_block_states_support

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -139,7 +139,7 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'background-color' => '#ff0000 !important',
-				'background-image' => 'unset !important',
+				'background-image' => 'unset',
 			),
 			$actual
 		);

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -162,16 +162,18 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that trailing !important does not make otherwise safe gradient values fail CSS sanitization.
+	 * Tests that important declarations are added after CSS sanitization.
 	 *
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
-	public function test_should_allow_gradient_values_with_important() {
-		$input_declarations = array(
-			'background-image' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important',
+	public function test_should_add_important_after_sanitizing_declarations() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			true
 		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
 
 		$this->assertSame(
 			'background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;',

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -172,7 +172,9 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$css_declarations->add_declaration(
 			'background-image',
 			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
-			true
+			array(
+				'important' => true,
+			)
 		);
 
 		$this->assertSame(

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -162,6 +162,24 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that trailing !important does not make otherwise safe gradient values fail CSS sanitization.
+	 *
+	 * @covers ::get_declarations_string
+	 * @covers ::filter_declaration
+	 */
+	public function test_should_allow_gradient_values_with_important() {
+		$input_declarations = array(
+			'background-image' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
+
+		$this->assertSame(
+			'background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
 	 * Tests that CSS declarations are compiled into a CSS declarations block string.
 	 *
 	 * @covers ::get_declarations_string

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -184,6 +184,46 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that declaration options are stored and cleared with their declarations.
+	 *
+	 * @covers ::add_declaration
+	 * @covers ::remove_declaration
+	 * @covers ::get_declaration_options
+	 */
+	public function test_should_store_declaration_options_by_property() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'background-image' => array(
+					'important' => true,
+				),
+			),
+			$css_declarations->get_declaration_options()
+		);
+
+		$css_declarations->add_declaration( 'background-image', 'url("https://wordpress.org")' );
+		$this->assertSame( array(), $css_declarations->get_declaration_options() );
+
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+		$css_declarations->remove_declaration( 'background-image' );
+		$this->assertSame( array(), $css_declarations->get_declaration_options() );
+	}
+
+	/**
 	 * Tests that CSS declarations are compiled into a CSS declarations block string.
 	 *
 	 * @covers ::get_declarations_string

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -333,6 +333,43 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that CSS rules with different declaration options are not combined.
+	 *
+	 * @covers ::get_css
+	 */
+	public function test_should_not_combine_css_rules_with_different_declaration_options() {
+		$important_declarations = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+		$important_declarations->add_declaration(
+			'color',
+			'red',
+			array(
+				'important' => true,
+			)
+		);
+
+		$important_rule = new WP_Style_Engine_CSS_Rule_Gutenberg( '.important-rule', $important_declarations );
+		$regular_rule   = new WP_Style_Engine_CSS_Rule_Gutenberg(
+			'.regular-rule',
+			array(
+				'color' => 'red',
+			)
+		);
+
+		$processor = new WP_Style_Engine_Processor_Gutenberg();
+		$processor->add_rules( array( $important_rule, $regular_rule ) );
+
+		$this->assertSame(
+			'.important-rule{color:red !important;}.regular-rule{color:red;}',
+			$processor->get_css(
+				array(
+					'prettify' => false,
+					'optimize' => true,
+				)
+			)
+		);
+	}
+
+	/**
 	 * Tests that incoming CSS rules are optimized and merged with existing CSS rules.
 	 *
 	 * @ticket 58811

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -826,14 +826,17 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
 	 */
-	public function test_should_return_stylesheet_with_important_css_rules() {
+	public function test_should_return_stylesheet_with_important_declarations() {
+		$declarations = new WP_Style_Engine_CSS_Declarations_Gutenberg();
+		$declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			true
+		);
 		$css_rules = array(
 			array(
 				'selector'     => '.responsive-state',
-				'declarations' => array(
-					'background-image' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
-				),
-				'important'    => true,
+				'declarations' => $declarations,
 			),
 		);
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -821,6 +821,27 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests returning a generated stylesheet with important declarations.
+	 *
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
+	 * @covers WP_Style_Engine_Gutenberg::compile_stylesheet_from_css_rules
+	 */
+	public function test_should_return_stylesheet_with_important_css_rules() {
+		$css_rules = array(
+			array(
+				'selector'     => '.responsive-state',
+				'declarations' => array(
+					'background-image' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+				),
+				'important'    => true,
+			),
+		);
+
+		$compiled_stylesheet = gutenberg_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+		$this->assertSame( '.responsive-state{background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;}', $compiled_stylesheet );
+	}
+
+	/**
 	 * Tests returning a generated stylesheet from a set of nested rules and merging their declarations.
 	 */
 	public function test_should_merge_declarations_for_rules_groups() {

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -831,7 +831,9 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		$declarations->add_declaration(
 			'background-image',
 			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
-			true
+			array(
+				'important' => true,
+			)
 		);
 		$css_rules = array(
 			array(


### PR DESCRIPTION
## What? How????


Fixes responsive background gradients not rendering on the frontend when state styles need `!important`.

The style engine now tracks `important` at the declaration level via an options array.

This means values are sanitized first and `!important` is appended afterward. 

Block state styles create declaration objects and mark each generated declaration with `array( 'important' => true )`, instead of applying importance at the whole rule level.

## Why

Frontend generated CSS was previously adding `!important` before CSS sanitization. That caused gradient values like `linear-gradient(...) !important` to be rejected by `safecss_filter_attr()`, while the same responsive gradient still worked in the editor.

A side note:

This supports the wider style engine architecture by keeping declaration metadata structured until serialization, instead of requiring callers to encode CSS behavior inside raw value strings. 

This is the boundary that we'd like to keep for the Theme JSON to eventually hand off style generation to the style engine (while Theme JSON focuses on resolving style intent). See https://github.com/WordPress/gutenberg/issues/65728

## Testing

There should be no states/styles regressions, and  gradient backgrounds in mobile/tablet/desktop should work in the frontend.

<details>

<summary>Example HTML</summary>

```html
<!-- wp:group {"metadata":{"name":"Test gradient states"},"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"0","margin":{"top":"0","bottom":"0"}},"@tablet":{"background":{"gradient":"linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)"}},"background":{"gradient":"linear-gradient(135deg,rgb(224,225,225) 0%,rgb(129,0,250) 100%)"},"@mobile":{"background":{"gradient":"linear-gradient(135deg,rgb(229,6,65) 0%,rgb(0,0,0) 100%)"}}},"backgroundColor":"accent-4","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull has-accent-4-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}}} -->
<p>Desktop</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"desktop":false,"tablet":false}}}} -->
<p>Mobile</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"blockVisibility":{"viewport":{"desktop":false,"mobile":false}}}} -->
<p>Tablet</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

```

</details>

1. Add a Group block with responsive background styles:
    - desktop background gradient
    - tablet background gradient
    - mobile background image
2. Save the post and view it on the frontend.
3. Resize the frontend viewport to tablet width, between `481px` and `782px`.
4. Confirm the tablet `linear-gradient(...)` background appears.
5. Resize to mobile width, `480px` or below, and confirm the mobile background image appears.
6. Resize above `782px` and confirm the desktop background still appears.



https://github.com/user-attachments/assets/13ada35d-79c4-4f3f-8e9e-3cc93d7f0b4a


