### PR TITLE
Tabs: Prevent tab list from moving focus during revision navigation

### DIFF
--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -102,17 +102,11 @@ function Edit( {
 
 		const focusButtonAt = ( index ) => {
 			window.requestAnimationFrame( () => {
-				const buttons = menuRef.current?.querySelectorAll( 'button' );
-				const target = buttons?.[ index ];
-				if ( ! target ) {
-					return;
-				}
-				const richText = target.querySelector( '[contenteditable]' );
-				if ( richText ) {
-					richText.focus();
-				} else {
-					target.focus();
-				}
+				const button =
+					menuRef.current?.querySelectorAll( 'button' )?.[ index ];
+				(
+					button?.querySelector( '[contenteditable]' ) ?? button
+				)?.focus();
 			} );
 		};
 

--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -56,6 +56,8 @@ function Edit( {
 		},
 		[ clientId ]
 	);
+	const { isBlockSelected, hasSelectedInnerBlock } =
+		useSelect( blockEditorStore );
 	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { insertTab, removeTab } = useTabActions( tabsClientId );
@@ -90,6 +92,14 @@ function Edit( {
 			return;
 		}
 
+		// Only move focus during active editing, not external data changes.
+		if (
+			! isBlockSelected( tabsClientId ) &&
+			! hasSelectedInnerBlock( tabsClientId, true )
+		) {
+			return;
+		}
+
 		const focusButtonAt = ( index ) => {
 			window.requestAnimationFrame( () => {
 				const buttons = menuRef.current?.querySelectorAll( 'button' );
@@ -107,7 +117,13 @@ function Edit( {
 		};
 
 		focusButtonAt( effectiveActiveIndex );
-	}, [ tabsList.length, effectiveActiveIndex ] );
+	}, [
+		effectiveActiveIndex,
+		hasSelectedInnerBlock,
+		isBlockSelected,
+		tabsClientId,
+		tabsList.length,
+	] );
 
 	const blockProps = useBlockProps( {
 		role: 'tablist',


### PR DESCRIPTION
## What?
Closes #79697.
Alternative to #79710. Doesn't rely on the fact that blocks are rendered in an iframe document.

PR fixes a focus-steal issue in the Tab List block.

The tab-list focuses on a tab button whenever the tab count changes. This also fired on non-editing re-renders, most visibly when navigating revisions with different tab counts, pulling focus away from the revisions slider.

## Why?

The focus effect lacked a guard against editing context. A `tabsList.length` change can come from a user action (add/remove/insert) or from external data swaps (revisions, undo/redo, entity switches); the effect treats them the same.

## How?

Gate the focus on the block actually being edited: `isBlockSelected( tabsClientId ) || hasSelectedInnerBlock( tabsClientId, true )`. Insertion and add/remove still focus (the block/inner block is selected); revision previews don't (nothing selected there). Mirrors the guard `useFocusFirstElement` already uses, and avoids coupling to iframe/document focus.

## Testing Instructions
1. Add a Tabs block, add/remove a tab, save a few times to create revisions.
2. Open the Revisions screen and move the slider with the keyboard.
3. Focus stays on the slider as revisions load.
4. Regression check: inserting a Tabs block still focuses the first tab; adding/removing a tab still focuses the right one.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9f897a49-1cf2-468a-9994-b53cef57e1cc

## Use of AI Tools

Assisted by Claude.
