### PR TITLE
Render the selected static inner block synchronously

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `InnerContent`: Render the selected inner block synchronously so its rich text selection stays current while typing; otherwise a stale selection offset could place a typed character at the wrong position in editable static inner blocks ([#79726](https://github.com/WordPress/gutenberg/pull/79726)).
 -   `useTypingObserver`: Capture the window reference at mount and reuse it during cleanup so the ref cleanup no longer reads `node.ownerDocument.defaultView` (which is `null` once the iframe-hosted editor has been detached from its window) and throws, which was also leaking the `removeEventListener` calls that follow it ([#78772](https://github.com/WordPress/gutenberg/pull/78772)).
 
 ### Breaking Changes

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -8,7 +8,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import { safeHTML } from '@wordpress/dom';
 
 /**
@@ -43,12 +43,14 @@ const LAYOUT = { type: 'default', alignments: [] };
  *                                should be rendered.
  */
 export default function InnerContent( { clientId } ) {
-	const { innerContent, order } = useSelect(
+	const { innerContent, order, selectedClientIds } = useSelect(
 		( select ) => {
-			const { getBlock, getBlockOrder } = select( blockEditorStore );
+			const { getBlock, getBlockOrder, getSelectedBlockClientIds } =
+				select( blockEditorStore );
 			return {
 				innerContent: getBlock( clientId )?.innerContent,
 				order: getBlockOrder( clientId ),
+				selectedClientIds: getSelectedBlockClientIds(),
 			};
 		},
 		[ clientId ]
@@ -94,10 +96,19 @@ export default function InnerContent( { clientId } ) {
 			{ order.map( ( childClientId, index ) =>
 				slots[ index ]
 					? createPortal(
-							<BlockListBlock
-								rootClientId={ clientId }
-								clientId={ childClientId }
-							/>,
+							// Render the selected block synchronously, as the block list does.
+							<AsyncModeProvider
+								value={
+									! selectedClientIds.includes(
+										childClientId
+									)
+								}
+							>
+								<BlockListBlock
+									rootClientId={ clientId }
+									clientId={ childClientId }
+								/>
+							</AsyncModeProvider>,
 							slots[ index ],
 							childClientId
 					  )


### PR DESCRIPTION
## What?

Closes #79654

Follow up to #79115, which added `InnerContent` and the test.

Fixes misplaced characters when typing in an editable inner block of a block with `innerContent` support (e.g. the HTML block's static inner blocks): a typed character can land at the wrong position.

## Why?

`InnerContent` (added in #79115) portals each inner block directly with `createPortal`, bypassing the per-block `AsyncModeProvider` that the block list wraps around every child. Because of that, the **selected** inner block runs in **async** mode, so its `useSelect` subscriptions (including the rich text selection offset) invalidate on a deferred schedule instead of synchronously.

While typing, the content change and the selection change are dispatched together, but a content-driven re-render can reach the rich text before the deferred selection invalidation lands. `useSelect` then hands back its cached (stale) selection offset for one render, and the rich text applies that stale caret, so the next keystrokes land at the wrong offset. The selected block in the normal block list never hits this because it renders synchronously.

## How?

Wrap each portalled inner block in an `AsyncModeProvider` keyed on its selection, exactly as the block list does. The selected inner block then renders synchronously, its selection subscription invalidates immediately, and the rich text never reads a stale offset.

## Testing Instructions

1. Add an HTML block and set its content to a static wrapper containing an editable inner paragraph.
2. Click into the inner paragraph, move the caret to the end, and type several characters.
3. The characters appear in order at the caret (before this fix a character could land at the wrong position).

Covered by the existing e2e test `editor/blocks/html.spec.js` "supports editable inner blocks within static HTML" (the flaky test in #79654).

How it was verified: on CI (Linux, headed) the race usually wins, so #79654 sees intermittent first-attempt failures. Two in-flight branches shift the CI timing enough to lose it on every run rather than intermittently: the editableRoot work (#79105) and the always-listen cleanup (#79712) each made this test fail consistently on CI until they picked up this fix. Locally with Playwright headless (macOS) it is deterministic: without this change the test fails on **every** run, and with it the test passes on **every** run.

Note the fix has no dedicated regression test: on CI the existing test passes even without it (timing), so CI will not guard against a regression here.

### Testing Instructions for Keyboard

Same as above; the whole flow is keyboard driven.

## Use of AI Tools

Investigated and authored with Claude Code (Claude Opus 4.8); reviewed by the PR author.




