### PR TITLE
Tests: Fix flaky 'GIF to Video' e2e test

### DIFF
--- a/test/e2e/specs/editor/various/gif-to-video.spec.js
+++ b/test/e2e/specs/editor/various/gif-to-video.spec.js
@@ -76,6 +76,7 @@ class GifToVideoUtils {
 					.getItems();
 				return items.length === 0;
 			},
+			undefined,
 			{ timeout }
 		);
 	}
@@ -129,6 +130,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 
 	test( 'switches an uploaded GIF to the video GIF variation', async ( {
 		editor,
+		page,
 		gifToVideoUtils,
 		requestUtils,
 	} ) => {
@@ -155,16 +157,17 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		await gifToVideoUtils.waitForUploadQueueEmpty( 60_000 );
 
 		// The block becomes a core/video block.
-		await gifToVideoUtils.page.waitForFunction(
+		await page.waitForFunction(
 			() =>
 				window.wp.data
 					.select( 'core/block-editor' )
 					.getBlocks()
 					.some( ( block ) => block.name === 'core/video' ),
+			undefined,
 			{ timeout: 30_000 }
 		);
 
-		const videoBlock = await gifToVideoUtils.page.evaluate( () =>
+		const videoBlock = await page.evaluate( () =>
 			window.wp.data
 				.select( 'core/block-editor' )
 				.getBlocks()


### PR DESCRIPTION
## What?
Closes #79734.

PR tries to fix the new `Video conversion: animated GIF to video` e2e tests, which are flaky.

## Why?
`waitForUploadQueueEmpty`'s 60s timeout was **silently ignored** — the wait was dying at exactly **10000ms** in both trace attempts.

Playwright's signature is `waitForFunction( pageFunction, arg?, options? )`. The test passed `{ timeout }` in the **second** slot (`arg`), so `options` was `undefined`. The wait then fell back to the base config default `actionTimeout: 10_000` instead of 60s.

## Testing Instructions
CI checks are green.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.