### PR TITLE
Test fixes to infinite scroll on media upload modal

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
-- DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads asynchronously, which made the list jump upward as each page settled.
+- DataViews: Fix infinite scroll when pages load asynchronously: the list no longer jumps while a page loads, no longer stalls at the bottom, and the scroll position no longer bounces as the loading spinner appears and disappears.
 - DataForm panel layout: use `overflow: clip` on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+- DataViews: Stop infinite-scroll anchor restoration from undoing the user's scrolling while a page loads asynchronously, which made the list jump upward as each page settled.
 - DataForm panel layout: use `overflow: clip` on field controls so focus rings of inner elements are no longer clipped. [#79275](https://github.com/WordPress/gutenberg/pull/79275)
 
 ### Code Quality

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -394,6 +394,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list' );
 	const isDelayedLoading = useDelayedLoading( !! isLoading );
+	const { paginationInfo } = useContext( DataViewsContext );
 
 	const selectedItem = data?.findLast( ( item ) =>
 		selection.includes( getItemId( item ) )
@@ -535,6 +536,11 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const dataByGroup =
 		hasData && groupField ? getDataByGroup( data, groupField ) : null;
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
+	// Whether the server still has rows beyond the current window.
+	const hasMoreToLoad =
+		isInfiniteScroll &&
+		( view.startPosition ?? 1 ) + ( view.perPage ?? 0 ) <
+			paginationInfo.totalItems;
 	if ( ! hasData ) {
 		return (
 			<div
@@ -663,8 +669,14 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					);
 				} ) }
 			</Composite>
