### PR TITLE
Theme: Clarify focus token naming docs

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
 
+### Documentation
+
+-   Clarify that `--wpds-color-stroke-focus` is a standalone exception to the normal color token naming pattern ([#79764](https://github.com/WordPress/gutenberg/pull/79764)).
+
 ## 0.17.0 (2026-06-30)
 
 ### Breaking Changes

--- a/packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts
@@ -13,7 +13,7 @@ Each segment of a token name answers one question about the value being applied:
 
 -   **Type** identifies the kind of value, like \`color\` or \`dimension\`. It is usually determined by the CSS property being set.
 -   **Property** describes which aspect of the element the token applies to, such as \`background\`, \`foreground\`, \`stroke\`, \`padding\`, or \`gap\`.
--   **Target** describes the kind of element the token applies to, such as a \`surface\`, an \`interactive\` control, static \`content\`, a \`track\` or \`thumb\`, or a \`focus\` indicator.
+-   **Target** describes the kind of element the token applies to, such as a \`surface\`, an \`interactive\` control, static \`content\`, or a \`track\` or \`thumb\`. The standalone focus-ring color token is documented below as an exception.
 -   **Tone** describes the semantic intent of a color, such as \`neutral\`, \`brand\`, \`success\`, or \`error\`.
 -   **Emphasis** and **state** are modifiers that adjust strength and reflect interactive states.
 
@@ -21,7 +21,7 @@ Each segment of a token name answers one question about the value being applied:
 
 Semantic tokens follow a consistent naming pattern:
 
-\`\`\`
+\`\`\`text
 --wpds-<type>-<property>-<target>[-<modifier>]
 \`\`\`
 
@@ -69,7 +69,6 @@ The component or element type the token applies to.
 | \`content\`     | Static content like body text and icons. Use for foreground colors where there is no interactive behavior.                        |
 | \`track\`       | The non-moving rail of a track-and-thumb control (scrollbar track, slider track, progressbar track).                              |
 | \`thumb\`       | The moving indicator of a track-and-thumb control (scrollbar thumb, slider handle, filled progress).                              |
-| \`focus\`       | Focus indicators and rings.                                                                                                       |
 
 ### Modifier
 
@@ -81,11 +80,13 @@ An optional size or intensity modifier.
 
 ## Color token modifiers
 
-Color tokens extend the base pattern with additional modifiers for tone, emphasis, and state:
+Most color tokens extend the base pattern with additional modifiers for tone, emphasis, and state:
 
-\`\`\`
+\`\`\`text
 --wpds-color-<property>-<target>-<tone>[-<emphasis>][-<state>]
 \`\`\`
+
+\`--wpds-color-stroke-focus\` is the only color token that does not follow this target/tone grammar. Its \`focus\` segment describes the focus-ring purpose directly, and the token intentionally applies across tones.
 
 ### Tone
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -13,7 +13,7 @@ Each segment of a token name answers one question about the value being applied:
 
 -   **Type** identifies the kind of value, like `color` or `dimension`. It is usually determined by the CSS property being set.
 -   **Property** describes which aspect of the element the token applies to, such as `background`, `foreground`, `stroke`, `padding`, or `gap`.
--   **Target** describes the kind of element the token applies to, such as a `surface`, an `interactive` control, static `content`, a `track` or `thumb`, or a `focus` indicator.
+-   **Target** describes the kind of element the token applies to, such as a `surface`, an `interactive` control, static `content`, or a `track` or `thumb`. The standalone focus-ring color token is documented below as an exception.
 -   **Tone** describes the semantic intent of a color, such as `neutral`, `brand`, `success`, or `error`.
 -   **Emphasis** and **state** are modifiers that adjust strength and reflect interactive states.
 
@@ -21,7 +21,7 @@ Each segment of a token name answers one question about the value being applied:
 
 Semantic tokens follow a consistent naming pattern:
 
-```
+```text
 --wpds-<type>-<property>-<target>[-<modifier>]
 ```
 
@@ -69,7 +69,6 @@ The component or element type the token applies to.
 | `content`     | Static content like body text and icons. Use for foreground colors where there is no interactive behavior.                                    |
 | `track`       | The non-moving rail of a track-and-thumb control (scrollbar track, slider track, progressbar track).                                          |
 | `thumb`       | The moving indicator of a track-and-thumb control (scrollbar thumb, slider handle, filled progress).                                          |
-| `focus`       | Focus indicators and rings.                                                                                                                   |
 
 ### Modifier
 
@@ -81,11 +80,13 @@ An optional size or intensity modifier.
 
 ## Color token modifiers
 
-Color tokens extend the base pattern with additional modifiers for tone, emphasis, and state:
+Most color tokens extend the base pattern with additional modifiers for tone, emphasis, and state:
 
-```
+```text
 --wpds-color-<property>-<target>-<tone>[-<emphasis>][-<state>]
 ```
+
+`--wpds-color-stroke-focus` is the only color token that does not follow this target/tone grammar. Its `focus` segment describes the focus-ring purpose directly, and the token intentionally applies across tones.
 
 ### Tone
 


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/issues/77462, point A2.

Clarifies the generated design-token documentation so `--wpds-color-stroke-focus` is documented as the standalone exception to the normal color target/tone grammar.

## Why?
The docs listed `focus` as a regular target while the token model treats `--wpds-color-stroke-focus` outside the normal target grammar. Calling out the exception keeps the generated docs consistent with the token names and generated types.

## How?
Updates the token docs generator preamble, removes `focus` from the generic target table, and regenerates `packages/theme/docs/tokens.md`.

## Testing Instructions
1. Run `npm run --workspace @wordpress/theme build:tokens`.
2. Run `npm run --workspace @wordpress/theme postbuild`.
3. Run `npm run lint:js -- packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts`.
4. Run `npm run lint:md:docs -- packages/theme/docs/tokens.md`.
5. Run `git diff --check`.

### Testing Instructions for Keyboard
Not applicable; documentation-only change.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Used OpenAI Codex to implement the documentation-generator update and run verification.