### PR TITLE
Radio: Hard deprecate 40px default size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,7 @@
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `RangeControl` ([#79590](https://github.com/WordPress/gutenberg/pull/79590))
-    -   `Radio` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD))
+    -   `Radio` ([#79657](https://github.com/WordPress/gutenberg/pull/79657))
     -   `TreeSelect` ([#79550](https://github.com/WordPress/gutenberg/pull/79550))
 
 ### Documentation

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `RangeControl` ([#79590](https://github.com/WordPress/gutenberg/pull/79590))
+    -   `Radio` ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD))
     -   `TreeSelect` ([#79550](https://github.com/WordPress/gutenberg/pull/79550))
 
 ### Documentation

--- a/packages/components/src/radio-group/README.md
+++ b/packages/components/src/radio-group/README.md
@@ -57,10 +57,10 @@ const MyControlledRadioRadioGroup = () => {
 	const [ checked, setChecked ] = useState( '25' );
 	return (
 		<RadioGroup label="Width" onChange={ setChecked } checked={ checked }>
-			<Radio __next40pxDefaultSize value="25">25%</Radio>
-			<Radio __next40pxDefaultSize value="50">50%</Radio>
-			<Radio __next40pxDefaultSize value="75">75%</Radio>
-			<Radio __next40pxDefaultSize value="100">100%</Radio>
+			<Radio value="25">25%</Radio>
+			<Radio value="50">50%</Radio>
+			<Radio value="75">75%</Radio>
+			<Radio value="100">100%</Radio>
 		</RadioGroup>
 	);
 };
@@ -80,10 +80,10 @@ import {
 const MyUncontrolledRadioRadioGroup = () => {
 	return (
 		<RadioGroup label="Width" defaultChecked="25">
-			<Radio __next40pxDefaultSize value="25">25%</Radio>
-			<Radio __next40pxDefaultSize value="50">50%</Radio>
-			<Radio __next40pxDefaultSize value="75">75%</Radio>
-			<Radio __next40pxDefaultSize value="100">100%</Radio>
+			<Radio value="25">25%</Radio>
+			<Radio value="50">50%</Radio>
+			<Radio value="75">75%</Radio>
+			<Radio value="100">100%</Radio>
 		</RadioGroup>
 	);
 };

--- a/packages/components/src/radio-group/radio.tsx
+++ b/packages/components/src/radio-group/radio.tsx
@@ -15,12 +15,12 @@ import Button from '../button';
 import { RadioGroupContext } from './context';
 import type { WordPressComponentProps } from '../context';
 import type { RadioProps } from './types';
-import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 function UnforwardedRadio(
 	{
 		value,
 		children,
+		__next40pxDefaultSize: _next40pxDefaultSize,
 		...props
 	}: WordPressComponentProps< RadioProps, 'button', false >,
 	ref: React.ForwardedRef< any >
@@ -30,12 +30,6 @@ function UnforwardedRadio(
 	const selectedValue = Ariakit.useStoreState( store, 'value' );
 	const isChecked = selectedValue !== undefined && selectedValue === value;
 
-	maybeWarnDeprecated36pxSize( {
-		componentName: 'Radio',
-		size: undefined,
-		__next40pxDefaultSize: props.__next40pxDefaultSize,
-	} );
-
 	return (
 		<Ariakit.Radio
 			disabled={ disabled }
@@ -43,10 +37,9 @@ function UnforwardedRadio(
 			ref={ ref }
 			value={ value }
 			render={
-				// Disable: the parent component already takes care of the `__next40pxDefaultSize` prop.
-				// eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop
 				<Button
 					variant={ isChecked ? 'primary' : 'secondary' }
+					__next40pxDefaultSize
 					{ ...props }
 				/>
 			}

--- a/packages/components/src/radio-group/stories/index.story.tsx
+++ b/packages/components/src/radio-group/stories/index.story.tsx
@@ -52,15 +52,9 @@ Default.args = {
 	defaultChecked: 'option2',
 	children: (
 		<>
-			<Radio __next40pxDefaultSize value="option1">
-				Option 1
-			</Radio>
-			<Radio __next40pxDefaultSize value="option2">
-				Option 2
-			</Radio>
-			<Radio __next40pxDefaultSize value="option3">
-				Option 3
-			</Radio>
+			<Radio value="option1">Option 1</Radio>
+			<Radio value="option2">Option 2</Radio>
+			<Radio value="option3">Option 3</Radio>
 		</>
 	),
 };

--- a/packages/components/src/radio-group/types.ts
+++ b/packages/components/src/radio-group/types.ts
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import type { ButtonProps } from '../button/types';
-
 export type RadioGroupProps = {
 	/**
 	 * Accessible label for the radio group
@@ -32,7 +27,14 @@ export type RadioGroupProps = {
 	children: React.ReactNode;
 };
 
-export type RadioProps = Pick< ButtonProps, '__next40pxDefaultSize' > & {
+export type RadioProps = {
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @deprecated Default behavior since WordPress 7.1. Prop can be safely removed.
+	 * @ignore
+	 */
+	__next40pxDefaultSize?: boolean;
 	/**
 	 * The actual value of the radio element.
 	 */

--- a/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/components-no-missing-40px-size-prop.js
@@ -21,7 +21,6 @@ const COMPONENTS_REQUIRING_40PX = new Set( [
 	'IconButton',
 	'InputControl',
 	'NumberControl',
-	'Radio',
 	'SelectControl',
 	'ToggleGroupControl',
 	'UnitControl',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -186,6 +186,7 @@ const restrictedSyntax = [
 		'LineHeightControl',
 		'QueryControls',
 		'RangeControl',
+		'Radio',
 		'SearchControl',
 		'TextControl',
 		'TextIndentControl',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to #65751

Hard-deprecates the `__next40pxDefaultSize` prop on `Radio` (`__experimentalRadio`). The prop is stripped at the component boundary and the 40px default size is always applied on the inner `Button`.

## Why?

The opt-in period for the larger default size on `Radio` is over. The prop is no longer needed and can be safely removed from call sites.

## How?

- Destructure and discard `__next40pxDefaultSize` from `Radio` props.
- Hardcode `__next40pxDefaultSize` on the inner `Button`.
- Mark the prop as deprecated in types.
- Remove `__next40pxDefaultSize` from README and Storybook examples.
- Remove `Radio` from the ESLint require list and add it to the forbid list for the prop.

## Testing Instructions

1. Run Storybook and open **Components → Deprecated → RadioGroup**.
2. Verify the default, disabled, and controlled stories render with the expected 40px button size.
3. Confirm keyboard navigation between radio options still works (arrow keys, Tab).
