### PR TITLE
Dedupe @testing-library/dom to a single 10.4.1 in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14184,22 +14184,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/dom": {
-			"version": "9.3.4",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
-			"integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
 				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.1.3",
-				"chalk": "^4.1.0",
+				"aria-query": "5.3.0",
 				"dom-accessibility-api": "^0.5.9",
 				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
 				"pretty-format": "^27.0.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
@@ -14215,48 +14216,14 @@
 			}
 		},
 		"node_modules/@testing-library/dom/node_modules/aria-query": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"deep-equal": "^2.0.5"
+				"dequal": "^2.0.3"
 			}
-		},
-		"node_modules/@testing-library/dom/node_modules/deep-equal": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-			"integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-			"dev": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.0",
-				"call-bind": "^1.0.2",
-				"es-get-iterator": "^1.1.3",
-				"get-intrinsic": "^1.2.1",
-				"is-arguments": "^1.1.1",
-				"is-array-buffer": "^3.0.2",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.0",
-				"side-channel": "^1.0.4",
-				"which-boxed-primitive": "^1.0.2",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.9"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/@testing-library/dom/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
 		},
 		"node_modules/@testing-library/dom/node_modules/pretty-format": {
 			"version": "27.5.1",
@@ -24792,32 +24759,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/es-get-iterator": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
-				"has-symbols": "^1.0.3",
-				"is-arguments": "^1.1.1",
-				"is-map": "^2.0.2",
-				"is-set": "^2.0.2",
-				"is-string": "^1.0.7",
-				"isarray": "^2.0.5",
-				"stop-iteration-iterator": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es-get-iterator/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
-		},
 		"node_modules/es-iterator-helpers": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
@@ -28791,22 +28732,6 @@
 			"dependencies": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -36207,22 +36132,6 @@
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -47518,71 +47427,6 @@
 				}
 			}
 		},
-		"packages/admin-ui/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/admin-ui/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/admin-ui/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/admin-ui/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/admin-ui/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/annotations": {
 			"name": "@wordpress/annotations",
 			"version": "3.49.0",
@@ -47809,71 +47653,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/block-directory/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/block-directory/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/block-directory/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/block-directory/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/block-directory/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/block-editor": {
 			"name": "@wordpress/block-editor",
 			"version": "15.22.0",
@@ -47955,49 +47734,6 @@
 				}
 			}
 		},
-		"packages/block-editor/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/block-editor/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/block-editor/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"packages/block-editor/node_modules/diff": {
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -48023,28 +47759,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"license": "MIT"
-		},
-		"packages/block-editor/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/block-editor/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"packages/block-library": {
@@ -48135,71 +47849,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/arraypress"
 			}
-		},
-		"packages/block-library/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/block-library/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/block-library/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/block-library/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/block-library/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/block-serialization-default-parser": {
 			"name": "@wordpress/block-serialization-default-parser",
@@ -48464,49 +48113,6 @@
 				"@emotion/utils": "^1.4.2"
 			}
 		},
-		"packages/components/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/components/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/components/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"packages/components/node_modules/framer-motion": {
 			"version": "11.15.0",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
@@ -48539,21 +48145,6 @@
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
 			"license": "MIT"
 		},
-		"packages/components/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
 		"packages/components/node_modules/react-colorful": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
@@ -48563,13 +48154,6 @@
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"
 			}
-		},
-		"packages/components/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/compose": {
 			"name": "@wordpress/compose",
@@ -48609,71 +48193,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/compose/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/compose/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/compose/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/compose/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/compose/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/connectors": {
 			"name": "@wordpress/connectors",
@@ -49007,31 +48526,11 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
-		"packages/core-data/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"packages/core-data/node_modules/@testing-library/dom/node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
+			"extraneous": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -49044,7 +48543,7 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
+			"extraneous": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
@@ -49059,18 +48558,8 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
+			"extraneous": true,
 			"license": "MIT"
-		},
-		"packages/core-data/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
 		},
 		"packages/core-data/node_modules/babel-plugin-istanbul": {
 			"version": "7.0.1",
@@ -49582,71 +49071,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/customize-widgets/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/customize-widgets/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/customize-widgets/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/customize-widgets/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/customize-widgets/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/dashboard-init": {
 			"name": "@wordpress/dashboard-init",
 			"version": "1.0.0",
@@ -49718,71 +49142,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"packages/data/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/data/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/data/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/data/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/data/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/dataviews": {
 			"name": "@wordpress/dataviews",
 			"version": "17.0.0",
@@ -49835,71 +49194,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/dataviews/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/dataviews/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/dataviews/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/dataviews/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/dataviews/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/dataviews/node_modules/storybook/node_modules/esbuild": {
 			"version": "0.25.12",
@@ -50170,71 +49464,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/edit-post/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/edit-post/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/edit-post/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/edit-post/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/edit-post/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
 			"version": "6.49.0",
@@ -50366,71 +49595,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/edit-widgets/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/edit-widgets/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/edit-widgets/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/edit-widgets/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/edit-widgets/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
 			"version": "14.49.0",
@@ -50514,49 +49678,6 @@
 				}
 			}
 		},
