### PR TITLE
stylelint-config: Enable token fallback rule

### DIFF
--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   `length-zero-no-unit` rule now ignores custom properties and `var` functions, for better compatibility with usage inside `calc` functions. `calc` functions are already [exempt from the rule by default](https://stylelint.io/user-guide/rules/length-zero-no-unit/), and this change extends the same exemption to variables that may be used within `calc` functions, as [unitless zeros are not valid in CSS math functions](https://www.w3.org/TR/css-values-4/#calc-type-checking) ([#79786](https://github.com/WordPress/gutenberg/pull/79786)).
+-   Include `plugin-wpds/no-token-fallback-values` from `@wordpress/theme` to catch manual design token fallbacks in the shared Stylelint config ([#79768](https://github.com/WordPress/gutenberg/pull/79768)).
 -   Update `@stylistic/stylelint-plugin` to `^3.1.3` ([#79648](https://github.com/WordPress/gutenberg/pull/79648)).
 -   Convert configuration to ESM ([#79755](https://github.com/WordPress/gutenberg/pull/79755)).
 

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -8,6 +8,7 @@ export default {
 	plugins: [
 		'@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens',
 		'@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties',
+		'@wordpress/theme/stylelint-plugins/no-token-fallback-values',
 	],
 	rules: {
 		'at-rule-empty-line-before': [
@@ -78,6 +79,7 @@ export default {
 		'selector-type-case': 'lower',
 		'value-keyword-case': 'lower',
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
+		'plugin-wpds/no-token-fallback-values': true,
 		'plugin-wpds/no-unknown-ds-tokens': true,
 
 		/* Disable new rules from stylelint-config-recommended 7 > 14 */

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Enhancements
 
+-   Improve the `plugin-wpds/no-token-fallback-values` Stylelint rule message to point developers to the `@wordpress/theme` README for fallback setup guidance ([#79768](https://github.com/WordPress/gutenberg/pull/79768)).
 -   Widen React peer dependency ranges to `^18 || ^19` to support both React 18 and React 19 environments ([#80024](https://github.com/WordPress/gutenberg/pull/80024)).
 
 ## 0.17.0 (2026-06-30)

--- a/packages/theme/src/stylelint-plugins/no-token-fallback-values.mjs
+++ b/packages/theme/src/stylelint-plugins/no-token-fallback-values.mjs
@@ -15,7 +15,7 @@ const varWithFallbackRegex = /var\(\s*(--wpds-[\w-]+)\s*,/g;
 
 const messages = ruleMessages( ruleName, {
 	rejected: ( tokenName ) =>
-		`Do not add a fallback value for Design System token '${ tokenName }'. Fallbacks are injected automatically at build time.`,
+		`Do not add a fallback value for Design System token '${ tokenName }'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README).`,
 } );
 
 /** @type {import('stylelint').Rule} */

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-token-fallback-values.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-token-fallback-values.test.ts.snap
@@ -9,7 +9,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 3,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-color-foreground-content-neutral'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-color-foreground-content-neutral'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
   {
     "column": 20,
@@ -18,7 +18,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 4,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-color-background-surface-neutral-weak'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-color-background-surface-neutral-weak'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
   {
     "column": 17,
@@ -27,7 +27,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 5,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-border-radius-sm'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-border-radius-sm'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
   {
     "column": 11,
@@ -36,7 +36,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 10,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-border-width-focus'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-border-width-focus'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
   {
     "column": 53,
@@ -45,7 +45,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 10,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-color-stroke-focus'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-color-stroke-focus'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
   {
     "column": 32,
@@ -54,7 +54,7 @@ exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warni
     "line": 15,
     "rule": "plugin-wpds/no-token-fallback-values",
     "severity": "error",
-    "text": "Do not add a fallback value for Design System token '--wpds-color-foreground-content-neutral'. Fallbacks are injected automatically at build time. (plugin-wpds/no-token-fallback-values)",
+    "text": "Do not add a fallback value for Design System token '--wpds-color-foreground-content-neutral'. Fallbacks should be injected automatically at build time (see @wordpress/theme package README). (plugin-wpds/no-token-fallback-values)",
   },
 ]
 `;


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/issues/77462.

Enables `plugin-wpds/no-token-fallback-values` in `@wordpress/stylelint-config` by default, alongside the existing WPDS token rules.

## Why?
Manual fallbacks for `--wpds-*` design tokens are not the intended path. Projects using WPDS tokens should either rely on the `@wordpress/build` pipeline, use the `@wordpress/theme` build plugins, or load the generated design tokens stylesheet so token values are available without handwritten fallbacks.

## How?
Adds the `@wordpress/theme` fallback-value Stylelint plugin to the shared preset. The rule-specific guidance stays on the main developer path by pointing the rule error message to the `@wordpress/theme` README.

## Testing Instructions
1. Run `npm run test:unit -- packages/theme/src/stylelint-plugins/test/no-token-fallback-values.test.ts`.
2. Run `npm run lint:js -- packages/stylelint-config/index.js packages/theme/src/stylelint-plugins/no-token-fallback-values.mjs packages/theme/src/stylelint-plugins/test/no-token-fallback-values.test.ts`.
3. Run a direct smoke check that `packages/stylelint-config/index.js` reports `plugin-wpds/no-token-fallback-values` for a `--wpds-*` fallback.
4. Run `git diff --check origin/trunk...HEAD`.
5. Run `npm run lint:md:docs -- packages/stylelint-config/CHANGELOG.md packages/theme/CHANGELOG.md`.

Note: the markdown lint command currently reports pre-existing changelog-wide heading issues in both package changelogs.

### Testing Instructions for Keyboard
Not applicable; this PR does not change UI.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Used Codex to rebase the branch, resolve conflicts, inspect review feedback, update the implementation, run verification, and update this PR description.
