### PR TITLE
Dependency Extraction Webpack Plugin: pretty-print generated asset output

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Pretty-print generated asset files with line breaks and indentation ([#48106](https://github.com/WordPress/gutenberg/issues/48106)).
+
 ## 6.53.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -13,6 +13,16 @@ const { AsyncDependenciesBlock } = webpack;
 
 const defaultExternalizedReportFileName = 'externalized-dependencies.json';
 
+/**
+ * A single PHP printer, created on first use and reused for every asset file.
+ * Many builds emit only JSON (or no asset file at all), so it is built lazily.
+ * Tab indentation and newlines make the generated `*.asset.php` files read like
+ * the pretty-printed `block.json` files WordPress ships.
+ *
+ * @type {undefined | ( ( data: unknown ) => string )}
+ */
+let phpPrinter;
+
 class DependencyExtractionWebpackPlugin {
 	constructor( options ) {
 		this.options = Object.assign(
@@ -129,12 +139,18 @@ class DependencyExtractionWebpackPlugin {
 	 */
 	stringify( asset ) {
 		if ( this.options.outputFormat === 'php' ) {
-			return `<?php return ${ json2php(
+			if ( ! phpPrinter ) {
+				phpPrinter = json2php.make( {
+					linebreak: '\n',
+					indent: '\t',
+				} );
+			}
+			return `<?php return ${ phpPrinter(
 				JSON.parse( JSON.stringify( asset ) )
 			) };\n`;
 		}
 
-		return JSON.stringify( asset );
+		return JSON.stringify( asset, null, '\t' );
 	}
 
 	/** @type {webpack.WebpackPluginInstance['apply']} */

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,23 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '270cb9e2d17f391e9270', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '4cf36c37afb98cbb1f86', 'type' => 'module'));
+"<?php return array(
+	'fileA.mjs' => array(
+		'dependencies' => array(
+			'@wordpress/blob',
+			'lodash'
+		),
+		'version' => '270cb9e2d17f391e9270',
+		'type' => 'module'
+	),
+	'fileB.mjs' => array(
+		'dependencies' => array(
+			'@wordpress/token-list'
+		),
+		'version' => '4cf36c37afb98cbb1f86',
+		'type' => 'module'
+	)
+);
 "
 `;
 
@@ -26,7 +42,13 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => '3432e19e5eaf6d6f4b77', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity'
+	),
+	'version' => '3432e19e5eaf6d6f4b77',
+	'type' => 'module'
+);
 "
 `;
 
@@ -41,7 +63,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '076698e41df140e724d8', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		array(
+			'id' => '@wordpress/interactivity',
+			'import' => 'dynamic'
+		)
+	),
+	'version' => '076698e41df140e724d8',
+	'type' => 'module'
+);
 "
 `;
 
@@ -56,7 +87,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-depe
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '1241febf0f1b74e69d6a', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		array(
+			'id' => '@wordpress/interactivity',
+			'import' => 'dynamic'
+		)
+	),
+	'version' => '1241febf0f1b74e69d6a',
+	'type' => 'module'
+);
 "
 `;
 
@@ -71,7 +111,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-dep
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'import' => 'dynamic')), 'version' => '3f8407fd25e98c44c5ff', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		array(
+			'id' => '@wordpress/blob',
+			'import' => 'dynamic'
+		)
+	),
+	'version' => '3f8407fd25e98c44c5ff',
+	'type' => 'module'
+);
 "
 `;
 
@@ -95,7 +144,14 @@ Module not found: Error: Attempted to use WordPress script in a module: @wordpre
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'b68363f122fe0a26183e', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => 'b68363f122fe0a26183e',
+	'type' => 'module'
+);
 "
 `;
 
@@ -115,7 +171,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'fd4b8dcc8741c1523219', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => 'fd4b8dcc8741c1523219',
+	'type' => 'module'
+);
 "
 `;
 
@@ -135,7 +198,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '79d3c39076be7f6df4ea', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'renamed--@my/module',
+		'renamed--other-module'
+	),
+	'version' => '79d3c39076be7f6df4ea',
+	'type' => 'module'
+);
 "
 `;
 
@@ -155,7 +225,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => 'f509a71faab9f56557c1', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		array(
+			'id' => '@wordpress/interactivity',
+			'import' => 'dynamic'
+		)
+	),
+	'version' => 'f509a71faab9f56557c1',
+	'type' => 'module'
+);
 "
 `;
 
@@ -170,21 +249,40 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-impo
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '60d4e92bd289da4738ed', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => '60d4e92bd289da4738ed',
+	'type' => 'module'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '47abc9f11d44c8d2ea89', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => '47abc9f11d44c8d2ea89',
+	'type' => 'module'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'b68363f122fe0a26183e', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => 'b68363f122fe0a26183e',
+	'type' => 'module'
+);
 "
 `;
 
@@ -204,7 +302,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'b68363f122fe0a26183e', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => 'b68363f122fe0a26183e',
+	'type' => 'module'
+);
 "
 `;
 
