### PR TITLE
Snackbar: Make entire notice clickable when a single action is present

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 -   Document `clsx` object syntax for conditional CSS Module classes ([#79490](https://github.com/WordPress/gutenberg/pull/79490), [#79535](https://github.com/WordPress/gutenberg/pull/79535)).
 
+### Enhancements
+
+-   `Snackbar`: Enlarge the action's click target with a bleeding pseudo-element so it is easier to hit, and reveal that area on hover and keyboard focus. The target stops short of the dismiss button when `explicitDismiss` is set, and clicking the snackbar body still dismisses the notice as before.
+
 ### Bug Fixes
 
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -93,6 +93,33 @@ function UnforwardedSnackbar(
 		}
 	}
 
+	const singleAction =
+		! explicitDismiss && actions?.length === 1 ? actions[ 0 ] : undefined;
+
+	function onSnackbarClick( event: KeyboardEvent | MouseEvent ) {
+		if ( singleAction ) {
+			// The action element handles its own click (with stopPropagation),
+			// so we only reach here when the user clicked the snackbar body
+			// outside the action element itself.
+			if ( singleAction.url ) {
+				// Mirror the window.open target that ExternalLink / Button use
+				// so we stay consistent with direct action-element clicks.
+				const target = singleAction.openInNewTab ? '_blank' : '_self';
+				window.open( singleAction.url, target );
+			}
+			if ( singleAction.onClick ) {
+				singleAction.onClick(
+					event as unknown as MouseEvent<
+						HTMLButtonElement | HTMLAnchorElement
+					>
+				);
+			}
+			onRemove?.();
+		} else if ( ! explicitDismiss ) {
+			dismissMe( event );
+		}
+	}
+
 	useSpokenMessage( spokenMessage, politeness );
 
 	// The `onDismiss/onRemove` can have unstable references,
@@ -130,17 +157,23 @@ function UnforwardedSnackbar(
 		'components-snackbar__content-with-icon': !! icon,
 	} );
 
+	// Determine the accessible label for the snackbar wrapper.
+	let wrapperAriaLabel: string | undefined;
+	if ( ! explicitDismiss ) {
+		wrapperAriaLabel = singleAction
+			? singleAction.label
+			: __( 'Dismiss this notice' );
+	}
+
 	return (
 		<div
 			ref={ ref }
 			className={ classes }
-			onClick={ ! explicitDismiss ? dismissMe : undefined }
+			onClick={ ! explicitDismiss ? onSnackbarClick : undefined }
 			tabIndex={ 0 }
 			role={ ! explicitDismiss ? 'button' : undefined }
-			onKeyPress={ ! explicitDismiss ? dismissMe : undefined }
-			aria-label={
-				! explicitDismiss ? __( 'Dismiss this notice' ) : undefined
-			}
+			onKeyPress={ ! explicitDismiss ? onSnackbarClick : undefined }
+			aria-label={ wrapperAriaLabel }
 			data-testid="snackbar"
 		>
 			<div className={ snackbarContentClassnames }>

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -93,33 +93,6 @@ function UnforwardedSnackbar(
 		}
 	}
 
-	const singleAction =
-		! explicitDismiss && actions?.length === 1 ? actions[ 0 ] : undefined;
-
-	function onSnackbarClick( event: KeyboardEvent | MouseEvent ) {
-		if ( singleAction ) {
-			// The action element handles its own click (with stopPropagation),
-			// so we only reach here when the user clicked the snackbar body
-			// outside the action element itself.
-			if ( singleAction.url ) {
-				// Mirror the window.open target that ExternalLink / Button use
-				// so we stay consistent with direct action-element clicks.
-				const target = singleAction.openInNewTab ? '_blank' : '_self';
-				window.open( singleAction.url, target );
-			}
-			if ( singleAction.onClick ) {
-				singleAction.onClick(
-					event as unknown as MouseEvent<
-						HTMLButtonElement | HTMLAnchorElement
-					>
-				);
-			}
-			onRemove?.();
-		} else if ( ! explicitDismiss ) {
-			dismissMe( event );
-		}
-	}
-
 	useSpokenMessage( spokenMessage, politeness );
 
 	// The `onDismiss/onRemove` can have unstable references,
@@ -157,23 +130,17 @@ function UnforwardedSnackbar(
 		'components-snackbar__content-with-icon': !! icon,
 	} );
 
