### PR TITLE
PHP-only patterns: Render blocks' server output in the editor through islands

### DIFF
--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -36,12 +36,15 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		if ( empty( $block_type->supports['autoRegister'] ) || empty( $block_type->pattern ) || ! is_string( $block_type->pattern ) ) {
 			continue;
 		}
-		// Opt into an SSR preview instead of canvas editing; falls through to the
-		// SSR registration (needs a render_callback).
+		// `patternEditorPreview: 'ssr'` opts into SSR-islands mode: the editor
+		// renders the PHP `render_callback` shell server-side and portals the
+		// editable pattern blocks into its slots (WYSIWYG). It needs a
+		// render_callback to produce that shell; otherwise it edits the pattern
+		// blocks directly in the canvas.
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
-		if ( isset( $block_type->patternEditorPreview ) && 'ssr' === $block_type->patternEditorPreview ) {
-			continue;
-		}
+		$wants_ssr_islands = isset( $block_type->patternEditorPreview ) && 'ssr' === $block_type->patternEditorPreview;
+		$editor_mode       = ( $wants_ssr_islands && ! empty( $block_type->render_callback ) ) ? 'ssr-islands' : 'canvas';
+
 		// `lock` mode: 'contentOnly' (default) locks tightly but its section UI
 		// hides the generated controls; `false` keeps them visible with a softer
 		// lock (`'patternLock' => false`).
@@ -52,6 +55,7 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 			'markup'            => $block_type->pattern,
 			'lock'              => $lock,
 			'hasRenderCallback' => ! empty( $block_type->render_callback ),
+			'editorMode'        => $editor_mode,
 		);
 	}
 

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -3,12 +3,13 @@
  */
 import {
 	createPortal,
+	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useRegistry } from '@wordpress/data';
 import { safeHTML } from '@wordpress/dom';
 
 /**
@@ -41,8 +42,14 @@ const LAYOUT = { type: 'default', alignments: [] };
  * @param {Object} props          Component props.
  * @param {string} props.clientId Client ID of the block whose inner content
  *                                should be rendered.
+ * @param {string} [props.html]   Slot-bearing markup to use verbatim instead of
+ *                                building it from the block's `innerContent`.
+ *                                The markup must already contain
+ *                                `<wp-inner-block-slot data-slot-index>` elements
+ *                                (e.g. a server-rendered shell). When omitted, the
+ *                                markup is derived from `innerContent` as usual.
  */
