### PR TITLE
Experimental Media Modal: Ensure selection is properly cleared between open/close

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -77,6 +77,21 @@ const defaultQueryParams: ViewQueryParams = {
 	search: '',
 };
 
+/**
+ * Derives the selection (attachment IDs as strings) from the `value` prop, which
+ * may be a single id, an array of ids, or undefined.
+ *
+ * @param value The currently selected media item(s).
+ */
+function getSelectionFromValue(
+	value: number | number[] | undefined
+): string[] {
+	if ( ! value ) {
+		return [];
+	}
+	return Array.isArray( value ) ? value.map( String ) : [ String( value ) ];
+}
+
 const defaultView: View = {
 	type: LAYOUT_PICKER_GRID,
 	fields: [],
@@ -125,8 +140,9 @@ interface MediaUploadModalProps {
 	multiple?: boolean;
 
 	/**
-	 * The currently selected media item(s).
-	 * Can be a single ID number or array of IDs for multiple selection.
+	 * Media item(s) to pre-select — a single ID or an array of IDs. Seeds the
+	 * selection each time the modal opens (so an external change is picked up on
+	 * the next open); changes while the modal is open are not tracked.
 	 */
 	value?: number | number[];
 
@@ -222,14 +238,9 @@ export function MediaUploadModal( {
 	search = true,
 	searchLabel = __( 'Search media' ),
 }: MediaUploadModalProps ) {
-	const [ selection, setSelection ] = useState< string[] >( () => {
-		if ( ! value ) {
-			return [];
-		}
-		return Array.isArray( value )
-			? value.map( String )
-			: [ String( value ) ];
-	} );
+	const [ selection, setSelection ] = useState< string[] >( () =>
+		getSelectionFromValue( value )
+	);
 
 	const { createSuccessNotice, removeAllNotices } =
 		useDispatch( noticesStore );
@@ -466,8 +477,24 @@ export function MediaUploadModal( {
 		onClose?.();
 	}, [ removeAllNotices, onClose ] );
 
+	// Keep the latest `value` in a ref so the open effect can read it without
+	// depending on it. Not depending on `value` means a change while the modal is
+	// open won't discard the user's in-progress selection, and an unstable array
+	// prop can't retrigger the effect.
+	const valueRef = useRef( value );
 	useEffect( () => {
-		if ( ! isOpen ) {
+		valueRef.current = value;
+	}, [ value ] );
+
+	useEffect( () => {
+		if ( isOpen ) {
+			// The modal instance stays mounted between opens, so re-seed the
+			// selection from the current `value` each time it opens. This clears
+			// a previous session's selection and picks up any change to `value`
+			// made while the modal was closed.
+			setSelection( getSelectionFromValue( valueRef.current ) );
+		} else {
+			// Reset the view (page/search) on close, as before.
 			setQueryParams( defaultQueryParams );
 		}
 	}, [ isOpen ] );

--- a/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -44,7 +44,37 @@ jest.mock( '@wordpress/core-data', () => {
 const mockUseEntityRecordsWithPermissions = unlock( coreDataPrivateApis )
 	.useEntityRecordsWithPermissions as jest.Mock;
 
-function renderModal( { isOpen = true } = {} ) {
+const IMAGE_RECORDS = [
+	{
+		id: 1,
+		title: { raw: 'Cat', rendered: 'Cat' },
+		media_type: 'image',
+		mime_type: 'image/png',
+		source_url: 'https://example.com/cat.png',
+		alt_text: '',
+	},
+	{
+		id: 2,
+		title: { raw: 'Dog', rendered: 'Dog' },
+		media_type: 'image',
+		mime_type: 'image/png',
+		source_url: 'https://example.com/dog.png',
+		alt_text: '',
+	},
+];
+
+function mockRecords( records: unknown[] ) {
+	mockUseEntityRecordsWithPermissions.mockReturnValue( {
+		records,
+		isResolving: false,
+		totalItems: records.length,
+		totalPages: 1,
+	} );
+}
+
+type ModalProps = { isOpen?: boolean; value?: number | number[] };
+
+function renderModal( { isOpen = true, value }: ModalProps = {} ) {
 	const registry = createRegistry();
 	registry.register( noticesStore );
 	registry.register( preferencesStore );
@@ -56,13 +86,14 @@ function renderModal( { isOpen = true } = {} ) {
 		<RegistryProvider value={ registry }>
 			<MediaUploadModal
 				isOpen={ isOpen }
+				value={ value }
 				onSelect={ onSelect }
 				onClose={ onClose }
 			/>
 		</RegistryProvider>
 	);
 
-	const rerender = ( props: { isOpen: boolean } ) => {
+	const rerender = ( props: ModalProps ) => {
 		view.rerender(
 			<RegistryProvider value={ registry }>
 				<MediaUploadModal
@@ -122,6 +153,65 @@ describe( 'MediaUploadModal', () => {
 				expect.objectContaining( { page: 1, search: '' } )
 			);
 		} );
+	} );
+
+	it( 'clears a user selection when the modal is closed and reopened', async () => {
+		const user = userEvent.setup();
+		mockRecords( IMAGE_RECORDS );
+
+		const { rerender } = renderModal();
+
+		const options = within( screen.getByRole( 'listbox' ) ).getAllByRole(
+			'option'
+		);
+		await user.click( options[ 0 ] );
+		expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+
+		// The modal instance stays mounted between opens, so the selection must
+		// be reset rather than persisting into the next open session.
+		rerender( { isOpen: false } );
+		rerender( { isOpen: true } );
+
+		const reopenedOptions = within(
+			screen.getByRole( 'listbox' )
+		).getAllByRole( 'option' );
+		expect( reopenedOptions[ 0 ] ).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
+	} );
+
+	it( 'seeds the selection from `value`, reflecting an external change on the next open', async () => {
+		mockRecords( IMAGE_RECORDS );
+
+		// Opens with item 1 pre-selected via `value`.
+		const { rerender } = renderModal( { value: 1 } );
+
+		const options = within( screen.getByRole( 'listbox' ) ).getAllByRole(
+			'option'
+		);
+		expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'false' );
+
+		// Close first (still item 1), THEN change `value` to item 2 while the
+		// modal is closed. Keeping these as separate steps is what makes this
+		// exercise the open path: if the selection were only re-seeded on close,
+		// it would still hold item 1 on reopen.
+		rerender( { isOpen: false, value: 1 } );
+		rerender( { isOpen: false, value: 2 } );
+		rerender( { isOpen: true, value: 2 } );
+
+		const reopenedOptions = within(
+			screen.getByRole( 'listbox' )
+		).getAllByRole( 'option' );
+		expect( reopenedOptions[ 0 ] ).toHaveAttribute(
+			'aria-selected',
+			'false'
+		);
+		expect( reopenedOptions[ 1 ] ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
 	} );
 
 	it( 'updates the media query when the picker changes page', async () => {


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/77117
* https://github.com/WordPress/gutenberg/issues/73085

Ensure the experimental media modal selection is updated between open/close.

## Why?

Noticed while working on https://github.com/WordPress/gutenberg/pull/79336 where the "Attach images" modal for attachments should always start from a clean slate (i.e. it does not pass in _value_) so that it doesn't give the impression that _detach_ can happen via the modal.

In the core media library modal, selection is not preserved via open/close — instead `value` is used to determine whether the selection should be pre-set.

This PR ensures the new experimental media modal behaves in the same way.

## How?

* Store the value in a ref
* Whenever the value changes, update the ref
* When the modal opens (goes from closed to open) update the selection to match the current state of the ref
* We use a ref to sync the `value` so that we can keep the effect that fires on open/close to only depend on the open/close state

## Testing Instructions

* Activate the DataViews-powered media modal experiment in Gutenberg settings:

<img width="604" height="91" alt="image" src="https://github.com/user-attachments/assets/9e094349-9944-4748-a24f-4db4a46dd945" />

* In a post or page, go to attach some images from the "Attached images" category of the media inserter. Each time you open the media library it should be from a fresh selection state (nothing preselected)
* Then, go to add a Gallery block to the post and give it some images
* Go to the Gallery block's block toolbar and select "Add" — each time you open the modal it should remember the selection of the Gallery block itself

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9a7b36d9-70bc-48bb-98ef-f2a9a1431873

## Use of AI Tools

Claude Code