### PR TITLE
Declare undeclared workspace dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10650,7 +10650,6 @@
 			"version": "1.58.2",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
 			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright": "1.58.2"
@@ -35877,7 +35876,6 @@
 			"version": "1.58.2",
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
 			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.58.2"
@@ -35896,7 +35894,6 @@
 			"version": "1.58.2",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
 			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
@@ -44865,8 +44862,10 @@
 				"clsx": "^2.1.1"
 			},
 			"devDependencies": {
+				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"@wordpress/icons": "file:../icons"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -45157,6 +45156,7 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@types/postcss-prefix-selector": "^1.16.3",
+				"@wordpress/block-library": "file:../block-library",
 				"deep-freeze": "^0.0.1"
 			},
 			"engines": {
@@ -45242,6 +45242,7 @@
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
+				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@wordpress/stylelint-tools": "file:../../tools/stylelint",
@@ -46712,6 +46713,9 @@
 				"@wordpress/interactivity": "file:../interactivity",
 				"@wordpress/interactivity-router": "file:../interactivity-router"
 			},
+			"devDependencies": {
+				"y-websocket": "^3.0.0"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -46971,6 +46975,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
+				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -47811,6 +47816,7 @@
 				"gl-matrix": "^3.4.3"
 			},
 			"devDependencies": {
+				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1"
@@ -48246,7 +48252,9 @@
 			"devDependencies": {
 				"glob": "^7.1.2",
 				"mkdirp": "^3.0.1",
-				"terser-webpack-plugin": "^5.3.10"
+				"rimraf": "^5.0.10",
+				"terser-webpack-plugin": "^5.3.10",
+				"webpack": "^5.108.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -48264,6 +48272,9 @@
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
+			},
+			"devDependencies": {
+				"redux": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -48283,6 +48294,7 @@
 				"@jest/test-result": "^29.6.2",
 				"@octokit/types": "^6.34.0",
 				"@octokit/webhooks-types": "^5.8.0",
+				"@playwright/test": "^1.58.2",
 				"jest-message-util": "^29.6.2"
 			},
 			"devDependencies": {
@@ -48530,6 +48542,9 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/url": "file:../url"
+			},
+			"devDependencies": {
+				"@types/jest": "^29.5.14"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -49321,6 +49336,7 @@
 				"@testing-library/user-event": "^14.6.1",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.19.39",
+				"fast-glob": "^3.2.7",
 				"storybook": "^10.4.3"
 			},
 			"engines": {
@@ -49703,6 +49719,7 @@
 				"@wordpress/a11y": "file:../../packages/a11y",
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/api-fetch": "file:../../packages/api-fetch",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/connectors": "file:../../packages/connectors",
 				"@wordpress/core-data": "file:../../packages/core-data",
@@ -50248,6 +50265,7 @@
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"babel-jest": "^29.7.0",
 				"babel-plugin-transform-import-meta": "^2.3.3",
+				"client-zip": "^2.4.5",
 				"glob": "^7.1.2",
 				"jest": "^29.6.2",
 				"jest-environment-jsdom": "^30.2.0",
@@ -50291,6 +50309,7 @@
 			"devDependencies": {
 				"@apidevtools/json-schema-ref-parser": "^11.6.4",
 				"@babel/core": "^7.25.7",
+				"@wordpress/docgen": "file:../../packages/docgen",
 				"chalk": "^4.1.1",
 				"change-case": "^4.1.2",
 				"comment-parser": "^1.1.1",
@@ -50388,6 +50407,8 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
+				"@wordpress/theme": "file:../../packages/theme",
 				"stylelint-plugin-logical-css": "^1.2.3"
 			}
 		},

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -54,8 +54,10 @@
 		"clsx": "^2.1.1"
 	},
 	"devDependencies": {
+		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"@wordpress/icons": "file:../icons"
 	},
 	"peerDependencies": {
 		"@types/react": "^18.3.27",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -118,6 +118,7 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/postcss-prefix-selector": "^1.16.3",
+		"@wordpress/block-library": "file:../block-library",
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -142,6 +142,7 @@
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
+		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/stylelint-tools": "file:../../tools/stylelint",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,6 +27,9 @@
 		"@wordpress/interactivity": "file:../interactivity",
 		"@wordpress/interactivity-router": "file:../interactivity-router"
 	},
