### PR TITLE
Build: Use GUTENBERG_TOKEN when creating the release draft

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -433,6 +433,7 @@ jobs:
                   RELEASE_NAME: ${{ steps.get_release_version.outputs.version }}
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               with:
+                  github-token: ${{ secrets.GUTENBERG_TOKEN }}
                   script: |
                       const fs = require('fs');
 


### PR DESCRIPTION
## What?

Pass `secrets.GUTENBERG_TOKEN` to the `actions/github-script` step that creates the GitHub release draft in the `Build Gutenberg Plugin Zip` workflow.

## Why?

The release run for 23.5.0 failed at the **Create Release Draft and Attach Asset** step ([failed job](https://github.com/WordPress/gutenberg/actions/runs/28522232790/job/84550136423)):

```
POST /repos/WordPress/gutenberg/releases - 403
HttpError: Resource not accessible by integration
```

#78258 replaced `actions/create-release` + `actions/upload-release-asset` with `actions/github-script`. The old `actions/create-release@v1` read its token from the `GITHUB_TOKEN` env var, but `actions/github-script` ignores that and uses its `github-token` input, which defaults to the ephemeral default `GITHUB_TOKEN`. That token is not permitted to create releases on this repo, so `github.rest.repos.createRelease()` returns 403.

Every other privileged write in this workflow — the version bump pushing to the protected `release/*` branch and `trunk`, and the npm publish — already uses `secrets.GUTENBERG_TOKEN`. This makes the release-draft step consistent with them.

## How?

Add `github-token: ${{ secrets.GUTENBERG_TOKEN }}` under `with:` on the github-script step.

See https://wordpress.slack.com/archives/C02QB2JS7/p1782914167151859?thread_ts=1782897414.443919&cid=C02QB2JS7

## Testing Instructions

Trigger the release workflow (or re-run the failed 23.5.0 release). The **Create Release Draft and Attach Asset** step should now succeed and produce a draft release with `gutenberg.zip` attached.