### PR TITLE
Icons Registry: Allow digits and underscores in icon slugs

### DIFF
--- a/backport-changelog/7.1/11559.md
+++ b/backport-changelog/7.1/11559.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/11559
 
 * https://github.com/WordPress/gutenberg/pull/77260
+* https://github.com/WordPress/gutenberg/pull/79623

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -54,10 +54,10 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 			return false;
 		}
 
-		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $unqualified_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$/', $unqualified_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Icon names must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.', 'gutenberg' ),
+				__( 'Icon names must start and end with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.', 'gutenberg' ),
 				'7.1.0'
 			);
 			return false;

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -54,10 +54,10 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 			return false;
 		}
 
-		if ( ! preg_match( '/^[a-z][a-z0-9-]*$/', $unqualified_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $unqualified_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Icon names must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.', 'gutenberg' ),
+				__( 'Icon names must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.', 'gutenberg' ),
 				'7.1.0'
 			);
 			return false;

--- a/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
@@ -98,20 +98,18 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides valid namespaced icon names, including names that contain or
-	 * start with digits.
+	 * Provides valid namespaced icon names.
 	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public function data_valid_icon_names() {
 		return array(
-			'simple name'            => array( 'test-collection/my-icon' ),
+			'simple name'            => array( 'test-collection/myicon' ),
 			'digit at the start'     => array( 'test-collection/1-icon' ),
 			'digit in the name'      => array( 'test-collection/my-1-icon' ),
 			'digit at the end'       => array( 'test-collection/icon1' ),
 			'underscore in the name' => array( 'test-collection/my_icon' ),
-			'underscore at the end'  => array( 'test-collection/my-icon_' ),
-			'hyphen at the end'      => array( 'test-collection/my-icon-' ),
+			'hyphen in the name'     => array( 'test-collection/my-icon' ),
 		);
 	}
 
@@ -149,7 +147,9 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 			'uppercase in the name'   => array( 'test-collection/my-Icon' ),
 			'uppercase at the end'    => array( 'test-collection/my-iconX' ),
 			'underscore at the start' => array( 'test-collection/_my-icon' ),
+			'underscore at the end'   => array( 'test-collection/my-icon_' ),
 			'hyphen at the start'     => array( 'test-collection/-my-icon' ),
+			'hyphen at the end'       => array( 'test-collection/my-icon-' ),
 		);
 	}
 

--- a/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-icons-registry-gutenberg-test.php
@@ -98,17 +98,39 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should accept valid icon names.
+	 * Provides valid namespaced icon names, including names that contain or
+	 * start with digits.
+	 *
+	 * @return array<string, array{0: string}>
 	 */
-	public function test_register_icon() {
+	public function data_valid_icon_names() {
+		return array(
+			'simple name'            => array( 'test-collection/my-icon' ),
+			'digit at the start'     => array( 'test-collection/1-icon' ),
+			'digit in the name'      => array( 'test-collection/my-1-icon' ),
+			'digit at the end'       => array( 'test-collection/icon1' ),
+			'underscore in the name' => array( 'test-collection/my_icon' ),
+			'underscore at the end'  => array( 'test-collection/my-icon_' ),
+			'hyphen at the end'      => array( 'test-collection/my-icon-' ),
+		);
+	}
+
+	/**
+	 * Should accept valid icon names.
+	 *
+	 * @dataProvider data_valid_icon_names
+	 *
+	 * @param string $name Valid icon name candidate.
+	 */
+	public function test_register_icon( $name ) {
 		$settings = array(
 			'label'   => 'My Icon',
 			'content' => '<svg></svg>',
 		);
 
-		$result = $this->register( 'test-collection/my-icon', $settings );
+		$result = $this->register( $name, $settings );
 		$this->assertTrue( $result );
-		$this->assertTrue( $this->registry->is_registered( 'test-collection/my-icon' ) );
+		$this->assertTrue( $this->registry->is_registered( $name ) );
 	}
 
 	/**
@@ -118,10 +140,16 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 	 */
 	public function data_invalid_icon_names() {
 		return array(
-			'non-string name'      => array( 1 ),
-			'empty name'           => array( 'test-collection/' ),
-			'uppercase characters' => array( 'test-collection/Plus' ),
-			'invalid characters'   => array( 'test-collection/_doing_it_wrong' ),
+			'integer name'            => array( 1 ),
+			'null name'               => array( null ),
+			'boolean name'            => array( true ),
+			'array name'              => array( array() ),
+			'empty name'              => array( 'test-collection/' ),
+			'uppercase at the start'  => array( 'test-collection/Icon' ),
+			'uppercase in the name'   => array( 'test-collection/my-Icon' ),
+			'uppercase at the end'    => array( 'test-collection/my-iconX' ),
+			'underscore at the start' => array( 'test-collection/_my-icon' ),
+			'hyphen at the start'     => array( 'test-collection/-my-icon' ),
 		);
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/77260

## What?

Relax the icon slug validation in the Icons Registry to allow:

1. Digits in any position (e.g. `html5`, `500px`, `w3c`).
2. Underscores anywhere except the first character (e.g. `my_icon`).

## Why?

The current validation is too strict for real-world icon sets. Many widely used icons contain digits, such as `html5`, `500px`, and `w3c`. Some consumers also want to use underscores in addition to hyphens.

## How?

Update the validation regex, allowing the first character to be a lowercase letter or digit and the rest to include lowercase letters, digits, hyphens, and underscores. Unit tests have also been updated to thoroughly test these new rules.

## Testing Instructions

Run the icon registry unit tests: `npm run test:unit:php:base -- --filter 'WP_Test_Icons_Registry_Gutenberg'`

## Use of AI Tools

This PR was authored with the assistance of Claude Code, reviewed and verified by the contributor.
