### PR TITLE
Theme: Document public API boundary

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).
 -   Clarify that `--wpds-color-stroke-focus` is a standalone exception to the normal color token naming pattern ([#79764](https://github.com/WordPress/gutenberg/pull/79764)).
+-   Document the package's public API boundary, including supported imports and implementation details ([#79762](https://github.com/WordPress/gutenberg/pull/79762)).
 
 ## 0.17.0 (2026-06-30)
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).
 -   Clarify that `--wpds-color-stroke-focus` is a standalone exception to the normal color token naming pattern ([#79764](https://github.com/WordPress/gutenberg/pull/79764)).
--   Document the package's public API boundary, including supported imports and implementation details ([#79762](https://github.com/WordPress/gutenberg/pull/79762)).
+-   Document the package's public API boundary, including supported imports, implementation details, and compatibility expectations ([#79762](https://github.com/WordPress/gutenberg/pull/79762)).
 
 ## 0.17.0 (2026-06-30)
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -17,6 +17,29 @@ This README is the entry point for package consumers. It covers how to load desi
 -   To pick the right design token or browse every available token, see the generated [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
 -   To edit token source files, see the [Design Tokens Maintainer's Guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md).
 
+## Public API Boundary
+
+The supported external API is limited to the package root and documented subpath imports:
+
+-   `@wordpress/theme` — the `ThemeProvider` React component and the generated design token TypeScript types exported from the package root. The `ThemeProvider` props are part of the component API, but their internal type names, such as `ThemeProviderProps` and `ThemeProviderSettings`, are not standalone public exports. If you need the prop type in TypeScript, derive it from `ThemeProvider` instead of importing an internal type.
+-   `@wordpress/theme/design-tokens.css` — the stylesheet that defines the default `--wpds-*` CSS custom properties.
+-   `@wordpress/theme/design-tokens.js` — the generated list of known `--wpds-*` CSS custom properties.
+-   `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`, `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`, and `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks` — build plugins for injecting token fallback values.
+-   `@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens`, `@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties`, and `@wordpress/theme/stylelint-plugins/no-token-fallback-values` — Stylelint plugins for enforcing token usage.
+
+The deprecated `privateApis` root export is not public API. It exists only as a temporary migration path for WordPress internals and is not covered by the supported external API boundary.
+
+Do not import from repository or build-output paths such as `@wordpress/theme/src/*`, `@wordpress/theme/build/*`, `@wordpress/theme/build-module/*`, `@wordpress/theme/build-types/*`, `@wordpress/theme/tokens/*`, or other files that are not listed above. Those files are implementation details and may change without notice.
+
+Some public subpaths are generated from internal token sources. The generated values exposed by the public imports are part of the supported contract; the generator configuration, raw token JSON files, intermediate TypeScript, and emitted file locations are implementation details.
+
+Compatibility expectations depend on how the package is consumed:
+
+-   Runtime exports exposed through WordPress follow Gutenberg and WordPress backward compatibility expectations, not practical npm semver negotiation.
+-   Package semver still matters for published npm releases, especially tooling subpaths consumed directly from npm.
+-   Build plugins and Stylelint plugins are public tooling APIs; removing an exported plugin or changing its configuration or failure contract should be treated as breaking.
+-   Semantic `--wpds-*` token removals and renames are compatibility breaks. Additions are safe. Value changes are usually compatible when the token purpose is unchanged, but should be documented when visually meaningful.
+
 ## Design Tokens
 
 Design tokens are named values that describe the visual purpose of a value. Rather than hardcoding values like `#3858e9` or `16px`, use semantic custom properties like `--wpds-color-background-interactive-brand-strong` or `--wpds-dimension-padding-2xl`.
@@ -61,22 +84,6 @@ If your application renders React content into additional documents (an iframe, 
 For the best development experience, we recommend configuring the [Stylelint rules](#stylelint-plugins) provided by this package. The Stylelint rules catch typos, unknown tokens, and other discouraged patterns during development.
 
 If you reference `--wpds-*` tokens in CSS or JS/TS source, use the [build plugins](#build-plugins) to inject fallback values at build time so components render correctly even when the tokens stylesheet is not loaded. If you use `@wordpress/build`, these plugins are already enabled by default when `@wordpress/theme` is installed.
-
-## Public API Boundary
-
-The supported external API is limited to the package root and documented subpath imports:
-
--   `@wordpress/theme` — the `ThemeProvider` React component and the generated design token TypeScript types exported from the package root. The `ThemeProvider` props are part of the component API, but their internal type names, such as `ThemeProviderProps` and `ThemeProviderSettings`, are not standalone public exports. If you need the prop type in TypeScript, derive it from `ThemeProvider` instead of importing an internal type.
--   `@wordpress/theme/design-tokens.css` — the stylesheet that defines the default `--wpds-*` CSS custom properties.
--   `@wordpress/theme/design-tokens.js` — the generated list of known `--wpds-*` CSS custom properties.
--   `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`, `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`, and `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks` — build plugins for injecting token fallback values.
--   `@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens`, `@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties`, and `@wordpress/theme/stylelint-plugins/no-token-fallback-values` — Stylelint plugins for enforcing token usage.
-
-The deprecated `privateApis` root export is not public API. It exists only as a temporary migration path for WordPress internals and is not covered by the supported external API boundary.
-
-Do not import from repository or build-output paths such as `@wordpress/theme/src/*`, `@wordpress/theme/build/*`, `@wordpress/theme/build-module/*`, `@wordpress/theme/build-types/*`, `@wordpress/theme/tokens/*`, or other files that are not listed above. Those files are implementation details and may change without notice.
-
-Some public subpaths are generated from internal token sources. The generated values exposed by the public imports are part of the supported contract; the generator configuration, raw token JSON files, intermediate TypeScript, and emitted file locations are implementation details.
 
 ## Theme Provider
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -62,6 +62,22 @@ For the best development experience, we recommend configuring the [Stylelint rul
 
 If you reference `--wpds-*` tokens in CSS or JS/TS source, use the [build plugins](#build-plugins) to inject fallback values at build time so components render correctly even when the tokens stylesheet is not loaded. If you use `@wordpress/build`, these plugins are already enabled by default when `@wordpress/theme` is installed.
 
+## Public API Boundary
+
+The semver-protected public API is limited to the package root and documented subpath imports:
+
+-   `@wordpress/theme` — the `ThemeProvider` React component and the generated design token TypeScript types exported from the package root. The `ThemeProvider` props are part of the component API, but their internal type names, such as `ThemeProviderProps` and `ThemeProviderSettings`, are not standalone public exports. If you need the prop type in TypeScript, derive it from `ThemeProvider` instead of importing an internal type.
+-   `@wordpress/theme/design-tokens.css` — the stylesheet that defines the default `--wpds-*` CSS custom properties.
+-   `@wordpress/theme/design-tokens.js` — the generated list of known `--wpds-*` CSS custom properties.
+-   `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`, `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`, and `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks` — build plugins for injecting token fallback values.
+-   `@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens`, `@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties`, and `@wordpress/theme/stylelint-plugins/no-token-fallback-values` — Stylelint plugins for enforcing token usage.
+
+The deprecated `privateApis` root export is not public API. It exists only as a temporary migration path for WordPress internals and is not semver-protected.
+
+Do not import from repository or build-output paths such as `@wordpress/theme/src/*`, `@wordpress/theme/build/*`, `@wordpress/theme/build-module/*`, `@wordpress/theme/build-types/*`, `@wordpress/theme/tokens/*`, or other files that are not listed above. Those files are implementation details and may change without notice.
+
+Some public subpaths are generated from internal token sources. The generated values exposed by the public imports are part of the supported contract; the generator configuration, raw token JSON files, intermediate TypeScript, and emitted file locations are implementation details.
+
 ## Theme Provider
 
 The `ThemeProvider` is a React component that should wrap your application to provide design tokens and theme context to the child UI components. It accepts a set of customizable seed values and automatically generates a set of design tokens, which are exposed as CSS custom properties for use throughout the application.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -64,7 +64,7 @@ If you reference `--wpds-*` tokens in CSS or JS/TS source, use the [build plugin
 
 ## Public API Boundary
 
-The semver-protected public API is limited to the package root and documented subpath imports:
+The supported external API is limited to the package root and documented subpath imports:
 
 -   `@wordpress/theme` — the `ThemeProvider` React component and the generated design token TypeScript types exported from the package root. The `ThemeProvider` props are part of the component API, but their internal type names, such as `ThemeProviderProps` and `ThemeProviderSettings`, are not standalone public exports. If you need the prop type in TypeScript, derive it from `ThemeProvider` instead of importing an internal type.
 -   `@wordpress/theme/design-tokens.css` — the stylesheet that defines the default `--wpds-*` CSS custom properties.
@@ -72,7 +72,7 @@ The semver-protected public API is limited to the package root and documented su
 -   `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`, `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`, and `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks` — build plugins for injecting token fallback values.
 -   `@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens`, `@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties`, and `@wordpress/theme/stylelint-plugins/no-token-fallback-values` — Stylelint plugins for enforcing token usage.
 
-The deprecated `privateApis` root export is not public API. It exists only as a temporary migration path for WordPress internals and is not semver-protected.
+The deprecated `privateApis` root export is not public API. It exists only as a temporary migration path for WordPress internals and is not covered by the supported external API boundary.
 
 Do not import from repository or build-output paths such as `@wordpress/theme/src/*`, `@wordpress/theme/build/*`, `@wordpress/theme/build-module/*`, `@wordpress/theme/build-types/*`, `@wordpress/theme/tokens/*`, or other files that are not listed above. Those files are implementation details and may change without notice.
 


### PR DESCRIPTION
## What?
Follow-up to #77462.

Documents the `@wordpress/theme` public API boundary in the package README, addressing both point A1 and the useful compatibility-policy parts of point D2.

## Why?
Point A1 asks us to make the external API surface explicit before stabilization: which root exports and subpath imports consumers can rely on, and which generated/source files are implementation details. Point D2 also asks for stability guidance, so this PR folds the relevant compatibility expectations into the same Public API Boundary section without framing WordPress-externalized runtime APIs as practical npm semver contracts.

## How?
Adds a Public API Boundary section that:

- lists the supported package root and documented subpath imports;
- clarifies that `ThemeProviderProps` / `ThemeProviderSettings` are internal type names, not standalone public exports;
- marks `privateApis`, repository paths, build output paths, raw token sources, and generator internals as non-public implementation details;
- documents concise compatibility expectations for WordPress runtime exports, npm tooling subpaths, build/Stylelint plugins, and semantic `--wpds-*` token changes.

## Testing Instructions
1. Read `packages/theme/README.md`.
2. Confirm the new Public API Boundary section lists only the documented package root and subpath imports.
3. Confirm the compatibility note distinguishes WordPress-externalized runtime APIs from npm/tooling consumption.
4. Confirm it does not introduce new standalone type exports for `ThemeProviderProps` or `ThemeProviderSettings`.

### Testing Instructions for Keyboard
Not applicable; documentation-only change.

## Screenshots or screencast
Not applicable; documentation-only change.

## Use of AI Tools
Used Codex to inspect the issue/package surface, update the README, run focused checks, and prepare this draft PR.