### PR TITLE
Edit Post: Fix template part reload error by preserving original post URL

### DIFF
--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -22,14 +22,12 @@ export default function BrowserURL() {
 	const { postId, postStatus, isTemplate } = useSelect( ( select ) => {
 		const { getCurrentPost } = select( editorStore );
 		const post = getCurrentPost();
-		const { id, status } = post;
+		const { id, status, type } = post;
 
 		return {
 			postId: id,
 			postStatus: status,
-			isTemplate: [ 'wp_template', 'wp_template_part' ].includes(
-				post.type
-			),
+			isTemplate: [ 'wp_template', 'wp_template_part' ].includes( type ),
 		};
 	}, [] );
 

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -19,24 +19,25 @@ export function getPostEditURL( postId ) {
 
 export default function BrowserURL() {
 	const [ historyId, setHistoryId ] = useState( null );
-	const { postId, postStatus } = useSelect( ( select ) => {
+	const { postId, postStatus, isTemplate } = useSelect( ( select ) => {
 		const { getCurrentPost } = select( editorStore );
 		const post = getCurrentPost();
-		let { id, status, type } = post;
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			type
-		);
-		if ( isTemplate ) {
-			id = post.wp_id;
-		}
+		const { id, status } = post;
 
 		return {
 			postId: id,
 			postStatus: status,
+			isTemplate: [ 'wp_template', 'wp_template_part' ].includes(
+				post.type
+			),
 		};
 	}, [] );
 
 	useEffect( () => {
+		if ( isTemplate ) {
+			return;
+		}
+
 		if ( postId && postId !== historyId && postStatus !== 'auto-draft' ) {
 			window.history.replaceState(
 				{ id: postId },
@@ -45,7 +46,7 @@ export default function BrowserURL() {
 			);
 			setHistoryId( postId );
 		}
-	}, [ postId, postStatus, historyId ] );
+	}, [ postId, postStatus, historyId, isTemplate ] );
 
 	return null;
 }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/72733

This PR prevents the browser URL from syncing to the template/template part ID when entering focus mode from within the standard post editor.

## Why?
When a user edits a template part from the post editor (e.g., clicking "Edit original" on a Header), the `BrowserURL` component previously synced the URL to reflect the template part's internal database ID (e.g., `post.php?post=321`). If the user hard-reloads the page at this point, the PHP backend crashes with a "You do not have permission" error because `post.php` is strictly designed for standard post types, not `wp_template_part`.

As suggested in the issue, the most acceptable and robust fallback is to simply ensure the user is returned to the post they were originally editing upon reload.

## How?
Updated the `BrowserURL` component within the `edit-post` package to detect when the editor shifts into a template or template part context. When `isTemplate` is true, the URL synchronization hook returns early, effectively freezing the URL on the parent post (e.g., `post.php?post=636`). 

If a user reloads the page, they are safely dropped back into the parent post editor. If they click "Back" in the UI, the editor restores seamlessly.

## Testing Instructions
1. Open a standard Post or Page in the editor.
2. Ensure template preview mode is active, double-click a template part (like the Header), and select "Edit" to enter focus mode.
3. Observe the URL in your browser. Verify that it **does not** change to a new ID, but remains anchored to your original post.
4. Hard refresh the page.
5. Verify that the editor loads safely back into the original post without throwing a permission error.

## Screenshots or screencast

https://github.com/user-attachments/assets/919e9aa2-2fec-482d-be9a-953792e4e0c1

