### PR TITLE
Background Support: Allow modern color functions in standalone gradients

### DIFF
--- a/lib/compat/wordpress-7.1/kses.php
+++ b/lib/compat/wordpress-7.1/kses.php
@@ -97,3 +97,41 @@ function gutenberg_add_svg_to_safe_style_css( array $attr ): array {
 	return array_unique( array_merge( $attr, $svg_properties ) );
 }
 add_filter( 'safe_style_css', 'gutenberg_add_svg_to_safe_style_css' );
+
+/**
+ * Allow gradient background-image values, including gradients combined with a
+ * url() image, in inline styles.
+ *
+ * Without this, {@see safecss_filter_attr()} strips gradients that use functions
+ * beyond rgb()/rgba(), or that are combined with a url() image. This removes each
+ * gradient from the test string and re-checks the remainder, so those values
+ * survive sanitization.
+ *
+ * @param bool   $allow_css       Whether the CSS is allowed.
+ * @param string $css_test_string The CSS declaration to test.
+ * @return bool Whether the CSS is allowed.
+ */
+function gutenberg_allow_extended_gradient_backgrounds( $allow_css, $css_test_string ) {
+	if ( $allow_css ) {
+		return $allow_css;
+	}
+
+	if ( ! preg_match( '/^background-image\s*:/', $css_test_string ) ) {
+		return $allow_css;
+	}
+
+	/*
+	 * Remove each gradient (allowing one level of nested functions such as
+	 * rgb(), hsl(), or calc()) and re-test. Any url() has already been removed
+	 * and protocol-checked by safecss_filter_attr() before this filter runs.
+	 */
+	$stripped = preg_replace( '/(?:repeating-)?(?:linear|radial|conic)-gradient\((?:[^()]|\([^()]*\))*\)/', '', $css_test_string );
+
+	if ( ! preg_match( '%[\\\(&=}]|/\*%', $stripped ) ) {
+		return true;
+	}
+
+	return $allow_css;
+}
+
+add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_allow_extended_gradient_backgrounds', 10, 2 );

