### PR TITLE
Tabs: Prevent tab list from stealing focus during revision navigation

### DIFF
--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -92,6 +92,12 @@ function Edit( {
 
 		const focusButtonAt = ( index ) => {
 			window.requestAnimationFrame( () => {
+				// Only move focus if the editor canvas currently has focus,
+				// preventing focus theft from external UI like the revisions slider.
+				if ( ! menuRef.current?.ownerDocument.hasFocus() ) {
+					return;
+				}
+
 				const buttons = menuRef.current?.querySelectorAll( 'button' );
 				const target = buttons?.[ index ];
 				if ( ! target ) {


### PR DESCRIPTION
## What?
Closes #79697
Prevents the Tabs block from stealing focus from external UI (like the revisions slider) during revision navigation.

## Why?
When switching between revisions with different tab counts, the `tab-list` component's `useEffect` re-renders and auto-focuses a tab. This unconditionally stole focus from the revision slider in the editor header, interrupting keyboard navigation.

## How?
Add `ownerDocument.hasFocus()` guard to check before calling `.focus()`. The tab will now only be auto-focused if the editor canvas (iframe) already has focus, protecting external UI from focus theft while still allowing tabs to auto-focus during normal block insertion.

## Testing Instructions
1. Create a post and add a Tabs block.
2. Add/remove a tab, make changes, and save to create a few revisions.
3. Switch to the Revisions screen.
4. Try switching the revision slider in the header using the keyboard (arrow keys).
5. Verify that the Tabs block no longer steals focus from the slider as the revisions load.

## Screenshots or screencast <!-- if applicable -->

### Before:

https://github.com/user-attachments/assets/6c2d3f97-1592-4bd7-b9b3-11a7500a14de

### After
https://github.com/user-attachments/assets/13f9a1a7-8c4f-4908-ad1c-c5c16c174ee7

