### PR TITLE
LineHeightControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
     -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
-    -   `LineHeightControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+    -   `LineHeightControl` ([#79589](https://github.com/WordPress/gutenberg/pull/79589)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Breaking Changes
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
--   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
+    -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
+    -   `LineHeightControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
 
 ### Deprecations
 

--- a/packages/block-editor/src/components/line-height-control/README.md
+++ b/packages/block-editor/src/components/line-height-control/README.md
@@ -18,7 +18,6 @@ const MyLineHeightControl = () => (
 	<LineHeightControl
 		value={ lineHeight }
 		onChange={ onChange }
-		__next40pxDefaultSize
 	/>
 );
 ```
@@ -36,13 +35,6 @@ The value of the line height.
 -   **Type:** `Function`
 
 A callback function that handles the application of the line height value.
-
-#### `__next40pxDefaultSize`
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Start opting into the larger default height that will become the default size in a future version.
 
 ## Related components
 

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -15,19 +15,12 @@ import {
 	isLineHeightDefined,
 } from './utils';
 
-/**
- * Control for line height.
- *
- * @param {Object}                  props                         Component props.
- * @param {boolean}                 [props.__next40pxDefaultSize] Start opting into the larger default height that will become the default size in a future version.
- * @param {string|number|undefined} props.value                   The value of the line height.
- * @param {Function}                props.onChange                A callback function that handles the application of the line height value.
- * @param {string|number|undefined} props.__unstableInputWidth    Input width to pass through to inner NumberControl. Should be a valid CSS value.
- *
- * @return {Element} Line height control.
- */
 const LineHeightControl = ( {
-	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+	 */
 	__next40pxDefaultSize: _next40pxDefaultSize,
 	value: lineHeight,
 	onChange,
@@ -104,7 +97,6 @@ const LineHeightControl = ( {
 		<div className="block-editor-line-height-control">
 			<NumberControl
 				{ ...otherProps }
-				__shouldNotWarnDeprecated36pxSize
 				__next40pxDefaultSize
 				__unstableInputWidth={ __unstableInputWidth }
 				__unstableStateReducer={ stateReducer }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -16,9 +15,20 @@ import {
 	isLineHeightDefined,
 } from './utils';
 
+/**
+ * Control for line height.
+ *
+ * @param {Object}                  props                         Component props.
+ * @param {boolean}                 [props.__next40pxDefaultSize] Start opting into the larger default height that will become the default size in a future version.
+ * @param {string|number|undefined} props.value                   The value of the line height.
+ * @param {Function}                props.onChange                A callback function that handles the application of the line height value.
+ * @param {string|number|undefined} props.__unstableInputWidth    Input width to pass through to inner NumberControl. Should be a valid CSS value.
+ *
+ * @return {Element} Line height control.
+ */
 const LineHeightControl = ( {
-	/** Start opting into the larger default height that will become the default size in a future version. */
-	__next40pxDefaultSize = false,
+	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
+	__next40pxDefaultSize: _next40pxDefaultSize,
 	value: lineHeight,
 	onChange,
 	__unstableInputWidth = '60px',
@@ -90,23 +100,12 @@ const LineHeightControl = ( {
 		onChange( `${ nextValue }` );
 	};
 
-	if (
-		! __next40pxDefaultSize &&
-		( otherProps.size === undefined || otherProps.size === 'default' )
-	) {
-		deprecated( `36px default size for wp.blockEditor.LineHeightControl`, {
-			since: '6.8',
-			version: '7.1',
-			hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
-		} );
-	}
-
 	return (
 		<div className="block-editor-line-height-control">
 			<NumberControl
 				{ ...otherProps }
 				__shouldNotWarnDeprecated36pxSize
-				__next40pxDefaultSize={ __next40pxDefaultSize }
+				__next40pxDefaultSize
 				__unstableInputWidth={ __unstableInputWidth }
 				__unstableStateReducer={ stateReducer }
 				onChange={ handleOnChange }

--- a/packages/block-editor/src/components/line-height-control/stories/index.story.jsx
+++ b/packages/block-editor/src/components/line-height-control/stories/index.story.jsx
@@ -22,7 +22,6 @@ const Template = ( props ) => {
 
 export const Default = Template.bind( {} );
 Default.args = {
-	__next40pxDefaultSize: true,
 	__unstableInputWidth: '100px',
 };
 

--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -19,13 +19,7 @@ const SPIN = STEP * SPIN_FACTOR;
 
 const ControlledLineHeightControl = () => {
 	const [ value, setValue ] = useState();
-	return (
-		<LineHeightControl
-			value={ value }
-			onChange={ setValue }
-			__next40pxDefaultSize
-		/>
-	);
+	return <LineHeightControl value={ value } onChange={ setValue } />;
 };
 
 describe( 'LineHeightControl', () => {

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -16,7 +16,6 @@ The following components are checked by this rule:
 -   FormFileUpload (special case - see below)
 -   FormTokenField
 -   InputControl
--   LineHeightControl
 -   NumberControl
 -   RangeControl
 -   SelectControl

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -116,7 +116,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					FontFamilyControl,
 					FormTokenField,
 					InputControl,
-					LineHeightControl,
 					NumberControl,
 					RangeControl,
 					SelectControl,
@@ -130,7 +129,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					<FontFamilyControl __next40pxDefaultSize />
 					<FormTokenField __next40pxDefaultSize />
 					<InputControl __next40pxDefaultSize />
-					<LineHeightControl __next40pxDefaultSize />
 					<NumberControl __next40pxDefaultSize />
 					<RangeControl __next40pxDefaultSize />
 					<SelectControl __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -21,7 +21,6 @@ const COMPONENTS_REQUIRING_40PX = new Set( [
 	'FormTokenField',
 	'IconButton',
 	'InputControl',
-	'LineHeightControl',
 	'NumberControl',
 	'Radio',
 	'RangeControl',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -176,6 +176,7 @@ const restrictedSyntax = [
 		'FocalPointPicker',
 		'FontSizePicker',
 		'LetterSpacingControl',
+		'LineHeightControl',
 		'QueryControls',
 		'SearchControl',
 		'TextControl',


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the deprecated `__next40pxDefaultSize` prop from `LineHeightControl`, making the 40px default size the permanent default.

## Why?

The soft deprecation was introduced in WP 6.8 with a 36px console warning when the prop was not set. Block Editor typography wrappers are being updated before the primitives they embed.

## How?

- Hard-deprecate `__next40pxDefaultSize` on `LineHeightControl`: always pass `__next40pxDefaultSize` to the inner `NumberControl`, remove the `deprecated()` 36px warning, and accept (but ignore) the prop for backward compatibility.
- Update README, Storybook, and unit test usage.
- Remove `LineHeightControl` from the `components-no-missing-40px-size-prop` ESLint rule and add it to the restricted-syntax forbid list in `tools/eslint/config.mjs`.
- Document the breaking change in `@wordpress/block-editor` CHANGELOG.

## Testing Instructions

1. Open Storybook to **BlockEditor / LineHeightControl** and smoke test the default story.
2. In the editor, select a Paragraph block and confirm Line height in the Typography panel renders at 40px height.
3. Confirm line-height changes still work.
4. Confirm no console warnings are logged.