### PR TITLE
Navigation Link/Submenu: run post-status check also without Gutenberg plugin (draft/deleted links regression)

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -127,9 +127,12 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
-			return '';
-		}
+		$should_render = gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block );
+	} else {
+		$should_render = block_core_shared_navigation_item_should_render( $attributes, $block );
+	}
+	if ( ! $should_render ) {
+		return '';
 	}
 
 	// Don't render the block's subtree if it has no label.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -76,9 +76,12 @@ function block_core_navigation_submenu_get_submenu_visibility( $context ) {
 function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// Check if this navigation item should render based on post status.
 	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		if ( ! gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block ) ) {
-			return '';
-		}
+		$should_render = gutenberg_block_core_shared_navigation_item_should_render( $attributes, $block );
+	} else {
+		$should_render = block_core_shared_navigation_item_should_render( $attributes, $block );
+	}
+	if ( ! $should_render ) {
+		return '';
 	}
 
 	// Don't render the block's subtree if it has no label.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79745

<!-- In a few words, what is the PR actually doing? -->
Makes the Navigation Link and Navigation Submenu blocks hide items that link to non-published or missing pages on core installs (Gutenberg plugin inactive) too, restoring the pre-7.0 behavior.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
On a plain WordPress core install (Gutenberg plugin inactive), Navigation Link / Navigation Submenu items pointing to draft / pending / private / trashed / deleted pages are rendered on the front end — a regression from 6.9.x.

The post-status check calls `gutenberg_block_core_shared_navigation_item_should_render()` only inside `if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN )`, with no `else` branch. On a core build the constant is undefined, so the core (un-prefixed) `block_core_shared_navigation_item_should_render()` is never called and the check is skipped entirely. Introduced in #74461.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the missing `else` branch calling the core helper in both render callbacks (`navigation-link` and `navigation-submenu`), using the same `IS_GUTENBERG_PLUGIN ? gutenberg_… : block_core_…` selection pattern already used for `block_core_shared_navigation_render_submenu_icon()` a few lines below in the same files.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
On a core build (or with the Gutenberg plugin deactivated):

1. Add a Page Link to a Navigation block (stores `"kind":"post-type"`, `"type":"page"`, `"id"`).
2. Set the target page to Draft (or move it to Trash / delete it).
3. View the front end as a logged-out visitor.

Expected (with this fix): the navigation item is not rendered. Before the fix: the item renders from the stored label/url (a 404 for deleted pages).

Note on unit tests: the existing `test_returns_empty_when_draft` / `test_returns_empty_when_custom_post_type_draft` pass in the Gutenberg PHPUnit environment because it defines `IS_GUTENBERG_PLUGIN`, so only the `if` branch runs — the `else` (core) path can't be exercised there (the constant can't be undefined). This is also why the regression was invisible to CI. The fix mirrors the already-working submenu-icon pattern in the same files.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes. Tool: Claude Code (Anthropic Claude Opus 4.8).

Used for: investigating the root cause, tracing the regressing commit (#74461) through the source and git history, drafting the linked issue (#79745), and writing this code change and PR description.

My role: I directed the investigation and fact-checked every claim against the current Gutenberg source and commit history, chose the code structure to match the existing in-file `IS_GUTENBERG_PLUGIN` pattern rather than the assistant's first suggestion, and I reviewed, syntax-checked, committed, and understand the change and can explain it in review.
