### PR TITLE
Allow tooltip color customization

### DIFF
--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -164,6 +164,37 @@ export const WithCustomZIndex: StoryObj< typeof Tooltip.Root > = {
 };
 
 /**
+ * The `--wp-ui-tooltip-background-color` and `--wp-ui-tooltip-color` CSS
+ * variables control the tooltip popup's surface and text colors. Override them
+ * either globally on `:root` or `body`, or per instance by passing a
+ * `Tooltip.Portal` with a `style` or `className` to `Tooltip.Popup`'s `portal`
+ * prop. The variables cascade from the portal wrapper to the popup rendered
+ * inside it.
+ */
+export const WithCustomColors: StoryObj< typeof Tooltip.Root > = {
+	name: 'With Custom Colors',
+	args: {
+		children: (
+			<>
+				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+				<Tooltip.Popup
+					portal={
+						<Tooltip.Portal
+							style={ {
+								'--wp-ui-tooltip-background-color': '#fff',
+								'--wp-ui-tooltip-color': '#1e1e1e',
+							} }
+						/>
+					}
+				>
+					Save
+				</Tooltip.Popup>
+			</>
+		),
+	},
+};
+
+/**
  * Use `Tooltip.Provider` to control the delay before tooltips appear.
  * This is useful when you have multiple tooltips and want them to share
  * the same delay configuration.

--- a/packages/ui/src/tooltip/style.module.css
+++ b/packages/ui/src/tooltip/style.module.css
@@ -7,7 +7,10 @@
 		}
 
 		.popup {
-			background-color: var(--wpds-color-background-surface-neutral-strong);
+			background-color: var(
+				--wp-ui-tooltip-background-color,
+				var(--wpds-color-background-surface-neutral-strong)
+			);
 			padding:
 				var(--wpds-dimension-padding-xs)
 				var(--wpds-dimension-padding-sm);
@@ -15,7 +18,10 @@
 			font-family: var(--wpds-typography-font-family-body);
 			font-size: var(--wpds-typography-font-size-sm);
 			line-height: 1.4; /* TODO: use DS token for line height */
-			color: var(--wpds-color-foreground-content-neutral);
+			color: var(
+				--wp-ui-tooltip-color,
+				var(--wpds-color-foreground-content-neutral)
+			);
 			box-shadow: var(--wpds-elevation-sm);
 
 			/*


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See Automattic/studio#3981.

Adds tooltip popup color customization variables:

- `--wp-ui-tooltip-background-color`
- `--wp-ui-tooltip-color`

The default tooltip appearance is unchanged because both variables fall back to the existing WPDS tooltip surface and foreground tokens. The PR also adds a Storybook story showing per-instance color customization through `Tooltip.Portal`.

## Why?

Consumers can already customize tooltip stacking with `--wp-ui-tooltip-z-index`, but tooltip colors are currently fixed inside the component stylesheet. That makes app-level theme adjustments hard when a product needs a different tooltip treatment in a specific theme, such as Studio's dark mode.

Exposing semantic tooltip CSS variables gives consumers a stable API instead of pushing them toward generated CSS module selectors or wrapper-specific workarounds.

## How?

The tooltip stylesheet now reads the popup background and text colors from CSS custom properties before falling back to the current design-system tokens.

The new Storybook example mirrors the existing custom z-index story: consumers can set the variables globally on `:root`/`body`, or per tooltip by passing a styled `Tooltip.Portal` to `Tooltip.Popup`.

## Testing Instructions

1. Open the Tooltip Storybook examples.
2. Open "With Custom Colors".
3. Hover or focus the trigger.
4. Confirm the tooltip popup uses the custom background and text colors.
5. Open the default Tooltip story and confirm the default tooltip colors are unchanged.

Validation run:

- `git diff --check`

Full Gutenberg lint/test commands were not run in this temporary sparse checkout because dependencies were not installed.

### Testing Instructions for Keyboard

1. Open the Tooltip "With Custom Colors" story.
2. Use keyboard navigation to focus the trigger.
3. Confirm the tooltip popup appears with the custom background and text colors.

## Screenshots or screencast <!-- if applicable -->

Not captured.

## Use of AI Tools

Codex helped trace the downstream Studio use case and draft this small source change. I reviewed the resulting diff before opening the PR.
