### PR TITLE
Icons: Fix viewBox casing assertion in wp_get_icon test for older WP

### DIFF
--- a/phpunit/class-wp-icon-test.php
+++ b/phpunit/class-wp-icon-test.php
@@ -20,8 +20,9 @@ class Tests_Icons_WpGetIcon extends WP_UnitTestCase {
 
 	public function test_wp_get_icon_default_attributes() {
 		$output = wp_get_icon( 'core/plus' );
-		// WP_HTML_Tag_Processor lowercases attribute names.
-		$this->assertStringContainsString( 'viewbox="0 0 24 24"', $output );
+		// WP 7.0+ lowercases `viewBox` to `viewbox` via the HTML API in
+		// `wp_kses()`; older versions keep the original casing.
+		$this->assertStringContainsStringIgnoringCase( 'viewbox="0 0 24 24"', $output );
 		$this->assertStringContainsString( 'width="24"', $output );
 		$this->assertStringContainsString( 'height="24"', $output );
 		$this->assertStringContainsString( 'aria-hidden="true"', $output );


### PR DESCRIPTION
Follow-up to #78332

## What?

Fixes the `test_wp_get_icon_default_attributes` unit test failing on the previous major WordPress version.

https://github.com/WordPress/gutenberg/actions/runs/28224303166/job/83612783910

```
There was 1 failure:

1) Tests_Icons_WpGetIcon::test_wp_get_icon_default_attributes
Failed asserting that '<svg aria-hidden="true" focusable="false" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">\n
	<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" />\n
</svg>\n
' contains "viewbox="0 0 24 24"".

/var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-icon-test.php:24
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:106
```

## Why?

The test asserts a lowercase `viewbox` attribute. This only holds on WP 7.0+, where `wp_kses()` parses attributes via the HTML API and lowercases attribute names (`viewBox` → `viewbox`). The previous major WP version preserves the original `viewBox` casing, so the assertion failed there.

## How?

Asserts the `viewBox` attribute case-insensitively so the test passes on both the latest and previous WordPress versions.

## Testing Instructions

This version-dependent failure can't be reproduced in this PR's CI against trunk. Once merged, the unit test job against the previous major WordPress version should pass, confirming the fix.

## Use of AI Tools

Authored with assistance from Claude Code. All changes were reviewed by the author.
