### PR TITLE
Performance: Follow-up normalization in prepend_to_selector() and append_to_selector().

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1275,7 +1275,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The new selector.
 	 */
 	protected static function append_to_selector( $selector, $to_append ) {
-			if ( ! str_contains( $selector, ',' ) ) {
+		if ( ! str_contains( $selector, ',' ) ) {
 			return trim( $selector, " \t\n" ) . $to_append;
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1275,8 +1275,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string The new selector.
 	 */
 	protected static function append_to_selector( $selector, $to_append ) {
-		if ( ! str_contains( $selector, ',' ) ) {
-			return $selector . $to_append;
+			if ( ! str_contains( $selector, ',' ) ) {
+			return trim( $selector, " \t\n" ) . $to_append;
 		}
 
 		/**
@@ -1299,7 +1299,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * @see https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
 		 */
 		if ( strlen( $selector ) === strcspn( $selector, '/\'"(<\\' ) ) {
-			return str_replace( ',', $to_append . ',', $selector ) . $to_append;
+			return preg_replace( '~[ \t\n]*,[ \t\n]*~', "{$to_append}, ", trim( $selector, " \t\n" ) ) . $to_append;
 		}
 
 		$new_selectors = array();
@@ -1325,7 +1325,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	protected static function prepend_to_selector( $selector, $to_prepend ) {
 		if ( ! str_contains( $selector, ',' ) ) {
-			return $to_prepend . $selector;
+			return $to_prepend . trim( $selector, " \t\n" );
 		}
 
 		/**
@@ -1348,7 +1348,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * @see https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
 		 */
 		if ( strlen( $selector ) === strcspn( $selector, '/\'"(<\\' ) ) {
-			return $to_prepend . str_replace( ',', ',' . $to_prepend, $selector );
+			return $to_prepend . preg_replace( '~[ \t\n]*,[ \t\n]*~', ", {$to_prepend}", trim( $selector, " \t\n" ) );
 		}
 
 		$new_selectors = array();

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7589,7 +7589,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover, .wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover, .wp-block-button .wp-block-button__link .wp-block-button__link:hover){color: orange;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8141,17 +8141,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'two comma-separated selectors without spaces' => array(
 				'selector'   => 'h1,h2',
 				'to_prepend' => '.wrapper ',
-				'expected'   => '.wrapper h1,.wrapper h2',
+				'expected'   => '.wrapper h1, .wrapper h2',
 			),
 			'three comma-separated selectors without spaces' => array(
 				'selector'   => 'h1,h2,h3',
 				'to_prepend' => '.some-class ',
-				'expected'   => '.some-class h1,.some-class h2,.some-class h3',
+				'expected'   => '.some-class h1, .some-class h2, .some-class h3',
 			),
 			'comma-separated class selectors without spaces' => array(
 				'selector'   => '.foo,.bar',
 				'to_prepend' => '.prefix ',
-				'expected'   => '.prefix .foo,.prefix .bar',
+				'expected'   => '.prefix .foo, .prefix .bar',
 			),
 			'prepend without trailing space'               => array(
 				'selector'   => '.child',
@@ -8161,7 +8161,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'compound selector without trailing space no comma spaces' => array(
 				'selector'   => '.a,.b',
 				'to_prepend' => '.parent',
-				'expected'   => '.parent.a,.parent.b',
+				'expected'   => '.parent.a, .parent.b',
 			),
 			'descendant selector prepended'                => array(
 				'selector'   => '.block .inner',
@@ -8171,7 +8171,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'descendant selectors comma-separated without spaces' => array(
 				'selector'   => '.block .inner,.block .alt',
 				'to_prepend' => '.scope ',
-				'expected'   => '.scope .block .inner,.scope .block .alt',
+				'expected'   => '.scope .block .inner, .scope .block .alt',
 			),
 			'empty selector'                               => array(
 				'selector'   => '',
@@ -8201,7 +8201,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'many comma-separated selectors without spaces' => array(
 				'selector'   => 'h1,h2,h3,h4,h5,h6',
 				'to_prepend' => '.content ',
-				'expected'   => '.content h1,.content h2,.content h3,.content h4,.content h5,.content h6',
+				'expected'   => '.content h1, .content h2, .content h3, .content h4, .content h5, .content h6',
 			),
 			'real world block element selector'            => array(
 				'selector'   => 'p',
@@ -8211,22 +8211,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'real world compound block element selectors'  => array(
 				'selector'   => 'a,.wp-element-button',
 				'to_prepend' => '.wp-block-group ',
-				'expected'   => '.wp-block-group a,.wp-block-group .wp-element-button',
+				'expected'   => '.wp-block-group a, .wp-block-group .wp-element-button',
 			),
-			'spaces after commas are preserved'            => array(
+			'spaces after commas are normalized'            => array(
 				'selector'   => 'h1, h2, h3',
 				'to_prepend' => '.some-class ',
-				'expected'   => '.some-class h1,.some-class  h2,.some-class  h3',
+				'expected'   => '.some-class h1, .some-class  h2, .some-class  h3',
 			),
-			'spaces after commas preserved with class selectors' => array(
+			'spaces after commas normalized with class selectors' => array(
 				'selector'   => '.foo, .bar',
 				'to_prepend' => '.prefix ',
-				'expected'   => '.prefix .foo,.prefix  .bar',
+				'expected'   => '.prefix .foo, .prefix  .bar',
 			),
-			'mixed whitespace around commas preserved'     => array(
+			'mixed whitespace around commas trimmed'     => array(
 				'selector'   => '.a ,  .b , .c',
 				'to_prepend' => '.pre ',
-				'expected'   => '.pre .a ,.pre   .b ,.pre  .c',
+				'expected'   => '.pre .a, .pre   .b, .pre  .c',
 			),
 			'where with internal commas and no top-level comma' => array(
 				'selector'   => ':where(.a, .b)',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8213,7 +8213,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'to_prepend' => '.wp-block-group ',
 				'expected'   => '.wp-block-group a, .wp-block-group .wp-element-button',
 			),
-			'spaces after commas are normalized'            => array(
+			'spaces after commas are normalized'           => array(
 				'selector'   => 'h1, h2, h3',
 				'to_prepend' => '.some-class ',
 				'expected'   => '.some-class h1, .some-class  h2, .some-class  h3',
@@ -8223,7 +8223,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'to_prepend' => '.prefix ',
 				'expected'   => '.prefix .foo, .prefix  .bar',
 			),
-			'mixed whitespace around commas trimmed'     => array(
+			'mixed whitespace around commas trimmed'       => array(
 				'selector'   => '.a ,  .b , .c',
 				'to_prepend' => '.pre ',
 				'expected'   => '.pre .a, .pre   .b, .pre  .c',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7589,7 +7589,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button,.wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover,.wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover,.wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
@@ -8216,17 +8216,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'spaces after commas are normalized'           => array(
 				'selector'   => 'h1, h2, h3',
 				'to_prepend' => '.some-class ',
-				'expected'   => '.some-class h1, .some-class  h2, .some-class  h3',
+				'expected'   => '.some-class h1, .some-class h2, .some-class  h3',
 			),
 			'spaces after commas normalized with class selectors' => array(
 				'selector'   => '.foo, .bar',
 				'to_prepend' => '.prefix ',
-				'expected'   => '.prefix .foo, .prefix  .bar',
+				'expected'   => '.prefix .foo, .prefix .bar',
 			),
-			'mixed whitespace around commas trimmed'       => array(
+			'mixed whitespace around commas normalized'    => array(
 				'selector'   => '.a ,  .b , .c',
 				'to_prepend' => '.pre ',
-				'expected'   => '.pre .a, .pre   .b, .pre  .c',
+				'expected'   => '.pre .a, .pre .b, .pre .c',
 			),
 			'where with internal commas and no top-level comma' => array(
 				'selector'   => ':where(.a, .b)',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7589,7 +7589,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover,.wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover, .wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
@@ -8216,7 +8216,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'spaces after commas are normalized'           => array(
 				'selector'   => 'h1, h2, h3',
 				'to_prepend' => '.some-class ',
-				'expected'   => '.some-class h1, .some-class h2, .some-class  h3',
+				'expected'   => '.some-class h1, .some-class h2, .some-class h3',
 			),
 			'spaces after commas normalized with class selectors' => array(
 				'selector'   => '.foo, .bar',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7589,7 +7589,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover, .wp-block-button .wp-block-button__link .wp-block-button__link:hover){color: orange;}';
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button, .wp-block-button .wp-block-button__link .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover, .wp-block-button .wp-block-button__link .wp-block-button__link:hover){color: orange;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 


### PR DESCRIPTION
Trac ticket: Core-65533

Whitespaces were normalized in #79499 when improving the reliability of
the `split_selector_list()` method, but the fast-paths in
`append_to_selector()` and `prepend_to_selector()` still left whitespace
untouched. This led to inconsistent test cases depending on whether the
fast path was taken, or the full path.

This patch normalizes behavior for these methods so that callees need
only be aware of the one operating mode, where whitespace beteween and
around top-level selectors in a compound selector list are normalized.