### PR TITLE
E2E: Ban `uuid` package via ESLint, use `crypto.randomUUID()` instead

### DIFF
--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -69,7 +69,7 @@ class MediaProcessingUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-media-' )
 		);
-		const uniqueName = uuid();
+		const uniqueName = randomUUID();
 		const extension = path.extname( fileName );
 		const tmpFileName = path.join( tmpDirectory, uniqueName + extension );
 		await fs.copyFile( path.join( ASSETS_DIR, fileName ), tmpFileName );
@@ -402,7 +402,7 @@ test.describe( 'Client-side media processing', () => {
 		const tmpFiles = [];
 
 		for ( const file of files ) {
-			const uniqueName = uuid();
+			const uniqueName = randomUUID();
 			const ext = path.extname( file );
 			const tmpFile = path.join( tmpDirectory, uniqueName + ext );
 			await fs.copyFile( path.join( ASSETS_DIR, file ), tmpFile );

--- a/test/e2e/specs/editor/various/gif-to-video.spec.js
+++ b/test/e2e/specs/editor/various/gif-to-video.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -55,7 +55,7 @@ class GifToVideoUtils {
 		const tmpDirectory = await fs.mkdtemp(
 			path.join( os.tmpdir(), 'gutenberg-test-gif-' )
 		);
-		const uniqueName = uuid();
+		const uniqueName = randomUUID();
 		const extension = path.extname( fileName );
 		const tmpFileName = path.join( tmpDirectory, uniqueName + extension );
 		await fs.copyFile( path.join( ASSETS_DIR, fileName ), tmpFileName );

--- a/test/performance/specs/media-upload.spec.js
+++ b/test/performance/specs/media-upload.spec.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
-const { v4: uuid } = require( 'uuid' );
+const { randomUUID } = require( 'crypto' );
 
 /**
  * WordPress dependencies
@@ -36,7 +36,7 @@ async function createTempImage( sourceFile, ext ) {
 	const tmpDirectory = await fs.mkdtemp(
 		path.join( os.tmpdir(), 'gutenberg-perf-media-' )
 	);
-	const tmpFileName = path.join( tmpDirectory, uuid() + ext );
+	const tmpFileName = path.join( tmpDirectory, randomUUID() + ext );
 	await fs.copyFile( path.join( E2E_ASSETS_PATH, sourceFile ), tmpFileName );
 	return { tmpFileName, tmpDirectory };
 }
@@ -218,7 +218,7 @@ test.describe( 'Media Upload Performance', () => {
 				for ( let j = 0; j < 5; j++ ) {
 					const tmpFileName = path.join(
 						tmpDirectory,
-						uuid() + '.jpeg'
+						randomUUID() + '.jpeg'
 					);
 					await fs.copyFile(
 						path.join(

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -515,6 +515,14 @@ export default dedupePlugins( [
 		rules: {
 			'@wordpress/no-global-active-element': 'off',
 			'@wordpress/no-global-get-selection': 'off',
+			'no-restricted-imports': [
+				'error',
+				{
+					name: 'uuid',
+					message:
+						'`uuid` is ESM-only and breaks `require()` call sites (see #77960). Use the built-in `crypto.randomUUID()` instead.',
+				},
+			],
 			'no-restricted-syntax': [
 				'error',
 				{
@@ -530,6 +538,12 @@ export default dedupePlugins( [
 					selector:
 						'CallExpression[callee.object.name="page"][callee.property.name="waitForTimeout"]',
 					message: 'Prefer page.locator instead.',
+				},
+				{
+					selector:
+						'CallExpression[callee.name="require"][arguments.0.value="uuid"]',
+					message:
+						'`uuid` is ESM-only and breaks `require()` call sites (see #77960). Use the built-in `crypto.randomUUID()` instead.',
 				},
 			],
 			'playwright/no-conditional-in-test': 'off',


### PR DESCRIPTION
## What?

Adds an ESLint rule banning the `uuid` package in E2E/performance specs and migrates the remaining consumers to Node's built-in `crypto.randomUUID()`. Follow up to #77960.

## Why?

`uuid` v14 is ESM-only, so `require('uuid')` throws `ERR_REQUIRE_ESM`. #77960 removed the root dependency, but the test specs still used `uuid` and nothing stopped new ones from reintroducing it.

## How?

In the E2E override of `tools/eslint/config.mjs` (`test/e2e/**`, `test/performance/**`, `packages/e2e-test-utils-playwright/**`): added `no-restricted-imports` for the ESM form and a `no-restricted-syntax` selector for `require('uuid')` (which `no-restricted-imports` can't catch). Both messages suggest `crypto.randomUUID()`. Migrated the three consumers to `const { randomUUID } = require( 'crypto' )`.

## Testing Instructions

1. `npm run lint:js` passes.
2. Add `require( 'uuid' )` to any E2E spec and lint — the rule reports the error and suggests `crypto.randomUUID()`.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

Authored with assistance from Claude Code (Opus 4.8); reviewed and tested by the PR author.
