### PR TITLE
Image: insert multiple media-library images as individual blocks

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -127,7 +127,10 @@ export function MediaPlaceholder( {
 	isAppender,
 	accept,
 	addToGallery,
+	gallery: galleryProp,
 	multiple = false,
+	multipleUpload = multiple,
+	multipleBlockDrop = multiple,
 	handleUpload = true,
 	disableDropZone,
 	disableMediaButtons,
@@ -185,6 +188,7 @@ export function MediaPlaceholder( {
 				allowedType === 'image' || allowedType.startsWith( 'image/' )
 		);
 	};
+	const gallery = galleryProp ?? ( multiple && onlyAllowsImages() );
 
 	const onFilesUpload = ( files ) => {
 		if (
@@ -195,7 +199,7 @@ export function MediaPlaceholder( {
 		}
 		onFilesPreUpload( files );
 		let setMedia;
-		if ( multiple ) {
+		if ( multipleUpload ) {
 			if ( addToGallery ) {
 				// Since the setMedia function runs multiple times per upload group
 				// and is passed newMedia containing every item in its group each time, we must
@@ -242,7 +246,7 @@ export function MediaPlaceholder( {
 			filesList: files,
 			onFileChange: setMedia,
 			onError,
-			multiple,
+			multiple: multipleUpload,
 		} );
 	};
 
@@ -291,7 +295,9 @@ export function MediaPlaceholder( {
 			return;
 		}
 
-		onSelect( multiple ? uploadedMediaList : uploadedMediaList[ 0 ] );
+		onSelect(
+			multipleBlockDrop ? uploadedMediaList : uploadedMediaList[ 0 ]
+		);
 	}
 
 	const onUpload = ( event ) => {
@@ -395,7 +401,7 @@ export function MediaPlaceholder( {
 					return (
 						types.every( ( type ) =>
 							allowedTypes.includes( type )
-						) && ( multiple ? true : types.length === 1 )
+						) && ( multipleBlockDrop ? true : types.length === 1 )
 					);
 				} }
 			/>
@@ -465,7 +471,7 @@ export function MediaPlaceholder( {
 		const uploadMediaLibraryButton = (
 			<MediaUpload
 				addToGallery={ addToGallery }
-				gallery={ multiple && onlyAllowsImages() }
+				gallery={ gallery }
 				multiple={ multiple }
 				onSelect={ onSelect }
 				allowedTypes={ allowedTypes }
@@ -486,7 +492,7 @@ export function MediaPlaceholder( {
 					<FormFileUpload
 						onChange={ onUpload }
 						accept={ computedAccept }
-						multiple={ !! multiple }
+						multiple={ !! multipleUpload }
 						render={ ( { openFileDialog } ) => {
 							const content = (
 								<>
@@ -534,7 +540,7 @@ export function MediaPlaceholder( {
 						) }
 						onChange={ onUpload }
 						accept={ computedAccept }
-						multiple={ !! multiple }
+						multiple={ !! multipleUpload }
 					/>
 					{ uploadMediaLibraryButton }
 					{ renderUrlSelectionUI() }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -58,7 +58,9 @@ const MediaReplaceFlow = ( {
 	removeNotice,
 	children,
 	multiple = false,
+	multipleUpload = multiple,
 	addToGallery,
+	gallery: galleryProp,
 	handleUpload = true,
 	variant,
 	popoverProps,
@@ -127,10 +129,11 @@ const MediaReplaceFlow = ( {
 		mediaUpload( {
 			allowedTypes,
 			filesList: files,
-			onFileChange: ( [ media ] ) => {
-				selectMedia( media, closeMenu );
+			onFileChange: ( media ) => {
+				selectMedia( multipleUpload ? media : media[ 0 ], closeMenu );
 			},
 			onError: onUploadError,
+			multiple: multipleUpload,
 		} );
 	};
 
@@ -152,7 +155,7 @@ const MediaReplaceFlow = ( {
 		);
 	};
 
-	const gallery = multiple && onlyAllowsImages();
+	const gallery = galleryProp ?? ( multiple && onlyAllowsImages() );
 
 	const mergedPopoverProps = {
 		...popoverProps,
@@ -196,7 +199,12 @@ const MediaReplaceFlow = ( {
 								gallery={ gallery }
 								addToGallery={ addToGallery }
 								multiple={ multiple }
-								value={ multiple ? mediaIds : mediaId }
+								value={
+									multiple
+										? mediaIds ??
+										  ( mediaId ? [ mediaId ] : undefined )
+										: mediaId
+								}
 								onSelect={ ( media ) =>
 									selectMedia( media, onClose )
 								}
@@ -215,7 +223,7 @@ const MediaReplaceFlow = ( {
 									uploadFiles( event, onClose );
 								} }
 								accept={ computedAccept }
-								multiple={ !! multiple }
+								multiple={ !! multipleUpload }
 								render={ ( { openFileDialog } ) => {
 									return (
 										<MenuItem

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -173,16 +173,111 @@ export function ImageEdit( {
 		}
 	}
 
-	function onSelectImagesList( images ) {
-		const win = containerRef.current?.ownerDocument.defaultView;
+	function getDefaultLinkDestination() {
+		if ( attributes.linkDestination ) {
+			return attributes.linkDestination;
+		}
 
-		if ( images.every( ( file ) => file instanceof win.File ) ) {
+		// Use the WordPress option to determine the proper default.
+		// The constants used in Gutenberg do not match WP options so a little more complicated than ideal.
+		switch (
+			window?.wp?.media?.view?.settings?.defaultProps?.link ||
+			LINK_DESTINATION_NONE
+		) {
+			case 'file':
+			case LINK_DESTINATION_MEDIA:
+				return LINK_DESTINATION_MEDIA;
+			case 'post':
+			case LINK_DESTINATION_ATTACHMENT:
+				return LINK_DESTINATION_ATTACHMENT;
+			case LINK_DESTINATION_CUSTOM:
+				return LINK_DESTINATION_CUSTOM;
+			case LINK_DESTINATION_NONE:
+				return LINK_DESTINATION_NONE;
+		}
+
+		return LINK_DESTINATION_NONE;
+	}
+
+	function getImageAttributesFromMedia(
+		media,
+		{ preserveCurrentCaption = false, resetSize = true } = {}
+	) {
+		const { imageDefaultSize } = getSettings();
+
+		// Try to use the previous selected image size if its available
+		// otherwise try the default image size or fallback to "full"
+		let newSize = DEFAULT_MEDIA_SIZE_SLUG;
+		if ( sizeSlug && hasSize( media, sizeSlug ) ) {
+			newSize = sizeSlug;
+		} else if ( hasSize( media, imageDefaultSize ) ) {
+			newSize = imageDefaultSize;
+		}
+
+		let mediaAttributes = pickRelevantMediaFiles( media, newSize );
+
+		// Normalize newline characters in caption to <br />
+		// to preserve line breaks in both editor and frontend.
+		if (
+			typeof mediaAttributes.caption === 'string' &&
+			mediaAttributes.caption.includes( '\n' )
+		) {
+			mediaAttributes.caption = mediaAttributes.caption.replace(
+				/\n/g,
+				'<br>'
+			);
+		}
+
+		// If a caption text was meanwhile written by the user,
+		// make sure the text is not overwritten by empty captions.
+		if (
+			preserveCurrentCaption &&
+			captionRef.current &&
+			! mediaAttributes.caption
+		) {
+			const { caption: omittedCaption, ...restMediaAttributes } =
+				mediaAttributes;
+			mediaAttributes = restMediaAttributes;
+		}
+
+		const linkDestination = getDefaultLinkDestination();
+
+		// Check if the image is linked to it's media.
+		let href;
+		switch ( linkDestination ) {
+			case LINK_DESTINATION_MEDIA:
+				href = media.url;
+				break;
+			case LINK_DESTINATION_ATTACHMENT:
+				href = media.link;
+				break;
+		}
+		mediaAttributes.href = href;
+
+		return {
+			blob: undefined,
+			...mediaAttributes,
+			...( resetSize && { sizeSlug: newSize } ),
+			linkDestination,
+		};
+	}
+
+	function onSelectImagesList( images ) {
+		const selectedImages = Array.from( images );
+		const isFile = ( item ) =>
+			Object.prototype.toString.call( item ) === '[object File]';
+
+		if ( selectedImages.length === 1 && ! isFile( selectedImages[ 0 ] ) ) {
+			onSelectImage( selectedImages[ 0 ] );
+			return;
+		}
+
+		if ( selectedImages.every( isFile ) ) {
 			/** @type {File[]} */
-			const files = images;
+			const files = selectedImages;
 			const rootClientId = getBlockRootClientId( clientId );
 
 			if ( files.some( ( file ) => ! isValidFileType( file ) ) ) {
-				// Copied from the same notice in the gallery block.
 				createErrorNotice(
 					__(
 						'If uploading to a gallery all files need to be image formats'
@@ -199,6 +294,10 @@ export function ImageEdit( {
 					} )
 				);
 
+			if ( ! imageBlocks.length ) {
+				return;
+			}
+
 			if ( getBlockName( rootClientId ) === 'core/gallery' ) {
 				replaceBlock( clientId, imageBlocks );
 			} else if ( canInsertBlockType( 'core/gallery', rootClientId ) ) {
@@ -210,11 +309,28 @@ export function ImageEdit( {
 
 				replaceBlock( clientId, galleryBlock );
 			}
+			return;
+		}
+
+		const imageBlocks = selectedImages
+			.filter( ( image ) => image?.url )
+			.map( ( image ) =>
+				createBlock(
+					'core/image',
+					getImageAttributesFromMedia( image )
+				)
+			);
+
+		if ( imageBlocks.length ) {
+			replaceBlock( clientId, imageBlocks );
 		}
 	}
 
 	function onSelectImage( media ) {
-		if ( Array.isArray( media ) ) {
+		if (
+			Array.isArray( media ) ||
+			Object.prototype.toString.call( media ) === '[object FileList]'
+		) {
 			onSelectImagesList( media );
 			return;
 		}
@@ -289,90 +405,14 @@ export function ImageEdit( {
 			return;
 		}
 
-		const { imageDefaultSize } = getSettings();
-
-		// Try to use the previous selected image size if its available
-		// otherwise try the default image size or fallback to "full"
-		let newSize = DEFAULT_MEDIA_SIZE_SLUG;
-		if ( sizeSlug && hasSize( media, sizeSlug ) ) {
-			newSize = sizeSlug;
-		} else if ( hasSize( media, imageDefaultSize ) ) {
-			newSize = imageDefaultSize;
-		}
-
-		let mediaAttributes = pickRelevantMediaFiles( media, newSize );
-
-		// Normalize newline characters in caption to <br />
-		// to preserve line breaks in both editor and frontend.
-		if (
-			typeof mediaAttributes.caption === 'string' &&
-			mediaAttributes.caption.includes( '\n' )
-		) {
-			mediaAttributes.caption = mediaAttributes.caption.replace(
-				/\n/g,
-				'<br>'
-			);
-		}
-
-		// If a caption text was meanwhile written by the user,
-		// make sure the text is not overwritten by empty captions.
-		if ( captionRef.current && ! mediaAttributes.caption ) {
-			const { caption: omittedCaption, ...restMediaAttributes } =
-				mediaAttributes;
-			mediaAttributes = restMediaAttributes;
-		}
-
-		let additionalAttributes;
 		// Reset the dimension attributes if changing to a different image.
-		if ( ! media.id || media.id !== id ) {
-			additionalAttributes = {
-				sizeSlug: newSize,
-			};
-		}
-
-		// Check if default link setting should be used.
-		let linkDestination = attributes.linkDestination;
-		if ( ! linkDestination ) {
-			// Use the WordPress option to determine the proper default.
-			// The constants used in Gutenberg do not match WP options so a little more complicated than ideal.
-			switch (
-				window?.wp?.media?.view?.settings?.defaultProps?.link ||
-				LINK_DESTINATION_NONE
-			) {
-				case 'file':
-				case LINK_DESTINATION_MEDIA:
-					linkDestination = LINK_DESTINATION_MEDIA;
-					break;
-				case 'post':
-				case LINK_DESTINATION_ATTACHMENT:
-					linkDestination = LINK_DESTINATION_ATTACHMENT;
-					break;
-				case LINK_DESTINATION_CUSTOM:
-					linkDestination = LINK_DESTINATION_CUSTOM;
-					break;
-				case LINK_DESTINATION_NONE:
-					linkDestination = LINK_DESTINATION_NONE;
-					break;
-			}
-		}
-
-		// Check if the image is linked to it's media.
-		let href;
-		switch ( linkDestination ) {
-			case LINK_DESTINATION_MEDIA:
-				href = media.url;
-				break;
-			case LINK_DESTINATION_ATTACHMENT:
-				href = media.link;
-				break;
-		}
-		mediaAttributes.href = href;
+		const resetSize = ! media.id || media.id !== id;
 
 		setAttributes( {
-			blob: undefined,
-			...mediaAttributes,
-			...additionalAttributes,
-			linkDestination,
+			...getImageAttributesFromMedia( media, {
+				preserveCurrentCaption: true,
+				resetSize,
+			} ),
 		} );
 		setTemporaryURL();
 	}
@@ -549,7 +589,11 @@ export function ImageEdit( {
 					onError={ onUploadError }
 					placeholder={ placeholder }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					gallery={ false }
 					handleUpload={ ( files ) => files.length === 1 }
+					multiple="add"
+					multipleUpload={ false }
+					multipleBlockDrop={ false }
 					value={ { id, src } }
 					mediaPreview={ mediaPreview }
 					disableMediaButtons={ temporaryURL || url }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -890,6 +890,9 @@ export default function Image( {
 				mediaId={ id }
 				mediaURL={ url }
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				gallery={ false }
+				multiple="add"
+				multipleUpload={ false }
 				onSelect={ onSelectImage }
 				onSelectURL={ onSelectURL }
 				onError={ onUploadError }

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -456,9 +456,22 @@ export function MediaUploadModal( {
 					);
 
 					// Transform the selected posts to the expected Attachment format
+					const selectionOrder = new Map(
+						selection.map( ( id, index ) => [
+							String( id ),
+							index,
+						] )
+					);
 					const transformedPosts = ( selectedPosts ?? [] )
 						.map( transformAttachment )
-						.filter( Boolean );
+						.filter( Boolean )
+						.sort(
+							( a, b ) =>
+								( selectionOrder.get( String( a.id ) ) ??
+									selection.length ) -
+								( selectionOrder.get( String( b.id ) ) ??
+									selection.length )
+						);
 
 					const selectedItems = multiple
 						? transformedPosts


### PR DESCRIPTION
> [!NOTE]
> This is a draft to test the UX and the expectations around what should happen when selecting/uploading images from an image block. The code is one-shot and rough!

## What?

Lets the Image block accept a **multi-selection from the media library** and insert each selected item as its own `core/image` block, instead of forcing one-at-a-time insertion or a Gallery.

Part of #73085. See https://github.com/WordPress/gutenberg/issues/73085#issuecomment-4858963302

## Why? How?

Allows users to select several existing images from the library and insert them all at once, in the order chosen, as individual images. Today the Image block only inserts one library item at a time, and the only multi-image path (uploading/dropping files) forces a Gallery.



## Testing Instructions

1. Add an Image block and open **Media Library**. Select **several** images and insert. → Each becomes its own Image block, in the order selected.
2. Select a **single** library image. → Behaves exactly as before.
3. On an existing Image block, open **Replace** → the current image is highlighted in the library.
4. **Upload** (via drag-drop) **multiple image files** onto an empty Image block. → A Gallery is created (unchanged).
5. Drop a **single** image file. → A single Image block (unchanged).
6. Confirm Gallery, Playlist, Video and other blocks that consume `MediaPlaceholder`/`MediaReplaceFlow` are unaffected.

## Screenshots or screencast


https://github.com/user-attachments/assets/2b2f7714-dca7-4e55-a007-18dc77b4bb34


