### PR TITLE
Remove Playlist border radius support

### DIFF
--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -58,12 +58,10 @@
 		},
 		"__experimentalBorder": {
 			"color": true,
-			"radius": true,
 			"style": true,
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
-				"radius": true,
 				"style": true,
 				"width": true
 			}

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -4,11 +4,6 @@
 $waveform-player-height: 100px;
 
 .wp-block-playlist {
-	// Clip content to respect border-radius.
-	// `overflow: hidden` is a fallback for browsers that don't support `overflow: clip`.
-	overflow: hidden;
-	overflow: clip;
-
 	// Main waveform player container.
 	.wp-block-playlist__waveform-player {
 		width: 100%;


### PR DESCRIPTION
## What?

Removes border-radius support from the experimental Playlist block.

This PR moves the border-radius support removal out of #78980 so it can be reviewed independently from the waveform seek accessibility changes.

## Why?

The updated waveform player markup does not reliably support clipping all rendered player content to the Playlist block border radius. Keeping the radius control exposed would allow users to configure a style that no longer maps cleanly to the rendered block.

## How?

- Removes `radius` from the Playlist block border support settings.
- Removes the Playlist wrapper overflow clipping that existed to make radius styling clip the waveform player content.

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Playlist block.
3. Confirm the Playlist block exposes border color, style, and width controls.
4. Confirm the Playlist block no longer exposes a border radius control.

## Validation

- `npm run format -- packages/block-library/src/playlist/block.json`
- `./node_modules/.bin/wp-scripts lint-style packages/block-library/src/playlist/style.scss`
- `git diff --check`
