### PR TITLE
Update webpack to 5.108.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,12 +111,6 @@
 				"url": "https://github.com/sponsors/philsturgeon"
 			}
 		},
-		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/@types/json-schema": {
-			"version": "7.0.15",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
-		},
 		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3379,12 +3373,6 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
-		},
-		"node_modules/@eslint/core/node_modules/@types/json-schema": {
-			"version": "7.0.15",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
 			"version": "10.0.1",
@@ -14536,25 +14524,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/eslint": {
-			"version": "8.56.9",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz",
-			"integrity": "sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==",
-			"dependencies": {
-				"@types/estree": "*",
-				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -14562,9 +14531,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/express": {
 			"version": "4.17.17",
@@ -14671,9 +14641,10 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -19109,6 +19080,18 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-phases": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"peerDependencies": {
+				"acorn": "^8.14.0"
 			}
 		},
 		"node_modules/acorn-jsx": {
@@ -25530,12 +25513,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/eslint/node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"license": "MIT"
-		},
 		"node_modules/eslint/node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -27504,11 +27481,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
 		},
 		"node_modules/global-modules": {
 			"version": "2.0.0",
@@ -34155,6 +34127,135 @@
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/minimizer-webpack-plugin/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/minipass": {
@@ -45979,34 +46080,33 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/webpack": {
-			"version": "5.97.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.0.tgz",
-			"integrity": "sha512-CWT8v7ShSfj7tGs4TLRtaOLmOCPWhoKEvp+eA7FVx8Xrjb3XfT0aXdxDItnRZmE8sHcH+a8ayDrJCOjXKxVFfQ==",
+			"version": "5.108.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.1.tgz",
+			"integrity": "sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
-				"@types/estree": "^1.0.6",
+				"@types/estree": "^1.0.8",
+				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.14.0",
-				"browserslist": "^4.24.0",
+				"acorn": "^8.16.0",
+				"acorn-import-phases": "^1.0.3",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.1",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.22.2",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
-				"mime-types": "^2.1.27",
+				"loader-runner": "^4.3.2",
+				"mime-db": "^1.54.0",
+				"minimizer-webpack-plugin": "^5.6.1",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.2.0",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.10",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.2.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"watchpack": "^2.5.2",
+				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -46403,9 +46503,10 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+			"integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -46415,12 +46516,6 @@
 			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
 			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/webpack/node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/@webassemblyjs/ast": {
@@ -46553,9 +46648,9 @@
 			}
 		},
 		"node_modules/webpack/node_modules/acorn": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -46564,33 +46659,36 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/webpack/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+		"node_modules/webpack/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3"
 			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
