### PR TITLE
Image: Use Playwright's locator.drop for media placeholder drop test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50196,6 +50196,7 @@
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
+				"@wordpress/vips": "file:../../packages/vips",
 				"@y/websocket-server": "^0.1.1",
 				"esbuild": "^0.27.2",
 				"filenamify": "^4.2.0",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -26,6 +26,7 @@
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",
+		"@wordpress/vips": "file:../../packages/vips",
 		"@y/websocket-server": "^0.1.1",
 		"esbuild": "^0.27.2",
 		"filenamify": "^4.2.0",

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -196,7 +196,6 @@ test.describe( 'Image', () => {
 
 	test( 'should drag and drop files into media placeholder', async ( {
 		editor,
-		page,
 		imageBlockUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
@@ -208,32 +207,9 @@ test.describe( 'Image', () => {
 			name: 'This image has an empty alt attribute',
 		} );
 
-		const tmpInput = await page.evaluateHandle( () => {
-			const input = document.createElement( 'input' );
-			input.type = 'file';
-			return input;
+		await imageBlock.drop( {
+			files: [ imageBlockUtils.TEST_IMAGE_FILE_PATH ],
 		} );
-
-		await imageBlockUtils.upload( tmpInput );
-
-		const paragraphRect = await imageBlock.boundingBox();
-		const pX = paragraphRect.x + paragraphRect.width / 2;
-		const pY = paragraphRect.y + paragraphRect.height / 3;
-
-		await imageBlock.evaluate(
-			( element, [ input, clientX, clientY ] ) => {
-				const dataTransfer = new window.DataTransfer();
-				dataTransfer.items.add( input.files[ 0 ] );
-				const event = new window.DragEvent( 'drop', {
-					bubbles: true,
-					clientX,
-					clientY,
-					dataTransfer,
-				} );
-				element.dispatchEvent( event );
-			},
-			[ tmpInput, pX, pY ]
-		);
 
 		// Wait for upload to complete (includes client-side media processing time).
 		await expect( image ).toHaveAttribute( 'src', /^https?:\/\//, {


### PR DESCRIPTION
## What?

- Migrated the image block's "drag and drop files into media placeholder" e2e test to Playwright v1.60's native `locator.drop`. Replaced the manual temp `<input>` + `evaluateHandle` + hand-built `DragEvent`/`DataTransfer` dispatch with a single `imageBlock.drop({ files: [ ... ] })` call (`image.spec.js)
- Declared `@wordpress/vips` as a devDependency of the e2e-tests workspace. See https://github.com/WordPress/gutenberg/pull/78632#discussion_r3504019775.

## Testing Instructions
CI checks are green.