-export default function InnerContent( { clientId } ) {
+export default function InnerContent( { clientId, html: htmlProp } ) {
 	const { innerContent, order } = useSelect(
 		( select ) => {
 			const { getBlock, getBlockOrder } = select( blockEditorStore );
@@ -54,6 +61,11 @@ export default function InnerContent( { clientId } ) {
 		[ clientId ]
 	);
 	const html = useMemo( () => {
+		// An externally supplied shell (e.g. server-rendered) already carries its
+		// own slot placeholders, so it is used as-is.
+		if ( htmlProp !== undefined ) {
+			return htmlProp;
+		}
 		let slotIndex = 0;
 		return ( innerContent ?? [] )
 			.map( ( item ) =>
@@ -62,13 +74,24 @@ export default function InnerContent( { clientId } ) {
 					: item
 			)
 			.join( '' );
-	}, [ innerContent ] );
+	}, [ htmlProp, innerContent ] );
 
+	const registry = useRegistry();
 	const containerRef = useRef();
 	const [ slots, setSlots ] = useState( [] );
 
+	// When the markup changes (e.g. a re-rendered server shell), re-injecting it
+	// remounts the portalled inner blocks and drops DOM focus, even though the
+	// block selection survives in the store. Remember whether the caret was
+	// inside an island so it can be restored after the re-portal.
+	const restoreFocusRef = useRef( false );
+
 	useLayoutEffect( () => {
 		const container = containerRef.current;
+
+		restoreFocusRef.current = container.contains(
+			container.ownerDocument.activeElement
+		);
 
 		// Sanitize before injecting into the canvas: `safeHTML` removes
 		// `<script>` elements and inline event handlers, matching how block
@@ -83,6 +106,29 @@ export default function InnerContent( { clientId } ) {
 			)
 		);
 	}, [ html ] );
+
+	// After the inner blocks re-portal into the freshly injected slots, refocus
+	// the selected child's editable so RichText restores the caret from the
+	// store. Best effort: a no-op when the caret was not inside this block.
+	useEffect( () => {
+		if ( ! restoreFocusRef.current ) {
+			return;
+		}
+		restoreFocusRef.current = false;
+
+		const selectedClientId = registry
+			.select( blockEditorStore )
+			.getSelectedBlockClientId();
+		if ( ! selectedClientId ) {
+			return;
+		}
+
+		containerRef.current
+			?.querySelector(
+				`[data-block="${ selectedClientId }"] [contenteditable="true"]`
+			)
+			?.focus();
+	}, [ slots, registry ] );
 
 	return (
 		<LayoutProvider value={ LAYOUT }>

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -76,6 +76,29 @@ describe( 'InnerContent', () => {
 		expect( root.querySelector( '[onclick]' ) ).toBeNull();
 		expect( root.querySelector( 'button' ) ).toHaveTextContent( 'Click' );
 	} );
+
+	it( 'uses the `html` prop verbatim instead of building from innerContent', () => {
+		const block = createBlock(
+			BLOCK_NAME,
+			{},
+			[],
+			[ '<p class="from-inner-content">derived</p>' ]
+		);
+		const shell =
+			'<div class="ssr-shell"><wp-inner-block-slot data-slot-index="0"></wp-inner-block-slot></div>';
+		const { container } = render(
+			<BlockEditorProvider value={ [ block ] }>
+				<InnerContent clientId={ block.clientId } html={ shell } />
+			</BlockEditorProvider>
+		);
+		const root = container.querySelector( '.block-editor-inner-content' );
+
+		// The provided shell (and its slot) is injected as-is...
+		expect( root.querySelector( '.ssr-shell' ) ).not.toBeNull();
+		expect( root.querySelector( 'wp-inner-block-slot' ) ).not.toBeNull();
+		// ...and the innerContent-derived markup is ignored.
+		expect( root.querySelector( '.from-inner-content' ) ).toBeNull();
+	} );
 } );
 
 /* eslint-enable testing-library/no-node-access, testing-library/no-container, testing-library/render-result-naming-convention */

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -17,8 +17,9 @@ import {
 	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -318,6 +319,8 @@ export const __experimentalGetCoreBlocks = () =>
 		( { metadata } ) => ! isBlockMetadataExperimental( metadata )
 	);
 
+const { InnerContent } = unlock( blockEditorPrivateApis );
+
 /**
  * Builds `edit`/`save` for a PHP-only block that uses a `pattern` markup string.
  * On first insert the pattern becomes real inner blocks (content blocks stay
@@ -383,6 +386,97 @@ function createPatternBlockComponents(
 			return <InnerBlocks.Content />;
 		}
 		return <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
+	}
+
+	return { edit: Edit, save };
+}
+
+/**
+ * Builds `edit`/`save` for a PHP-only `pattern` block in SSR-islands mode
+ * (`patternEditorPreview: 'ssr'`).
+ *
+ * The editor renders the PHP `render_callback` shell server-side and portals the
+ * editable pattern inner blocks (the islands) into its slots, so the editor
+ * matches the frontend (WYSIWYG) while the islands stay editable in the canvas.
+ * In the editor SSR context the block renders with no inner content, so the
+ * `render_callback` receives `$content === ''` and emits its wrapper with
+ * `<wp-inner-block-slot>` placeholders instead of the saved content.
+ *
+ * @param {string} blockName Block name, used to fetch the server-rendered shell.
+ * @param {string} markup    Pattern markup seeded as the editable inner blocks.
+ * @return {{ edit: Function, save: Function }} The edit and save components.
+ */
+function createSsrIslandsComponents( blockName, markup ) {
+	function Edit( { clientId, attributes } ) {
+		const registry = useRegistry();
+		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+			useDispatch( blockEditorStore );
+
+		// Seed the pattern as editable inner blocks once, when empty (same as the
+		// canvas-editable pattern mode). On reload they come from the saved post.
+		useLayoutEffect( () => {
+			const seeded = parse( markup );
+			if ( ! seeded.length ) {
+				return;
+			}
+			if (
+				registry.select( blockEditorStore ).getBlocks( clientId ).length
+			) {
+				return;
+			}
+			__unstableMarkNextChangeAsNotPersistent();
+			replaceInnerBlocks( clientId, seeded, false );
+		}, [
+			clientId,
+			registry,
+			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
+		] );
+
+		const { content, status } = useServerSideRender( {
+			block: blockName,
+			attributes,
+		} );
+
+		// Hold the last good shell: `useServerSideRender` drops `content` while
+		// loading, and the islands must never disappear mid-edit.
+		const shellRef = useRef();
+		if ( status === 'success' && typeof content === 'string' ) {
+			shellRef.current = content;
+		}
+		const shell = shellRef.current;
+
+		// Lock the island structure (content editable; no add/move/remove). The
+		// `useInnerBlocksProps` side effect applies the lock; the blocks render
+		// either inline (fallback) or portalled into the shell.
+		//
+		// `'all'` rather than `'contentOnly'`: contentOnly turns the block into a
+		// content-only section whose inspector UI replaces the auto-generated
+		// `variant`/`featured` controls — but SSR-islands needs those controls
+		// visible to drive the shell re-fetch. `'all'` locks the structure the
+		// same way without the section treatment, keeping the controls.
+		const blockProps = useBlockProps();
+		const innerBlocksProps = useInnerBlocksProps( blockProps, {
+			templateLock: 'all',
+			renderAppender: false,
+		} );
+
+		// Until the first shell arrives (or on error), show the editable islands
+		// plainly so they are never hidden.
+		if ( ! shell ) {
+			return <div { ...innerBlocksProps } />;
+		}
+
+		return (
+			<div { ...blockProps }>
+				<InnerContent clientId={ clientId } html={ shell } />
+			</div>
+		);
+	}
+
+	function save() {
+		// PHP wraps the saved islands on the frontend; save only the inner blocks.
+		return <InnerBlocks.Content />;
 	}
 
 	return { edit: Edit, save };
@@ -470,7 +564,10 @@ export const registerCoreBlocks = (
 	// Auto-register PHP-only `pattern` blocks as real, locked inner blocks.
 	if ( window.__unstableAutoRegisterBlockPatterns ) {
 		Object.entries( window.__unstableAutoRegisterBlockPatterns ).forEach(
-			( [ blockName, { markup, lock, hasRenderCallback } ] ) => {
+			( [
+				blockName,
+				{ markup, lock, hasRenderCallback, editorMode },
+			] ) => {
 				const bootstrappedBlockType = unlock(
 					select( blocksStore )
 				).getBootstrappedBlockType( blockName );
@@ -481,11 +578,16 @@ export const registerCoreBlocks = (
 					...( ( bootstrappedBlockType?.apiVersion ?? 0 ) < 3 && {
 						apiVersion: 3,
 					} ),
-					...createPatternBlockComponents(
-						markup,
-						lock,
-						hasRenderCallback
-					),
+					// `ssr-islands` renders the PHP shell server-side and portals
+					// the editable islands into it (WYSIWYG); the default mode
+					// edits the pattern blocks directly in the canvas.
+					...( editorMode === 'ssr-islands'
+						? createSsrIslandsComponents( blockName, markup )
+						: createPatternBlockComponents(
+								markup,
+								lock,
+								hasRenderCallback
+						  ) ),
 				} );
 			}
 		);

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -196,10 +196,22 @@ add_action(
 			),
 		);
 
-		// $content is the rendered inner blocks (empty for the SSR preview, which
-		// falls back to the pattern). `variant` sets a class, `featured` a ribbon.
+		// $content is the rendered inner blocks. It is empty in the editor SSR
+		// context (the block-renderer REST endpoint builds the block with no inner
+		// content): there, SSR-islands mode emits a slot placeholder so the editor
+		// can portal the editable islands into the shell. One slot per top-level
+		// pattern block; this pattern is a single group, so one slot at index 0.
+		// On the frontend (not a REST request) an empty block falls back to the
+		// pattern, so the raw slot never leaks. `variant` sets a class, `featured`
+		// a ribbon.
 		$render_pattern_block = static function ( $attributes, $content ) use ( $pattern_markup ) {
-			$body     = ( '' !== trim( (string) $content ) ) ? $content : do_blocks( $pattern_markup );
+			if ( '' !== trim( (string) $content ) ) {
+				$body = $content;
+			} elseif ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+				$body = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
+			} else {
+				$body = do_blocks( $pattern_markup );
+			}
 			$variant  = isset( $attributes['variant'] ) ? sanitize_html_class( $attributes['variant'] ) : 'default';
 			$featured = ! empty( $attributes['featured'] );
 			$classes  = 'pattern-block-demo is-variant-' . $variant . ( $featured ? ' is-featured' : '' );
@@ -256,15 +268,17 @@ add_action(
 			)
 		);
 
-		// Block 3 - SSR (`patternEditorPreview => 'ssr'`): control changes preview
-		// live in the editor, but the content is not editable in the canvas.
+		// Block 3 - SSR-islands (`patternEditorPreview => 'ssr'`): the editor renders
+		// the PHP render_callback shell server-side and portals the editable pattern
+		// blocks into its slots, so the editor matches the frontend (WYSIWYG) while
+		// the islands stay editable in the canvas.
 		register_block_type(
 			'test/php-only-pattern-ssr',
 			array(
-				'title'                => 'PHP-only pattern: SSR (controls live, no inline edit)',
+				'title'                => 'PHP-only pattern: SSR-islands (WYSIWYG, editable)',
 				'icon'                 => 'layout',
 				'category'             => 'widgets',
-				'description'          => 'Pattern content previewed with ServerSideRender. Controls update the rendered output in the editor, but there is no in-canvas editing.',
+				'description'          => 'The PHP wrapper is rendered server-side in the editor with the editable pattern blocks portalled into it, so the editor matches the frontend while the content stays editable in the canvas.',
 				'keywords'             => array( 'pattern', 'autotest' ),
 				'attributes'           => $pattern_attributes,
 				'supports'             => array(

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -333,3 +333,66 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		} );
 	} );
 } );
