### PR TITLE
Add an e2e test for single paragraph selection on triple click

### DIFF
--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -835,6 +835,47 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should select a single paragraph on triple click', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second' },
+		} );
+
+		// Move the caret into the first paragraph so its block toolbar
+		// repositions above it and stops overlapping the text.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Triple click selects the paragraph. The browser extends the forward
+		// selection into the next block at offset 0; that overshoot must not
+		// collapse the selection or extend it into the next block.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first()
+			.click( { clickCount: 3 } );
+
+		// Only the first paragraph is selected, not a multi-block selection
+		// reaching into the second.
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		// The whole paragraph is selected (not collapsed), so typing replaces
+		// its content.
+		await page.keyboard.type( 'a' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'a' } },
+			{ name: 'core/paragraph', attributes: { content: 'Second' } },
+		] );
+	} );
+
 	test( 'should gradually multi-select', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?

Add an e2e test that triple clicking a paragraph selects only that paragraph, preparatory for #79105.

## Why?

Triple-click selection of a single text block is verified nowhere. The behavior was introduced in #64928 (which corrects the forward-selection overshoot into the next block) without a test, and #79105 changes the selection internals significantly, so a characterization test guards against regressing it.

## How?

Insert two paragraphs, triple click the first, and assert:

- `getSelectedBlocks` returns exactly one paragraph (the selection did not extend into the second block), and
- typing replaces the whole paragraph (the selection covers it and is not collapsed).

The test passes on trunk. Under #79105's editing-host model it is load-bearing: with the overshoot guard disabled there it fails on the multi-block assertion, and without the end-offset clamp it fails on the collapse assertion.

## Testing Instructions

Run `npm run test:e2e -- test/e2e/specs/editor/various/multi-block-selection.spec.js -g "single paragraph on triple click"`.

## Use of AI Tools

This pull request was authored with assistance from Claude Code (Claude Opus 4.8). All changes were reviewed by the PR author.