### PR TITLE
Navigation Link: Fix "[object Object]" in link preview for untitled entities

### DIFF
--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -500,6 +500,23 @@ describe( 'useLinkPreview', () => {
 			expect( result.current.title ).toBe( 'Test Category' );
 		} );
 
+		it( 'should show "(no title)" for an untitled entity, not the title object', () => {
+			const { result } = renderHook( () =>
+				useLinkPreview( {
+					url: 'https://example.com/page',
+					// Untitled page: an empty `title.rendered` object.
+					entityRecord: { title: { raw: '', rendered: '' } },
+					type: 'page',
+					hasBinding: false,
+					isEntityAvailable: true,
+				} )
+			);
+
+			expect( result.current.title ).toBe( '(no title)' );
+			// Truthy title, so no rich URL fetch.
+			expect( mockUseRemoteUrlData ).toHaveBeenCalledWith( null );
+		} );
+
 		it( 'should use entityRecord.name for taxonomy terms', () => {
 			const { result } = renderHook( () =>
 				useLinkPreview( {

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -204,14 +204,18 @@ export function computeBadges( {
 function getEntityTitle( entityRecord ) {
 	const title = entityRecord?.title;
 
-	// Posts and pages expose `title` as a { raw, rendered } object; some entity
-	// types use a plain string.
-	if ( title && typeof title === 'object' ) {
+	// Some entity types use a plain string for the title.
+	if ( typeof title === 'string' ) {
+		return title;
+	}
+
+	// Posts and pages expose `title` as a { raw, rendered } object.
+	if ( title && 'rendered' in title ) {
 		// translators: displayed when an entity has an empty title.
 		return title.rendered || __( '(no title)' );
 	}
 
-	return title || entityRecord?.name;
+	return entityRecord?.name;
 }
 
 /**

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -195,6 +195,26 @@ export function computeBadges( {
 }
 
 /**
+ * Returns an entity record's display title: the rendered title, "(no title)"
+ * for an untitled entity, or the record's name.
+ *
+ * @param {Object} entityRecord The entity record.
+ * @return {string|undefined} The display title.
+ */
+function getEntityTitle( entityRecord ) {
+	const title = entityRecord?.title;
+
+	// Posts and pages expose `title` as a { raw, rendered } object; some entity
+	// types use a plain string.
+	if ( title && typeof title === 'object' ) {
+		// translators: displayed when an entity has an empty title.
+		return title.rendered || __( '(no title)' );
+	}
+
+	return title || entityRecord?.name;
+}
+
+/**
  * Hook to compute link preview data for display.
  *
  * This hook takes raw link data and entity information and computes
@@ -223,10 +243,7 @@ export function useLinkPreview( {
 		)?.home;
 	}, [] );
 
-	const title =
-		entityRecord?.title?.rendered ||
-		entityRecord?.title ||
-		entityRecord?.name;
+	const title = getEntityTitle( entityRecord );
 
 	// Fetch rich URL data if we don't have a title. Internal links should have passed a title.
 	const { richData } = useRemoteUrlData( title ? null : url );

--- a/packages/block-library/src/navigation-link/shared/use-link-preview.js
+++ b/packages/block-library/src/navigation-link/shared/use-link-preview.js
@@ -211,7 +211,6 @@ function getEntityTitle( entityRecord ) {
 
 	// Posts and pages expose `title` as a { raw, rendered } object.
 	if ( title && 'rendered' in title ) {
-		// translators: displayed when an entity has an empty title.
 		return title.rendered || __( '(no title)' );
 	}
 


### PR DESCRIPTION
## What?

The navigation link "Link to" preview displays `[object Object]` for a page (or entity) with an empty title.

## Why?

For an untitled page the entity record's title is `{ raw: '', rendered: '' }`. The preview's title computation was `entityRecord?.title?.rendered || entityRecord?.title || entityRecord?.name`, so the empty `rendered` string fell through to `entityRecord?.title` — the title object itself — which displays as `[object Object]`.

Earlier this rendered an object as a React child and crashed the block with _"This block has encountered an error and cannot be previewed."_ A later change wrapped the preview title in `stripHTML`, which coerced the object to the harmless `[object Object]` string; this PR fixes the underlying cause.

## How?

For a known entity whose title object is empty, fall back to the standard `(no title)` placeholder (the display fallback Page List and the front end already use) instead of surfacing the `{ raw, rendered }` object. The placeholder is truthy, so — like the object it replaces — it does not trigger a rich URL fetch; rich-preview behavior is unchanged.

## Testing Instructions

1. Publish a page with no title.
2. Add it as a link in a Navigation block, select the link, and open Settings → "Link to".
3. The preview shows `(no title)`, not `[object Object]`.

Automated:

```
npm run test:unit -- --testPathPattern "use-link-preview.test"
```

### Testing Instructions for Keyboard

No keyboard-specific changes.

## Use of AI Tools

This pull request was authored with the assistance of Claude Code (Anthropic). All changes, including the added test, were reviewed and verified by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
