### PR TITLE
lintstaged: Avoid appending filenames to the `prelint:js` command

### DIFF
--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+	'*.{js,json,ts,tsx,yml,yaml}': [ 'wp-scripts format' ],
+	'**/*.{js,ts,tsx,jsx}': [
+		() => 'npm run prelint:js',
+		'node ./tools/eslint/lint-js.cjs --config eslint.config.strict.cjs',
+	],
+	'*.scss': [ 'wp-scripts lint-style' ],
+	'package-lock.json': [ 'npm run lint:lockfile' ],
+	'packages/*/package.json': [ 'wp-scripts lint-pkg-json' ],
+	'{docs/toc.json,tools/docs/*.cjs,packages/{*/README.md,components/src/*/**/README.md,block-library/src/*/README.md}}':
+		[ 'npm run docs:gen' ],
+	'packages/**/*.{js,ts,tsx,json}': [
+		'npm run docs:api-ref',
+		'npm run docs:blocks',
+		'npm run docs:blocks-detail',
+		'npm run docs:theme-ref',
+		'npm run docs:check-api-docs-unstaged',
+	],
+	'packages/icons/src/library/*': [ 'npm run -w packages/icons build' ],
+	'**/tsconfig.json': [ 'npm run lint:tsconfig' ],
+};

--- a/package.json
+++ b/package.json
@@ -177,40 +177,6 @@
 		"wp-env": "wp-env",
 		"wp-env-test": "wp-env --config .wp-env.test.json"
 	},
-	"lint-staged": {
-		"*.{js,json,ts,tsx,yml,yaml}": [
-			"wp-scripts format"
-		],
-		"**/*.{js,ts,tsx,jsx}": [
-			"npm run prelint:js",
-			"node ./tools/eslint/lint-js.cjs --config eslint.config.strict.cjs"
-		],
-		"*.scss": [
-			"wp-scripts lint-style"
-		],
-		"package-lock.json": [
-			"npm run lint:lockfile"
-		],
-		"packages/*/package.json": [
-			"wp-scripts lint-pkg-json"
-		],
-		"{docs/toc.json,tools/docs/*.cjs,packages/{*/README.md,components/src/*/**/README.md,block-library/src/*/README.md}}": [
-			"npm run docs:gen"
-		],
-		"packages/**/*.{js,ts,tsx,json}": [
-			"npm run docs:api-ref",
-			"npm run docs:blocks",
-			"npm run docs:blocks-detail",
-			"npm run docs:theme-ref",
-			"npm run docs:check-api-docs-unstaged"
-		],
-		"packages/icons/src/library/*": [
-			"npm run -w packages/icons build"
-		],
-		"**/tsconfig.json": [
-			"npm run lint:tsconfig"
-		]
-	},
 	"workspaces": [
 		"packages/*",
 		"routes/*",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
After #79718, precommit hooks always fail for any js file changes.

The issue seems to be that #79718 added `"prelint:js": "npm run build:js"` to the package.json, which runs `pegjs`.

`lintstaged` runs this command on a precommit hook and appends matching filenames to the `pegjs` command. `pegjs` doesn't support these extra arguments so throws an error like this:
```
> pegjs --format commonjs -o ./parser.js ./grammar.pegjs /Users/dan-a8c/code/wp/gutenberg/packages/block-editor/src/hooks/position.js

Too many arguments.
npm error Lifecycle script `build:js` failed with error:
npm error code 1
npm error path /Users/dan-a8c/code/wp/gutenberg/packages/block-serialization-spec-parser
npm error workspace @wordpress/block-serialization-spec-parser@5.49.0
npm error location /Users/dan-a8c/code/wp/gutenberg/packages/block-serialization-spec-parser
npm error command failed
npm error command sh -c pegjs --format commonjs -o ./parser.js ./grammar.pegjs /Users/dan-a8c/code/wp/gutenberg/packages/block-editor/src/hooks/position.js
npm error Lifecycle script `prelint:js` failed with error:
npm error code 1
npm error path /Users/dan-a8c/code/wp/gutenberg/packages/block-serialization-spec-parser
npm error workspace @wordpress/block-serialization-spec-parser@5.49.0
npm error location /Users/dan-a8c/code/wp/gutenberg/packages/block-serialization-spec-parser
npm error command failed
npm error command sh -c npm run build:js /Users/dan-a8c/code/wp/gutenberg/packages/block-editor/src/hooks/position.js
```

The fix in this PR is to move the lint-staged config out of package.json and into its own file, where `prelint` can be configured as `() => 'npm run prelint:js'` to avoid the filenames being appended. The anonymous function isn't possible in the package.json.

I'm happy for this fix to be revised any other way, right now my only concern is to unblock committing to any branch.

## Steps to repro
1. Make any changes to a JS file
2. Try to commit them

In this PR - the commit succeeds if there are no valid lint errors
On current latest trunk - the precommit hook throws an error completely unrelated to the staged changes.