### PR TITLE
Docs: Add image hosting contributor guidelines and CI validation check

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -111,5 +111,9 @@ jobs:
             - name: Check local changes
               run: npm run other:check-local-changes
 
+            - name: Check documentation image sources
+              if: ${{ matrix.annotations }}
+              run: npm run lint:md:images
+
             - name: License compatibility
               run: npm run other:check-licenses

--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -107,6 +107,24 @@ An example, the link to this page is: `/docs/contributors/documentation/README.m
 <b>Note:</b> The usual link transformation is not applied to links in callouts. See below.
 </div>
 
+### Using images
+
+Images used in documentation must be hosted in the [developer.wordpress.org Media Library](https://developer.wordpress.org/wp-admin/upload.php), **not** on GitHub (e.g. `raw.githubusercontent.com`). Images hosted on GitHub are subject to rate limiting and may fail to load when the documentation is rendered in the [Block Editor Handbook](https://developer.wordpress.org/block-editor/).
+
+To add an image to the documentation:
+
+1. Upload the image to the developer.wordpress.org Media Library. If you don't have the required permissions, reach out in the `#docs` channel in [Make WordPress Slack](https://make.wordpress.org/chat) for assistance.
+2. Copy the URL of the uploaded image. It will follow this format: `https://developer.wordpress.org/files/YYYY/MM/image-name.png`
+3. Use the URL in the markdown document:
+
+```md
+![Alt text describing the image](https://developer.wordpress.org/files/YYYY/MM/image-name.png)
+```
+
+<div class="callout callout-warning">
+Do <b>not</b> reference images using <code>raw.githubusercontent.com</code> URLs. A CI check will flag any documentation contributions that use GitHub-hosted images.
+</div>
+
 ### Code examples
 
 The code example in markdown should be wrapped in three tick marks \`\`\` and should additionally include a language specifier. See this [GitHub documentation around fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
 		"lint:lockfile": "npm run --workspace @wordpress/validation-tools validate-package-lock --",
 		"lint:tsconfig": "npm run --workspace @wordpress/validation-tools validate-tsconfig --",
 		"lint:md:docs": "wp-scripts lint-md-docs",
+		"lint:md:images": "npm run --workspace @wordpress/validation-tools check-doc-image-sources --",
 		"prelint:php": "npm run other:update-packages:php",
 		"lint:php": "wp-env run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script lint",
 		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",

--- a/tools/validation/check-doc-image-sources.mjs
+++ b/tools/validation/check-doc-image-sources.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Check documentation image sources.
+ *
+ * Scans all markdown files under `docs/` and verifies that image references
+ * do not use `raw.githubusercontent.com`. Images must be hosted in the
+ * developer.wordpress.org Media Library so they aren't subject to rate
+ * limiting when the Block Editor Handbook is rendered.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/79521
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import glob from 'glob';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const REPO_ROOT = resolve( __dirname, '../..' );
+const DOCS_DIR = resolve( REPO_ROOT, 'docs' );
+
+// Match markdown image syntax: ![alt](url) and HTML <img> tags with src attribute.
+const IMAGE_PATTERNS = [
+	// Markdown images: ![...](https://raw.githubusercontent.com/...)
+	/!\[[^\]]*\]\(https?:\/\/raw\.githubusercontent\.com[^)]*\)/g,
+	// HTML img tags: <img ... src="https://raw.githubusercontent.com/..." ...>
+	/<img\b[^>]*\bsrc\s*=\s*["']https?:\/\/raw\.githubusercontent\.com[^"']*["'][^>]*>/gi,
+];
+
+const mdFiles = glob.sync( '**/*.md', { cwd: DOCS_DIR, absolute: true } );
+
+let totalViolations = 0;
+const violations = [];
+
+for ( const filePath of mdFiles ) {
+	const content = readFileSync( filePath, 'utf8' );
+	const lines = content.split( '\n' );
+
+	for ( let i = 0; i < lines.length; i++ ) {
+		const line = lines[ i ];
+		for ( const pattern of IMAGE_PATTERNS ) {
+			// Reset lastIndex since we reuse the regex.
+			pattern.lastIndex = 0;
+			let match;
+			while ( ( match = pattern.exec( line ) ) !== null ) {
+				totalViolations++;
+				violations.push( {
+					file: relative( REPO_ROOT, filePath ),
+					line: i + 1,
+					match: match[ 0 ],
+				} );
+			}
+		}
+	}
+}
+
+if ( totalViolations > 0 ) {
+	console.error(
+		`\nFound ${ totalViolations } image(s) hosted on GitHub in documentation:\n`
+	);
+
+	for ( const { file, line, match } of violations ) {
+		console.error( `  ${ file }:${ line }` );
+		console.error( `    ${ match }\n` );
+	}
+
+	console.error(
+		'Images in documentation must be hosted in the developer.wordpress.org'
+	);
+	console.error(
+		'Media Library, not on GitHub. GitHub-hosted images are rate-limited'
+	);
+	console.error(
+		'and may break when rendered in the Block Editor Handbook.'
+	);
+	console.error(
+		'\nSee: https://developer.wordpress.org/block-editor/contributors/documentation/#using-images\n'
+	);
+
+	process.exitCode = 1;
+} else {
+	console.log(
+		'All documentation images are properly hosted. No GitHub-hosted images found.'
+	);
+}

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -40,6 +40,7 @@
 		"check-root-dependencies": "node ./check-root-dependencies.mjs",
 		"test-create-block": "node ./test-create-block.mjs",
 		"validate-package-lock": "node ./validate-package-lock.cjs",
-		"validate-tsconfig": "node ./validate-tsconfig.mjs"
+		"validate-tsconfig": "node ./validate-tsconfig.mjs",
+		"check-doc-image-sources": "node ./check-doc-image-sources.mjs"
 	}
 }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79569
Closes #79570
See #79521
Follow up to https://github.com/WordPress/gutenberg/pull/79529

<!-- In a few words, what is the PR actually doing? -->
This PR adds contributor documentation guidance requiring documentation images to be hosted on the `developer.wordpress.org` Media Library rather than GitHub, and implements an automated static validation check in CI to prevent future GitHub-hosted images in documentation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As reported in #79521, images embedded in documentation markdown files that are hosted directly on GitHub (`raw.githubusercontent.com`) get rate-limited. When synced and rendered in the Block Editor Handbook on `developer.wordpress.org`, these images frequently break. 

While #79529 migrates existing images to the Media Library, this PR ensures future contributions adhere to the hosting policy and prevents future broken images via automated CI enforcement.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. **Contributor Guidance (#79569)**: Added a new `### Using images` subsection to `docs/contributors/documentation/README.md` detailing Media Library hosting requirements, upload instructions, and CI rules.
2. **Validation Script (#79570)**: Created `tools/validation/check-doc-image-sources.mjs` which scans all markdown files under `docs/` for markdown (`![alt](url)`) and HTML (`<img src="...">`) image tags referencing `raw.githubusercontent.com`.
3. **Scripts Configuration**: Added the `check-doc-image-sources` script entry to `@wordpress/validation-tools` and exposed `lint:md:images` in root `package.json`.
4. **CI Integration**: Added a `Check documentation image sources` job step to `.github/workflows/static-checks.yml`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Run the validation check locally:
   ```bash
   npm run lint:md:images
   ```
2. Verify that any markdown or HTML image tag pointing to raw.githubusercontent.com inside docs/ is reported with its file path, line number, and snippet.
3. Verify that non-image raw GitHub URLs (such as nvm installation scripts or Playground blueprint links) are properly ignored by the scanner.

## Testing Instructions for Keyboard
N/A (Documentation and build tooling changes only)

## Screenshots or screencast
N/A

## Use of AI Tools
Assisted by Claude Opus 4.6 (Antigravity) for validation script scaffolding and workflow testing. All generated code and documentation content have been reviewed and validated.