-		"packages/editor/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/editor/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/editor/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"packages/editor/node_modules/diff": {
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -50565,28 +49686,6 @@
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"packages/editor/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/editor/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/element": {
 			"name": "@wordpress/element",
@@ -50610,71 +49709,6 @@
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
-		},
-		"packages/element/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/element/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/element/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/element/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/element/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/env": {
 			"name": "@wordpress/env",
@@ -50989,71 +50023,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/format-library/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/format-library/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/format-library/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/format-library/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/format-library/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/global-styles-engine": {
 			"name": "@wordpress/global-styles-engine",
 			"version": "1.16.0",
@@ -51123,71 +50092,6 @@
 				}
 			}
 		},
-		"packages/global-styles-ui/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/global-styles-ui/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/global-styles-ui/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/global-styles-ui/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/global-styles-ui/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/grid": {
 			"name": "@wordpress/grid",
 			"version": "0.1.0",
@@ -51224,71 +50128,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/grid/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/grid/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/grid/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/grid/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/grid/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/hooks": {
 			"name": "@wordpress/hooks",
@@ -51449,71 +50288,6 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
-		},
-		"packages/interface/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/interface/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/interface/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/interface/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/interface/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/is-shallow-equal": {
 			"name": "@wordpress/is-shallow-equal",
@@ -51766,71 +50540,6 @@
 				}
 			}
 		},
-		"packages/media-editor/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/media-editor/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/media-editor/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/media-editor/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/media-editor/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/media-fields": {
 			"name": "@wordpress/media-fields",
 			"version": "0.14.0",
@@ -51870,71 +50579,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/media-fields/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/media-fields/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/media-fields/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/media-fields/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/media-fields/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/media-utils": {
 			"name": "@wordpress/media-utils",
@@ -51977,71 +50621,6 @@
 				}
 			}
 		},
-		"packages/media-utils/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/media-utils/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/media-utils/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/media-utils/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/media-utils/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"packages/notices": {
 			"name": "@wordpress/notices",
 			"version": "5.49.0",
@@ -52070,71 +50649,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/notices/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/notices/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/notices/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/notices/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/notices/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/npm-package-json-lint-config": {
 			"name": "@wordpress/npm-package-json-lint-config",
@@ -52169,71 +50683,6 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
-		},
-		"packages/nux/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/nux/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/nux/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/nux/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/nux/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/patterns": {
 			"name": "@wordpress/patterns",
@@ -52300,71 +50749,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/plugins/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/plugins/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/plugins/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/plugins/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/plugins/node_modules/pretty-format/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/plugins/node_modules/react-is": {
 			"version": "18.3.1",
@@ -53731,49 +52115,6 @@
 				}
 			}
 		},
-		"packages/theme/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/theme/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/theme/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"packages/theme/node_modules/colorjs.io": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
@@ -53783,28 +52124,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/color"
 			}
-		},
-		"packages/theme/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/theme/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/token-list": {
 			"name": "@wordpress/token-list",
@@ -53859,71 +52178,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/ui/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/ui/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/ui/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/ui/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/ui/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/undo-manager": {
 			"name": "@wordpress/undo-manager",
@@ -54010,71 +52264,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/viewport/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/viewport/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/viewport/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/viewport/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/viewport/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/views": {
 			"name": "@wordpress/views",
@@ -54173,71 +52362,6 @@
 					"optional": true
 				}
 			}
