### PR TITLE
Theme: Document token naming grammar

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).
 -   Document intentional design token omissions in the design system tokens reference ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
 -   Clarify that `--wpds-color-stroke-focus` is a standalone exception to the normal color token naming pattern ([#79764](https://github.com/WordPress/gutenberg/pull/79764)).
+-   Document the design token naming grammar in the token reference ([#79769](https://github.com/WordPress/gutenberg/pull/79769)).
 
 ## 0.17.0 (2026-06-30)
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -6,7 +6,9 @@ Design tokens are named values. They encode design decisions which describe the 
 
 ## How to pick a token
 
-Each segment of a token name answers one question about the value being applied:
+Pick tokens by meaning first, then by the CSS property they will feed. The raw value is an implementation detail; a token name should describe the role that value plays in the interface.
+
+Each segment of a public token name answers one question about the value being applied:
 
 -   **Type** identifies the kind of value, like `color` or `dimension`. It is usually determined by the CSS property being set.
 -   **Property** describes which aspect of the element the token applies to, such as `background`, `foreground`, `stroke`, `padding`, or `gap`.
@@ -16,11 +18,30 @@ Each segment of a token name answers one question about the value being applied:
 
 ## Naming pattern
 
-Semantic tokens follow a consistent naming pattern:
+Semantic tokens use the `--wpds-` prefix followed by the token type and one or more role segments:
 
 ```text
---wpds-<type>-<property>-<target>[-<modifier>]
+--wpds-<type>-<role>[-<modifier>...]
 ```
+
+The most complete grammar is used by color tokens:
+
+```text
+--wpds-color-<property>-<target>-<tone>[-<emphasis>][-<state>]
+```
+
+Other token families use shorter forms when a segment would be redundant:
+
+| Token family            | Pattern                                                          | Example                                                   |
+| ----------------------- | ---------------------------------------------------------------- | --------------------------------------------------------- |
+| Color                   | `--wpds-color-<property>-<target>-<tone>[-<emphasis>][-<state>]` | `--wpds-color-background-interactive-brand-strong-active` |
+| Dimension               | `--wpds-dimension-<property>-<size>`                             | `--wpds-dimension-padding-lg`                             |
+| Dimension surface width | `--wpds-dimension-surface-width-<size>`                          | `--wpds-dimension-surface-width-md`                       |
+| Border                  | `--wpds-border-<property>-<size-or-target>`                      | `--wpds-border-radius-sm`                                 |
+| Typography              | `--wpds-typography-<property>-<role-or-size>`                    | `--wpds-typography-font-size-md`                          |
+| Motion                  | `--wpds-motion-<property>-<scale-or-intent>`                     | `--wpds-motion-easing-balanced`                           |
+| Elevation               | `--wpds-elevation-<size>`                                        | `--wpds-elevation-sm`                                     |
+| Cursor                  | `--wpds-cursor-<target>`                                         | `--wpds-cursor-control`                                   |
 
 ### Type
 
@@ -31,6 +52,7 @@ Indicates what kind of value the token represents, usually mapping to a [DTCG](h
 | `color`      | Color values for backgrounds, foregrounds, and strokes                         |
 | `dimension`  | Spacing, sizing, and other measurable lengths (e.g., padding, margins, widths) |
 | `border`     | Border properties like radius and width                                        |
+| `cursor`     | Cursor values for interactive affordances                                      |
 | `elevation`  | Shadow definitions for layering and depth                                      |
 | `motion`     | Animation durations and easing curves                                          |
 | `typography` | Typography properties like font family, font size, and line-height             |
@@ -39,21 +61,23 @@ Indicates what kind of value the token represents, usually mapping to a [DTCG](h
 
 The specific design property being defined.
 
-| Value         | Description                        |
-| ------------- | ---------------------------------- |
-| `background`  | Background color                   |
-| `foreground`  | Foreground color (text and icons)  |
-| `stroke`      | Border and outline color           |
-| `padding`     | Internal spacing within an element |
-| `gap`         | Spacing between elements           |
-| `radius`      | Border radius for rounded corners  |
-| `width`       | Border width                       |
-| `duration`    | Animation duration                 |
-| `easing`      | Animation easing curve             |
-| `font-size`   | Font size                          |
-| `font-family` | Font family                        |
-| `font-weight` | Font weight                        |
-| `line-height` | Line height                        |
+| Value           | Description                        |
+| --------------- | ---------------------------------- |
+| `background`    | Background color                   |
+| `foreground`    | Foreground color (text and icons)  |
+| `stroke`        | Border and outline color           |
+| `padding`       | Internal spacing within an element |
+| `gap`           | Spacing between elements           |
+| `radius`        | Border radius for rounded corners  |
+| `width`         | Border width                       |
+| `size`          | Control, icon, and marker sizing   |
+| `surface-width` | Maximum width for layout surfaces  |
+| `duration`      | Animation duration                 |
+| `easing`        | Animation easing curve             |
+| `font-size`     | Font size                          |
+| `font-family`   | Font family                        |
+| `font-weight`   | Font weight                        |
+| `line-height`   | Line height                        |
 
 ### Target
 
@@ -66,14 +90,27 @@ The component or element type the token applies to.
 | `content`     | Static content like body text and icons. Use for foreground colors where there is no interactive behavior.                                    |
 | `track`       | The non-moving rail of a track-and-thumb control (scrollbar track, slider track, progressbar track).                                          |
 | `thumb`       | The moving indicator of a track-and-thumb control (scrollbar thumb, slider handle, filled progress).                                          |
+| `control`     | Interactive controls that are not links.                                                                                                      |
 
 ### Modifier
 
-An optional size or intensity modifier.
+An optional size, intensity, state, or role modifier.
 
-| Value                                      | Description          |
-| ------------------------------------------ | -------------------- |
-| `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl` | Size scale modifiers |
+| Value                                                                  | Description                    |
+| ---------------------------------------------------------------------- | ------------------------------ |
+| `5xs`, `4xs`, `3xs`, `2xs`, `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl` | Size scale modifiers           |
+| `weak`, `strong`                                                       | Color emphasis modifiers       |
+| `active`, `disabled`                                                   | Interactive state modifiers    |
+| `heading`, `body`, `mono`, `regular`, `medium`                         | Typography role modifiers      |
+| `subtle`, `balanced`, `expressive`                                     | Motion easing intent modifiers |
+
+### Shortened and compound forms
+
+Some public tokens intentionally use shortened or compound forms:
+
+-   `--wpds-dimension-surface-width-*` keeps `surface-width` together as a compound role for layout surface widths.
+-   `--wpds-border-width-focus` uses `focus` as the target because it describes the focus indicator width, not a size on the border scale.
+-   `--wpds-color-stroke-focus` is the standalone color-token exception described below.
 
 ## Color token modifiers
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -6,7 +6,7 @@ Design tokens are named values. They encode design decisions which describe the 
 
 ## How to pick a token
 
-Pick tokens by meaning first, then by the CSS property they will feed. The raw value is an implementation detail; a token name should describe the role that value plays in the interface.
+Start from what you are styling and the CSS property you are setting. For example, when setting the text or icon color for an interactive control with neutral intent, choose `--wpds-color-foreground-interactive-neutral`: `foreground` for the CSS property, `interactive` for the target, and `neutral` for the tone. The raw value is an implementation detail; a token name should describe the role that value plays in the interface.
 
 Each segment of a public token name answers one question about the value being applied:
 
@@ -61,23 +61,23 @@ Indicates what kind of value the token represents, usually mapping to a [DTCG](h
 
 The specific design property being defined.
 
-| Value           | Description                        |
-| --------------- | ---------------------------------- |
-| `background`    | Background color                   |
-| `foreground`    | Foreground color (text and icons)  |
-| `stroke`        | Border and outline color           |
-| `padding`       | Internal spacing within an element |
-| `gap`           | Spacing between elements           |
-| `radius`        | Border radius for rounded corners  |
-| `width`         | Border width                       |
-| `size`          | Control, icon, and marker sizing   |
-| `surface-width` | Maximum width for layout surfaces  |
-| `duration`      | Animation duration                 |
-| `easing`        | Animation easing curve             |
-| `font-size`     | Font size                          |
-| `font-family`   | Font family                        |
-| `font-weight`   | Font weight                        |
-| `line-height`   | Line height                        |
+| Value           | Description                         |
+| --------------- | ----------------------------------- |
+| `background`    | Background color                    |
+| `foreground`    | Foreground color (text and icons)   |
+| `stroke`        | Border and outline color            |
+| `padding`       | Internal spacing within an element  |
+| `gap`           | Spacing between elements            |
+| `radius`        | Border radius for rounded corners   |
+| `width`         | Width for the relevant token family |
+| `size`          | Control, icon, and marker sizing    |
+| `surface-width` | Maximum width for layout surfaces   |
+| `duration`      | Animation duration                  |
+| `easing`        | Animation easing curve              |
+| `font-size`     | Font size                           |
+| `font-family`   | Font family                         |
+| `font-weight`   | Font weight                         |
+| `line-height`   | Line height                         |
 
 ### Target
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -122,6 +122,12 @@ Most color tokens extend the base pattern with additional modifiers for tone, em
 
 `--wpds-color-stroke-focus` is the only color token that does not follow this target/tone grammar. Its `focus` segment describes the focus-ring purpose directly, and the token intentionally applies across tones.
 
+### Keep color roles aligned
+
+When styling one UI element across states, keep the token role aligned and change only the state segment. For example, pair `--wpds-color-foreground-interactive-neutral` with `--wpds-color-foreground-interactive-neutral-active` and `--wpds-color-foreground-interactive-neutral-disabled` rather than switching tones between states.
+
+When styling related parts of the same UI element, prefer matching the target and tone across properties. For example, an interactive neutral control should generally use the corresponding `background`, `foreground`, and `stroke` interactive neutral tokens. Mixing tones or targets should be intentional, usually to satisfy contrast, hierarchy, or a documented component-specific pattern.
+
 ### Tone
 
 The semantic intent of the color.


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/issues/77462.

Documents the `@wordpress/theme` token naming grammar in the Design Tokens reference.

## Why?
Point N1 asks us to write down the grammar behind token names: property, target, tone, emphasis/state, and known exceptions. The reference already had a short naming overview, but it did not spell out category-specific patterns, deliberate shortened forms, or how to keep color token roles aligned across states and related properties.

## How?
- Expands the authored guidance in `packages/theme/docs/tokens.md`, which now acts as the template around the generated token tables.
- Adds examples for each token family and calls out shortened or compound forms.
- Documents that one UI element should keep color token roles aligned across states, and that related parts should generally share target and tone across `background`, `foreground`, and `stroke`.
- Leaves `packages/theme/bin/terrazzo-plugin-ds-tokens-docs/index.ts` on trunk's current structure, where it only replaces the generated token-table section.
- Adds the package changelog entry under `Unreleased > Documentation`.

## Testing Instructions
1. Run `npm run build --workspace @wordpress/theme`.
2. Run `npm run lint:md:docs -- packages/theme/docs/tokens.md`.
3. Read `packages/theme/docs/tokens.md` and confirm the naming section documents token family patterns, shortened/compound forms, and color role alignment guidance.

### Testing Instructions for Keyboard
Not applicable. This is a documentation-only change.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
This PR was implemented with assistance from OpenAI Codex.