### PR TITLE
Block position: Allow options dropdown to flip

### DIFF
--- a/packages/block-editor/src/hooks/block-hooks.scss
+++ b/packages/block-editor/src/hooks/block-hooks.scss
@@ -15,3 +15,26 @@
 		margin-bottom: $grid-unit-20;
 	}
 }
+
+.block-editor-hooks__position-control-item {
+	// Allow Base UI's item text wrapper to shrink inside the select item's flex row.
+	> div {
+		min-width: 0;
+	}
+}
+
+.block-editor-hooks__position-control-item-content,
+.block-editor-hooks__position-control-item-hint {
+	display: block;
+	white-space: normal;
+}
+
+.block-editor-hooks__position-control-item-content {
+	max-inline-size: 280px;
+}
+
+.block-editor-hooks__position-control-item-hint {
+	color: $gray-700;
+	margin-block-start: $grid-unit-05;
+	overflow-wrap: break-word;
+}

--- a/packages/block-editor/src/hooks/block-hooks.scss
+++ b/packages/block-editor/src/hooks/block-hooks.scss
@@ -18,6 +18,11 @@
 }
 
 .block-editor-hooks__position-control-item {
+
+	/**
+	 * Try to make items match the width of the anchor, subtract any margin on
+	 * items to calculate the correct inner width.
+	 */
 	max-inline-size: max(calc(var(--anchor-width) - (2 * var(--wp-ui-popup-padding))), 223px);
 }
 

--- a/packages/block-editor/src/hooks/block-hooks.scss
+++ b/packages/block-editor/src/hooks/block-hooks.scss
@@ -2,6 +2,7 @@
 @use "@wordpress/base-styles/colors" as *;
 
 .block-editor-hooks__block-hooks {
+
 	/**
 	 * Un-reverse the flex direction for the toggle's label.
 	 */
@@ -17,24 +18,10 @@
 }
 
 .block-editor-hooks__position-control-item {
-	// Allow Base UI's item text wrapper to shrink inside the select item's flex row.
-	> div {
-		min-width: 0;
-	}
-}
-
-.block-editor-hooks__position-control-item-content,
-.block-editor-hooks__position-control-item-hint {
-	display: block;
-	white-space: normal;
-}
-
-.block-editor-hooks__position-control-item-content {
-	max-inline-size: 280px;
+	max-inline-size: max(calc(var(--anchor-width) - (2 * var(--wp-ui-popup-padding))), 223px);
 }
 
 .block-editor-hooks__position-control-item-hint {
-	color: $gray-700;
+	color: var(--wpds-color-foreground-content-neutral-weak);
 	margin-block-start: $grid-unit-05;
-	overflow-wrap: break-word;
 }

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -10,7 +10,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useId, useMemo } from '@wordpress/element';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Use the portal-based popup to avoid inspector clipping.
 import { SelectControl } from '@wordpress/ui';
 
