### PR TITLE
TextIndentControl: Remove unnecessary __next40pxDefaultSize prop

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
 -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
--   `TextIndentControl` ([#79597](https://github.com/WordPress/gutenberg/pull/79597)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
 -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
+-   `TextIndentControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
 
 ### Deprecations
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
 -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
--   `TextIndentControl` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+-   `TextIndentControl` ([#79597](https://github.com/WordPress/gutenberg/pull/79597)).
 
 ### Deprecations
 

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -693,7 +693,6 @@ export default function TypographyPanel( {
 					<TextIndentControl
 						value={ textIndent }
 						onChange={ setTextIndentValue }
-						size="__unstable-large"
 						__unstableInputWidth="auto"
 						withSlider
 						hasBottomMargin={ isGlobalStyles }

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -34,7 +34,8 @@ import { useSettings } from '../../components/use-settings';
  * @return {Element} Text indent control.
  */
 export default function TextIndentControl( {
-	__next40pxDefaultSize = false,
+	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
+	__next40pxDefaultSize: _next40pxDefaultSize,
 	value,
 	onChange,
 	__unstableInputWidth = '60px',
@@ -68,7 +69,7 @@ export default function TextIndentControl( {
 	if ( ! withSlider ) {
 		return (
 			<UnitControl
-				__next40pxDefaultSize={ __next40pxDefaultSize }
+				__next40pxDefaultSize
 				__shouldNotWarnDeprecated36pxSize
 				{ ...otherProps }
 				label={ __( 'Line indent' ) }
@@ -89,7 +90,7 @@ export default function TextIndentControl( {
 			<Flex>
 				<FlexItem isBlock>
 					<UnitControl
-						__next40pxDefaultSize={ __next40pxDefaultSize }
+						__next40pxDefaultSize
 						__shouldNotWarnDeprecated36pxSize
 						label={ __( 'Line indent' ) }
 						labelPosition="top"
@@ -106,7 +107,7 @@ export default function TextIndentControl( {
 					<FlexItem isBlock>
 						<Spacer marginX={ 2 } marginBottom={ 0 }>
 							<RangeControl
-								__next40pxDefaultSize={ __next40pxDefaultSize }
+								__next40pxDefaultSize
 								__shouldNotWarnDeprecated36pxSize
 								label={ __( 'Line indent' ) }
 								hideLabelFromVision

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -66,8 +66,8 @@ export default function TextIndentControl( {
 	if ( ! withSlider ) {
 		return (
 			<UnitControl
-				__next40pxDefaultSize
 				{ ...otherProps }
+				__next40pxDefaultSize
 				label={ __( 'Line indent' ) }
 				value={ value }
 				__unstableInputWidth={ __unstableInputWidth }

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -22,20 +22,17 @@ import { useSettings } from '../../components/use-settings';
 /**
  * Control for line text indent.
  *
- * @param {Object}                  props                       Component props.
- * @param {boolean}                 props.__next40pxDefaultSize Start opting into the larger default height that will become the default size in a future version.
- * @param {string}                  props.value                 Currently selected text indent.
- * @param {Function}                props.onChange              Handles change in text indent selection.
- * @param {string|number|undefined} props.__unstableInputWidth  Input width to pass through to inner UnitControl. Should be a valid CSS value.
- * @param {boolean}                 props.withSlider            Whether to show the slider control.
- * @param {boolean}                 props.hasBottomMargin       Whether to add bottom margin below the control.
- * @param {string}                  props.help                  Help text to display below the control.
+ * @param {Object}                  props                      Component props.
+ * @param {string}                  props.value                Currently selected text indent.
+ * @param {Function}                props.onChange             Handles change in text indent selection.
+ * @param {string|number|undefined} props.__unstableInputWidth Input width to pass through to inner UnitControl. Should be a valid CSS value.
+ * @param {boolean}                 props.withSlider           Whether to show the slider control.
+ * @param {boolean}                 props.hasBottomMargin      Whether to add bottom margin below the control.
+ * @param {string}                  props.help                 Help text to display below the control.
  *
  * @return {Element} Text indent control.
  */
 export default function TextIndentControl( {
-	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
-	__next40pxDefaultSize: _next40pxDefaultSize,
 	value,
 	onChange,
 	__unstableInputWidth = '60px',

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -67,7 +67,6 @@ export default function TextIndentControl( {
 		return (
 			<UnitControl
 				__next40pxDefaultSize
-				__shouldNotWarnDeprecated36pxSize
 				{ ...otherProps }
 				label={ __( 'Line indent' ) }
 				value={ value }
@@ -88,13 +87,11 @@ export default function TextIndentControl( {
 				<FlexItem isBlock>
 					<UnitControl
 						__next40pxDefaultSize
-						__shouldNotWarnDeprecated36pxSize
 						label={ __( 'Line indent' ) }
 						labelPosition="top"
 						hideLabelFromVision
 						value={ value }
 						onChange={ onChange }
-						size={ otherProps.size }
 						units={ units }
 						__unstableInputWidth={ __unstableInputWidth }
 						min={ 0 }
@@ -105,7 +102,6 @@ export default function TextIndentControl( {
 						<Spacer marginX={ 2 } marginBottom={ 0 }>
 							<RangeControl
 								__next40pxDefaultSize
-								__shouldNotWarnDeprecated36pxSize
 								label={ __( 'Line indent' ) }
 								hideLabelFromVision
 								value={ valueQuantity }

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -179,6 +179,7 @@ const restrictedSyntax = [
 		'QueryControls',
 		'SearchControl',
 		'TextControl',
+		'TextIndentControl',
 		'TreeSelect',
 	].map( ( componentName ) => ( {
 		selector: `JSXElement[openingElement.name.name="${ componentName }"] JSXAttribute[name.name="__next40pxDefaultSize"]`,


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the `__next40pxDefaultSize` prop from the internal `TextIndentControl` component.

## Why?

`TextIndentControl` is not exported from `@wordpress/block-editor`. It only has one caller, in the typography panel. Exposing `__next40pxDefaultSize` on this wrapper was unnecessary: sizing belongs on the embedded form controls, not on an internal helper.

This is a small code quality cleanup. No changelog entry, since there is no external API surface.

## How?

- Remove `__next40pxDefaultSize` from `TextIndentControl` props and JSDoc.
- Hardcode `__next40pxDefaultSize` on the embedded `UnitControl` and `RangeControl` instances.
- Remove the redundant `size="__unstable-large"` pass-through in `typography-panel.js` (40px is now unconditional on the inner controls).
- Add `TextIndentControl` to the restricted-syntax ESLint rule that forbids passing `__next40pxDefaultSize`, as a monorepo guard.

## Testing Instructions

### Basic Usage

1. Open a post or page in the block editor
2. Add multiple paragraph blocks with text content
3. Select any paragraph block
4. In the block settings sidebar, go to Typography section
5. Find the "Line indent" control.
