### PR TITLE
Revert npm v11 supply-chain settings (allow-git, allow-remote, allowScripts)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,7 +3,3 @@ legacy-peer-deps = true
 prefer-dedupe = true
 lockfile-version = 3
 min-release-age = 1
-# do not allow git dependencies
-allow-git = none
-# do not allow dependencies from unknown remote sources
-allow-remote = none

--- a/package.json
+++ b/package.json
@@ -222,16 +222,5 @@
 		"test/unit",
 		"tools/*",
 		"widgets/*"
-	],
-	"allowScripts": {
-		"@parcel/watcher": false,
-		"core-js": false,
-		"core-js-pure": false,
-		"esbuild": false,
-		"fs-ext": false,
-		"fsevents": false,
-		"leveldown": true,
-		"nx": false,
-		"unrs-resolver": false
-	}
+	]
 }


### PR DESCRIPTION
## What?

Reverts the npm v11 supply-chain settings added in #79614 — the `.npmrc` `allow-git` / `allow-remote` keys and the `package.json` `allowScripts` field.

## Why?

They fail CI on Node 24, whose bundled npm predates the version that supports these features. Reverting until CI runs an npm version that does.

The `package-lock.json` cleanup from #79614 (removing an extraneous `esbuild` entry) is independent of the supply-chain features, so it's intentionally kept.

## How?

- Revert the `.npmrc` `allow-git = none` / `allow-remote = none` additions.
- Remove the `allowScripts` field from `package.json`.
- Leave `package-lock.json` unchanged.

## Testing Instructions

1. CI should be happy

## Use of AI Tools

This revert and description were prepared with help from an AI coding agent and reviewed before submission.
