### PR TITLE
Global Styles: Match block panel order to the block inspector

### DIFF
--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -364,15 +364,6 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					</VStack>
 				</div>
 			) }
-			{ hasBackgroundPanel && (
-				<StylesBackgroundPanel
-					inheritedValue={ inheritedStyle }
-					value={ style }
-					onChange={ setStyle }
-					settings={ settings }
-					defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
-				/>
-			) }
 			{ hasTypographyPanel && (
 				<StylesTypographyPanel
 					inheritedValue={ inheritedStyle }
@@ -383,6 +374,24 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					// paragraphs") when not editing a state-specific variation,
 					// because those settings are global and cannot be per-breakpoint.
 					isGlobalStyles={ ! hasSelectedState }
+				/>
+			) }
+			{ hasBackgroundPanel && (
+				<StylesBackgroundPanel
+					inheritedValue={ inheritedStyle }
+					value={ style }
+					onChange={ setStyle }
+					settings={ settings }
+					defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
+				/>
+			) }
+			{ shouldShowFiltersPanel && (
+				<StylesFiltersPanel
+					inheritedValue={ inheritedStyleWithLayout }
+					value={ styleWithLayout }
+					onChange={ setStyle }
+					settings={ settings }
+					includeLayoutControls
 				/>
 			) }
 			{ hasDimensionsPanel && (
@@ -400,15 +409,6 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 					value={ style }
 					onChange={ onChangeBorders }
 					settings={ settings }
-				/>
-			) }
-			{ shouldShowFiltersPanel && (
-				<StylesFiltersPanel
-					inheritedValue={ inheritedStyleWithLayout }
-					value={ styleWithLayout }
-					onChange={ setStyle }
-					settings={ settings }
-					includeLayoutControls
 				/>
 			) }
 			{ hasColorPanel && (


### PR DESCRIPTION
## What?

Reorder the panels on the block-type Global Styles screen so they match the block inspector's Styles tab:

- Before: Background, Typography, Dimensions, Border, Filters, Color
- After: Typography, Background, Filters, Dimensions, Border, Color

Image settings and Advanced are unchanged and remain last.

## Why?

Follow up to #77279, which relocated the text, background, and element color controls into the Typography, Background, and Elements/Color panels. That PR updated the block inspector's panel order and moved the Color panel to the end
in Global Styles, but it didn't bring the rest of the Global Styles panels in line.

The result is that the same block shows its panels in a different order depending on where you edit it. This is purely a consistency fix so the two surfaces read the same way.

## How?

Reordered the conditionally rendered panels in `packages/global-styles-ui/src/screen-block.tsx`. No prop, hook, or logic changes; each panel keeps its existing render guards.

## Screenshots

| Global Styles - Before | Global Styles - After | Block Inspector |
|---|---|---|
| <img width="139" height="1127" alt="Screenshot 2026-07-01 at 3 34 51 pm" src="https://github.com/user-attachments/assets/16688077-9f68-444a-9dad-c20e52189515" /> | <img width="139" height="1119" alt="Screenshot 2026-07-01 at 3 42 17 pm" src="https://github.com/user-attachments/assets/911f0b20-a50d-4b30-b8ad-7020ec335285" /> | <img width="140" height="462" alt="Screenshot 2026-07-01 at 3 44 11 pm" src="https://github.com/user-attachments/assets/3b7e86f7-d8ac-4a74-b660-41b4d50b4deb" /> |


## Testing Instructions

1. Open the Site Editor and go to Styles > Blocks, then pick a block (e.g.
   Group or Paragraph).
2. Note the panels order: Typography, Background, Filters
   (where applicable), Dimensions, Border, Color, Image settings, Advanced.
3. Select the same block in the editor canvas and open the inspector's Styles
   tab.
4. Confirm the shared panels follow the same order.
