### PR TITLE
Release: Revert to 23.5rc-3

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 23.5.1
+ * Version: 23.5.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 23.5.0
+ * Version: 23.5.0-rc.3
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.1",
+	"version": "23.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "23.5.1",
+			"version": "23.5.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.0",
+	"version": "23.5.0-rc.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "23.5.0",
+			"version": "23.5.0-rc.3",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.0",
+	"version": "23.5.0-rc.3",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.1",
+	"version": "23.5.0",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## What?
Revert `trunk` to `23.5rc-3`

## Why?
We're hitting some release problems and planning to start from scratch, see:

https://wordpress.slack.com/archives/C02QB2JS7/p1782905499270349?thread_ts=1782897414.443919&cid=C02QB2JS7

## How?
Reverting the 2 commits back to RC3. 

## Testing Instructions
Verify we're properly back to RC3 state. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None

## Use of AI Tools

None