### PR TITLE
Experiments: move long intro to content

### DIFF
--- a/routes/experiments-home/stage.tsx
+++ b/routes/experiments-home/stage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { Link } from '@wordpress/ui';
+import { Card, Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -163,22 +163,41 @@ function ExperimentsPage() {
 	return (
 		<Page
 			title={ __( 'Gutenberg Experiments' ) }
-			subTitle={ createInterpolateElement(
-				__(
-					'The Gutenberg plugin adds editing, customization, and site building to WordPress, and gives early adopters access to the latest block and full site editing features before they ship in a WordPress release. <br />The experiments below are in active development, so expect rough edges and changes over time. <br />To learn more about the project and how to build with blocks, see the <a>Block Editor Handbook</a>.'
-				),
-				{
-					a: (
-						<Link
-							href="https://developer.wordpress.org/block-editor/"
-							openInNewTab
-						/>
-					),
-					br: <br />,
-				}
+			subTitle={ __(
+				'The latest block and full site editing features before they ship in a WordPress release.'
 			) }
 		>
-			<div className="experiments-page__form">
+			<Stack
+				className="experiments-page__container"
+				direction="column"
+				gap="md"
+			>
+				<Card.Root>
+					<Card.Content>
+						<Stack direction="column" gap="md">
+							<Text variant="body-lg" render={ <p /> }>
+								{ __(
+									'The Gutenberg plugin adds editing, customization, and site building to WordPress, and gives early adopters access to the latest block and full site editing features before they ship in a WordPress release.'
+								) }
+							</Text>
+							<Text variant="body-lg" render={ <p /> }>
+								{ createInterpolateElement(
+									__(
+										'The experiments below are in active development, so expect rough edges and changes over time. To learn more about the project and how to build with blocks, see the <a>Block Editor Handbook</a>.'
+									),
+									{
+										a: (
+											<Link
+												href="https://developer.wordpress.org/block-editor/"
+												openInNewTab
+											/>
+										),
+									}
+								) }
+							</Text>
+						</Stack>
+					</Card.Content>
+				</Card.Root>
 				<DataForm
 					data={ settings }
 					fields={ fields }
@@ -190,7 +209,7 @@ function ExperimentsPage() {
 						setSettings( values );
 					} }
 				/>
-			</div>
+			</Stack>
 		</Page>
 	);
 }

--- a/routes/experiments-home/style.scss
+++ b/routes/experiments-home/style.scss
@@ -1,9 +1,9 @@
 @use "@wordpress/base-styles/variables" as *;
 
-.experiments-page__form {
+.experiments-page__container {
 	box-sizing: border-box;
 	width: 100%;
 	padding: $grid-unit-30;
 	max-width: 680px;
-	margin: 0 auto;
+	margin-inline: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/79456

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The header's subtitle feels optimized for shorter texts, expanding on the actual title, rather than lengthier content.

There was [discussion](https://github.com/WordPress/gutenberg/pull/79456#discussion_r3466398124) about how the intro in content was implemented, which I think was accurate, but I don't think the conclusion to move all the content to the header was the best possible either.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Leaves a shorter, to-the-point subtitle. If you have an improved copy suggestion, please suggest!
- Moves longer content to the page within Card, as [body-lg variant](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs#all-variants), which I felt was suitable for short intro text rather than body-md (but happy to revisit, two paragraphs of body-lg is also a bit of a stretch).

### Before
<img width="1295" height="820" alt="image" src="https://github.com/user-attachments/assets/6e96129d-16ce-4c17-bd1a-ff4499dc65b5" />
<img width="345"  alt="image" src="https://github.com/user-attachments/assets/8399a792-6e19-4c51-a756-decb30658373" />


### After
<img width="1292" height="948" alt="Screenshot 2026-06-26 at 11 18 58" src="https://github.com/user-attachments/assets/a426ead1-c887-4c4a-a68b-2773c7442126" />
<img width="339" alt="image" src="https://github.com/user-attachments/assets/779476d2-a236-46e1-9bb0-f0226976cf60" />



### Alternatives

I also explored using Notice or custom styles:

<img width="1296" height="632" alt="Screenshot 2026-06-26 at 11 19 46" src="https://github.com/user-attachments/assets/559eb7ef-5293-4c1b-8001-6f05eaee5a31" />
<img width="1299" height="656" alt="Screenshot 2026-06-26 at 11 20 01" src="https://github.com/user-attachments/assets/315d948f-c546-4881-97d8-5b7c3bd08215" />
<img width="1298" height="683" alt="Screenshot 2026-06-26 at 11 00 00" src="https://github.com/user-attachments/assets/4deb31f0-f390-4de5-9bb3-12c25eae3814" />

Here's also Connectors page for comparison:
<img width="1303" height="880" alt="image" src="https://github.com/user-attachments/assets/94fe927e-779a-4fda-ab35-841726209e51" />



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to Settings → Experiments page. Try mobile and desktop.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->