### PR TITLE
Media Editor: Use new Tabs component from the ui package, and its minimal variant

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -6,16 +6,14 @@ import {
 	Flex,
 	Spinner,
 	__experimentalConfirmDialog as ConfirmDialog,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { Stack, Tabs } from '@wordpress/ui';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	createPortal,
 	useCallback,
-	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -50,7 +48,6 @@ import MediaEditorFineRotation from '../media-editor-fine-rotation';
 import MediaEditorImageControls from '../media-editor-image-controls';
 import MediaEditorCropPanel from '../media-editor-crop-panel';
 import MediaForm from '../media-form';
-import { unlock } from '../../lock-unlock';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { MediaEditorStateProvider, useMediaEditor } from '../../state';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
@@ -71,8 +68,6 @@ export type { MediaEditorSaveResult } from './use-save-media-editor';
 const ATTACHMENT_EMBED_QUERY = { _embed: 'author,wp:attached-to' } as const;
 
 const PLACEMENT_CONTROL_IDLE_MS = 300;
-
-const { Tabs } = unlock( componentsPrivateApis );
 
 interface EditorTab {
 	id: string;
@@ -116,7 +111,10 @@ export interface MediaEditorProps {
 }
 
 function MediaEditorSidebar( { tabs }: { tabs: EditorTab[] } ) {
-	const tabsContextValue = useContext( Tabs.Context );
+	// The tab list and panels must share one `<Tabs.Root>`, but they render in
+	// separate `ComplementaryArea` regions (header vs body). A non-virtual Slot
+	// reconciles both inline at the Slot, so the `Root` is lifted to wrap this
+	// Fill and that Slot together — see `MediaEditorContent`.
 	return (
 		<ComplementaryArea
 			scope="media-editor"
@@ -129,28 +127,20 @@ function MediaEditorSidebar( { tabs }: { tabs: EditorTab[] } ) {
 			headerClassName="media-editor__sidebar-header"
 			closeLabel={ __( 'Close media panel' ) }
 			header={
-				<Tabs.Context.Provider value={ tabsContextValue }>
-					<Tabs.TabList>
-						{ tabs.map( ( tab ) => (
-							<Tabs.Tab key={ tab.id } tabId={ tab.id }>
-								{ tab.title }
-							</Tabs.Tab>
-						) ) }
-					</Tabs.TabList>
-				</Tabs.Context.Provider>
+				<Tabs.List variant="minimal">
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab key={ tab.id } value={ tab.id }>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
 			}
 		>
-			<Tabs.Context.Provider value={ tabsContextValue }>
-				{ tabs.map( ( tab ) => (
-					<Tabs.TabPanel
-						key={ tab.id }
-						tabId={ tab.id }
-						focusable={ false }
-					>
-						{ tab.panel }
-					</Tabs.TabPanel>
-				) ) }
-			</Tabs.Context.Provider>
+			{ tabs.map( ( tab ) => (
+				<Tabs.Panel key={ tab.id } value={ tab.id } tabIndex={ -1 }>
+					{ tab.panel }
+				</Tabs.Panel>
+			) ) }
 		</ComplementaryArea>
 	);
 }
@@ -501,6 +491,13 @@ function MediaEditorContent( {
 		isPanelLayout,
 	] );
 
+	// Control the active tab from state here so the selection survives the
+	// sidebar closing (which unmounts the `ComplementaryArea` Fill and its
+	// tabs). Fall back to the first tab until one is picked, so images open on
+	// Crop.
+	const [ selectedTabId, setSelectedTabId ] = useState< string >();
+	const activeTabId = selectedTabId ?? tabs[ 0 ]?.id;
+
 	const handleChange = ( updates: Partial< Media > ) => {
 		editEntityRecord( 'postType', 'attachment', id, updates );
 	};
@@ -581,58 +578,62 @@ function MediaEditorContent( {
 			onChange={ handleChange }
 			settings={ { fields } }
 		>
-			<div className="media-editor">
-				{ ! media ? (
+			{ ! media ? (
+				<div className="media-editor">
 					<div className="media-editor__loading">
 						<Spinner />
 					</div>
-				) : (
-					<>
-						<Tabs>
-							<MediaEditorSidebar tabs={ tabs } />
-						</Tabs>
-						<InterfaceSkeleton
-							className="media-editor__skeleton"
-							labels={ {
-								body: isImage
-									? __( 'Image editor' )
-									: __( 'Media preview' ),
-								sidebar: __( 'Media details' ),
-							} }
-							content={
-								<div className="media-editor__content">
-									<div className="media-editor__canvas-area">
-										{ isImage ? (
-											<MediaEditorCanvas
-												focusOnMount
-												isPlacementActive={
-													isPlacementActive
-												}
-												onGestureStart={
-													handleCanvasGestureStart
-												}
-												onGestureEnd={
-													handleCanvasGestureEnd
-												}
-											/>
-										) : (
-											<MediaPreview />
-										) }
-									</div>
-									{ isImage && (
-										<div className="media-editor__canvas-toolbar">
-											{ ruler }
-										</div>
+				</div>
+			) : (
+				<Tabs.Root
+					className="media-editor"
+					value={ activeTabId }
+					onValueChange={ ( value ) =>
+						setSelectedTabId( value as string )
+					}
+				>
+					<MediaEditorSidebar tabs={ tabs } />
+					<InterfaceSkeleton
+						className="media-editor__skeleton"
+						labels={ {
+							body: isImage
+								? __( 'Image editor' )
+								: __( 'Media preview' ),
+							sidebar: __( 'Media details' ),
+						} }
+						content={
+							<div className="media-editor__content">
+								<div className="media-editor__canvas-area">
+									{ isImage ? (
+										<MediaEditorCanvas
+											focusOnMount
+											isPlacementActive={
+												isPlacementActive
+											}
+											onGestureStart={
+												handleCanvasGestureStart
+											}
+											onGestureEnd={
+												handleCanvasGestureEnd
+											}
+										/>
+									) : (
+										<MediaPreview />
 									) }
 								</div>
-							}
-							sidebar={
-								<ComplementaryArea.Slot scope="media-editor" />
-							}
-						/>
-					</>
-				) }
-			</div>
+								{ isImage && (
+									<div className="media-editor__canvas-toolbar">
+										{ ruler }
+									</div>
+								) }
+							</div>
+						}
+						sidebar={
+							<ComplementaryArea.Slot scope="media-editor" />
+						}
+					/>
+				</Tabs.Root>
+			) }
 			<ConfirmDialog
 				isOpen={ isDiscardDialogOpen }
 				confirmButtonText={ __( 'Discard' ) }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1764,11 +1764,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-editor/src/components/media-editor/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/media-editor/src/components/media-form/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?

Part of:

* #73771 

Refactor part of the Media Editor to use the new Tabs component from the `ui` package and its `minimal` variant.

## Why?

Based on feedback from @fcoveram, currently in this sidebar the tab label does not line up with the headings / labels for the controls within the sidebar.

However, if we use the minimal variant of the new Tabs component, then there's no horizontal padding on the tab label, so it can sit flush with the left edge of the controls, which makes things look a bit neater.

## How?

* Wrap the sidebar and interface skeleton with `Tabs.Root` so that the tabs context is available for both the tabs list and panel
* Add state to track which tab is selected so that we preserve selection when toggling the sidebar visibility

## Testing Instructions

* Upload an image to a post or page
* Click the Crop icon in the block toolbar after selecting an image block
* Try out the Crop and Details tabs
* Try toggling the sidebar and make sure it remembers which tab you had selected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before (trunk)

<img width="1220" height="705" alt="image" src="https://github.com/user-attachments/assets/e7b3e80d-b1f3-4410-ab23-dd10e911216f" />

### After (this PR)

<img width="1217" height="702" alt="image" src="https://github.com/user-attachments/assets/fe17a0fd-90d6-4116-8a3b-b4459e569f5e" />

## Use of AI Tools

Claude code and a little manual tweaking here and there