### PR TITLE
Collaboration: purge stale CRDT state when site URL changes after DB migration

### DIFF
--- a/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
+++ b/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php
@@ -509,6 +509,31 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 		 * } Response data for this room.
 		 */
 		private function get_updates( string $room, int $client_id, int $cursor, bool $is_compactor ): array {
+			// Detect stale state from a database migration: if the stored origin URL
+			// exists but does not match the current site, or if no origin is recorded
+			// (legacy data predating this fix), purge the room so the editor loads
+			// cleanly from canonical post_content.
+			$stored_origin = $this->storage->get_origin_url( $room );
+			if ( null === $stored_origin || site_url() !== $stored_origin ) {
+				error_log(
+					sprintf(
+						'Gutenberg: Purging stale collaborative editing state for room "%s". Stored origin: %s, current site URL: %s. This typically indicates a database migration or domain change.',
+						$room,
+						null === $stored_origin ? 'none (legacy data)' : $stored_origin,
+						site_url()
+					)
+				);
+				$this->storage->purge_room( $room );
+
+				return array(
+					'end_cursor'     => 0,
+					'room'           => $room,
+					'should_compact' => false,
+					'total_updates'  => 0,
+					'updates'        => array(),
+				);
+			}
+
 			$updates_after_cursor = $this->storage->get_updates_after_cursor( $room, $cursor );
 			$total_updates        = $this->storage->get_update_count( $room );
 

--- a/lib/compat/wordpress-7.1/class-wp-sync-post-meta-storage.php
+++ b/lib/compat/wordpress-7.1/class-wp-sync-post-meta-storage.php
@@ -43,6 +43,17 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 		const SYNC_UPDATE_META_KEY = 'wp_sync_update_data';
 
 		/**
+		 * Meta key for storing the originating site URL.
+		 *
+		 * Stored alongside sync updates so that a site URL mismatch
+		 * (indicating a database migration) can be detected on read.
+		 *
+		 * @since 7.1.0
+		 * @var string
+		 */
+		const ORIGIN_URL_META_KEY = '_wp_sync_origin_url';
+
+		/**
 		 * Cache of cursors by room.
 		 *
 		 * @since 7.0.0
@@ -267,6 +278,11 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 				if ( null === $canonical_post_id ) {
 					return null;
 				}
+
+				// Record the site URL at creation time. Using add_post_meta with
+				// $unique = true means a concurrent winner that already wrote this
+				// meta will not be overwritten.
+				add_post_meta( $canonical_post_id, self::ORIGIN_URL_META_KEY, site_url(), true );
 
 				self::$storage_post_ids[ $room_hash ] = $canonical_post_id;
 				return $canonical_post_id;
@@ -496,6 +512,88 @@ if ( ! class_exists( 'WP_Sync_Post_Meta_Storage' ) ) {
 			if ( false === $deleted_rows ) {
 				return false;
 			}
+
+			return true;
+		}
+
+		/**
+		 * Gets the site URL recorded when this room's storage was first created.
+		 *
+		 * Returns null when the room does not exist or was created before origin
+		 * tracking was introduced (legacy data).
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $room Room identifier.
+		 * @return string|null Stored origin URL, or null if not recorded.
+		 */
+		public function get_origin_url( string $room ): ?string {
+			$room_hash = md5( $room );
+
+			// Use the static cache to avoid a DB query when the post was already
+			// looked up during this request.
+			$post_id = self::$storage_post_ids[ $room_hash ] ?? $this->find_canonical_storage_post_id( $room_hash );
+			if ( null === $post_id ) {
+				return null;
+			}
+
+			$origin = get_post_meta( $post_id, self::ORIGIN_URL_META_KEY, true );
+			return ( is_string( $origin ) && '' !== $origin ) ? $origin : null;
+		}
+
+		/**
+		 * Destroys all sync state for a room so the editor can start fresh from
+		 * canonical post content.
+		 *
+		 * Deletes all sync updates, awareness state, and the storage post itself.
+		 * The post is recreated on the next polling request with the current site
+		 * URL recorded as the new origin.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @global wpdb $wpdb WordPress database abstraction object.
+		 *
+		 * @param string $room Room identifier.
+		 * @return bool True on success, false on failure.
+		 */
+		public function purge_room( string $room ): bool {
+			global $wpdb;
+
+			// Use cache + find (not get_storage_post_id) to avoid creating a new
+			// storage post just to immediately delete it.
+			$room_hash = md5( $room );
+			$post_id   = self::$storage_post_ids[ $room_hash ] ?? $this->find_canonical_storage_post_id( $room_hash );
+			if ( null === $post_id ) {
+				return true; // Nothing to purge.
+			}
+
+			// Delete all sync update meta rows.
+			$wpdb->delete(
+				$wpdb->postmeta,
+				array(
+					'post_id'  => $post_id,
+					'meta_key' => self::SYNC_UPDATE_META_KEY,
+				),
+				array( '%d', '%s' )
+			);
+
+			// Delete awareness meta rows.
+			$wpdb->delete(
+				$wpdb->postmeta,
+				array(
+					'post_id'  => $post_id,
+					'meta_key' => self::AWARENESS_META_KEY,
+				),
+				array( '%d', '%s' )
+			);
+
+			// Delete the storage post itself.
+			wp_delete_post( $post_id, true );
+
+			// Clear caches.
+			unset( self::$storage_post_ids[ $room_hash ] );
+			unset( $this->room_cursors[ $room ] );
+			unset( $this->room_update_counts[ $room ] );
 
 			return true;
 		}

--- a/lib/compat/wordpress-7.1/collaboration.php
+++ b/lib/compat/wordpress-7.1/collaboration.php
@@ -104,8 +104,80 @@ if ( ! function_exists( 'wp_collaboration_register_meta' ) ) {
 				'type'              => 'string',
 			)
 		);
