### PR TITLE
Add `PluginPostStatusInfo` in DataForm post summary

### DIFF
--- a/packages/editor/src/components/sidebar/dataform-post-summary.js
+++ b/packages/editor/src/components/sidebar/dataform-post-summary.js
@@ -13,6 +13,7 @@ import { useViewConfig } from '@wordpress/views';
  * Internal dependencies
  */
 import PostCardPanel from '../post-card-panel';
+import PluginPostStatusInfo from '../plugin-post-status-info';
 import PostPanelSection from '../post-panel-section';
 import { store as editorStore } from '../../store';
 import PostTrash from '../post-trash';
@@ -394,7 +395,18 @@ export default function DataFormPostSummary( { onActionPerformed } ) {
 					onChange={ onChange }
 				/>
 				{ ! isPostStatusRemoved && (
-					<PostTrash onActionPerformed={ onActionPerformed } />
+					<>
+						<PluginPostStatusInfo.Slot>
+							{ ( fills ) =>
+								fills.length > 0 && (
+									<Stack direction="column" gap="xs">
+										{ fills }
+									</Stack>
+								)
+							}
+						</PluginPostStatusInfo.Slot>
+						<PostTrash onActionPerformed={ onActionPerformed } />
+					</>
 				) }
 			</Stack>
 		</PostPanelSection>


### PR DESCRIPTION


## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076

This PR just adds in DataForm post summary the `fills` from `PluginPostStatusInfo` in the same place where they would render in the current post summary panel.

Currently there are no APIs merged to start deprecation messages to register new fields and actions, so it's just about feature parity between the two summaries.


## Testing Instructions
1. I tested with https://wordpress.org/plugins/duplicate-post/, but other plugins that use `PluginPostStatusInfo` could be used for testing
2. Install and activate the above plugin
3. Enable the `Editor Inspector: Use DataForm` experiment.
4. Go to a post and observe that the action buttons are rendered like before


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="283" height="340" alt="Screenshot 2026-06-26 at 2 27 57 PM" src="https://github.com/user-attachments/assets/72caf4e7-cd6f-4254-80b2-14647fb912cd" />|<img width="283" height="340" alt="Screenshot 2026-06-26 at 2 27 38 PM" src="https://github.com/user-attachments/assets/6a198428-7bc0-4c7a-8f75-2148b87f9a3a" />|
