### PR TITLE
React 19 patch: log warnings when polyfills are hit

### DIFF
--- a/tools/build-scripts/packages/codemod-react-legacy-element.mjs
+++ b/tools/build-scripts/packages/codemod-react-legacy-element.mjs
@@ -21,6 +21,12 @@
  * coerces any string `inert` value to `true` in the `case 'inert'` of the
  * attribute-setting switch.
  *
+ * Both patches also emit a one-time `console.warn` (prefixed
+ * `[wordpress-react-19]`) when their compatibility path is exercised at runtime:
+ * once when a legacy element is encountered, and once when an empty-string
+ * `inert` value is coerced. A small compatibility-warning helper is prepended to
+ * every patched bundle to back these warnings.
+ *
  * Edits are applied to the original source with `magic-string`, so the output
  * is byte-for-byte identical except at the patched locations (handy for
  * diffing against the unpatched `-orig` files).
@@ -39,6 +45,114 @@ const traverse = _traverse.default ?? _traverse;
 const TRANSITIONAL_SYMBOL = 'react.transitional.element';
 const LEGACY_SYMBOL = 'react.element';
 const DEFAULT_LEGACY_NAME = 'REACT_LEGACY_ELEMENT_TYPE';
+
+// Name of the compatibility-warning helper injected into patched bundles. The
+// patches call it to surface compatibility behaviour (legacy elements, string
+// `inert`) at runtime, warning at most once per `key`.
+const WARN_HELPER_NAME = '__wpWarnCompat';
+
+// Warning ids. Each id warns at most once; call sites pass only the id and the
+// message is looked up from the table embedded in the injected helper.
+const LEGACY_ELEMENT_WARNING = 'legacy-element';
+const INERT_WARNING = 'inert';
+
+// Warning messages keyed by id. Embedded once into the patched bundle by the
+// injected helper, so call sites never repeat the message text. The
+// `[wordpress-react-19]` prefix is added by the helper at runtime.
+const WARNING_MESSAGES = {
+	[ LEGACY_ELEMENT_WARNING ]:
+		'A React element created by an older React runtime (React 17/18) was detected and is handled by a compatibility patch. This usually means a bundled package ships its own React; align it with React 19.',
+	[ INERT_WARNING ]:
+		'An empty-string `inert` attribute was used. React 19 treats `inert` as a boolean, so the value was coerced to `true` by a compatibility patch. Pass `inert={true}` instead.',
+};
+
+/**
+ * Source for the compatibility-warning helper that {@link injectWarnHelper}
+ * inserts into every patched bundle. It is a plain function declaration so it
+ * hoists to the top of the enclosing scope and is reachable from the patched
+ * call sites via closure. Call sites pass only a warning id; the message table
+ * is embedded here once. Warnings are deduplicated per id and prefixed with
+ * `[wordpress-react-19]`.
+ *
+ * @return {string} Helper source code.
+ */
+function warnHelperSource() {
+	return (
+		`function ${ WARN_HELPER_NAME }(key) {` +
+		`var w = ${ WARN_HELPER_NAME }.warned || (${ WARN_HELPER_NAME }.warned = {});` +
+		`if (w[key]) return;` +
+		`w[key] = true;` +
+		`var messages = ${ JSON.stringify( WARNING_MESSAGES ) };` +
+		`if (typeof console !== "undefined" && console.warn) {` +
+		`console.warn("[wordpress-react-19] " + messages[key]);` +
+		`}` +
+		`}\n`
+	);
+}
+
+/**
+ * Extracts the immediately-invoked function expression (IIFE) from a top-level
+ * statement, if it is one. Handles esbuild's `var Global = (() => { … })();`
+ * output as well as bare `(function () { … })();` expression statements.
+ *
+ * @param {Object} statement AST statement node.
+ * @return {Object|undefined} The IIFE function node (arrow/function expression).
+ */
+function getIifeFunction( statement ) {
+	let expression;
+	if (
+		statement.type === 'VariableDeclaration' &&
+		statement.declarations.length === 1
+	) {
+		expression = statement.declarations[ 0 ].init;
+	} else if ( statement.type === 'ExpressionStatement' ) {
+		expression = statement.expression;
+		// `!function(){}()` and similar minifier wrappers.
+		if ( expression.type === 'UnaryExpression' ) {
+			expression = expression.argument;
+		}
+	}
+
+	if ( ! expression || expression.type !== 'CallExpression' ) {
+		return undefined;
+	}
+
+	const callee = expression.callee;
+	if (
+		( callee.type === 'ArrowFunctionExpression' ||
+			callee.type === 'FunctionExpression' ) &&
+		callee.body.type === 'BlockStatement'
+	) {
+		return callee;
+	}
+
+	return undefined;
+}
+
+/**
+ * Inserts the compatibility-warning helper at the start of the bundle's IIFE
+ * body, so it stays scoped to the bundle instead of leaking a global (these
+ * bundles run as classic scripts). The helper is reachable from the patched
+ * call sites deeper in the same IIFE via closure.
+ *
+ * Falls back to prepending at the top of the file when no top-level IIFE is
+ * found, which keeps the helper available regardless of the bundle shape.
+ *
+ * @param {Object}      ast Parsed AST (File node).
+ * @param {MagicString} ms  Magic string for the source being edited.
+ */
+function injectWarnHelper( ast, ms ) {
+	for ( const statement of ast.program.body ) {
+		const iife = getIifeFunction( statement );
+		if ( iife ) {
+			// `body.start` is the opening `{`; insert right after it.
+			ms.appendRight( iife.body.start + 1, `\n${ warnHelperSource() }` );
+			return;
+		}
+	}
+
+	ms.prepend( warnHelperSource() );
+}
 
 /**
  * Whether a node is a `Symbol.for( '<value>' )` call.
@@ -147,13 +261,20 @@ function patchReference( refPath, legacyName, ms, filename ) {
 		return;
 	}
 
-	// `case TRANSITIONAL:` -> add a fall-through `case LEGACY:` before it.
+	// `case TRANSITIONAL:` -> add a fall-through `case LEGACY:` before it, with a
+	// warning that runs only when a legacy element actually reaches this case
+	// (the warning sits between the two labels, so the transitional case skips
+	// it and falls straight into the original body).
 	if ( parent.type === 'SwitchCase' && parent.test === node ) {
-		ms.appendLeft( parent.start, `case ${ legacyName }: ` );
+		ms.appendLeft(
+			parent.start,
+			`case ${ legacyName }: ${ WARN_HELPER_NAME }("${ LEGACY_ELEMENT_WARNING }"); `
+		);
 		return;
 	}
 
-	// `a === TRANSITIONAL` -> `( a === TRANSITIONAL || a === LEGACY )`.
+	// `a === TRANSITIONAL` -> `( a === TRANSITIONAL || ( a === LEGACY && warn ) )`.
+	// The warning only fires when the legacy branch matches.
 	if (
 		parent.type === 'BinaryExpression' &&
 		parent.operator === '===' &&
@@ -165,7 +286,7 @@ function patchReference( refPath, legacyName, ms, filename ) {
 		ms.overwrite(
 			parent.start,
 			parent.end,
-			`(${ original } || ${ otherText } === ${ legacyName })`
+			`(${ original } || (${ otherText } === ${ legacyName } && (${ WARN_HELPER_NAME }("${ LEGACY_ELEMENT_WARNING }"), true)))`
 		);
 		return;
 	}
@@ -424,10 +545,16 @@ function patchInertAttribute( ast, ms, filename ) {
 	}
 
 	const { inertCase, valueName } = matches[ 0 ];
-	// Append as the last statement of the `inert` case body (right before the
-	// fall-through), so the preceding empty-string warning still sees the
-	// original value. `SwitchCase.end` is the end of the last consequent
-	// statement, or just after the `case 'inert':` label when the body is empty.
+	// Append at the end of the `inert` case body (right before the fall-through).
+	// `SwitchCase.end` is the end of the last consequent statement, or just after
+	// the `case 'inert':` label when the body is empty.
+	//
+	// The empty-string warning is appended first so it still sees the original
+	// value, then the coercion of any string `inert` value to `true`.
+	ms.appendLeft(
+		inertCase.end,
+		` if ( "" === ${ valueName } ) ${ WARN_HELPER_NAME }("${ INERT_WARNING }"); `
+	);
 	ms.appendLeft(
 		inertCase.end,
 		` if ( "string" === typeof ${ valueName } ) ${ valueName } = true; `
@@ -459,6 +586,11 @@ export function createPatcher( ...passes ) {
 		for ( const pass of passes ) {
 			pass( ast, ms, filename );
 		}
+
+		// Inject the compatibility-warning helper that the patches call at
+		// runtime. It is a hoisted function declaration, so it is reachable from
+		// the patched call sites (inside the bundle's IIFE) via closure.
+		injectWarnHelper( ast, ms );
 
 		return ms.toString();
 	};

--- a/tools/react-19/react-dom.js
+++ b/tools/react-19/react-dom.js
@@ -1,6 +1,24 @@
-module.exports = {
+const { warnCompat } = require( './warn-compat' );
+
+const SECRET_INTERNALS_KEY =
+	'__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED';
+
+const reactDOM = {
 	...require( 'react-dom' ),
 	...require( 'react-dom/client' ),
 	...require( './react-polyfill' ),
-	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {},
 };
+
+Object.defineProperty( reactDOM, SECRET_INTERNALS_KEY, {
+	enumerable: true,
+	configurable: true,
+	get() {
+		warnCompat(
+			'react-dom-secret-internals',
+			`Accessing \`${ SECRET_INTERNALS_KEY }\` was removed in React 19 and is provided by a compatibility shim.`
+		);
+		return {};
+	},
+} );
+
+module.exports = reactDOM;

--- a/tools/react-19/react-dom.js
+++ b/tools/react-19/react-dom.js
@@ -3,6 +3,8 @@ const { warnCompat } = require( './warn-compat' );
 const SECRET_INTERNALS_KEY =
 	'__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED';
 
+const secretInternals = {};
+
 const reactDOM = {
 	...require( 'react-dom' ),
 	...require( 'react-dom/client' ),
@@ -17,7 +19,7 @@ Object.defineProperty( reactDOM, SECRET_INTERNALS_KEY, {
 			'react-dom-secret-internals',
 			`Accessing \`${ SECRET_INTERNALS_KEY }\` was removed in React 19 and is provided by a compatibility shim.`
 		);
-		return {};
+		return secretInternals;
 	},
 } );
 

--- a/tools/react-19/react-jsx-runtime.js
+++ b/tools/react-19/react-jsx-runtime.js
@@ -1,9 +1,15 @@
 const jsxRuntime = require( 'react/jsx-runtime' );
+const { warnCompat } = require( './warn-compat' );
 
 function applyDefaultProps( type, config ) {
 	if ( ! type || ! type.defaultProps ) {
 		return config;
 	}
+
+	warnCompat(
+		'jsx-default-props',
+		'`defaultProps` on function components was removed in React 19 and is emulated by a compatibility polyfill. Use default parameters instead.'
+	);
 
 	const defaultProps = type.defaultProps;
 	let props = config;

--- a/tools/react-19/react-polyfill.js
+++ b/tools/react-19/react-polyfill.js
@@ -1,6 +1,8 @@
 import { flushSync } from 'react-dom';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 
+import { warnCompat } from './warn-compat';
+
 const internalsKey = '_reactInternals';
 
 // HostComponent fiber tag, represents a DOM element like <div>.
@@ -55,6 +57,11 @@ function findHostFiberImpl( fiber ) {
 }
 
 export function findDOMNode( instance ) {
+	warnCompat(
+		'findDOMNode',
+		'`ReactDOM.findDOMNode` was removed in React 19 and is emulated by a compatibility polyfill. Use refs instead.'
+	);
+
 	if ( instance === null || instance === undefined ) {
 		return null;
 	}
@@ -81,6 +88,11 @@ export function findDOMNode( instance ) {
 const roots = new WeakMap();
 
 export function render( element, container, callback ) {
+	warnCompat(
+		'render',
+		'`ReactDOM.render` was removed in React 19 and is emulated by a compatibility polyfill. Use `createRoot` instead.'
+	);
+
 	let root = roots.get( container );
 	if ( ! root ) {
 		root = createRoot( container );
@@ -97,6 +109,11 @@ export function render( element, container, callback ) {
 }
 
 export function hydrate( element, container, callback ) {
+	warnCompat(
+		'hydrate',
+		'`ReactDOM.hydrate` was removed in React 19 and is emulated by a compatibility polyfill. Use `hydrateRoot` instead.'
+	);
+
 	let root = roots.get( container );
 	if ( ! root ) {
 		root = hydrateRoot( container, element );
@@ -111,6 +128,11 @@ export function hydrate( element, container, callback ) {
 }
 
 export function unmountComponentAtNode( container ) {
+	warnCompat(
+		'unmountComponentAtNode',
+		'`ReactDOM.unmountComponentAtNode` was removed in React 19 and is emulated by a compatibility polyfill. Use `root.unmount` instead.'
+	);
+
 	const root = roots.get( container );
 	if ( ! root ) {
 		return false;

--- a/tools/react-19/react.js
+++ b/tools/react-19/react.js
@@ -1,12 +1,41 @@
-module.exports = {
-	...require( 'react' ),
-	// Polyfill React 18 internals for older versions of `react/jsx-runtime`.
-	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
-		ReactCurrentOwner: { current: null },
-		ReactCurrentDispatcher: { current: null },
-		ReactDebugCurrentFrame: {
-			setExtraStackFrame: () => {},
-			getStackAddendum: () => '',
+const { warnCompat } = require( './warn-compat' );
+
+const SECRET_INTERNALS_KEY =
+	'__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED';
+
+// Polyfill React 18 internals for older versions of `react/jsx-runtime`.
+const secretInternals = {
+	ReactCurrentOwner: { current: null },
+	ReactCurrentDispatcher: { current: null },
+	ReactDebugCurrentFrame: {
+		setExtraStackFrame() {
+			warnCompat(
+				'react-secret-internals-setExtraStackFrame',
+				`\`${ SECRET_INTERNALS_KEY }.ReactDebugCurrentFrame.setExtraStackFrame\` was removed in React 19 and is a no-op compatibility shim.`
+			);
+		},
+		getStackAddendum() {
+			warnCompat(
+				'react-secret-internals-getStackAddendum',
+				`\`${ SECRET_INTERNALS_KEY }.ReactDebugCurrentFrame.getStackAddendum\` was removed in React 19 and is a no-op compatibility shim.`
+			);
+			return '';
 		},
 	},
 };
+
+const react = { ...require( 'react' ) };
+
+Object.defineProperty( react, SECRET_INTERNALS_KEY, {
+	enumerable: true,
+	configurable: true,
+	get() {
+		warnCompat(
+			'react-secret-internals',
+			`Accessing \`${ SECRET_INTERNALS_KEY }\` was removed in React 19 and is provided by a compatibility shim.`
+		);
+		return secretInternals;
+	},
+} );
+
+module.exports = react;

--- a/tools/react-19/warn-compat.js
+++ b/tools/react-19/warn-compat.js
@@ -1,0 +1,21 @@
+const PREFIX = '[wordpress-react-19]';
+
+const warned = new Set();
+
+/**
+ * Warns about reliance on a React 18 compatibility shim that emulates an API
+ * removed in React 19. Each distinct `key` warns at most once, so repeated use
+ * of the same shim does not flood the console.
+ *
+ * @param {string} key     Unique identifier for the compatibility warning.
+ * @param {string} message Human-readable warning message.
+ */
+export function warnCompat( key, message ) {
+	if ( warned.has( key ) ) {
+		return;
+	}
+	warned.add( key );
+	if ( typeof console !== 'undefined' && console.warn ) {
+		console.warn( `${ PREFIX } ${ message }` );
+	}
+}