+			"peerDependencies": {
+				"ajv": "^8.8.2"
 			}
 		},
 		"node_modules/webpack/node_modules/enhanced-resolve": {
-			"version": "5.17.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+			"version": "5.24.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+			"integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/webpack/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/eslint-scope": {
 			"version": "5.1.1",
@@ -46605,21 +46703,37 @@
 			}
 		},
 		"node_modules/webpack/node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+			"integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.11.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/webpack/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/webpack/node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+			"license": "MIT",
 			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -46630,20 +46744,24 @@
 			}
 		},
 		"node_modules/webpack/node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/webpack/node_modules/watchpack": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+			"integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
 			"license": "MIT",
 			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			},
 			"engines": {
@@ -49280,7 +49398,8 @@
 				"glob": "^7.1.2",
 				"lodash": "^4.17.21",
 				"mini-css-extract-plugin": "^2.9.2",
-				"mkdirp": "^3.0.1"
+				"mkdirp": "^3.0.1",
+				"webpack": "^5.108.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -49827,12 +49946,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"packages/eslint-plugin/node_modules/@es-joy/jsdoccomment/node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"license": "MIT"
 		},
 		"packages/eslint-plugin/node_modules/@types/eslint": {
 			"version": "9.6.1",
@@ -51185,7 +51298,7 @@
 				"stylelint": "^16.8.2",
 				"terser-webpack-plugin": "^5.3.10",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.97.0",
+				"webpack": "^5.108.1",
 				"webpack-bundle-analyzer": "^4.9.1",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1"

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Extract dynamically imported external modules that webpack code-splits into their own async chunk in the module build ([#79633](https://github.com/WordPress/gutenberg/pull/79633)).
+
 ## 6.49.0 (2026-06-24)
 
 ## 6.48.1 (2026-06-16)

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -296,12 +296,24 @@ class DependencyExtractionWebpackPlugin {
 
 			/**
 			 * @param {webpack.Module} m
+			 * @param {boolean}        [fromAsyncChunk] Module was found in an
+			 *                                          async chunk of the entry.
 			 */
-			const processModule = ( m ) => {
+			const processModule = ( m, fromAsyncChunk ) => {
 				const { userRequest } = m;
 				if ( this.externalizedDeps.has( userRequest ) ) {
 					if ( this.useModules ) {
+						// A static occurrence (in the entry chunk) wins.
+						if (
+							fromAsyncChunk &&
+							chunkStaticDeps.has( m.request )
+						) {
+							return;
+						}
+						// Externals in an async chunk are reached via a dynamic
+						// import by definition.
 						const isStatic =
+							! fromAsyncChunk &&
 							DependencyExtractionWebpackPlugin.hasStaticDependencyPathToRoot(
 								compilation,
 								m
@@ -318,16 +330,49 @@ class DependencyExtractionWebpackPlugin {
 				}
 			};
 
-			// Search for externalized modules in all chunks.
-			for ( const chunkModule of compilation.chunkGraph.getChunkModulesIterable(
-				chunk
-			) ) {
-				processModule( chunkModule );
-				// Loop through submodules of ConcatenatedModule.
-				if ( chunkModule.modules ) {
-					for ( const concatModule of chunkModule.modules ) {
-						processModule( concatModule );
+			/**
+			 * @param {webpack.Chunk} searchChunk
+			 * @param {boolean}       [fromAsyncChunk]
+			 */
+			const processChunkModules = ( searchChunk, fromAsyncChunk ) => {
+				for ( const chunkModule of compilation.chunkGraph.getChunkModulesIterable(
+					searchChunk
+				) ) {
+					processModule( chunkModule, fromAsyncChunk );
+					// Loop through submodules of ConcatenatedModule.
+					if ( chunkModule.modules ) {
+						for ( const concatModule of chunkModule.modules ) {
+							processModule( concatModule, fromAsyncChunk );
+						}
 					}
+				}
+			};
+
+			processChunkModules( chunk );
+
+			/*
+			 * Also search the entry's async chunks: webpack can code-split a
+			 * dynamically imported external into its own chunk.
+			 */
+			for ( const group of chunk.groupsIterable ) {
+				if (
+					typeof group.getEntrypointChunk !== 'function' ||
+					group.getEntrypointChunk() !== chunk
+				) {
+					continue;
+				}
+				const seenGroups = new Set();
+				const groupQueue = [ ...group.getChildren() ];
+				while ( groupQueue.length ) {
+					const childGroup = groupQueue.pop();
+					if ( seenGroups.has( childGroup ) ) {
+						continue;
+					}
+					seenGroups.add( childGroup );
+					for ( const asyncChunk of childGroup.chunks ) {
+						processChunkModules( asyncChunk, true );
+					}
+					groupQueue.push( ...childGroup.getChildren() );
 				}
 			}
 

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -46,7 +46,8 @@
 		"glob": "^7.1.2",
 		"lodash": "^4.17.21",
 		"mini-css-extract-plugin": "^2.9.2",
-		"mkdirp": "^3.0.1"
+		"mkdirp": "^3.0.1",
+		"webpack": "^5.108.1"
 	},
 	"peerDependencies": {
 		"webpack": "^5.0.0"

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -154,6 +154,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` sh
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '545e35ddcaa625ec66be', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "module",
+    "request": "@wordpress/interactivity",
+    "userRequest": "@wordpress/interactivity",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '1e17a24e97ed7776722f', 'type' => 'module');
 "
@@ -551,6 +566,24 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` sh
       "renamed--other-module",
     ],
     "userRequest": "other-module",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'f106056c2c97892f532b');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "interactivity",
+    ],
+    "userRequest": "@wordpress/interactivity",
   },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -41,7 +41,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'decbc01a27e4dbb98c28', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => 'decbc01a27e4dbb98c28', 'type' => 'module');
 "
 `;
 
@@ -335,7 +335,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash'), 'version' => '19d196fe140333588868', 'type' => 'module');
+"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '19d196fe140333588868', 'type' => 'module');
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '4ab8cc4b6b7619053443', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '5c4197fd48811f25807f', 'type' => 'module'));
+"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '5202d062e624638839cf', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '610e232865e99068a0be', 'type' => 'module'));
 "
 `;
 
@@ -26,7 +26,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => '1e02dcb4017382a2799f', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => 'be216763535510675ce9', 'type' => 'module');
 "
 `;
 
@@ -41,7 +41,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '3ca651be783423315165', 'type' => 'module');
+"<?php return array('dependencies' => array(), 'version' => 'decbc01a27e4dbb98c28', 'type' => 'module');
 "
 `;
 
@@ -56,7 +56,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-depe
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '095eb9129a2ad858900d', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '8160d5c123a7103eb3c5', 'type' => 'module');
 "
 `;
 
@@ -71,7 +71,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-dep
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'import' => 'dynamic')), 'version' => 'fbb215dc4902543bce35', 'type' => 'module');
+"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'import' => 'dynamic')), 'version' => 'bb58caab8f1f94bf03ed', 'type' => 'module');
 "
 `;
 
@@ -95,7 +95,7 @@ Module not found: Error: Attempted to use WordPress script in a module: @wordpre
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
@@ -115,7 +115,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '8308f1ac78c21f09c721', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'ded8b9fa0ae5bbe26273', 'type' => 'module');
 "
 `;
 
@@ -135,7 +135,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '91070a8471d11e83a5f6', 'type' => 'module');
+"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '94912422ad4246a8b80d', 'type' => 'module');
 "
 `;
 
@@ -155,21 +155,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'fcac76462c8a830d8d92', 'type' => 'module');
+"<?php return array('dependencies' => array(), 'version' => '1e17a24e97ed7776722f', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'e37fbd452a6188261d74', 'type' => 'module');
+"<?php return array('dependencies' => array(), 'version' => '47abc9f11d44c8d2ea89', 'type' => 'module');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
@@ -189,7 +189,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
@@ -208,7 +208,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"4e62c01516f9dab8041f","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"b3f94e0b15eab389ca33","type":"module"}"`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -221,7 +221,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => '259fc706528651fc00c1', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => '440538f4e5c478ec44e7', 'type' => 'module');
 "
 `;
 
@@ -251,7 +251,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '9725ab782f6b09598d3d', 'type' => 'module');
+"<?php return array('dependencies' => array('wp-polyfill'), 'version' => 'ce3c6b76208e3e42fe21', 'type' => 'module');
 "
 `;
 
@@ -265,17 +265,17 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comm
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '8a4fbb1aeaeb24991a36', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-a');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '00ad69a407b9d8fe017b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-a');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '977c8928c68e753edad9', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-b');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '8f3ca66c17c6a5908643', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-b');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '5e629382dfc54f7deb4b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-runtime');
+"<?php return array('dependencies' => array(), 'version' => '5ab1f5b70c1a8b8e348b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-runtime');
 "
 `;
 
@@ -295,7 +295,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '22d18a3461df47fbaa79', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '3c934db1d1abd24df590', 'type' => 'module');
 "
 `;
 
@@ -315,7 +315,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'e325da3aa7dbb0c0c151', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
@@ -335,7 +335,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '3004d92fa670e58cb987', 'type' => 'module');
+"<?php return array('dependencies' => array('lodash'), 'version' => '19d196fe140333588868', 'type' => 'module');
 "
 `;
 