-			{ isInfiniteScroll && isLoading && (
-				<p className="dataviews-loading-more">
+			{ ( hasMoreToLoad || ( isInfiniteScroll && isLoading ) ) && (
+				// Keep the spinner mounted until everything is loaded so its
+				// height stays reserved and the scroll position doesn't bounce as
+				// loading starts/stops. Hidden (and silent to a11y) while idle.
+				<p
+					className="dataviews-loading-more"
+					aria-hidden={ ! isLoading }
+				>
 					<Spinner />
 				</p>
 			) }

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -1,0 +1,179 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViews from '../index';
+import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../constants';
+import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
+import type { View } from '../../types';
+import { actions, data as fixtureData, fields } from './fixtures';
+
+// The fixtures only contain ~50 rows; repeat them (with unique ids) so there
+// are enough rows to page through several times.
+const data = Array.from( { length: 8 }, ( _, batch ) =>
+	fixtureData.map( ( item ) => ( {
+		...item,
+		id: item.id + batch * 1000,
+		name: {
+			...item.name,
+			title: `${ item.name.title } #${ batch + 1 }`,
+		},
+	} ) )
+).flat();
+
+const PAGE = 20;
+// Simulated per-page network latency. The jump only reproduces while the user
+// keeps scrolling *during* this window, so it is deliberately long enough to
+// scroll within — both by hand and from the `play` function.
+const LOAD_DELAY_MS = 1000;
+
+/**
+ * Reproduces a real-world infinite-scroll consumer (e.g. a notifications list)
+ * that the static `InfiniteScroll` story does not: pages are revealed one at a
+ * time *asynchronously* and `isLoading` toggles for each page.
+ *
+ * The bug: the scroll handler captures a scroll-anchor the instant it advances
+ * the window, but the anchor is only restored on a later render gated on
+ * `isLoading`. When pages load over the network the user keeps scrolling in that
+ * gap, and the restoration can't tell that user-driven movement from a
+ * content-driven shift — so it "corrects" it, snapping the list back to where
+ * the anchor sat at capture time and undoing the scrolling done while loading.
+ *
+ * Scroll down continuously (the HUD shows the live `scrollTop`): on `trunk` the
+ * number jerks back upward as each page settles; with the fix it keeps climbing.
+ * The `play` function in `index.story.tsx` reproduces and asserts this without
+ * relying on hand-timed scrolling.
+ */
+const AsyncInfiniteScroll = () => {
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_LIST,
+		search: '',
+		startPosition: 1,
+		perPage: PAGE,
+		filters: [],
+		fields: [ 'satellites' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+		infiniteScrollEnabled: true,
+	} );
+
+	// A "server" that reveals rows one page at a time, asynchronously, keeping
+	// two pages buffered ahead of the scroll window. The buffer is what gives the
+	// user rows to scroll into while the next page is still loading — i.e. the
+	// async gap the anchor restoration mishandles.
+	const [ loadedCount, setLoadedCount ] = useState( PAGE );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const loadingRef = useRef( false );
+
+	const loadedData = useMemo(
+		() => data.slice( 0, loadedCount ),
+		[ loadedCount ]
+	);
+	const { data: shownData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( loadedData, view, fields ),
+		[ loadedData, view ]
+	);
+
+	const startPosition = view.startPosition ?? 1;
+	useEffect( () => {
+		if (
+			startPosition + PAGE * 2 <= loadedCount ||
+			loadingRef.current ||
+			loadedCount >= data.length
+		) {
+			return undefined;
+		}
+		loadingRef.current = true;
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setLoadedCount( ( count ) =>
+				Math.min( count + PAGE, data.length )
+			);
+			setIsLoading( false );
+			loadingRef.current = false;
+		}, LOAD_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ startPosition, loadedCount ] );
+
+	// Live scroll-position read-out so the jump is observable as a number, not
+	// just a flicker. The scrollable element is the internal
+	// `.dataviews-layout__container`; scroll events don't bubble but do fire in
+	// the capture phase, so we can observe it from the wrapper.
+	const wrapperRef = useRef< HTMLDivElement >( null );
+	const [ scrollTop, setScrollTop ] = useState( 0 );
+	useEffect( () => {
+		const wrapper = wrapperRef.current;
+		if ( ! wrapper ) {
+			return undefined;
+		}
+		const onScroll = ( event: Event ) => {
+			const target = event.target as HTMLElement;
+			if (
+				target?.classList?.contains( 'dataviews-layout__container' )
+			) {
+				setScrollTop( Math.round( target.scrollTop ) );
+			}
+		};
+		wrapper.addEventListener( 'scroll', onScroll, true );
+		return () => wrapper.removeEventListener( 'scroll', onScroll, true );
+	}, [] );
+
+	return (
+		<div
+			ref={ wrapperRef }
+			data-testid="async-infinite-scroll"
+			data-loading={ isLoading ? 'true' : 'false' }
+			data-loaded-count={ loadedCount }
+			style={ { position: 'relative' } }
+		>
+			<style>{ `
+			.dataviews-wrapper {
+				height: 600px;
+				overflow: auto;
+			}
+		` }</style>
+			<div
+				aria-hidden="true"
+				style={ {
+					position: 'absolute',
+					top: 8,
+					right: 8,
+					zIndex: 10,
+					padding: '6px 10px',
+					borderRadius: 4,
+					font: '12px/1.5 monospace',
+					whiteSpace: 'pre',
+					background: isLoading ? '#b32d2e' : '#1e1e1e',
+					color: '#fff',
+					pointerEvents: 'none',
+				} }
+			>
+				{ `scrollTop: ${ scrollTop }px\n${
+					isLoading ? 'loading next page…' : 'idle'
+				}\nloaded: ${ loadedCount } / ${ data.length }` }
+			</div>
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ shownData }
+				view={ view }
+				fields={ fields }
+				onChangeView={ setView }
+				isLoading={ isLoading }
+				actions={ actions }
+				defaultLayouts={ {
+					[ LAYOUT_TABLE ]: true,
+					[ LAYOUT_GRID ]: true,
+					[ LAYOUT_LIST ]: true,
+				} }
+			/>
+		</div>
+	);
+};
+
+export default AsyncInfiniteScroll;

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -26,27 +26,18 @@ const data = Array.from( { length: 8 }, ( _, batch ) =>
 ).flat();
 
 const PAGE = 20;