--- a/lib/experimental/kses.php
+++ b/lib/experimental/kses.php
@@ -96,58 +96,6 @@ if ( ! function_exists( 'allow_filter_in_styles' ) ) {
 add_filter( 'safecss_filter_attr_allow_css', 'allow_filter_in_styles', 10, 2 );
 
 /**
- * Allow combined gradient and url() background-image values in inline styles.
- *
- * WordPress's safecss_filter_attr() handles gradient and url() values
- * separately for background-image, but fails when both appear in a single
- * comma-separated declaration. The url() portion is stripped from the test
- * string before the filter runs, but the gradient regex in core expects the
- * gradient to be the only value and doesn't match when a trailing comma and
- * whitespace remain. This leaves parentheses in the test string, which
- * triggers the unsafe-character check.
- *
- * This filter catches that case: the test string still contains a valid
- * gradient function with only commas and whitespace remaining after the
- * url() was removed.
- *
- * @param bool   $allow_css       Whether the CSS is allowed.
- * @param string $css_test_string The CSS declaration to test.
- * @return bool Whether the CSS is allowed.
- */
-function gutenberg_allow_background_image_combined( $allow_css, $css_test_string ) {
-	if ( $allow_css ) {
-		return $allow_css;
-	}
-	/*
-	 * The test string at this point has url() values already removed by
-	 * safecss_filter_attr. What remains is a gradient with comma/whitespace
-	 * residue where the url() was stripped. Two possible forms:
-	 *
-	 * Gradient first: "background-image:<gradient>(...), "
-	 * URL first:      "background-image:, <gradient>(...)"
-	 *
-	 * A trailing or leading comma (with optional whitespace) must be present
-	 * to confirm a url() was actually removed. Without that residue, the
-	 * gradient alone would already pass core's own check.
-	 */
-	$gradient_pattern = '(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\((?:[^()]|\([^()]*\))*\)';
-	$var_pattern      = 'var\(--[a-zA-Z0-9_-]+(?:--[a-zA-Z0-9_-]+)*\)';
-	$value_pattern    = "(?:$gradient_pattern|$var_pattern)";
-
-	// Gradient/var first, then comma+whitespace residue from stripped url().
-	$pattern_gradient_first = '/^background-image\s*:\s*' . $value_pattern . '\s*,[\s,]*$/';
-	// Stripped url() first (comma+whitespace residue), then gradient/var.
-	$pattern_url_first = '/^background-image\s*:[\s,]*,\s*' . $value_pattern . '\s*$/';
-
-	if ( preg_match( $pattern_gradient_first, $css_test_string ) || preg_match( $pattern_url_first, $css_test_string ) ) {
-		return true;
-	}
-
-	return $allow_css;
-}
-add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_allow_background_image_combined', 10, 2 );
-
-/**
  * Update allowed inline style attributes list.
  *
  * @param string[] $attrs Array of allowed CSS attributes.

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -289,31 +289,27 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that combined background gradient and image CSS values pass KSES.
+	 * Tests that background gradients using functions beyond rgb()/rgba(), and
+	 * gradients combined with a url() image, survive KSES sanitization.
 	 *
-	 * WordPress's safecss_filter_attr() handles gradient and url() values
-	 * separately but strips the declaration when both appear in a single
-	 * comma-separated background-image. The gutenberg_allow_background_image_combined
-	 * filter should ensure these combined values survive sanitization.
+	 * @covers ::gutenberg_allow_extended_gradient_backgrounds
 	 *
-	 * @covers ::gutenberg_allow_background_image_combined
-	 *
-	 * @dataProvider data_background_combined_values_pass_kses
+	 * @dataProvider data_background_gradient_values_pass_kses
 	 *
 	 * @param string $css The CSS declaration to test.
 	 */
-	public function test_background_combined_values_pass_kses( $css ) {
+	public function test_background_gradient_values_pass_kses( $css ) {
 		$result = safecss_filter_attr( $css );
 		$this->assertNotEmpty( $result, "Expected CSS to be allowed: $css" );
 		$this->assertStringContainsString( 'background-image', $result );
 	}
 
 	/**
-	 * Data provider for combined background-image KSES tests.
+	 * Data provider for gradient background-image KSES tests.
 	 *
 	 * @return array[]
 	 */
-	public function data_background_combined_values_pass_kses() {
+	public function data_background_gradient_values_pass_kses() {
 		return array(
 			'gradient first with rgb colors'     => array(
 				'background-image: linear-gradient(135deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%), url(https://example.com/image.jpg)',
@@ -353,6 +349,15 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 			),
 			'gradient with hex colors'           => array(
 				'background-image: linear-gradient(135deg, #ff0000 0%, #0000ff 100%), url(https://example.com/image.jpg)',
+			),
+			'standalone hsl gradient'            => array(
+				'background-image: linear-gradient(135deg, hsl(0, 100%, 50%) 0%, hsl(240, 100%, 50%) 100%)',
+			),
+			'standalone oklch gradient'          => array(
+				'background-image: linear-gradient(oklch(0.7 0.15 30), oklch(0.5 0.2 260))',
+			),
+			'standalone gradient with calc'      => array(
+				'background-image: linear-gradient(red 0%, blue calc(50% + 10px))',
 			),
 		);
 	}


### PR DESCRIPTION
## What?

Brings the changes from the Core backport (WordPress/wordpress-develop#11384) back to Gutenberg, and moves the gradient KSES filter into the WordPress 7.1 compat folder.

Follow up to #75859.

## Why?

The Core backport updates `safecss_filter_attr()` directly to allow gradient background values. This PR aligns Gutenberg with tweaks made to Core's approach and relocates the shim so it is removed automatically once these changes reach Gutenberg's minimum supported WordPress version.

## How?

- Moves the filter from `lib/experimental/kses.php` into `lib/compat/wordpress-7.1/kses.php`, so it is deleted along with that folder once 7.1 is the minimum supported version.
- Updates the logic to match Core. It removes each gradient from the test string and re-checks the remainder, which allows gradients using functions beyond `rgb()` and `rgba()` (such as `hsl()`, `oklch()` and `calc()`), whether standalone or combined with a `url()` image.
- Renames the function to `gutenberg_allow_extended_gradient_backgrounds` to reflect what it now covers.
- Registers the filter unconditionally, like the neighbouring shim. It is a no-op on WordPress 7.1 and later, where Core handles these values natively.
- Extends the background support tests with standalone gradient cases.

## Testing Instructions

No manual testing needed. Coverage lives in the background support tests (`phpunit/block-supports/background-test.php`). Wait for CI and the e2e tests to pass.
