### PR TITLE
Deprecate `@wordpress/reusable-blocks` public APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48330,6 +48330,7 @@
 				"@wordpress/components": "file:../components",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
+				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",

--- a/packages/reusable-blocks/CHANGELOG.md
+++ b/packages/reusable-blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecated the `wp.reusableBlocks.ReusableBlocksMenuItems` component and the `core/reusable-blocks` store actions (`__experimentalConvertBlockToStatic`, `__experimentalConvertBlocksToReusable`, `__experimentalDeleteReusableBlock`, `__experimentalSetEditingReusableBlock`) and selector (`__experimentalIsEditingReusableBlock`). The package is unused by core and will become a no-op compatibility package in a future release.
+
 ## 5.49.0 (2026-06-24)
 
 ## 5.48.1 (2026-06-16)

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -55,6 +55,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -10,6 +11,9 @@ import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlocksManageButton from './reusable-blocks-manage-button';
 
 export default function ReusableBlocksMenuItems( { rootClientId } ) {
+	deprecated( 'wp.reusableBlocks.ReusableBlocksMenuItems', {
+		since: '7.1',
+	} );
 	return (
 		<BlockSettingsMenuControls>
 			{ ( { onClose, selectedClientIds } ) => (

--- a/packages/reusable-blocks/src/store/actions.js
+++ b/packages/reusable-blocks/src/store/actions.js
@@ -9,15 +9,24 @@ import {
 	serialize,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Returns a generator converting a reusable block into a static block.
+ *
+ * @deprecated
  *
  * @param {string} clientId The client ID of the block to attach.
  */
 export const __experimentalConvertBlockToStatic =
 	( clientId ) =>
 	( { registry } ) => {
+		deprecated(
+			"wp.data.dispatch( 'core/reusable-blocks' ).__experimentalConvertBlockToStatic",
+			{
+				since: '7.1',
+			}
+		);
 		const oldBlock = registry
 			.select( blockEditorStore )
 			.getBlock( clientId );
@@ -42,6 +51,8 @@ export const __experimentalConvertBlockToStatic =
 /**
  * Returns a generator converting one or more static blocks into a pattern.
  *
+ * @deprecated
+ *
  * @param {string[]}             clientIds The client IDs of the block to detach.
  * @param {string}               title     Pattern title.
  * @param {undefined|'unsynced'} syncType  They way block is synced, current undefined (synced) and 'unsynced'.
@@ -49,6 +60,12 @@ export const __experimentalConvertBlockToStatic =
 export const __experimentalConvertBlocksToReusable =
 	( clientIds, title, syncType ) =>
 	async ( { registry, dispatch } ) => {
+		deprecated(
+			"wp.data.dispatch( 'core/reusable-blocks' ).__experimentalConvertBlocksToReusable",
+			{
+				since: '7.1',
+			}
+		);
 		const meta =
 			syncType === 'unsynced'
 				? {
@@ -90,11 +107,19 @@ export const __experimentalConvertBlocksToReusable =
 /**
  * Returns a generator deleting a reusable block.
  *
+ * @deprecated
+ *
  * @param {string} id The ID of the reusable block to delete.
  */
 export const __experimentalDeleteReusableBlock =
 	( id ) =>
 	async ( { registry } ) => {
+		deprecated(
+			"wp.data.dispatch( 'core/reusable-blocks' ).__experimentalDeleteReusableBlock",
+			{
+				since: '7.1',
+			}
+		);
 		const reusableBlock = registry
 			.select( 'core' )
 			.getEditedEntityRecord( 'postType', 'wp_block', id );
@@ -128,11 +153,19 @@ export const __experimentalDeleteReusableBlock =
 /**
  * Returns an action descriptor for SET_EDITING_REUSABLE_BLOCK action.
  *
+ * @deprecated
+ *
  * @param {string}  clientId  The clientID of the reusable block to target.
  * @param {boolean} isEditing Whether the block should be in editing state.
  * @return {Object} Action descriptor.
  */
 export function __experimentalSetEditingReusableBlock( clientId, isEditing ) {
+	deprecated(
+		"wp.data.dispatch( 'core/reusable-blocks' ).__experimentalSetEditingReusableBlock",
+		{
+			since: '7.1',
+		}
+	);
 	return {
 		type: 'SET_EDITING_REUSABLE_BLOCK',
 		clientId,

--- a/packages/reusable-blocks/src/store/selectors.js
+++ b/packages/reusable-blocks/src/store/selectors.js
@@ -1,10 +1,23 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Returns true if reusable block is in the editing state.
+ *
+ * @deprecated
  *
  * @param {Object} state    Global application state.
  * @param {number} clientId the clientID of the block.
  * @return {boolean} Whether the reusable block is in the editing state.
  */
 export function __experimentalIsEditingReusableBlock( state, clientId ) {
+	deprecated(
+		"wp.data.select( 'core/reusable-blocks' ).__experimentalIsEditingReusableBlock",
+		{
+			since: '7.1',
+		}
+	);
 	return state.isEditingReusableBlock[ clientId ];
 }

--- a/packages/reusable-blocks/src/store/test/actions.js
+++ b/packages/reusable-blocks/src/store/test/actions.js
@@ -13,6 +13,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { logged } from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -75,6 +76,13 @@ describe( 'Actions', () => {
 		unregisterBlockType( 'core/block' );
 	} );
 
+	afterEach( () => {
+		// Reset the deprecation cache so each test observes its own warning.
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
+	} );
+
 	describe( '__experimentalSetEditingReusableBlock', () => {
 		it( 'should flip the editing state', () => {
 			const registry = createRegistryWithStores();
@@ -96,6 +104,8 @@ describe( 'Actions', () => {
 					.select( reusableBlocksStore )
 					.__experimentalIsEditingReusableBlock( 3 )
 			).toBe( false );
+
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
@@ -146,6 +156,8 @@ describe( 'Actions', () => {
 					.select( reusableBlocksStore )
 					.__experimentalIsEditingReusableBlock( newClientId )
 			).toBe( true );
+
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
@@ -196,6 +208,8 @@ describe( 'Actions', () => {
 			delete updatedBlocks[ 0 ].innerBlocks[ 0 ].clientId;
 			delete updatedBlocks[ 0 ].innerBlocks[ 1 ].clientId;
 			expect( updatedBlocks ).toMatchSnapshot();
+
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
@@ -268,6 +282,8 @@ describe( 'Actions', () => {
 			// Check if block instances were removed from the editor.
 			const blocksAfter = registry.select( blockEditorStore ).getBlocks();
 			expect( blocksAfter ).toHaveLength( 3 );
+
+			expect( console ).toHaveWarned();
 		} );
 	} );
 } );

--- a/packages/reusable-blocks/src/store/test/selectors.js
+++ b/packages/reusable-blocks/src/store/test/selectors.js
@@ -1,9 +1,21 @@
 /**
+ * WordPress dependencies
+ */
+import { logged } from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import { __experimentalIsEditingReusableBlock } from '../selectors';
 
 describe( '__experimentalIsEditingReusableBlock', () => {
+	afterEach( () => {
+		// Reset the deprecation cache so each test observes its own warning.
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
+	} );
+
 	it( 'gets the value for clientId', () => {
 		expect(
 			__experimentalIsEditingReusableBlock(
@@ -23,5 +35,7 @@ describe( '__experimentalIsEditingReusableBlock', () => {
 				3
 			)
 		).toBe( undefined );
+
+		expect( console ).toHaveWarned();
 	} );
 } );


### PR DESCRIPTION
## What?
PR adds deprecation notices to the `@wordpress/reusable-blocks` public API — the `core/reusable-blocks` store actions (`__experimentalConvertBlockToStatic`, `__experimentalConvertBlocksToReusable`, `__experimentalDeleteReusableBlock`, `__experimentalSetEditingReusableBlock`), the `__experimentalIsEditingReusableBlock` selector, and the `ReusableBlocksMenuItems` component. Everything still works exactly as before; it just logs a `deprecated()` warning when used.

## Why?
The package hasn't been used by core in a while. This ships the deprecation notices first so consumers get a heads-up, and a release or two later, we'll follow up by making the package a no-op (see #79186).

## Testing Instructions
1. Smoke test editors; nothing should change.
2. Call one of the deprecated APIs, e.g., `wp.data.dispatch( 'core/reusable-blocks' ).__experimentalConvertBlocksToReusable( ... )`.
3. Confirm a deprecation warning is logged to the console and the action still behaves as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
