### PR TITLE
Page List: Prevent crash when a page has no title

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -156,7 +156,9 @@ export default function PageListEdit( {
 		// https://core.trac.wordpress.org/ticket/39037
 		const sortedPages = pages.sort( ( a, b ) => {
 			if ( a.menu_order === b.menu_order ) {
-				return a.title.rendered.localeCompare( b.title.rendered );
+				return ( a.title?.rendered ?? '' ).localeCompare(
+					b.title?.rendered ?? ''
+				);
 			}
 			return a.menu_order - b.menu_order;
 		} );
@@ -198,10 +200,11 @@ export default function PageListEdit( {
 
 			return childPages.reduce( ( tree, page ) => {
 				const hasChildren = pagesByParentId.has( page.id );
+				const name = page.title?.rendered ?? '';
 				const item = {
 					value: page.id,
-					label: '— '.repeat( level ) + page.title.rendered,
-					rawName: page.title.rendered,
+					label: '— '.repeat( level ) + name,
+					rawName: name,
 				};
 				tree.push( item );
 				if ( hasChildren ) {
@@ -223,18 +226,17 @@ export default function PageListEdit( {
 
 			return childPages.reduce( ( template, page ) => {
 				const hasChildren = pagesByParentId.has( page.id );
+				const renderedTitle = page.title?.rendered ?? '';
+				// Match the front end's "(no title)" fallback (index.php).
+				// translators: displayed when a page has an empty title.
+				const displayTitle =
+					renderedTitle.trim() !== ''
+						? renderedTitle
+						: __( '(no title)' );
 				const pageProps = {
 					id: page.id,
-					label:
-						// translators: displayed when a page has an empty title.
-						page.title?.rendered?.trim() !== ''
-							? page.title?.rendered
-							: __( '(no title)' ),
-					title:
-						// translators: displayed when a page has an empty title.
-						page.title?.rendered?.trim() !== ''
-							? page.title?.rendered
-							: __( '(no title)' ),
+					label: displayTitle,
+					title: displayTitle,
 					link: page.url,
 					hasChildren,
 				};

--- a/packages/block-library/src/page-list/test/convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/test/convert-to-navigation-links.js
@@ -584,5 +584,89 @@ describe( 'page list convert to links', () => {
 				},
 			] );
 		} );
+
+		it( 'Falls back to "(no title)" for empty or missing titles', () => {
+			const pages = [
+				// Empty rendered title (an untitled page).
+				{
+					title: { raw: '', rendered: '' },
+					id: 2,
+					parent: 0,
+					link: 'http://wordpress.local/?page_id=2',
+					type: 'page',
+				},
+				// Title field absent (a partial record); previously threw.
+				{
+					id: 34,
+					parent: 0,
+					link: 'http://wordpress.local/?page_id=34',
+					type: 'page',
+				},
+			];
+
+			const convertLinks = convertToNavigationLinks( pages );
+			const labels = convertLinks.map(
+				( link ) => link.attributes.label
+			);
+
+			// A non-empty label is required or navigation-link drops the item.
+			expect( labels ).toEqual( [ '(no title)', '(no title)' ] );
+		} );
+
+		it( 'Keeps a missing-title parent (and its children) as a submenu', () => {
+			const pages = [
+				// Parent page with no title field (a partial record).
+				{
+					id: 34,
+					parent: 0,
+					link: 'http://wordpress.local/?page_id=34',
+					type: 'page',
+				},
+				// Child of the untitled parent.
+				{
+					title: { raw: 'Child', rendered: 'Child' },
+					id: 738,
+					parent: 34,
+					link: 'http://wordpress.local/?page_id=738',
+					type: 'page',
+				},
+			];
+
+			const convertLinks = convertToNavigationLinks( pages );
+
+			// The untitled parent must render as a "(no title)" submenu so the
+			// front end does not drop it (and its children) for an empty label.
+			expect( convertLinks ).toEqual( [
+				{
+					attributes: {
+						id: 34,
+						kind: 'post-type',
+						label: '(no title)',
+						type: 'page',
+						url: 'http://wordpress.local/?page_id=34',
+						metadata: {
+							bindings: EXPECTED_ENTITY_BINDING,
+						},
+					},
+					innerBlocks: [
+						{
+							attributes: {
+								id: 738,
+								kind: 'post-type',
+								label: 'Child',
+								type: 'page',
+								url: 'http://wordpress.local/?page_id=738',
+								metadata: {
+									bindings: EXPECTED_ENTITY_BINDING,
+								},
+							},
+							innerBlocks: [],
+							name: 'core/navigation-link',
+						},
+					],
+					name: 'core/navigation-submenu',
+				},
+			] );
+		} );
 	} );
 } );

--- a/packages/block-library/src/page-list/use-convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/use-convert-to-navigation-links.js
@@ -4,6 +4,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,11 +25,16 @@ function createNavigationLinks( pages = [] ) {
 	pages.forEach( ( { id, title, link: url, type, parent } ) => {
 		// See if a placeholder exists. This is created if children appear before parents in list.
 		const innerBlocks = linkMap[ id ]?.innerBlocks ?? [];
+		const renderedTitle = title?.rendered ?? '';
+		// Empty labels are dropped by the navigation-link/submenu renderers, so
+		// fall back to "(no title)", matching the Page List preview.
+		const label =
+			renderedTitle.trim() !== '' ? renderedTitle : __( '(no title)' );
 		linkMap[ id ] = createBlock(
 			'core/navigation-link',
 			{
 				id,
-				label: title.rendered,
+				label,
 				url,
 				type,
 				kind: POST_TYPE_KIND,

--- a/test/e2e/specs/editor/blocks/page-list.spec.js
+++ b/test/e2e/specs/editor/blocks/page-list.spec.js
@@ -87,4 +87,54 @@ test.describe( 'Page List block', () => {
 		expect( innerHTML ).not.toContain( '&lt;strong&gt;' );
 		expect( innerHTML ).not.toContain( '&lt;/strong&gt;' );
 	} );
+
+	test( 'does not crash when a page record has no title', async ( {
+		editor,
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// Two published pages so the alphabetical title tie-break runs (pages
+		// default to menu_order 0).
+		const { id: pageId } = await requestUtils.createPage( {
+			title: 'Alpha',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( { title: 'Beta', status: 'publish' } );
+
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'core/page-list' } );
+
+		const pageListBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Page List',
+		} );
+		const alphaItem = pageListBlock.getByText( 'Alpha', { exact: true } );
+		await expect( alphaItem ).toBeVisible( { timeout: 10000 } );
+
+		// Drop the title from a page record, reproducing a partial record that
+		// reached the store without its title field. An empty title renders fine;
+		// an undefined title is what trips the sort comparator.
+		await page.evaluate( ( id ) => {
+			window.wp.data
+				.dispatch( 'core' )
+				.receiveEntityRecords( 'postType', 'page', [
+					{ id, title: undefined },
+				] );
+		}, pageId );
+
+		// The mutation re-renders the block: the affected item falls back to the
+		// localized "(no title)" label (matching the front end) — proving the
+		// partial record reached it without leaking the literal string
+		// "undefined" or falling into the error boundary.
+		await expect( alphaItem ).toBeHidden();
+		await expect(
+			pageListBlock.getByText( '(no title)', { exact: true } )
+		).toBeVisible();
+		await expect( pageListBlock.getByText( 'undefined' ) ).toHaveCount( 0 );
+		await expect(
+			editor.canvas.getByText(
+				'This block has encountered an error and cannot be previewed.'
+			)
+		).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
## What?

Editing the Navigation block (or inserting a Page List) on a site that has untitled pages could trip the block's error boundary — _"This block has encountered an error and cannot be previewed."_ This guards the Page List against pages that have no title.

## Why?

Page List sorts pages alphabetically as a tie-break (every page shares the default menu order), and several spots read the page title without guarding it. A page record whose title isn't a usable string throws while sorting or building the menu, taking down the whole block. An empty title renders fine; an absent title is what crashes.

## How?

Guard the page-title reads in the sort comparator and the parent-page dropdown so a missing title no longer throws. Where a title is actually rendered — the Page List preview and the navigation-link conversion — fall back to the localized `(no title)`, matching the front end; an empty label would otherwise drop the item (and any submenu children) from the rendered menu.

## Testing Instructions

1. Use a block theme and publish two or more pages with empty titles.
2. Open the Site Editor and add a Navigation block (or insert a Page List block).
3. Add the untitled pages. The block renders the list — untitled pages show "(no title)" — instead of "This block has encountered an error and cannot be previewed."
4. Use the Page List "Edit" action to convert to navigation links. Untitled pages remain as "(no title)" links/submenus instead of disappearing on the front end.

Automated coverage:

```
npm run test:unit -- --testPathPattern "page-list/test/convert-to-navigation-links"
npm run test:e2e -- test/e2e/specs/editor/blocks/page-list.spec.js
```

### Testing Instructions for Keyboard

No keyboard-specific changes; the Page List is navigated as before.

## Use of AI Tools

This pull request was authored with the assistance of Claude Code (Anthropic). All changes, including the added unit and end-to-end tests, were reviewed and verified by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
