### PR TITLE
Packages: Backport UI and theme release changelogs

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Breaking Changes
-
--   Remove the root `CornerRadiusPreset` type export. Derive it from `ThemeProvider`'s `cornerRadius` prop instead ([#79620](https://github.com/WordPress/gutenberg/pull/79620)).
-
 ### New Features
 
 -   Export `@wordpress/theme/utils` with a generated `var()` Sass function for compile-time design token fallback injection ([#79470](https://github.com/WordPress/gutenberg/pull/79470)).
@@ -13,6 +9,12 @@
 ### Bug Fixes
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
+
+## 0.17.0 (2026-06-30)
+
+### Breaking Changes
+
+-   Remove the root `CornerRadiusPreset` type export. Derive it from `ThemeProvider`'s `cornerRadius` prop instead ([#79620](https://github.com/WordPress/gutenberg/pull/79620)).
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,9 +10,14 @@
 ### Internal
 
 -   Add an explicit return type to an internal overlay focus helper so the published type definitions stay self-contained ([#79684](https://github.com/WordPress/gutenberg/pull/79684)).
--   Add a temporary `@wordpress/theme` `ThemeProvider` compatibility fallback for older WordPress runtimes ([#79620](https://github.com/WordPress/gutenberg/pull/79620)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).
+
+## 0.16.1 (2026-06-30)
+
+### Internal
+
+-   Add a temporary `@wordpress/theme` `ThemeProvider` compatibility fallback for older WordPress runtimes ([#79620](https://github.com/WordPress/gutenberg/pull/79620)).
 
 ## 0.16.0 (2026-06-24)
 


### PR DESCRIPTION
## What?
Backports the `wp/latest` bugfix package release changelog sections for `@wordpress/ui` `0.16.1` and `@wordpress/theme` `0.17.0` to `trunk`.

## Why?
So the trunk changelogs reflect that the `ThemeProvider` compatibility changes have already shipped in package releases, while unrelated trunk-only entries remain under `Unreleased`.

## How?
Moves the released `@wordpress/ui` entry for #79620 into `0.16.1`, and the released `@wordpress/theme` entries for #79594/#79620 into `0.17.0`. This does not backport package version bumps.

## Testing Instructions
1. Review `packages/ui/CHANGELOG.md` and confirm `0.16.1` contains the #79620 compatibility fallback entry.
2. Review `packages/theme/CHANGELOG.md` and confirm `0.17.0` contains the #79620 breaking-change entry and the #79594/#79620 internal entry.
3. Confirm the unrelated trunk-only changelog entries remain under `Unreleased`.

## Use of AI Tools
This PR was created with assistance from OpenAI Codex. I reviewed the diff and validation output.