### PR TITLE
Update @terrazzo/* to 2.4.0 and regenerate design tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14100,33 +14100,34 @@
 				}
 			}
 		},
-		"node_modules/@terrazzo/plugin-css": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.0.3.tgz",
-			"integrity": "sha512-c6Lp8fHy883bxkj1XppGMETI7TA+Bv80RY7ICIdn0dlsp6sTiNUAILZQ0kR8CizptuQv9TIT3p+xVNmW1q3O8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@terrazzo/token-tools": "^2.0.3"
-			},
-			"peerDependencies": {
-				"@terrazzo/cli": "^2.0.3",
-				"@terrazzo/parser": "^2.0.3"
-			}
-		},
-		"node_modules/@terrazzo/plugin-css/node_modules/@terrazzo/token-tools": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.0.3.tgz",
-			"integrity": "sha512-/5Mbqcq3hXWOz4G/AjhYY/PHU00TJJJOJrZS2Fosg4sOkb18VaDHU9Sbj1g8M/R86OmSibQF99zB3DkUSjAYFA==",
+		"node_modules/@terrazzo/parser": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.4.0.tgz",
+			"integrity": "sha512-9lTsqAp13nOARSWPFN+55A09OaSU2UfMh3K1x4XlbpTvUGnUtb1rnUg+3t8+5VwTGWVtDA5cUhZfpNESQpxucA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@humanwhocodes/momoa": "^3.3.10",
+				"@terrazzo/json-schema-tools": "^0.2.1",
+				"@terrazzo/token-tools": "^2.4.0",
+				"@terrazzo/token-types": "^2.4.0",
+				"@types/babel__code-frame": "^7.27.0",
 				"colorjs.io": "^0.6.1",
-				"wildcard-match": "^5.1.4"
+				"fast-deep-equal": "^3.1.3",
+				"merge-anything": "^5.1.7",
+				"picocolors": "^1.1.1",
+				"scule": "^1.3.0"
+			},
+			"peerDependencies": {
+				"yaml-to-momoa": "0.0.9"
+			},
+			"peerDependenciesMeta": {
+				"yaml-to-momoa": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@terrazzo/plugin-css/node_modules/colorjs.io": {
+		"node_modules/@terrazzo/parser/node_modules/colorjs.io": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
 			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
@@ -14136,6 +14137,51 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/color"
 			}
+		},
+		"node_modules/@terrazzo/plugin-css": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.4.0.tgz",
+			"integrity": "sha512-mGyrW15w3vqGaO5f/jjntQoAlPNjlnbMWt70UxZkN4ITsFBaxTsWrrm6zuKibkbNuYFX5HcZSUiwf5f7Gd1Vsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@terrazzo/token-tools": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@terrazzo/cli": "^2.4.0",
+				"@terrazzo/parser": "^2.4.0"
+			}
+		},
+		"node_modules/@terrazzo/token-tools": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.4.0.tgz",
+			"integrity": "sha512-nO0VFZrhsgX3IVsTxVxHiQS4qZK8rFSR7rMh39jJ81xfIlNELYEmE251vgzdly6JHUFk8m8k4EI5L74ekcoxvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@humanwhocodes/momoa": "^3.3.10",
+				"@terrazzo/token-types": "^2.4.0",
+				"colorjs.io": "^0.6.1",
+				"wildcard-match": "^5.1.4"
+			}
+		},
+		"node_modules/@terrazzo/token-tools/node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
+		},
+		"node_modules/@terrazzo/token-types": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.4.0.tgz",
+			"integrity": "sha512-VE1hhpGCGw57pfflLzC6Xjn/akag526lM6gAf3SNVjEL6AUvGRevjyWG3mgX8I9O5UzbMOH/Gn3RVp63SdE+NA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@testing-library/dom": {
 			"version": "9.3.4",
@@ -53637,9 +53683,9 @@
 			},
 			"devDependencies": {
 				"@storybook/react-vite": "^10.4.3",
-				"@terrazzo/parser": "^2.0.3",
-				"@terrazzo/plugin-css": "^2.0.3",
-				"@terrazzo/token-tools": "^2.0.3",
+				"@terrazzo/parser": "^2.4.0",
+				"@terrazzo/plugin-css": "^2.4.0",
+				"@terrazzo/token-tools": "^2.4.0",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
@@ -53680,44 +53726,6 @@
 				"vite": {
 					"optional": true
 				}
-			}
-		},
-		"packages/theme/node_modules/@terrazzo/parser": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.0.3.tgz",
-			"integrity": "sha512-+MDp2SHcxPJhT+1fGmptJ1iFzUMseEpFjlNutslFLyeOhA/6fcil8YNGmp7RJM41G7LhIZOqp3rX2DuB18dNzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/json-schema-tools": "^0.2.1",
-				"@terrazzo/token-tools": "^2.0.3",
-				"@types/babel__code-frame": "^7.27.0",
-				"colorjs.io": "^0.6.1",
-				"fast-deep-equal": "^3.1.3",
-				"merge-anything": "^5.1.7",
-				"picocolors": "^1.1.1",
-				"scule": "^1.3.0"
-			},
-			"peerDependencies": {
-				"yaml-to-momoa": "0.0.9"
-			},
-			"peerDependenciesMeta": {
-				"yaml-to-momoa": {
-					"optional": true
-				}
-			}
-		},
-		"packages/theme/node_modules/@terrazzo/token-tools": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.0.3.tgz",
-			"integrity": "sha512-/5Mbqcq3hXWOz4G/AjhYY/PHU00TJJJOJrZS2Fosg4sOkb18VaDHU9Sbj1g8M/R86OmSibQF99zB3DkUSjAYFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@humanwhocodes/momoa": "^3.3.10",
-				"colorjs.io": "^0.6.1",
-				"wildcard-match": "^5.1.4"
 			}
 		},
 		"packages/theme/node_modules/@testing-library/dom": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -94,9 +94,9 @@
 	},
 	"devDependencies": {
 		"@storybook/react-vite": "^10.4.3",
-		"@terrazzo/parser": "^2.0.3",
-		"@terrazzo/plugin-css": "^2.0.3",
-		"@terrazzo/token-tools": "^2.0.3",
+		"@terrazzo/parser": "^2.4.0",
+		"@terrazzo/plugin-css": "^2.4.0",
+		"@terrazzo/token-tools": "^2.4.0",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -284,17 +284,17 @@
 	/* 2x extra large surface width */
 	--wpds-dimension-surface-width-2xl: 960px;
 	/* For sections and containers that group related content and controls, which may overlap other content. Example: Preview Frame. */
