### PR TITLE
FontFamilyControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
+    -   `FontFamilyControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
     -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
     -   `LineHeightControl` ([#79589](https://github.com/WordPress/gutenberg/pull/79589)).
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Breaking Changes
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
-    -   `FontFamilyControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+    -   `FontFamilyControl` ([#79593](https://github.com/WordPress/gutenberg/pull/79593)).
     -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
     -   `LineHeightControl` ([#79589](https://github.com/WordPress/gutenberg/pull/79589)).
 

--- a/packages/block-editor/src/components/font-family/README.md
+++ b/packages/block-editor/src/components/font-family/README.md
@@ -28,7 +28,6 @@ const MyFontFamilyControl = () => {
 			onChange={ ( newFontFamily ) => {
 				setFontFamily( newFontFamily );
 			} }
-			__next40pxDefaultSize
 		/>
 	);
 };
@@ -74,11 +73,3 @@ The current font family value.
 - Default: ''
 
 The rest of the props are passed down to the underlying `<SelectControl />` instance.
-
-#### `__next40pxDefaultSize`
-
-- Type: `boolean`
-- Required: No
-- Default: `false`
-
-Start opting into the larger default height that will become the default size in a future version.

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { CustomSelectControl } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,8 +15,12 @@ import { __ } from '@wordpress/i18n';
 import { useSettings } from '../use-settings';
 
 export default function FontFamilyControl( {
-	/** Start opting into the larger default height that will become the default size in a future version. */
-	__next40pxDefaultSize = false,
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+	 */
+	__next40pxDefaultSize: _next40pxDefaultSize,
 	value = '',
 	onChange,
 	fontFamilies,
@@ -45,26 +48,11 @@ export default function FontFamilyControl( {
 		} ) ),
 	];
 
-	if (
-		! __next40pxDefaultSize &&
-		( props.size === undefined || props.size === 'default' )
-	) {
-		deprecated(
-			`36px default size for wp.blockEditor.__experimentalFontFamilyControl`,
-			{
-				since: '6.8',
-				version: '7.1',
-				hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
-			}
-		);
-	}
-
 	const selectedValue =
 		options.find( ( option ) => option.key === value ) ?? '';
 	return (
 		<CustomSelectControl
-			__next40pxDefaultSize={ __next40pxDefaultSize }
-			__shouldNotWarnDeprecated36pxSize
+			__next40pxDefaultSize
 			label={ __( 'Font' ) }
 			value={ selectedValue }
 			onChange={ ( { selectedItem } ) => onChange( selectedItem.key ) }

--- a/packages/block-editor/src/components/font-family/stories/index.story.jsx
+++ b/packages/block-editor/src/components/font-family/stories/index.story.jsx
@@ -49,6 +49,5 @@ export const Default = {
 				slug: 'system-font',
 			},
 		],
-		__next40pxDefaultSize: true,
 	},
 };

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -605,7 +605,6 @@ export default function TypographyPanel( {
 						fontFamilies={ fontFamilies }
 						value={ fontFamily }
 						onChange={ setFontFamily }
-						size="__unstable-large"
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -661,7 +661,6 @@ export default function TypographyPanel( {
 						__unstableInputWidth="auto"
 						value={ lineHeight }
 						onChange={ setLineHeight }
-						size="__unstable-large"
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -12,7 +12,6 @@ The following components are checked by this rule:
 -   ComboboxControl
 -   CustomSelectControl
 -   FontAppearanceControl
--   FontFamilyControl
 -   FormFileUpload (special case - see below)
 -   FormTokenField
 -   InputControl

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -113,7 +113,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					ComboboxControl,
 					CustomSelectControl,
 					FontAppearanceControl,
-					FontFamilyControl,
 					FormTokenField,
 					InputControl,
 					NumberControl,
@@ -126,7 +125,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					<ComboboxControl __next40pxDefaultSize />
 					<CustomSelectControl __next40pxDefaultSize />
 					<FontAppearanceControl __next40pxDefaultSize />
-					<FontFamilyControl __next40pxDefaultSize />
 					<FormTokenField __next40pxDefaultSize />
 					<InputControl __next40pxDefaultSize />
 					<NumberControl __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -17,7 +17,6 @@ const COMPONENTS_REQUIRING_40PX = new Set( [
 	'ComboboxControl',
 	'CustomSelectControl',
 	'FontAppearanceControl',
-	'FontFamilyControl',
 	'FormTokenField',
 	'IconButton',
 	'InputControl',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -174,6 +174,7 @@ const restrictedSyntax = [
 		'BorderControl',
 		'BoxControl',
 		'FocalPointPicker',
+		'FontFamilyControl',
 		'FontSizePicker',
 		'LetterSpacingControl',
 		'LineHeightControl',


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the deprecated `__next40pxDefaultSize` prop from `FontFamilyControl`, making the 40px default size the permanent default.

## Why?

The soft deprecation was introduced in WP 6.8 with a 36px console warning when the prop was not set. Block Editor typography wrappers are being updated before the primitives they embed.

## How?

- Hard-deprecate `__next40pxDefaultSize` on `FontFamilyControl`: always pass `__next40pxDefaultSize` to the inner `CustomSelectControl`, remove the `deprecated()` 36px warning, and accept (but ignore) the prop for backward compatibility.
- Update README and Storybook usage.
- Remove `FontFamilyControl` from the `components-no-missing-40px-size-prop` ESLint rule and add it to the restricted-syntax forbid list in `tools/eslint/config.mjs`.
- Document the breaking change in `@wordpress/block-editor` CHANGELOG.

## Testing Instructions

1. Open Storybook to **BlockEditor / FontFamilyControl** and smoke test the default story.
2. In the editor, select a Paragraph block and confirm Font family in the Typography panel renders at 40px height.
3. Confirm font family changes still work.
4. Confirm no console warnings are logged.

### Testing Instructions for Keyboard

1. Tab to the Font family control in the Typography panel and confirm it is operable with the keyboard.

## Use of AI Tools

Cursor was used to implement this change from an existing plan aligned with prior typography wrapper PRs.