### PR TITLE
Playlist: Add waveform style controls

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -637,7 +637,7 @@ Embed a simple playlist.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding)
--	**Attributes:** caption, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
+-	**Attributes:** caption, customWaveformBackgroundColor, customWaveformColor, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type, waveformBackgroundColor, waveformBackgroundColorValue, waveformColor, waveformColorValue
 
 ## Playlist track
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -70,6 +70,7 @@ function StyleInspectorSlots( {
 				label={ __( 'Background' ) }
 				className="background-block-support-panel__inner-wrapper"
 			/>
+			<InspectorControls.Slot group="styles" />
 			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
 			<InspectorControls.Slot
 				group="dimensions"
@@ -82,7 +83,6 @@ function StyleInspectorSlots( {
 				className="elements-block-support-panel__inner-wrapper"
 			/>
 			{ showPositionControls && <PositionControls /> }
-			<InspectorControls.Slot group="styles" />
 			{ showBindingsControls && (
 				<InspectorControls.Slot group="bindings" />
 			) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -140,6 +140,7 @@ const StylesTab = ( {
 						label={ __( 'Background' ) }
 						className="background-block-support-panel__inner-wrapper"
 					/>
+					<InspectorControls.Slot group="styles" />
 					<InspectorControls.Slot group="filter" />
 					<InspectorControls.Slot
 						group="layout"
@@ -159,7 +160,6 @@ const StylesTab = ( {
 						className="elements-block-support-panel__inner-wrapper"
 					/>
 					<PositionControls />
-					<InspectorControls.Slot group="styles" />
 				</>
 			) }
 		</>

--- a/packages/block-library/src/playlist/README.md
+++ b/packages/block-library/src/playlist/README.md
@@ -29,6 +29,12 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `showArtists` | `boolean` | `true` | — |
 | `showNumbers` | `boolean` | `true` | — |
 | `showTrackLength` | `boolean` | `true` | — |
+| `waveformColor` | `string` | — | — |
+| `customWaveformColor` | `string` | — | — |
+| `waveformColorValue` | `string` | — | — |
+| `waveformBackgroundColor` | `string` | — | — |
+| `customWaveformBackgroundColor` | `string` | — | — |
+| `waveformBackgroundColorValue` | `string` | — | — |
 | `caption` | `string` | — | — |
 
 ## Supports

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -38,6 +38,24 @@
 			"type": "boolean",
 			"default": true
 		},
+		"waveformColor": {
+			"type": "string"
+		},
+		"customWaveformColor": {
+			"type": "string"
+		},
+		"waveformColorValue": {
+			"type": "string"
+		},
+		"waveformBackgroundColor": {
+			"type": "string"
+		},
+		"customWaveformBackgroundColor": {
+			"type": "string"
+		},
+		"waveformBackgroundColorValue": {
+			"type": "string"
+		},
 		"caption": {
 			"type": "string"
 		}

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -17,6 +17,9 @@ import {
 	BlockControls,
 	InspectorControls,
 	InnerBlocks,
+	withColors,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -48,6 +51,10 @@ const PlaylistEdit = ( {
 	isSelected,
 	insertBlocksAfter,
 	clientId,
+	waveformColor,
+	setWaveformColor,
+	waveformBackgroundColor,
+	setWaveformBackgroundColor,
 } ) => {
 	const {
 		order,
@@ -56,15 +63,19 @@ const PlaylistEdit = ( {
 		showImages,
 		showArtists,
 		showTrackLength,
-		style,
-		textColor,
+		waveformColorValue,
+		waveformBackgroundColorValue,
 	} = attributes;
 
 	// Extract the waveform style from the block style variation class.
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
-	const waveformColorKey = [ textColor, style?.color?.text ].join( '|' );
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+	const resolvedWaveformColor = waveformColor.color || waveformColorValue;
+	const resolvedWaveformBackgroundColor =
+		waveformBackgroundColor.color || waveformBackgroundColorValue;
+	const waveformPanelId = `${ clientId }-waveform`;
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -361,10 +372,76 @@ const PlaylistEdit = ( {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
+			{ colorGradientSettings.hasColorsOrGradients && (
+				<InspectorControls group="styles">
+					<ToolsPanel
+						label={ __( 'Waveform' ) }
+						resetAll={ () => {
+							setWaveformColor( undefined );
+							setWaveformBackgroundColor( undefined );
+							setAttributes( {
+								waveformColorValue: undefined,
+								waveformBackgroundColorValue: undefined,
+							} );
+						} }
+						panelId={ waveformPanelId }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ColorGradientSettingsDropdown
+							__experimentalIsRenderedInSidebar
+							settings={ [
+								{
+									colorValue: resolvedWaveformColor,
+									label: __( 'Color' ),
+									onColorChange: ( colorValue ) => {
+										setWaveformColor( colorValue );
+										setAttributes( {
+											waveformColorValue: colorValue,
+										} );
+									},
+									isShownByDefault: true,
+									resetAllFilter: () => {
+										setWaveformColor( undefined );
+										setAttributes( {
+											waveformColorValue: undefined,
+										} );
+									},
+									enableAlpha: true,
+									clearable: true,
+								},
+								{
+									colorValue: resolvedWaveformBackgroundColor,
+									label: __( 'Background' ),
+									onColorChange: ( colorValue ) => {
+										setWaveformBackgroundColor(
+											colorValue
+										);
+										setAttributes( {
+											waveformBackgroundColorValue:
+												colorValue,
+										} );
+									},
+									isShownByDefault: true,
+									resetAllFilter: () => {
+										setWaveformBackgroundColor( undefined );
+										setAttributes( {
+											waveformBackgroundColorValue:
+												undefined,
+										} );
+									},
+									enableAlpha: true,
+									clearable: true,
+								},
+							] }
+							panelId={ waveformPanelId }
+							{ ...colorGradientSettings }
+						/>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 			<figure { ...blockProps }>
 				<Disabled isDisabled={ ! isSelected }>
 					<WaveformPlayer
-						key={ waveformColorKey }
 						src={ currentTrackData?.src }
 						title={ currentTrackData?.title }
 						artist={ currentTrackData?.artist }
@@ -378,6 +455,8 @@ const PlaylistEdit = ( {
 								? currentTrackData?.imageAlt
 								: undefined
 						}
+						color={ resolvedWaveformColor }
+						backgroundColor={ resolvedWaveformBackgroundColor }
 						waveformStyle={ waveformStyle }
 						onEnded={ onTrackEnded }
 					/>
@@ -410,4 +489,7 @@ const PlaylistEdit = ( {
 	);
 };
 
-export default PlaylistEdit;
+export default withColors(
+	{ waveformColor: 'color' },
+	{ waveformBackgroundColor: 'background-color' }
+)( PlaylistEdit );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -62,6 +62,14 @@ const PlaylistEdit = ( {
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
+	const waveformColorContext = useMemo(
+		() =>
+			JSON.stringify( {
+				className: blockProps.className,
+				style: blockProps.style,
+			} ),
+		[ blockProps.className, blockProps.style ]
+	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -375,6 +383,7 @@ const PlaylistEdit = ( {
 								: undefined
 						}
 						waveformStyle={ waveformStyle }
+						colorContext={ waveformColorContext }
 						onEnded={ onTrackEnded }
 					/>
 				</Disabled>

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -56,20 +56,15 @@ const PlaylistEdit = ( {
 		showImages,
 		showArtists,
 		showTrackLength,
+		style,
+		textColor,
 	} = attributes;
 
 	// Extract the waveform style from the block style variation class.
 	const waveformStyle =
 		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
-	const waveformColorContext = useMemo(
-		() =>
-			JSON.stringify( {
-				className: blockProps.className,
-				style: blockProps.style,
-			} ),
-		[ blockProps.className, blockProps.style ]
-	);
+	const waveformColorKey = [ textColor, style?.color?.text ].join( '|' );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -369,6 +364,7 @@ const PlaylistEdit = ( {
 			<figure { ...blockProps }>
 				<Disabled isDisabled={ ! isSelected }>
 					<WaveformPlayer
+						key={ waveformColorKey }
 						src={ currentTrackData?.src }
 						title={ currentTrackData?.title }
 						artist={ currentTrackData?.artist }
@@ -383,7 +379,6 @@ const PlaylistEdit = ( {
 								: undefined
 						}
 						waveformStyle={ waveformStyle }
-						colorContext={ waveformColorContext }
 						onEnded={ onTrackEnded }
 					/>
 				</Disabled>

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -33,6 +33,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -386,56 +387,66 @@ const PlaylistEdit = ( {
 						} }
 						panelId={ waveformPanelId }
 						dropdownMenuProps={ dropdownMenuProps }
+						__experimentalFirstVisibleItemClass="first"
+						__experimentalLastVisibleItemClass="last"
 					>
-						<ColorGradientSettingsDropdown
-							__experimentalIsRenderedInSidebar
-							settings={ [
-								{
-									colorValue: resolvedWaveformColor,
-									label: __( 'Color' ),
-									onColorChange: ( colorValue ) => {
-										setWaveformColor( colorValue );
-										setAttributes( {
-											waveformColorValue: colorValue,
-										} );
+						<Stack
+							direction="column"
+							style={ { gridColumn: '1 / -1' } }
+						>
+							<ColorGradientSettingsDropdown
+								__experimentalIsRenderedInSidebar
+								settings={ [
+									{
+										colorValue: resolvedWaveformColor,
+										label: __( 'Color' ),
+										onColorChange: ( colorValue ) => {
+											setWaveformColor( colorValue );
+											setAttributes( {
+												waveformColorValue: colorValue,
+											} );
+										},
+										isShownByDefault: true,
+										resetAllFilter: () => {
+											setWaveformColor( undefined );
+											setAttributes( {
+												waveformColorValue: undefined,
+											} );
+										},
+										enableAlpha: true,
+										clearable: true,
 									},
-									isShownByDefault: true,
-									resetAllFilter: () => {
-										setWaveformColor( undefined );
-										setAttributes( {
-											waveformColorValue: undefined,
-										} );
+									{
+										colorValue:
+											resolvedWaveformBackgroundColor,
+										label: __( 'Background' ),
+										onColorChange: ( colorValue ) => {
+											setWaveformBackgroundColor(
+												colorValue
+											);
+											setAttributes( {
+												waveformBackgroundColorValue:
+													colorValue,
+											} );
+										},
+										isShownByDefault: true,
+										resetAllFilter: () => {
+											setWaveformBackgroundColor(
+												undefined
+											);
+											setAttributes( {
+												waveformBackgroundColorValue:
+													undefined,
+											} );
+										},
+										enableAlpha: true,
+										clearable: true,
 									},
-									enableAlpha: true,
-									clearable: true,
-								},
-								{
-									colorValue: resolvedWaveformBackgroundColor,
-									label: __( 'Background' ),
-									onColorChange: ( colorValue ) => {
-										setWaveformBackgroundColor(
-											colorValue
-										);
-										setAttributes( {
-											waveformBackgroundColorValue:
-												colorValue,
-										} );
-									},
-									isShownByDefault: true,
-									resetAllFilter: () => {
-										setWaveformBackgroundColor( undefined );
-										setAttributes( {
-											waveformBackgroundColorValue:
-												undefined,
-										} );
-									},
-									enableAlpha: true,
-									clearable: true,
-								},
-							] }
-							panelId={ waveformPanelId }
-							{ ...colorGradientSettings }
-						/>
+								] }
+								panelId={ waveformPanelId }
+								{ ...colorGradientSettings }
+							/>
+						</Stack>
 					</ToolsPanel>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -91,9 +91,9 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	);
 
 	// Add waveform player container with translated button labels.
-	$label_play                         = esc_attr__( 'Play' );
-	$label_pause                        = esc_attr__( 'Pause' );
-	$label_seek                         = esc_attr__( 'Seek' );
+	$label_play  = esc_attr__( 'Play' );
+	$label_pause = esc_attr__( 'Pause' );
+	$label_seek  = esc_attr__( 'Seek' );
 	/* translators: %1$s: current audio time, %2$s: total audio duration. */
 	$label_seek_value                   = esc_attr_x(
 		'%1$s of %2$s',

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -91,15 +91,31 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	);
 
 	// Add waveform player container with translated button labels.
-	$label_play  = esc_attr__( 'Play' );
-	$label_pause = esc_attr__( 'Pause' );
-	$label_seek  = esc_attr__( 'Seek' );
+	$label_play                         = esc_attr__( 'Play' );
+	$label_pause                        = esc_attr__( 'Pause' );
+	$label_seek                         = esc_attr__( 'Seek' );
 	/* translators: %1$s: current audio time, %2$s: total audio duration. */
-	$label_seek_value = esc_attr_x(
+	$label_seek_value                   = esc_attr_x(
 		'%1$s of %2$s',
 		'audio current time of total duration'
 	);
-	$html             = '<div class="wp-block-playlist__waveform-player"
+	$waveform_color_data_attributes     = '';
+	$waveform_background_data_attribute = '';
+	if ( ! empty( $attributes['waveformColorValue'] ) ) {
+		$waveform_color_data_attributes = sprintf(
+			' data-waveform-player-color="%s"',
+			esc_attr( $attributes['waveformColorValue'] )
+		);
+	}
+	if ( ! empty( $attributes['waveformBackgroundColorValue'] ) ) {
+		$waveform_background_data_attribute = sprintf(
+			' data-waveform-player-background-color="%s"',
+			esc_attr( $attributes['waveformBackgroundColorValue'] )
+		);
+	}
+	$html = '<div class="wp-block-playlist__waveform-player"' .
+		$waveform_color_data_attributes .
+		$waveform_background_data_attribute . '
 		data-wp-watch="callbacks.initWaveformPlayer"
 		data-label-play="' . $label_play . '"
 		data-label-pause="' . $label_pause . '"

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -118,6 +118,8 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 		artist: track.artist,
 		image: track.image,
 		imageAlt: track.imageAlt,
+		color: ref.dataset.waveformPlayerColor,
+		backgroundColor: ref.dataset.waveformPlayerBackgroundColor,
 		autoPlay: shouldAutoPlay,
 		labels,
 		waveformStyle: context.waveformStyle,

--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -155,6 +155,27 @@ describe( 'WaveformPlayer', () => {
 		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'destroys the player when remounted', () => {
+		const { rerender } = render(
+			<WaveformPlayer key="before" { ...baseProps } />
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+
+		rerender( <WaveformPlayer key="after" { ...baseProps } /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+	} );
+
 	it( 'recreates the player to show an image added to a track that had none', () => {
 		const { rerender } = render(
 			<WaveformPlayer { ...baseProps } image="" />

--- a/packages/block-library/src/utils/test/waveform-player.js
+++ b/packages/block-library/src/utils/test/waveform-player.js
@@ -8,9 +8,13 @@ import { act, render } from '@testing-library/react';
  * Internal dependencies
  */
 import { WaveformPlayer } from '../waveform-player';
-import { initWaveformPlayer } from '../waveform-utils';
+import {
+	applyWaveformPlayerStyles,
+	initWaveformPlayer,
+} from '../waveform-utils';
 
 jest.mock( '../waveform-utils', () => ( {
+	applyWaveformPlayerStyles: jest.fn(),
 	initWaveformPlayer: jest.fn(),
 	updateSeekControlLabel: jest.fn(),
 } ) );
@@ -24,6 +28,10 @@ jest.mock( '../waveform-utils', () => ( {
  * @return {Object} The fake player.
  */
 function createFakePlayer( options, element ) {
+	const container = document.createElement( 'div' );
+	const waveformContainer = document.createElement( 'div' );
+	waveformContainer.className = 'waveform-container';
+
 	const titleEl = document.createElement( 'span' );
 	titleEl.textContent = options.title ?? '';
 	// The subtitle and artwork elements only exist when the track had an
@@ -40,16 +48,20 @@ function createFakePlayer( options, element ) {
 		artworkEl.alt = options.imageAlt || '';
 	}
 
-	element.append( titleEl );
+	container.append( titleEl );
 	if ( subtitleEl ) {
-		element.append( subtitleEl );
+		container.append( subtitleEl );
 	}
 	if ( artworkEl ) {
-		element.append( artworkEl );
+		container.append( artworkEl );
 	}
+	container.append( waveformContainer );
+	element.append( container );
 
 	return {
 		instance: { titleEl, subtitleEl, artworkEl },
+		container,
+		waveformContainer,
 		destroy: jest.fn(),
 	};
 }
@@ -65,6 +77,7 @@ describe( 'WaveformPlayer', () => {
 	afterEach( () => {
 		jest.runOnlyPendingTimers();
 		jest.useRealTimers();
+		applyWaveformPlayerStyles.mockReset();
 		initWaveformPlayer.mockReset();
 	} );
 
@@ -155,9 +168,9 @@ describe( 'WaveformPlayer', () => {
 		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'destroys the player when remounted', () => {
+	it( 'recreates the player when the color changes', () => {
 		const { rerender } = render(
-			<WaveformPlayer key="before" { ...baseProps } />
+			<WaveformPlayer { ...baseProps } color="#000000" />
 		);
 
 		act( () => {
@@ -165,8 +178,15 @@ describe( 'WaveformPlayer', () => {
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
+		expect( initWaveformPlayer.mock.calls[ 0 ][ 0 ] ).not.toHaveStyle( {
+			color: '#000000',
+		} );
+		expect( applyWaveformPlayerStyles ).toHaveBeenLastCalledWith(
+			player.container,
+			expect.objectContaining( { color: '#000000' } )
+		);
 
-		rerender( <WaveformPlayer key="after" { ...baseProps } /> );
+		rerender( <WaveformPlayer { ...baseProps } color="#ffffff" /> );
 
 		act( () => {
 			jest.advanceTimersByTime( 100 );
@@ -174,6 +194,54 @@ describe( 'WaveformPlayer', () => {
 
 		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
 		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 2 );
+		const secondPlayer = initWaveformPlayer.mock.results[ 1 ].value;
+		expect( initWaveformPlayer.mock.calls[ 1 ][ 0 ] ).not.toHaveStyle( {
+			color: '#ffffff',
+		} );
+		expect( applyWaveformPlayerStyles ).toHaveBeenLastCalledWith(
+			secondPlayer.container,
+			expect.objectContaining( { color: '#ffffff' } )
+		);
+	} );
+
+	it( 'updates the background color without recreating the player', () => {
+		const { rerender } = render(
+			<WaveformPlayer { ...baseProps } backgroundColor="#eeeeee" />
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+
+		const player = initWaveformPlayer.mock.results[ 0 ].value;
+		const element = initWaveformPlayer.mock.calls[ 0 ][ 0 ];
+		expect( element ).not.toHaveStyle( {
+			backgroundColor: '#eeeeee',
+		} );
+		expect( player.container ).not.toHaveStyle( {
+			backgroundColor: '#eeeeee',
+		} );
+		expect( applyWaveformPlayerStyles ).toHaveBeenLastCalledWith(
+			player.container,
+			expect.objectContaining( { backgroundColor: '#eeeeee' } )
+		);
+
+		rerender(
+			<WaveformPlayer { ...baseProps } backgroundColor="#222222" />
+		);
+
+		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
+		expect( player.destroy ).not.toHaveBeenCalled();
+		expect( element ).not.toHaveStyle( {
+			backgroundColor: '#222222',
+		} );
+		expect( player.container ).not.toHaveStyle( {
+			backgroundColor: '#222222',
+		} );
+		expect( applyWaveformPlayerStyles ).toHaveBeenLastCalledWith(
+			player.container,
+			expect.objectContaining( { backgroundColor: '#222222' } )
+		);
 	} );
 
 	it( 'recreates the player to show an image added to a track that had none', () => {

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -9,7 +9,6 @@ import '@testing-library/jest-dom';
 import {
 	createWaveformContainer,
 	styleSvgIcons,
-	updateWaveformPlayerColors,
 	setupPlayButtonAccessibility,
 	updateSeekControlLabel,
 	logPlayError,
@@ -52,11 +51,6 @@ describe( 'Waveform utilities', () => {
 				'#000000'
 			);
 			expect( container ).toHaveAttribute( 'data-seek-label', 'Seek' );
-			expect( container ).toHaveStyle( {
-				'--wfp-button-color': '#000000',
-				'--wfp-text-color': '#000000',
-				'--wfp-text-secondary-color': '#000000',
-			} );
 		} );
 
 		it( 'should set optional attributes when provided', () => {
@@ -108,47 +102,6 @@ describe( 'Waveform utilities', () => {
 			} );
 
 			expect( container ).toHaveAttribute( 'data-height', '150' );
-		} );
-	} );
-
-	describe( 'updateWaveformPlayerColors', () => {
-		it( 'should update a live player from the current text color', () => {
-			const element = document.createElement( 'div' );
-			element.style.color = '#000080';
-			document.body.appendChild( element );
-
-			const container = createWaveformContainer( basePlayerData );
-			const svg = document.createElementNS(
-				'http://www.w3.org/2000/svg',
-				'svg'
-			);
-			const path = document.createElementNS(
-				'http://www.w3.org/2000/svg',
-				'path'
-			);
-			const instance = {
-				options: {},
-				drawWaveform: jest.fn(),
-			};
-
-			svg.appendChild( path );
-			container.appendChild( svg );
-
-			updateWaveformPlayerColors( { element, container, instance } );
-
-			expect( container ).toHaveStyle( {
-				'--wfp-button-color': 'rgb(0, 0, 128)',
-				'--wfp-text-color': 'rgb(0, 0, 128)',
-				'--wfp-text-secondary-color': 'rgb(0, 0, 128)',
-			} );
-			expect( instance.options ).toMatchObject( {
-				waveformColor: 'rgba(0, 0, 128, 0.3)',
-				progressColor: 'rgba(0, 0, 128, 0.6)',
-			} );
-			expect( instance.drawWaveform ).toHaveBeenCalled();
-			expect( path ).toHaveStyle( { fill: '#ffffff' } );
-
-			element.remove();
 		} );
 	} );
 

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom';
 import {
 	createWaveformContainer,
 	styleSvgIcons,
+	updateWaveformPlayerColors,
 	setupPlayButtonAccessibility,
 	updateSeekControlLabel,
 	logPlayError,
@@ -51,6 +52,11 @@ describe( 'Waveform utilities', () => {
 				'#000000'
 			);
 			expect( container ).toHaveAttribute( 'data-seek-label', 'Seek' );
+			expect( container ).toHaveStyle( {
+				'--wfp-button-color': '#000000',
+				'--wfp-text-color': '#000000',
+				'--wfp-text-secondary-color': '#000000',
+			} );
 		} );
 
 		it( 'should set optional attributes when provided', () => {
@@ -102,6 +108,47 @@ describe( 'Waveform utilities', () => {
 			} );
 
 			expect( container ).toHaveAttribute( 'data-height', '150' );
+		} );
+	} );
+
+	describe( 'updateWaveformPlayerColors', () => {
+		it( 'should update a live player from the current text color', () => {
+			const element = document.createElement( 'div' );
+			element.style.color = '#000080';
+			document.body.appendChild( element );
+
+			const container = createWaveformContainer( basePlayerData );
+			const svg = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'svg'
+			);
+			const path = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'path'
+			);
+			const instance = {
+				options: {},
+				drawWaveform: jest.fn(),
+			};
+
+			svg.appendChild( path );
+			container.appendChild( svg );
+
+			updateWaveformPlayerColors( { element, container, instance } );
+
+			expect( container ).toHaveStyle( {
+				'--wfp-button-color': 'rgb(0, 0, 128)',
+				'--wfp-text-color': 'rgb(0, 0, 128)',
+				'--wfp-text-secondary-color': 'rgb(0, 0, 128)',
+			} );
+			expect( instance.options ).toMatchObject( {
+				waveformColor: 'rgba(0, 0, 128, 0.3)',
+				progressColor: 'rgba(0, 0, 128, 0.6)',
+			} );
+			expect( instance.drawWaveform ).toHaveBeenCalled();
+			expect( path ).toHaveStyle( { fill: '#ffffff' } );
+
+			element.remove();
 		} );
 	} );
 

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom';
  * Internal dependencies
  */
 import {
+	applyWaveformPlayerStyles,
 	createWaveformContainer,
 	styleSvgIcons,
 	setupPlayButtonAccessibility,
@@ -102,6 +103,52 @@ describe( 'Waveform utilities', () => {
 			} );
 
 			expect( container ).toHaveAttribute( 'data-height', '150' );
+		} );
+	} );
+
+	describe( 'applyWaveformPlayerStyles', () => {
+		it( 'should apply background color only to the waveform area', () => {
+			const container = document.createElement( 'div' );
+			const titleArea = document.createElement( 'div' );
+			const waveformContainer = document.createElement( 'div' );
+			waveformContainer.className = 'waveform-container';
+
+			container.appendChild( titleArea );
+			container.appendChild( waveformContainer );
+
+			applyWaveformPlayerStyles( container, {
+				color: '#111111',
+				backgroundColor: '#eeeeee',
+			} );
+
+			expect( container ).toHaveStyle( { color: '#111111' } );
+			expect( container ).not.toHaveStyle( {
+				backgroundColor: '#eeeeee',
+			} );
+			expect( titleArea ).not.toHaveStyle( {
+				backgroundColor: '#eeeeee',
+			} );
+			expect( waveformContainer ).toHaveStyle( {
+				backgroundColor: '#eeeeee',
+			} );
+		} );
+
+		it( 'should clear custom styles', () => {
+			const container = document.createElement( 'div' );
+			const waveformContainer = document.createElement( 'div' );
+			waveformContainer.className = 'waveform-container';
+			container.appendChild( waveformContainer );
+
+			applyWaveformPlayerStyles( container, {
+				color: '#111111',
+				backgroundColor: '#eeeeee',
+			} );
+			applyWaveformPlayerStyles( container );
+
+			expect( container ).not.toHaveStyle( { color: '#111111' } );
+			expect( waveformContainer ).not.toHaveStyle( {
+				backgroundColor: '#eeeeee',
+			} );
 		} );
 	} );
 

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -8,11 +8,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	initWaveformPlayer,
-	updateSeekControlLabel,
-	updateWaveformPlayerColors,
-} from './waveform-utils';
+import { initWaveformPlayer, updateSeekControlLabel } from './waveform-utils';
 
 const EMPTY_ARTIST_PLACEHOLDER = '\u00a0';
 
@@ -68,7 +64,6 @@ function updatePlayerMetadata( instance, { title, artist, image, imageAlt } ) {
  * @param {string}   props.image         - The artwork image URL.
  * @param {string}   props.imageAlt      - The artwork image alt text.
  * @param {string}   props.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
- * @param {string}   props.colorContext  - Context value that changes when inherited colors may have changed.
  * @param {Function} props.onEnded       - Callback when the track finishes playing.
  * @return {Element} The WaveformPlayer element.
  */
@@ -79,7 +74,6 @@ export function WaveformPlayer( {
 	image,
 	imageAlt,
 	waveformStyle,
-	colorContext,
 	onEnded,
 } ) {
 	// Store onEnded in a stable callback so it doesn't need to be a useRefEffect dependency.
@@ -115,12 +109,6 @@ export function WaveformPlayer( {
 			} );
 		}
 	}, [ title, artist, image, imageAlt ] );
-
-	useEffect( () => {
-		if ( playerRef.current ) {
-			updateWaveformPlayerColors( playerRef.current );
-		}
-	}, [ colorContext ] );
 
 	const ref = useRefEffect(
 		( element ) => {

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -8,7 +8,11 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { initWaveformPlayer, updateSeekControlLabel } from './waveform-utils';
+import {
+	initWaveformPlayer,
+	updateSeekControlLabel,
+	updateWaveformPlayerColors,
+} from './waveform-utils';
 
 const EMPTY_ARTIST_PLACEHOLDER = '\u00a0';
 
@@ -64,6 +68,7 @@ function updatePlayerMetadata( instance, { title, artist, image, imageAlt } ) {
  * @param {string}   props.image         - The artwork image URL.
  * @param {string}   props.imageAlt      - The artwork image alt text.
  * @param {string}   props.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
+ * @param {string}   props.colorContext  - Context value that changes when inherited colors may have changed.
  * @param {Function} props.onEnded       - Callback when the track finishes playing.
  * @return {Element} The WaveformPlayer element.
  */
@@ -74,6 +79,7 @@ export function WaveformPlayer( {
 	image,
 	imageAlt,
 	waveformStyle,
+	colorContext,
 	onEnded,
 } ) {
 	// Store onEnded in a stable callback so it doesn't need to be a useRefEffect dependency.
@@ -109,6 +115,12 @@ export function WaveformPlayer( {
 			} );
 		}
 	}, [ title, artist, image, imageAlt ] );
+
+	useEffect( () => {
+		if ( playerRef.current ) {
+			updateWaveformPlayerColors( playerRef.current );
+		}
+	}, [ colorContext ] );
 
 	const ref = useRefEffect(
 		( element ) => {

--- a/packages/block-library/src/utils/waveform-player.js
+++ b/packages/block-library/src/utils/waveform-player.js
@@ -8,7 +8,11 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { initWaveformPlayer, updateSeekControlLabel } from './waveform-utils';
+import {
+	applyWaveformPlayerStyles,
+	initWaveformPlayer,
+	updateSeekControlLabel,
+} from './waveform-utils';
 
 const EMPTY_ARTIST_PLACEHOLDER = '\u00a0';
 
@@ -52,19 +56,37 @@ function updatePlayerMetadata( instance, { title, artist, image, imageAlt } ) {
 }
 
 /**
+ * Update custom colors on the generated waveform player container.
+ *
+ * @param {Object} player                 - The waveform player object.
+ * @param {Object} styles                 - The player styles.
+ * @param {string} styles.color           - The player color.
+ * @param {string} styles.backgroundColor - The player background color.
+ */
+function updatePlayerStyles( player, { color, backgroundColor } ) {
+	if ( ! player?.container ) {
+		return;
+	}
+
+	applyWaveformPlayerStyles( player.container, { color, backgroundColor } );
+}
+
+/**
  * A reusable WaveformPlayer component for the block editor.
  *
  * Renders an audio waveform visualization with play/pause controls.
- * Automatically inherits colors from the parent block's text color.
+ * Uses a provided color or falls back to the inherited text color.
  *
- * @param {Object}   props               - Component props.
- * @param {string}   props.src           - The audio file URL.
- * @param {string}   props.title         - The track title.
- * @param {string}   props.artist        - The artist name.
- * @param {string}   props.image         - The artwork image URL.
- * @param {string}   props.imageAlt      - The artwork image alt text.
- * @param {string}   props.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
- * @param {Function} props.onEnded       - Callback when the track finishes playing.
+ * @param {Object}   props                 - Component props.
+ * @param {string}   props.src             - The audio file URL.
+ * @param {string}   props.title           - The track title.
+ * @param {string}   props.artist          - The artist name.
+ * @param {string}   props.image           - The artwork image URL.
+ * @param {string}   props.imageAlt        - The artwork image alt text.
+ * @param {string}   props.color           - The player color.
+ * @param {string}   props.backgroundColor - The player background color.
+ * @param {string}   props.waveformStyle   - Waveform style (bars, mirror, line, blocks, dots, seekbar).
+ * @param {Function} props.onEnded         - Callback when the track finishes playing.
  * @return {Element} The WaveformPlayer element.
  */
 export function WaveformPlayer( {
@@ -73,6 +95,8 @@ export function WaveformPlayer( {
 	artist,
 	image,
 	imageAlt,
+	color,
+	backgroundColor,
 	waveformStyle,
 	onEnded,
 } ) {
@@ -83,6 +107,7 @@ export function WaveformPlayer( {
 	// during editor resizes.
 	const onEndedEvent = useEvent( onEnded );
 	const metadataRef = useRef( { title, artist, image, imageAlt } );
+	const stylesRef = useRef( { color, backgroundColor } );
 	const playerRef = useRef();
 
 	// The artwork element only exists when an image was present when the
@@ -110,6 +135,12 @@ export function WaveformPlayer( {
 		}
 	}, [ title, artist, image, imageAlt ] );
 
+	useEffect( () => {
+		stylesRef.current = { color, backgroundColor };
+
+		updatePlayerStyles( playerRef.current, stylesRef.current );
+	}, [ color, backgroundColor ] );
+
 	const ref = useRefEffect(
 		( element ) => {
 			if ( ! src ) {
@@ -126,6 +157,7 @@ export function WaveformPlayer( {
 				const player = initWaveformPlayer( element, {
 					src,
 					...metadataRef.current,
+					...stylesRef.current,
 					waveformStyle,
 					artist:
 						metadataRef.current.artist || EMPTY_ARTIST_PLACEHOLDER,
@@ -141,6 +173,7 @@ export function WaveformPlayer( {
 				} );
 				playerRef.current = player;
 				updatePlayerMetadata( player.instance, metadataRef.current );
+				updatePlayerStyles( player, stylesRef.current );
 				const { destroy } = player;
 				playerDestroy = destroy;
 			}
@@ -161,7 +194,7 @@ export function WaveformPlayer( {
 				playerDestroy?.();
 			};
 		},
-		[ onEndedEvent, src, waveformStyle, hasImage ]
+		[ onEndedEvent, src, waveformStyle, hasImage, color ]
 	);
 
 	return <div ref={ ref } className="wp-block-playlist__waveform-player" />;

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -89,9 +89,6 @@ export function createWaveformContainer( {
 	}
 	container.setAttribute( 'data-text-color', buttonColor );
 	container.setAttribute( 'data-text-secondary-color', buttonColor );
-	container.style.setProperty( '--wfp-button-color', buttonColor );
-	container.style.setProperty( '--wfp-text-color', buttonColor );
-	container.style.setProperty( '--wfp-text-secondary-color', buttonColor );
 	if ( title ) {
 		container.setAttribute( 'data-title', title );
 	}
@@ -120,33 +117,6 @@ export function styleSvgIcons( container, buttonColor ) {
 	svgPaths.forEach( ( path ) => {
 		path.style.fill = iconColor;
 	} );
-}
-
-/**
- * Update a live waveform player when inherited colors change.
- *
- * @param {Object}  player           - The waveform player object.
- * @param {Element} player.element   - The element to derive colors from.
- * @param {Element} player.container - The waveform container element.
- * @param {Object}  player.instance  - The waveform player instance.
- */
-export function updateWaveformPlayerColors( { element, container, instance } ) {
-	const colors = getWaveformColors( element );
-
-	container.style.setProperty( '--wfp-button-color', colors.textColor );
-	container.style.setProperty( '--wfp-text-color', colors.textColor );
-	container.style.setProperty(
-		'--wfp-text-secondary-color',
-		colors.textColor
-	);
-
-	if ( instance.options ) {
-		instance.options.waveformColor = colors.waveformColor;
-		instance.options.progressColor = colors.progressColor;
-	}
-
-	instance.drawWaveform?.();
-	styleSvgIcons( container, colors.textColor );
 }
 
 /**
@@ -292,7 +262,7 @@ export function initWaveformPlayer(
 	let cleanupPlayButtonAccessibility;
 	const handlers = {
 		ready: () => {
-			updateWaveformPlayerColors( { element, container, instance } );
+			styleSvgIcons( container, textColor );
 			cleanupPlayButtonAccessibility = setupPlayButtonAccessibility(
 				container,
 				labels

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -29,11 +29,12 @@ function getComputedStyle( element ) {
 /**
  * Get all colors needed for the waveform player based on the element's styles.
  *
- * @param {Element} element - The element to derive colors from.
+ * @param {Element} element   - The element to derive colors from.
+ * @param {string}  textValue - The text color value to use.
  * @return {Object} Object containing textColor, waveformColor, and progressColor.
  */
-export function getWaveformColors( element ) {
-	const textColor = getComputedStyle( element ).color;
+export function getWaveformColors( element, textValue ) {
+	const textColor = textValue || getComputedStyle( element ).color;
 	const waveformColor = colord( textColor ).alpha( 0.3 ).toRgbString();
 	const progressColor = colord( textColor ).alpha( 0.6 ).toRgbString();
 
@@ -99,6 +100,36 @@ export function createWaveformContainer( {
 		container.setAttribute( 'data-artwork', artwork );
 	}
 	return container;
+}
+
+/**
+ * Apply custom styles to a generated waveform player.
+ *
+ * @param {Element} container              - The generated player container.
+ * @param {Object}  styles                 - The player styles.
+ * @param {string}  styles.color           - The player color.
+ * @param {string}  styles.backgroundColor - The waveform area background color.
+ */
+export function applyWaveformPlayerStyles(
+	container,
+	{ color, backgroundColor } = {}
+) {
+	if ( color ) {
+		container.style.color = color;
+	} else {
+		container.style.removeProperty( 'color' );
+	}
+
+	const waveformContainer = container.querySelector( '.waveform-container' );
+	if ( ! waveformContainer ) {
+		return;
+	}
+
+	if ( backgroundColor ) {
+		waveformContainer.style.backgroundColor = backgroundColor;
+	} else {
+		waveformContainer.style.removeProperty( 'background-color' );
+	}
 }
 
 /**
@@ -204,17 +235,19 @@ export function logPlayError( error ) {
  * This is the shared core logic used by both the React component (editor)
  * and the Interactivity API (frontend).
  *
- * @param {Element}  element               - The container element (must be in DOM).
- * @param {Object}   options               - Configuration options.
- * @param {string}   options.src           - The audio file URL.
- * @param {string}   options.title         - The track title.
- * @param {string}   options.artist        - The artist name.
- * @param {string}   options.image         - The artwork image URL.
- * @param {string}   options.imageAlt      - The artwork image alt text.
- * @param {boolean}  options.autoPlay      - Whether to auto-play when ready.
- * @param {Function} options.onEnded       - Callback when track ends.
- * @param {Object}   options.labels        - Translated button labels.
- * @param {string}   options.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
+ * @param {Element}  element                 - The container element (must be in DOM).
+ * @param {Object}   options                 - Configuration options.
+ * @param {string}   options.src             - The audio file URL.
+ * @param {string}   options.title           - The track title.
+ * @param {string}   options.artist          - The artist name.
+ * @param {string}   options.image           - The artwork image URL.
+ * @param {string}   options.imageAlt        - The artwork image alt text.
+ * @param {string}   options.color           - The player color.
+ * @param {string}   options.backgroundColor - The player background color.
+ * @param {boolean}  options.autoPlay        - Whether to auto-play when ready.
+ * @param {Function} options.onEnded         - Callback when track ends.
+ * @param {Object}   options.labels          - Translated button labels.
+ * @param {string}   options.waveformStyle   - Waveform style (bars, mirror, line, blocks, dots, seekbar).
  * @return {Object} Object with element, instance, container, and destroy function.
  */
 export function initWaveformPlayer(
@@ -225,6 +258,8 @@ export function initWaveformPlayer(
 		artist,
 		image,
 		imageAlt,
+		color,
+		backgroundColor,
 		autoPlay,
 		onEnded,
 		labels,
@@ -232,8 +267,10 @@ export function initWaveformPlayer(
 	}
 ) {
 	// Get colors from computed styles.
-	const { textColor, waveformColor, progressColor } =
-		getWaveformColors( element );
+	const { textColor, waveformColor, progressColor } = getWaveformColors(
+		element,
+		color
+	);
 
 	// Create the waveform container.
 	const container = createWaveformContainer( {
@@ -257,6 +294,7 @@ export function initWaveformPlayer(
 	if ( instance.artworkEl ) {
 		instance.artworkEl.alt = imageAlt || '';
 	}
+	applyWaveformPlayerStyles( container, { color, backgroundColor } );
 
 	// Set up event handlers.
 	let cleanupPlayButtonAccessibility;

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -30,7 +30,7 @@ function getComputedStyle( element ) {
  * Get all colors needed for the waveform player based on the element's styles.
  *
  * @param {Element} element - The element to derive colors from.
- * @return {Object} Object containing textColor, waveformColor, progressColor.
+ * @return {Object} Object containing textColor, waveformColor, and progressColor.
  */
 export function getWaveformColors( element ) {
 	const textColor = getComputedStyle( element ).color;
@@ -89,7 +89,9 @@ export function createWaveformContainer( {
 	}
 	container.setAttribute( 'data-text-color', buttonColor );
 	container.setAttribute( 'data-text-secondary-color', buttonColor );
-
+	container.style.setProperty( '--wfp-button-color', buttonColor );
+	container.style.setProperty( '--wfp-text-color', buttonColor );
+	container.style.setProperty( '--wfp-text-secondary-color', buttonColor );
 	if ( title ) {
 		container.setAttribute( 'data-title', title );
 	}
@@ -118,6 +120,33 @@ export function styleSvgIcons( container, buttonColor ) {
 	svgPaths.forEach( ( path ) => {
 		path.style.fill = iconColor;
 	} );
+}
+
+/**
+ * Update a live waveform player when inherited colors change.
+ *
+ * @param {Object}  player           - The waveform player object.
+ * @param {Element} player.element   - The element to derive colors from.
+ * @param {Element} player.container - The waveform container element.
+ * @param {Object}  player.instance  - The waveform player instance.
+ */
+export function updateWaveformPlayerColors( { element, container, instance } ) {
+	const colors = getWaveformColors( element );
+
+	container.style.setProperty( '--wfp-button-color', colors.textColor );
+	container.style.setProperty( '--wfp-text-color', colors.textColor );
+	container.style.setProperty(
+		'--wfp-text-secondary-color',
+		colors.textColor
+	);
+
+	if ( instance.options ) {
+		instance.options.waveformColor = colors.waveformColor;
+		instance.options.progressColor = colors.progressColor;
+	}
+
+	instance.drawWaveform?.();
+	styleSvgIcons( container, colors.textColor );
 }
 
 /**
@@ -216,7 +245,7 @@ export function logPlayError( error ) {
  * @param {Function} options.onEnded       - Callback when track ends.
  * @param {Object}   options.labels        - Translated button labels.
  * @param {string}   options.waveformStyle - Waveform style (bars, mirror, line, blocks, dots, seekbar).
- * @return {Object} Object with instance, container, and destroy function.
+ * @return {Object} Object with element, instance, container, and destroy function.
  */
 export function initWaveformPlayer(
 	element,
@@ -263,7 +292,7 @@ export function initWaveformPlayer(
 	let cleanupPlayButtonAccessibility;
 	const handlers = {
 		ready: () => {
-			styleSvgIcons( container, textColor );
+			updateWaveformPlayerColors( { element, container, instance } );
 			cleanupPlayButtonAccessibility = setupPlayButtonAccessibility(
 				container,
 				labels
@@ -280,6 +309,7 @@ export function initWaveformPlayer(
 
 	// Return instance, container, and cleanup function.
 	return {
+		element,
 		instance,
 		container,
 		destroy: () => {


### PR DESCRIPTION
## What?

Adds dedicated Playlist block waveform style controls for the waveform player color and background.

The controls appear in the Styles tab under a `Waveform` panel with two options:

- `Color`
- `Background`

## Why?

The waveform player previously derived its colors from the Playlist block text color. That made waveform styling dependent on text styling and meant changing the block text color was the only way to affect the waveform colors.

This gives the waveform player its own styling controls while keeping those styles scoped to the waveform player output. The background setting is limited to the generated `.waveform-container` waveform area, so the player title/metadata area and outer Playlist wrapper are not styled unintentionally.

## How?

- Adds `waveformColor` / `waveformBackgroundColor` attributes and fallback value attributes for custom colors.
- Adds a `Waveform` panel in the Styles tab with `Color` and `Background` controls.
- Passes the selected values through the editor `WaveformPlayer` and frontend playlist view initialization.
- Uses the custom waveform color to derive the waveform bars, progress color, button color, and icon contrast.
- Applies the selected background only to the generated `.waveform-container` area where the waveform is rendered.
- Recreates the editor player when the waveform color changes, while background changes update the generated waveform area without recreating the player.
- Updates the generated Playlist block docs for the new waveform attributes.

## Screenshots
<img width="1283" height="651" alt="Screenshot 2026-07-08 at 16 47 56" src="https://github.com/user-attachments/assets/78cf12c7-df00-45e1-bff4-ff7b88112385" />



## Testing Instructions

1. Add or open a Playlist block in the editor.
2. Open the Styles tab and expand the `Waveform` panel.
3. Change `Color` and confirm the waveform bars/progress/button color update.
4. Change `Background` and confirm only the actual waveform area receives the background; the title/metadata area remains unchanged.
5. Confirm the outer `.wp-block-playlist__waveform-player` mount node does not receive the custom color/background inline styles.
6. Save and view the post on the frontend; confirm both waveform color settings persist and playback still works.

## Validation

- `npm run lint:js -- packages/block-library/src/playlist/edit.js packages/block-library/src/playlist/view.js packages/block-library/src/utils/waveform-player.js packages/block-library/src/utils/waveform-utils.js packages/block-library/src/utils/test/waveform-player.js packages/block-library/src/utils/test/waveform-utils.js`
- `npm run test:unit packages/block-library/src/utils/test/waveform-player.js`
- `npm run test:unit packages/block-library/src/utils/test/waveform-utils.js`
- `npm run docs:blocks`
- `npm run docs:blocks-detail`
- `php -l packages/block-library/src/playlist/index.php`
- `git diff --check`
- Pre-commit hook passed for `a91eeb9f124`
