### PR TITLE
Theme: Fill semantic token state gaps

### DIFF
--- a/packages/base-styles/internal/_wpds-token-fallbacks.scss
+++ b/packages/base-styles/internal/_wpds-token-fallbacks.scss
@@ -59,9 +59,9 @@ $fallbacks: (
 	'--wpds-color-background-thumb-brand-active':
 		'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-background-thumb-brand-disabled': '#dbdbdb',
-	'--wpds-color-background-thumb-neutral-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-weak': '#8d8d8d',
 	'--wpds-color-background-thumb-neutral-weak-active': '#6e6e6e',
+	'--wpds-color-background-thumb-neutral-weak-disabled': '#dbdbdb',
 	'--wpds-color-background-track-neutral': '#dbdbdb',
 	'--wpds-color-background-track-neutral-weak': '#f0f0f0',
 	'--wpds-color-foreground-content-caution': '#281d00',

--- a/packages/base-styles/internal/_wpds-token-fallbacks.scss
+++ b/packages/base-styles/internal/_wpds-token-fallbacks.scss
@@ -97,6 +97,7 @@ $fallbacks: (
 	'--wpds-color-foreground-interactive-neutral-strong-active': '#f0f0f0',
 	'--wpds-color-foreground-interactive-neutral-strong-disabled': '#8d8d8d',
 	'--wpds-color-foreground-interactive-neutral-weak': '#707070',
+	'--wpds-color-foreground-interactive-neutral-weak-active': '#1e1e1e',
 	'--wpds-color-foreground-interactive-neutral-weak-disabled': '#8d8d8d',
 	'--wpds-color-stroke-focus': 'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-stroke-interactive-brand':

--- a/packages/base-styles/internal/_wpds-token-fallbacks.scss
+++ b/packages/base-styles/internal/_wpds-token-fallbacks.scss
@@ -58,6 +58,7 @@ $fallbacks: (
 		'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-background-thumb-brand-active':
 		'var(--wp-admin-theme-color, #3858e9)',
+	'--wpds-color-background-thumb-brand-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-weak': '#8d8d8d',
 	'--wpds-color-background-thumb-neutral-weak-active': '#6e6e6e',

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -10,16 +10,16 @@
 	&:hover,
 	&:focus,
 	&[aria-current="true"] {
-		color: var(--wpds-color-foreground-interactive-neutral-active);
+		color: var(--wpds-color-foreground-interactive-neutral-weak-active);
 
 		.edit-site-sidebar-navigation-item__drilldown-indicator {
-			fill: var(--wpds-color-foreground-interactive-neutral-active);
+			fill: var(--wpds-color-foreground-interactive-neutral-weak-active);
 		}
 	}
 
 	&[aria-current="true"] {
 		background: var(--wpds-color-background-interactive-neutral-weak-active);
-		color: var(--wpds-color-foreground-interactive-neutral-active);
+		color: var(--wpds-color-foreground-interactive-neutral-weak-active);
 		font-weight: $font-weight-medium;
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -27,7 +27,7 @@
 		&:hover,
 		&:focus,
 		&[aria-current] {
-			color: var(--wpds-color-foreground-interactive-neutral-active);
+			color: var(--wpds-color-foreground-interactive-neutral-weak-active);
 		}
 	}
 
@@ -35,7 +35,7 @@
 		color: var(--wpds-color-foreground-interactive-neutral-weak);
 		&:hover,
 		&:focus {
-			color: var(--wpds-color-foreground-interactive-neutral-active);
+			color: var(--wpds-color-foreground-interactive-neutral-weak-active);
 		}
 	}
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
 
+### New Features
+
+-   Add `--wpds-color-background-thumb-brand-disabled` for parity with the existing brand thumb state tokens ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
+
 ### Documentation
 
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Rename `--wpds-color-background-thumb-neutral-disabled` to `--wpds-color-background-thumb-neutral-weak-disabled` so the disabled token belongs to the existing neutral weak thumb family ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
+
 ### Bug Fixes
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).
+-   Document intentional design token omissions in the design system tokens reference ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
 -   Clarify that `--wpds-color-stroke-focus` is a standalone exception to the normal color token naming pattern ([#79764](https://github.com/WordPress/gutenberg/pull/79764)).
 
 ## 0.17.0 (2026-06-30)

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### New Features
 
 -   Add `--wpds-color-background-thumb-brand-disabled` for parity with the existing brand thumb state tokens ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
+-   Add `--wpds-color-foreground-interactive-neutral-weak-active` for parity with the existing neutral weak foreground interactive state tokens ([#79770](https://github.com/WordPress/gutenberg/pull/79770)).
 
 ### Documentation
 

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -212,6 +212,7 @@ The semantic token set is not a complete matrix of every property, target, tone,
 | `--wpds-color-foreground-interactive-neutral-strong-active`   | Foreground color for interactive elements with neutral tone and strong emphasis that are hovered, focused, or active.                       |
 | `--wpds-color-foreground-interactive-neutral-strong-disabled` | Foreground color for interactive elements with neutral tone and strong emphasis, in their disabled state.                                   |
 | `--wpds-color-foreground-interactive-neutral-weak`            | Foreground color for interactive elements with neutral tone and weak emphasis.                                                              |
+| `--wpds-color-foreground-interactive-neutral-weak-active`     | Foreground color for interactive elements with neutral tone and weak emphasis that are hovered, focused, or active.                         |
 | `--wpds-color-foreground-interactive-neutral-weak-disabled`   | Foreground color for interactive elements with neutral tone and weak emphasis, in their disabled state.                                     |
 | `--wpds-color-foreground-interactive-brand`                   | Foreground color for interactive elements with brand tone and normal emphasis.                                                              |
 | `--wpds-color-foreground-interactive-brand-active`            | Foreground color for interactive elements with brand tone and normal emphasis that are hovered, focused, or active.                         |

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -119,6 +119,14 @@ The interactive state of the element. The default (no modifier) is the idle stat
 | `active`   | Hovered, pressed, or selected state |
 | `disabled` | Unavailable or inoperable state     |
 
+## Intentional omissions
+
+The semantic token set is not a complete matrix of every property, target, tone, emphasis, and state combination. Omitted combinations are intentional when they do not map to a supported design-system role.
+
+-   Do not create a new token only to fill a missing slot in the naming pattern. Add a token when there is a documented role and a concrete component need.
+-   Use the existing neutral disabled tokens for track-and-thumb controls when the disabled state should be tone-agnostic, such as `--wpds-color-background-thumb-neutral-disabled`.
+-   Use the normal-emphasis stroke tokens for brand or error interactive borders unless a component specifically needs a distinct strong stroke role, such as `--wpds-color-stroke-interactive-brand` or `--wpds-color-stroke-interactive-error`.
+
 <!-- START GENERATED TOKEN TABLES: Do not edit this section directly. -->
 
 ## Semantic tokens

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -124,7 +124,7 @@ The interactive state of the element. The default (no modifier) is the idle stat
 The semantic token set is not a complete matrix of every property, target, tone, emphasis, and state combination. Omitted combinations are intentional when they do not map to a supported design-system role.
 
 -   Do not create a new token only to fill a missing slot in the naming pattern. Add a token when there is a documented role and a concrete component need.
--   Add a missing state token when the same role already exists for that target and tone in other states, such as `--wpds-color-background-thumb-brand-disabled` complementing the brand thumb tokens.
+-   Add a missing state token when the same role already exists for that target, tone, and emphasis in other states, such as `--wpds-color-background-thumb-brand-disabled` complementing the brand thumb tokens.
 -   Use the normal-emphasis stroke tokens for brand or error interactive borders unless a component specifically needs a distinct strong stroke role, such as `--wpds-color-stroke-interactive-brand` or `--wpds-color-stroke-interactive-error`.
 
 <!-- START GENERATED TOKEN TABLES: Do not edit this section directly. -->
@@ -192,7 +192,7 @@ The semantic token set is not a complete matrix of every property, target, tone,
 | `--wpds-color-background-thumb-brand`                         | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track).                                      |
 | `--wpds-color-background-thumb-brand-active`                  | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track) that are hovered, focused, or active. |
 | `--wpds-color-background-thumb-brand-disabled`                | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state.             |
-| `--wpds-color-background-thumb-neutral-disabled`              | Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state.           |
+| `--wpds-color-background-thumb-neutral-weak-disabled`         | Background color for thumbs with a neutral tone and weak emphasis (eg. scrollbar thumb), in their disabled state.                           |
 | `--wpds-color-foreground-content-neutral`                     | Foreground color for content like text with normal emphasis.                                                                                |
 | `--wpds-color-foreground-content-neutral-weak`                | Foreground color for content like text with weak emphasis.                                                                                  |
 | `--wpds-color-foreground-content-success`                     | Foreground color for content like text with success tone and normal emphasis.                                                               |

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -124,7 +124,7 @@ The interactive state of the element. The default (no modifier) is the idle stat
 The semantic token set is not a complete matrix of every property, target, tone, emphasis, and state combination. Omitted combinations are intentional when they do not map to a supported design-system role.
 
 -   Do not create a new token only to fill a missing slot in the naming pattern. Add a token when there is a documented role and a concrete component need.
--   Use the existing neutral disabled tokens for track-and-thumb controls when the disabled state should be tone-agnostic, such as `--wpds-color-background-thumb-neutral-disabled`.
+-   Add a missing state token when the same role already exists for that target and tone in other states, such as `--wpds-color-background-thumb-brand-disabled` complementing the brand thumb tokens.
 -   Use the normal-emphasis stroke tokens for brand or error interactive borders unless a component specifically needs a distinct strong stroke role, such as `--wpds-color-stroke-interactive-brand` or `--wpds-color-stroke-interactive-error`.
 
 <!-- START GENERATED TOKEN TABLES: Do not edit this section directly. -->
@@ -191,7 +191,8 @@ The semantic token set is not a complete matrix of every property, target, tone,
 | `--wpds-color-background-thumb-neutral-weak-active`           | Background color for thumbs with a neutral tone and weak emphasis (eg. scrollbar thumb) that are hovered, focused, or active.               |
 | `--wpds-color-background-thumb-brand`                         | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track).                                      |
 | `--wpds-color-background-thumb-brand-active`                  | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track) that are hovered, focused, or active. |
-| `--wpds-color-background-thumb-neutral-disabled`              | Background color for thumbs with normal emphasis (eg. slider thumb and filled track), in their disabled state, regardless of the tone.      |
+| `--wpds-color-background-thumb-brand-disabled`                | Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state.             |
+| `--wpds-color-background-thumb-neutral-disabled`              | Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state.           |
 | `--wpds-color-foreground-content-neutral`                     | Foreground color for content like text with normal emphasis.                                                                                |
 | `--wpds-color-foreground-content-neutral-weak`                | Foreground color for content like text with weak emphasis.                                                                                  |
 | `--wpds-color-foreground-content-success`                     | Foreground color for content like text with success tone and normal emphasis.                                                               |

--- a/packages/theme/docs/tokens.md
+++ b/packages/theme/docs/tokens.md
@@ -121,11 +121,11 @@ The interactive state of the element. The default (no modifier) is the idle stat
 
 ## Intentional omissions
 
-The semantic token set is not a complete matrix of every property, target, tone, emphasis, and state combination. Omitted combinations are intentional when they do not map to a supported design-system role.
+The semantic token set is role-based, not a complete matrix of every property, target, tone, emphasis, and state combination. A missing combination should stay omitted when it does not map to a supported design-system role.
 
--   Do not create a new token only to fill a missing slot in the naming pattern. Add a token when there is a documented role and a concrete component need.
--   Add a missing state token when the same role already exists for that target, tone, and emphasis in other states, such as `--wpds-color-background-thumb-brand-disabled` complementing the brand thumb tokens.
--   Use the normal-emphasis stroke tokens for brand or error interactive borders unless a component specifically needs a distinct strong stroke role, such as `--wpds-color-stroke-interactive-brand` or `--wpds-color-stroke-interactive-error`.
+-   Do not create a token only to fill a missing slot in the naming pattern.
+-   Add a missing state token when the same target, tone, and emphasis already define the role in other states, and a component needs that state.
+-   Treat emphasis and tone variants as separate roles. For example, do not add strong interactive stroke variants unless a component specifically needs a distinct strong stroke role.
 
 <!-- START GENERATED TOKEN TABLES: Do not edit this section directly. -->
 

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -147,6 +147,8 @@
 	--wpds-color-foreground-interactive-neutral-strong-disabled: #8d8d8d;
 	/* Foreground color for interactive elements with neutral tone and weak emphasis. */
 	--wpds-color-foreground-interactive-neutral-weak: #707070;
+	/* Foreground color for interactive elements with neutral tone and weak emphasis that are hovered, focused, or active. */
+	--wpds-color-foreground-interactive-neutral-weak-active: #1e1e1e;
 	/* Foreground color for interactive elements with neutral tone and weak emphasis, in their disabled state. */
 	--wpds-color-foreground-interactive-neutral-weak-disabled: #8d8d8d;
 	/* Foreground color for interactive elements with brand tone and normal emphasis. */

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -107,8 +107,8 @@
 	--wpds-color-background-thumb-brand-active: #3858e9;
 	/* Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state. */
 	--wpds-color-background-thumb-brand-disabled: #dbdbdb;
-	/* Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state. */
-	--wpds-color-background-thumb-neutral-disabled: #dbdbdb;
+	/* Background color for thumbs with a neutral tone and weak emphasis (eg. scrollbar thumb), in their disabled state. */
+	--wpds-color-background-thumb-neutral-weak-disabled: #dbdbdb;
 	/* Foreground color for content like text with normal emphasis. */
 	--wpds-color-foreground-content-neutral: #1e1e1e;
 	/* Foreground color for content like text with weak emphasis. */

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -105,7 +105,9 @@
 	--wpds-color-background-thumb-brand: #3858e9;
 	/* Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track) that are hovered, focused, or active. */
 	--wpds-color-background-thumb-brand-active: #3858e9;
-	/* Background color for thumbs with normal emphasis (eg. slider thumb and filled track), in their disabled state, regardless of the tone. */
+	/* Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state. */
+	--wpds-color-background-thumb-brand-disabled: #dbdbdb;
+	/* Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state. */
 	--wpds-color-background-thumb-neutral-disabled: #dbdbdb;
 	/* Foreground color for content like text with normal emphasis. */
 	--wpds-color-foreground-content-neutral: #1e1e1e;

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -95,6 +95,7 @@ export default {
 	'--wpds-color-foreground-interactive-neutral-strong-active': '#f0f0f0',
 	'--wpds-color-foreground-interactive-neutral-strong-disabled': '#8d8d8d',
 	'--wpds-color-foreground-interactive-neutral-weak': '#707070',
+	'--wpds-color-foreground-interactive-neutral-weak-active': '#1e1e1e',
 	'--wpds-color-foreground-interactive-neutral-weak-disabled': '#8d8d8d',
 	'--wpds-color-stroke-focus': 'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-stroke-interactive-brand':

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -56,6 +56,7 @@ export default {
 		'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-background-thumb-brand-active':
 		'var(--wp-admin-theme-color, #3858e9)',
+	'--wpds-color-background-thumb-brand-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-weak': '#8d8d8d',
 	'--wpds-color-background-thumb-neutral-weak-active': '#6e6e6e',

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -57,9 +57,9 @@ export default {
 	'--wpds-color-background-thumb-brand-active':
 		'var(--wp-admin-theme-color, #3858e9)',
 	'--wpds-color-background-thumb-brand-disabled': '#dbdbdb',
-	'--wpds-color-background-thumb-neutral-disabled': '#dbdbdb',
 	'--wpds-color-background-thumb-neutral-weak': '#8d8d8d',
 	'--wpds-color-background-thumb-neutral-weak-active': '#6e6e6e',
+	'--wpds-color-background-thumb-neutral-weak-disabled': '#dbdbdb',
 	'--wpds-color-background-track-neutral': '#dbdbdb',
 	'--wpds-color-background-track-neutral-weak': '#f0f0f0',
 	'--wpds-color-foreground-content-caution': '#281d00',

--- a/packages/theme/src/prebuilt/js/design-tokens.mjs
+++ b/packages/theme/src/prebuilt/js/design-tokens.mjs
@@ -55,6 +55,7 @@ export default [
 	'--wpds-color-background-thumb-neutral-weak-active',
 	'--wpds-color-background-thumb-brand',
 	'--wpds-color-background-thumb-brand-active',
+	'--wpds-color-background-thumb-brand-disabled',
 	'--wpds-color-background-thumb-neutral-disabled',
 	'--wpds-color-foreground-content-neutral',
 	'--wpds-color-foreground-content-neutral-weak',

--- a/packages/theme/src/prebuilt/js/design-tokens.mjs
+++ b/packages/theme/src/prebuilt/js/design-tokens.mjs
@@ -76,6 +76,7 @@ export default [
 	'--wpds-color-foreground-interactive-neutral-strong-active',
 	'--wpds-color-foreground-interactive-neutral-strong-disabled',
 	'--wpds-color-foreground-interactive-neutral-weak',
+	'--wpds-color-foreground-interactive-neutral-weak-active',
 	'--wpds-color-foreground-interactive-neutral-weak-disabled',
 	'--wpds-color-foreground-interactive-brand',
 	'--wpds-color-foreground-interactive-brand-active',

--- a/packages/theme/src/prebuilt/js/design-tokens.mjs
+++ b/packages/theme/src/prebuilt/js/design-tokens.mjs
@@ -56,7 +56,7 @@ export default [
 	'--wpds-color-background-thumb-brand',
 	'--wpds-color-background-thumb-brand-active',
 	'--wpds-color-background-thumb-brand-disabled',
-	'--wpds-color-background-thumb-neutral-disabled',
+	'--wpds-color-background-thumb-neutral-weak-disabled',
 	'--wpds-color-foreground-content-neutral',
 	'--wpds-color-foreground-content-neutral-weak',
 	'--wpds-color-foreground-content-success',

--- a/packages/theme/src/prebuilt/ts/color-tokens.ts
+++ b/packages/theme/src/prebuilt/ts/color-tokens.ts
@@ -92,6 +92,7 @@ export default {
 		'foreground-content-neutral',
 		'foreground-interactive-neutral',
 		'foreground-interactive-neutral-active',
+		'foreground-interactive-neutral-weak-active',
 	],
 	'bg-fgSurface3': [
 		'foreground-content-neutral-weak',

--- a/packages/theme/src/prebuilt/ts/color-tokens.ts
+++ b/packages/theme/src/prebuilt/ts/color-tokens.ts
@@ -118,7 +118,7 @@ export default {
 	],
 	'bg-stroke2': [
 		'background-thumb-brand-disabled',
-		'background-thumb-neutral-disabled',
+		'background-thumb-neutral-weak-disabled',
 		'background-track-neutral',
 		'stroke-interactive-brand-disabled',
 		'stroke-interactive-error-disabled',

--- a/packages/theme/src/prebuilt/ts/color-tokens.ts
+++ b/packages/theme/src/prebuilt/ts/color-tokens.ts
@@ -117,6 +117,7 @@ export default {
 		'stroke-interactive-neutral-strong',
 	],
 	'bg-stroke2': [
+		'background-thumb-brand-disabled',
 		'background-thumb-neutral-disabled',
 		'background-track-neutral',
 		'stroke-interactive-brand-disabled',

--- a/packages/theme/src/prebuilt/ts/token-types.ts
+++ b/packages/theme/src/prebuilt/ts/token-types.ts
@@ -167,6 +167,7 @@ export type ForegroundColor =
 	| 'neutral-strong'
 	| 'neutral-strong-active'
 	| 'neutral-strong-disabled'
+	| 'neutral-weak-active'
 	| 'neutral-weak-disabled'
 	| 'brand'
 	| 'brand-active'

--- a/packages/theme/tokens/color.json
+++ b/packages/theme/tokens/color.json
@@ -1274,9 +1274,13 @@
 					"$value": "{wpds-color.primitive.primary.stroke3}",
 					"$description": "Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track) that are hovered, focused, or active."
 				},
+				"brand-disabled": {
+					"$value": "{wpds-color.primitive.bg.stroke2}",
+					"$description": "Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state."
+				},
 				"neutral-disabled": {
 					"$value": "{wpds-color.primitive.bg.stroke2}",
-					"$description": "Background color for thumbs with normal emphasis (eg. slider thumb and filled track), in their disabled state, regardless of the tone."
+					"$description": "Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state."
 				}
 			},
 			"$extensions": {

--- a/packages/theme/tokens/color.json
+++ b/packages/theme/tokens/color.json
@@ -1278,9 +1278,9 @@
 					"$value": "{wpds-color.primitive.bg.stroke2}",
 					"$description": "Background color for thumbs with a brand tone and normal emphasis (eg. slider thumb and filled track), in their disabled state."
 				},
-				"neutral-disabled": {
+				"neutral-weak-disabled": {
 					"$value": "{wpds-color.primitive.bg.stroke2}",
-					"$description": "Background color for thumbs with a neutral tone and normal emphasis (eg. slider thumb and filled track), in their disabled state."
+					"$description": "Background color for thumbs with a neutral tone and weak emphasis (eg. scrollbar thumb), in their disabled state."
 				}
 			},
 			"$extensions": {

--- a/packages/theme/tokens/color.json
+++ b/packages/theme/tokens/color.json
@@ -1367,6 +1367,10 @@
 					"$value": "{wpds-color.primitive.bg.fgSurface3}",
 					"$description": "Foreground color for interactive elements with neutral tone and weak emphasis."
 				},
+				"neutral-weak-active": {
+					"$value": "{wpds-color.primitive.bg.fgSurface4}",
+					"$description": "Foreground color for interactive elements with neutral tone and weak emphasis that are hovered, focused, or active."
+				},
 				"neutral-weak-disabled": {
 					"$value": "{wpds-color.primitive.bg.fgSurface2}",
 					"$description": "Foreground color for interactive elements with neutral tone and weak emphasis, in their disabled state."


### PR DESCRIPTION
## What?
Follow up to #77462.

Fills a few semantic token state gaps exposed while documenting intentional token omissions:

- Adds `--wpds-color-background-thumb-brand-disabled`.
- Renames `--wpds-color-background-thumb-neutral-disabled` to `--wpds-color-background-thumb-neutral-weak-disabled`.
- Adds `--wpds-color-foreground-interactive-neutral-weak-active`.
- Updates matching edit-site sidebar navigation styles.
- Clarifies that token omissions are role-based, not matrix-based.

## Why?
These roles already existed in nearby states, but one state was missing and consumers had to use a less precise token. The new tokens keep the same visual values while making the semantic roles explicit.

## Testing Instructions
1. `npm run build:tokens --workspace @wordpress/theme`
2. `npm run postbuild --workspace @wordpress/theme`
3. `npm run lint:md:docs -- packages/theme/docs/tokens.md`
4. `npx wp-scripts lint-style packages/edit-site/src/components/sidebar-navigation-item/style.scss packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss`
5. `git diff --check`
6. `npx wp-scripts test-unit-js --config test/unit/jest.config.js packages/theme`

### Testing Instructions for Keyboard
Not applicable; this PR only updates design tokens and existing token references.

## Screenshots or screencast
Not applicable; token values are visually unchanged.

## Use of AI Tools
This PR was created with assistance from OpenAI Codex. I reviewed and verified the generated changes.