-// Simulated per-page network latency. The jump only reproduces while the user
-// keeps scrolling *during* this window, so it is deliberately long enough to
-// scroll within — both by hand and from the `play` function.
-const LOAD_DELAY_MS = 1000;
+// Simulated per-page network latency.
+const LOAD_DELAY_MS = 800;
 
 /**
- * Reproduces a real-world infinite-scroll consumer (e.g. a notifications list)
- * that the static `InfiniteScroll` story does not: pages are revealed one at a
- * time *asynchronously* and `isLoading` toggles for each page.
+ * A realistic network-backed infinite-scroll consumer (e.g. the experimental
+ * media modal): there is no prefetch buffer. The hook drives pagination by
+ * advancing `view.startPosition`; the consumer fetches exactly the window it was
+ * asked for, toggling `isLoading` while that request is in flight, and reports
+ * the *true* server total so the hook knows more remains.
  *
- * The bug: the scroll handler captures a scroll-anchor the instant it advances
- * the window, but the anchor is only restored on a later render gated on
- * `isLoading`. When pages load over the network the user keeps scrolling in that
- * gap, and the restoration can't tell that user-driven movement from a
- * content-driven shift — so it "corrects" it, snapping the list back to where
- * the anchor sat at capture time and undoing the scrolling done while loading.
- *
- * Scroll down continuously (the HUD shows the live `scrollTop`): on `trunk` the
- * number jerks back upward as each page settles; with the fix it keeps climbing.
- * The `play` function in `index.story.tsx` reproduces and asserts this without
- * relying on hand-timed scrolling.
+ * Use the HUD (top-right) to watch `scrollTop` / `scrollHeight` / `isLoading`
+ * while reproducing.
  */
 const AsyncInfiniteScroll = () => {
 	const [ view, setView ] = useState< View >( {
@@ -62,13 +53,27 @@ const AsyncInfiniteScroll = () => {
 		infiniteScrollEnabled: true,
 	} );
 
-	// A "server" that reveals rows one page at a time, asynchronously, keeping
-	// two pages buffered ahead of the scroll window. The buffer is what gives the
-	// user rows to scroll into while the next page is still loading — i.e. the
-	// async gap the anchor restoration mishandles.
+	// The "server": how many rows have been delivered so far, and whether a
+	// request for the current window is in flight.
 	const [ loadedCount, setLoadedCount ] = useState( PAGE );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const loadingRef = useRef( false );
+
+	const startPosition = view.startPosition ?? 1;
+	const perPage = view.perPage ?? PAGE;
+	// Rows required to fill the window the hook is currently asking for.
+	const needed = Math.min( startPosition - 1 + perPage, data.length );
+
+	useEffect( () => {
+		if ( needed <= loadedCount ) {
+			return undefined;
+		}
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setLoadedCount( needed );
+			setIsLoading( false );
+		}, LOAD_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ needed, loadedCount ] );
 
 	const loadedData = useMemo(
 		() => data.slice( 0, loadedCount ),
@@ -78,34 +83,22 @@ const AsyncInfiniteScroll = () => {
 		() => filterSortAndPaginate( loadedData, view, fields ),
 		[ loadedData, view ]
 	);
+	// Report the true server total (not just what's loaded) so infinite scroll
+	// keeps requesting until the dataset is exhausted.
+	const serverPaginationInfo = useMemo(
+		() => ( { ...paginationInfo, totalItems: data.length } ),
+		[ paginationInfo ]
+	);
 
-	const startPosition = view.startPosition ?? 1;
-	useEffect( () => {
-		if (
-			startPosition + PAGE * 2 <= loadedCount ||
-			loadingRef.current ||
-			loadedCount >= data.length
-		) {
-			return undefined;
-		}
-		loadingRef.current = true;
-		setIsLoading( true );
-		const timer = setTimeout( () => {
-			setLoadedCount( ( count ) =>
-				Math.min( count + PAGE, data.length )
-			);
-			setIsLoading( false );
-			loadingRef.current = false;
-		}, LOAD_DELAY_MS );
-		return () => clearTimeout( timer );
-	}, [ startPosition, loadedCount ] );
-
-	// Live scroll-position read-out so the jump is observable as a number, not
-	// just a flicker. The scrollable element is the internal
+	// Live scroll-position read-out. The scrollable element is the internal
 	// `.dataviews-layout__container`; scroll events don't bubble but do fire in
 	// the capture phase, so we can observe it from the wrapper.
 	const wrapperRef = useRef< HTMLDivElement >( null );
-	const [ scrollTop, setScrollTop ] = useState( 0 );
+	const [ metrics, setMetrics ] = useState( {
+		scrollTop: 0,
+		scrollHeight: 0,
+		clientHeight: 0,
+	} );
 	useEffect( () => {
 		const wrapper = wrapperRef.current;
 		if ( ! wrapper ) {
@@ -116,12 +109,19 @@ const AsyncInfiniteScroll = () => {
 			if (
 				target?.classList?.contains( 'dataviews-layout__container' )
 			) {
-				setScrollTop( Math.round( target.scrollTop ) );
+				setMetrics( {
+					scrollTop: Math.round( target.scrollTop ),
+					scrollHeight: Math.round( target.scrollHeight ),
+					clientHeight: Math.round( target.clientHeight ),
+				} );
 			}
 		};
 		wrapper.addEventListener( 'scroll', onScroll, true );
 		return () => wrapper.removeEventListener( 'scroll', onScroll, true );
 	}, [] );
+
+	const distanceToBottom =
+		metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop;
 
 	return (
 		<div
@@ -153,13 +153,19 @@ const AsyncInfiniteScroll = () => {
 					pointerEvents: 'none',
 				} }
 			>
-				{ `scrollTop: ${ scrollTop }px\n${
-					isLoading ? 'loading next page…' : 'idle'
-				}\nloaded: ${ loadedCount } / ${ data.length }` }
+				{ `${
+					isLoading ? 'loading…' : 'idle'
+				}\nloaded: ${ loadedCount } / ${
+					data.length
+				}\nstartPosition: ${ startPosition }\nscrollTop: ${
+					metrics.scrollTop
+				}\nscrollHeight: ${
+					metrics.scrollHeight
+				}\nto bottom: ${ distanceToBottom }px` }
 			</div>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
-				paginationInfo={ paginationInfo }
+				paginationInfo={ serverPaginationInfo }
 				data={ shownData }
 				view={ view }
 				fields={ fields }

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta } from '@storybook/react-vite';
+import { expect, waitFor } from 'storybook/test';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import LayoutGridComponent from './layout-grid';
 import LayoutListComponent from './layout-list';
 import LayoutCustomComponent from './layout-custom';
 import InfiniteScrollComponent from './infinite-scroll';
+import AsyncInfiniteScrollComponent from './async-infinite-scroll';
 import WithCardComponent from './with-card';
 import FreeCompositionComponent from './free-composition';
 import MinimalUIComponent from './minimal-ui';
@@ -276,5 +278,86 @@ export const InfiniteScroll = {
 				disable: true,
 			},
 		},
+	},
+};
+
+/**
+ * Infinite scroll where pages load asynchronously (with `isLoading`), like a
+ * real network-backed consumer. The `play` function reproduces the scroll-anchor
+ * jump deterministically: it advances the window, keeps scrolling *while the
+ * page is still loading*, and asserts the list does not snap back up when the
+ * page settles. It fails against the buggy `trunk` hook and passes with the fix.
+ */
+export const AsyncInfiniteScroll = {
+	render: AsyncInfiniteScrollComponent,
+	parameters: {
+		containerHeight: '600px',
+	},
+	argTypes: {
+		containerHeight: {
+			control: false,
+			table: {
+				disable: true,
+			},
+		},
+	},
+	play: async ( { canvasElement }: { canvasElement: HTMLElement } ) => {
+		const getContainer = () =>
+			canvasElement.querySelector< HTMLElement >(
+				'.dataviews-layout__container'
+			);
+		const isLoading = () =>
+			canvasElement
+				.querySelector( '[data-testid="async-infinite-scroll"]' )
+				?.getAttribute( 'data-loading' ) === 'true';
+
+		// Wait for the first page to render.
+		const container = await waitFor( () => {
+			const el = getContainer();
+			expect( el ).toBeTruthy();
+			expect(
+				el!.querySelectorAll( '[aria-posinset]' ).length
+			).toBeGreaterThan( 5 );
+			return el!;
+		} );
+
+		// Reproduce the scenario a few times to page well into the list: advance
+		// the window (revealing buffered rows and starting an async fetch), keep
+		// scrolling while the fetch is in flight, then assert the list stayed put
+		// once it settled.
+		for ( let i = 0; i < 3; i++ ) {
+			// 1) Scroll to the bottom: advances the window and captures the
+			//    scroll-anchor.
+			container.scrollTop = container.scrollHeight;
+
+			// 2) Wait until a fetch is actually in flight (so rows have been
+			//    revealed and there is room to keep scrolling).
+			await waitFor( () => expect( isLoading() ).toBe( true ), {
+				timeout: 4000,
+			} );
+
+			// 3) The user keeps scrolling down into the freshly revealed rows
+			//    while the fetch is still pending — this is the movement the
+			//    buggy restoration used to undo.
+			container.scrollTop = container.scrollHeight;
+			const scrolledTo = container.scrollTop;
+			expect( scrolledTo ).toBeGreaterThan( 0 );
+
+			// 4) Let the fetch settle; the anchor-restoration layout effect runs
+			//    here.
+			await waitFor( () => expect( isLoading() ).toBe( false ), {
+				timeout: 4000,
+			} );
+
+			// 5) The viewport must stay where the user left it. On `trunk` the
+			//    restoration snaps `scrollTop` back toward its capture-time value,
+			//    yanking the list upward; the small tolerance absorbs sub-pixel
+			//    rounding only.
+			await waitFor( () =>
+				expect( container.scrollTop ).toBeGreaterThanOrEqual(
+					scrolledTo - 24
+				)
+			);
+		}
 	},
 };

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { Meta } from '@storybook/react-vite';
-import { expect, waitFor } from 'storybook/test';
 
 /**
  * Internal dependencies
@@ -283,10 +282,9 @@ export const InfiniteScroll = {
 
 /**
  * Infinite scroll where pages load asynchronously (with `isLoading`), like a
- * real network-backed consumer. The `play` function reproduces the scroll-anchor
- * jump deterministically: it advances the window, keeps scrolling *while the
- * page is still loading*, and asserts the list does not snap back up when the
- * page settles. It fails against the buggy `trunk` hook and passes with the fix.
+ * real network-backed consumer that fetches one window at a time. Use it to
+ * reproduce the scroll-position jump and the load stall manually; see the HUD
+ * in the story for live scroll metrics.
  */
 export const AsyncInfiniteScroll = {
 	render: AsyncInfiniteScrollComponent,
@@ -300,64 +298,5 @@ export const AsyncInfiniteScroll = {
 				disable: true,
 			},
 		},
