### PR TITLE
Search Block: Add hidden submit button for "No Button" option to meet accessibility requirements

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -665,7 +665,26 @@ export default function SearchEdit( {
 						</>
 					) }
 
-					{ hasNoButton && renderTextField() }
+					{ hasNoButton && (
+						<>
+							{ renderTextField() }
+							{ /*
+							 * When 'No button' is chosen, a visually hidden submit
+							 * button is still rendered so assistive technologies and
+							 * keyboard-only users can submit the search form.
+							 * screen-reader-text hides it visually but keeps it in
+							 * the accessibility tree.
+							 */ }
+							<button
+								type="submit"
+								className="wp-block-search__button screen-reader-text"
+							>
+								{ buttonText
+									? stripHTML( buttonText )
+									: __( 'Search' ) }
+							</button>
+						</>
+					) }
 				</ResizableBox>
 			</Wrapper>
 		</>

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -103,6 +103,14 @@ function render_block_core_search( $attributes ) {
 		}
 	}
 
+	if ( ! $show_button ) {
+		$button_label = empty( $attributes['buttonText'] ) ? __( 'Search' ) : wp_strip_all_tags( $attributes['buttonText'] );
+		$button       = sprintf(
+			'<button type="submit" class="wp-block-search__button screen-reader-text">%s</button>',
+			esc_html( $button_label )
+		);
+	}
+
 	if ( $show_button ) {
 		$button_classes         = array( 'wp-block-search__button' );
 		$button_internal_markup = '';


### PR DESCRIPTION
## What?
Closes #38924

When the "No Button" option is selected in the Search block, the visible submit button is intentionally hidden for design purposes. However, this completely removed the `<button type="submit">` from the DOM, leaving the search form with no accessible submission mechanism.

This PR adds a visually hidden submit button (using the `screen-reader-text` class) whenever "No Button" is selected, so the form remains accessible without any visual change.

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert a **Search** block.
3. In the block settings sidebar, set **Button position** to **No button**.
4. Save/publish the post and view it on the front end.
5. Open browser DevTools and inspect the rendered form.
6. Confirm a `<button type="submit" class="wp-block-search__button screen-reader-text">` is present in the DOM.
7. Confirm the button is **not visible** on the page.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/221bc0e5-49d0-494b-9eeb-5943103ac410

