### PR TITLE
Theme: Revert ThemeProvider stable API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53630,6 +53630,7 @@
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/element": "file:../element",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
 				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
@@ -53816,6 +53817,7 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/primitives": "file:../primitives",
+				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
 				"@wordpress/theme": "file:../theme",
 				"clsx": "^2.1.1",

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -20,7 +20,7 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Page, getAdminThemeColors } from '@wordpress/admin-ui';
 import { Tooltip } from '@wordpress/ui';
-import { ThemeProvider } from '@wordpress/theme';
+import { privateApis as themePrivateApis } from '@wordpress/theme';
 
 /**
  * Internal dependencies
@@ -34,6 +34,7 @@ import type { CanvasData } from '../../store/types';
 import './style.scss';
 
 const { useLocation, useMatches, Outlet } = unlock( routePrivateApis );
+const { ThemeProvider } = unlock( themePrivateApis );
 
 export default function Root() {
 	const matches = useMatches();

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -11,7 +11,7 @@ import { SnackbarNotices } from '@wordpress/notices';
 import { SlotFillProvider } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getAdminThemeColors } from '@wordpress/admin-ui';
-import { ThemeProvider } from '@wordpress/theme';
+import { privateApis as themePrivateApis } from '@wordpress/theme';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ import './style.scss';
 import useRouteTitle from '../app/use-route-title';
 
 const { useMatches, Outlet } = unlock( routePrivateApis );
+const { ThemeProvider } = unlock( themePrivateApis );
 
 /**
  * Root component for single page mode (no sidebar).

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -28,7 +28,7 @@ import {
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { ThemeProvider } from '@wordpress/theme';
+import { privateApis as themePrivateApis } from '@wordpress/theme';
 import { PluginArea } from '@wordpress/plugins';
 import { SnackbarNotices, store as noticesStore } from '@wordpress/notices';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -50,6 +50,7 @@ import SavePanel from '../save-panel';
 
 const { useLocation } = unlock( routerPrivateApis );
 const { useStyle, UploadProgressSnackbar } = unlock( editorPrivateApis );
+const { ThemeProvider } = unlock( themePrivateApis );
 
 const ANIMATION_DURATION = 0.3;
 const CONTENT_COLOR = { background: '#ffffff' };

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Remove `ThemeProvider` from the public package exports and restore access through `privateApis` ([#79594](https://github.com/WordPress/gutenberg/pull/79594)).
+
 ### New Features
 
 -   Export `@wordpress/theme/utils` with a generated `var()` Sass function for compile-time design token fallback injection ([#79470](https://github.com/WordPress/gutenberg/pull/79470)).

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -87,6 +87,7 @@
 	"dependencies": {
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",
 		"colorjs.io": "^0.6.0",
 		"memize": "^2.1.0"

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,3 +1,4 @@
+export { privateApis } from './private-apis';
 export type * from './prebuilt/ts/token-types';
-export { ThemeProvider } from './theme-provider';
+export { type ThemeProvider } from './theme-provider';
 export type { CornerRadiusPreset } from './types';

--- a/packages/theme/src/lock-unlock.ts
+++ b/packages/theme/src/lock-unlock.ts
@@ -1,0 +1,7 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/theme'
+	);

--- a/packages/theme/src/private-apis.ts
+++ b/packages/theme/src/private-apis.ts
@@ -1,0 +1,9 @@
+import { lock } from './lock-unlock';
+import { ThemeProvider } from './theme-provider';
+import { useThemeProviderStyles } from './use-theme-provider-styles';
+
+export const privateApis = {};
+lock( privateApis, {
+	ThemeProvider,
+	useThemeProviderStyles,
+} );

--- a/packages/theme/src/stories/index.story.tsx
+++ b/packages/theme/src/stories/index.story.tsx
@@ -22,6 +22,7 @@ const meta: Meta< typeof ThemeProvider > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
+	tags: [ 'status-private' ],
 };
 export default meta;
 

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -10,6 +10,7 @@
 	"references": [
 		{ "path": "../compose" },
 		{ "path": "../element" },
+		{ "path": "../private-apis" },
 		{ "path": "../style-runtime" }
 	]
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Internal
 
+-   Restore private API access for `@wordpress/theme`'s `ThemeProvider` ([#79594](https://github.com/WordPress/gutenberg/pull/79594)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,6 +51,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/primitives": "file:../primitives",
+		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",
 		"@wordpress/theme": "file:../theme",
 		"clsx": "^2.1.1",

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -3,7 +3,10 @@ import clsx from 'clsx';
 import { forwardRef, useContext } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
 
 import { renderSlotWithChildren } from '../utils/render-slot-with-children';
 import { Button } from '../button';
@@ -15,12 +18,16 @@ import {
 	SCROLL_CONTAINER_ATTR,
 	useOverlayScrollStateAttributes,
 } from '../utils/use-overlay-scroll-state-attributes';
+import { unlock } from '../lock-unlock';
 import { Stack } from '../stack';
 import { Text } from '../text';
 import { AlertDialogContext } from './context';
 import { Portal } from './portal';
 import alertDialogStyles from './style.module.css';
 import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const Popup = forwardRef< HTMLDivElement, PopupProps >(
 	function AlertDialogPopup(

--- a/packages/ui/src/dialog/popup.tsx
+++ b/packages/ui/src/dialog/popup.tsx
@@ -2,7 +2,11 @@ import { Dialog as _Dialog } from '@base-ui/react/dialog';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { SCROLL_CONTAINER_ATTR } from '../utils/use-overlay-scroll-state-attributes';
 import { renderSlotWithChildren } from '../utils/render-slot-with-children';
@@ -10,6 +14,9 @@ import { DialogValidationProvider, useDialogModal } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const CLOSE_ICON_ATTR = 'data-wp-ui-dialog-close-icon';
 

--- a/packages/ui/src/drawer/popup.tsx
+++ b/packages/ui/src/drawer/popup.tsx
@@ -2,7 +2,11 @@ import { Drawer as _Drawer } from '@base-ui/react/drawer';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { SCROLL_CONTAINER_ATTR } from '../utils/use-overlay-scroll-state-attributes';
 import { renderSlotWithChildren } from '../utils/render-slot-with-children';
@@ -10,6 +14,9 @@ import { DrawerValidationProvider, useDrawerModal } from './context';
 import { Portal } from './portal';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const CLOSE_ICON_ATTR = 'data-wp-ui-drawer-close-icon';
 

--- a/packages/ui/src/form/primitives/autocomplete/popup.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/popup.tsx
@@ -1,12 +1,19 @@
 import { Autocomplete as _Autocomplete } from '@base-ui/react/autocomplete';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../../../lock-unlock';
 import { renderSlotWithChildren } from '../../../utils/render-slot-with-children';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import { Portal } from './portal';
 import { Positioner } from './positioner';
 import type { AutocompletePopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 export const Popup = forwardRef< HTMLDivElement, AutocompletePopupProps >(
 	function Popup( { className, portal, positioner, ...restProps }, ref ) {

--- a/packages/ui/src/form/primitives/combobox/popup.tsx
+++ b/packages/ui/src/form/primitives/combobox/popup.tsx
@@ -1,12 +1,19 @@
 import { Combobox as _Combobox } from '@base-ui/react/combobox';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../../../lock-unlock';
 import { Portal } from './portal';
 import { Positioner } from './positioner';
 import { renderSlotWithChildren } from '../../../utils/render-slot-with-children';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import type { ComboboxPopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 export const Popup = forwardRef< HTMLDivElement, ComboboxPopupProps >(
 	function Popup( { className, portal, positioner, ...restProps }, ref ) {

--- a/packages/ui/src/form/primitives/select/popup.tsx
+++ b/packages/ui/src/form/primitives/select/popup.tsx
@@ -1,12 +1,19 @@
 import { Select as _Select } from '@base-ui/react/select';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../../../lock-unlock';
 import { Portal } from './portal';
 import { Positioner } from './positioner';
 import { renderSlotWithChildren } from '../../../utils/render-slot-with-children';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import type { SelectPopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 export const Popup = forwardRef< HTMLDivElement, SelectPopupProps >(
 	function Popup(

--- a/packages/ui/src/lock-unlock.ts
+++ b/packages/ui/src/lock-unlock.ts
@@ -1,0 +1,7 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/ui'
+	);

--- a/packages/ui/src/popover/popup.tsx
+++ b/packages/ui/src/popover/popup.tsx
@@ -2,7 +2,11 @@ import { Popover as _Popover } from '@base-ui/react/popover';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
+import { unlock } from '../lock-unlock';
 import { useDeprioritizedInitialFocus } from '../utils/use-deprioritized-initial-focus';
 import { renderSlotWithChildren } from '../utils/render-slot-with-children';
 import { PopoverValidationProvider } from './context';
@@ -10,6 +14,9 @@ import { Portal } from './portal';
 import { Positioner } from './positioner';
 import styles from './style.module.css';
 import type { PopupProps } from './types';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 const CLOSE_ATTR = 'data-wp-ui-popover-close';
 

--- a/packages/ui/src/tooltip/popup.tsx
+++ b/packages/ui/src/tooltip/popup.tsx
@@ -1,12 +1,19 @@
 import clsx from 'clsx';
 import { Tooltip as _Tooltip } from '@base-ui/react/tooltip';
 import { forwardRef } from '@wordpress/element';
-import { ThemeProvider } from '@wordpress/theme';
+import {
+	type ThemeProvider as ThemeProviderType,
+	privateApis as themePrivateApis,
+} from '@wordpress/theme';
 import type { PopupProps } from './types';
+import { unlock } from '../lock-unlock';
 import { Portal } from './portal';
 import { Positioner } from './positioner';
 import { renderSlotWithChildren } from '../utils/render-slot-with-children';
 import styles from './style.module.css';
+
+const ThemeProvider: typeof ThemeProviderType =
+	unlock( themePrivateApis ).ThemeProvider;
 
 /*
  * This should ideally use whatever dark color makes sense, and not be

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -17,6 +17,7 @@
 		{ "path": "../icons" },
 		{ "path": "../keycodes" },
 		{ "path": "../primitives" },
+		{ "path": "../private-apis" },
 		{ "path": "../style-runtime" },
 		{ "path": "../theme" }
 	],

--- a/storybook/decorators/with-design-system-theme.tsx
+++ b/storybook/decorators/with-design-system-theme.tsx
@@ -1,7 +1,15 @@
 import type { CornerRadiusPreset } from '@wordpress/theme';
-import { ThemeProvider } from '@wordpress/theme';
+import { privateApis as themeApis } from '@wordpress/theme';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import type { StoryContext } from 'storybook/internal/types';
 import { storyIdMatchesDesignSystemTheme } from './utils/design-system-theme-story-matchers';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/theme'
+);
+
+const { ThemeProvider } = unlock( themeApis );
 
 /**
  * Decorator that applies Design System theme based on toolbar selections.

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -2,7 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
 import { useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
-import { ThemeProvider, type CornerRadiusPreset } from '@wordpress/theme';
+import type { CornerRadiusPreset } from '@wordpress/theme';
+import { privateApis as themeApis } from '@wordpress/theme';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import {
 	Badge,
 	Button,
@@ -18,6 +20,13 @@ import {
 } from '@wordpress/ui';
 
 import { withRouter } from '../../decorators/with-router';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/theme'
+);
+
+const { ThemeProvider } = unlock( themeApis );
 
 const sidebarNavItems = [
 	'Dashboard',


### PR DESCRIPTION
## What?


Reverts #78958

Reverts the stable public API promotion for `@wordpress/theme`'s `ThemeProvider`, while keeping the changelog entries and `ThemeProvider` JSDoc from the original PR.

## Why?

The changes in #78958 are causing build errors for bundled packages that rely on the previous way to import `ThemeProvider` via private API.

This restores the previous private API boundary without losing the non-runtime documentation/context that should remain.

## How?
- Restores `@wordpress/theme`'s `privateApis` export and lock/unlock wiring.
- Moves `ThemeProvider` consumers in `@wordpress/ui`, boot, edit-site, and Storybook back to private API access.
- Restores the `@wordpress/private-apis` workspace dependencies and TS project references.
- Leaves package changelogs, `ThemeProvider` JSDoc, and the JSDoc lint configuration untouched.

## Testing Instructions
1. `npm run lint:pkg-json -- packages/theme/package.json packages/ui/package.json`
2. `npm run lint:tsconfig -- packages/theme/tsconfig.src.json packages/ui/tsconfig.json`
3. `npx tsgo --build packages/theme/tsconfig.src.json`
4. `npx tsgo --build packages/ui/tsconfig.json`
5. `npm run lint:js -- packages/boot/src/components/root/index.tsx packages/boot/src/components/root/single-page.tsx packages/edit-site/src/components/layout/index.js packages/theme/src/index.ts packages/theme/src/lock-unlock.ts packages/theme/src/private-apis.ts packages/theme/src/stories/index.story.tsx packages/ui/src/alert-dialog/popup.tsx packages/ui/src/dialog/popup.tsx packages/ui/src/drawer/popup.tsx packages/ui/src/form/primitives/autocomplete/popup.tsx packages/ui/src/form/primitives/combobox/popup.tsx packages/ui/src/form/primitives/select/popup.tsx packages/ui/src/lock-unlock.ts packages/ui/src/popover/popup.tsx packages/ui/src/tooltip/popup.tsx storybook/decorators/with-design-system-theme.tsx storybook/stories/design-system/theme-example-application.story.tsx`
6. `npm run lint:deps`
7. `npm run lint:lockfile`

### Testing Instructions for Keyboard
Not applicable; this restores API wiring and package metadata without changing UI behavior.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Created with assistance from OpenAI Codex. The diff and verification output were reviewed before opening this PR.