@@ -355,7 +355,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'ee5a6866beeb5643397c', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'c794f84248de09f057b3', 'type' => 'module');
 "
 `;
 
@@ -375,7 +375,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\`
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e1840d27f0719ffa42d3'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '1e60e007d6496c9b46cf'));
+"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e1840d27f0719ffa42d3'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7a1390bf33761ae364eb'));
 "
 `;
 
@@ -424,7 +424,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => '162f4d352c99e6c37be1');
+"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'd76f4397b70cf8945132');
 "
 `;
 
@@ -442,7 +442,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-depe
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => '4c336c2cbbbff439b43e');
+"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'dfaa91b1f8015937bb82');
 "
 `;
 
@@ -460,7 +460,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-dep
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => '29070464c1c503708675');
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'b6e6a7f3f50454805aa6');
 "
 `;
 
@@ -484,7 +484,7 @@ Module not found: Error: Ensure error in script build.
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '0633d70f7567175ad0d5');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
@@ -556,7 +556,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'be8b28b738de0d6b883a');
+"<?php return array('dependencies' => array(), 'version' => '00e44c3b74e4e22ce7be');
 "
 `;
 
@@ -570,7 +570,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should pr
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '0633d70f7567175ad0d5');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
@@ -593,7 +593,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '0633d70f7567175ad0d5');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
@@ -615,7 +615,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"b36983b739da7af0ccd4"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"e30269b38e67582b534d"}"`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -681,17 +681,17 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comm
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => 'cdbe22bb74f37e307523', 'handle' => 'runtime-chunk-single-scripts-a');
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'e8bba1440f7003e4988b', 'handle' => 'runtime-chunk-single-scripts-a');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '845bc6d4ffbdb9419ebd', 'handle' => 'runtime-chunk-single-scripts-b');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '8c8cea3e6127c51f6aac', 'handle' => 'runtime-chunk-single-scripts-b');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'efde7a3c666ea9dae180', 'handle' => 'runtime-chunk-single-scripts-runtime');
+"<?php return array('dependencies' => array(), 'version' => '2028470a91d96d4f591d', 'handle' => 'runtime-chunk-single-scripts-runtime');
 "
 `;
 
@@ -714,7 +714,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '041fb611b5192ffe83f9');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '6b9c03a10ce7f2850f41');
 "
 `;
 
