### PR TITLE
Declare @types/node explicitly and harden no-unsafe-wp-apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49958,7 +49958,8 @@
 				"design-system-mcp": "bin/design-system-mcp.mjs"
 			},
 			"devDependencies": {
-				"@types/jest": "^29.5.14"
+				"@types/jest": "^29.5.14",
+				"@types/node": "^20.19.39"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -46,7 +46,8 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@types/jest": "^29.5.14"
+		"@types/jest": "^29.5.14",
+		"@types/node": "^20.19.39"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/design-system-mcp/tsconfig.json
+++ b/packages/design-system-mcp/tsconfig.json
@@ -3,7 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"types": [ "jest" ]
+		"types": [ "jest", "node" ]
 	},
 	"include": [ "src" ],
 	"exclude": []

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
@@ -54,6 +54,13 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 		},
 		{ code: "import * as s from '@wordpress/package';", options },
+		{
+			// String-literal imports (e.g. `import { 'a' as b }`) have a
+			// non-identifier `imported` node and are ignored by the rule.
+			code: "import { '__experimentalUnsafe' as s } from '@wordpress/package';",
+			options,
+			languageOptions: { sourceType: 'module', ecmaVersion: 2022 },
+		},
 	],
 
 	invalid: [

--- a/packages/eslint-plugin/rules/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin/rules/no-unsafe-wp-apis.js
@@ -63,6 +63,11 @@ function makeListener( { allowedImports, context } ) {
 				return;
 			}
 
+			/* `imported` may be a string literal (e.g. `import { 'a' as b }`); only identifiers are relevant here. */
+			if ( specifierNode.imported.type !== 'Identifier' ) {
+				return;
+			}
+
 			const importedName = specifierNode.imported.name;
 
 			if (

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -3,7 +3,12 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"moduleResolution": "bundler",
-		"types": [ "jest", "style-imports", "react-css-custom-properties" ]
+		"types": [
+			"jest",
+			"node",
+			"style-imports",
+			"react-css-custom-properties"
+		]
 	},
 	"exclude": [],
 	"files": [ "global.d.ts" ],


### PR DESCRIPTION
Extracted from #79618

## What?

Makes the type setup of `@wordpress/theme` and `@wordpress/design-system-mcp` robust to dependency layouts that don't hoist `@types/node` into reach, and hardens the `no-unsafe-wp-apis` ESLint rule against the import-specifier shape in newer `@types/estree`.

- Add `node` to the TypeScript `types` of `@wordpress/theme` (`tsconfig.src.json`, inherited by `tsconfig.bin.json`) and `@wordpress/design-system-mcp`, and declare `@types/node` as a devDependency of `design-system-mcp`.
- Guard `no-unsafe-wp-apis` against non-identifier import specifiers.

## Why?

Both are latent fragilities that surface once dependency resolution changes (e.g. an isolated/linked install layout, or a deduped lockfile):

- `@wordpress/theme`'s `bin/` token scripts and `design-system-mcp`'s `src/data.ts` use Node globals (`node:fs`, `process`, …). They currently compile only because `@types/node` happens to be hoisted to the root `node_modules`. Under a layout that doesn't hoist it there (or that the package doesn't itself declare), tsc fails with `Cannot find name 'process'` / `Cannot find name 'node:path'`. Declaring `node` in `types` (and the dependency) makes this explicit instead of incidental.
- `no-unsafe-wp-apis` reads `specifierNode.imported.name`. Newer `@types/estree` types `ImportSpecifier.imported` as `Identifier | Literal` (string-literal imports, e.g. `import { 'a' as b }`), where `Literal` has no `.name`, so tsc reports `Property 'name' does not exist on type 'BigIntLiteral'`. Guarding for `Identifier` is behavior-preserving — these WordPress imports are always identifiers.

Pulling these out as their own change keeps a follow-up `package-lock.json` dedupe focused on the lockfile alone.

## How?

`types` arrays gain `node`; `design-system-mcp` gains an `@types/node` devDependency; the rule returns early when `imported` is not an `Identifier`.

## Testing Instructions

1. `npm ci`
2. `npm run build` — completes cleanly.
3. `npm run test:unit packages/eslint-plugin` — passes.

## Use of AI Tools

AI (Claude Code) assisted with diagnosing the type-resolution fragility and drafting this description. All changes were reviewed by the author.
