### PR TITLE
Packages: Backport package release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44849,7 +44849,7 @@
 		},
 		"packages/admin-ui": {
 			"name": "@wordpress/admin-ui",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -45051,7 +45051,7 @@
 		},
 		"packages/block-directory": {
 			"name": "@wordpress/block-directory",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -45094,7 +45094,7 @@
 		},
 		"packages/block-editor": {
 			"name": "@wordpress/block-editor",
-			"version": "15.22.0",
+			"version": "15.22.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -45188,7 +45188,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "10.0.0",
+			"version": "10.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@arraypress/waveform-player": "^1.2.1",
@@ -45357,7 +45357,7 @@
 		},
 		"packages/boot": {
 			"name": "@wordpress/boot",
-			"version": "0.16.0",
+			"version": "0.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -45414,7 +45414,7 @@
 		},
 		"packages/commands": {
 			"name": "@wordpress/commands",
-			"version": "1.49.0",
+			"version": "1.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -45441,7 +45441,7 @@
 		},
 		"packages/components": {
 			"name": "@wordpress/components",
-			"version": "36.0.0",
+			"version": "36.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.29",
@@ -45691,7 +45691,7 @@
 		},
 		"packages/core-commands": {
 			"name": "@wordpress/core-commands",
-			"version": "1.49.0",
+			"version": "1.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "file:../block-editor",
@@ -45719,7 +45719,7 @@
 		},
 		"packages/core-data": {
 			"name": "@wordpress/core-data",
-			"version": "7.49.0",
+			"version": "7.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -46385,7 +46385,7 @@
 		},
 		"packages/customize-widgets": {
 			"name": "@wordpress/customize-widgets",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -46499,7 +46499,7 @@
 		},
 		"packages/dataviews": {
 			"name": "@wordpress/dataviews",
-			"version": "17.0.0",
+			"version": "17.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.29",
@@ -46729,7 +46729,7 @@
 		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
-			"version": "8.49.0",
+			"version": "8.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -46783,7 +46783,7 @@
 		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
-			"version": "6.49.0",
+			"version": "6.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -46865,7 +46865,7 @@
 		},
 		"packages/edit-widgets": {
 			"name": "@wordpress/edit-widgets",
-			"version": "6.49.0",
+			"version": "6.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -46914,7 +46914,7 @@
 		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
-			"version": "14.49.0",
+			"version": "14.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -47057,7 +47057,7 @@
 		},
 		"packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "25.5.0",
