### PR TITLE
WP Build: improve documentation for routes

### DIFF
--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -514,7 +514,7 @@ The canvas is a full-screen area typically used for editor previews. To use a cu
 Export a `route` object with optional hooks. Each hook receives `{ params, search }` — path parameters and query string values from the URL.
 
 - **`beforeLoad`** — Runs before navigation completes. Use for auth checks, validation, or redirects. Throw `redirect()` or `notFound()` from `@wordpress/route` to abort navigation.
-- **`loader`** — Runs while the route is loading. Use to preload data (for example, `resolveSelect` from `@wordpress/data`) so `stage` components can read from the store without a loading state. May return an object whose properties are merged into the route's loader data. For data that must be available before the SPA loads, use [`rest_preload_api_request()`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) in your page's PHP render callback instead.
+- **`loader`** — Runs while the route is loading. Use to preload data (for example, `resolveSelect` from `@wordpress/data`) so `stage` components can read from the store without a loading state. May return an object whose properties are merged into the route's loader data. For data that must be available before the JavaScript application loads, use [`rest_preload_api_request()`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) in your page's PHP render callback instead.
 - **`canvas`** — Runs in parallel with `loader`. Controls which canvas is rendered depending on return values:
     - `CanvasData` (`{ postType, postId, isPreview?, editLink? }`) → default WordPress editor canvas
     - `null` → custom `canvas.tsx` component (if provided)

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -231,6 +231,7 @@ The prefix used for WordPress script handles in `.asset.php` files (e.g., `wp-da
 ```
 
 With this configuration:
+
 - `@my-plugin/editor` → `window.myPlugin.editor` with handle `mp-editor`
 - `@my-plugin/data` → `window.myPlugin.data` with handle `mp-data`
 
@@ -256,6 +257,7 @@ Additional package namespaces to externalize (consume as externals, not expose).
 ```
 
 This allows your packages to consume third-party dependencies as externals:
+
 - `import { Cart } from '@woo/cart'` → `window.woo.cart` with handle `woocommerce-cart`
 - `import { Button } from '@acme/ui'` → `window.acme.ui` with handle `acme-plugin-ui`
 - Dependencies are tracked in `.asset.php` files
@@ -283,15 +285,17 @@ Pages can be defined as simple strings or as objects with initialization modules
 ```
 
 **Page Configuration:**
+
 - **String format**: `"my-admin-page"` - Simple page with no init modules
 - **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "experimental": true }` - Page with optional init modules
-  - **`id`** (required): The page slug used in WordPress admin URLs
-  - **`init`** (optional): Array of script module IDs to execute during page initialization
-  - **`experimental`** (optional, default `false`): When `true`, the page is excluded from WordPress Core builds (`IS_WORDPRESS_CORE=true`), along with any route that belongs only to experimental pages.
+    - **`id`** (required): The page slug used in WordPress admin URLs
+    - **`init`** (optional): Array of script module IDs to execute during page initialization
+    - **`experimental`** (optional, default `false`): When `true`, the page is excluded from WordPress Core builds (`IS_WORDPRESS_CORE=true`), along with any route that belongs only to experimental pages.
 
 **Generated Files:**
 
 This generates two page modes:
+
 - `build/pages/my-admin-page/page.php` - Full-page mode (takes over entire admin screen with custom sidebar)
 - `build/pages/my-admin-page/page-wp-admin.php` - WP-Admin mode (integrates within standard wp-admin interface)
 - `build/pages.php` - Loader for all pages
@@ -320,6 +324,7 @@ The page slug is `my-admin-page-wp-admin` (your page ID + `-wp-admin`). WordPres
 **Deep linking with the `p` query parameter:**
 
 Users and extensions can link directly to specific routes using the `p` query parameter:
+
 ```php
 // Link to a specific route
 $url = admin_url( 'admin.php?page=my-admin-page-wp-admin&p=' . urlencode( '/settings' ) );
