### PR TITLE
Add Git tracing to WP package publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -125,5 +125,7 @@ jobs:
                   npm ci
                   npx lerna publish patch --dist-tag "wp-$WP_VERSION" --no-private --yes --no-verify-access
               env:
+                  GIT_TRACE: '1'
+                  GIT_CURL_VERBOSE: '1'
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}


### PR DESCRIPTION
## What?
Adds `GIT_TRACE=1` and `GIT_CURL_VERBOSE=1` to the WordPress major-version npm package publishing workflow step.

## Why?
It is needed to debug this failure: https://github.com/WordPress/gutenberg/actions/runs/28435075151/job/84270366206

## Testing
Not run; this is a workflow environment-only debugging change.