### PR TITLE
Media editor modal: balance top padding for sidebar controls

### DIFF
--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -132,7 +132,7 @@
 		padding: $grid-unit-20;
 
 		@include break-small() {
-			padding: $grid-unit-20 $grid-unit-30 0 0;
+			padding: $grid-unit-30 $grid-unit-30 0 0;
 		}
 	}
 


### PR DESCRIPTION


## What?

Follow up to https://github.com/WordPress/gutenberg/issues/73771#issuecomment-4810340132

Tweak top padding of sidebar controls in media editor modal.

## Why?

Bring balance to the force.

## How?

16 + 8 = 24.

## Testing Instructions


Test in Playground if you like: https://playground.wordpress.net/gutenberg.html?pr=79660


1. Create a post, insert an image block. Select that block. 
2. Click the crop icon on the block tool bar
3. Check out the modal's sidebar controls (wide viewport sizes)

## Screenshots or screencast <!-- if applicable -->



|Before|After|
|-|-|
|<img width="464" height="339" alt="Screenshot 2026-06-30 at 10 50 12 am" src="https://github.com/user-attachments/assets/211a968f-1421-43c0-9e49-300ebad705fc" />|<img width="519" height="333" alt="Screenshot 2026-06-30 at 10 50 27 am" src="https://github.com/user-attachments/assets/3513c3f8-9800-4a9a-807a-6e7f7fb25852" />|

## Use of AI Tools

I asked Claude to help me book a holiday today. It can't apparently help me pay for business class seats.



