### PR TITLE
FontAppearanceControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
+    -   `FontAppearanceControl` ([#79635](https://github.com/WordPress/gutenberg/pull/79635)).
     -   `FontFamilyControl` ([#79593](https://github.com/WordPress/gutenberg/pull/79593)).
     -   `LetterSpacingControl` ([#79533](https://github.com/WordPress/gutenberg/pull/79533)).
     -   `LineHeightControl` ([#79589](https://github.com/WordPress/gutenberg/pull/79589)).

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -33,30 +33,25 @@ const getFontAppearanceLabel = ( hasFontStyles, hasFontWeights ) => {
 /**
  * Control to display font style and weight options of the active font.
  *
- * @param {Object}   props                         Component props.
- * @param {boolean}  [props.__next40pxDefaultSize] Start opting into the larger default height that will become the default size in a future version.
- * @param {Function} props.onChange                Handles change in font appearance selection.
- * @param {boolean}  [props.hasFontStyles]         Whether font styles are enabled and present.
- * @param {boolean}  [props.hasFontWeights]        Whether font weights are enabled and present.
- * @param {Array}    props.fontFamilyFaces         Font family faces for the active font.
- * @param {Object}   props.value                   Currently selected font style and weight.
- * @param {string}   props.value.fontStyle         Currently selected font style.
- * @param {string}   props.value.fontWeight        Currently selected font weight.
- * @param {Array}    [props.options]               Options override.
+ * @param {Object} props Component props.
  *
  * @return {Element} Font appearance control.
  */
-export default function FontAppearanceControl( {
-	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
-	__next40pxDefaultSize: _next40pxDefaultSize,
-	onChange,
-	hasFontStyles = true,
-	hasFontWeights = true,
-	fontFamilyFaces,
-	value: { fontStyle, fontWeight },
-	options,
-	...otherProps
-} ) {
+export default function FontAppearanceControl( props ) {
+	const {
+		/**
+		 * Start opting into the larger default height that will become the default size in a future version.
+		 *
+		 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+		 */
+		__next40pxDefaultSize: _next40pxDefaultSize,
+		onChange,
+		hasFontStyles = true,
+		hasFontWeights = true,
+		fontFamilyFaces,
+		value: { fontStyle, fontWeight },
+		...otherProps
+	} = props;
 	const hasStylesOrWeights = hasFontStyles || hasFontWeights;
 	const label = getFontAppearanceLabel( hasFontStyles, hasFontWeights );
 	const defaultOption = {
@@ -111,7 +106,12 @@ export default function FontAppearanceControl( {
 
 		// Display only font style options or font weight options.
 		return hasFontStyles ? styleOptions() : weightOptions();
-	}, [ options, fontStyles, fontWeights, combinedStyleAndWeightOptions ] );
+	}, [
+		props.options,
+		fontStyles,
+		fontWeights,
+		combinedStyleAndWeightOptions,
+	] );
 
 	// Find current selection by comparing font style & weight against options,
 	// and fall back to the Default option if there is no matching option.

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { CustomSelectControl } from '@wordpress/components';
-import deprecated from '@wordpress/deprecated';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -34,21 +33,30 @@ const getFontAppearanceLabel = ( hasFontStyles, hasFontWeights ) => {
 /**
  * Control to display font style and weight options of the active font.
  *
- * @param {Object} props Component props.
+ * @param {Object}   props                         Component props.
+ * @param {boolean}  [props.__next40pxDefaultSize] Start opting into the larger default height that will become the default size in a future version.
+ * @param {Function} props.onChange                Handles change in font appearance selection.
+ * @param {boolean}  [props.hasFontStyles]         Whether font styles are enabled and present.
+ * @param {boolean}  [props.hasFontWeights]        Whether font weights are enabled and present.
+ * @param {Array}    props.fontFamilyFaces         Font family faces for the active font.
+ * @param {Object}   props.value                   Currently selected font style and weight.
+ * @param {string}   props.value.fontStyle         Currently selected font style.
+ * @param {string}   props.value.fontWeight        Currently selected font weight.
+ * @param {Array}    [props.options]               Options override.
  *
  * @return {Element} Font appearance control.
  */
-export default function FontAppearanceControl( props ) {
-	const {
-		/** Start opting into the larger default height that will become the default size in a future version. */
-		__next40pxDefaultSize = false,
-		onChange,
-		hasFontStyles = true,
-		hasFontWeights = true,
-		fontFamilyFaces,
-		value: { fontStyle, fontWeight },
-		...otherProps
-	} = props;
+export default function FontAppearanceControl( {
+	/** @deprecated Default behavior since WordPress 7.1. Prop can be safely removed. */
+	__next40pxDefaultSize: _next40pxDefaultSize,
+	onChange,
+	hasFontStyles = true,
+	hasFontWeights = true,
+	fontFamilyFaces,
+	value: { fontStyle, fontWeight },
+	options,
+	...otherProps
+} ) {
 	const hasStylesOrWeights = hasFontStyles || hasFontWeights;
 	const label = getFontAppearanceLabel( hasFontStyles, hasFontWeights );
 	const defaultOption = {
@@ -103,12 +111,7 @@ export default function FontAppearanceControl( props ) {
 
 		// Display only font style options or font weight options.
 		return hasFontStyles ? styleOptions() : weightOptions();
-	}, [
-		props.options,
-		fontStyles,
-		fontWeights,
-		combinedStyleAndWeightOptions,
-	] );
+	}, [ options, fontStyles, fontWeights, combinedStyleAndWeightOptions ] );
 
 	// Find current selection by comparing font style & weight against options,
 	// and fall back to the Default option if there is no matching option.
@@ -148,27 +151,12 @@ export default function FontAppearanceControl( props ) {
 		);
 	};
 
-	if (
-		! __next40pxDefaultSize &&
-		( otherProps.size === undefined || otherProps.size === 'default' )
-	) {
-		deprecated(
-			`36px default size for wp.blockEditor.__experimentalFontAppearanceControl`,
-			{
-				since: '6.8',
-				version: '7.1',
-				hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
-			}
-		);
-	}
-
 	return (
 		hasStylesOrWeights && (
 			<CustomSelectControl
 				{ ...otherProps }
+				__next40pxDefaultSize
 				className="components-font-appearance-control"
-				__next40pxDefaultSize={ __next40pxDefaultSize }
-				__shouldNotWarnDeprecated36pxSize
 				label={ label }
 				describedBy={ getDescribedBy() }
 				options={ selectOptions }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -644,7 +644,6 @@ export default function TypographyPanel( {
 						hasFontStyles={ hasFontStyles }
 						hasFontWeights={ hasFontWeights }
 						fontFamilyFaces={ fontFamilyFaces }
-						size="__unstable-large"
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -11,7 +11,6 @@ The following components are checked by this rule:
 -   Button
 -   ComboboxControl
 -   CustomSelectControl
--   FontAppearanceControl
 -   FormFileUpload (special case - see below)
 -   FormTokenField
 -   InputControl

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -112,7 +112,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 				import {
 					ComboboxControl,
 					CustomSelectControl,
-					FontAppearanceControl,
 					FormTokenField,
 					InputControl,
 					NumberControl,
@@ -124,7 +123,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 				<>
 					<ComboboxControl __next40pxDefaultSize />
 					<CustomSelectControl __next40pxDefaultSize />
-					<FontAppearanceControl __next40pxDefaultSize />
 					<FormTokenField __next40pxDefaultSize />
 					<InputControl __next40pxDefaultSize />
 					<NumberControl __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -16,7 +16,6 @@ const COMPONENTS_REQUIRING_40PX = new Set( [
 	'ClipboardButton',
 	'ComboboxControl',
 	'CustomSelectControl',
-	'FontAppearanceControl',
 	'FormTokenField',
 	'IconButton',
 	'InputControl',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -174,6 +174,7 @@ const restrictedSyntax = [
 		'BorderControl',
 		'BoxControl',
 		'FocalPointPicker',
+		'FontAppearanceControl',
 		'FontFamilyControl',
 		'FontSizePicker',
 		'LetterSpacingControl',


### PR DESCRIPTION
## What?

Follow up to #65751

Remove the deprecated `__next40pxDefaultSize` prop from `FontAppearanceControl`, making the 40px default size the permanent default.

## Why?

The soft deprecation was introduced in WP 6.8 with a 36px console warning when the prop was not set. Block Editor typography wrappers are being updated before the primitives they embed.

## How?

- Hard-deprecate `__next40pxDefaultSize` on `FontAppearanceControl`: always pass `__next40pxDefaultSize` to the inner `CustomSelectControl`, remove the `deprecated()` 36px warning, and accept (but ignore) the prop for backward compatibility.
- Remove redundant `size="__unstable-large"` from the Typography panel usage.
- Remove `FontAppearanceControl` from the `components-no-missing-40px-size-prop` ESLint rule and add it to the restricted-syntax forbid list in `tools/eslint/config.mjs`.
- Document the breaking change in `@wordpress/block-editor` CHANGELOG.

## Testing Instructions

1. In the Site Editor, open **Styles > Typography** with a theme that has font families with style/weight variants (for example, Twenty Twenty-Five).
2. Select a font family and confirm the Appearance control renders at 40px height.
3. Confirm font appearance changes still work.
4. Confirm no console warnings are logged.