+	"devDependencies": {
+		"y-websocket": "^3.0.0"
+	},
 	"peerDependencies": {
 		"jest": ">=29",
 		"puppeteer-core": ">=23",

--- a/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
@@ -7,7 +7,6 @@
  * window.__gutenbergTestWebSocketSync.rooms that the Playwright fixtures poll.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies -- declared in test/e2e/package.json, only loaded by the WS e2e harness.
 import { WebsocketProvider } from 'y-websocket';
 
 const TEST_PROVIDER_NAMESPACE = 'gutenberg-test/rtc-websocket-provider';

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -117,6 +117,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
+		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -64,6 +64,7 @@
 		"gl-matrix": "^3.4.3"
 	},
 	"devDependencies": {
+		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1"

--- a/packages/readable-js-assets-webpack-plugin/package.json
+++ b/packages/readable-js-assets-webpack-plugin/package.json
@@ -35,7 +35,9 @@
 	"devDependencies": {
 		"glob": "^7.1.2",
 		"mkdirp": "^3.0.1",
-		"terser-webpack-plugin": "^5.3.10"
+		"rimraf": "^5.0.10",
+		"terser-webpack-plugin": "^5.3.10",
+		"webpack": "^5.108.1"
 	},
 	"peerDependencies": {
 		"webpack": "^4.8.3 || ^5.0.0"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -50,6 +50,9 @@
 		"is-promise": "^4.0.0",
 		"rungen": "^0.3.2"
 	},
+	"devDependencies": {
+		"redux": "^5.0.1"
+	},
 	"peerDependencies": {
 		"redux": ">=4"
 	},

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -38,6 +38,7 @@
 		"@jest/test-result": "^29.6.2",
 		"@octokit/types": "^6.34.0",
 		"@octokit/webhooks-types": "^5.8.0",
+		"@playwright/test": "^1.58.2",
 		"jest-message-util": "^29.6.2"
 	},
 	"devDependencies": {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -54,6 +54,9 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},
