### PR TITLE
[codex] Dashboard: Move Howdy greeting into welcome widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50576,6 +50576,7 @@
 				"@wordpress/icons": "file:../../packages/icons",
 				"@wordpress/primitives": "file:../../packages/primitives",
 				"@wordpress/ui": "file:../../packages/ui",
+				"@wordpress/widget-primitives": "file:../../packages/widget-primitives",
 				"clsx": "^2.1.1"
 			}
 		}

--- a/packages/widget-dashboard/src/components/widget-frame/widget-frame.tsx
+++ b/packages/widget-dashboard/src/components/widget-frame/widget-frame.tsx
@@ -85,18 +85,23 @@ export function WidgetFrame( {
 	const isHeaderHidden = presentation === 'full-bleed';
 	const isBodyBleeding =
 		presentation === 'full-bleed' || presentation === 'content-bleed';
+	const isHostHeadingRendered = ! widgetType.hasOwnHeading;
 
 	const body = (
 		<WidgetErrorBoundary>
 			<Suspense fallback={ <LoadingOverlay /> }>
-				<WidgetRender widget={ widget } widgetType={ widgetType } />
+				<WidgetRender
+					widget={ widget }
+					widgetType={ widgetType }
+					titleId={ titleId }
+				/>
 			</Suspense>
 		</WidgetErrorBoundary>
 	);
 
 	return (
 		<>
-			{ ! isHeaderHidden && (
+			{ isHostHeadingRendered && ! isHeaderHidden && (
 				<WidgetHeader
 					showIdentity
 					widgetType={ widgetType }
@@ -110,11 +115,13 @@ export function WidgetFrame( {
 					isBodyBleeding && styles.bleedContent
 				) }
 			>
-				{ isHeaderHidden && widgetType.title && (
-					<VisuallyHidden render={ <h2 id={ titleId } /> }>
-						{ widgetType.title }
-					</VisuallyHidden>
-				) }
+				{ isHostHeadingRendered &&
+					isHeaderHidden &&
+					widgetType.title && (
+						<VisuallyHidden render={ <h2 id={ titleId } /> }>
+							{ widgetType.title }
+						</VisuallyHidden>
+					) }
 				{ body }
 			</Card.Content>
 		</>

--- a/packages/widget-dashboard/src/components/widget-render/widget-render.tsx
+++ b/packages/widget-dashboard/src/components/widget-render/widget-render.tsx
@@ -14,6 +14,7 @@ import type { DashboardWidget } from '../../types';
 interface WidgetRenderProps {
 	widget: DashboardWidget< unknown >;
 	widgetType: WidgetType;
+	titleId?: string;
 }
 
 /**
@@ -24,7 +25,11 @@ interface WidgetRenderProps {
  *
  * @param {WidgetRenderProps} props Component props.
  */
-export function WidgetRender( { widget, widgetType }: WidgetRenderProps ) {
+export function WidgetRender( {
+	widget,
+	widgetType,
+	titleId,
+}: WidgetRenderProps ) {
 	const { layout, onLayoutChange, resolveWidgetModule } =
 		useDashboardInternalContext();
 
@@ -52,6 +57,7 @@ export function WidgetRender( { widget, widgetType }: WidgetRenderProps ) {
 			widgetType={ widgetType }
 			attributes={ widget.attributes }
 			setAttributes={ setAttributes }
+			titleId={ titleId }
 			resolveWidgetModule={ resolveWidgetModule }
 		/>
 	);

--- a/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
@@ -40,6 +40,10 @@ function TestWidget( {
 	);
 }
 
+function OwnHeadingWidget( { titleId }: WidgetRenderProps ) {
+	return <h2 id={ titleId }>Howdy, admin</h2>;
+}
+
 const widgetTypes: WidgetType[] = [
 	{
 		apiVersion: 1,
@@ -47,12 +51,27 @@ const widgetTypes: WidgetType[] = [
 		title: 'Greet',
 		renderModule: 'test-greet-module',
 	},
+	{
+		apiVersion: 1,
+		name: 'test/own-heading',
+		title: 'Welcome',
+		renderModule: 'test-own-heading-module',
+		presentation: 'full-bleed',
+		hasOwnHeading: true,
+	},
 ];
 
 const resolveWidgetModule: ResolveWidgetModule = async ( id ) => {
 	if ( id === 'test-greet-module' ) {
 		return {
 			default: TestWidget as ComponentType<
+				WidgetRenderProps< unknown >
+			>,
+		};
+	}
+	if ( id === 'test-own-heading-module' ) {
+		return {
+			default: OwnHeadingWidget as ComponentType<
 				WidgetRenderProps< unknown >
 			>,
 		};
@@ -182,6 +201,36 @@ describe( 'WidgetDashboard', () => {
 		expect( screen.getByText( 'does/not-exist' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'heading', { level: 2 } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'allows a full-bleed widget to provide the heading for its region', async () => {
+		render(
+			<WidgetDashboard
+				layout={ [
+					{
+						uuid: 'w1',
+						type: 'test/own-heading',
+						placement: { width: 1, height: 1 },
+					},
+				] }
+				onLayoutChange={ () => {} }
+				widgetTypes={ widgetTypes }
+				resolveWidgetModule={ resolveWidgetModule }
+			/>
+		);
+
+		expect(
+			await screen.findByRole( 'heading', {
+				level: 2,
+				name: 'Howdy, admin',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'region', { name: 'Howdy, admin' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'heading', { name: 'Welcome' } )
 		).not.toBeInTheDocument();
 	} );
 

--- a/packages/widget-primitives/src/components/widget-render/widget-render.tsx
+++ b/packages/widget-primitives/src/components/widget-render/widget-render.tsx
@@ -6,12 +6,17 @@
  * Internal dependencies
  */
 import { getLazyWidgetComponent } from '../../tools/get-lazy-widget-component';
-import type { ResolveWidgetModule, WidgetType } from '../../types';
+import type {
+	ResolveWidgetModule,
+	WidgetRenderProps as WidgetRenderComponentProps,
+	WidgetType,
+} from '../../types';
 
 interface WidgetRenderProps< Item = unknown > {
 	widgetType: WidgetType< Item >;
 	attributes?: Item;
 	setAttributes?: ( next: Partial< Item > ) => void;
+	titleId?: string;
 	resolveWidgetModule: ResolveWidgetModule;
 }
 
@@ -24,6 +29,7 @@ export function WidgetRender< Item = unknown >( {
 	widgetType,
 	attributes,
 	setAttributes,
+	titleId,
 	resolveWidgetModule,
 }: WidgetRenderProps< Item > ) {
 	const WidgetComponent = getLazyWidgetComponent(
@@ -31,14 +37,17 @@ export function WidgetRender< Item = unknown >( {
 		resolveWidgetModule
 	);
 
+	const componentProps: WidgetRenderComponentProps< Item > = {
+		attributes: attributes as Item,
+		setAttributes,
+		...( widgetType.hasOwnHeading ? { titleId } : {} ),
+	};
+
 	return (
 		<>
 			{ /* Cached `lazy()` keyed by renderModule; identity is stable across renders. */ }
 			{ /* eslint-disable-next-line react-hooks/static-components */ }
-			<WidgetComponent
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-			/>
+			<WidgetComponent { ...componentProps } />
 		</>
 	);
 }

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -98,6 +98,12 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	keywords?: string[];
 
 	/**
+	 * Whether the widget render component supplies the section heading that
+	 * labels its host chrome.
+	 */
+	hasOwnHeading?: boolean;
+
+	/**
 	 * Widget version, used for asset cache invalidation.
 	 */
 	version?: string;
@@ -156,6 +162,11 @@ export interface WidgetRenderProps< Item = unknown > {
 	 * User-configured attributes for this widget instance.
 	 */
 	attributes: Item;
+
+	/**
+	 * Id for the widget's section heading when the widget owns that heading.
+	 */
+	titleId?: string;
 
 	/**
 	 * Updates the attributes of this instance. Optional because some

--- a/widgets/welcome/components/banner/banner.module.css
+++ b/widgets/welcome/components/banner/banner.module.css
@@ -19,6 +19,9 @@
 .bannerContent {
 	position: relative;
 	z-index: 1;
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-sm);
 }
 
 .bannerLink {

--- a/widgets/welcome/components/banner/banner.tsx
+++ b/widgets/welcome/components/banner/banner.tsx
@@ -1,8 +1,11 @@
 /**
  * WordPress dependencies
  */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 /**
  * Internal dependencies
@@ -12,21 +15,35 @@ import styles from './banner.module.css';
 
 const DISPLAY_VERSION = '7.1';
 
-export function Banner() {
+export function Banner( { titleId }: Pick< WidgetRenderProps, 'titleId' > ) {
+	const currentUserName = useSelect(
+		( select ) =>
+			( ( select( coreStore ) as any ).getCurrentUser()
+				?.name as string ) ?? '',
+		[]
+	);
+	const trimmedCurrentUserName = currentUserName.trim();
+
 	return (
 		<Stack className={ styles.banner } direction="column" justify="center">
 			<HeaderBackground version={ DISPLAY_VERSION } />
 
-			<Stack
-				className={ styles.bannerContent }
-				gap="sm"
-				direction="column"
-			>
-				<Text variant="heading-2xl">
+			<hgroup className={ styles.bannerContent }>
+				<Text id={ titleId } variant="heading-2xl" render={ <h2 /> }>
+					{ trimmedCurrentUserName
+						? sprintf(
+								/* translators: %s: Current user's display name. */
+								__( 'Howdy, %s' ),
+								trimmedCurrentUserName
+						  )
+						: __( 'Howdy' ) }
+				</Text>
+
+				<Text render={ <p /> } variant="heading-lg">
 					{ __( 'Welcome to WordPress!' ) }
 				</Text>
 
-				<Text variant="heading-lg">
+				<Text render={ <p /> } variant="heading-lg">
 					<Link
 						className={ styles.bannerLink }
 						href="/wp-admin/about.php"
@@ -39,7 +56,7 @@ export function Banner() {
 						) }
 					</Link>
 				</Text>
-			</Stack>
+			</hgroup>
 		</Stack>
 	);
 }

--- a/widgets/welcome/package.json
+++ b/widgets/welcome/package.json
@@ -9,8 +9,9 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/ui": "file:../../packages/ui",
 		"@wordpress/primitives": "file:../../packages/primitives",
+		"@wordpress/ui": "file:../../packages/ui",
+		"@wordpress/widget-primitives": "file:../../packages/widget-primitives",
 		"clsx": "^2.1.1"
 	}
 }

--- a/widgets/welcome/render.tsx
+++ b/widgets/welcome/render.tsx
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { layout, pencil, styles as stylesIcon } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 /**
  * Internal dependencies
@@ -13,7 +14,9 @@ import { Stack } from '@wordpress/ui';
 import { Banner, FeatureHighlight } from './components';
 import styles from './style.module.css';
 
-export default function WelcomeBanner() {
+export default function WelcomeBanner( {
+	titleId,
+}: Pick< WidgetRenderProps, 'titleId' > ) {
 	const isClassicTheme = useSelect(
 		( select ) =>
 			select( coreStore ).getCurrentTheme()?.is_block_theme === false,
@@ -62,7 +65,7 @@ export default function WelcomeBanner() {
 
 	return (
 		<Stack className={ styles.root } direction="column" gap="lg">
-			<Banner />
+			<Banner titleId={ titleId } />
 
 			<Stack className={ styles.columns }>
 				<FeatureHighlight

--- a/widgets/welcome/widget.ts
+++ b/widgets/welcome/widget.ts
@@ -12,6 +12,7 @@ const widget = {
 	),
 	icon: 'wordpress',
 	category: 'dashboard',
+	hasOwnHeading: true,
 };
 
 export default widget;


### PR DESCRIPTION
## What?

Moves the personal "Howdy" greeting out of the experimental Dashboard page title and into the bundled Welcome widget as the widget's visible `h2` heading.

## Why?

The Dashboard page `h1` should identify the page topic. A personal greeting works better inside the Welcome widget, where it can label that widget section while preserving the page-level heading as "Dashboard".

## How?

- Adds a `hasOwnHeading` widget metadata flag so a full-bleed widget can provide the heading that labels its widget region.
- Passes the widget chrome `titleId` through render props for widgets that opt into owning their heading.
- Updates the Welcome widget banner to render `Howdy, {display name}` as an `h2` inside an `hgroup`, with the previous welcome/version copy as paragraphs.
- Adds regression coverage for a full-bleed widget whose visible `h2` labels its region.

Fixes #79240.

## Testing Instructions

- `npm run test:unit packages/widget-dashboard/src/test/widget-dashboard.test.tsx -- --runInBand`
- `npm run lint:js -- packages/widget-primitives/src/types.ts packages/widget-primitives/src/components/widget-render/widget-render.tsx packages/widget-dashboard/src/components/widget-frame/widget-frame.tsx packages/widget-dashboard/src/components/widget-render/widget-render.tsx packages/widget-dashboard/src/test/widget-dashboard.test.tsx widgets/welcome/components/banner/banner.tsx widgets/welcome/render.tsx widgets/welcome/widget.ts`
- `npm run lint:css -- widgets/welcome/components/banner/banner.module.css`
- `npm run lint:lockfile`
- `npm run lint:deps`
- `npm run lint:pkg-json`
- `npm run build -- --webpack-no-externals --webpack-copy-php --webpack-bundle-analyzer=false --packages=widget-dashboard,widget-primitives`

Browser testing was not completed in this workspace because `wp-env start` cannot connect to Docker (`Cannot connect to the Docker daemon at unix:///Users/ben/.docker/run/docker.sock`).