### PR TITLE
CI: Enforce pruned ESLint suppressions during lint

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -95,7 +95,14 @@ jobs:
             - name: Lint JavaScript
               if: ${{ matrix.annotations }}
               # `--quiet` reports only errors so they aren't buried under warnings in the CI log.
-              run: npm run lint:js -- --format compact --quiet
+              # `--prune-suppressions` plus the diff below ensures `suppressions.json` stays in sync.
+              run: |
+                  set -euo pipefail
+                  npm run lint:js -- --format compact --quiet --prune-suppressions
+                  if ! git diff --exit-code tools/eslint/suppressions.json; then
+                      echo "::error::tools/eslint/suppressions.json is out of date. Run \`npm run lint:js:prune-suppressions\` and commit the changes."
+                      exit 1
+                  fi
 
             - name: Lint Styles
               if: ${{ matrix.annotations }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -95,14 +95,8 @@ jobs:
             - name: Lint JavaScript
               if: ${{ matrix.annotations }}
               # `--quiet` reports only errors so they aren't buried under warnings in the CI log.
-              # `--prune-suppressions` plus the diff below ensures `suppressions.json` stays in sync.
-              run: |
-                  set -euo pipefail
-                  npm run lint:js -- --format compact --quiet --prune-suppressions
-                  if ! git diff --exit-code tools/eslint/suppressions.json; then
-                      echo "::error::tools/eslint/suppressions.json is out of date. Run \`npm run lint:js:prune-suppressions\` and commit the changes."
-                      exit 1
-                  fi
+              # `--prune-suppressions` ensures `suppressions.json` stays in sync.
+              run: npm run lint:js -- --format compact --quiet --prune-suppressions
 
             - name: Lint Styles
               if: ${{ matrix.annotations }}

--- a/tools/eslint/README.md
+++ b/tools/eslint/README.md
@@ -8,7 +8,7 @@ Consolidated ESLint configuration for the Gutenberg monorepo. This is a **privat
 -   **`config.strict.mjs`** — Extends the base config with stricter rules (e.g., `import/order`). Used by lint-staged for pre-commit checks via the root `eslint.config.strict.cjs`.
 -   **`import-resolver.cjs`** — Custom import resolver that maps `@wordpress/*` package imports to source files (`src/`) instead of built files (`build-module/`), so linting works without a build step.
 -   **`lint-js.cjs`** — Wrapper around `wp-scripts lint-js` used by `npm run lint:js`. Streams ESLint output through, detects the "stale suppressions" hint, and formats `suppressions.json` after `--prune-suppressions` runs.
--   **`suppressions.json`** — ESLint suppressions file for pre-existing violations. Updated via `npm run lint:js:prune-suppressions`.
+-   **`suppressions.json`** — ESLint suppressions file for pre-existing violations. Updated via `npm run lint:js:prune-suppressions`. CI enforces that this file is pruned and committed.
 
 ## Why a workspace package?
 

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1007,16 +1007,6 @@
 			"count": 1
 		}
 	},
-	"packages/compose/src/hooks/use-dragging/index.js": {
-		"react-hooks/immutability": {
-			"count": 1
-		}
-	},
-	"packages/compose/src/hooks/use-focus-return/index.js": {
-		"react-hooks/immutability": {
-			"count": 2
-		}
-	},
 	"packages/compose/src/hooks/use-merge-refs/index.ts": {
 		"react-hooks/refs": {
 			"count": 1
@@ -1343,11 +1333,6 @@
 	"packages/editor/src/components/post-publish-panel/postpublish.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		}
-	},
-	"packages/editor/src/components/post-revisions-panel/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
 		}
 	},
 	"packages/editor/src/components/post-status/index.js": {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1007,6 +1007,16 @@
 			"count": 1
 		}
 	},
+	"packages/compose/src/hooks/use-dragging/index.js": {
+		"react-hooks/immutability": {
+			"count": 1
+		}
+	},
+	"packages/compose/src/hooks/use-focus-return/index.js": {
+		"react-hooks/immutability": {
+			"count": 2
+		}
+	},
 	"packages/compose/src/hooks/use-merge-refs/index.ts": {
 		"react-hooks/refs": {
 			"count": 1
@@ -1333,6 +1343,11 @@
 	"packages/editor/src/components/post-publish-panel/postpublish.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-revisions-panel/index.js": {
+		"@wordpress/use-recommended-components": {
+			"count": 2
 		}
 	},
 	"packages/editor/src/components/post-status/index.js": {

--- a/tools/validation/check-local-changes.cjs
+++ b/tools/validation/check-local-changes.cjs
@@ -44,6 +44,7 @@ SimpleGit()
 				`There are local changes after running one or more of the following commands:
 
 - npm install
+- npm run lint:js:prune-suppressions
 - npm run docs:build
 - npm run --workspace @wordpress/theme build
 


### PR DESCRIPTION
## What?

Enforces that `tools/eslint/suppressions.json` stays pruned by running `--prune-suppressions` as part of the existing Lint JavaScript CI step, then failing if the file would change.

Also removes stale orphan suppression entries that were left behind after earlier file renames and deletions.

## Why?

ESLint suppressions can drift out of sync with the codebase: counts can become too high after violations are fixed, and entries can be left behind when files are renamed or deleted ([noticed here](https://github.com/WordPress/gutenberg/pull/79636/changes/BASE..c599f53c684d7e18b122401ebbc8d979249e8ab7#r3494457417)). Today CI only fails when suppressions are too low (uncovered violations). Orphaned and over-counted entries are not enforced, which can lead to unrelated cleanup showing up in feature PRs.

## How?

- Extend the Lint JavaScript step in `static-checks.yml` to pass `--prune-suppressions` and `git diff --exit-code tools/eslint/suppressions.json`.
- Prune stale orphan entries from `suppressions.json` so trunk is in sync when this lands.

## Testing Instructions

See that the CI flagged the outdated suppressions file in 59dd285.