@@ -223,7 +328,15 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"11156aba3b369605e939","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `
+"{
+	"dependencies": [
+		"lodash"
+	],
+	"version": "11156aba3b369605e939",
+	"type": "module"
+}"
+`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -236,7 +349,16 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => 'af74b6f7d8a3f114b5b3', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'@wordpress/url',
+		'rxjs',
+		'rxjs/operators'
+	),
+	'version' => 'af74b6f7d8a3f114b5b3',
+	'type' => 'module'
+);
 "
 `;
 
@@ -266,31 +388,65 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-polyfill'), 'version' => 'ce3c6b76208e3e42fe21', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'wp-polyfill'
+	),
+	'version' => 'ce3c6b76208e3e42fe21',
+	'type' => 'module'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '31d6cfe0d16ae931b73c', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'wp-polyfill'
+	),
+	'version' => '31d6cfe0d16ae931b73c',
+	'type' => 'module'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '00ad69a407b9d8fe017b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-a');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob'
+	),
+	'version' => '00ad69a407b9d8fe017b',
+	'type' => 'module',
+	'handle' => 'runtime-chunk-single-modules-a'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '8f3ca66c17c6a5908643', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-b');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => '8f3ca66c17c6a5908643',
+	'type' => 'module',
+	'handle' => 'runtime-chunk-single-modules-b'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '7e4f3787fd93b418a0d4', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-runtime');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => '7e4f3787fd93b418a0d4',
+	'type' => 'module',
+	'handle' => 'runtime-chunk-single-modules-runtime'
+);
 "
 `;
 
@@ -310,7 +466,13 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '24df66bb21cda0d08963', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob'
+	),
+	'version' => '24df66bb21cda0d08963',
+	'type' => 'module'
+);
 "
 `;
 
@@ -325,7 +487,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\`
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '825b69f70b86760c73a3', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => '825b69f70b86760c73a3',
+	'type' => 'module'
+);
 "
 `;
 
@@ -345,7 +514,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'b68363f122fe0a26183e', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => 'b68363f122fe0a26183e',
+	'type' => 'module'
+);
 "
 `;
 
@@ -365,7 +541,17 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '2f6f06cb476e5837f787', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		array(
+			'id' => '@wordpress/interactivity',
+			'import' => 'dynamic'
+		)
+	),
+	'version' => '2f6f06cb476e5837f787',
+	'type' => 'module'
+);
 "
 `;
 
@@ -385,7 +571,14 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '9dcb7bb56f3fd06c5087', 'type' => 'module');
+"<?php return array(
+	'dependencies' => array(
+		'@wordpress/blob',
+		'lodash'
+	),
+	'version' => '9dcb7bb56f3fd06c5087',
+	'type' => 'module'
+);
 "
 `;
 
@@ -405,7 +598,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\`
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => '09504998b440d7f5861d'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => 'f2d7349feffd62e5e874'));
+"<?php return array(
+	'fileA.js' => array(
+		'dependencies' => array(
+			'lodash',
+			'wp-blob'
+		),
+		'version' => '09504998b440d7f5861d'
+	),
+	'fileB.js' => array(
+		'dependencies' => array(
+			'wp-token-list'
+		),
+		'version' => 'f2d7349feffd62e5e874'
+	)
+);
 "
 `;
 
