### PR TITLE
Icons Registry test: Fix trigger_error suppression on WP < 7.0

### DIFF
--- a/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
@@ -318,9 +318,13 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 			)
 		);
 
-		add_filter( 'wp_trigger_error_trigger_error', '__return_false' );
+		// Suppress the `wp_trigger_error()` notice. A local error handler is used
+		// instead of the `wp_trigger_error_trigger_error` filter, which is WP 7.0+.
+		// TODO: Replace with `add_filter( 'wp_trigger_error_trigger_error', '__return_false' )`
+		// once the minimum supported WordPress version is 7.0 or later.
+		set_error_handler( '__return_true' );
 		$icon = $this->registry->get_registered_icon( 'test-collection/invalid-file' );
-		remove_filter( 'wp_trigger_error_trigger_error', '__return_false' );
+		restore_error_handler();
 
 		$this->assertNull( $icon['content'] );
 	}


### PR DESCRIPTION
## What?
Fixes the `WP_Test_Icons_Registry_Gutenberg::test_get_content_returns_null_for_invalid_file` failures on the "previous major version" (WP 6.9) CI job.

## Why?
The test suppressed the notice from `get_content()` via the `wp_trigger_error_trigger_error` filter, which only exists in WordPress 7.0+. On WP 6.9 the filter is absent, so `trigger_error()` fired and the test suite reported it as an error.

## How?
Replaced the filter with a local error handler (`set_error_handler( '__return_true' )` / `restore_error_handler()`) that works across supported WordPress versions.

## Testing Instructions
1. Run the test against WP 6.9: `npm run test:unit:php:base -- --filter test_get_content_returns_null_for_invalid_file`.
2. Confirm it passes.

## Use of AI Tools
Authored with assistance from Claude Code; reviewed by the author.
