### PR TITLE
Responsive style states: Update responsive editing help text and avoid showing desktop badge

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -394,13 +394,14 @@ const BlockInspectorSingleBlock = ( {
 	selectedBlockStyleState,
 	showStateOnCanvas,
 	isResponsiveEditing,
-	isBlockStyleStateSelected,
 } ) => {
 	const listViewRef = useRef( null );
 	const hasMultipleTabs = availableTabs?.length > 1;
 	const hasPseudoState = hasPseudoBlockStyleState( selectedBlockStyleState );
 	const isEditingStyleState =
-		isBlockStyleStateSelected || isResponsiveEditing;
+		( hasViewportBlockStyleState( selectedBlockStyleState ) &&
+			isResponsiveEditing ) ||
+		hasPseudoBlockStyleState( selectedBlockStyleState );
 	const hasParentChildBlockCards =
 		editedContentOnlySection &&
 		editedContentOnlySection !== renderedBlockClientId;

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -22,18 +22,12 @@ export const RESPONSIVE_STATE_LABELS = {
 	'@mobile': __( 'Mobile' ),
 };
 
-// Viewport states are selected globally via the editor's device preview
-// (Responsive editing). 'default' maps to the Desktop device, the remaining
-// options are derived from the shared responsive-state labels.
-const DEVICE_STATE_OPTIONS = [
-	{ value: 'default', label: __( 'Desktop' ) },
-	...Object.entries( RESPONSIVE_STATE_LABELS ).map(
-		( [ value, label ] ) => ( {
-			value,
-			label,
-		} )
-	),
-];
+const DEVICE_STATE_OPTIONS = Object.entries( RESPONSIVE_STATE_LABELS ).map(
+	( [ value, label ] ) => ( {
+		value,
+		label,
+	} )
+);
 
 // Keep in sync with WP_Theme_JSON_Gutenberg::VALID_BLOCK_PSEUDO_SELECTORS
 // and packages/global-styles-engine/src/core/render.tsx.

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -175,7 +175,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							role="menuitemcheckbox"
 							onClick={ handleResponsiveEditingChange }
 							info={ __(
-								'Edits apply only to the current state.'
+								'Style changes apply only to the current viewport.'
 							) }
 						>
 							{ __( 'Responsive editing' ) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -133,7 +133,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Tablet' ),
 			icon: tablet,
 			info: isResponsiveEditing
-				? __( 'Make tablet exclusive changes.' )
+				? __( 'Make tablet exclusive style changes.' )
 				: __( 'Preview tablet viewport.' ),
 		},
 		{
@@ -141,7 +141,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Mobile' ),
 			icon: mobile,
 			info: isResponsiveEditing
-				? __( 'Make mobile exclusive changes.' )
+				? __( 'Make mobile exclusive style changes.' )
 				: __( 'Preview mobile viewport.' ),
 		},
 	];


### PR DESCRIPTION
## What?
Makes a few small changes to the behavior introduced in #75121:
- Updates the copy from 'Edits apply only to the current state' to 'Style changes apply only to the current viewport'. That should help clarify to users that only style edits are applied.
- Avoids showing the 'Desktop' badge in the block card in the inspector when responsive editing is enabled. I think this could lead users to believe that edits they make are only applied on desktop instead of universally, because that's how it works for tablet/mobile.

## Testing Instructions
1. Create a post and insert a block
2. Open the viewport dropdown. Observe the copy change for the responsive editing help text.
3. Enable responsive editing and ensure you have the 'desktop badge selected.
4. Observe that there's no badge shown in the inspector
5. Select tablet/mobile, observe that the badge is now shown.

## Screenshots or screencast <!-- if applicable -->

### Responsive dropdown
|Before|After|
|-|-|
| <img width="254" height="315" alt="Screenshot 2026-06-29 at 11 42 31 am" src="https://github.com/user-attachments/assets/b9b7a039-2e58-4e2d-88eb-874909136714" /> | <img width="264" height="374" alt="Screenshot 2026-06-29 at 11 05 43 am" src="https://github.com/user-attachments/assets/516e98c7-aa6c-4408-aa23-09001b787303" /> |

### Block card
|Before|After|
|-|-|
| <img width="276" height="148" alt="Screenshot 2026-06-29 at 11 42 38 am" src="https://github.com/user-attachments/assets/900132b4-a684-436a-a184-f56a87ffc27c" /> | <img width="271" height="147" alt="Screenshot 2026-06-29 at 11 05 58 am" src="https://github.com/user-attachments/assets/08f87f04-a99a-4538-8777-ddd942c464a9" /> |

## Use of AI Tools
None