### PR TITLE
RTC: Fix autosave update with no content

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -110,7 +110,7 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 
 		if ( $should_update_parent_draft_post ) {
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
-		} elseif ( $this->is_redundant_autosave( $post, (array) $prepared_post, $user_id ) ) {
+		} elseif ( $this->is_redundant_autosave( $post, (array) $prepared_post, (array) $request->get_param( 'meta' ), $user_id ) ) {
 			/*
 			 * Nothing changed and there is no existing autosave to update, so
 			 * storing a revision would only create one that is identical to the
@@ -143,21 +143,23 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 	 * When none exists yet, it still creates a brand-new revision even if that
 	 * revision is identical to the parent post.
 	 *
-	 * Only the revisioned post fields (title, content, excerpt) are compared,
-	 * since those are what the revision comparison UI surfaces and what makes the
-	 * stale autosave notice incorrect. Meta is intentionally excluded: the editor
-	 * sends meta (e.g. the constantly changing `_crdt_document`) with every
-	 * autosave. A meta-only autosave would also display a blank, change-free
-	 * revision, so there is nothing useful to preserve by storing one.
+	 * The revisioned post fields (title, content, excerpt) and revisioned meta
+	 * (e.g. `footnotes`) are compared, matching the fields core itself diffs.
+	 * Revisioned meta matters because some edits live only in meta: changing a
+	 * footnote's text leaves the post content untouched, and previewing those
+	 * changes depends on the autosave carrying the new meta, so it must not be
+	 * skipped. Non-revisioned meta (e.g. the constantly changing `_crdt_document`)
+	 * is naturally excluded because it is not a revisioned meta key.
 	 *
 	 * @since 7.0.0
 	 *
 	 * @param WP_Post $post      The saved parent post.
 	 * @param array   $post_data Prepared autosave post data.
+	 * @param array   $meta      Meta values submitted with the autosave.
 	 * @param int     $user_id   The current user ID.
 	 * @return bool Whether the autosave can be skipped without losing anything.
 	 */
-	private function is_redundant_autosave( $post, $post_data, $user_id ) {
+	private function is_redundant_autosave( $post, $post_data, $meta, $user_id ) {
 		// Core already returns the existing autosave unchanged when nothing
 		// differs, so only the first autosave needs guarding here.
 		if ( wp_get_post_autosave( $post->ID, $user_id ) ) {
@@ -169,6 +171,18 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 
 		foreach ( array_intersect( array_keys( $new_autosave ), array_keys( $revision_fields ) ) as $field ) {
 			if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) ) {
+				return false;
+			}
+		}
+
+		foreach ( wp_post_revision_meta_keys( $post->post_type ) as $meta_key ) {
+			// get_metadata_raw avoids the registered default. Treat an unset value
+			// and an empty string as equivalent so the editor's empty default for
+			// an unset key is not mistaken for a change.
+			$old_meta = get_metadata_raw( 'post', $post->ID, $meta_key, true ) ?? '';
+			$new_meta = $meta[ $meta_key ] ?? '';
+
+			if ( $old_meta !== $new_meta ) {
 				return false;
 			}
 		}

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-autosaves-controller.php
@@ -110,6 +110,14 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 
 		if ( $should_update_parent_draft_post ) {
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
+		} elseif ( $this->is_redundant_autosave( $post, (array) $prepared_post, $user_id ) ) {
+			/*
+			 * Nothing changed and there is no existing autosave to update, so
+			 * storing a revision would only create one that is identical to the
+			 * post. Avoid a no-op revision because WordPress decides whether to warn
+			 * about "a more recent autosave" by comparing timestamps.
+			 */
+			$autosave_id = $post->ID;
 		} else {
 			$autosave_id = $this->create_post_autosave( (array) $prepared_post, (array) $request->get_param( 'meta' ) );
 		}
@@ -125,5 +133,46 @@ class Gutenberg_REST_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 		$response = rest_ensure_response( $response );
 
 		return $response;
+	}
+
+	/**
+	 * Determines whether an incoming autosave would be a redundant no-op.
+	 *
+	 * Core's WP_REST_Autosaves_Controller::create_post_autosave() already avoids
+	 * a redundant write, but only when an autosave already exists for the user.
+	 * When none exists yet, it still creates a brand-new revision even if that
+	 * revision is identical to the parent post.
+	 *
+	 * Only the revisioned post fields (title, content, excerpt) are compared,
+	 * since those are what the revision comparison UI surfaces and what makes the
+	 * stale autosave notice incorrect. Meta is intentionally excluded: the editor
+	 * sends meta (e.g. the constantly changing `_crdt_document`) with every
+	 * autosave. A meta-only autosave would also display a blank, change-free
+	 * revision, so there is nothing useful to preserve by storing one.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_Post $post      The saved parent post.
+	 * @param array   $post_data Prepared autosave post data.
+	 * @param int     $user_id   The current user ID.
+	 * @return bool Whether the autosave can be skipped without losing anything.
+	 */
+	private function is_redundant_autosave( $post, $post_data, $user_id ) {
+		// Core already returns the existing autosave unchanged when nothing
+		// differs, so only the first autosave needs guarding here.
+		if ( wp_get_post_autosave( $post->ID, $user_id ) ) {
+			return false;
+		}
+
+		$new_autosave    = _wp_post_revision_data( $post_data, true );
+		$revision_fields = _wp_post_revision_fields( $post );
+
+		foreach ( array_intersect( array_keys( $new_autosave ), array_keys( $revision_fields ) ) as $field ) {
+			if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/phpunit/tests/collaboration/restAutosavesController.php
+++ b/phpunit/tests/collaboration/restAutosavesController.php
@@ -180,6 +180,51 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertFalse( $autosave, 'Expected no autosave revision for an unchanged autosave.' );
 	}
 
+	public function test_draft_autosave_creates_revision_when_revisioned_meta_changes() {
+		// `footnotes` is the real-world example of a revisioned meta key, but a
+		// dedicated key is registered here so the test does not depend on whether
+		// footnotes happens to be registered in the test bootstrap.
+		$meta_key = 'test_revisioned_meta';
+		register_post_meta(
+			'post',
+			$meta_key,
+			array(
+				'single'            => true,
+				'type'              => 'string',
+				'show_in_rest'      => true,
+				'revisions_enabled' => true,
+			)
+		);
+
+		$title   = 'RTC draft title with revisioned meta';
+		$content = '<!-- wp:paragraph --><p>RTC draft content with revisioned meta</p><!-- /wp:paragraph -->';
+		$post_id = $this->create_draft( $title, $content );
+		update_post_meta( $post_id, $meta_key, 'original meta value' );
+
+		// Autosave with identical title and content but a changed revisioned meta
+		// value. Because the meta is revisioned, the change is recoverable and must
+		// be stored as a revision rather than skipped as a no-op.
+		$response = $this->dispatch_autosave(
+			$post_id,
+			$title,
+			$content,
+			array(
+				$meta_key => 'updated meta value',
+			)
+		);
+
+		unregister_post_meta( 'post', $meta_key );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$autosave = wp_get_post_autosave( $post_id, self::$author_id );
+		$this->assertInstanceOf( WP_Post::class, $autosave );
+		$this->assertSame(
+			'updated meta value',
+			get_post_meta( $autosave->ID, $meta_key, true )
+		);
+	}
+
 	public function test_draft_autosave_does_not_store_crdt_doc_meta_on_revision() {
 		$original_title   = 'Original RTC draft title with CRDT meta';
 		$original_content = '<!-- wp:paragraph --><p>Original RTC draft content with CRDT meta</p><!-- /wp:paragraph -->';

--- a/phpunit/tests/collaboration/restAutosavesController.php
+++ b/phpunit/tests/collaboration/restAutosavesController.php
@@ -155,6 +155,31 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertSame( $content, $autosave->post_content );
 	}
 
+	public function test_draft_autosave_does_not_create_revision_when_content_is_unchanged() {
+		$title   = 'Unchanged RTC draft title';
+		$content = '<!-- wp:paragraph --><p>Unchanged RTC draft content</p><!-- /wp:paragraph -->';
+		$post_id = $this->create_draft( $title, $content );
+
+		// Autosave with the exact same title and content as the saved post, while
+		// still sending meta as the editor does (the CRDT document changes on
+		// every autosave). The unchanged revisioned fields must win: a no-op
+		// autosave should not leave behind a revision that would later be flagged
+		// as "a more recent autosave" purely by its timestamp.
+		$response = $this->dispatch_autosave(
+			$post_id,
+			$title,
+			$content,
+			array(
+				self::CRDT_DOC_META_KEY => 'changed-crdt-doc',
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$autosave = wp_get_post_autosave( $post_id, self::$author_id );
+		$this->assertFalse( $autosave, 'Expected no autosave revision for an unchanged autosave.' );
+	}
+
 	public function test_draft_autosave_does_not_store_crdt_doc_meta_on_revision() {
 		$original_title   = 'Original RTC draft title with CRDT meta';
 		$original_content = '<!-- wp:paragraph --><p>Original RTC draft content with CRDT meta</p><!-- /wp:paragraph -->';

--- a/test/e2e/specs/editor/collaboration/collaboration-stale-autosave-notice.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stale-autosave-notice.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import type { Page, Response } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+type RestPost = {
+	id: number;
+	status: string;
+	title?: { raw?: string; rendered?: string } | string;
+	content?: { raw?: string; rendered?: string } | string;
+};
+
+function rawField( field: RestPost[ 'content' ] ): string {
+	if ( ! field ) {
+		return '';
+	}
+
+	return typeof field === 'string'
+		? field
+		: field.raw ?? field.rendered ?? '';
+}
+
+async function getCurrentPostId( page: Page ): Promise< number > {
+	return page.evaluate( () =>
+		( window as any ).wp.data.select( 'core/editor' ).getCurrentPostId()
+	);
+}
+
+function isAutosaveResponse( response: Response, postId: number ): boolean {
+	if ( response.request().method() !== 'POST' ) {
+		return false;
+	}
+
+	const url = new URL( response.url() );
+	const route = `/wp/v2/posts/${ postId }/autosaves`;
+
+	return (
+		url.pathname.includes( `/wp-json${ route }` ) ||
+		url.searchParams.get( 'rest_route' ) === route
+	);
+}
+
+test.describe( 'Collaboration - stale autosave notice', () => {
+	// Reproduces the spurious "There is an autosave of this post that is more
+	// recent than the version below" notice that appears in real-time
+	// collaboration.
+	//
+	// Root cause is two factors combining:
+	//
+	// 1. With RTC enabled, the author's draft autosave is NOT applied to the
+	//    parent post (see Gutenberg_REST_Autosaves_Controller::create_item).
+	//    It is stored as a per-user autosave revision instead, so the revision
+	//    is always more recent than the parent post, even for a no-op autosave
+	//    whose content is identical to the post.
+	//
+	// 2. WordPress core decides whether to show the notice in
+	//    wp-admin/edit-form-blocks.php by comparing ONLY timestamps
+	//    (`$autosave->post_modified_gmt > $post->post_modified_gmt`), never the
+	//    revisioned fields. So a content-identical autosave still triggers the
+	//    notice, and "View the autosave" opens a revision screen with no Content
+	//    diff (just the title), because the content matches the saved post.
+	test( 'does not show a spurious notice in RTC after a no-op autosave', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		test.setTimeout( 120_000 );
+
+		const marker = 'rtc-stale-autosave-content';
+
+		// Seed the post with the editor's canonical block serialization so the
+		// autosave that follows is a true no-op (byte-identical content), which
+		// is what makes the revision's Content diff blank.
+		const content = `<!-- wp:paragraph -->\n<p>${ marker }</p>\n<!-- /wp:paragraph -->`;
+
+		// Create a draft authored by the current user (admin). `wp_get_post_autosave`
+		// resolves the autosave for the current user, so the author must own the
+		// post. Backdate it so its `post_modified` is deterministically older than
+		// the autosave we trigger below (autosave timestamps have one-second
+		// resolution), without resorting to a wall-clock wait.
+		const post = await requestUtils.createPost( {
+			title: 'RTC stale autosave notice',
+			status: 'draft',
+			content,
+			date_gmt: new Date( Date.now() - 60 * 60 * 1000 ).toISOString(),
+		} );
+
+		await collaborationUtils.openPost( post.id );
+		await collaborationUtils.waitForEntityReady( page, {
+			timeout: 30_000,
+		} );
+
+		const postId = await getCurrentPostId( page );
+		expect( postId ).toBe( post.id );
+
+		// Trigger a no-op autosave (nothing has been edited since load).
+		const autosaveRequest = page.waitForResponse(
+			( response ) => isAutosaveResponse( response, postId ),
+			{ timeout: 30_000 }
+		);
+		await page.evaluate( () =>
+			( window as any ).wp.data.dispatch( 'core/editor' ).autosave()
+		);
+		const autosaveResponse = await autosaveRequest;
+		expect( autosaveResponse.status() ).toBe( 200 );
+		await page.waitForFunction(
+			() =>
+				! ( window as any ).wp.data
+					.select( 'core/editor' )
+					.isAutosavingPost(),
+			undefined,
+			{ timeout: 30_000 }
+		);
+
+		// The autosave was stored as a revision (RTC does not update the parent
+		// draft) and its content is identical to the post: a no-op that produces
+		// a blank Content diff in the revision UI.
+		const savedPost = await requestUtils.rest< RestPost >( {
+			path: `/wp/v2/posts/${ postId }`,
+			params: { context: 'edit' },
+		} );
+		const autosaves = await requestUtils.rest< RestPost[] >( {
+			path: `/wp/v2/posts/${ postId }/autosaves`,
+			params: { context: 'edit' },
+		} );
+		expect( autosaves.length ).toBeGreaterThanOrEqual( 1 );
+
+		const latestAutosave = autosaves[ autosaves.length - 1 ];
+		expect( rawField( latestAutosave.content ).trim() ).toBe(
+			rawField( savedPost.content ).trim()
+		);
+		expect( rawField( savedPost.content ).trim() ).toBe( content.trim() );
+
+		// Reload. The autosave was a no-op, so the editor should NOT warn that a
+		// more recent autosave exists. Today this fails: the server computes
+		// `settings.autosave` by comparing only timestamps and surfaces the
+		// spurious notice. The fix should make this assertion pass.
+		await page.reload();
+		await collaborationUtils.waitForCollaborationReady( page, {
+			timeout: 30_000,
+		} );
+		await collaborationUtils.waitForEntityReady( page, {
+			timeout: 30_000,
+		} );
+
+		// Wait until the editor has fully mounted (our paragraph is rendered).
+		// The notice, if any, is created in the editor provider's mount effect,
+		// so by this point it would already be present. This prevents a false
+		// pass from asserting absence before the editor has had a chance to show it.
+		await expect( editor.canvas.getByText( marker ) ).toBeVisible( {
+			timeout: 30_000,
+		} );
+
+		await expect(
+			page.locator( '.components-notice__content' ).filter( {
+				hasText:
+					'There is an autosave of this post that is more recent than the version below.',
+			} )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-stale-autosave-notice.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stale-autosave-notice.spec.ts
@@ -64,7 +64,7 @@ test.describe( 'Collaboration - stale autosave notice', () => {
 	//    revisioned fields. So a content-identical autosave still triggers the
 	//    notice, and "View the autosave" opens a revision screen with no Content
 	//    diff (just the title), because the content matches the saved post.
-	test( 'does not show a spurious notice in RTC after a no-op autosave', async ( {
+	test( 'does not show an unnecessary notice in RTC after a no-op autosave', async ( {
 		collaborationUtils,
 		editor,
 		page,
@@ -118,9 +118,9 @@ test.describe( 'Collaboration - stale autosave notice', () => {
 			{ timeout: 30_000 }
 		);
 
-		// The autosave was stored as a revision (RTC does not update the parent
-		// draft) and its content is identical to the post: a no-op that produces
-		// a blank Content diff in the revision UI.
+		// The autosave was a no-op (identical content), so the server must not
+		// persist a redundant autosave revision. A lingering revision is exactly
+		// what would later out-date the post and surface the spurious notice.
 		const savedPost = await requestUtils.rest< RestPost >( {
 			path: `/wp/v2/posts/${ postId }`,
 			params: { context: 'edit' },
@@ -129,18 +129,13 @@ test.describe( 'Collaboration - stale autosave notice', () => {
 			path: `/wp/v2/posts/${ postId }/autosaves`,
 			params: { context: 'edit' },
 		} );
-		expect( autosaves.length ).toBeGreaterThanOrEqual( 1 );
-
-		const latestAutosave = autosaves[ autosaves.length - 1 ];
-		expect( rawField( latestAutosave.content ).trim() ).toBe(
-			rawField( savedPost.content ).trim()
-		);
 		expect( rawField( savedPost.content ).trim() ).toBe( content.trim() );
+		expect( autosaves ).toHaveLength( 0 );
 
-		// Reload. The autosave was a no-op, so the editor should NOT warn that a
-		// more recent autosave exists. Today this fails: the server computes
-		// `settings.autosave` by comparing only timestamps and surfaces the
-		// spurious notice. The fix should make this assertion pass.
+		// Reload. The autosave was a no-op, so no autosave revision exists to
+		// out-date the post, and the editor must not warn about "a more recent
+		// autosave". Without the controller fix, WordPress would have stored a
+		// redundant revision and surfaced the spurious notice here.
 		await page.reload();
 		await collaborationUtils.waitForCollaborationReady( page, {
 			timeout: 30_000,


### PR DESCRIPTION
## What?

Address `There is an autosave of this post that is more recent than the version below` warning sometimes shown with RTC when no autosave with newer content is actually available.

<img width="892" height="109" alt="autosave-warning" src="https://github.com/user-attachments/assets/74bc39ff-042c-4aab-8428-5ae8c92ad6fa" />

## Why?

When RTC is enabled, draft autosaves are stored as revisions rather than applied to the parent post. Why? In traditional WordPress, post authors have a different save flow than non-authors in drafts. Post authors autosave directly to the parent post, but non-authors autosave to a revision. This non-symmetrical flow doesn't play well with the RTC model where we don't want to modify post content for some peers but not others, and can lead to content duplication (see #75105). With that fix in place, all autosaves on a draft post (regardless of post authorship or lock hold) are stored in revisions.

WordPress decides whether to warn about a "more recent autosave" by comparing [the latest autosave's timestamp](https://github.com/WordPress/wordpress-develop/blob/260fcbea3475459052c3ed3338c880a4d365ff5f/src/wp-admin/edit-form-blocks.php#L293-L296), so any autosave that is newer than the (never-updated) parent draft causes the notice, even when the autosave call saved no new changes.

This can be demonstrated by creating a new post, saving, and then changing a taxonomy term on the post:

On `trunk` (sped up for autosave timing):

https://github.com/user-attachments/assets/7b99aca8-4e05-44ee-ab5c-5da75510c50d

When the autosave fires, it includes `title`, `excerpt`, `content`, and `meta` (e.g. `footnotes`) [in the request to the server](https://github.com/WordPress/gutenberg/blob/c79cd960397aa7a54254867001eb1c0ecdc46482/packages/core-data/src/actions.js#L681-L709). Taxonomy terms and other post updates are not included.

On `trunk`, the taxonomy change still marks the post dirty. On the server-side, nothing is new in `title`/`content`/etc, so the revision is empty except for a timestamp change. This causes the bug.

If we also verify that there's changed values server-side, we no longer create the ghost revision:

On `fix/rtc-draft-autosave-warning` (autosave timing sped up):

https://github.com/user-attachments/assets/a0451c00-19e7-43c3-be21-6e48509026ef

We explicitly ignore non-revisioned post meta (like the CRDT doc). An update to non-revisioned meta with no content change is treated as a no-op. Revisioned meta such as `footnotes` is still honored, since it appears in the revision and previews depend on it.

### Why are revisions blank?

As shown in the reproduction above, clicking on "View the autosave" for a no-op autosave shows a "blank" revision:

<img width="1706" height="539" alt="blank-revision" src="https://github.com/user-attachments/assets/ba208728-81a2-47fb-8ebe-d68bf03e4907" />

This is because the revisions page [just skips showing post content](https://github.com/WordPress/wordpress-develop/blob/260fcbea3475459052c3ed3338c880a4d365ff5f/src/wp-admin/includes/revision.php#L145-L151) when there's no changes in the diff, but [shows the post title](https://github.com/WordPress/wordpress-develop/blob/260fcbea3475459052c3ed3338c880a4d365ff5f/src/wp-admin/includes/revision.php#L121-L126) as a special case. That means the revision is essentially showing "nothing changed", but due to the UI looks as though the revision itself is lost. A real "lost" revision would show a diff of all of the content removed.

## How?

The autosave controller decides whether an autosave updates the post or is stored as a revision. This adds a new branch when none of the revisioned post fields or revisioned meta changed. If that's the case, the request is treated as a no-op instead of creating a revision with just a timestamp. The existing autosave case is delegated to core.

The comparison looks at the revisioned post fields (`title`, `content`, `excerpt`) and revisioned `meta` such as footnotes, the same fields a revision actually stores. It ignores non-revisioned meta. Altough the editor sends `_crdt_document` with every autosave and its value changes constantly, it isn't part of a revision, so comparing it would make every autosave look without a content change. A change to non-revisioned meta produces a blank revision and is skipped. A change to revisioned meta like footnotes still creates a revision, because it shows in the diff and previews depend on it.

## Testing Instructions

First, test on `trunk`:

1. Enable RTC via Settings -> Writing -> "Enable real-time collaboration" checkbox.
2. Create a new post, add a title and a paragraph of content, and save the draft.
3. After saving, change the post's category selection. Do not manually save.
3. Open network tools and filter for `autosave`. Wait ~60 seconds until an autosave fires.
4. Reload the editor.
5. See the "There is an autosave of this post that is more recent than the version below." notice appears after a reload.

Retry the same steps on this branch (`fix/rtc-draft-autosave-warning`), and note that the unsaved changes warning and is removed.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: Investigating the root cause across the autosave controller and core detection path, and drafting the fix and tests.