+
+test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-pattern-blocks',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'renders the PHP shell in the editor with editable islands, keeps controls, and saves clean inner blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'test/php-only-pattern-ssr' } );
+
+		// The server-rendered PHP shell is shown in the canvas, with the
+		// pattern's editable blocks portalled in place inside it (WYSIWYG). In the
+		// editor the heading/paragraph are editable RichText (role `textbox`), so
+		// assert on their text being inside the shell.
+		const shell = editor.canvas.locator( '.pattern-block-demo' );
+		await expect( shell ).toBeVisible();
+		await expect( shell ).toContainText( 'Title' );
+		await expect( shell ).toContainText( 'Body text' );
+
+		// Unlike a content-only section, the auto-generated controls stay
+		// visible — SSR-islands needs them to drive the re-fetch.
+		await editor.openDocumentSettingsSidebar();
+		await expect( page.getByLabel( 'Variant' ) ).toBeVisible();
+		const featured = page.getByLabel( 'Featured' );
+		await expect( featured ).toBeVisible();
+
+		// Toggling an attribute re-renders the shell server-side: the ribbon the
+		// render_callback adds for `featured` appears, and the island survives.
+		await featured.check();
+		await expect(
+			shell.locator( '.pattern-block-demo__ribbon' )
+		).toBeVisible();
+		await expect( shell ).toContainText( 'Title' );
+
+		// The PHP wrapper is editor-only: the block saves just the inner blocks,
+		// which the render_callback wraps on the frontend.
+		const content = await editor.getEditedPostContent();
+		// Opening delimiter carries the toggled attributes, so match its prefix.
+		expect( content ).toContain( '<!-- wp:test/php-only-pattern-ssr' );
+		expect( content ).toContain(
+			'<h2 class="wp-block-heading">Title</h2>'
+		);
+		expect( content ).not.toContain( 'pattern-block-demo' );
+	} );
+} );