-		},
-		"packages/widget-dashboard/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"packages/widget-dashboard/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/widget-dashboard/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"packages/widget-dashboard/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"packages/widget-dashboard/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"packages/widget-primitives": {
 			"name": "@wordpress/widget-primitives",
@@ -54427,71 +52551,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"routes/connectors-home/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"routes/connectors-home/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"routes/connectors-home/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"routes/connectors-home/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"routes/connectors-home/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"routes/content-types": {
 			"name": "@wordpress/content-types-route",
 			"version": "1.0.0",
@@ -54529,71 +52588,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0"
 			}
-		},
-		"routes/dashboard/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"routes/dashboard/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"routes/dashboard/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
-		"routes/dashboard/node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"routes/dashboard/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"routes/experiments-home": {
 			"name": "@wordpress/experiments-home-route",

--- a/packages/block-editor/src/components/link-picker/test/index.js
+++ b/packages/block-editor/src/components/link-picker/test/index.js
@@ -141,7 +141,9 @@ describe( 'LinkPicker', () => {
 			);
 
 			const button = screen.getByRole( 'button' );
-			const image = within( button ).getByRole( 'img', { hidden: true } );
+			const image = within( button ).getByRole( 'presentation', {
+				hidden: true,
+			} );
 
 			expect( image ).toHaveAttribute(
 				'src',

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -217,7 +217,7 @@ describe( 'Cover block', () => {
 			await selectBlock( 'Block: Cover' );
 			expect(
 				within( screen.getByLabelText( 'Block: Cover' ) ).getByRole(
-					'img'
+					'presentation'
 				)
 			).toBeInTheDocument();
 
@@ -232,7 +232,7 @@ describe( 'Cover block', () => {
 
 			expect(
 				within( screen.getByLabelText( 'Block: Cover' ) ).queryByRole(
-					'img'
+					'presentation'
 				)
 			).not.toBeInTheDocument();
 		} );
@@ -318,7 +318,7 @@ describe( 'Cover block', () => {
 
 			expect(
 				within( screen.getByLabelText( 'Block: Cover' ) ).getByRole(
-					'img'
+					'presentation'
 				)
 			).toHaveStyle( 'object-position: 100% 50%;' );
 		} );


### PR DESCRIPTION
## What?

Dedupes `@testing-library/dom` in `package-lock.json` to a single hoisted `10.4.1`, removing a stale root `9.3.4` and ~30 redundant nested copies (−153 lockfile entries). No `package.json` changes.

Extracted out of #79618 — splitting the behavior-relevant pieces of the `package-lock.json` dedupe into focused PRs.

## Why?

The lockfile pinned `@testing-library/dom@9.3.4` at the root while ~28 workspace packages each carried their own nested `10.4.1`. Nothing actually requires v9 — every consumer's range is satisfied by `10.4.1`:

| Consumer | Range |
|---|---|
| `@ariakit/test` | `^8 \|\| ^9 \|\| ^10` |
| `@testing-library/user-event` | `>=7.21.4` |
| `eslint-plugin-jest-dom` | `^8 \|\| ^9 \|\| ^10` |
| `@testing-library/react` | `^10.0.0` |
| workspace packages (×28) | `^10.4.1` |

The `9.3.4` is a leftover hoist from npm's incremental install history (npm never re-hoists an already-satisfied dependency). Collapsing it ahead of a broader `package-lock.json` dedupe keeps that follow-up focused.

## How?

- Temporarily added an `overrides` entry (`@testing-library/dom: ^10.4.1`), forced npm to re-resolve, then removed the override — leaving a lockfile that hoists a single `10.4.1` and stays valid without the override.
- This also collapses the transitive `aria-query` to `5.3.x`, which maps `<img alt="">` to the `presentation` role instead of `img`. The `cover` and `link-picker` tests are updated to query the decorative images by `presentation` accordingly.

## Testing Instructions

1. `npm ci`
2. `npm run test:unit` — passes (full suite).
3. Spot-check: `npm run test:unit packages/block-library/src/cover packages/block-editor/src/components/link-picker`.

## Use of AI Tools

AI (Claude Code) assisted with diagnosing the stale resolution, performing the override-based collapse, updating the affected tests, and drafting this description. All changes were reviewed by the author.
