### PR TITLE
Backport package version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57681,7 +57681,7 @@
 		},
 		"packages/block-directory": {
 			"name": "@wordpress/block-directory",
-			"version": "5.40.0",
+			"version": "5.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -57720,7 +57720,7 @@
 		},
 		"packages/block-editor": {
 			"name": "@wordpress/block-editor",
-			"version": "15.13.0",
+			"version": "15.13.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -57809,7 +57809,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "9.40.0",
+			"version": "9.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -57945,7 +57945,7 @@
 		},
 		"packages/boot": {
 			"name": "@wordpress/boot",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -58203,7 +58203,7 @@
 		},
 		"packages/core-commands": {
 			"name": "@wordpress/core-commands",
-			"version": "1.40.0",
+			"version": "1.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "file:../block-editor",
@@ -58231,7 +58231,7 @@
 		},
 		"packages/core-data": {
 			"name": "@wordpress/core-data",
-			"version": "7.40.0",
+			"version": "7.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -59061,7 +59061,7 @@
 		},
 		"packages/customize-widgets": {
 			"name": "@wordpress/customize-widgets",
-			"version": "5.40.0",
+			"version": "5.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -59387,7 +59387,7 @@
 		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
-			"version": "8.40.0",
+			"version": "8.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -59435,7 +59435,7 @@
 		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
-			"version": "6.40.0",
+			"version": "6.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -59515,7 +59515,7 @@
 		},
 		"packages/edit-widgets": {
 			"name": "@wordpress/edit-widgets",
-			"version": "6.40.0",
+			"version": "6.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -59561,7 +59561,7 @@
 		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
-			"version": "14.40.0",
+			"version": "14.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@floating-ui/react-dom": "2.0.8",
@@ -59763,7 +59763,7 @@
 		},
 		"packages/fields": {
 			"name": "@wordpress/fields",
-			"version": "0.32.0",
+			"version": "0.32.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -59806,7 +59806,7 @@
 		},
 		"packages/format-library": {
 			"name": "@wordpress/format-library",
-			"version": "5.40.0",
+			"version": "5.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -59859,7 +59859,7 @@
 		},
 		"packages/global-styles-ui": {
 			"name": "@wordpress/global-styles-ui",
-			"version": "1.7.0",
+			"version": "1.7.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -60144,7 +60144,7 @@
 		},
 		"packages/lazy-editor": {
 			"name": "@wordpress/lazy-editor",
-			"version": "1.6.0",
+			"version": "1.6.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/asset-loader": "file:../asset-loader",
@@ -60227,7 +60227,7 @@
 		},
 		"packages/media-fields": {
 			"name": "@wordpress/media-fields",
-			"version": "0.5.0",
+			"version": "0.5.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -60258,7 +60258,7 @@
 		},
 		"packages/media-utils": {
 			"name": "@wordpress/media-utils",
-			"version": "5.40.0",
+			"version": "5.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -60341,7 +60341,7 @@
 		},
 		"packages/patterns": {
 			"name": "@wordpress/patterns",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -60893,7 +60893,7 @@
 		},
 		"packages/reusable-blocks": {
 			"name": "@wordpress/reusable-blocks",
-			"version": "5.40.0",
+			"version": "5.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -62156,7 +62156,7 @@
 		},
 		"packages/upload-media": {
 			"name": "@wordpress/upload-media",
-			"version": "0.25.0",
+			"version": "0.25.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/blob": "file:../blob",
@@ -62229,7 +62229,7 @@
 		},
 		"packages/vips": {
 			"name": "@wordpress/vips",
-			"version": "1.0.0-prerelease",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/worker-threads": "file:../worker-threads",
@@ -62260,7 +62260,7 @@
 		},
 		"packages/widgets": {
 			"name": "@wordpress/widgets",
-			"version": "4.40.0",
+			"version": "4.40.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -62297,7 +62297,7 @@
 		},
 		"packages/worker-threads": {
 			"name": "@wordpress/worker-threads",
-			"version": "1.0.0-prerelease",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"comctx": "^1.4.3"

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "5.40.0",
+	"version": "5.40.1",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-editor",
-	"version": "15.13.0",
+	"version": "15.13.1",
 	"description": "Generic block editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "9.40.0",
+	"version": "9.40.1",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/boot",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Minimal boot package for WordPress admin pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-commands",
-	"version": "1.40.0",
+	"version": "1.40.1",
 	"description": "WordPress core reusable commands.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-data",
-	"version": "7.40.0",
+	"version": "7.40.1",
 	"description": "Access to and manipulation of core WordPress entities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"version": "5.40.0",
+	"version": "5.40.1",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "8.40.0",
+	"version": "8.40.1",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "6.40.0",
+	"version": "6.40.1",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-widgets",
-	"version": "6.40.0",
+	"version": "6.40.1",
 	"description": "Widgets Page module for WordPress..",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "14.40.0",
+	"version": "14.40.1",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/fields",
-	"version": "0.32.0",
+	"version": "0.32.1",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/format-library",
-	"version": "5.40.0",
+	"version": "5.40.1",
 	"description": "Format library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/global-styles-ui",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"description": "Global Styles UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/lazy-editor",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "Lazy-loading editor component with automatic asset and settings management.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-fields",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Reusable field definitions for displaying and editing media attachment properties in WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-utils",
-	"version": "5.40.0",
+	"version": "5.40.1",
 	"description": "WordPress Media Upload Utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/patterns",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Management of user pattern editing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/reusable-blocks",
-	"version": "5.40.0",
+	"version": "5.40.1",
 	"description": "Reusable blocks utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/vips/CHANGELOG.md
+++ b/packages/vips/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0 (2026-02-23)
+
 ### New Features
 
 -   Initial release of `@wordpress/vips` package for client-side image processing using `wasm-vips` ([#74785](https://github.com/WordPress/gutenberg/pull/74785)).

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/vips",
-	"version": "1.0.0-prerelease",
+	"version": "1.0.0",
 	"description": "Utils for working with libvips.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widgets",
-	"version": "4.40.0",
+	"version": "4.40.1",
 	"description": "Functionality used by the widgets block editor in the Widgets screen and the Customizer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/worker-threads/CHANGELOG.md
+++ b/packages/worker-threads/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0 (2026-02-23)
+
 ### New Features
 
 -   Initial release of `@wordpress/worker-threads` package ([#74785](https://github.com/WordPress/gutenberg/pull/74785)).

--- a/packages/worker-threads/package.json
+++ b/packages/worker-threads/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/worker-threads",
-	"version": "1.0.0-prerelease",
+	"version": "1.0.0",
 	"description": "Utilities for type-safe Web Worker communication with RPC.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Backports the package version bump from https://github.com/WordPress/gutenberg/commit/398c509dbbdcdb525d17e968edd83da33a0a7bde to the `wp/7.0` branch.

The related changes from https://github.com/WordPress/gutenberg/pull/75752 and https://github.com/WordPress/gutenberg/pull/75758 have already been backported to WordPress Core. However, the corresponding package version bump was published from `wp/latest` and is not present on `wp/7.0`.

Because npm package versions are global across dist-tags, publishing from `wp/7.0` while the branch still has the previous package versions causes the release process to try publishing versions that already exist.

This PR brings `wp/7.0` up to date with the already-published package versions, unblocking publication under the `wp-7.0` dist-tag.

<img width="1811" height="381" alt="image" src="https://github.com/user-attachments/assets/603ed598-3b22-447c-bb97-7fe94bf1712b" />

Slack thread: https://wordpress.slack.com/archives/C02QB2JS7/p1780499303839469

