### PR TITLE
Upgrade @y/websocket-server to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18909,15 +18909,57 @@
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
-		"node_modules/@y/websocket-server": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@y/websocket-server/-/websocket-server-0.1.1.tgz",
-			"integrity": "sha512-pPtXm5Ceqs4orhXXHwm2I+u1mKNBDNzlrwNiI7OMwM7PlVS4WCMpiIuSB8WsYeSuISbvpXPNvaj6H1MoQBbE+g==",
+		"node_modules/@y/protocols": {
+			"version": "1.0.6-rc.1",
+			"resolved": "https://registry.npmjs.org/@y/protocols/-/protocols-1.0.6-rc.1.tgz",
+			"integrity": "sha512-e/qs7hXcLk/SeNitxMXv2ymozyWFTULwbJEi7cAf/K/iXw9nGwGXHrR5TNluQ/bMwOX1cwuUT0hjEojkfH0gsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"lib0": "^1.0.0-rc.1"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			},
+			"peerDependencies": {
+				"@y/y": "*"
+			}
+		},
+		"node_modules/@y/protocols/node_modules/lib0": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-1.0.0-rc.15.tgz",
+			"integrity": "sha512-TYRy/rwOV3xJ9IjTAJeQdoBAKaLKIZQUacAyT5PPRDyi2ejnITaNAbHn06zfdttz/aI3D+wzkgcwJzY7DwFJ4Q==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"0ecdsa-generate-keypair": "src/bin/0ecdsa-generate-keypair.js",
+				"0gentesthtml": "src/bin/gentesthtml.js",
+				"0serve": "src/bin/0serve.js"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			}
+		},
+		"node_modules/@y/websocket-server": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@y/websocket-server/-/websocket-server-0.1.5.tgz",
+			"integrity": "sha512-ue1zENKxwj66AV8QoTwk0MPEH6veUhgvw+Gn84iX6Tco4lN9DHuF9k8oEKObJSPWoKBsOjeUk/ZYJcSK7iGc1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@y/protocols": "^1.0.6-1",
 				"lib0": "^0.2.102",
-				"y-protocols": "^1.0.5"
+				"ws": "^6.2.1",
+				"yjs": "^14.0.0-7"
 			},
 			"bin": {
 				"y-websocket": "src/server.js",
@@ -18930,13 +18972,6 @@
 			"funding": {
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
-			},
-			"optionalDependencies": {
-				"ws": "^6.2.1",
-				"y-leveldb": "^0.1.0"
-			},
-			"peerDependencies": {
-				"yjs": "^13.5.6"
 			}
 		},
 		"node_modules/@y/websocket-server/node_modules/lib0": {
@@ -18967,9 +19002,26 @@
 			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"async-limiter": "~1.0.0"
+			}
+		},
+		"node_modules/@y/websocket-server/node_modules/yjs": {
+			"version": "14.0.0-16",
+			"resolved": "https://registry.npmjs.org/yjs/-/yjs-14.0.0-16.tgz",
+			"integrity": "sha512-n7jMrQz4pgU/NFnf4qY53K2adR/fu6ViQ79qVIw6Og+BtuDs1hx3DjOi3iREVnA6tsxQXXVG3gvG0I2kpmAwoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lib0": "^0.2.115-6"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=8.0.0"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
 		"node_modules/@yarnpkg/lockfile": {
@@ -19023,59 +19075,6 @@
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
-		},
-		"node_modules/abstract-leveldown": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-			"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"immediate": "^3.2.3",
-				"level-concat-iterator": "~2.0.0",
-				"level-supports": "~1.0.0",
-				"xtend": "~4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/abstract-leveldown/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/abstract-leveldown/node_modules/immediate": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -19730,8 +19729,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
 			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -24051,22 +24049,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/deferred-leveldown": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-			"integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"abstract-leveldown": "~6.2.1",
-				"inherits": "^2.0.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -24549,24 +24531,6 @@
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"dependencies": {
 				"iconv-lite": "^0.6.2"
-			}
-		},
-		"node_modules/encoding-down": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-			"integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"abstract-leveldown": "^6.2.1",
-				"inherits": "^2.0.3",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -31963,242 +31927,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/level": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
-			"integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"level-js": "^5.0.0",
-				"level-packager": "^5.1.0",
-				"leveldown": "^5.4.0"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"buffer": "^5.6.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-codec/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-concat-iterator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-			"integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"errno": "~0.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-			"integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0",
-				"xtend": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-iterator-stream/node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true
-		},
-		"node_modules/level-iterator-stream/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/level-js": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
-			"integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
-			"deprecated": "Superseded by browser-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"abstract-leveldown": "~6.2.3",
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.3",
-				"ltgt": "^2.1.2"
-			}
-		},
-		"node_modules/level-js/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/level-packager": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-			"integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"encoding-down": "^6.3.0",
-				"levelup": "^4.3.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-			"integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"xtend": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/leveldown": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
-			"integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
-			"deprecated": "Superseded by classic-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"abstract-leveldown": "~6.2.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "~4.1.0"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/levelup": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-			"integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-			"deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"deferred-leveldown": "~5.3.0",
-				"level-errors": "~2.0.0",
-				"level-iterator-stream": "~4.0.0",
-				"level-supports": "~1.0.0",
-				"xtend": "~4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -33174,14 +32902,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"license": "ISC"
-		},
-		"node_modules/ltgt": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-			"integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
@@ -34736,14 +34456,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/napi-postinstall": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -34879,19 +34591,6 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/node-gyp-build": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-			"integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-gyp/node_modules/abbrev": {
@@ -47315,25 +47014,6 @@
 				"node": ">=0.4"
 			}
 		},
