### PR TITLE
ComboboxControl: Hard deprecate 40px default size

### DIFF
--- a/packages/block-library/src/avatar/user-control.js
+++ b/packages/block-library/src/avatar/user-control.js
@@ -47,7 +47,6 @@ export default function UserControl( { value, onChange } ) {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			label={ __( 'User' ) }
 			help={ __(
 				'Select the avatar user to display, if it is blank it will use the post/page author.'

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -332,7 +332,6 @@ export default function PageListEdit( {
 								isShownByDefault
 							>
 								<ComboboxControl
-									__next40pxDefaultSize
 									className="editor-page-attributes__parent"
 									label={ __( 'Parent' ) }
 									value={ parentPageID }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -107,7 +107,6 @@ function AuthorCombobox( { value, onChange } ) {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			value={ value?.id }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
     -   `BorderBoxControl` ([#79420](https://github.com/WordPress/gutenberg/pull/79420))
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))
+    -   `ComboboxControl`
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `TreeSelect` ([#79550](https://github.com/WordPress/gutenberg/pull/79550))
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   The `__next40pxDefaultSize` prop is now true by default. The prop can be safely removed from the following:
     -   `BorderBoxControl` ([#79420](https://github.com/WordPress/gutenberg/pull/79420))
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))
-    -   `ComboboxControl`
+    -   `ComboboxControl` ([#79636](https://github.com/WordPress/gutenberg/pull/79636)).
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `TreeSelect` ([#79550](https://github.com/WordPress/gutenberg/pull/79550))
 

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -34,7 +34,6 @@ function MyComboboxControl() {
 	const [ filteredOptions, setFilteredOptions ] = useState( options );
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			label="Font Size"
 			value={ fontSize }
 			onChange={ setFontSize }
@@ -132,14 +131,6 @@ Custom renderer invoked for each option in the suggestion list. The render prop 
 
 -   Type: `( args: { item: object } ) => ReactNode`
 -   Required: No
-
-#### __next40pxDefaultSize
-
-Start opting into the larger default height that will become the default size in a future version.
-
-- Type: `Boolean`
-- Required: No
-- Default: `false`
 
 ## Related components
 

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -32,9 +32,7 @@ import { useControlledValue } from '../utils/hooks';
 import { normalizeTextString } from '../utils/strings';
 import type { ComboboxControlOption, ComboboxControlProps } from './types';
 import type { TokenInputProps } from '../form-token-field/types';
-import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
-import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 import Spinner from '../spinner';
 
 const noop = () => {};
@@ -94,7 +92,6 @@ const getIndexOfMatchingSuggestion = (
  * 	const [ filteredOptions, setFilteredOptions ] = useState( options );
  * 	return (
  * 		<ComboboxControl
- * 			__next40pxDefaultSize
  * 			label="Font Size"
  * 			value={ fontSize }
  * 			onChange={ setFontSize }
@@ -115,7 +112,6 @@ const getIndexOfMatchingSuggestion = (
  */
 function ComboboxControl( props: ComboboxControlProps ) {
 	const {
-		__next40pxDefaultSize = false,
 		value: valueProp,
 		label,
 		options,
@@ -132,7 +128,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		__experimentalRenderItem,
 		expandOnFocus = true,
 		placeholder,
-	} = useDeprecated36pxDefaultSizeProp( props );
+	} = props;
 
 	const [ value, setValue ] = useControlledValue( {
 		value: valueProp,
@@ -315,12 +311,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		}
 	}, [ matchingSuggestions, isExpanded ] );
 
-	maybeWarnDeprecated36pxSize( {
-		componentName: 'ComboboxControl',
-		__next40pxDefaultSize,
-		size: undefined,
-	} );
-
 	// Disable reason: There is no appropriate role which describes the
 	// input container intended accessible usability.
 	// TODO: Refactor click detection to use blur to stop propagation.
@@ -339,9 +329,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 					tabIndex={ -1 }
 					onKeyDown={ onKeyDown }
 				>
-					<InputWrapperFlex
-						__next40pxDefaultSize={ __next40pxDefaultSize }
-					>
+					<InputWrapperFlex>
 						<FlexBlock>
 							<TokenInput
 								className="components-combobox-control__input"

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -75,7 +75,6 @@ const Template: StoryFn< typeof ComboboxControl > = ( {
 	return (
 		<>
 			<ComboboxControl
-				__next40pxDefaultSize
 				{ ...args }
 				value={ value }
 				onChange={ ( ...changeArgs ) => {
@@ -88,7 +87,6 @@ const Template: StoryFn< typeof ComboboxControl > = ( {
 };
 export const Default = Template.bind( {} );
 Default.args = {
-	__next40pxDefaultSize: true,
 	label: 'Country',
 	options: countryOptions,
 	help: 'Help text to describe the control.',

--- a/packages/components/src/combobox-control/styles.ts
+++ b/packages/components/src/combobox-control/styles.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import styled from '@emotion/styled';
-
-/**
- * Internal dependencies
- */
 import { Flex } from '../flex';
 import { space } from '../utils/space';
 

--- a/packages/components/src/combobox-control/styles.ts
+++ b/packages/components/src/combobox-control/styles.ts
@@ -2,29 +2,15 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
 /**
  * Internal dependencies
  */
 import { Flex } from '../flex';
 import { space } from '../utils/space';
-import type { ComboboxControlProps } from './types';
-
-const deprecatedDefaultSize = ( {
-	__next40pxDefaultSize,
-}: Pick< ComboboxControlProps, '__next40pxDefaultSize' > ) =>
-	! __next40pxDefaultSize &&
-	css`
-		height: 28px; // 30px - 2px vertical borders on parent container
-		padding-left: ${ space( 1 ) };
-		padding-right: ${ space( 1 ) };
-	`;
 
 export const InputWrapperFlex = styled( Flex )`
 	height: 38px; // 40px - 2px vertical borders on parent container
 	padding-left: ${ space( 2 ) };
 	padding-right: ${ space( 2 ) };
-
-	${ deprecatedDefaultSize }
 `;

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -58,7 +58,7 @@ const getOptionSearchString = ( option: ComboboxControlOption ) =>
 	option.label.substring( 0, 11 );
 
 const ComboboxControl = ( props: ComboboxControlProps ) => {
-	return <_ComboboxControl { ...props } __next40pxDefaultSize />;
+	return <_ComboboxControl { ...props } />;
 };
 
 const ControlledComboboxControl = ( {

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -37,7 +37,8 @@ export type ComboboxControlProps = Pick<
 	/**
 	 * Start opting into the larger default height that will become the default size in a future version.
 	 *
-	 * @default false
+	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+	 * @ignore
 	 */
 	__next40pxDefaultSize?: boolean;
 	/**

--- a/packages/components/src/validated-form-controls/components/combobox-control.tsx
+++ b/packages/components/src/validated-form-controls/components/combobox-control.tsx
@@ -52,7 +52,7 @@ const UnforwardedValidatedComboboxControl = (
 				)
 			}
 		>
-			<ComboboxControl __next40pxDefaultSize { ...restProps } />
+			<ComboboxControl { ...restProps } />
 		</ControlWithError>
 	);
 };

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -195,7 +195,6 @@ export function PageAttributesParent() {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			className="editor-page-attributes__parent"
 			label={ __( 'Parent' ) }
 			help={ __( 'Choose a parent page.' ) }

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -34,7 +34,6 @@ export default function PostAuthorCombobox() {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			value={ authorId }

--- a/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
+++ b/packages/eslint-plugin/docs/rules/components-no-missing-40px-size-prop.md
@@ -9,7 +9,6 @@ This is a temporary rule to help migrate components to the new default size. Onc
 The following components are checked by this rule:
 
 -   Button
--   ComboboxControl
 -   CustomSelectControl
 -   FontAppearanceControl
 -   FormFileUpload (special case - see below)

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -110,7 +110,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 		{
 			code: `
 				import {
-					ComboboxControl,
 					CustomSelectControl,
 					FontAppearanceControl,
 					FormTokenField,
@@ -122,7 +121,6 @@ ruleTester.run( 'components-no-missing-40px-size-prop', rule, {
 					UnitControl,
 				} from '@wordpress/components';
 				<>
-					<ComboboxControl __next40pxDefaultSize />
 					<CustomSelectControl __next40pxDefaultSize />
 					<FontAppearanceControl __next40pxDefaultSize />
 					<FormTokenField __next40pxDefaultSize />

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -14,7 +14,6 @@ const { hasTruthyJsxAttribute } = require( '../utils' );
 const COMPONENTS_REQUIRING_40PX = new Set( [
 	'Button',
 	'ClipboardButton',
-	'ComboboxControl',
 	'CustomSelectControl',
 	'FontAppearanceControl',
 	'FormTokenField',

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -261,7 +261,6 @@ export function PageAttributesParent( {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
 			label={ __( 'Parent' ) }
 			help={ __( 'Choose a parent page.' ) }
 			value={ pageId?.toString() }

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -170,7 +170,6 @@ export default function MediaAttachedToEdit( {
 	return (
 		<ComboboxControl
 			className="dataviews-media-field__attached-to"
-			__next40pxDefaultSize
 			isLoading={ isLoading }
 			label={ __( 'Attached to' ) }
 			help={ help }

--- a/routes/guidelines/components/block-guideline-modal.tsx
+++ b/routes/guidelines/components/block-guideline-modal.tsx
@@ -143,7 +143,6 @@ export default function BlockGuidelineModal( {
 					/>
 				) : (
 					<ComboboxControl
-						__next40pxDefaultSize
 						label={ __( 'Block' ) }
 						options={ availableBlockOptions }
 						value={ selectedBlock }

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -173,6 +173,7 @@ const restrictedSyntax = [
 		'BorderBoxControl',
 		'BorderControl',
 		'BoxControl',
+		'ComboboxControl',
 		'FocalPointPicker',
 		'FontFamilyControl',
 		'FontSizePicker',

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1007,6 +1007,16 @@
 			"count": 1
 		}
 	},
+	"packages/compose/src/hooks/use-dragging/index.js": {
+		"react-hooks/immutability": {
+			"count": 1
+		}
+	},
+	"packages/compose/src/hooks/use-focus-return/index.js": {
+		"react-hooks/immutability": {
+			"count": 2
+		}
+	},
 	"packages/compose/src/hooks/use-merge-refs/index.ts": {
 		"react-hooks/refs": {
 			"count": 1
@@ -1333,6 +1343,11 @@
 	"packages/editor/src/components/post-publish-panel/postpublish.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-revisions-panel/index.js": {
+		"@wordpress/use-recommended-components": {
+			"count": 2
 		}
 	},
 	"packages/editor/src/components/post-status/index.js": {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -661,7 +661,7 @@
 	},
 	"packages/components/src/combobox-control/styles.ts": {
 		"no-restricted-imports": {
-			"count": 2
+			"count": 1
 		}
 	},
 	"packages/components/src/confirm-dialog/styles.ts": {
@@ -1007,16 +1007,6 @@
 			"count": 1
 		}
 	},
-	"packages/compose/src/hooks/use-dragging/index.js": {
-		"react-hooks/immutability": {
-			"count": 1
-		}
-	},
-	"packages/compose/src/hooks/use-focus-return/index.js": {
-		"react-hooks/immutability": {
-			"count": 2
-		}
-	},
 	"packages/compose/src/hooks/use-merge-refs/index.ts": {
 		"react-hooks/refs": {
 			"count": 1
@@ -1343,11 +1333,6 @@
 	"packages/editor/src/components/post-publish-panel/postpublish.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		}
-	},
-	"packages/editor/src/components/post-revisions-panel/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
 		}
 	},
 	"packages/editor/src/components/post-status/index.js": {


### PR DESCRIPTION
## What?

Follow up to #65751

Hard deprecates the `__next40pxDefaultSize` prop on `ComboboxControl`, making the 40px default size unconditional.

## Why?

The opt-in period for the larger default size on `ComboboxControl` is over. The prop is no longer needed and can be safely removed from call sites.

## How?

- Remove deprecated 28px size styles and legacy warning hook usage from `ComboboxControl`.
- Strip `__next40pxDefaultSize` from all `ComboboxControl` call sites across the monorepo.
- Update ESLint bookkeeping: add `ComboboxControl` to the forbid list and remove it from the required-prop rule.
- Add a changelog entry under Breaking Changes.

## Testing Instructions

1. Run `npm run storybook:start` and open the ComboboxControl stories.
2. Verify the control renders at the 40px height and suggestions open/close as expected.
3. Open the post editor and test a `ComboboxControl` surface, such as the parent page combobox (Document settings > Parent) or the post author combobox.
4. Confirm filtering, selection, and reset still work.

