### PR TITLE
IconButton: Use length zero for inline padding

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `IconButton`: Keep the inline padding override valid when reused in button length calculations ([#79722](https://github.com/WordPress/gutenberg/pull/79722)).
 -   `IconButton`: Restore the default tooltip delay on hover ([#79505](https://github.com/WordPress/gutenberg/pull/79505)).
 -   `Button`: Fix corner artifacts by using `background-clip: border-box` ([#79524](https://github.com/WordPress/gutenberg/pull/79524))
 

--- a/packages/ui/src/icon-button/style.module.css
+++ b/packages/ui/src/icon-button/style.module.css
@@ -4,7 +4,8 @@
 	@layer compositions {
 		.icon-button {
 			--wp-ui-button-aspect-ratio: 1;
-			--wp-ui-button-padding-inline: 0;
+			/* stylelint-disable-next-line length-zero-no-unit -- This custom property is reused in Button's min-width calc(), where a unitless zero is invalid. */
+			--wp-ui-button-padding-inline: 0px;
 			--wp-ui-button-min-width: unset;
 		}
 


### PR DESCRIPTION
Follow up to #79627.

## What?

Updates `IconButton`'s `--wp-ui-button-padding-inline` override from unitless `0` to `0px`, and adds the `@wordpress/ui` changelog entry.

## Why?

`Button` uses that custom property inside its `--wp-ui-button-min-width` `calc()`. `IconButton` currently overrides the min-width too, so this does not cause a visible bug today, but the padding token should remain a valid length anywhere the shared button CSS consumes it.

## How?

Sets the `IconButton` inline padding override to a length zero and scopes the stylelint exception to that declaration with the reason in place.

## Testing Instructions

1. Run `npm run lint:css -- packages/ui/src/icon-button/style.module.css`.
2. Run `git diff --check`.
3. Ran `npm run lint:md:docs -- packages/ui/CHANGELOG.md`; this still reports the existing changelog-wide `MD041` / repeated `MD024` heading warnings.

### Testing Instructions for Keyboard

No UI behavior changed.

## Screenshots or screencast

N/A. No visual change expected.

## Use of AI Tools

AI tools assisted with this follow-up patch and PR description. The changes were reviewed before publishing.