### PR DESCRIPTION
## What

Part of #79330.

**🚧 Builds on #79598; can't be merged until it lands on trunk.🚧**

A PHP-only pattern block that opts into `patternEditorPreview: 'ssr'` shows its server-rendered wrapper in the editor, with the pattern's blocks editable in place inside it. The editor matches what the front end renders, and the content stays editable in the canvas.

## Why

On #79598, these blocks hit a trade-off: once a render callback wrapped or decorated the content, the editor showed the bare blocks while the front end showed the wrapped output, so the two didn't match. This closes that gap for the `'ssr'` mode.

## How

- Rendering the block's server output in the editor and mounting the editable blocks into the spots it marks for them when there's no saved content yet.
- Repurposing the experimental `'ssr'` preview so it is editable in place instead of read-only.
- Reusing the inner-content rendering from #79115 so the editable blocks can sit inside a server-rendered shell.

## Testing Instructions

1. Enable the "Pattern-based PHP blocks" experiment.
2. With the server-side-rendered-block test plugin active, open a new post.
3. Insert the "PHP-only pattern: SSR-islands" block. Confirm the editor shows the wrapper (variant class, plus the "Featured" ribbon when enabled) with the heading and paragraph editable in place.
4. Change Variant or toggle Featured in the sidebar. Confirm the wrapper updates and the edited content survives.
5. Save and view the post on the front end. Confirm it matches the editor.

## Screen recording
Notice you can actually edit the block in the canvas AND see the changes in the canvas at the pattern level, which wasn't possible in #79598:

https://github.com/user-attachments/assets/222f5f47-6c2d-461b-9dd4-1bcf3f10f8a5

---
I used Claude and GPT to implement the code changes while I guided and reviewed the approach.