@@ -436,7 +643,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => '2f1a57170044bbe4b31e');
+"<?php return array(
+	'dependencies' => array(
+		'wp-interactivity'
+	),
+	'version' => '2f1a57170044bbe4b31e'
+);
 "
 `;
 
@@ -454,7 +666,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-g
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'e72ee7c17819745462a7');
+"<?php return array(
+	'dependencies' => array(
+		'wp-interactivity'
+	),
+	'version' => 'e72ee7c17819745462a7'
+);
 "
 `;
 
@@ -472,7 +689,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-depe
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => '2a9d03bfae20128046c0');
+"<?php return array(
+	'dependencies' => array(
+		'wp-interactivity'
+	),
+	'version' => '2a9d03bfae20128046c0'
+);
 "
 `;
 
@@ -490,7 +712,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-dep
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => 'f4c47bb9efae7a108052');
+"<?php return array(
+	'dependencies' => array(
+		'wp-blob'
+	),
+	'version' => 'f4c47bb9efae7a108052'
+);
 "
 `;
 
@@ -514,7 +741,13 @@ Module not found: Error: Ensure error in script build.
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e9b912dd9bf4a70e4cb0');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => 'e9b912dd9bf4a70e4cb0'
+);
 "
 `;
 
@@ -537,7 +770,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-fil
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'd4f650de95657219702b');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => 'd4f650de95657219702b'
+);
 "
 `;
 
@@ -560,7 +799,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffi
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '556545d20d0075ed699f');
+"<?php return array(
+	'dependencies' => array(
+		'renamed--@my/module',
+		'renamed--other-module'
+	),
+	'version' => '556545d20d0075ed699f'
+);
 "
 `;
 
@@ -586,7 +831,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` sh
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'a91c78cd3d9af44f15af');
+"<?php return array(
+	'dependencies' => array(
+		'wp-interactivity'
+	),
+	'version' => 'a91c78cd3d9af44f15af'
+);
 "
 `;
 
@@ -604,21 +854,37 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-impo
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '17ace6f7f49c7c077a6c');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => '17ace6f7f49c7c077a6c'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'b922a4320dd8b7a352f4');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => 'b922a4320dd8b7a352f4'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e9b912dd9bf4a70e4cb0');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => 'e9b912dd9bf4a70e4cb0'
+);
 "
 `;
 
@@ -641,7 +907,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-out
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e9b912dd9bf4a70e4cb0');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => 'e9b912dd9bf4a70e4cb0'
+);
 "
 `;
 
@@ -663,7 +935,14 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"3ffb54e851eb354c0170"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `
+"{
+	"dependencies": [
+		"lodash"
+	],
+	"version": "3ffb54e851eb354c0170"
+}"
+`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 [
@@ -676,7 +955,14 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '96b889b779d0e972229e');
+"<?php return array(
+	'dependencies' => array(
+		'wp-blob',
+		'wp-script-handle-for-rxjs',
+		'wp-url'
+	),
+	'version' => '96b889b779d0e972229e'
+);
 "
 `;
 