-	--wpds-elevation-xs: 0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005,
-		0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003;
+	--wpds-elevation-xs: 0px 1px 1px 0px #00000008, 0px 1px 2px 0px #00000005,
+		0px 3px 3px 0px #00000005, 0px 4px 4px 0px #00000003;
 	/* For components that provide contextual feedback without being intrusive. Generally non-interruptive. Example: Tooltips, Snackbar. */
-	--wpds-elevation-sm: 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a,
-		0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005;
+	--wpds-elevation-sm: 0px 1px 2px 0px #0000000d, 0px 2px 3px 0px #0000000a,
+		0px 6px 6px 0px #00000008, 0px 8px 8px 0px #00000005;
 	/* For components that offer additional actions. Example: Menus, Command Palette */
-	--wpds-elevation-md: 0 2px 3px 0 #0000000d, 0 4px 5px 0 #0000000a,
-		0 12px 12px 0 #00000008, 0 16px 16px 0 #00000005;
+	--wpds-elevation-md: 0px 2px 3px 0px #0000000d, 0px 4px 5px 0px #0000000a,
+		0px 12px 12px 0px #00000008, 0px 16px 16px 0px #00000005;
 	/* For components that confirm decisions or handle necessary interruptions. Example: Modals. */
-	--wpds-elevation-lg: 0 5px 15px 0 #00000014, 0 15px 27px 0 #00000012,
-		0 30px 36px 0 #0000000a, 0 50px 43px 0 #00000005;
+	--wpds-elevation-lg: 0px 5px 15px 0px #00000014, 0px 15px 27px 0px #00000012,
+		0px 30px 36px 0px #0000000a, 0px 50px 43px 0px #00000005;
 	/* Micro-delays and transition offsets */
 	--wpds-motion-duration-xs: 50ms;
 	/* Micro-interactions like focus rings and state changes */
