### PR TITLE
Tabs: Fix rich text label comparison when syncing the list

### DIFF
--- a/packages/block-library/src/tabs/use-tab-list-items-sync.js
+++ b/packages/block-library/src/tabs/use-tab-list-items-sync.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import fastDeepEqual from 'fast-deep-equal/es6/index.js';
-
-/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -37,7 +32,7 @@ export default function useTabListItemsSync( { tabPanels, tabListClientId } ) {
 
 		// Skip the update when the stored tabs already match the derived ones.
 		const currentTabs = getBlockAttributes( tabListClientId )?.tabs ?? [];
-		if ( fastDeepEqual( newTabs, currentTabs ) ) {
+		if ( JSON.stringify( newTabs ) === JSON.stringify( currentTabs ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## What?
This is a follow-up to #79554.
Related #79540.

After #79554 labels are represented as `RichTextData` at runtime, the `fastDeepEqual` will fail comparing these objects even though their string representations are the same.

The `JSON.stringify` works better for this case. I overlooked this while reviewing the original PR.

## Testing Instructions
1. With React StrictMode enabled.
2. Open a post.
3. Insert the Tabs blocks.
4. Save the post.
5. Reload the editor.
6. Freshly saved post shouldn't become dirty.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.