### PR TITLE
Boot: Merge root theme providers

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Use a single root `ThemeProvider` for boot layouts so document-level design tokens match the boot layout theme context. ([#79679](https://github.com/WordPress/gutenberg/pull/79679))
+
 ## 0.16.0 (2026-06-24)
 
 ### Enhancements

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -63,143 +63,132 @@ export default function Root() {
 	return (
 		<SlotFillProvider>
 			<Tooltip.Provider>
-				<ThemeProvider
-					isRoot
-					color={ { ...themeColors, background: '#f8f8f8' } }
-				>
-					<ThemeProvider color={ themeColors }>
-						<div
-							className={ clsx( 'boot-layout', {
-								'has-canvas': !! canvas || canvas === null,
-								'has-full-canvas': isFullScreen,
-							} ) }
-						>
-							<SavePanel />
-							<SnackbarNotices className="boot-notices__snackbar" />
-							{ isMobileViewport && (
-								<Page.SidebarToggleFill>
-									<Button
-										icon={ menu }
+				<ThemeProvider isRoot color={ themeColors }>
+					<div
+						className={ clsx( 'boot-layout', {
+							'has-canvas': !! canvas || canvas === null,
+							'has-full-canvas': isFullScreen,
+						} ) }
+					>
+						<SavePanel />
+						<SnackbarNotices className="boot-notices__snackbar" />
+						{ isMobileViewport && (
+							<Page.SidebarToggleFill>
+								<Button
+									icon={ menu }
+									onClick={ () =>
+										setIsMobileSidebarOpen( true )
+									}
+									label={ __( 'Open navigation panel' ) }
+									size="compact"
+								/>
+							</Page.SidebarToggleFill>
+						) }
+						{ /* Mobile Sidebar Backdrop */ }
+						<AnimatePresence>
+							{ isMobileViewport &&
+								isMobileSidebarOpen &&
+								! isFullScreen && (
+									<motion.div
+										initial={ { opacity: 0 } }
+										animate={ { opacity: 1 } }
+										exit={ { opacity: 0 } }
+										transition={ {
+											type: 'tween',
+											duration: disableMotion ? 0 : 0.2,
+											ease: 'easeOut',
+										} }
+										className="boot-layout__sidebar-backdrop"
 										onClick={ () =>
-											setIsMobileSidebarOpen( true )
+											setIsMobileSidebarOpen( false )
 										}
-										label={ __( 'Open navigation panel' ) }
-										size="compact"
-									/>
-								</Page.SidebarToggleFill>
-							) }
-							{ /* Mobile Sidebar Backdrop */ }
-							<AnimatePresence>
-								{ isMobileViewport &&
-									isMobileSidebarOpen &&
-									! isFullScreen && (
-										<motion.div
-											initial={ { opacity: 0 } }
-											animate={ { opacity: 1 } }
-											exit={ { opacity: 0 } }
-											transition={ {
-												type: 'tween',
-												duration: disableMotion
-													? 0
-													: 0.2,
-												ease: 'easeOut',
-											} }
-											className="boot-layout__sidebar-backdrop"
-											onClick={ () =>
-												setIsMobileSidebarOpen( false )
+										onKeyDown={ ( event ) => {
+											if ( event.key === 'Escape' ) {
+												setIsMobileSidebarOpen( false );
 											}
-											onKeyDown={ ( event ) => {
-												if ( event.key === 'Escape' ) {
-													setIsMobileSidebarOpen(
-														false
-													);
-												}
-											} }
-											role="button"
-											tabIndex={ -1 }
-											aria-label={ __(
-												'Close navigation panel'
-											) }
-										/>
-									) }
-							</AnimatePresence>
-							{ /* Mobile Sidebar */ }
-							<AnimatePresence>
-								{ isMobileViewport &&
-									isMobileSidebarOpen &&
-									! isFullScreen && (
-										<motion.div
-											initial={ { x: '-100%' } }
-											animate={ { x: 0 } }
-											exit={ { x: '-100%' } }
-											transition={ {
-												type: 'tween',
-												duration: disableMotion
-													? 0
-													: 0.2,
-												ease: 'easeOut',
-											} }
-											className="boot-layout__sidebar is-mobile"
-										>
-											<Sidebar />
-										</motion.div>
-									) }
-							</AnimatePresence>
-							{ /* Desktop Sidebar */ }
-							{ ! isMobileViewport && ! isFullScreen && (
-								<div className="boot-layout__sidebar">
-									<Sidebar />
-								</div>
-							) }
-							<div className="boot-layout__surfaces">
-								<ThemeProvider
-									color={ {
-										...themeColors,
-										background: '#ffffff',
-									} }
-								>
-									<Outlet />
-									{ /* Render Canvas in Root to prevent remounting on route changes */ }
-									{ ( canvas || canvas === null ) && (
-										<div
-											className={ clsx(
-												'boot-layout__canvas',
-												{
-													'has-mobile-drawer':
-														canvas?.isPreview &&
-														isMobileViewport,
-												}
-											) }
-										>
-											{ canvas?.isPreview &&
-												isMobileViewport && (
-													<div className="boot-layout__mobile-sidebar-drawer">
-														<Button
-															icon={ menu }
-															onClick={ () =>
-																setIsMobileSidebarOpen(
-																	true
-																)
-															}
-															label={ __(
-																'Open navigation panel'
-															) }
-															size="compact"
-														/>
-													</div>
-												) }
-											<CanvasRenderer
-												canvas={ canvas }
-												routeContentModule={
-													routeContentModule
-												}
-											/>
-										</div>
-									) }
-								</ThemeProvider>
+										} }
+										role="button"
+										tabIndex={ -1 }
+										aria-label={ __(
+											'Close navigation panel'
+										) }
+									/>
+								) }
+						</AnimatePresence>
+						{ /* Mobile Sidebar */ }
+						<AnimatePresence>
+							{ isMobileViewport &&
+								isMobileSidebarOpen &&
+								! isFullScreen && (
+									<motion.div
+										initial={ { x: '-100%' } }
+										animate={ { x: 0 } }
+										exit={ { x: '-100%' } }
+										transition={ {
+											type: 'tween',
+											duration: disableMotion ? 0 : 0.2,
+											ease: 'easeOut',
+										} }
+										className="boot-layout__sidebar is-mobile"
+									>
+										<Sidebar />
+									</motion.div>
+								) }
+						</AnimatePresence>
+						{ /* Desktop Sidebar */ }
+						{ ! isMobileViewport && ! isFullScreen && (
+							<div className="boot-layout__sidebar">
+								<Sidebar />
 							</div>
+						) }
+						<div className="boot-layout__surfaces">
+							<ThemeProvider
+								color={ {
+									...themeColors,
+									background: '#ffffff',
+								} }
+							>
+								<Outlet />
+								{ /* Render Canvas in Root to prevent remounting on route changes */ }
+								{ ( canvas || canvas === null ) && (
+									<div
+										className={ clsx(
+											'boot-layout__canvas',
+											{
+												'has-mobile-drawer':
+													canvas?.isPreview &&
+													isMobileViewport,
+											}
+										) }
+									>
+										{ canvas?.isPreview &&
+											isMobileViewport && (
+												<div className="boot-layout__mobile-sidebar-drawer">
+													<Button
+														icon={ menu }
+														onClick={ () =>
+															setIsMobileSidebarOpen(
+																true
+															)
+														}
+														label={ __(
+															'Open navigation panel'
+														) }
+														size="compact"
+													/>
+												</div>
+											) }
+										<CanvasRenderer
+											canvas={ canvas }
+											routeContentModule={
+												routeContentModule
+											}
+										/>
+									</div>
+								) }
+							</ThemeProvider>
 						</div>
-					</ThemeProvider>
+					</div>
 				</ThemeProvider>
 			</Tooltip.Provider>
 		</SlotFillProvider>

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -46,45 +46,37 @@ export default function RootSinglePage() {
 
 	return (
 		<SlotFillProvider>
-			<ThemeProvider
-				isRoot
-				color={ { ...themeColors, background: '#f8f8f8' } }
-			>
-				<ThemeProvider color={ themeColors }>
-					<div
-						className={ clsx(
-							'boot-layout boot-layout--single-page',
-							{
-								'has-canvas': !! canvas || canvas === null,
-								'has-full-canvas': isFullScreen,
-							}
-						) }
-					>
-						<SavePanel />
-						<SnackbarNotices className="boot-notices__snackbar" />
-						<div className="boot-layout__surfaces">
-							<ThemeProvider
-								color={ {
-									...themeColors,
-									background: '#ffffff',
-								} }
-							>
-								<Outlet />
-								{ /* Render Canvas in Root to prevent remounting on route changes */ }
-								{ ( canvas || canvas === null ) && (
-									<div className="boot-layout__canvas">
-										<CanvasRenderer
-											canvas={ canvas }
-											routeContentModule={
-												routeContentModule
-											}
-										/>
-									</div>
-								) }
-							</ThemeProvider>
-						</div>
+			<ThemeProvider isRoot color={ themeColors }>
+				<div
+					className={ clsx( 'boot-layout boot-layout--single-page', {
+						'has-canvas': !! canvas || canvas === null,
+						'has-full-canvas': isFullScreen,
+					} ) }
+				>
+					<SavePanel />
+					<SnackbarNotices className="boot-notices__snackbar" />
+					<div className="boot-layout__surfaces">
+						<ThemeProvider
+							color={ {
+								...themeColors,
+								background: '#ffffff',
+							} }
+						>
+							<Outlet />
+							{ /* Render Canvas in Root to prevent remounting on route changes */ }
+							{ ( canvas || canvas === null ) && (
+								<div className="boot-layout__canvas">
+									<CanvasRenderer
+										canvas={ canvas }
+										routeContentModule={
+											routeContentModule
+										}
+									/>
+								</div>
+							) }
+						</ThemeProvider>
 					</div>
-				</ThemeProvider>
+				</div>
 			</ThemeProvider>
 		</SlotFillProvider>
 	);

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Use the boot layout background token for generated wp-admin page body backgrounds. ([#79679](https://github.com/WordPress/gutenberg/pull/79679))
+
 ## 0.17.0 (2026-06-24)
 
 ### Documentation

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -270,7 +270,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 			overflow-y: auto;
 		}
 		body {
-			background: #fff;
+			background: var(--wpds-color-background-surface-neutral-weak);
 		}
 
 		/* Reset wp-admin padding */
@@ -320,4 +320,3 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 
 // Hook the enqueue function to admin_enqueue_scripts
 add_action( 'admin_enqueue_scripts', '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' );
-


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/78587.

Tries merging the two adjacent boot root `ThemeProvider` instances so the root provider and `.boot-layout` use the same admin theme color context.

## Why?
The overscroll fix in #78587 needs a body background token that resolves in the same theme context as `.boot-layout`. Using one root provider should make the document-level tokens forwarded by `isRoot` match the boot layout tokens, instead of requiring a separate foreground-token workaround in the generated wp-admin template.

## How?
- Removes the outer root `ThemeProvider` that only overrode `background` to `#f8f8f8`.
- Makes the existing admin-color-scheme provider the root provider.
- Updates the generated wp-admin body background to use `--wpds-color-background-surface-neutral-weak`, matching `.boot-layout`.

## Testing Instructions
1. Build and load a boot-powered wp-admin page, such as the Connectors page.
2. Switch between at least the `fresh` and `light` admin color schemes.
3. On macOS, overscroll past the top and bottom of the page.
4. Verify the revealed body background matches the boot layout background.
5. Verify no duplicate root `ThemeProvider` warning appears in the console.

### Testing Instructions for Keyboard
No keyboard interaction changes are expected. Use keyboard navigation through the boot page and confirm focus order is unchanged.

## Screenshots or screencast
Not included. This is an experiment to validate the provider structure discussed in #78587.

## Use of AI Tools
This PR was drafted with help from OpenAI Codex. I reviewed the generated changes and ran the checks listed below.

## Checks
- `npm run lint:js -- packages/boot/src/components/root/index.tsx packages/boot/src/components/root/single-page.tsx`
- `git diff --check`
- `npx tsgo --build packages/boot/tsconfig.json` currently fails before these changes on missing generated `worker-code` modules in `packages/vips` and `packages/video-conversion`.