@@ -361,15 +361,15 @@
 [data-wpds-corner-radius='none'],
 :root:has( [data-wpds-root-provider='true'][data-wpds-corner-radius='none'] ) {
 	/* Buttons and other elements nested inside controls. */
-	--wpds-border-radius-xs: 0;
+	--wpds-border-radius-xs: 0px;
 	/* Standalone buttons, inputs, and compact controls. */
-	--wpds-border-radius-sm: 0;
+	--wpds-border-radius-sm: 0px;
 	/* Menus, popovers, and other small portaled overlays. */
-	--wpds-border-radius-md: 0;
+	--wpds-border-radius-md: 0px;
 	/* Cards, dialogs, notices, and other larger content containers. */
-	--wpds-border-radius-lg: 0;
+	--wpds-border-radius-lg: 0px;
 	/* Page and app shell surfaces. */
-	--wpds-border-radius-xl: 0;
+	--wpds-border-radius-xl: 0px;
 }
 
 [data-wpds-corner-radius='subtle'],

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -156,13 +156,13 @@ export default {
 	'--wpds-dimension-surface-width-xl': '720px',
 	'--wpds-dimension-surface-width-xs': '240px',
 	'--wpds-elevation-lg':
-		'0 5px 15px 0 #00000014, 0 15px 27px 0 #00000012, 0 30px 36px 0 #0000000a, 0 50px 43px 0 #00000005',
+		'0px 5px 15px 0px #00000014, 0px 15px 27px 0px #00000012, 0px 30px 36px 0px #0000000a, 0px 50px 43px 0px #00000005',
 	'--wpds-elevation-md':
-		'0 2px 3px 0 #0000000d, 0 4px 5px 0 #0000000a, 0 12px 12px 0 #00000008, 0 16px 16px 0 #00000005',
+		'0px 2px 3px 0px #0000000d, 0px 4px 5px 0px #0000000a, 0px 12px 12px 0px #00000008, 0px 16px 16px 0px #00000005',
 	'--wpds-elevation-sm':
-		'0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005',
+		'0px 1px 2px 0px #0000000d, 0px 2px 3px 0px #0000000a, 0px 6px 6px 0px #00000008, 0px 8px 8px 0px #00000005',
 	'--wpds-elevation-xs':
-		'0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003',
+		'0px 1px 1px 0px #00000008, 0px 1px 2px 0px #00000005, 0px 3px 3px 0px #00000005, 0px 4px 4px 0px #00000003',
 	'--wpds-motion-duration-lg': '300ms',
 	'--wpds-motion-duration-md': '200ms',
 	'--wpds-motion-duration-sm': '100ms',

--- a/packages/theme/src/prebuilt/scss/design-token-fallbacks.scss
+++ b/packages/theme/src/prebuilt/scss/design-token-fallbacks.scss
@@ -158,13 +158,13 @@ $fallbacks: (
 	'--wpds-dimension-surface-width-xl': '720px',
 	'--wpds-dimension-surface-width-xs': '240px',
 	'--wpds-elevation-lg':
-		'0 5px 15px 0 #00000014, 0 15px 27px 0 #00000012, 0 30px 36px 0 #0000000a, 0 50px 43px 0 #00000005',
+		'0px 5px 15px 0px #00000014, 0px 15px 27px 0px #00000012, 0px 30px 36px 0px #0000000a, 0px 50px 43px 0px #00000005',
 	'--wpds-elevation-md':
-		'0 2px 3px 0 #0000000d, 0 4px 5px 0 #0000000a, 0 12px 12px 0 #00000008, 0 16px 16px 0 #00000005',
+		'0px 2px 3px 0px #0000000d, 0px 4px 5px 0px #0000000a, 0px 12px 12px 0px #00000008, 0px 16px 16px 0px #00000005',
 	'--wpds-elevation-sm':
-		'0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005',
+		'0px 1px 2px 0px #0000000d, 0px 2px 3px 0px #0000000a, 0px 6px 6px 0px #00000008, 0px 8px 8px 0px #00000005',
 	'--wpds-elevation-xs':
-		'0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003',
+		'0px 1px 1px 0px #00000008, 0px 1px 2px 0px #00000005, 0px 3px 3px 0px #00000005, 0px 4px 4px 0px #00000003',
 	'--wpds-motion-duration-lg': '300ms',
 	'--wpds-motion-duration-md': '200ms',
 	'--wpds-motion-duration-sm': '100ms',


### PR DESCRIPTION
## What?

Updates the `@terrazzo/*` token tooling in `@wordpress/theme` from `^2.0.3` to `^2.4.0` (`@terrazzo/parser`, `@terrazzo/plugin-css`, `@terrazzo/token-tools`) and regenerates the prebuilt design-token files to match.

Extracted out of #79618 — pulling the dependency-version changes into their own focused PRs so the follow-up `package-lock.json` dedupe stays limited to the lockfile.

## Why?

`@terrazzo/token-tools` 2.4.0 serializes zero-valued dimensions with an explicit `0px` unit (box-shadow offsets, border radii) instead of a bare `0`. Without this PR, that newer version would otherwise arrive silently via a transitive bump and rewrite the committed token files as a side effect of unrelated work. Updating the whole `@terrazzo` suite together (rather than letting only `token-tools` drift up) keeps the versions coherent and the regeneration reviewable on its own.

## How?

- Bump the three `@terrazzo/*` ranges in `packages/theme/package.json` to `^2.4.0` and `npm install`.
- Rebuilt the design tokens, regenerating:
    - `packages/theme/src/prebuilt/css/design-tokens.css`
    - `packages/theme/src/prebuilt/js/design-token-fallbacks.mjs`
    - `packages/theme/src/prebuilt/scss/design-token-fallbacks.scss`

The only output change is `0` → `0px` for zero values in the elevation and border-radius tokens.

## Testing Instructions

1. `npm ci`
2. `npm run build` — completes cleanly with no further `src/prebuilt` drift.
3. `npm run test:unit packages/theme` — passes.

## Use of AI Tools

AI (Claude Code) assisted with the bump and drafting this description. All changes were reviewed by the author.