+			"version": "25.5.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.28.6",
@@ -47231,7 +47231,7 @@
 		},
 		"packages/fields": {
 			"name": "@wordpress/fields",
-			"version": "0.41.0",
+			"version": "0.41.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -47281,7 +47281,7 @@
 		},
 		"packages/format-library": {
 			"name": "@wordpress/format-library",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -47340,7 +47340,7 @@
 		},
 		"packages/global-styles-ui": {
 			"name": "@wordpress/global-styles-ui",
-			"version": "1.16.0",
+			"version": "1.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -47385,7 +47385,7 @@
 		},
 		"packages/grid": {
 			"name": "@wordpress/grid",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",
@@ -47491,7 +47491,7 @@
 		},
 		"packages/image-cropper": {
 			"name": "@wordpress/image-cropper",
-			"version": "1.13.0",
+			"version": "1.13.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -47549,7 +47549,7 @@
 		},
 		"packages/interface": {
 			"name": "@wordpress/interface",
-			"version": "9.34.0",
+			"version": "9.34.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -47711,7 +47711,7 @@
 		},
 		"packages/lazy-editor": {
 			"name": "@wordpress/lazy-editor",
-			"version": "1.15.0",
+			"version": "1.15.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/asset-loader": "file:../asset-loader",
@@ -47762,7 +47762,7 @@
 		},
 		"packages/list-reusable-blocks": {
 			"name": "@wordpress/list-reusable-blocks",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -47792,7 +47792,7 @@
 		},
 		"packages/media-editor": {
 			"name": "@wordpress/media-editor",
-			"version": "0.12.0",
+			"version": "0.12.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -47837,7 +47837,7 @@
 		},
 		"packages/media-fields": {
 			"name": "@wordpress/media-fields",
-			"version": "0.14.0",
+			"version": "0.14.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -47877,7 +47877,7 @@
 		},
 		"packages/media-utils": {
 			"name": "@wordpress/media-utils",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -47918,7 +47918,7 @@
 		},
 		"packages/notices": {
 			"name": "@wordpress/notices",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -47981,7 +47981,7 @@
 		},
 		"packages/patterns": {
 			"name": "@wordpress/patterns",
-			"version": "2.49.0",
+			"version": "2.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -48012,7 +48012,7 @@
 		},
 		"packages/plugins": {
 			"name": "@wordpress/plugins",
-			"version": "7.49.0",
+			"version": "7.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -48083,7 +48083,7 @@
 		},
 		"packages/preferences": {
 			"name": "@wordpress/preferences",
-			"version": "4.49.0",
+			"version": "4.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -48307,7 +48307,7 @@
 		},
 		"packages/reusable-blocks": {
 			"name": "@wordpress/reusable-blocks",
-			"version": "5.49.0",
+			"version": "5.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -48412,7 +48412,7 @@
 		},
 		"packages/scripts": {
 			"name": "@wordpress/scripts",
-			"version": "32.5.0",
+			"version": "32.5.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "^7.25.7",
@@ -48530,7 +48530,7 @@
 		},
 		"packages/server-side-render": {
 			"name": "@wordpress/server-side-render",
-			"version": "6.25.0",
+			"version": "6.25.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -48604,7 +48604,7 @@
 		},
 		"packages/stylelint-config": {
 			"name": "@wordpress/stylelint-config",
-			"version": "23.41.0",
+			"version": "23.41.1",
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.1.3",
@@ -49231,7 +49231,7 @@
 		},
 		"packages/theme": {
 			"name": "@wordpress/theme",
-			"version": "0.16.0",
+			"version": "0.17.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
@@ -49310,7 +49310,7 @@
 		},
 		"packages/ui": {
 			"name": "@wordpress/ui",
-			"version": "0.16.0",
+			"version": "0.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.6.0",
@@ -49371,7 +49371,7 @@
 		},
 		"packages/upload-media": {
 			"name": "@wordpress/upload-media",
-			"version": "0.34.0",
+			"version": "0.34.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/blob": "file:../blob",
@@ -49456,7 +49456,7 @@
 		},
 		"packages/views": {
 			"name": "@wordpress/views",
-			"version": "1.16.0",
+			"version": "1.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/core-data": "file:../core-data",
@@ -49508,7 +49508,7 @@
 		},
 		"packages/widget-dashboard": {
 			"name": "@wordpress/widget-dashboard",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/commands": "file:../commands",
@@ -49554,7 +49554,7 @@
 		},
 		"packages/widget-primitives": {
 			"name": "@wordpress/widget-primitives",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dataviews": "file:../dataviews",
@@ -49585,7 +49585,7 @@
 		},
 		"packages/widgets": {
 			"name": "@wordpress/widgets",
-			"version": "4.49.0",
+			"version": "4.49.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/admin-ui",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Generic components to be used in the Admin UI.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-editor",
-	"version": "15.22.0",
+	"version": "15.22.1",
 	"description": "Generic block editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/boot",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"description": "Minimal boot package for WordPress admin pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/commands",
-	"version": "1.49.0",
+	"version": "1.49.1",
 	"description": "Handles the commands menu.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/components",
-	"version": "36.0.0",
+	"version": "36.0.1",
 	"description": "UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-commands",
-	"version": "1.49.0",
+	"version": "1.49.1",
 	"description": "WordPress core reusable commands.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-data",
-	"version": "7.49.0",
+	"version": "7.49.1",
 	"description": "Access to and manipulation of core WordPress entities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dataviews",
-	"version": "17.0.0",
+	"version": "17.0.1",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "8.49.0",
+	"version": "8.49.1",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "6.49.0",
+	"version": "6.49.1",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-widgets",
-	"version": "6.49.0",
+	"version": "6.49.1",
 	"description": "Widgets Page module for WordPress..",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "14.49.0",
+	"version": "14.49.1",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/eslint-plugin",
-	"version": "25.5.0",
+	"version": "25.5.1",
 	"description": "ESLint plugin for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/fields",
-	"version": "0.41.0",
+	"version": "0.41.1",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/format-library",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "Format library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/global-styles-ui",
-	"version": "1.16.0",
+	"version": "1.16.1",
 	"description": "Global Styles UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/grid",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Grid layout components for arranging tiles in dashboard-style surfaces, with drag-to-reorder and tile resizing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/image-cropper",
-	"version": "1.13.0",
+	"version": "1.13.1",
 	"description": "A basic image cropper component.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/interface",
-	"version": "9.34.0",
+	"version": "9.34.1",
 	"description": "Interface module for WordPress. The package contains shared functionality across the modern JavaScript-based WordPress screens.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/lazy-editor",
-	"version": "1.15.0",
+	"version": "1.15.1",
 	"description": "Lazy-loading editor component with automatic asset and settings management.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/list-reusable-blocks",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "Adding Export/Import support to the reusable blocks listing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-editor",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"description": "Media editor components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-fields",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"description": "Reusable field definitions for displaying and editing media attachment properties in WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-utils",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "WordPress Media Upload Utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/notices",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "State management for notices.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/patterns",
-	"version": "2.49.0",
+	"version": "2.49.1",
 	"description": "Management of user pattern editing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/plugins",
-	"version": "7.49.0",
+	"version": "7.49.1",
 	"description": "Plugins module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences",
-	"version": "4.49.0",
+	"version": "4.49.1",
 	"description": "Utilities for managing WordPress preferences.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/reusable-blocks",
-	"version": "5.49.0",
+	"version": "5.49.1",
 	"description": "Reusable blocks utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/scripts",
-	"version": "32.5.0",
+	"version": "32.5.1",
 	"description": "Collection of reusable scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/server-side-render",
-	"version": "6.25.0",
+	"version": "6.25.1",
 	"description": "The component used with WordPress to server-side render a preview of dynamic blocks to display in the editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/stylelint-config",
-	"version": "23.41.0",
+	"version": "23.41.1",
 	"description": "stylelint config for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/theme",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "Theme and context provider for the WordPress Design System.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/ui",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"description": "Themeable React UI components for the WordPress Design System.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
-	"version": "0.34.0",
+	"version": "0.34.1",
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/views",
-	"version": "1.16.0",
+	"version": "1.16.1",
 	"description": "View persistence and management for WordPress DataViews.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widget-dashboard/package.json
+++ b/packages/widget-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widget-dashboard",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Stateless rendering engine for widget dashboards: the WidgetDashboard compound component and its grid-settings kit.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widget-primitives/package.json
+++ b/packages/widget-primitives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widget-primitives",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Host-agnostic toolkit for dashboard widgets: the widget contract types, the discovery hook, and the render entry point.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widgets",
-	"version": "4.49.0",
+	"version": "4.49.1",
 	"description": "Functionality used by the widgets block editor in the Widgets screen and the Customizer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What?
Backports the package version metadata from the `wp/latest` publish commit: https://github.com/WordPress/gutenberg/commit/9a75283890dda96ae1d37197b5070fae8c9cf66f

This updates the affected `packages/*/package.json` versions and the matching workspace entries in `package-lock.json`.

## Why?
Follow-up to #79690, which backported the changelog release sections from https://github.com/WordPress/gutenberg/commit/5e90da06d5cf96a1b84c599e52f36d10db6d140d.

Together, #79690 and this PR restore the combined release metadata effect from `wp/latest` on `trunk`.

## How?
Applies the package metadata effect of `9a75283890d` on top of current `trunk`. The changelog backport remains in #79690.

## Testing Instructions
1. Confirm this PR updates the package versions from the `wp/latest` publish commit.
2. Confirm `package-lock.json` has matching workspace package versions.
3. Confirm #79690 remains the changelog backport for the same package release.

Validation run:

- `npm install --package-lock-only --ignore-scripts --offline`
- `npm run lint:pkg-json`
- `npm run lint:lockfile`
- `git diff --check origin/trunk`

### Testing Instructions for Keyboard
Not applicable; package metadata-only change.

## Screenshots or screencast
Not applicable; package metadata-only change.

## Use of AI Tools
This PR was created with assistance from OpenAI Codex. I reviewed the diff and validation output.
