### PR TITLE
View config: Add better post type default `form`

### DIFF
--- a/backport-changelog/7.1/12288.md
+++ b/backport-changelog/7.1/12288.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/12288
 
 * https://github.com/WordPress/gutenberg/pull/79452
+* https://github.com/WordPress/gutenberg/pull/79625

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -10,6 +10,86 @@
  */
 
 /**
+ * Builds the default `form` configuration shared by every post type entity.
+ *
+ * This is the single `form` consumed today; it is a sensible default for `post`,
+ * `page`, and custom post types alike rather than being tailored per type.
+ *
+ * It is intentionally NOT gated by `supports`. The registered fields are the
+ * single source of truth for what applies: each field is registered for a post
+ * type based on its `supports` (and related flags such as `theme_supports`), and
+ * the editor drops any form field whose definition is absent or whose `isVisible`
+ * returns `false`.
+ *
+ * @return array The default form configuration.
+ */
+function _gutenberg_get_default_post_type_form() {
+	return array(
+		'layout' => array( 'type' => 'panel' ),
+		'fields' => array(
+			array(
+				'id'     => 'featured_media',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'none',
+				),
+			),
+			array(
+				'id'     => 'post-content-info',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'none',
+				),
+			),
+			array(
+				'id'     => 'excerpt',
+				'layout' => array(
+					'type'          => 'panel',
+					'labelPosition' => 'top',
+				),
+			),
+			array(
+				'id'       => 'status',
+				'label'    => __( 'Status', 'gutenberg' ),
+				'children' => array(
+					array(
+						'id'     => 'status',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					'scheduled_date',
+					'password',
+					'sticky',
+				),
+			),
+			'date',
+			'slug',
+			'author',
+			'template',
+			array(
+				'id'       => 'discussion',
+				'label'    => __( 'Discussion', 'gutenberg' ),
+				'children' => array(
+					array(
+						'id'     => 'comment_status',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					'ping_status',
+				),
+			),
+			'parent',
+			'format',
+			'revisions',
+		),
+	);
+}
+
+/**
  * Returns the view configuration for the given entity.
  *
  * Builds the default configuration shared by all entities and then exposes it
@@ -62,7 +142,7 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		'default_view'    => $default_view,
 		'default_layouts' => $default_layouts,
 		'view_list'       => $view_list,
-		'form'            => array(),
+		'form'            => 'postType' === $kind ? _gutenberg_get_default_post_type_form() : array(),
 	);
 
 	/**
@@ -231,146 +311,6 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 					),
 				),
 			),
-		),
-	);
-
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'featured_media',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'post-content-info',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'excerpt',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
-				),
-			),
-			array(
-				'id'       => 'status',
-				'label'    => __( 'Status', 'gutenberg' ),
-				'children' => array(
-					array(
-						'id'     => 'status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'scheduled_date',
-					'password',
-					'sticky',
-				),
-			),
-			'date',
-			'slug',
-			'author',
-			'template',
-			array(
-				'id'       => 'discussion',
-				'label'    => __( 'Discussion', 'gutenberg' ),
-				'children' => array(
-					array(
-						'id'     => 'comment_status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'ping_status',
-				),
-			),
-			'parent',
-			'format',
-			'revisions',
-		),
-	);
-
-	return $config;
-}
-
-/**
- * Provides the view configuration for the `post` post type.
- *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
- */
-function _gutenberg_get_entity_view_config_post_type_post( $config ) {
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'featured_media',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'post-content-info',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'excerpt',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
-				),
-			),
-			array(
-				'id'       => 'status',
-				'label'    => __( 'Status', 'gutenberg' ),
-				'children' => array(
-					array(
-						'id'     => 'status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'scheduled_date',
-					'password',
-					'sticky',
-				),
-			),
-			'date',
-			'slug',
-			'author',
-			'template',
-			array(
-				'id'       => 'discussion',
-				'label'    => __( 'Discussion', 'gutenberg' ),
-				'children' => array(
-					array(
-						'id'     => 'comment_status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'ping_status',
-				),
-			),
-			'parent',
-			'format',
-			'revisions',
 		),
 	);
 
@@ -798,6 +738,10 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
  * plugin always ships the newest configuration, so it removes the core defaults
  * and installs its own `_gutenberg_*` callbacks instead.
  *
+ * Post types without a dedicated `_gutenberg_*` callback (e.g. `post`) still have
+ * the core callback removed so they fall back to the supports-derived default
+ * built in gutenberg_get_entity_view_config().
+ *
  * This runs on `init` rather than at file include time so that the core
  * defaults are guaranteed to be registered first, regardless of whether core
  * registers them at include time or lazily on a hook.
