### PR TITLE
Add intersection observer to dataviews list layout

### DIFF
--- a/packages/dataviews/src/components/dataviews-layouts/activity/activity-item.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/activity-item.tsx
@@ -17,6 +17,7 @@ import { Stack, VisuallyHidden } from '@wordpress/ui';
 import ItemActions, { PrimaryActions } from '../../dataviews-item-actions';
 import DataViewsContext from '../../dataviews-context';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
+import { useIntersectionObserver } from '../utils/use-infinite-scroll';
 import type { NormalizedField, ViewActivityProps } from '../../../types';
 
 function ActivityItem< Item >(
@@ -51,6 +52,7 @@ function ActivityItem< Item >(
 	const itemRef = useRef< HTMLDivElement >( null );
 	const registry = useRegistry();
 	const { paginationInfo } = useContext( DataViewsContext );
+	useIntersectionObserver( itemRef, posinset );
 
 	const { primaryActions, eligibleActions } = useMemo( () => {
 		// If an action is eligible for all items, doesn't need

--- a/packages/dataviews/src/components/dataviews-layouts/activity/activity-items.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/activity-items.tsx
@@ -4,14 +4,18 @@
 import ActivityItem from './activity-item';
 import type { ViewActivityProps } from '../../../types';
 
+type ActivityItemsProps< Item > = ViewActivityProps< Item > & {
+	isInfiniteScroll?: boolean;
+};
+
 function isDefined< T >( item: T | undefined ): item is T {
 	return !! item;
 }
 
 export default function ActivityItems< Item >(
-	props: ViewActivityProps< Item >
+	props: ActivityItemsProps< Item >
 ) {
-	const { data, fields, getItemId, view } = props;
+	const { data, fields, getItemId, isInfiniteScroll, view } = props;
 
 	// Determine which fields to display based on view configuration
 	const titleField = fields.find( ( field ) => field.id === view.titleField );
@@ -23,7 +27,8 @@ export default function ActivityItems< Item >(
 		.map( ( fieldId ) => fields.find( ( f ) => fieldId === f.id ) )
 		.filter( isDefined );
 
-	return data.map( ( item, index ) => {
+	return data.map( ( item ) => {
+		const { position: posinset } = item as { position?: number };
 		return (
 			<ActivityItem
 				{ ...props }
@@ -33,7 +38,7 @@ export default function ActivityItems< Item >(
 				titleField={ titleField }
 				descriptionField={ descriptionField }
 				otherFields={ otherFields }
-				posinset={ view.infiniteScrollEnabled ? index + 1 : undefined }
+				posinset={ isInfiniteScroll ? posinset : undefined }
 			/>
 		);
 	} );

--- a/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
@@ -91,11 +91,14 @@ export default function ViewActivity< Item >(
 		<>
 			<div
 				className={ wrapperClassName }
-				role={ view.infiniteScrollEnabled ? 'feed' : undefined }
+				role={ isInfiniteScroll ? 'feed' : undefined }
 				// @ts-ignore
 				inert={ isInert ? 'true' : undefined }
 			>
-				<ActivityItems< Item > { ...props } />
+				<ActivityItems< Item >
+					{ ...props }
+					isInfiniteScroll={ isInfiniteScroll }
+				/>
 			</div>
 			{ isInfiniteScroll && isLoading && (
 				<p className="dataviews-loading-more">

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -41,6 +41,7 @@ import type {
 	ActionModal as ActionModalType,
 } from '../../../types';
 import getDataByGroup from '../utils/get-data-by-group';
+import { useIntersectionObserver } from '../utils/use-infinite-scroll';
 
 interface ListViewItemProps< Item > {
 	view: ViewListType;
@@ -161,6 +162,7 @@ function ListItem< Item >( {
 	const itemRef = useRef< HTMLDivElement >( null );
 	const labelId = `${ idPrefix }-label`;
 	const descriptionId = `${ idPrefix }-description`;
+	useIntersectionObserver( itemRef, posinset );
 
 	const registry = useRegistry();
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -642,8 +644,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					! isInfiniteScroll && !! isLoading ? 'true' : undefined
 				}
 			>
-				{ data.map( ( item, index ) => {
+				{ data.map( ( item ) => {
 					const id = generateCompositeItemIdPrefix( item );
+					const posinset = ( item as { position?: number } ).position;
 					return (
 						<ListItem
 							key={ id }
@@ -660,11 +663,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 							onDropdownTriggerKeyDown={
 								onDropdownTriggerKeyDown
 							}
-							posinset={
-								view.infiniteScrollEnabled
-									? index + 1
-									: undefined
-							}
+							posinset={ isInfiniteScroll ? posinset : undefined }
 						/>
 					);
 				} ) }

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -41,6 +41,7 @@ import ColumnHeaderMenu from './column-header-menu';
 import ColumnPrimary from './column-primary';
 import { useScrollState } from './use-scroll-state';
 import getDataByGroup from '../utils/get-data-by-group';
+import { useIntersectionObserver } from '../utils/use-infinite-scroll';
 import { PropertiesSection } from '../../dataviews-view-config/properties-section';
 import { useDelayedLoading } from '../../../hooks/use-delayed-loading';
 
@@ -142,6 +143,8 @@ function TableRow< Item >( {
 		showDescription = true,
 		infiniteScrollEnabled,
 	} = view;
+	const rowRef = useRef< HTMLTableRowElement >( null );
+	useIntersectionObserver( rowRef, posinset );
 	// Will be set to true if `onTouchStart` fires. This happens before
 	// `onClick` and can be used to exclude touchscreen devices from certain
 	// behaviours.
@@ -154,6 +157,7 @@ function TableRow< Item >( {
 
 	return (
 		<tr
+			ref={ rowRef }
 			className={ clsx( 'dataviews-view-table__row', {
 				'is-selected': hasPossibleBulkAction && isSelected,
 				'has-bulk-actions': hasPossibleBulkAction,
@@ -300,7 +304,7 @@ function ViewTable< Item >( {
 	className,
 	empty,
 }: ViewTableProps< Item > ) {
-	const { containerRef } = useContext( DataViewsContext );
+	const { containerRef, paginationInfo } = useContext( DataViewsContext );
 	const isDelayedLoading = useDelayedLoading( isLoading );
 	const headerMenuRefs = useRef<
 		Map< string, { node: HTMLButtonElement; fallback: string } >
@@ -397,6 +401,10 @@ function ViewTable< Item >( {
 			}
 		};
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
+	const hasMoreItems =
+		isInfiniteScroll &&
+		( view.startPosition ?? 1 ) + ( view.perPage ?? 0 ) <
+			paginationInfo.totalItems;
 	const isRtl = isRTL();
 	if ( ! hasData ) {
 		return (
@@ -424,7 +432,9 @@ function ViewTable< Item >( {
 					'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
 				} ) }
 				aria-busy={ isLoading }
-				aria-describedby={ tableNoticeId }
+				aria-describedby={
+					isInfiniteScroll && isLoading ? tableNoticeId : undefined
+				}
 				role={ isInfiniteScroll ? 'feed' : undefined }
 				// @ts-ignore Reason: inert is a recent HTML attribute
 				inert={ ! isInfiniteScroll && isLoading ? 'true' : undefined }
@@ -643,47 +653,60 @@ function ViewTable< Item >( {
 				) : (
 					<tbody>
 						{ hasData &&
-							data.map( ( item, index ) => (
-								<TableRow
-									key={ getItemId( item ) }
-									item={ item }
-									level={
-										view.showLevels &&
-										typeof getItemLevel === 'function'
-											? getItemLevel( item )
-											: undefined
-									}
-									hasBulkActions={ hasBulkActions }
-									actions={ actions }
-									fields={ fields }
-									id={ getItemId( item ) || index.toString() }
-									view={ view }
-									titleField={ titleField }
-									mediaField={ mediaField }
-									descriptionField={ descriptionField }
-									selection={ selection }
-									getItemId={ getItemId }
-									onChangeSelection={ onChangeSelection }
-									onClickItem={ onClickItem }
-									renderItemLink={ renderItemLink }
-									isItemClickable={ isItemClickable }
-									isActionsColumnSticky={
-										! isHorizontalScrollEnd
-									}
-									posinset={
-										isInfiniteScroll ? index + 1 : undefined
-									}
-								/>
-							) ) }
+							data.map( ( item, index ) => {
+								const itemId = getItemId( item );
+								const { position: posinset } = item as {
+									position?: number;
+								};
+								return (
+									<TableRow
+										key={ itemId }
+										item={ item }
+										level={
+											view.showLevels &&
+											typeof getItemLevel === 'function'
+												? getItemLevel( item )
+												: undefined
+										}
+										hasBulkActions={ hasBulkActions }
+										actions={ actions }
+										fields={ fields }
+										id={ itemId || index.toString() }
+										view={ view }
+										titleField={ titleField }
+										mediaField={ mediaField }
+										descriptionField={ descriptionField }
+										selection={ selection }
+										getItemId={ getItemId }
+										onChangeSelection={ onChangeSelection }
+										onClickItem={ onClickItem }
+										renderItemLink={ renderItemLink }
+										isItemClickable={ isItemClickable }
+										isActionsColumnSticky={
+											! isHorizontalScrollEnd
+										}
+										posinset={
+											isInfiniteScroll
+												? posinset
+												: undefined
+										}
+									/>
+								);
+							} ) }
 					</tbody>
 				) }
 			</table>
-			{ isInfiniteScroll && isLoading && (
-				<div className="dataviews-loading" id={ tableNoticeId }>
-					<p className="dataviews-loading-more">
-						<Spinner />
-					</p>
-				</div>
+			{ ( hasMoreItems || ( isInfiniteScroll && isLoading ) ) && (
+				// Keep the spinner's height reserved while loading more so the
+				// scroll position doesn't bounce. Hidden, and silent to a11y,
+				// while idle.
+				<p
+					className="dataviews-loading-more"
+					id={ tableNoticeId }
+					aria-hidden={ ! isLoading }
+				>
+					<Spinner />
+				</p>
 			) }
 		</>
 	);

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -28,6 +28,33 @@ const data = Array.from( { length: 8 }, ( _, batch ) =>
 const PAGE = 20;
 // Simulated per-page network latency.
 const LOAD_DELAY_MS = 800;
+const INITIAL_VIEW: View = {
+	type: LAYOUT_LIST,
+	search: '',
+	startPosition: 1,
+	perPage: PAGE,
+	filters: [],
+	fields: [ 'satellites' ],
+	titleField: 'title',
+	descriptionField: 'description',
+	mediaField: 'image',
+	infiniteScrollEnabled: true,
+};
+
+function getRequestKey( view: View ) {
+	return JSON.stringify( {
+		startPosition: view.startPosition ?? 1,
+		perPage: view.perPage ?? PAGE,
+		search: view.search ?? '',
+		filters: view.filters ?? [],
+		sort: view.sort,
+		groupBy: view.groupBy,
+	} );
+}
+
+function fetchWindow( view: View ) {
+	return filterSortAndPaginate( data, view, fields );
+}
 
 /**
  * A realistic network-backed infinite-scroll consumer: the hook advances
@@ -35,55 +62,37 @@ const LOAD_DELAY_MS = 800;
  * (toggling `isLoading`) while reporting the true server total.
  */
 const AsyncInfiniteScroll = () => {
-	const [ view, setView ] = useState< View >( {
-		type: LAYOUT_LIST,
-		search: '',
-		startPosition: 1,
-		perPage: PAGE,
-		filters: [],
-		fields: [ 'satellites' ],
-		titleField: 'title',
-		descriptionField: 'description',
-		mediaField: 'image',
-		infiniteScrollEnabled: true,
-	} );
+	const [ view, setView ] = useState< View >( INITIAL_VIEW );
 
-	// The "server": how many rows have been delivered so far, and whether a
-	// request for the current window is in flight.
-	const [ loadedCount, setLoadedCount ] = useState( PAGE );
+	// The "server": only the currently requested window is cached, so scrolling
+	// up has to re-fetch unloaded rows just like scrolling down fetches new ones.
+	const [ fetchedRequestKey, setFetchedRequestKey ] = useState( () =>
+		getRequestKey( INITIAL_VIEW )
+	);
+	const [ fetchedData, setFetchedData ] = useState(
+		() => fetchWindow( INITIAL_VIEW ).data
+	);
 	const [ isLoading, setIsLoading ] = useState( false );
 
-	const startPosition = view.startPosition ?? 1;
-	const perPage = view.perPage ?? PAGE;
-	// Rows required to fill the window the hook is currently asking for.
-	const needed = Math.min( startPosition - 1 + perPage, data.length );
+	const requestKey = getRequestKey( view );
+	const isRequestLoaded = fetchedRequestKey === requestKey;
 
 	useEffect( () => {
-		if ( needed <= loadedCount ) {
+		if ( isRequestLoaded ) {
+			setIsLoading( false );
 			return undefined;
 		}
 		setIsLoading( true );
 		const timer = setTimeout( () => {
-			setLoadedCount( needed );
+			setFetchedData( fetchWindow( view ).data );
+			setFetchedRequestKey( requestKey );
 			setIsLoading( false );
 		}, LOAD_DELAY_MS );
 		return () => clearTimeout( timer );
-	}, [ needed, loadedCount ] );
+	}, [ isRequestLoaded, requestKey, view ] );
 
-	const loadedData = useMemo(
-		() => data.slice( 0, loadedCount ),
-		[ loadedCount ]
-	);
-	const { data: shownData, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( loadedData, view, fields ),
-		[ loadedData, view ]
-	);
-	// Report the true server total (not just what's loaded) so infinite scroll
-	// keeps requesting until the dataset is exhausted.
-	const serverPaginationInfo = useMemo(
-		() => ( { ...paginationInfo, totalItems: data.length } ),
-		[ paginationInfo ]
-	);
+	const shownData = isRequestLoaded ? fetchedData : [];
+	const { paginationInfo } = useMemo( () => fetchWindow( view ), [ view ] );
 
 	return (
 		<div style={ { height: '100%' } }>
@@ -95,12 +104,12 @@ const AsyncInfiniteScroll = () => {
 		` }</style>
 			<DataViews
 				getItemId={ ( item ) => item.id.toString() }
-				paginationInfo={ serverPaginationInfo }
+				paginationInfo={ paginationInfo }
 				data={ shownData }
 				view={ view }
 				fields={ fields }
 				onChangeView={ setView }
-				isLoading={ isLoading }
+				isLoading={ isLoading || ! isRequestLoaded }
 				actions={ actions }
 				defaultLayouts={ {
 					[ LAYOUT_TABLE ]: true,

--- a/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
+++ b/packages/dataviews/src/dataviews/stories/async-infinite-scroll.tsx
@@ -7,7 +7,12 @@ import { useState, useMemo, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViews from '../index';
-import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../constants';
+import {
+	LAYOUT_ACTIVITY,
+	LAYOUT_GRID,
+	LAYOUT_LIST,
+	LAYOUT_TABLE,
+} from '../../constants';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
 import type { View } from '../../types';
 import { actions, data as fixtureData, fields } from './fixtures';
@@ -115,6 +120,7 @@ const AsyncInfiniteScroll = () => {
 					[ LAYOUT_TABLE ]: true,
 					[ LAYOUT_GRID ]: true,
 					[ LAYOUT_LIST ]: true,
+					[ LAYOUT_ACTIVITY ]: true,
 				} }
 			/>
 		</div>

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -14,60 +14,6 @@ import { throttle } from '@wordpress/compose';
  */
 import type { View } from '../types';
 
-/**
- * Captures an anchor element for scroll position preservation.
- * Finds the element closest to the center of the viewport and stores its position.
- *
- * @param container        The scrollable container element.
- * @param anchorElementRef Ref to store the anchor element data.
- * @param direction        The scroll direction ('up' or 'down').
- * @return Whether an anchor element was successfully captured.
- */
-function captureAnchorElement(
-	container: HTMLElement,
-	anchorElementRef: React.MutableRefObject< {
-		posinset: number;
-		viewportOffset: number;
-		scrollTop: number;
-		direction: 'up' | 'down' | null;
-	} | null >,
-	direction: 'up' | 'down'
-): boolean {
-	// Find a visible element to use as anchor - prefer one in the middle of the viewport
-	const containerRect = container.getBoundingClientRect();
-	const centerY = containerRect.top + containerRect.height / 2;
-
-	// Query all items with aria-posinset and find the one closest to center
-	const items = Array.from( container.querySelectorAll( '[aria-posinset]' ) );
-
-	if ( items.length === 0 ) {
-		return false;
-	}
-
-	// Find the item closest to the center of the viewport
-	const bestAnchor = items.reduce( ( best, item ) => {
-		const itemRect = item.getBoundingClientRect();
-		const itemCenterY = itemRect.top + itemRect.height / 2;
-		const distance = Math.abs( itemCenterY - centerY );
-
-		const bestRect = best.getBoundingClientRect();
-		const bestCenterY = bestRect.top + bestRect.height / 2;
-		const bestDistance = Math.abs( bestCenterY - centerY );
-
-		return distance < bestDistance ? item : best;
-	} );
-
-	const posinset = Number( bestAnchor.getAttribute( 'aria-posinset' ) );
-	const anchorRect = bestAnchor.getBoundingClientRect();
-	anchorElementRef.current = {
-		posinset,
-		viewportOffset: anchorRect.top - containerRect.top,
-		scrollTop: container.scrollTop,
-		direction,
-	};
-	return true;
-}
-
 type UseInfiniteScrollProps = {
 	view: View;
 	onChangeView: ( view: View ) => void;
@@ -92,18 +38,15 @@ export function useInfiniteScroll( {
 	containerRef,
 	setVisibleEntries,
 }: UseInfiniteScrollProps ): UseInfiniteScrollResult {
-	// Track an anchor element for scroll position preservation
-	// This approach is robust even when items are added/removed from both ends simultaneously
-	const anchorElementRef = useRef< {
-		posinset: number;
-		viewportOffset: number;
-		scrollTop: number;
-		direction: 'up' | 'down' | null;
-	} | null >( null );
 	const viewRef = useRef( view );
 	const isLoadingRef = useRef( isLoading );
 	const onChangeViewRef = useRef( onChangeView );
 	const totalItemsRef = useRef( paginationInfo.totalItems );
+	// posinset of the top rendered item captured when a "load earlier items"
+	// (scroll-up) request is triggered, used to keep the viewport in place when
+	// the prepended page arrives while pinned at the very top — the one spot
+	// native scroll anchoring can't cover (see the effect below).
+	const prependAnchorRef = useRef< number | null >( null );
 
 	useLayoutEffect( () => {
 		viewRef.current = view;
@@ -152,46 +95,70 @@ export function useInfiniteScroll( {
 			[ setVisibleEntries ]
 		);
 
-	// Preserve scroll position when items are added or removed during infinite scroll
-	// Uses anchor element approach: find the same element after render and restore its viewport position
+	// Scroll position across content changes (pages loading in, items unloading
+	// from either end) is preserved by the browser's native scroll anchoring
+	// (`overflow-anchor`, on by default). It keeps whatever element is adjacent
+	// to the viewport visually fixed as content is inserted or removed above it,
+	// including across the async gap of a page load — the data is preserved
+	// while a request is in flight, so the user scrolls freely and the only
+	// content mutation happens when the page resolves. A JS anchor-restore used
+	// to run here too, but it duplicated that work and double-compensated
+	// unload-induced shifts (the list would jump upward as pages arrived).
+
+	// Keep the viewport in place when a "load earlier items" page is prepended
+	// while the user is pinned at the very top. Native scroll anchoring covers
+	// prepends everywhere else, but is suppressed at scrollTop 0, so without this
+	// the content jumps down by the height of the newly inserted items. Runs on
+	// `isLoading` transitions; acts only once the prepend has actually landed
+	// (the top posinset dropped below the captured one) and only while still at
+	// the top (scrollTop ~ 0), so it never overlaps with native anchoring.
 	useLayoutEffect( () => {
 		const container = containerRef.current;
-		const anchor = anchorElementRef.current;
+		const anchorPosinset = prependAnchorRef.current;
 
 		if (
 			! container ||
 			! view.infiniteScrollEnabled ||
-			! anchor ||
-			isLoading
+			isLoading ||
+			anchorPosinset === null
 		) {
 			return;
 		}
 
-		// Find the anchor element by its posinset
-		const anchorElement = container.querySelector(
-			`[aria-posinset="${ anchor.posinset }"]`
-		);
+		const firstItem = container.querySelector( '[aria-posinset]' );
+		const firstPosinset = firstItem
+			? Number( firstItem.getAttribute( 'aria-posinset' ) )
+			: null;
 
-		if ( anchorElement ) {
-			const containerRect = container.getBoundingClientRect();
-			const anchorRect = anchorElement.getBoundingClientRect();
-			const currentOffset = anchorRect.top - containerRect.top;
-
-			// Compensate only for the content shift, not for scrolling the user
-			// did during an async load. Adding back the scroll delta since capture
-			// keeps the list from snapping back to the capture-time position.
-			const scrollAdjustment =
-				currentOffset -
-				anchor.viewportOffset +
-				( container.scrollTop - anchor.scrollTop );
-
-			if ( Math.abs( scrollAdjustment ) > 1 ) {
-				container.scrollTop += scrollAdjustment;
-			}
+		// The prepended page hasn't rendered yet; wait for a later commit.
+		if ( firstPosinset === null || firstPosinset >= anchorPosinset ) {
+			return;
 		}
 
-		// Reset the anchor state now that we've adjusted
-		anchorElementRef.current = null;
+		prependAnchorRef.current = null;
+
+		// Above scrollTop 0 the browser already compensated the prepend; leaving
+		// it alone avoids double-adjusting.
+		if ( container.scrollTop > 2 ) {
+			return;
+		}
+
+		const anchorElement = container.querySelector(
+			`[aria-posinset="${ anchorPosinset }"]`
+		);
+		if ( ! anchorElement ) {
+			return;
+		}
+
+		// The captured item was at the top edge (scrollTop 0) before the page
+		// arrived; its offset now equals the height inserted above it.
+		const prependedHeight =
+			anchorElement.getBoundingClientRect().top -
+			container.getBoundingClientRect().top;
+
+		if ( prependedHeight > 1 ) {
+			container.scrollTop += prependedHeight;
+		}
 	}, [ containerRef, isLoading, view.infiniteScrollEnabled ] );
 
 	// Create and expose a shared IntersectionObserver for provider-level reuse.
@@ -264,9 +231,6 @@ export function useInfiniteScroll( {
 				if ( currentEndPosition < totalItems ) {
 					const newStartPosition = currentEndPosition;
 
-					// Capture anchor element for scroll position preservation
-					captureAnchorElement( target, anchorElementRef, 'down' );
-
 					onChangeViewRef.current( {
 						...currentView,
 						startPosition: newStartPosition,
@@ -286,8 +250,12 @@ export function useInfiniteScroll( {
 							? 1
 							: calculatedStartPosition;
 
-					// Capture anchor element for scroll position preservation
-					captureAnchorElement( target, anchorElementRef, 'up' );
+					// Remember the current top item so the viewport can be kept
+					// in place if this page arrives while pinned at the top.
+					const firstItem = target.querySelector( '[aria-posinset]' );
+					prependAnchorRef.current = firstItem
+						? Number( firstItem.getAttribute( 'aria-posinset' ) )
+						: null;
 
 					onChangeViewRef.current( {
 						...currentView,

--- a/packages/dataviews/src/hooks/use-infinite-scroll.ts
+++ b/packages/dataviews/src/hooks/use-infinite-scroll.ts
@@ -14,6 +14,60 @@ import { throttle } from '@wordpress/compose';
  */
 import type { View } from '../types';
 
+/**
+ * Captures an anchor element for scroll position preservation.
+ * Finds the element closest to the center of the viewport and stores its position.
+ *
+ * @param container        The scrollable container element.
+ * @param anchorElementRef Ref to store the anchor element data.
+ * @param direction        The scroll direction ('up' or 'down').
+ * @return Whether an anchor element was successfully captured.
+ */
+function captureAnchorElement(
+	container: HTMLElement,
+	anchorElementRef: React.MutableRefObject< {
+		posinset: number;
+		viewportOffset: number;
+		scrollTop: number;
+		direction: 'up' | 'down' | null;
+	} | null >,
+	direction: 'up' | 'down'
+): boolean {
+	// Find a visible element to use as anchor - prefer one in the middle of the viewport
+	const containerRect = container.getBoundingClientRect();
+	const centerY = containerRect.top + containerRect.height / 2;
+
+	// Query all items with aria-posinset and find the one closest to center
+	const items = Array.from( container.querySelectorAll( '[aria-posinset]' ) );
+
+	if ( items.length === 0 ) {
+		return false;
+	}
+
+	// Find the item closest to the center of the viewport
+	const bestAnchor = items.reduce( ( best, item ) => {
+		const itemRect = item.getBoundingClientRect();
+		const itemCenterY = itemRect.top + itemRect.height / 2;
+		const distance = Math.abs( itemCenterY - centerY );
+
+		const bestRect = best.getBoundingClientRect();
+		const bestCenterY = bestRect.top + bestRect.height / 2;
+		const bestDistance = Math.abs( bestCenterY - centerY );
+
+		return distance < bestDistance ? item : best;
+	} );
+
+	const posinset = Number( bestAnchor.getAttribute( 'aria-posinset' ) );
+	const anchorRect = bestAnchor.getBoundingClientRect();
+	anchorElementRef.current = {
+		posinset,
+		viewportOffset: anchorRect.top - containerRect.top,
+		scrollTop: container.scrollTop,
+		direction,
+	};
+	return true;
+}
+
 type UseInfiniteScrollProps = {
 	view: View;
 	onChangeView: ( view: View ) => void;
@@ -38,15 +92,18 @@ export function useInfiniteScroll( {
 	containerRef,
 	setVisibleEntries,
 }: UseInfiniteScrollProps ): UseInfiniteScrollResult {
+	// Track an anchor element for scroll position preservation
+	// This approach is robust even when items are added/removed from both ends simultaneously
+	const anchorElementRef = useRef< {
+		posinset: number;
+		viewportOffset: number;
+		scrollTop: number;
+		direction: 'up' | 'down' | null;
+	} | null >( null );
 	const viewRef = useRef( view );
 	const isLoadingRef = useRef( isLoading );
 	const onChangeViewRef = useRef( onChangeView );
 	const totalItemsRef = useRef( paginationInfo.totalItems );
-	// posinset of the top rendered item captured when a "load earlier items"
-	// (scroll-up) request is triggered, used to keep the viewport in place when
-	// the prepended page arrives while pinned at the very top — the one spot
-	// native scroll anchoring can't cover (see the effect below).
-	const prependAnchorRef = useRef< number | null >( null );
 
 	useLayoutEffect( () => {
 		viewRef.current = view;
@@ -95,70 +152,46 @@ export function useInfiniteScroll( {
 			[ setVisibleEntries ]
 		);
 
-	// Scroll position across content changes (pages loading in, items unloading
-	// from either end) is preserved by the browser's native scroll anchoring
-	// (`overflow-anchor`, on by default). It keeps whatever element is adjacent
-	// to the viewport visually fixed as content is inserted or removed above it,
-	// including across the async gap of a page load — the data is preserved
-	// while a request is in flight, so the user scrolls freely and the only
-	// content mutation happens when the page resolves. A JS anchor-restore used
-	// to run here too, but it duplicated that work and double-compensated
-	// unload-induced shifts (the list would jump upward as pages arrived).
-
-	// Keep the viewport in place when a "load earlier items" page is prepended
-	// while the user is pinned at the very top. Native scroll anchoring covers
-	// prepends everywhere else, but is suppressed at scrollTop 0, so without this
-	// the content jumps down by the height of the newly inserted items. Runs on
-	// `isLoading` transitions; acts only once the prepend has actually landed
-	// (the top posinset dropped below the captured one) and only while still at
-	// the top (scrollTop ~ 0), so it never overlaps with native anchoring.
+	// Preserve scroll position when items are added or removed during infinite scroll
+	// Uses anchor element approach: find the same element after render and restore its viewport position
 	useLayoutEffect( () => {
 		const container = containerRef.current;
-		const anchorPosinset = prependAnchorRef.current;
+		const anchor = anchorElementRef.current;
 
 		if (
 			! container ||
 			! view.infiniteScrollEnabled ||
-			isLoading ||
-			anchorPosinset === null
+			! anchor ||
+			isLoading
 		) {
 			return;
 		}
 
-		const firstItem = container.querySelector( '[aria-posinset]' );
-		const firstPosinset = firstItem
-			? Number( firstItem.getAttribute( 'aria-posinset' ) )
-			: null;
-
-		// The prepended page hasn't rendered yet; wait for a later commit.
-		if ( firstPosinset === null || firstPosinset >= anchorPosinset ) {
-			return;
-		}
-
-		prependAnchorRef.current = null;
-
-		// Above scrollTop 0 the browser already compensated the prepend; leaving
-		// it alone avoids double-adjusting.
-		if ( container.scrollTop > 2 ) {
-			return;
-		}
-
+		// Find the anchor element by its posinset
 		const anchorElement = container.querySelector(
-			`[aria-posinset="${ anchorPosinset }"]`
+			`[aria-posinset="${ anchor.posinset }"]`
 		);
-		if ( ! anchorElement ) {
-			return;
+
+		if ( anchorElement ) {
+			const containerRect = container.getBoundingClientRect();
+			const anchorRect = anchorElement.getBoundingClientRect();
+			const currentOffset = anchorRect.top - containerRect.top;
+
+			// Compensate only for the content shift, not for scrolling the user
+			// did during an async load. Adding back the scroll delta since capture
+			// keeps the list from snapping back to the capture-time position.
+			const scrollAdjustment =
+				currentOffset -
+				anchor.viewportOffset +
+				( container.scrollTop - anchor.scrollTop );
+
+			if ( Math.abs( scrollAdjustment ) > 1 ) {
+				container.scrollTop += scrollAdjustment;
+			}
 		}
 
-		// The captured item was at the top edge (scrollTop 0) before the page
-		// arrived; its offset now equals the height inserted above it.
-		const prependedHeight =
-			anchorElement.getBoundingClientRect().top -
-			container.getBoundingClientRect().top;
-
-		if ( prependedHeight > 1 ) {
-			container.scrollTop += prependedHeight;
-		}
+		// Reset the anchor state now that we've adjusted
+		anchorElementRef.current = null;
 	}, [ containerRef, isLoading, view.infiniteScrollEnabled ] );
 
 	// Create and expose a shared IntersectionObserver for provider-level reuse.
@@ -231,6 +264,9 @@ export function useInfiniteScroll( {
 				if ( currentEndPosition < totalItems ) {
 					const newStartPosition = currentEndPosition;
 
+					// Capture anchor element for scroll position preservation
+					captureAnchorElement( target, anchorElementRef, 'down' );
+
 					onChangeViewRef.current( {
 						...currentView,
 						startPosition: newStartPosition,
@@ -250,12 +286,8 @@ export function useInfiniteScroll( {
 							? 1
 							: calculatedStartPosition;
 
-					// Remember the current top item so the viewport can be kept
-					// in place if this page arrives while pinned at the top.
-					const firstItem = target.querySelector( '[aria-posinset]' );
-					prependAnchorRef.current = firstItem
-						? Number( firstItem.getAttribute( 'aria-posinset' ) )
-						: null;
+					// Capture anchor element for scroll position preservation
+					captureAnchorElement( target, anchorElementRef, 'up' );
 
 					onChangeViewRef.current( {
 						...currentView,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Builds on #79546 to add the intersection observer to the list layout, which improves infinite scroll performance on large lists.

Mostly un-reviewed AI changes so I'll leave this as a draft until I've done more testing and read the code. AI has been relatively unreliable for infinite scroll work so far so this needs careful checking 😅 

The goal was to ensure that with intersection observer added to list, we can still fix the jumping behaviour that #79546 tries to fix, and in testing so far this seems to be working well.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. `npm run storybook:dev`
2. Check the async infinite scroll story with list and grid layouts. To test intersection observer, I made the story load async from both sides.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

mix of gpt 5.5/codex and opus 4.8/claude