### PR TITLE
Add `workflows: write` permissions to release publishing steps

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -403,7 +403,7 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
-
+            workflows: write
         steps:
             - name: Set Release Version
               id: get_release_version


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds `workflows: write` permissions to the release publishing steps of the `build-plugin-zip.yml` workflow file.

## Why?
While `contents: write` should be all that's needed, [the documentation does state](https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release) that sometimes `workflows: write` is also required.

> The fine-grained token must have at least one of the following permission sets:
> 
> - "Contents" repository permissions (write)
> - "Contents" repository permissions (write) and "Workflows" repository permissions (write)

The [job's output also states this in the response](https://github.com/WordPress/gutenberg/actions/runs/28522232790/job/84550136423#step:5:258):

```
response: {
    url: 'https://api.github.com/repos/WordPress/gutenberg/releases',
    status: 403,
    headers: {
      'access-control-allow-origin': '*',
      'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset, Warning',
      'content-encoding': 'gzip',
      'content-security-policy': "default-src 'none'",
      'content-type': 'application/json; charset=utf-8',
      date: 'Wed, 01 Jul 2026 13:50:27 GMT',
      'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
      server: 'github.com',
      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
      'transfer-encoding': 'chunked',
      vary: 'Accept-Encoding, Accept, X-Requested-With',
      'x-accepted-github-permissions': 'contents=write; contents=write,workflows=write',
      'x-content-type-options': 'nosniff',
      'x-frame-options': 'deny',
      'x-github-api-version-selected': '2022-11-28',
      'x-github-media-type': 'github.v3; format=json',
      'x-github-request-id': '2880:84FBB:47CBE7:10489AD:6A451B1F',
      'x-ratelimit-limit': '15000',
      'x-ratelimit-remaining': '14015',
      'x-ratelimit-reset': '1782915402',
      'x-ratelimit-resource': 'core',
      'x-ratelimit-used': '985',
      'x-xss-protection': '0'
    },
    data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/releases/releases#create-a-release',
      status: '403'
    }
  }
```

If this doesn't work, then moving ahead with #79747 is reasonable.

## Use of AI Tools

AI Assistance: Yes
Tool: Claude Code was used to investigate possible solutions.