### PR TITLE
Clamp the selection end offset to the rich text content length

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Writing Flow: Clamp the selection end offset to the rich text content length when a forward selection overshoots past the element, so a single-block selection no longer collapses to its start ([#79704](https://github.com/WordPress/gutenberg/pull/79704)).
 -   `useTypingObserver`: Capture the window reference at mount and reuse it during cleanup so the ref cleanup no longer reads `node.ownerDocument.defaultView` (which is `null` once the iframe-hosted editor has been detached from its window) and throws, which was also leaking the `removeEventListener` calls that follow it ([#78772](https://github.com/WordPress/gutenberg/pull/78772)).
 
 ### Breaking Changes

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -247,7 +247,14 @@ export default function useSelectionObserver() {
 									attributeKey:
 										richTextElement.dataset
 											.wpBlockAttributeKey,
-									offset: richTextData.end,
+									// A forward selection can overshoot past the
+									// element (e.g. ending at offset 0 of the next
+									// block), leaving the end undefined. That means
+									// the selection reaches through the end of this
+									// element's content; clamp it like the start.
+									offset:
+										richTextData.end ??
+										richTextData.text.length,
 								},
 							} );
 						} else {


### PR DESCRIPTION
## What?

Clamp the selection end offset to the rich text content length when a forward selection overshoots past the element, so a single-block selection no longer collapses to its start.

Preparatory for #79105.

## Why?

In `useSelectionObserver`, when a non-collapsed selection falls within a single rich text element that does not have focus, the observer maps the native range onto the element and dispatches a `selectionChange`. If the selection overshoots past the element (its end lands at offset 0 of the next block), `create()` cannot map the end into the element and `richTextData.end` is `undefined`.

The start offset is already clamped with `?? 0`, but the end was passed through unclamped, so `selectionChange` received an undefined end offset and collapsed the selection to its start.

## How?

Clamp the end offset to the element's content length (`richTextData.end ?? richTextData.text.length`), mirroring the existing start clamp. An end that overshoots past the element means the selection reaches through the end of its content.

## Testing Instructions

This corrects a latent asymmetry (`start` was already clamped, `end` was not), so there is no behavior change for selections whose end maps within the element.

It is most visibly exercised by #79105, where the editing host owns focus and triple clicking a paragraph collapsed the caret to its start; that PR adds an e2e covering the regression. On trunk the same branch runs when a selection is dragged from the block wrapper padding past the end of a paragraph.

## Use of AI Tools

This pull request was authored with assistance from Claude Code (Claude Opus 4.8). All changes were reviewed by the PR author.