### PR TITLE
Tests: Honor waitForUploadQueueEmpty timeout in client-side media

### DIFF
--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -106,6 +106,7 @@ class MediaProcessingUtils {
 					.getItems();
 				return items.length === 0;
 			},
+			undefined,
 			{ timeout }
 		);
 	}

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -558,6 +558,12 @@ export default dedupePlugins( [
 					message:
 						'`uuid` is ESM-only and breaks `require()` call sites (see #77960). Use the built-in `crypto.randomUUID()` instead.',
 				},
+				{
+					selector:
+						'CallExpression[callee.property.name="waitForFunction"][arguments.length=2] > ObjectExpression.arguments:has(Property[key.name=/^(timeout|polling)$/])',
+					message:
+						'`waitForFunction( fn, arg, options )`: options is the third argument. Pass `undefined` as the second arg, otherwise `timeout`/`polling` is ignored and falls back to `actionTimeout`.',
+				},
 			],
 			'playwright/no-conditional-in-test': 'off',
 			// Playwright fixtures use `use()` which is not a React hook.


### PR DESCRIPTION
## What?
Same as #79758.
Related #77300.

Should fix failure logged in https://github.com/WordPress/gutenberg/actions/runs/28535674936/job/84596296456?pr=79759.

I've also added a new rule (thanks to Claude). It should flag similar cases `waitForFunction(fn, { timeout })` - 2 args where the 2nd is an options-like object literal (has `timeout`/`polling`). Cases:

- Buggy 2-arg form → error with a message pointing at the fix.
- Correct 3-arg form (`fn, undefined, { timeout }`) → passes.
- Legit 2-arg call with a real page-function `arg` object (no `timeout`/`polling` key) → passes.

## Why?
`waitForUploadQueueEmpty`'s 60s timeout was **silently ignored** — the wait was dying at exactly **10000ms** in both trace attempts.

Playwright's signature is `waitForFunction( pageFunction, arg?, options? )`. The test passed `{ timeout }` in the **second** slot (`arg`), so `options` was `undefined`. The wait then fell back to the base config default `actionTimeout: 10_000` instead of 60s.

## Testing Instructions
CI checks are green.