-	},
-	play: async ( { canvasElement }: { canvasElement: HTMLElement } ) => {
-		const getContainer = () =>
-			canvasElement.querySelector< HTMLElement >(
-				'.dataviews-layout__container'
-			);
-		const isLoading = () =>
-			canvasElement
-				.querySelector( '[data-testid="async-infinite-scroll"]' )
-				?.getAttribute( 'data-loading' ) === 'true';
-
-		// Wait for the first page to render.
-		const container = await waitFor( () => {
-			const el = getContainer();
-			expect( el ).toBeTruthy();
-			expect(
-				el!.querySelectorAll( '[aria-posinset]' ).length
-			).toBeGreaterThan( 5 );
-			return el!;
-		} );
-
-		// Reproduce the scenario a few times to page well into the list: advance
-		// the window (revealing buffered rows and starting an async fetch), keep
-		// scrolling while the fetch is in flight, then assert the list stayed put
-		// once it settled.
-		for ( let i = 0; i < 3; i++ ) {
-			// 1) Scroll to the bottom: advances the window and captures the
-			//    scroll-anchor.
-			container.scrollTop = container.scrollHeight;
-
-			// 2) Wait until a fetch is actually in flight (so rows have been
-			//    revealed and there is room to keep scrolling).
-			await waitFor( () => expect( isLoading() ).toBe( true ), {
-				timeout: 4000,
-			} );
-
-			// 3) The user keeps scrolling down into the freshly revealed rows
-			//    while the fetch is still pending — this is the movement the
-			//    buggy restoration used to undo.
-			container.scrollTop = container.scrollHeight;
-			const scrolledTo = container.scrollTop;
-			expect( scrolledTo ).toBeGreaterThan( 0 );
-
-			// 4) Let the fetch settle; the anchor-restoration layout effect runs
-			//    here.
-			await waitFor( () => expect( isLoading() ).toBe( false ), {
-				timeout: 4000,
-			} );
-
-			// 5) The viewport must stay where the user left it. On `trunk` the
-			//    restoration snaps `scrollTop` back toward its capture-time value,
-			//    yanking the list upward; the small tolerance absorbs sub-pixel
-			//    rounding only.
-			await waitFor( () =>
-				expect( container.scrollTop ).toBeGreaterThanOrEqual(
-					scrolledTo - 24
-				)
-			);
-		}
 	},
 };

