### PR TITLE
Embed: Refactor 'EmbedPlaceholder' to use recommended components

### DIFF
--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -5,14 +5,12 @@ import { __, _x } from '@wordpress/i18n';
 import {
 	Button,
 	Placeholder,
-	ExternalLink,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
+import { Link, Stack } from '@wordpress/ui';
 
-const EmbedPlaceholder = ( {
+export default function EmbedPlaceholder( {
 	icon,
 	label,
 	value,
@@ -21,7 +19,7 @@ const EmbedPlaceholder = ( {
 	cannotEmbed,
 	fallback,
 	tryAgain,
-} ) => {
+} ) {
 	return (
 		<Placeholder
 			icon={ <BlockIcon icon={ icon } showColors /> }
@@ -47,31 +45,32 @@ const EmbedPlaceholder = ( {
 				</Button>
 			</form>
 			<div className="wp-block-embed__learn-more">
-				<ExternalLink
+				<Link
+					openInNewTab
 					href={ __(
 						'https://wordpress.org/documentation/article/embeds/'
 					) }
 				>
 					{ __( 'Learn more about embeds' ) }
-				</ExternalLink>
+				</Link>
 			</div>
 			{ cannotEmbed && (
-				<VStack spacing={ 3 } className="components-placeholder__error">
+				<Stack
+					direction="column"
+					gap="md"
+					className="components-placeholder__error"
+				>
 					<div className="components-placeholder__instructions">
 						{ __( 'Sorry, this content could not be embedded.' ) }
 					</div>
-					<HStack
-						expanded={ false }
-						spacing={ 3 }
-						justify="flex-start"
-					>
+					<Stack direction="row" gap="md" justify="flex-start">
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
 							onClick={ tryAgain }
 						>
 							{ _x( 'Try again', 'button label' ) }
-						</Button>{ ' ' }
+						</Button>
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
@@ -79,11 +78,9 @@ const EmbedPlaceholder = ( {
 						>
 							{ _x( 'Convert to link', 'button label' ) }
 						</Button>
-					</HStack>
-				</VStack>
+					</Stack>
+				</Stack>
 			) }
 		</Placeholder>
 	);
-};
-
-export default EmbedPlaceholder;
+}

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -336,11 +336,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-library/src/embed/embed-placeholder.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
 	"packages/block-library/src/form-input/edit.js": {
 		"react-hooks/refs": {
 			"count": 3


### PR DESCRIPTION
## What?
PR refactors `EmbedPlaceholder` to use the new recommended components from `@wordpress/ui`.

## Testing Instructions
1. Open a post or page.
2. Insert the Embed block and confirm that the placeholder is displayed correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="646" height="396" alt="CleanShot 2026-07-01 at 21 19 37" src="https://github.com/user-attachments/assets/c6f6f674-03cd-448c-bd95-fbeef751c159" />

## Use of AI Tools

Assisted by Claude.