### PR DESCRIPTION
Updates the React 19 patch and polyfills to log a warning when the polyfill path is hit.

In the React patch, the original code is:
```js
case REACT_ELEMENT_TYPE:
```
or
```js
if ( el.$$typeof === REACT_ELEMENT_TYPE )
```
Before this PR, we were patching it to:
```js
case REACT_LEGACY_ELEMENT_TYPE:
case REACT_ELEMENT_TYPE:
```
or
```js
if ( el.$$typeof === REACT_ELEMENT_TYPE || el.$$typeof === REACT_LEGACY_ELEMENT_TYPE )
```
After this patch, the compat path includes a warning message:
```js
case REACT_LEGACY_ELEMENT_TYPE:
__wpWarnCompat(); // warn and fall through
case REACT_ELEMENT_TYPE:
```
or
```js
if (
  el.$$typeof === REACT_ELEMENT_TYPE ||
  ( el.$$typeof === REACT_LEGACY_ELEMENT_TYPE && ( __warnCompat(), true ) )
)
```

In a similar way we're also warning when a legacy `inert=""` attribute is detected.

This is how console warnings look like now with Elementor. It's a mixture of our custom warnings and React's own warnings:
<img width="1439" height="494" alt="react-19-elementor-compat-warnings" src="https://github.com/user-attachments/assets/ab234d6d-57c6-43ab-9951-cb9390e4caaa" />
