### PR TITLE
Build: Support --skip-types in npm run dev

### DIFF
--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -5,6 +5,7 @@
  */
 import spawn from 'cross-spawn';
 import { fileURLToPath } from 'url';
+import { parseArgs } from 'util';
 import path from 'path';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
@@ -78,7 +79,13 @@ function exec( command, args = [], options = {} ) {
  * Main build orchestration function.
  */
 async function build() {
-	const skipTypes = process.argv.includes( '--skip-types' );
+	const { values } = parseArgs( {
+		options: {
+			'skip-types': { type: 'boolean', default: false },
+		},
+		strict: false,
+	} );
+	const skipTypes = values[ 'skip-types' ];
 
 	console.log( '🔨 Starting build process...\n' );
 

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -114,6 +114,8 @@ const readyMarkerFile = {
  * Main dev orchestration function.
  */
 async function dev() {
+	const skipTypes = process.argv.includes( '--skip-types' );
+
 	console.log( '🔨 Starting development build...\n' );
 
 	const startTime = Date.now();
@@ -162,24 +164,26 @@ async function dev() {
 			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
 		] );
 
-		console.log( '\n📘 Building TypeScript types...\n' );
-		const tsStartTime = Date.now();
-		await exec( 'tsgo', [ '--build' ] ).catch( () => {
-			console.error(
-				'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
-			);
-			throw new Error( 'TypeScript compilation failed' );
-		} );
-		const buildTime = Date.now() - tsStartTime;
-		console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
+		if ( ! skipTypes ) {
+			console.log( '\n📘 Building TypeScript types...\n' );
+			const tsStartTime = Date.now();
+			await exec( 'tsgo', [ '--build' ] ).catch( () => {
+				console.error(
+					'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
+				);
+				throw new Error( 'TypeScript compilation failed' );
+			} );
+			const buildTime = Date.now() - tsStartTime;
+			console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
 
-		console.log( '\n✅ Checking type declaration files...' );
-		await exec( 'node', [
-			path.join(
-				__dirname,
-				'packages/check-build-type-declaration-files.cjs'
-			),
-		] );
+			console.log( '\n✅ Checking type declaration files...' );
+			await exec( 'node', [
+				path.join(
+					__dirname,
+					'packages/check-build-type-declaration-files.cjs'
+				),
+			] );
+		}
 
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [
@@ -194,15 +198,19 @@ async function dev() {
 		);
 
 		console.log( '👀 Starting watch mode...\n' );
-		console.log( '   - TypeScript compiler watching for type changes' );
+		if ( ! skipTypes ) {
+			console.log( '   - TypeScript compiler watching for type changes' );
+		}
 		console.log( '   - Package builder watching for source changes\n' );
 
-		// Start TypeScript watch
-		const tscWatch = execAsync( 'tsgo', [
-			'--build',
-			'--watch',
-			'--preserveWatchOutput',
-		] );
+		// Start TypeScript watch (unless types are skipped).
+		const tscWatch = skipTypes
+			? null
+			: execAsync( 'tsgo', [
+					'--build',
+					'--watch',
+					'--preserveWatchOutput',
+			  ] );
 
 		// Start package build watch and wait for initial build to complete
 		// before signaling ready. wp-build outputs "Watching for changes..."
@@ -217,7 +225,7 @@ async function dev() {
 		// Handle process termination
 		const cleanup = () => {
 			console.log( '\n\n👋 Stopping watch mode...' );
-			tscWatch.kill();
+			tscWatch?.kill();
 			buildWatch.kill();
 			readyMarkerFile.cleanup();
 			process.exit( 0 );

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -5,6 +5,7 @@
  */
 import { execSync, spawn } from 'child_process';
 import { fileURLToPath } from 'url';
+import { parseArgs } from 'util';
 import path from 'path';
 import fs from 'fs';
 
@@ -114,7 +115,13 @@ const readyMarkerFile = {
  * Main dev orchestration function.
  */
 async function dev() {
-	const skipTypes = process.argv.includes( '--skip-types' );
+	const { values } = parseArgs( {
+		options: {
+			'skip-types': { type: 'boolean', default: false },
+		},
+		strict: false,
+	} );
+	const skipTypes = values[ 'skip-types' ];
 
 	console.log( '🔨 Starting development build...\n' );
 


### PR DESCRIPTION
## What?

Adds support for the `--skip-types` flag to `npm run dev`, mirroring the flag already supported by `npm run build`.

```bash
npm run dev -- --skip-types
```

## Why?

`npm run build -- --skip-types` lets contributors skip TypeScript compilation for a faster build when they don't need type checking. The dev/watch pipeline had no equivalent, so anyone iterating with `npm run dev` always paid the cost of the initial `tsgo --build` and ran a `tsgo --build --watch` process for the whole session. This brings the two entry points to parity.

## How?

In `tools/build-scripts/dev.mjs`:

- Parse `const skipTypes = process.argv.includes( '--skip-types' )` at the start of `dev()`, same as `build.mjs`.
- Guard the initial TypeScript type build and the type-declaration-file check behind `if ( ! skipTypes )`.
- Skip spawning the `tsgo --build --watch` process when the flag is set (`tscWatch` is `null`), and suppress the corresponding "TypeScript compiler watching…" log line.
- Use `tscWatch?.kill()` in the cleanup handler to safely handle the null case.

Note: unlike `build.mjs`, `dev.mjs` invokes `wp-build` with a fixed `--watch` arg rather than forwarding `process.argv`, so no arg filtering is needed to keep `--skip-types` from reaching `wp-build`.

## Testing Instructions

1. Run `npm run dev -- --skip-types`.
2. Confirm the "Building TypeScript types" step and the type-declaration check are skipped during initial build.
3. Confirm watch mode starts with only the package builder watching (no TypeScript compiler watch line), and source changes still rebuild.
4. Run `npm run dev` (without the flag) and confirm TypeScript compilation and the type watcher still run as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)