### PR TITLE
Jest: Add missing clsx dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47616,6 +47616,9 @@
 				"babel-jest": "^29.7.0",
 				"change-case": "^4.1.2"
 			},
+			"devDependencies": {
+				"clsx": "^2.1.1"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -35,6 +35,9 @@
 		"babel-jest": "^29.7.0",
 		"change-case": "^4.1.2"
 	},
+	"devDependencies": {
+		"clsx": "^2.1.1"
+	},
 	"peerDependencies": {
 		"@babel/core": ">=7",
 		"jest": ">=29"


### PR DESCRIPTION
## What?
Follow up to #79535.

Adds `clsx` as a dev dependency of `@wordpress/jest-preset-default`.

## Why?
The package's `style-mock` unit test imports `clsx`, so the package should declare that test dependency directly.

## How?
Adds `clsx@^2.1.1` to `packages/jest-preset-default/package.json` and updates the corresponding `package-lock.json` workspace entry.

## Testing Instructions
Run:

```
npm run lint:lockfile
npm run lint:pkg-json
npm run lint:deps
npm run test:unit packages/jest-preset-default/test/style-mock.js
npm audit --workspace @wordpress/jest-preset-default --audit-level=high
```

### Testing Instructions for Keyboard
Not applicable; this is a package metadata change.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
OpenAI Codex helped prepare this patch; I reviewed the changes.