--- a/packages/dataviews/src/dataviews/style.scss
+++ b/packages/dataviews/src/dataviews/style.scss
@@ -70,6 +70,11 @@
 
 .dataviews-loading-more {
 	text-align: center;
+
+	// Hidden but keeps its box so the reserved height stays constant.
+	&[aria-hidden="true"] {
+		visibility: hidden;
+	}
 }
 
 @container (max-width: 430px) {

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -28,6 +28,7 @@ function captureAnchorElement(
 	anchorElementRef: React.MutableRefObject< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >,
 	direction: 'up' | 'down'
@@ -61,6 +62,7 @@ function captureAnchorElement(
 	anchorElementRef.current = {
 		posinset,
 		viewportOffset: anchorRect.top - containerRect.top,
+		scrollTop: container.scrollTop,
 		direction,
 	};
 	return true;
@@ -95,6 +97,7 @@ export function useInfiniteScroll( {
 	const anchorElementRef = useRef< {
 		posinset: number;
 		viewportOffset: number;
+		scrollTop: number;
 		direction: 'up' | 'down' | null;
 	} | null >( null );
 	const viewRef = useRef( view );
@@ -174,8 +177,16 @@ export function useInfiniteScroll( {
 			const anchorRect = anchorElement.getBoundingClientRect();
 			const currentOffset = anchorRect.top - containerRect.top;
 
-			// Calculate how much the anchor has moved and adjust scroll to compensate
-			const scrollAdjustment = currentOffset - anchor.viewportOffset;
+			// Compensate only for the content-driven shift, not for any scrolling
+			// the user did between capture (in the throttled scroll handler) and
+			// this restoration (which is gated on `isLoading`). When pages load
+			// asynchronously the user keeps scrolling in that gap; adding back the
+			// intervening scroll delta prevents the list from snapping back to the
+			// capture-time position and undoing that scroll.
+			const scrollAdjustment =
+				currentOffset -
+				anchor.viewportOffset +
+				( container.scrollTop - anchor.scrollTop );
 
 			if ( Math.abs( scrollAdjustment ) > 1 ) {
 				container.scrollTop += scrollAdjustment;

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -83,12 +83,14 @@ const defaultView: View = {
 	showTitle: false,
 	titleField: 'title',
 	mediaField: 'media_thumbnail',
+	startPosition: 1,
 	perPage: 50,
 	filters: [],
 	layout: {
 		previewSize: 170,
 		density: 'compact',
 	},
+	infiniteScrollEnabled: true,
 };
 
 const defaultLayouts: SupportedLayouts = {
@@ -322,6 +324,22 @@ export function MediaUploadModal( {
 			}
 		}
 
+		// For infinite scroll, use offset-based pagination
+		// For regular pagination, use page-based pagination
+		if ( view.infiniteScrollEnabled && view.startPosition !== undefined ) {
+			return {
+				offset: view.startPosition - 1,
+				per_page: view.perPage || 20,
+				status: 'inherit',
+				order: view.sort?.direction,
+				orderby: view.sort?.field,
+				search: view.search,
+				...filters,
+			};
+		}
+
+		// Regular page-based pagination
+
 		return {
 			per_page: view.perPage || 20,
 			page: view.page || 1,
@@ -528,13 +546,16 @@ export function MediaUploadModal( {
 		[ allowedTypes, handleUpload, registerBatch ]
 	);
 
-	const paginationInfo = useMemo(
-		() => ( {
-			totalItems,
-			totalPages,
-		} ),
-		[ totalItems, totalPages ]
-	);
+	const prevPaginationInfoRef = useRef( { totalItems: 0, totalPages: 0 } );
+
+	const paginationInfo = useMemo( () => {
+		// Only update when we have valid values (not both 0)
+		// to avoid showing 0 values during data fetching
+		if ( totalItems > 0 || totalPages > 0 ) {
+			prevPaginationInfoRef.current = { totalItems, totalPages };
+		}
+		return prevPaginationInfoRef.current;
+	}, [ totalItems, totalPages ] );
 
 	// Build accept attribute from allowedTypes
 	const acceptTypes = useMemo( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

FOR TESTING PURPOSES ONLY - DO NOT MERGE!!!


1. Go to Gutenberg > Experiments and enable "Media upload modal" under "Media".
2. Add an Image or Gallery to a post, and open the media library through it. 
3. Ensure your media library has at least 300 images in it.
4. Scroll through the modal and check that it feels smooth and not janky.

(the reason we don't want to enable infinite scroll on the media upload modal is because there's no off switch for it yet, and infinite scroll isn't hugely accessible so we should always be able to switch it off easily)