@@ -715,31 +1001,60 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '48f720dd907eea75c1fd');
+"<?php return array(
+	'dependencies' => array(
+		'wp-polyfill'
+	),
+	'version' => '48f720dd907eea75c1fd'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '31d6cfe0d16ae931b73c');
+"<?php return array(
+	'dependencies' => array(
+		'wp-polyfill'
+	),
+	'version' => '31d6cfe0d16ae931b73c'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => 'e8bba1440f7003e4988b', 'handle' => 'runtime-chunk-single-scripts-a');
+"<?php return array(
+	'dependencies' => array(
+		'wp-blob'
+	),
+	'version' => 'e8bba1440f7003e4988b',
+	'handle' => 'runtime-chunk-single-scripts-a'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '8c8cea3e6127c51f6aac', 'handle' => 'runtime-chunk-single-scripts-b');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => '8c8cea3e6127c51f6aac',
+	'handle' => 'runtime-chunk-single-scripts-b'
+);
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '2028470a91d96d4f591d', 'handle' => 'runtime-chunk-single-scripts-runtime');
+"<?php return array(
+	'dependencies' => array(
+		
+	),
+	'version' => '2028470a91d96d4f591d',
+	'handle' => 'runtime-chunk-single-scripts-runtime'
+);
 "
 `;
 
@@ -762,7 +1077,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-singl
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => '17feeb4acc899d3bd2d9');
+"<?php return array(
+	'dependencies' => array(
+		'wp-blob'
+	),
+	'version' => '17feeb4acc899d3bd2d9'
+);
 "
 `;
 
@@ -780,7 +1100,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\`
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '3e9f6eea2f65b1419318');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => '3e9f6eea2f65b1419318'
+);
 "
 `;
 
@@ -803,7 +1129,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` sho
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e9b912dd9bf4a70e4cb0');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => 'e9b912dd9bf4a70e4cb0'
+);
 "
 `;
 
@@ -826,7 +1158,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-interactivity'), 'version' => '6d6dd27ae8961236ce08');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-interactivity'
+	),
+	'version' => '6d6dd27ae8961236ce08'
+);
 "
 `;
 
@@ -849,7 +1187,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interacti
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '21cb4044c3c0bc8f09f8');
+"<?php return array(
+	'dependencies' => array(
+		'lodash',
+		'wp-blob'
+	),
+	'version' => '21cb4044c3c0bc8f09f8'
+);
 "
 `;
 

--- a/packages/dependency-extraction-webpack-plugin/test/stringify.js
+++ b/packages/dependency-extraction-webpack-plugin/test/stringify.js
@@ -1,0 +1,34 @@
+const DependencyExtractionWebpackPlugin = require( '../lib/index' );
+
+describe( 'stringify', () => {
+	const asset = {
+		dependencies: [ 'react', 'wp-element' ],
+		version: 'abc123',
+	};
+
+	test( 'pretty-prints PHP with line breaks and indentation', () => {
+		const plugin = new DependencyExtractionWebpackPlugin( {
+			outputFormat: 'php',
+		} );
+
+		expect( plugin.stringify( asset ) ).toBe(
+			`<?php return array(
+	'dependencies' => array(
+		'react',
+		'wp-element'
+	),
+	'version' => 'abc123'
+);\n`
+		);
+	} );
+
+	test( 'pretty-prints JSON with tab indentation', () => {
+		const plugin = new DependencyExtractionWebpackPlugin( {
+			outputFormat: 'json',
+		} );
+
+		expect( plugin.stringify( asset ) ).toBe(
+			JSON.stringify( asset, null, '\t' )
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes #48106.

Right now the generated asset files (`*.asset.php`, `assets.php`, and the JSON equivalents) get written all on one line, which makes something like `script-loader-packages.php` annoying to read or diff while you're working on it. This pretty-prints them with line breaks and tab indentation so they're readable and diff cleanly.

The change lives in `stringify()`: the PHP branch prints through a shared `json2php.make( { linebreak: '\n', indent: '\t' } )` instance (created lazily on first use, since many builds emit only JSON), and the JSON branch uses `JSON.stringify( asset, null, '\t' )`. Both formats print the same way on every build.

Following @sirreal's review, this no longer branches on `optimization.minimize`. The output was never meaningfully minified, only unformatted, and these files are conceptually like the pretty-printed `block.json` files WordPress already ships, so pretty-printing is just the right default.

To check it, run `npm run test:unit packages/dependency-extraction-webpack-plugin`, or build a package and open one of the generated `*.asset.php` files, it's now spread over indented lines.

Props: @mattyrob, who proposed the same change earlier in #49923.

## Use of AI Tools

This PR was written with AI assistance (Claude Code). I reviewed, tested, and understand every change, and I take responsibility for it.