+
+		register_meta(
+			'post',
+			'_crdt_document_origin_url',
+			array(
+				'auth_callback'     => static function ( bool $_allowed, string $_meta_key, int $object_id, int $user_id ): bool {
+					return user_can( $user_id, 'edit_post', $object_id );
+				},
+				'revisions_enabled' => false,
+				'show_in_rest'      => false,
+				'single'            => true,
+				'type'              => 'string',
+			)
+		);
 	}
 	add_action( 'init', 'gutenberg_rest_api_crdt_post_meta' );
+
+	/**
+	 * Records the origin URL when a CRDT document is persisted.
+	 */
+	function gutenberg_crdt_document_record_origin( $_meta_id, $object_id, $meta_key ) {
+		if ( '_crdt_document' === $meta_key ) {
+			// update_post_meta will trigger this action recursively if we're not careful,
+			// but we're updating a different key, so it's safe.
+			update_post_meta( $object_id, '_crdt_document_origin_url', site_url() );
+		}
+	}
+	add_action( 'added_post_meta', 'gutenberg_crdt_document_record_origin', 10, 3 );
+	add_action( 'updated_post_meta', 'gutenberg_crdt_document_record_origin', 10, 3 );
+
+	/**
+	 * Purges stale _crdt_document meta when the originating site URL
+	 * does not match the current site, indicating a database migration.
+	 */
+	function gutenberg_purge_stale_crdt_document_meta( $response, $post ) {
+		$origin      = get_post_meta( $post->ID, '_crdt_document_origin_url', true );
+		$current_url = site_url();
+
+		$should_purge = false;
+
+		if ( ! empty( $origin ) && $current_url !== $origin ) {
+			$should_purge = true;
+		} elseif ( empty( $origin ) ) {
+			$crdt_doc = get_post_meta( $post->ID, '_crdt_document', true );
+			if ( ! empty( $crdt_doc ) ) {
+				$should_purge = true;
+			}
+		}
+
+		if ( $should_purge ) {
+			error_log( sprintf( 'Gutenberg: Purging stale collaborative editing state (_crdt_document) for post ID %d due to site URL mismatch. This typically happens after a database migration or domain change.', $post->ID ) );
+			delete_post_meta( $post->ID, '_crdt_document' );
+			delete_post_meta( $post->ID, '_crdt_document_origin_url' );
+
+			$data = $response->get_data();
+			if ( isset( $data['meta']['_crdt_document'] ) ) {
+				$data['meta']['_crdt_document'] = '';
+				$response->set_data( $data );
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Registers the purge filter for all post types.
+	 */
+	function gutenberg_register_crdt_purge_filters() {
+		$post_types = get_post_types( array( 'show_in_rest' => true ), 'names' );
+		foreach ( $post_types as $post_type ) {
+			add_filter( "rest_prepare_{$post_type}", 'gutenberg_purge_stale_crdt_document_meta', 10, 2 );
+		}
+	}
+	add_action( 'rest_api_init', 'gutenberg_register_crdt_purge_filters' );
 }
 
 if ( ! function_exists( 'wp_collaboration_inject_setting' ) ) {

--- a/lib/compat/wordpress-7.1/interface-wp-sync-storage.php
+++ b/lib/compat/wordpress-7.1/interface-wp-sync-storage.php
@@ -85,5 +85,34 @@ if ( ! interface_exists( 'WP_Sync_Storage' ) ) {
 		 * @return bool True on success, false on failure.
 		 */
 		public function set_awareness_state( string $room, array $awareness ): bool;
+
+		/**
+		 * Gets the site URL recorded when this room's storage was first created.
+		 *
+		 * Returns null when the room does not exist or was created before origin
+		 * tracking was introduced (legacy data created before this fix shipped).
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $room Room identifier.
+		 * @return string|null Stored origin URL, or null if not recorded.
+		 */
+		public function get_origin_url( string $room ): ?string;
+
+		/**
+		 * Destroys all sync state for a room so the editor can start fresh from
+		 * canonical post content.
+		 *
+		 * Implementations must delete all stored updates, awareness state, and any
+		 * associated storage. The room is recreated automatically on the next
+		 * polling request, at which point the current site URL is recorded as the
+		 * new origin.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $room Room identifier.
+		 * @return bool True on success or when the room does not exist, false on failure.
+		 */
+		public function purge_room( string $room ): bool;
 	}
 }


### PR DESCRIPTION
## What?

Closes #79119

Adds server-side origin tracking to collaborative editing rooms and purges stale Yjs CRDT state when a site URL mismatch is detected — preventing phantom autosaves with broken URLs after a database migration.

## Why?

Gutenberg's collaborative editing stores Yjs CRDT state as base64-encoded binary in two places:

- `wp_sync_update_data` post meta on `wp_sync_storage` posts
- `_crdt_document` post meta on the edited post

Because the data is binary, **`wp search-replace` cannot see the URLs inside it.** After migrating a database between environments (e.g. staging → production), the stale CRDT state from the source environment survives the migration untouched. The first time an affected post is opened on the destination site, the editor fetches this stale state and surfaces it as a phantom autosave — newer than any real revision — containing hardcoded URLs from the source domain. If the user saves, those source-domain URLs are written into production `post_content`, causing 404s and broken pages with no search-replace trace.

## How?

**1. Origin stamping**

When a `wp_sync_storage` post is first created, `site_url()` is written to `_wp_sync_origin_url` post meta. This happens inside `get_storage_post_id()` so every new room is tagged at creation with no extra DB query on subsequent requests.

The same is done for `_crdt_document` via `added_post_meta` / `updated_post_meta` hooks, writing `site_url()` to `_crdt_document_origin_url` on the edited post whenever a CRDT snapshot is saved.

**2. Read-path invalidation (polling server)**

`get_updates()` in `WP_HTTP_Polling_Sync_Server` calls `$this->storage->get_origin_url( $room )` before returning any data. If the stored origin is missing (legacy data) or does not match `site_url()`, the room is purged via `$this->storage->purge_room( $room )` and the client receives an empty response:

```json
{ "end_cursor": 0, "total_updates": 0, "updates": [] }
```

The editor falls back to canonical `post_content`. On the next poll the room is recreated with the correct origin and collaboration resumes normally.

**3. Read-path invalidation (`_crdt_document`)**

A `rest_prepare_{post_type}` filter checks `_crdt_document_origin_url` against `site_url()` before the REST API response reaches the block editor. On mismatch, both `_crdt_document` and `_crdt_document_origin_url` are deleted and the response field is blanked — so the editor never applies stale document state.

**4. Legacy data**

Any storage post or `_crdt_document` entry created before this fix ships (no origin recorded) is treated as stale and purged on first access. `post_content` is always preserved — the editor re-syncs safely from canonical content.

**Interface changes**

Two methods are added to `WP_Sync_Storage`:

```php
public function get_origin_url( string $room ): ?string;
public function purge_room( string $room ): bool;
```

This keeps storage internals encapsulated — the polling server has no direct knowledge of how or where origin data is stored.

## Testing Instructions

**Setup:** Install the Gutenberg plugin with real-time collaboration enabled. Open a post in the block editor in two browser sessions as different users — confirm the collaboration bubble appears in the toolbar.

**Simulate a database migration:**

```sql
UPDATE wp_postmeta
SET meta_value = 'https://old-source-domain.example.com'
WHERE meta_key = '_wp_sync_origin_url';
```

**Verify the fix fires:**

1. Hard refresh the editor (`Cmd+Shift+R`)
2. Open DevTools → Network → filter by `wp-sync`
3. Click the first `updates?_locale=user` request → Response tab

**Expected (after fix):**
```json
{ "room": "postType/post:NNN", "end_cursor": 0, "total_updates": 0, "updates": [] }
```

**Expected in `wp-content/debug.log`:**
```
Gutenberg: Purging stale collaborative editing state for room "postType/post:NNN".
Stored origin: https://old-source-domain.example.com, current site URL: https://your-site.local.
This typically indicates a database migration or domain change.
```

4. No phantom autosave banner appears in the editor

**Verify clean recovery:**

```sql
UPDATE wp_postmeta
SET meta_value = 'https://your-site.local'
WHERE meta_key = '_wp_sync_origin_url';
```

Hard refresh — collaboration resumes normally, no banner, no stale content.

### Testing Instructions for Keyboard

No UI changes. All changes are server-side PHP only.

## Screenshots or screencast

**Before** — 8 Yjs binary blobs served to the client after simulated migration:

```json
{
  "room": "postType/post:606",
  "total_updates": 8,
  "updates": [
    { "data": "AAAG1vGfmh8MDAYemgIIAgECCgJCSgAfKAInAAQAJwAEACcAK...", "type": "update" },
    { "data": "AcIGAh7W+I/NDwAoAQVzdGF0ZQd2ZXJzaW9uAX0BKAEIZG9j...", "type": "sync_step2" }
  ]
}
```

**After** — origin mismatch detected, purge fires, empty response returned:

`wp-content/debug.log`:
```
[26-Jun-2026 13:39:29 UTC] Gutenberg: Purging stale collaborative editing state for room "postType/post:606". Stored origin: https://old-source-domain.example.com, current site URL: https://gutenberg.local. This typically indicates a database migration or domain change.
[26-Jun-2026 13:39:33 UTC] Gutenberg: Purging stale collaborative editing state for room "root/comment". Stored origin: https://old-source-domain.example.com, current site URL: https://gutenberg.local. This typically indicates a database migration or domain change.
[26-Jun-2026 13:39:33 UTC] Gutenberg: Purging stale collaborative editing state for room "taxonomy/wp_pattern_category". Stored origin: https://old-source-domain.example.com, current site URL: https://gutenberg.local. This typically indicates a database migration or domain change.
```

Network response — zero stale data delivered:
```json
{
  "room": "postType/post:606",
  "end_cursor": 0,
  "total_updates": 0,
  "updates": []
}
```

## Use of AI Tools

Claude Code (`claude-sonnet-4-6`) was used to assist with edge case analysis, and test authorship. All generated code was reviewed and manually tested in a Local by Flywheel environment.