@@ -737,7 +737,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '0633d70f7567175ad0d5');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
@@ -760,7 +760,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-interactivity'), 'version' => '5d6f3787a67ec0f2886d');
+"<?php return array('dependencies' => array('lodash', 'wp-interactivity'), 'version' => 'dfd7d906d8f46790f644');
 "
 `;
 
@@ -783,7 +783,7 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '7087050d1490e856fec8');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'ae7e90ce0ad991a09a13');
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/index.js
@@ -1,0 +1,3 @@
+// Two levels of dynamic import before reaching the external module, so it is
+// code-split into a nested async chunk.
+await import( './level-one.js' );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/level-one.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/level-one.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+const { store } = await import( '@wordpress/interactivity' );
+
+store( 'nested', { state: {} } );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/nested-dynamic-import/webpack.config.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -89,7 +89,7 @@
 		"stylelint": "^16.8.2",
 		"terser-webpack-plugin": "^5.3.10",
 		"url-loader": "^4.1.1",
-		"webpack": "^5.97.0",
+		"webpack": "^5.108.1",
 		"webpack-bundle-analyzer": "^4.9.1",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^4.15.1"


### PR DESCRIPTION
## What?

Updates `webpack` from `^5.97.0` to `^5.108.1` in `@wordpress/scripts` and `@wordpress/dependency-extraction-webpack-plugin`, refreshes the `dependency-extraction-webpack-plugin` asset snapshots, and adapts the plugin to a webpack change in how dynamically-imported externals are placed in chunks.

Extracted out of #79618 — splitting the behavior-relevant pieces of the `package-lock.json` dedupe into focused PRs.

## Why?

Keeps webpack current. Doing it deliberately here means a later `package-lock.json` dedupe won't carry this bump (and the work below) as an incidental side effect.

## How?

**webpack bump**

- Bump the `webpack` range to `^5.108.1` in the two packages and `npm install` to regenerate the lockfile (webpack core plus its sub-dependencies: `acorn`, `enhanced-resolve`, `schema-utils`, `tapable`, `watchpack`, `webpack-sources`, `es-module-lexer`, …).

**Plugin change (second commit)**

While updating the `dependency-extraction-webpack-plugin` snapshots, the dynamically-imported `@wordpress/interactivity` dependency *disappeared* from the extracted output of two module-build fixtures (`cyclic-dynamic-dependency-graph`, `wordpress-interactivity`) — not a hash change, the dependency was gone. For a consumer that would mean WordPress stops registering `@wordpress/interactivity` for that module.

Root cause: in the `output.module` build, webpack 5.108 now **code-splits a dynamically-imported external into its own async chunk** (`await import( '@wordpress/interactivity' )` → a separate `*.mjs` chunk), where it no longer appears among the entry chunk's modules. The plugin only scanned the entry chunk, so those externals dropped out.

The fix:

- Also scan the entry's async descendant chunks, so dynamically-imported externals are found again.
- Classify externals found in an async chunk as `dynamic` directly. Their async-chunk placement is authoritative; webpack 5.108's scope-hoisting can otherwise make the module-graph path look static for the cyclic fixture.

With the plugin change, the extracted dependencies are **unchanged** from before — the only snapshot differences are the content-hash `version` values, which change with the new webpack.

## Testing Instructions

1. `npm ci`
2. `npm run build` — completes cleanly.
3. `npm run test:unit packages/dependency-extraction-webpack-plugin` — passes.

## Use of AI Tools

AI (Claude Code) assisted with the bump, diagnosing the dropped-dependency regression, the plugin fix (reviewed via a Codex pass), refreshing the snapshots, and drafting this description. All changes were reviewed by the author.