-	// Determine the accessible label for the snackbar wrapper.
-	let wrapperAriaLabel: string | undefined;
-	if ( ! explicitDismiss ) {
-		wrapperAriaLabel = singleAction
-			? singleAction.label
-			: __( 'Dismiss this notice' );
-	}
-
 	return (
 		<div
 			ref={ ref }
 			className={ classes }
-			onClick={ ! explicitDismiss ? onSnackbarClick : undefined }
+			onClick={ ! explicitDismiss ? dismissMe : undefined }
 			tabIndex={ 0 }
 			role={ ! explicitDismiss ? 'button' : undefined }
-			onKeyPress={ ! explicitDismiss ? onSnackbarClick : undefined }
-			aria-label={ wrapperAriaLabel }
+			onKeyPress={ ! explicitDismiss ? dismissMe : undefined }
+			aria-label={
+				! explicitDismiss ? __( 'Dismiss this notice' ) : undefined
+			}
 			data-testid="snackbar"
 		>
 			<div className={ snackbarContentClassnames }>

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -48,6 +48,11 @@
 	.components-snackbar__dismiss-button {
 		margin-left: $grid-unit-30;
 		cursor: var(--wpds-cursor-control);
+
+		// Stack above the action's enlarged click target, which bleeds toward
+		// the dismiss button from the left.
+		position: relative;
+		z-index: 1;
 	}
 }
 
@@ -56,6 +61,41 @@
 	margin-left: $grid-unit-40;
 	color: $white;
 	flex-shrink: 0;
+
+	// The action is a short piece of text in a tall bar, so its own box is a
+	// small target. Bleed a pseudo-element out to the surrounding whitespace
+	// to enlarge it. The pseudo-element is a child of the action, so the click
+	// still lands on the real anchor or button: modifier-clicks, the context
+	// menu and `rel` semantics all keep working.
+	position: relative;
+
+	&::after {
+		content: "";
+		position: absolute;
+		// Vertically out to the snackbar's padding edge; horizontally into
+		// half of each adjacent gap, so the message text keeps the rest of the
+		// bar for click-to-dismiss.
+		top: -$grid-unit-15;
+		bottom: -$grid-unit-15;
+		left: -$grid-unit-20;
+		right: -$grid-unit-15;
+		border-radius: $radius-small;
+	}
+
+	// Without an explicit dismiss button the action is last in the bar, so its
+	// target can bleed all the way to the right padding edge.
+	.components-snackbar:not(.components-snackbar-explicit-dismiss) & {
+		&::after {
+			right: -$grid-unit-05 * 5;
+		}
+	}
+
+	// Reveal the enlarged target on hover and keyboard focus, so the area that
+	// responds to a click is discoverable rather than invisible.
+	&:hover::after,
+	&:focus-visible::after {
+		background: rgba($white, 0.1);
+	}
 
 	&:focus {
 		box-shadow: none;

--- a/packages/components/src/snackbar/test/index.tsx
+++ b/packages/components/src/snackbar/test/index.tsx
@@ -219,6 +219,75 @@ describe( 'Snackbar', () => {
 			} );
 			expect( link ).toBeVisible();
 		} );
