### PR TITLE
Remove redundant @jest-environment jsdom pragmas from unit tests

### DIFF
--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 describe( 'cross-origin-isolation', () => {
 	let originalCrossOriginIsolated;
 	let originalBody;

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { act, renderHook } from '@testing-library/react';

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { render, screen, fireEvent } from '@testing-library/react';

--- a/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';

--- a/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { renderHook } from '@testing-library/react';

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { renderHook } from '@testing-library/react';

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * Internal dependencies
  */
 import { getTrackAttributes } from '../utils';

--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import '@testing-library/jest-dom';

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import '@testing-library/jest-dom';

--- a/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { render } from '@testing-library/react';

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { render } from '@testing-library/react';

--- a/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { render, act, screen } from '@testing-library/react';

--- a/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
+++ b/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';

--- a/routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts
@@ -1,8 +1,4 @@
 /**
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import { act, renderHook } from '@testing-library/react';


### PR DESCRIPTION
## What?

Removes the redundant `@jest-environment jsdom` docblock pragma from unit test files where it has no effect.

## Why?

The unit test config (`test/unit/jest.config.js`) extends `@wordpress/jest-preset-default`, which already sets `testEnvironment: 'jsdom'` as the default. There is no per-package or root override, so every test file already runs under jsdom unless it opts into a different environment.

That makes a `@jest-environment jsdom` pragma a no-op — it documents the default rather than changing anything, and the inconsistency (most jsdom tests omit it) is mildly confusing. The `@jest-environment node` pragmas are genuine overrides and are left untouched.

## How?

Deleted the leading pragma docblock from the 12 test files that specified `@jest-environment jsdom`. No source or test logic changed. The intentional `@jest-environment node` overrides (compose SSR test, vips, theme stylelint plugins) are kept.

## Testing Instructions

1. Run the affected suites and confirm they still pass under the default jsdom environment:

   ```
   npm run test:unit -- packages/block-library packages/block-editor packages/grid packages/media-utils
   ```

2. Confirm no `@jest-environment jsdom` pragmas remain while `node` overrides are intact:

   ```
   grep -rn "@jest-environment" packages --include="*.js" --include="*.ts" --include="*.tsx"
   ```

### Testing Instructions for Keyboard

N/A — test-only change, no UI.

## Screenshots or screencast

N/A

## Use of AI Tools

This pull request was authored with assistance from Claude Code. All changes were reviewed by the contributor.
