### PR TITLE
Upgrade browserslist to ^4.28.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20386,6 +20386,18 @@
 				}
 			]
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.40",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+			"integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -20845,9 +20857,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"version": "4.28.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+			"integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -20864,10 +20876,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001726",
-				"electron-to-chromium": "^1.5.173",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.38",
+				"caniuse-lite": "^1.0.30001799",
+				"electron-to-chromium": "^1.5.376",
+				"node-releases": "^2.0.48",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -21261,9 +21274,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001793",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -24490,9 +24503,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.194",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
-			"integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
+			"version": "1.5.380",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+			"integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
 			"license": "ISC"
 		},
 		"node_modules/elliptic": {
@@ -34932,10 +34945,13 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-			"license": "MIT"
+			"version": "2.0.50",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+			"integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nopt": {
 			"version": "8.1.0",
@@ -45202,9 +45218,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -47684,7 +47700,7 @@
 				"@babel/preset-typescript": "^7.25.7",
 				"@wordpress/browserslist-config": "file:../browserslist-config",
 				"@wordpress/warning": "file:../warning",
-				"browserslist": "^4.21.10",
+				"browserslist": "^4.28.4",
 				"core-js": "^3.31.0",
 				"react": "^18.3.1"
 			},
@@ -48329,7 +48345,7 @@
 			"version": "6.49.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"browserslist": "^4.21.10"
+				"browserslist": "^4.28.4"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -52743,7 +52759,7 @@
 				"adm-zip": "^0.5.9",
 				"babel-jest": "^29.7.0",
 				"babel-loader": "^9.2.1",
-				"browserslist": "^4.21.10",
+				"browserslist": "^4.28.4",
 				"chalk": "^4.1.1",
 				"check-node-version": "^4.1.0",
 				"copy-webpack-plugin": "^10.2.0",

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -46,7 +46,7 @@
 		"@babel/preset-typescript": "^7.25.7",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/warning": "file:../warning",
-		"browserslist": "^4.21.10",
+		"browserslist": "^4.28.4",
 		"core-js": "^3.31.0",
 		"react": "^18.3.1"
 	},

--- a/packages/babel-preset-default/test/fixtures/polyfill.js
+++ b/packages/babel-preset-default/test/fixtures/polyfill.js
@@ -2,5 +2,5 @@
 // core-js dependencies are updated.
 // It should always test a feature that is supported, but requires
 // a polyfill to work across all supported browsers.
-const foo = new URLSearchParams();
-window.fooSize = foo.size;
+const { promise } = Promise.withResolvers();
+window.promise = promise;

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -32,7 +32,7 @@
 		"./package.json": "./package.json"
 	},
 	"devDependencies": {
-		"browserslist": "^4.21.10"
+		"browserslist": "^4.28.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,7 @@
 		"adm-zip": "^0.5.9",
 		"babel-jest": "^29.7.0",
 		"babel-loader": "^9.2.1",
-		"browserslist": "^4.21.10",
+		"browserslist": "^4.28.4",
 		"chalk": "^4.1.1",
 		"check-node-version": "^4.1.0",
 		"copy-webpack-plugin": "^10.2.0",


### PR DESCRIPTION
## What?

Extracted out of #79618

Upgrades `browserslist` from `^4.21.10` to `^4.28.4` across the packages that declare it (`@wordpress/babel-preset-default`, `@wordpress/browserslist-config`, `@wordpress/scripts`), refreshing the resolved browser data (`caniuse-lite` and friends).

## Why?

Keeps the browser-support data current. Doing it deliberately here means a later `package-lock.json` dedupe won't have to carry this bump (and its test fallout) as an incidental side effect.

## How?

- Bump the `browserslist` range to `^4.28.4` in the three packages and `npm install` to regenerate the lockfile. The only lockfile changes are the browserslist family: `browserslist`, `caniuse-lite`, `electron-to-chromium`, `node-releases`, `update-browserslist-db` (and the new `baseline-browser-mapping`).
- Update the `babel-preset-default` polyfill fixture. Its test asserts that a polyfill magic comment is emitted for a feature that's used but not supported across all target browsers. The newer `caniuse-lite` data now considers `URLSearchParams.prototype.size` universally supported, so no polyfill is injected for it anymore. The fixture is switched to `Promise.withResolvers()`, which still requires a polyfill under the current targets (verified against the preset).

## Testing Instructions

1. `npm ci`
2. `npm run build` — completes cleanly.
3. `npm run test:unit packages/babel-preset-default` — passes.

## Use of AI Tools

AI (Claude Code) assisted with the bump, probing the preset for a still-polyfilled feature for the fixture, and drafting this description. All changes were reviewed by the author.