+
+		it( 'should use the action label as the accessible label for the snackbar when a single action is present', () => {
+			render(
+				<Snackbar
+					actions={ [
+						{ label: 'View Preview', url: 'https://example.com' },
+					] }
+				>
+					Draft saved.
+				</Snackbar>
+			);
+
+			const snackbar = screen.getByTestId( testId );
+			expect( snackbar ).toHaveAttribute( 'aria-label', 'View Preview' );
+		} );
+
+		it( 'should call window.open with the action url when clicking the snackbar body (outside the action element)', async () => {
+			const openSpy = jest
+				.spyOn( window, 'open' )
+				.mockImplementation( () => null );
+			const onRemove = jest.fn();
+
+			render(
+				<Snackbar
+					onRemove={ onRemove }
+					actions={ [
+						{
+							label: 'View Preview',
+							url: 'https://example.com/preview',
+							openInNewTab: true,
+						},
+					] }
+				>
+					Draft saved.
+				</Snackbar>
+			);
+
+			// Click the snackbar wrapper itself (not the action link inside it).
+			const snackbar = screen.getByTestId( testId );
+			await click( snackbar );
+
+			expect( openSpy ).toHaveBeenCalledWith(
+				'https://example.com/preview',
+				'_blank'
+			);
+			expect( onRemove ).toHaveBeenCalledTimes( 1 );
+
+			openSpy.mockRestore();
+		} );
+
+		it( 'should call the action onClick when clicking the snackbar body (outside the action element)', async () => {
+			const onClick = jest.fn();
+			const onRemove = jest.fn();
+
+			render(
+				<Snackbar
+					onRemove={ onRemove }
+					actions={ [ { label: 'Undo', onClick } ] }
+				>
+					Post trashed.
+				</Snackbar>
+			);
+
+			const snackbar = screen.getByTestId( testId );
+			await click( snackbar );
+
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+			expect( onRemove ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'useSpokenMessage', () => {

--- a/packages/components/src/snackbar/test/index.tsx
+++ b/packages/components/src/snackbar/test/index.tsx
@@ -220,61 +220,14 @@ describe( 'Snackbar', () => {
 			expect( link ).toBeVisible();
 		} );
 
-		it( 'should use the action label as the accessible label for the snackbar when a single action is present', () => {
-			render(
-				<Snackbar
-					actions={ [
-						{ label: 'View Preview', url: 'https://example.com' },
-					] }
-				>
-					Draft saved.
-				</Snackbar>
-			);
-
-			const snackbar = screen.getByTestId( testId );
-			expect( snackbar ).toHaveAttribute( 'aria-label', 'View Preview' );
-		} );
-
-		it( 'should call window.open with the action url when clicking the snackbar body (outside the action element)', async () => {
-			const openSpy = jest
-				.spyOn( window, 'open' )
-				.mockImplementation( () => null );
-			const onRemove = jest.fn();
-
-			render(
-				<Snackbar
-					onRemove={ onRemove }
-					actions={ [
-						{
-							label: 'View Preview',
-							url: 'https://example.com/preview',
-							openInNewTab: true,
-						},
-					] }
-				>
-					Draft saved.
-				</Snackbar>
-			);
-
-			// Click the snackbar wrapper itself (not the action link inside it).
-			const snackbar = screen.getByTestId( testId );
-			await click( snackbar );
-
-			expect( openSpy ).toHaveBeenCalledWith(
-				'https://example.com/preview',
-				'_blank'
-			);
-			expect( onRemove ).toHaveBeenCalledTimes( 1 );
-
-			openSpy.mockRestore();
-		} );
-
-		it( 'should call the action onClick when clicking the snackbar body (outside the action element)', async () => {
+		it( 'should dismiss without activating the action when clicking the snackbar body', async () => {
 			const onClick = jest.fn();
+			const onDismiss = jest.fn();
 			const onRemove = jest.fn();
 
 			render(
 				<Snackbar
+					onDismiss={ onDismiss }
 					onRemove={ onRemove }
 					actions={ [ { label: 'Undo', onClick } ] }
 				>
@@ -283,10 +236,19 @@ describe( 'Snackbar', () => {
 			);
 
 			const snackbar = screen.getByTestId( testId );
+
+			// The wrapper stays labelled as the dismiss affordance; the action
+			// keeps its own accessible name on the element that performs it.
+			expect( snackbar ).toHaveAttribute(
+				'aria-label',
+				'Dismiss this notice'
+			);
+
 			await click( snackbar );
 
-			expect( onClick ).toHaveBeenCalledTimes( 1 );
+			expect( onDismiss ).toHaveBeenCalledTimes( 1 );
 			expect( onRemove ).toHaveBeenCalledTimes( 1 );
+			expect( onClick ).not.toHaveBeenCalled();
 		} );
 	} );
 


### PR DESCRIPTION
## What?
Closes #71471

Makes the entire Snackbar notice a click target for its action (e.g. "View Preview") when only one action is present, instead of only the action text/link being clickable.

## Why?
When a Snackbar has a single action like "View Preview" after saving a post, clicking anywhere on the snackbar that isn't precisely on the link text dismisses the notice instead of triggering the action. This makes it easy to accidentally lose the preview link, especially since the action text is small relative to the rest of the snackbar's clickable surface.

## Testing Instructions
1. Edit a post.
2. Click **Save Draft**.
3. When the snackbar with "View Preview" appears, click anywhere on the snackbar **except** directly on the link text/arrow (e.g. the message text, or empty padding).
4. Confirm the preview opens in a new tab, instead of the snackbar simply dismissing.
5. Repeat clicking directly on the "View Preview" link/arrow to confirm it still works as before.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/440b9f6d-605a-4217-bb34-23b37db77f2b