@@ -813,7 +757,9 @@ function gutenberg_register_entity_view_config_filters() {
 		if ( has_filter( $hook, $wp_callback ) ) {
 			remove_filter( $hook, $wp_callback );
 		}
-		add_filter( $hook, $gb_callback, 10, 1 );
+		if ( function_exists( $gb_callback ) ) {
+			add_filter( $hook, $gb_callback, 10, 1 );
+		}
 	}
 }
 add_action( 'init', 'gutenberg_register_entity_view_config_filters' );

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -10,10 +10,11 @@
  */
 
 /**
- * Builds the default `form` configuration shared by every post type entity.
+ * Builds the default `form` configuration for post types that don't provide their own.
  *
- * This is the single `form` consumed today; it is a sensible default for `post`,
- * `page`, and custom post types alike rather than being tailored per type.
+ * It is a sensible default for `post`, `page`, and custom post types alike rather
+ * than being tailored per type. Post types that need a different shape can replace
+ * it entirely with a dedicated `form` through their own filter callback.
  *
  * It is intentionally NOT gated by `supports`. The registered fields are the
  * single source of truth for what applies: each field is registered for a post
@@ -739,7 +740,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
  * and installs its own `_gutenberg_*` callbacks instead.
  *
  * Post types without a dedicated `_gutenberg_*` callback (e.g. `post`) still have
- * the core callback removed so they fall back to the supports-derived default
+ * the core callback removed so they fall back to the default configuration
  * built in gutenberg_get_entity_view_config().
  *
  * This runs on `init` rather than at file include time so that the core

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -20,6 +20,7 @@ import PatternOverridesPanel from '../pattern-overrides-panel';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebar from '../plugin-sidebar';
 import PostSummary from './post-summary';
+import DataFormPostSummary from './dataform-post-summary';
 import PostRevisionSummary from './post-revision-summary';
 import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import PostTransformPanel from '../post-transform-panel';
@@ -32,11 +33,6 @@ import useAutoSwitchEditorSidebars from '../provider/use-auto-switch-editor-side
 import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
-import {
-	NAVIGATION_POST_TYPE,
-	TEMPLATE_PART_POST_TYPE,
-	TEMPLATE_POST_TYPE,
-} from '../../store/constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
@@ -47,7 +43,6 @@ const SidebarContent = ( {
 	keyboardShortcut,
 	onActionPerformed,
 	extraPanels,
-	postType,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
@@ -89,15 +84,20 @@ const SidebarContent = ( {
 	if ( isRevisionsMode ) {
 		tabContent = <PostRevisionSummary />;
 	} else {
+		const isDataFormInspectorEnabled =
+			window?.__experimentalDataFormInspector;
 		tabContent = (
 			<>
-				<PostSummary onActionPerformed={ onActionPerformed } />
+				{ isDataFormInspectorEnabled ? (
+					<DataFormPostSummary
+						onActionPerformed={ onActionPerformed }
+					/>
+				) : (
+					<PostSummary onActionPerformed={ onActionPerformed } />
+				) }
 				<PluginDocumentSettingPanel.Slot />
 				<TemplateContentPanel />
-				{ window?.__experimentalDataFormInspector &&
-					[ 'page', 'post' ].includes( postType ) && (
-						<TemplateActionsPanel />
-					) }
+				{ isDataFormInspectorEnabled && <TemplateActionsPanel /> }
 				<TemplatePartContentPanel />
 				<PostTransformPanel />
 				<PostTaxonomiesPanel />
@@ -144,42 +144,29 @@ const SidebarContent = ( {
 
 const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	useAutoSwitchEditorSidebars();
-	const { tabName, keyboardShortcut, showSummary, postType } = useSelect(
-		( select ) => {
-			const shortcut = select(
-				keyboardShortcutsStore
-			).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
+	const { tabName, keyboardShortcut } = useSelect( ( select ) => {
+		const shortcut = select(
+			keyboardShortcutsStore
+		).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
 
-			const sidebar =
-				select( interfaceStore ).getActiveComplementaryArea( 'core' );
-			const _isEditorSidebarOpened = [
-				sidebars.block,
-				sidebars.document,
-			].includes( sidebar );
-			let _tabName = sidebar;
-			if ( ! _isEditorSidebarOpened ) {
-				_tabName = !! select(
-					blockEditorStore
-				).getBlockSelectionStart()
-					? sidebars.block
-					: sidebars.document;
-			}
+		const sidebar =
+			select( interfaceStore ).getActiveComplementaryArea( 'core' );
+		const _isEditorSidebarOpened = [
+			sidebars.block,
+			sidebars.document,
+		].includes( sidebar );
+		let _tabName = sidebar;
+		if ( ! _isEditorSidebarOpened ) {
+			_tabName = !! select( blockEditorStore ).getBlockSelectionStart()
+				? sidebars.block
+				: sidebars.document;
+		}
 
-			const _postType = select( editorStore ).getCurrentPostType();
-
-			return {
-				tabName: _tabName,
-				keyboardShortcut: shortcut,
-				showSummary: ! [
-					TEMPLATE_POST_TYPE,
-					TEMPLATE_PART_POST_TYPE,
-					NAVIGATION_POST_TYPE,
-				].includes( _postType ),
-				postType: _postType,
-			};
-		},
-		[]
-	);
+		return {
+			tabName: _tabName,
+			keyboardShortcut: shortcut,
+		};
+	}, [] );
 
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
@@ -201,10 +188,8 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 			<SidebarContent
 				tabName={ tabName }
 				keyboardShortcut={ keyboardShortcut }
-				showSummary={ showSummary }
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
-				postType={ postType }
 			/>
 		</Tabs>
 	);

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -7,7 +7,6 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import DataFormPostSummary from './dataform-post-summary';
 import PluginPostStatusInfo from '../plugin-post-status-info';
 import PostAuthorPanel from '../post-author/panel';
 import PostCardPanel from '../post-card-panel';
@@ -37,26 +36,6 @@ import PostTrash from '../post-trash';
 const PANEL_NAME = 'post-status';
 
 export default function PostSummary( { onActionPerformed } ) {
-	const postType = useSelect(
-		( select ) => select( editorStore ).getCurrentPostType(),
-		[]
-	);
-	if (
-		window?.__experimentalDataFormInspector &&
-		[
-			'page',
-			'post',
-			'wp_block',
-			'wp_template',
-			'wp_template_part',
-		].includes( postType )
-	) {
-		return <DataFormPostSummary onActionPerformed={ onActionPerformed } />;
-	}
-	return <ClassicPostSummary onActionPerformed={ onActionPerformed } />;
-}
-
-function ClassicPostSummary( { onActionPerformed } ) {
 	const { isRemovedPostStatusPanel, postType, postId } = useSelect(
 		( select ) => {
 			// We use isEditorPanelRemoved to hide the panel if it was programmatically removed. We do


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076

This PR does a couple of things:
1. Centralizes the  logic to load experiment in single place (sidebar component)
2. Open the experiment to any post type. 

Regarding `2` this PR adds a sensible default `form` config for `post`, `page` and custom post types alike rather than being tailored per type.  It is intentionally NOT gated by `supports`. The registered fields are the single source of truth for what applies: [each field is registered for a post type](https://github.com/WordPress/gutenberg/blob/34a87128afb638b66fe514deb736fd959b55a964/packages/editor/src/dataviews/store/private-actions.ts#L274) based on its `supports` (and related flags such as `theme_supports`), and the editor drops any form field whose definition is absent or whose `isVisible` returns `false`.



## Testing instructions
1. Enable the `Editor Inspector: Use DataForm` experiment.
2. Register a CPT and observe the post summary rendered with the experiment `enabled` and `disabled`. I have a test snippet for registering a CPT below.
3. Play around with some `supports` values and repeat `step 2`.

## Register CPT snippet
<details>
<summary>Click here to see/copy the snippet</summary>


```
function wpdocs_codex_book_init() {
	$labels = array(
		'name'                  => _x( 'Books', 'Post type general name', 'textdomain' ),
		'singular_name'         => _x( 'Book', 'Post type singular name', 'textdomain' ),
	);

	$args = array(
		'labels'             => $labels,
		'public'             => true,
		'publicly_queryable' => true,
		'show_ui'            => true,
		'show_in_menu'       => true,
		'query_var'          => true,
		'rewrite'            => array( 'slug' => 'book' ),
		'capability_type'    => 'post',
		'has_archive'        => true,
		'hierarchical'       => false,
		'menu_position'      => null,
		// 'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ),
		'show_in_rest'       => true,
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'wpdocs_codex_book_init' );
```
</details>






|Before|After|
|-|-|
|<img width="286" height="460" alt="Screenshot 2026-06-29 at 12 33 14 PM" src="https://github.com/user-attachments/assets/cacd5ff1-f16b-41c1-85d5-f26fa43efcdc" />|<img width="286" height="460" alt="Screenshot 2026-06-29 at 12 32 59 PM" src="https://github.com/user-attachments/assets/07e8d6c4-9cba-41d1-951e-60329279af7e" />|


## Use of AI Tools
Opus 4.8 with direction, changes and review
