### PR TITLE
fix: add wp-site-blocks class to `MemoizedBlockList`

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -108,7 +108,10 @@ function ScaledBlockPreview( {
 			>
 				<EditorStyles styles={ editorStyles } />
 				{ contentResizeListener }
-				<MemoizedBlockList renderAppender={ false } />
+				<MemoizedBlockList
+					renderAppender={ false }
+					className="wp-site-blocks"
+				/>
 			</Iframe>
 		</Disabled>
 	);


### PR DESCRIPTION
## What?
Closes #69492 

## Why?
blockGap set in theme.json under styles.spacing.blockGap has no visible effect in template thumbnails on the Site Editor's Templates list page. The thumbnails look flat/unspaced even when the full template editor renders the gap correctly.

Root cause: The CSS that drives blockGap targets .wp-site-blocks:

:root :where(.wp-site-blocks) > * { margin-block-start: <gap>; margin-block-end: 0; }

The full template editor passes className="wp-site-blocks" to BlockList in VisualEditor. But the template thumbnail path — BlockPreview → AutoBlockPreview → ScaledBlockPreview — renders BlockList with no className, so the selector never matches inside the preview iframe and the gap is invisible.

Fix: Pass className="wp-site-blocks" to MemoizedBlockList in ScaledBlockPreview (packages/block-editor/src/components/block-preview/auto.js), bringing it in line with what VisualEditor already does.

## How?
The fix is a single change in ScaledBlockPreview (packages/block-editor/src/components/block-preview/auto.js):

```js
// Before
<MemoizedBlockList renderAppender={ false } />
```

```js
// After
<MemoizedBlockList renderAppender={ false } className="wp-site-blocks" />
```

## Testing Instructions
1. Activate the Twenty Twenty-Five theme (it already has styles.spacing.blockGap: "1.2rem" in its theme.json).
2. Open the Site Editor → Templates list.
3. Observe the template thumbnails — blocks should have visible vertical spacing between them matching the theme's blockGap value.

Before this fix: thumbnails showed no gap between blocks regardless of what blockGap was set to in theme.json.
After this fix: thumbnails reflect the correct blockGap spacing, matching what you see when opening the template in the full editor.

## Use of AI Tools

Claude Code