@@ -337,12 +342,14 @@ add_menu_page( 'Title', 'Menu', 'capability', 'my-admin-page', 'my_plugin_my_adm
 
 **Init Modules:**
 Init modules are JavaScript packages that execute during page initialization, after menu items and routes are registered and before the app renders. They're ideal for:
+
 - Adding icons to menu items (icons can't be passed from PHP)
 - Registering command palette entries
 
 **Creating an Init Module:**
 
 In `packages/my-page-init/package.json`:
+
 ```json
 {
 	"name": "@my-plugin/my-page-init",
@@ -356,6 +363,7 @@ In `packages/my-page-init/package.json`:
 ```
 
 In `packages/my-page-init/src/index.ts`:
+
 ```typescript
 import { home, styles } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
@@ -386,6 +394,7 @@ The `init()` function is **mandatory** - all init modules must export this named
 ```
 
 This configuration:
+
 - Packages like `@wordpress/data` expose `window.wp.data`
 - Packages like `@wordpress/block-editor` expose `window.wp.blockEditor`
 - All packages can consume `@wordpress/*` as externals
@@ -403,6 +412,7 @@ This configuration:
 ```
 
 This configuration:
+
 - Packages like `@acme/editor` expose `window.acme.editor`
 - Packages like `@acme/data` expose `window.acme.data`
 - All packages can still consume `@wordpress/*` → `window.wp.*`
@@ -430,7 +440,7 @@ require_once plugin_dir_path( __FILE__ ) . 'build/build.php';
 
 Routes provide a file-based routing system for WordPress admin pages. Each route must be associated with a page defined in `wpPlugin.pages` (see above). Create a `routes/` directory at your repository root with subdirectories for each route.
 
-### Structure
+### Route Structure
 
 ```
 routes/
@@ -467,6 +477,7 @@ For routes that should appear on multiple pages:
 ```
 
 The `page` field can be either:
+
 - **String**: Route belongs to a single page
 - **Array**: Route appears on multiple pages (the build system will register the route for each page)
 
@@ -479,16 +490,19 @@ Routes inherit their experimental status from their pages: a route is excluded f
 ### Components
 
 **stage.tsx** - Main content (required):
+
 ```tsx
 export const stage = () => <div>Content</div>;
 ```
 
 **inspector.tsx** - Sidebar content (optional):
+
 ```tsx
 export const inspector = () => <div>Inspector</div>;
 ```
 
 **canvas.tsx** - Custom canvas component (optional):
+
 ```tsx
 export const canvas = () => <div>Custom Canvas</div>;
 ```
@@ -526,9 +540,10 @@ The `canvas()` function controls which canvas is rendered:
 - Returns `null` → Renders the custom canvas component from `canvas.tsx` (if provided)
 - Returns `undefined` or is omitted → No canvas is rendered
 
-### Build Output
+### Routes build output
 
 The build system generates:
+
 - `build/routes/{route-name}/content.js` - Bundled stage/inspector/canvas components
 - `build/routes/{route-name}/route.js` - Bundled lifecycle hooks (if present)
 - `build/routes/registry.php` - Route registry data
@@ -543,9 +558,9 @@ The boot package in Gutenberg will automatically use these routes and make them 
 
 Widgets provide a file-based discovery system for building self-contained UI components that are registered as WordPress script modules. Each widget lives in its own directory under `widgets/` at the repository root.
 
-### Structure
+### Widget Structure
 
-```
+```text
 widgets/
   hello-world/
     widget.json     # Static discovery metadata (required)
@@ -560,7 +575,7 @@ widgets/
 Widgets use a dual-entry pattern, similar in spirit to how blocks split metadata between `block.json` and `edit.js`:
 
 | Concern | Lives in | Reason |
-|---|---|---|
+| --- | --- | --- |
 | Identity (`name`) | both (must match) | server needs it to register; client uses it to resolve the runtime entry |
 | Static metadata (`title`, `description`, `category`) | `widget.json` | plain JSON the host can read without a JS runtime |
 | Translated title / labels (`__()`) | `widget.ts` | i18n calls need a JS runtime; JSON can only carry static strings |
@@ -581,6 +596,7 @@ Rule of thumb: anything expressible as plain JSON goes in `widget.json`. Anythin
 ```
 
 **Fields:**
+
 - **`name`** (required): Namespaced identifier (e.g., `"my-plugin/hello-world"`)
 - **`title`** (optional): Human-readable title
 - **`description`** (optional): Short description for listings
@@ -650,7 +666,7 @@ export default function HelloWorld( { attributes }: HelloWorldRenderProps ) {
 
 All non-JSON entries are optional. The build system checks for files with extensions in priority order: `.tsx`, `.ts`, `.jsx`, `.js`, `.mjs`.
 
-### Build Output
+### Widgets Build Output
 
 The build system generates:
 
@@ -665,7 +681,7 @@ The build system generates:
 
 The generated `widgets.php` registers each widget's entries as script modules via `wp_register_script_module()`. Module handles follow the pattern:
 
-```
+```text
 {handlePrefix}/widgets/{widget-dir-name}/render
 {handlePrefix}/widgets/{widget-dir-name}/widget
 ```

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -507,9 +507,19 @@ export const inspector = () => <div>Inspector</div>;
 export const canvas = () => <div>Custom Canvas</div>;
 ```
 
-The canvas is a full-screen area typically used for editor previews. You can provide a custom canvas component that will be conditionally rendered based on the `canvas()` function's return value in `route.tsx`.
+The canvas is a full-screen area typically used for editor previews. To use a custom canvas, export it from `canvas.tsx` and return `null` from `route.canvas()`.
 
-**route.tsx** - Lifecycle hooks (optional):
+### Lifecycle hooks (`route.tsx`)
+
+Export a `route` object with optional hooks. Each hook receives `{ params, search }` — path parameters and query string values from the URL.
+
+- **`beforeLoad`** — Runs before navigation completes. Use for auth checks, validation, or redirects. Throw `redirect()` or `notFound()` from `@wordpress/route` to abort navigation.
+- **`loader`** — Runs while the route is loading. Use to preload data (for example, `resolveSelect` from `@wordpress/data`) so `stage` components can read from the store without a loading state. May return an object whose properties are merged into the route's loader data. For data that must be available before the SPA loads, use [`rest_preload_api_request()`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) in your page's PHP render callback instead.
+- **`canvas`** — Runs in parallel with `loader`. Controls which canvas is rendered depending on return values:
+    - `CanvasData` (`{ postType, postId, isPreview?, editLink? }`) → default WordPress editor canvas
+    - `null` → custom `canvas.tsx` component (if provided)
+    - `undefined` or omitted → no canvas
+
 ```tsx
 export const route = {
 	beforeLoad: ({ params, search }) => {
@@ -521,9 +531,10 @@ export const route = {
 	canvas: ({ params, search }) => {
 		// Return CanvasData to use default canvas (editor)
 		return {
-			postType: 'post',
-			postId: '123',
-			isPreview: true
+			postType: params.type,
+			postId: params.id,
+			isPreview: true,
+			editLink: `/types/${ params.type }/edit/${ params.id }`,
 		};
 
 		// Return null to use custom canvas.tsx component
@@ -534,11 +545,6 @@ export const route = {
 	}
 };
 ```
-
-The `canvas()` function controls which canvas is rendered:
-- Returns `CanvasData` object (`{ postType, postId, isPreview? }`) → Renders the default WordPress editor canvas
-- Returns `null` → Renders the custom canvas component from `canvas.tsx` (if provided)
-- Returns `undefined` or is omitted → No canvas is rendered
 
 ### Routes build output
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

- Expands "route" documentation to better explain what `beforeLoad` and `loader` are for, and how to use `canvas` more specifically.

- Updates route example to use `params` instead of fixed values. Fixed values would work fine for docs if you'd prefer!

- Fixes lint issues around the file (separately in 1st commit):
    - "Fenced code blocks should have a language specified"
    - "Fenced code blocks should be surrounded by blank lines"
    - "Headings should be surrounded by blank lines"
    - "Lists should be surrounded by blank lines"
    - "Table column style [Table pipe is missing space to the right for style "compact"]"
    - "Multiple headings with the same content"

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Helps consumers adopt WP Build and router without studying code as much.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Read the docs; does it make sense to you?

Recommend using "View file":
<img width="227" height="185" alt="image" src="https://github.com/user-attachments/assets/d49eae65-9e4a-4567-8c33-b6bf5d0a56a6" />


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Use of AI Tools
Yes, but modified/curated manually.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
