### PR TITLE
Fix and permit unitless zeros used in CSS `calc` functions

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -18,8 +18,8 @@
 	}
 
 	&.zoom-out-animation {
-		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
-		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0px);
+		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0px);
 		$overflow-behavior: var(--wp-block-editor-iframe-zoom-out-overflow-behavior, scroll);
 
 		position: fixed;
@@ -34,7 +34,7 @@
 
 	&.is-zoomed-out {
 		$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size, 0);
+		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size, 0px);
 		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -232,9 +232,7 @@ html :where(img[class*="wp-image-"]) {
 // Set the admin bar offset for sticky positioned blocks to the height of the admin bar.
 // This allows sticky positioned blocks to be positioned correctly when the admin bar is visible.
 html :where(.is-position-sticky) {
-	/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 	--wp-admin--admin-bar--position-offset: var(--wp-admin--admin-bar--height, 0px);
-	/* stylelint-enable length-zero-no-unit */
 }
 
 // To support sticky positioning, reset the admin bar offset to 0px on mobile devices,
@@ -242,8 +240,6 @@ html :where(.is-position-sticky) {
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
 @media screen and (max-width: 600px) {
 	html :where(.is-position-sticky) {
-		/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 		--wp-admin--admin-bar--position-offset: 0px;
-		/* stylelint-enable length-zero-no-unit */
 	}
 }

--- a/packages/boot/src/components/root/style.scss
+++ b/packages/boot/src/components/root/style.scss
@@ -230,7 +230,7 @@
 	.boot-layout__inspector,
 	.boot-layout__canvas:not(.has-mobile-drawer) {
 		top: var(--wp-admin--admin-bar--height, 0);
-		height: calc(100vh - var(--wp-admin--admin-bar--height, 0));
+		height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 	}
 
 	.boot-layout__mobile-sidebar-drawer {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -12,7 +12,7 @@ body.js.block-editor-page {
 	&.is-fullscreen-mode {
 		@include break-medium {
 			&:has(.editor-editor-interface.is-distraction-free) {
-				--wp-admin--admin-bar--height: 0;
+				--wp-admin--admin-bar--height: 0px;
 
 				#wpadminbar {
 					display: none;
@@ -48,7 +48,7 @@ body.js.block-editor-page {
 
 	// The WP header height changes at this breakpoint.
 	@include break-medium {
-		min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0));
+		min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 	}
 
 	img {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -34,7 +34,7 @@
 	// This is only necessary for the exit animation
 	.edit-site-layout.is-full-canvas & {
 		position: fixed !important;
-		height: calc(100vh - var(--wp-admin--admin-bar--height, 0));
+		height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 		left: 0;
 		top: var(--wp-admin--admin-bar--height, 0);
 	}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -59,7 +59,7 @@ body.js.site-editor-php {
 
 	@include break-medium {
 		&:has(.editor-editor-interface.is-distraction-free) {
-			--wp-admin--admin-bar--height: 0;
+			--wp-admin--admin-bar--height: 0px;
 
 			#wpadminbar {
 				display: none;
@@ -78,7 +78,7 @@ body.js.site-editor-php {
 	@include break-small {
 		bottom: 0;
 		left: 0;
-		height: calc(100vh - var(--wp-admin--admin-bar--height, 0));
+		height: calc(100vh - var(--wp-admin--admin-bar--height, 0px));
 		padding-top: 0;
 		position: fixed;
 		right: 0;

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `length-zero-no-unit` rule now ignores custom properties and `var` functions, for better compatibility with usage inside `calc` functions. `calc` functions are already [exempt from the rule by default](https://stylelint.io/user-guide/rules/length-zero-no-unit/), and this change extends the same exemption to variables that may be used within `calc` functions, as [unitless zeros are not valid in CSS math functions](https://www.w3.org/TR/css-values-4/#calc-type-checking).
 -   Update `@stylistic/stylelint-plugin` to `^3.1.3` ([#79648](https://github.com/WordPress/gutenberg/pull/79648)).
 
 ## 23.41.0 (2026-06-24)

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `length-zero-no-unit` rule now ignores custom properties and `var` functions, for better compatibility with usage inside `calc` functions. `calc` functions are already [exempt from the rule by default](https://stylelint.io/user-guide/rules/length-zero-no-unit/), and this change extends the same exemption to variables that may be used within `calc` functions, as [unitless zeros are not valid in CSS math functions](https://www.w3.org/TR/css-values-4/#calc-type-checking).
+-   `length-zero-no-unit` rule now ignores custom properties and `var` functions, for better compatibility with usage inside `calc` functions. `calc` functions are already [exempt from the rule by default](https://stylelint.io/user-guide/rules/length-zero-no-unit/), and this change extends the same exemption to variables that may be used within `calc` functions, as [unitless zeros are not valid in CSS math functions](https://www.w3.org/TR/css-values-4/#calc-type-checking) ([#79786](https://github.com/WordPress/gutenberg/pull/79786)).
 -   Update `@stylistic/stylelint-plugin` to `^3.1.3` ([#79648](https://github.com/WordPress/gutenberg/pull/79648)).
 
 ## 23.41.0 (2026-06-24)

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -47,7 +47,10 @@ module.exports = {
 			},
 		],
 		'function-url-quotes': 'never',
-		'length-zero-no-unit': true,
+		'length-zero-no-unit': [
+			true,
+			{ ignore: [ 'custom-properties' ], ignoreFunctions: [ 'var' ] },
+		],
 		'rule-empty-line-before': [
 			'always',
 			{

--- a/packages/stylelint-config/test/values-valid.css
+++ b/packages/stylelint-config/test/values-valid.css
@@ -13,3 +13,8 @@
 		0 -1px 0 rgba(0, 0, 0, 0.5),
 		0 1px 0 #fff;
 }
+
+.zero-length-vars {
+	--custom-offset: 0px;
+	margin-block-start: var(--custom-offset, 0px);
+}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Enhancements
-
--   Updates the `--wp-ui-button-padding-block` CSS property to avoid using unitless values, which are incompatible when used in `calc` math functions ([#79786](https://github.com/WordPress/gutenberg/pull/79786)).
-
 ### Bug Fixes
 
 -   `IconButton`: Keep the inline padding override valid when reused in button length calculations ([#79722](https://github.com/WordPress/gutenberg/pull/79722)).
@@ -17,6 +13,7 @@
 -   Add an explicit return type to an internal overlay focus helper so the published type definitions stay self-contained ([#79684](https://github.com/WordPress/gutenberg/pull/79684)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).
+-   Update `--wp-ui-button-padding-block` CSS property to avoid using unitless values, which are incompatible when used in `calc` math functions ([#79786](https://github.com/WordPress/gutenberg/pull/79786)).
 
 ## 0.16.1 (2026-06-30)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Updates the `--wp-ui-button-padding-block` CSS property to avoid using unitless values, which are incompatible when used in `calc` math functions ([#79786](https://github.com/WordPress/gutenberg/pull/79786)).
+
 ### Bug Fixes
 
 -   `IconButton`: Keep the inline padding override valid when reused in button length calculations ([#79722](https://github.com/WordPress/gutenberg/pull/79722)).

--- a/packages/ui/src/button/style.module.css
+++ b/packages/ui/src/button/style.module.css
@@ -146,7 +146,7 @@
 		}
 
 		.is-small {
-			--wp-ui-button-padding-block: 0;
+			--wp-ui-button-padding-block: 0px;
 			--wp-ui-button-padding-inline: var(--wpds-dimension-padding-sm);
 			--wp-ui-button-height: var(--wpds-dimension-size-sm);
 		}

--- a/packages/ui/src/form/primitives/input/style.module.css
+++ b/packages/ui/src/form/primitives/input/style.module.css
@@ -4,8 +4,8 @@
 	@layer components {
 		.input {
 			--_gcd-input-padding:
-				var(--wp-ui-input-padding-block, 0)
-				var(--wp-ui-input-layout-padding-inline, 0);
+				var(--wp-ui-input-padding-block, 0px)
+				var(--wp-ui-input-layout-padding-inline, 0px);
 
 			padding-block: var(--wp-ui-input-padding-block, 0);
 			padding-inline: var(--wp-ui-input-layout-padding-inline, 0);

--- a/packages/ui/src/icon-button/style.module.css
+++ b/packages/ui/src/icon-button/style.module.css
@@ -4,7 +4,6 @@
 	@layer compositions {
 		.icon-button {
 			--wp-ui-button-aspect-ratio: 1;
-			/* stylelint-disable-next-line length-zero-no-unit -- This custom property is reused in Button's min-width calc(), where a unitless zero is invalid. */
 			--wp-ui-button-padding-inline: 0px;
 			--wp-ui-button-min-width: unset;
 		}


### PR DESCRIPTION
## What?

- Updates `@wordpress/stylelint-config` configuration to ignore [`length-zero-no-unit` rule](https://stylelint.io/user-guide/rules/length-zero-no-unit/) for `var` and custom properties
- Updates all existing problematic instances of unitless zeros that are used in `calc` or assigned to variables to specify the unit
- Removes now-unnecessary inline `/* stylelint-disable length-zero-no-unit */` overrides that existed to work around this issue

Related:

- https://github.com/WordPress/gutenberg/pull/79627#issuecomment-4835180355
- https://github.com/WordPress/gutenberg/pull/79197/files#r3501814400

## Why?

As described in [my earlier comment](https://github.com/WordPress/gutenberg/pull/79197/files#r3501814400) on #79197, the CSS specification [does not allow using unitless 0 values in calc functions](https://www.w3.org/TR/css-values-4/#calc-type-checking):

> Note: Because [`<number-token>`](https://www.w3.org/TR/css-syntax-3/#typedef-number-token)s are always interpreted as [`<number>`](https://www.w3.org/TR/css-values-4/#number-value)s or [`<integer>`](https://www.w3.org/TR/css-values-4/#integer-value)s, "unitless 0" [`<length>`](https://www.w3.org/TR/css-values-4/#length-value)s aren’t supported in [math functions](https://www.w3.org/TR/css-values-4/#math-function). That is, [`width: calc(0 + 5px);`](https://www.w3.org/TR/css-sizing-3/#propdef-width) is invalid, because it’s trying to add a `<number>` to a `<length>`, even though both `width: 0;` and `width: 5px;` are valid.

The `length-zero-no-unit` Stylelint rule [does not check values inside `calc`](https://stylelint.io/user-guide/rules/length-zero-no-unit/) , presumably for this very reason:

> This rule ignores lengths within math functions (e.g. `calc`).

But the default rule configuration does _not_ ignore other problematic unitless number usage within math functions, when referenced through variables.

For example:

```css
--foo: 0px;
margin-top: calc( 5px + var( --foo, 0px ) );
```

In the example above, both the custom variable value assignment as well as the fallback value inside `var` would have previously been flagged as a lint error encouraging the use of unitless zero, even when doing so would violate the spec and break styling in the browser.

## How?

- Updates `length-zero-no-unit` configuration to use [`ignore`](https://stylelint.io/user-guide/rules/length-zero-no-unit/#ignore) and [`ignoreFunctions`](https://stylelint.io/user-guide/rules/length-zero-no-unit/#ignorefunctions) to avoid reporting rules on usage of unitless zero within `var` or custom property assignment
- Updates existing variables to avoid unitless zero

Existing usages were audited using code regex searches for patterns `(var|calc)\([^)]+\d+[) ]` and `--[a-z-]+: \d+;`.

Worth noting that not all unitless zero usage within `calc` is actually problematic, despite the spec text quoted above painting a broad brush. From what I can tell and interpret from the spec, it's only a problem for addition and subtraction, but not a problem for multiplication and division. This is because the spec behavior for [adding two types](https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types) has failure states for mismatched types that do not extend to [multiplying two types](https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types).

This is relevant for a couple reasons:

- We have unitless zero used in `calc` functions that cannot and should not be updated, multiplying some unit number by a unitless factor ([example](https://github.com/WordPress/gutenberg/blob/aec5f7761b0fa01ee9e68dffcff32bdc2b457d5e/packages/grid/src/shared/grid-overlay.module.css#L29))
- If we were to consider a lint rule to _require_ units, we should be careful to make exceptions in some valid cases like these

I would like to explore a lint rule to require units where reasonable. Right now all this does is not explicitly forbid united numbers in `calc` functions, but there's nothing to actually _require_ it, despite the fact that omitting the unit can break styles.

## Testing Instructions

Verify `npm run lint:css` passes

Review updated styles for accuracy and/or check in browser for regressions.

To verify a real issue fixed by these issues, observe the `min-height` style applied to `.block-editor__container` with distraction free and full screen modes enabled, and a viewport size greater than 782px (see screenshot below).

## Screenshots or screencast <!-- if applicable -->

The before/after shows the computed `min-height` value of `.block-editor__container` at viewport size greater than 782px and distraction free/full screen modes enabled, where previously this would attempt to compute `calc(100vh - 0)` which is invalid and produces a computed value of `0` instead of the expected viewport height.

|Before|After|
|-|-|
<img width="1115" height="1192" alt="Screenshot 2026-07-01 at 2 46 56 PM" src="https://github.com/user-attachments/assets/edae8774-879a-4c27-9a0b-ce4ab4b0cb25" />|<img width="1115" height="1192" alt="Screenshot 2026-07-01 at 2 47 22 PM" src="https://github.com/user-attachments/assets/991b9c6e-c1e3-44d0-b097-d994bfc0cc5e" />


## Use of AI Tools

I used Claude Desktop chat + Opus 4.8 model for understanding the validity of multiplication of unitless numbers in math functions based on the specification language, but otherwise everything here was researched and implemented without AI assistance.