### PR TITLE
Block Library: Replace obsolete `View` primitive with plain `div`

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -14,7 +14,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { View } from '@wordpress/primitives';
 import { Caption } from '../utils/caption';
 
 /**
@@ -199,9 +198,9 @@ const EmbedEdit = ( props ) => {
 
 	if ( fetching ) {
 		return (
-			<View { ...blockProps }>
+			<div { ...blockProps }>
 				<EmbedLoading />
-			</View>
+			</div>
 		);
 	}
 
@@ -213,7 +212,7 @@ const EmbedEdit = ( props ) => {
 
 	if ( showEmbedPlaceholder ) {
 		return (
-			<View { ...blockProps }>
+			<div { ...blockProps }>
 				<EmbedPlaceholder
 					icon={ icon }
 					label={ label }
@@ -245,7 +244,7 @@ const EmbedEdit = ( props ) => {
 						invalidateResolution( 'getEmbedPreview', [ url ] );
 					} }
 				/>
-			</View>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -31,7 +31,6 @@ import {
 import { useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { View } from '@wordpress/primitives';
 import { createBlock } from '@wordpress/blocks';
 import { createBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
@@ -609,10 +608,10 @@ export default function GalleryEdit( props ) {
 
 	if ( ! hasImages ) {
 		return (
-			<View { ...innerBlocksProps }>
+			<div { ...innerBlocksProps }>
 				{ innerBlocksProps.children }
 				{ mediaPlaceholder }
-			</View>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -46,9 +45,9 @@ export default function Gallery( props ) {
 		>
 			{ blockProps.children }
 			{ isSelected && ! blockProps.children && (
-				<View className="blocks-gallery-media-placeholder-wrapper">
+				<div className="blocks-gallery-media-placeholder-wrapper">
 					{ mediaPlaceholder }
-				</View>
+				</div>
 			) }
 			<Caption
 				attributes={ attributes }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -132,13 +131,13 @@ function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 				clientId={ clientId }
 			/>
 			{ showPlaceholder && (
-				<View>
+				<div>
 					{ innerBlocksProps.children }
 					<GroupPlaceHolder
 						name={ name }
 						onSelect={ selectVariation }
 					/>
-				</View>
+				</div>
 			) }
 			{ layoutSupportEnabled && ! showPlaceholder && (
 				<TagName { ...innerBlocksProps } />

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -17,7 +17,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -65,7 +64,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 					__next40pxDefaultSize
 				/>
 			) : (
-				<View className="tools-panel-item-spacing">
+				<div className="tools-panel-item-spacing">
 					<SpacingSizesControl
 						values={ { all: computedValue } }
 						onChange={ ( { all } ) => {
@@ -78,7 +77,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 						splitOnAxis={ false }
 						showSideInLabel={ false }
 					/>
-				</View>
+				</div>
 			) }
 		</>
 	);

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,7 +16,6 @@ import {
 } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
-import { View } from '@wordpress/primitives';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -351,7 +350,7 @@ const SpacerEdit = ( {
 
 	return (
 		<>
-			<View
+			<div
 				{ ...useBlockProps( {
 					style,
 					className: clsx( className, {
@@ -361,7 +360,7 @@ const SpacerEdit = ( {
 			>
 				{ blockEditingMode === 'default' &&
 					resizableBoxWithOrientation( inheritedOrientation ) }
-			</View>
+			</div>
 			{ ! isFlexLayout && (
 				<SpacerControls
 					setAttributes={ setAttributes }


### PR DESCRIPTION
## What?
Removes leftover usage of the `View` component from `@wordpress/primitives` in the `block-library` package. `View` was a React Native abstraction that, on web, simply rendered a `div` — now obsolete since these edit components are web-only.

Replaced across 6 files (embed, group, gallery, spacer), dropping the `@wordpress/primitives` import from each. Spread props and `className` carry over unchanged, so there's no behavioral difference on the web.

## Testing Instructions
CI checks are passing.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