@@ -263,6 +263,7 @@ export function PositionPanelPure( {
 	const selectedOption = value
 		? options.find( ( option ) => option.value === value ) || DEFAULT_OPTION
 		: DEFAULT_OPTION;
+	const hintIdPrefix = useId();
 
 	// Only display position controls if there is at least one option to choose from.
 	return options.length > 1 ? (
@@ -276,25 +277,33 @@ export function PositionPanelPure( {
 				onValueChange={ ( selectedItem ) => {
 					onChangeType( selectedItem.value );
 				} }
-				size="large"
 			>
-				{ options.map( ( option ) => (
-					<SelectControl.Item
-						key={ option.key }
-						value={ option }
-						label={ option.label }
-						className="block-editor-hooks__position-control-item"
-					>
-						<span className="block-editor-hooks__position-control-item-content">
-							{ option.label }
+				{ options.map( ( option ) => {
+					const hintId = option.hint
+						? `${ hintIdPrefix }-${ option.key }`
+						: undefined;
+
+					return (
+						<SelectControl.Item
+							key={ option.key }
+							value={ option }
+							label={ option.label }
+							className="block-editor-hooks__position-control-item"
+							aria-describedby={ hintId }
+						>
+							<div>{ option.label }</div>
 							{ option.hint && (
-								<span className="block-editor-hooks__position-control-item-hint">
+								<div
+									id={ hintId }
+									className="block-editor-hooks__position-control-item-hint"
+									aria-hidden="true"
+								>
 									{ option.hint }
-								</span>
+								</div>
 							) }
-						</span>
-					</SelectControl.Item>
-				) ) }
+						</SelectControl.Item>
+					);
+				} ) }
 			</SelectControl>
 		</InspectorControls>
 	) : null;

--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -8,10 +8,11 @@ import clsx from 'clsx';
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
-import { BaseControl, CustomSelectControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Use the portal-based popup to avoid inspector clipping.
+import { SelectControl } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -27,13 +28,13 @@ const POSITION_SUPPORT_KEY = 'position';
 const DEFAULT_OPTION = {
 	key: 'default',
 	value: '',
-	name: __( 'Default' ),
+	label: __( 'Default' ),
 };
 
 const STICKY_OPTION = {
 	key: 'sticky',
 	value: 'sticky',
-	name: _x( 'Sticky', 'Name for the value of the CSS position property' ),
+	label: _x( 'Sticky', 'Name for the value of the CSS position property' ),
 	hint: __(
 		'The block will stick to the top of the window instead of scrolling.'
 	),
@@ -42,7 +43,7 @@ const STICKY_OPTION = {
 const FIXED_OPTION = {
 	key: 'fixed',
 	value: 'fixed',
-	name: _x( 'Fixed', 'Name for the value of the CSS position property' ),
+	label: _x( 'Fixed', 'Name for the value of the CSS position property' ),
 	hint: __( 'The block will not move when the page is scrolled.' ),
 };
 
@@ -266,22 +267,35 @@ export function PositionPanelPure( {
 	// Only display position controls if there is at least one option to choose from.
 	return options.length > 1 ? (
 		<InspectorControls group="position">
-			<BaseControl help={ stickyHelpText }>
-				<CustomSelectControl
-					label={ __( 'Position' ) }
-					hideLabelFromVision
-					describedBy={ sprintf(
-						// translators: %s: Currently selected position.
-						__( 'Currently selected position: %s' ),
-						selectedOption.name
-					) }
-					options={ options }
-					value={ selectedOption }
-					onChange={ ( { selectedItem } ) => {
-						onChangeType( selectedItem.value );
-					} }
-				/>
-			</BaseControl>
+			<SelectControl
+				label={ __( 'Position' ) }
+				hideLabelFromVision
+				description={ stickyHelpText }
+				items={ options }
+				value={ selectedOption }
+				onValueChange={ ( selectedItem ) => {
+					onChangeType( selectedItem.value );
+				} }
+				size="large"
+			>
+				{ options.map( ( option ) => (
+					<SelectControl.Item
+						key={ option.key }
+						value={ option }
+						label={ option.label }
+						className="block-editor-hooks__position-control-item"
+					>
+						<span className="block-editor-hooks__position-control-item-content">
+							{ option.label }
+							{ option.hint && (
+								<span className="block-editor-hooks__position-control-item-hint">
+									{ option.hint }
+								</span>
+							) }
+						</span>
+					</SelectControl.Item>
+				) ) }
+			</SelectControl>
 		</InspectorControls>
 	) : null;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue where the the Position dropdown on blocks opens a tiny dropdown when at the bottom of the screen (which is most of the time with my monitor size):
<img width="286" height="199" alt="Screenshot 2026-07-02 at 11 38 17 am" src="https://github.com/user-attachments/assets/d8bc62f1-4259-451a-848c-6274661e6580" />

This happens because `CustomSelectControl` seems to force its dropdown to open downwards, so it resizes to fit the available space, which barely any space at all. Opening it upwards when there's not enough space solves the issue.

This likely started happening after the ToolsPanels were rearranged a few times lately.

## How?
Note - I'm not completely sure this is the optimal fix, there's a lot of history and complexity to digest around the component. I could spend lots of time researching and still come up with the wrong fix, so I'm proposing initially the easiest option, but happy to receive feedback on how to approach it.

Adds a `allowPopoverFlip` option that allows `CustomSelectControl` to opt in to the flip behavior. This is opt-in because I don't want all `CustomSelectControl`s to have this behavior, it seems to have caused issues in the past -  #63180.

For a smaller dropdown flipping upwards is fine. I'm not sold on the exact naming, happy to take recommendations.

There are probably several other options for fixing this:
- Use the regular `SelectControl` - but I believe it means losing the help text on the options, which seems important.
- Use `@wordpress/ui` `SelectControl` - this works, and it's my preferred option, but linting recommends not to use this component currently. It seems to have some small differences to `CustomSelectControl`, but not sure if that's from my quick attempt at an implementation.
- Reorder the ToolsPanels so that Position isn't at the bottom. This doesn't really solve the situation, there's no guarantee that Position will never be at the bottom given the inspector is extensible.

## Testing Instructions
1. Add a group block
2. Open the block inspector
3. Resize your browser window if necessary to the point where there's a scrollbar in the block inspector.
4. Scroll down and open 'Position'

In this PR: The options popover opens to its full size, above the control if necessary.
In trunk: The options popover opens below, and is possibly very small.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="286" height="199" alt="Screenshot 2026-07-02 at 11 38 17 am" src="https://github.com/user-attachments/assets/bd7e15cc-1646-498b-a47c-589d1170b1d8" /> |<img width="259" height="253" alt="Screenshot 2026-07-02 at 12 03 03 pm" src="https://github.com/user-attachments/assets/f0c0777b-6f66-448f-b71c-7a82d8d5f00b" /> |

## Use of AI Tools
OpenCode / Codex