-		"node_modules/y-leveldb": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/y-leveldb/-/y-leveldb-0.1.2.tgz",
-			"integrity": "sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"level": "^6.0.1",
-				"lib0": "^0.2.31"
-			},
-			"funding": {
-				"type": "GitHub Sponsors ❤",
-				"url": "https://github.com/sponsors/dmonad"
-			},
-			"peerDependencies": {
-				"yjs": "^13.0.0"
-			}
-		},
 		"node_modules/y-protocols": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
@@ -53168,7 +52848,7 @@
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
-				"@y/websocket-server": "^0.1.1",
+				"@y/websocket-server": "^0.1.2",
 				"esbuild": "^0.27.2",
 				"filenamify": "^4.2.0",
 				"ws": "^8.18.3",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -26,7 +26,7 @@
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",
-		"@y/websocket-server": "^0.1.1",
+		"@y/websocket-server": "^0.1.2",
 		"esbuild": "^0.27.2",
 		"filenamify": "^4.2.0",
 		"ws": "^8.18.3",


### PR DESCRIPTION
## What?

Related to #79614.

Upgrades `@y/websocket-server` (a dev dependency of `test/e2e`, used by the collaboration / RTC websocket e2e suite) from `0.1.1` to `0.1.5`.

## Why?

`0.1.5` drops its optional `y-leveldb` persistence dependency, which removes the native `leveldown → level → y-leveldb` chain from the tree.

`leveldown` builds a native addon via an install script and ships no `darwin-arm64` prebuild, so it's the one dependency that doesn't play well with the npm v11 supply-chain hardening in #79614 — denying its install script leaves no binary on Apple Silicon, and the collaboration e2e server fails to load it. Dropping the dependency removes the problem entirely, so #79614 no longer needs to special-case `leveldown`.

## How?

- Bump `@y/websocket-server` to `^0.1.5` in `test/e2e/package.json`.
- Lockfile: removes `leveldown`, `level`, `y-leveldb`, `abstract-leveldown`, `levelup`, and the `level-*` packages; adds `@y/protocols` and a nested `yjs@14` for the websocket server.

Note: `@y/websocket-server@0.1.5` depends on `yjs@14` (currently a prerelease) for the server. It resolves nested under the package, separate from the editor's `yjs@13.6.29`; the RTC provider bundle aliases `yjs`, so the client side stays on our version.

## Testing Instructions

1. `npm ci`
2. Run the collaboration e2e suite and confirm it passes:
    - `npm run test:e2e:rtc-websocket`

## Use of AI Tools

These changes and this description were prepared with help from an AI coding agent and reviewed before submission.