+	"devDependencies": {
+		"@types/jest": "^29.5.14"
+	},
 	"peerDependencies": {
 		"@types/react": "^18.3.27",
 		"react": "^18.0.0",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Internal
 
+-   Add an explicit return type to an internal overlay focus helper so the published type definitions stay self-contained ([#79684](https://github.com/WordPress/gutenberg/pull/79684)).
 -   Add a temporary `@wordpress/theme` `ThemeProvider` compatibility fallback for older WordPress runtimes ([#79620](https://github.com/WordPress/gutenberg/pull/79620)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,6 +66,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^20.19.39",
+		"fast-glob": "^3.2.7",
 		"storybook": "^10.4.3"
 	},
 	"peerDependencies": {

--- a/packages/ui/src/utils/use-deprioritized-initial-focus.ts
+++ b/packages/ui/src/utils/use-deprioritized-initial-focus.ts
@@ -9,6 +9,11 @@ import { tabbable } from 'tabbable';
  */
 type InitialFocus = _Popover.Popup.Props[ 'initialFocus' ];
 
+type DeprioritizedInitialFocus = {
+	resolvedInitialFocus: InitialFocus;
+	popupRef: React.RefObject< HTMLDivElement >;
+};
+
 /**
  * Options matching Base UI's internal tabbable configuration.
  * @see https://github.com/floating-ui/floating-ui/blob/master/packages/react/src/utils/tabbable.ts
@@ -49,7 +54,7 @@ export function useDeprioritizedInitialFocus( {
 }: {
 	initialFocus: InitialFocus;
 	deprioritizedAttributes: string[];
-} ) {
+} ): DeprioritizedInitialFocus {
 	const popupRef = useRef< HTMLDivElement >( null );
 
 	// Returning a fresh callback on every render is intentional. Base UI

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -12,6 +12,7 @@
 		"@wordpress/a11y": "file:../../packages/a11y",
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
 		"@wordpress/api-fetch": "file:../../packages/api-fetch",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/connectors": "file:../../packages/connectors",
 		"@wordpress/core-data": "file:../../packages/core-data",

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"babel-jest": "^29.7.0",
 		"babel-plugin-transform-import-meta": "^2.3.3",
+		"client-zip": "^2.4.5",
 		"glob": "^7.1.2",
 		"jest": "^29.6.2",
 		"jest-environment-jsdom": "^30.2.0",

--- a/tools/docs/package.json
+++ b/tools/docs/package.json
@@ -22,6 +22,7 @@
 	"devDependencies": {
 		"@apidevtools/json-schema-ref-parser": "^11.6.4",
 		"@babel/core": "^7.25.7",
+		"@wordpress/docgen": "file:../../packages/docgen",
 		"chalk": "^4.1.1",
 		"change-case": "^4.1.2",
 		"comment-parser": "^1.1.1",

--- a/tools/stylelint/package.json
+++ b/tools/stylelint/package.json
@@ -23,6 +23,8 @@
 		"./config": "./config.js"
 	},
 	"dependencies": {
+		"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
+		"@wordpress/theme": "file:../../packages/theme",
 		"stylelint-plugin-logical-css": "^1.2.3"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## What?

Issues caught by #75814.

Declares direct dependencies that several workspace packages use but don't list in their `package.json`, and adds an explicit return type to `useDeprioritizedInitialFocus` in `@wordpress/ui`.

## Why?

A number of workspaces import packages they never declare, relying on them being hoisted into the root `node_modules`. Phantom dependencies like these break under isolated/linked installs and obscure each package's real dependency graph.

Separately, `useDeprioritizedInitialFocus` had its return type inferred. TypeScript inferred a non-portable path through a transitive dependency (`@base-ui/utils`), which is fragile for declaration emit. An explicit return type pins it to the package's own public types.

## How?

- Added each missing dependency to the workspace that actually uses it, classified as `dependencies` (used in shipped source) or `devDependencies` (used only in tests, stories, or build tooling):
  - `packages/admin-ui` — `@storybook/react-vite`, `@wordpress/icons` (stories)
  - `packages/block-editor` — `@wordpress/block-library` (stories + tests)
  - `packages/block-library` — `@testing-library/jest-dom` (tests)
  - `packages/e2e-tests` — `y-websocket` (RTC WebSocket test plugin)
  - `packages/editor` — `@storybook/react-vite` (stories)
  - `packages/media-editor` — `@storybook/react-vite` (stories)
  - `packages/readable-js-assets-webpack-plugin` — `rimraf`, `webpack`
  - `packages/redux-routine` — `redux`
  - `packages/report-flaky-tests` — `@playwright/test`
  - `packages/server-side-render` — `@types/jest`
  - `packages/ui` — `fast-glob` (test)
  - `routes/connectors-home` — `@wordpress/base-styles` (SCSS)
  - `test/unit` — `client-zip` (jest mock)
  - `tools/docs` — `@wordpress/docgen` (CLI)
  - `tools/stylelint` — `@wordpress/stylelint-config`, `@wordpress/theme`
- Removed the now-redundant `import/no-extraneous-dependencies` eslint-disable in the RTC WebSocket test plugin, since `y-websocket` is now declared.
- Added an explicit `DeprioritizedInitialFocus` return type to `useDeprioritizedInitialFocus` to prevent TS from inferring a non-portable path to a transitive dependency (`@base-ui/utils`).

## Testing Instructions

1. Run `npm install` and confirm the lockfile is unchanged.
2. `npm run lint:js` passes (no `import/no-extraneous-dependencies` violations).
3. `npm run test:unit packages/ui` and other affected packages pass.
4. `npm run build` succeeds.

### Testing Instructions for Keyboard

N/A — no user-facing UI changes.

## Use of AI Tools

Yes — drafted with the assistance of Claude Code, reviewed by the author.
