### PR TITLE
Experiments: shorten the page name

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -18,8 +18,8 @@
 function gutenberg_menu() {
 	add_submenu_page(
 		'options-general.php',
-		__( 'Experiments', 'gutenberg' ),
-		__( 'Experiments', 'gutenberg' ),
+		'Gutenberg',
+		'Gutenberg',
 		'manage_options',
 		'experiments-wp-admin',
 		'gutenberg_experiments_wp_admin_render_page'

--- a/lib/init.php
+++ b/lib/init.php
@@ -8,7 +8,7 @@
 /**
  * Gutenberg's Menu.
  *
- * Surfaces the Experiments screen as a "Gutenberg Experiments" submenu under
+ * Surfaces the "Experiments" screen as a submenu under
  * the core Settings menu, rather than as a dedicated top-level menu. The page
  * is rendered by the auto-generated `gutenberg_experiments_wp_admin_render_page()`
  * callback (see `lib/experimental/experiments/load.php`).
@@ -18,8 +18,8 @@
 function gutenberg_menu() {
 	add_submenu_page(
 		'options-general.php',
-		__( 'Gutenberg Experiments', 'gutenberg' ),
-		__( 'Gutenberg Experiments', 'gutenberg' ),
+		__( 'Experiments', 'gutenberg' ),
+		__( 'Experiments', 'gutenberg' ),
 		'manage_options',
 		'experiments-wp-admin',
 		'gutenberg_experiments_wp_admin_render_page'

--- a/routes/experiments-home/stage.tsx
+++ b/routes/experiments-home/stage.tsx
@@ -162,7 +162,7 @@ function ExperimentsPage() {
 
 	return (
 		<Page
-			title={ __( 'Gutenberg Experiments' ) }
+			title={ __( 'Experiments' ) }
 			subTitle={ __(
 				'The latest block and full site editing features before they ship in a WordPress release.'
 			) }

--- a/routes/experiments-home/stage.tsx
+++ b/routes/experiments-home/stage.tsx
@@ -162,7 +162,7 @@ function ExperimentsPage() {
 
 	return (
 		<Page
-			title={ __( 'Experiments' ) }
+			title={ __( 'Gutenberg Experiments' ) }
 			subTitle={ __(
 				'The latest block and full site editing features before they ship in a WordPress release.'
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/79456

<!-- In a few words, what is the PR actually doing? -->
Shortens page name from "Gutenberg Experiments" to "Experiments" in page and sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- In the sidebar, the name was fairly lengthy (in some translated languages it can get worse):
    <img width="171" height="411" alt="image" src="https://github.com/user-attachments/assets/6cc7a043-cfa9-487d-b7e8-998b3b5a7121" />
- Historically, we had "Gutenberg" top-level menu, so it was natural to include "Gutenberg" here; I see "Experiments" more as a meta feature itself, so it's natural to just use a shorter name rather than refer to the plugin name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Just shortens the name in the sidebar and page header.

### Before
<img width="1299" height="876" alt="image" src="https://github.com/user-attachments/assets/58ae6102-5837-4792-9bb5-9720accd9046" />

### After
<img width="1295" height="860" alt="Screenshot 2026-06-26 at 15 42 12" src="https://github.com/user-attachments/assets/5e1370d0-3d01-4a43-a7b3-58763c7310e2" />


An alternative could be using "WordPress Experiments" in the page header:

<img width="1297" height="870" alt="Screenshot 2026-06-26 at 11 45 29" src="https://github.com/user-attachments/assets/30ae3305-16da-4d57-b2ce-0208b0dc020c" />




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to Settings → Experiments page.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
