### PR TITLE
Fix wp/7.0 cherry-pick lint errors

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -569,7 +569,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 -	**Category:** design
 -	**Parent:** core/navigation
 -	**Supports:** anchor, interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
+-	**Attributes:** description, id, isParentSubmenu, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break
 
@@ -588,7 +588,7 @@ Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Category:** widgets
 -	**Allowed Blocks:** core/page-list-item
 -	**Supports:** anchor, color (background, gradients, link, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** isNested, parentPageID
+-	**Attributes:** parentPageID
 
 ## Page List Item
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -68,7 +68,6 @@ const SiteLogo = ( {
 	const isResizable = ! isWideAligned && isLargeViewport;
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
-	const cropButtonRef = useRef();
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -13,7 +13,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useMemo } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
 import { useFocusOnMount } from '@wordpress/compose';
 
 /**


### PR DESCRIPTION
## What?
- Removes a stray `cropButtonRef` declaration from the Site Logo cherry-pick where the wp/7.0 branch does not include the newer trunk media-editor code that uses it.
- Removes an unused `Stack` import from the revisions slider cherry-pick where wp/7.0 still uses `HStack` from `@wordpress/components`.
- Updates generated core block reference docs after running the docs build.

## Why?
The wp/7.0 static-analysis rerun failed in `npm run lint:js` after recent cherry-picks. These were cherry-pick context artifacts rather than intended release-branch behavior.

## Testing
- `npm run lint:js -- packages/block-library/src/site-logo/edit.js packages/editor/src/components/post-revisions-preview/revisions-slider.js`
- `npm run lint`
- `npm run docs:build`

## Cherry-picks
- `3c7620daf364cb6408130acfdc7052740185e868` - Editor: Move focus to revisions slider when entering revisions mode (#79691)
- `3a5ff539f1ef53bb85f024b6c3129402b67f8881` - Mark all controlled/mode block changes non-persistent (#79350)
