### PR TITLE
Editor: Move focus to revisions slider when entering revisions mode

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -9,6 +9,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -63,6 +64,8 @@ function RevisionsSlider() {
 	const { setCurrentRevisionId, setRevisionPage } = unlock(
 		useDispatch( editorStore )
 	);
+
+	const focusOnMountRef = useFocusOnMount( true );
 
 	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
@@ -132,6 +135,7 @@ function RevisionsSlider() {
 			<Spinner />
 		) : (
 			<RangeControl
+				ref={ focusOnMountRef }
 				aria-valuetext={ renderTooltipContent( selectedIndex ) }
 				className="editor-revisions-header__slider"
 				hideLabelFromVision


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77530
See https://github.com/WordPress/gutenberg/issues/77530#issuecomment-4599406303

This PR fixes a WCAG 2.4.3 Focus Order violation in the visual revisions feature by moving focus to the revisions slider when a user enters visual revisions mode.

## Why?

When a user clicks the "Revisions (N)" button in the post sidebar, the editor fully replaces its UI with the revisions header and diff canvas. Because the triggering button is no longer in the DOM, focus was previously dropped to `document.body`. 

Per the accessibility review in #77530, the correct and most logical focus target is the revisions slider since it is the primary control for navigating revisions.

## How?

This utilizes the standard `@wordpress/compose` hook `useFocusOnMount`. By passing `useFocusOnMount( true )` and providing the ref directly to the `<RangeControl>`, we are relying on Gutenberg's standardized focus management system. `RangeControl` natively supports ref forwarding to its inner `<input type="range">`, meaning focus lands precisely on the slider input as soon as it mounts. 

Using `useFocusOnMount` perfectly handles the asynchronous loading state (where the slider might briefly render as a `<Spinner>`), ensuring focus is applied the moment the actual input attaches to the DOM. This aligns the Revisions editor with how focus is managed in other Gutenberg dialogs and sidebars (e.g., `ListViewSidebar` and `StylesCanvas`).


### Testing Instructions for Keyboard

1. Enter revisions mode using the keyboard (tab to the "Revisions" button and press Enter).
2. The slider should receive focus.
3. Use the Left/Right Arrow keys immediately after entering revisions mode. The revisions should change without requiring any extra Tab presses.


## Screenshots or screencast <!-- if applicable -->

### Before




https://github.com/user-attachments/assets/6d557a8a-b5b1-4711-a736-1f1531845343



### After


https://github.com/user-attachments/assets/da3ae7c3-baf4-4ea6-8400-7b0addde38bd