### PR TITLE
View Config: Add version handling

### DIFF
--- a/backport-changelog/7.1/12391.md
+++ b/backport-changelog/7.1/12391.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12391
+
+* https://github.com/WordPress/gutenberg/pull/79809

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -85,11 +85,13 @@ DataViews-powered screens (such as the Pages list and its Quick Edit form) build
 
 The configuration has four keys: `default_view`, `default_layouts`, `view_list` (the saved views shown in the list), and `form` (the DataForm used by consumers like Quick Edit).
 
-In the following example, a custom saved view is added to the `page` list and the Trash view is removed from it, the `grid` layout option is unset, and `slug` and `author` fields are removed from the form.
+In the following example, a custom saved view is added to the `page` list, the existing Drafts view is retitled, the Trash view is removed, the `grid` layout option is unset, and `slug` and `author` fields are removed from the form.
 
 ```php
 function example_filter_page_view_config( $data ) {
-    // Merge a partial configuration: add a saved view to the list.
+    // Merge a partial configuration: add a saved view to the list, and
+    // retitle the existing Drafts view — matched by slug, only the given
+    // keys change.
     $data->update_with(
         array(
             'view_list' => array(
@@ -106,6 +108,10 @@ function example_filter_page_view_config( $data ) {
                             ),
                         ),
                     ),
+                ),
+                array(
+                    'slug'  => 'drafts',
+                    'title' => __( 'In progress', 'example' ),
                 ),
             ),
         ),

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -85,6 +85,16 @@ DataViews-powered screens (such as the Pages list and its Quick Edit form) build
 
 The configuration has four keys: `default_view`, `default_layouts`, `view_list` (the saved views shown in the list), and `form` (the DataForm used by consumers like Quick Edit).
 
+The filter receives an object holding the entity's view configuration. Change the configuration by calling its methods and return the object. Each method merges a partial change (a patch) into one part of the configuration, and patches follow three shared rules: an associative array merges key by key, a numerically indexed array replaces the current value wholesale, and `null` deletes what it names.
+
+-   `update_properties( $patch, $version )` merges into `default_view`, `default_layouts`, and the `form` properties other than its `fields`. Passing `null` for a whole top-level key resets it to its default.
+-   `update_view_list_items( $items, $version )` adds, updates, or removes views in the `view_list`, keyed by `slug`: a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view.
+-   `update_form_fields( $fields, $version )` adds, updates, or removes `form` fields, keyed by `id`. A field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id: a matching field merges in place, an unknown id appends a new field, and `null` removes the field. Within a field patch, `children` follows the shared rules: an associative array merges into the group's children by `id` (unknown ids append to the group), a numerically indexed array replaces the children wholesale, and `null` deletes the key.
+
+For form fields, the id always lives in the patch key and the value only carries overrides, so a new field with no overrides is expressed as `'my_field' => array()` — not `array( 'my_field' )`, which is a numerically indexed array and would replace the group's children with just that field. Patch entries apply in order and `null` removes every occurrence of an id, so to move a field into a group, remove it first and append it to the group's `children` later in the same patch.
+
+The `$version` argument declares the configuration schema version the patch was written against (currently `1`), so that a future release that changes the configuration shape can migrate existing patches forward instead of breaking them.
+
 In the following example, a custom saved view is added to the `page` list, the existing Drafts view is retitled, the Trash view is removed, the `grid` layout option is unset, and `slug` and `author` fields are removed from the form.
 
 ```php
@@ -117,12 +127,8 @@ function example_filter_page_view_config( $data ) {
 
     // Patch form fields by id, wherever they live in the form: update the
     // label position of the post content info field, remove the slug and
-    // author fields with null, and append a field to the discussion group.
-    // In a `children` map an unknown id appends. The id lives in the patch
-    // key, so the value only carries overrides: array() appends a plain
-    // reference. A bare string cannot express an addition —
-    // array( 'my_field' ) is a positional list, and a `children` list
-    // replaces the group's children wholesale instead.
+    // author fields with null, and append a new field to the discussion
+    // group's children ( array() carries no overrides ).
     $data->update_form_fields(
         array(
             'post-content-info' => array(
@@ -151,14 +157,6 @@ function example_filter_page_view_config( $data ) {
 }
 add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
 ```
-
-The filter receives an object holding the entity's view configuration. Contribute through its methods and return it:
-
--   `update_properties( $patch, $version )` merges the object-shaped configuration: `default_view`, `default_layouts`, and `form` properties other than its `fields`. A map value merges key by key, a list value replaces wholesale, and a value of `null` deletes the key it names — passing `null` for a whole top-level key resets it to its default.
--   `update_view_list_items( $items, $version )` patches the `view_list`, keyed by `slug`: a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view.
--   `update_form_fields( $fields, $version )` patches the `form` fields, keyed by `id`. A field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id: a matching field merges in place, an unknown id appends a new field, and `null` removes the field. The id always lives in the patch key and the value only carries overrides, so a new field with no overrides is expressed as `'my_field' => array()`, never as a bare string: a string can only appear in a list, and a `children` list means "replace the group's children wholesale", while a `children` map merges by `id` (unknown ids append to the group). Patch entries apply in order and a `null` removes every occurrence of the id, so to move a field into a group, remove it first and append it to the group's `children` later in the same patch.
-
-All `update_*` functions require a schema version so the contribution can be migrated forward if the configuration shape changes.
 
 ## Client-side (Editor) filters
 

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -4,12 +4,12 @@ The Editor provides numerous filters and hooks that allow you to modify the edit
 
 ## Editor settings
 
-One of the most common ways to modify the Editor is through the [`block_editor_settings_all`](https://developer.wordpress.org/reference/hooks/block_editor_settings_all/) PHP filter, which is applied before settings are sent to the initialized Editor. 
+One of the most common ways to modify the Editor is through the [`block_editor_settings_all`](https://developer.wordpress.org/reference/hooks/block_editor_settings_all/) PHP filter, which is applied before settings are sent to the initialized Editor.
 
 The `block_editor_settings_all` hook passes two parameters to the callback function:
 
-- `$settings` – An array of [configurable settings](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#editor-settings) for the Editor.
-- `$context` – An instance of [`WP_Block_Editor_Context`](https://developer.wordpress.org/reference/classes/wp_block_editor_context/), an object that contains information about the current Editor.
+-   `$settings` – An array of [configurable settings](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#editor-settings) for the Editor.
+-   `$context` – An instance of [`WP_Block_Editor_Context`](https://developer.wordpress.org/reference/classes/wp_block_editor_context/), an object that contains information about the current Editor.
 
 The following example disables the Code Editor for users who cannot activate plugins (Administrators). Add this to a plugin or your theme's `functions.php` file to test it.
 
@@ -28,25 +28,25 @@ function example_restrict_code_editor( $settings ) {
 }
 ```
 
-For more examples, check out the [Editor Hooks](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/) documentation that includes the following use cases: 
+For more examples, check out the [Editor Hooks](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/) documentation that includes the following use cases:
 
-- [Set a default image size](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#set-a-default-image-size)
-- [Disable Openverse](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-openverse)
-- [Disable the Font Library](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-the-font-library)
-- [Disable block inspector tabs](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-block-inspector-tabs)
+-   [Set a default image size](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#set-a-default-image-size)
+-   [Disable Openverse](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-openverse)
+-   [Disable the Font Library](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-the-font-library)
+-   [Disable block inspector tabs](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-block-inspector-tabs)
 
 ## Server-side theme.json filters
 
 The theme.json file is a great way to control interface options, but it only allows for global or block-level modifications, which can be limiting in some scenarios.
 
-For instance, in the previous section, color and typography controls were disabled globally using theme.json. But let's say you want to enable color settings for users who are Administrators. 
+For instance, in the previous section, color and typography controls were disabled globally using theme.json. But let's say you want to enable color settings for users who are Administrators.
 
 To provide more flexibility, WordPress 6.1 introduced server-side filters allowing you to customize theme.json data at four different data layers.
 
-- [`wp_theme_json_data_default`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_default/) - Hooks into the default data provided by WordPress
-- [`wp_theme_json_data_blocks`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_blocks/) - Hooks into the data provided by blocks.
-- [`wp_theme_json_data_theme`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_theme/) - Hooks into the data provided by the current theme.
-- [`wp_theme_json_data_user`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_user/) - Hooks into the data provided by the user.
+-   [`wp_theme_json_data_default`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_default/) - Hooks into the default data provided by WordPress
+-   [`wp_theme_json_data_blocks`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_blocks/) - Hooks into the data provided by blocks.
+-   [`wp_theme_json_data_theme`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_theme/) - Hooks into the data provided by the current theme.
+-   [`wp_theme_json_data_user`](https://developer.wordpress.org/reference/hooks/wp_theme_json_data_user/) - Hooks into the data provided by the user.
 
 In the following example, the data from the current theme's theme.json file is updated using the `wp_theme_json_data_theme` filter. Color controls are restored if the current user is an Administrator.
 
@@ -77,8 +77,63 @@ function example_filter_theme_json_data_theme( $theme_json ){
 add_filter( 'wp_theme_json_data_theme', 'example_filter_theme_json_data_theme' );
 ```
 
-The filter receives an instance of the `WP_Theme_JSON_Data class` with the data for the respective layer. Then, you pass new data in a valid theme.json-like structure to the `update_with( $new_data )` method. A theme.json version number is required in `$new_data`. 
+The filter receives an instance of the `WP_Theme_JSON_Data class` with the data for the respective layer. Then, you pass new data in a valid theme.json-like structure to the `update_with( $new_data )` method. A theme.json version number is required in `$new_data`.
 
+## Server-side view configuration filter
+
+DataViews-powered screens (such as the Pages list and its Quick Edit form) build their configuration on the server. A dynamic filter, `get_entity_view_config_{$kind}_{$name}`, lets you customize that configuration for a specific entity, where the dynamic portions are the entity kind (e.g. `postType`) and name (e.g. `page`).
+
+The configuration has four keys: `default_view`, `default_layouts`, `view_list` (the saved views shown in the list), and `form` (the DataForm used by consumers like Quick Edit).
+
+In the following example, a custom saved view is added to the `page` list and the Trash view is removed from it, the `grid` layout option is unset, and `slug` and `author` fields are removed from the form.
+
+```php
+function example_filter_page_view_config( $data ) {
+    // Merge a partial configuration: add a saved view to the list.
+    $data->update_with(
+        array(
+            'view_list' => array(
+                array(
+                    'title' => __( 'My drafts', 'example' ),
+                    'slug'  => 'my-drafts',
+                    'view'  => array(
+                        'filters' => array(
+                            array(
+                                'field'    => 'status',
+                                'operator' => 'isAny',
+                                'value'    => 'draft',
+                                'isLocked' => true,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        1
+    );
+
+    // Unset a nested value with null: drop the grid layout option.
+    $data->update_with(
+        array( 'default_layouts' => array( 'grid' => null ) ),
+        1
+    );
+
+    // Remove a view from the list by its slug.
+    $data->remove_view_list_items( 'trash' );
+
+    // Remove some fields from the form by their identity.
+    $data->remove_fields( array( 'slug', 'author' ) );
+
+    return $data;
+}
+add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+```
+
+The filter receives an object holding the entity's view configuration. Contribute through its methods and return it:
+
+-   `update_with( $patch, $version )` merges a partial configuration. Collection members are matched by identity — views by `slug` and form fields by `id` — so a matching member is merged in place and an unknown one is appended to the end. A value of `null` deletes that key — the way to unset a nested value such as a `default_layouts` entry, a nested layout property, or a field's `label` — and passing `null` for a whole top-level key resets it to its default. Null never deletes list content: use the remove helpers below for that. A schema version is required so the contribution can be migrated forward if the configuration shape changes.
+-   `remove_view_list_items( $slugs )` drops one or more `view_list` entries by `slug`.
+-   `remove_fields( $ids )` drops one or more `form` fields by `id`, including fields nested inside a group. Both remove helpers accept a single identity or an array.
 
 ## Client-side (Editor) filters
 
@@ -111,7 +166,7 @@ However, the `blockEditor.useSetting.before` filter is unique because it allows 
 In the following example, text color controls are disabled for the Heading block whenever the block is placed inside of a Media & Text block.
 
 ```js
-import { select } from  '@wordpress/data';
+import { select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -122,12 +177,16 @@ addFilter(
 	'example/useSetting.before',
 	( settingValue, settingName, clientId, blockName ) => {
 		if ( blockName === 'core/heading' ) {
-			const { getBlockParents, getBlockName } = select( 'core/block-editor' );
+			const { getBlockParents, getBlockName } =
+				select( 'core/block-editor' );
 			const blockParents = getBlockParents( clientId, true );
-			const inMediaText = blockParents.some( ( ancestorId ) => getBlockName( ancestorId ) === 'core/media-text' );
+			const inMediaText = blockParents.some(
+				( ancestorId ) =>
+					getBlockName( ancestorId ) === 'core/media-text'
+			);
 
 			if ( inMediaText && settingName === 'color.text' ) {
-			    return false;
+				return false;
 			}
 		}
 
@@ -140,13 +199,13 @@ addFilter(
 
 Beyond curating the Editor itself, there are many ways that you can modify individual blocks. Perhaps you want to disable particular block supports like background color or define which settings should be displayed by default on specific blocks.
 
-One of the most commonly used filters is [`block_type_metadata`](https://developer.wordpress.org/reference/hooks/block_type_metadata/). It allows you to filter the raw metadata loaded from a block's `block.json` file when a block type is registered on the server with PHP. 
+One of the most commonly used filters is [`block_type_metadata`](https://developer.wordpress.org/reference/hooks/block_type_metadata/). It allows you to filter the raw metadata loaded from a block's `block.json` file when a block type is registered on the server with PHP.
 
 The filter takes one parameter:
 
-- `$metadata` (`array`) – metadata loaded from `block.json` for registering a block type.
+-   `$metadata` (`array`) – metadata loaded from `block.json` for registering a block type.
 
-The `$metadata` array contains everything you might want to know about a block, from its description and [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) to block [supports](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/). 
+The `$metadata` array contains everything you might want to know about a block, from its description and [attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/) to block [supports](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/).
 
 In the following example, background color and gradient support are disabled for Heading blocks.
 
@@ -175,5 +234,5 @@ You can learn more about the available block filters in the [Block Filters](http
 
 ## Additional resources
 
-- [How to modify theme.json data using server-side filters](https://developer.wordpress.org/news/2023/07/05/how-to-modify-theme-json-data-using-server-side-filters/) (WordPress Developer Blog)
-- [Curating the Editor experience with client-side filters](https://developer.wordpress.org/news/2023/05/24/curating-the-editor-experience-with-client-side-filters/) (WordPress Developer Blog)
+-   [How to modify theme.json data using server-side filters](https://developer.wordpress.org/news/2023/07/05/how-to-modify-theme-json-data-using-server-side-filters/) (WordPress Developer Blog)
+-   [Curating the Editor experience with client-side filters](https://developer.wordpress.org/news/2023/05/24/curating-the-editor-experience-with-client-side-filters/) (WordPress Developer Blog)

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -134,9 +134,13 @@ function example_filter_page_view_config( $data ) {
         1
     );
 
-    // Unset a nested value with null: drop the grid layout option.
+    // Unset a nested value with null: drop the grid layout option. Form
+    // properties other than `fields` also merge here.
     $data->update_properties(
-        array( 'default_layouts' => array( 'grid' => null ) ),
+        array(
+            'default_layouts' => array( 'grid' => null ),
+            'form'            => array( 'layout' => array( 'type' => 'regular' ) ),
+        ),
         1
     );
 

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -115,19 +115,22 @@ function example_filter_page_view_config( $data ) {
         1
     );
 
-    // Patch form fields by id, wherever they live in the form: retitle the
-    // excerpt field, remove the slug and author fields with null, and append
-    // a field to the discussion group. In a `children` map an unknown id
-    // appends. The id lives in the patch key, so the value only carries
-    // overrides: array() appends a plain reference. A bare string cannot
-    // express an addition — array( 'my_field' ) is a positional list, and a
-    // `children` list replaces the group's children wholesale instead.
+    // Patch form fields by id, wherever they live in the form: update the
+    // label position of the post content info field, remove the slug and
+    // author fields with null, and append a field to the discussion group.
+    // In a `children` map an unknown id appends. The id lives in the patch
+    // key, so the value only carries overrides: array() appends a plain
+    // reference. A bare string cannot express an addition —
+    // array( 'my_field' ) is a positional list, and a `children` list
+    // replaces the group's children wholesale instead.
     $data->update_form_fields(
         array(
-            'excerpt'    => array( 'label' => __( 'Summary', 'example' ) ),
-            'slug'       => null,
-            'author'     => null,
-            'discussion' => array(
+            'post-content-info' => array(
+                'layout' => array( 'labelPosition' => 'side' ),
+            ),
+            'slug'              => null,
+            'author'            => null,
+            'discussion'        => array(
                 'children' => array( 'my_field' => array() ),
             ),
         ),

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -89,46 +89,56 @@ In the following example, a custom saved view is added to the `page` list, the e
 
 ```php
 function example_filter_page_view_config( $data ) {
-    // Merge a partial configuration: add a saved view to the list, and
-    // retitle the existing Drafts view — matched by slug, only the given
-    // keys change.
-    $data->update_with(
+    // Patch the view list by slug: add a saved view, retitle the existing
+    // Drafts view — only the given keys change — and remove the Trash view
+    // with null.
+    $data->update_view_list_items(
         array(
-            'view_list' => array(
-                array(
-                    'title' => __( 'My drafts', 'example' ),
-                    'slug'  => 'my-drafts',
-                    'view'  => array(
-                        'filters' => array(
-                            array(
-                                'field'    => 'status',
-                                'operator' => 'isAny',
-                                'value'    => 'draft',
-                                'isLocked' => true,
-                            ),
+            'my-drafts' => array(
+                'title' => __( 'My drafts', 'example' ),
+                'view'  => array(
+                    'filters' => array(
+                        array(
+                            'field'    => 'status',
+                            'operator' => 'isAny',
+                            'value'    => 'draft',
+                            'isLocked' => true,
                         ),
                     ),
                 ),
-                array(
-                    'slug'  => 'drafts',
-                    'title' => __( 'In progress', 'example' ),
-                ),
+            ),
+            'drafts'    => array(
+                'title' => __( 'In progress', 'example' ),
+            ),
+            'trash'     => null,
+        ),
+        1
+    );
+
+    // Patch form fields by id, wherever they live in the form: retitle the
+    // excerpt field, remove the slug and author fields with null, and append
+    // a field to the discussion group. In a `children` map an unknown id
+    // appends. The id lives in the patch key, so the value only carries
+    // overrides: array() appends a plain reference. A bare string cannot
+    // express an addition — array( 'my_field' ) is a positional list, and a
+    // `children` list replaces the group's children wholesale instead.
+    $data->update_form_fields(
+        array(
+            'excerpt'    => array( 'label' => __( 'Summary', 'example' ) ),
+            'slug'       => null,
+            'author'     => null,
+            'discussion' => array(
+                'children' => array( 'my_field' => array() ),
             ),
         ),
         1
     );
 
     // Unset a nested value with null: drop the grid layout option.
-    $data->update_with(
+    $data->update_properties(
         array( 'default_layouts' => array( 'grid' => null ) ),
         1
     );
-
-    // Remove a view from the list by its slug.
-    $data->remove_view_list_items( 'trash' );
-
-    // Remove some fields from the form by their identity.
-    $data->remove_fields( array( 'slug', 'author' ) );
 
     return $data;
 }
@@ -137,9 +147,11 @@ add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_co
 
 The filter receives an object holding the entity's view configuration. Contribute through its methods and return it:
 
--   `update_with( $patch, $version )` merges a partial configuration. Collection members are matched by identity — views by `slug` and form fields by `id` — so a matching member is merged in place and an unknown one is appended to the end. A value of `null` deletes that key — the way to unset a nested value such as a `default_layouts` entry, a nested layout property, or a field's `label` — and passing `null` for a whole top-level key resets it to its default. Null never deletes list content: use the remove helpers below for that. A schema version is required so the contribution can be migrated forward if the configuration shape changes.
--   `remove_view_list_items( $slugs )` drops one or more `view_list` entries by `slug`.
--   `remove_fields( $ids )` drops one or more `form` fields by `id`, including fields nested inside a group. Both remove helpers accept a single identity or an array.
+-   `update_properties( $patch, $version )` merges the object-shaped configuration: `default_view`, `default_layouts`, and `form` properties other than its `fields`. A map value merges key by key, a list value replaces wholesale, and a value of `null` deletes the key it names — passing `null` for a whole top-level key resets it to its default.
+-   `update_view_list_items( $items, $version )` patches the `view_list`, keyed by `slug`: a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view.
+-   `update_form_fields( $fields, $version )` patches the `form` fields, keyed by `id`. A field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id: a matching field merges in place, an unknown id appends a new field, and `null` removes the field. The id always lives in the patch key and the value only carries overrides, so a new field with no overrides is expressed as `'my_field' => array()`, never as a bare string: a string can only appear in a list, and a `children` list means "replace the group's children wholesale", while a `children` map merges by `id` (unknown ids append to the group). Patch entries apply in order and a `null` removes every occurrence of the id, so to move a field into a group, remove it first and append it to the group's `children` later in the same patch.
+
+All `update_*` functions require a schema version so the contribution can be migrated forward if the configuration shape changes.
 
 ## Client-side (Editor) filters
 

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -141,6 +141,7 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 		$response = array(
 			'kind'            => $kind,
 			'name'            => $name,
+			'version'         => Gutenberg_View_Config_Data::LATEST_VERSION,
 			'default_view'    => $this->cast_empty_objects( $config['default_view'], $schema['properties']['default_view'] ),
 			'default_layouts' => $this->cast_empty_objects( $config['default_layouts'], $schema['properties']['default_layouts'] ),
 			'view_list'       => $this->cast_empty_objects( $config['view_list'], $schema['properties']['view_list'] ),
@@ -248,6 +249,11 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 				'name'            => array(
 					'description' => __( 'Entity name.', 'gutenberg' ),
 					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'version'         => array(
+					'description' => __( 'The schema version of the configuration.', 'gutenberg' ),
+					'type'        => 'integer',
 					'readonly'    => true,
 				),
 				'default_view'    => array(

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -138,12 +138,10 @@ class Gutenberg_View_Config_Data {
 	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_properties( array $patch, $version ) {
+	public function update_properties( array $patch, int $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
-
-		$patch = $this->migrate( $patch, $version, 'properties' );
 
 		foreach ( $patch as $key => $value ) {
 			if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
@@ -181,8 +179,7 @@ class Gutenberg_View_Config_Data {
 				}
 			}
 			// A documented key that is not yet present merges onto an empty base.
-			$current              = array_key_exists( $key, $this->config ) ? $this->config[ $key ] : array();
-			$this->config[ $key ] = $this->deep_merge( $current, $value );
+			$this->config[ $key ] = $this->deep_merge( $this->config[ $key ] ?? array(), $value );
 		}
 
 		return $this;
@@ -209,14 +206,12 @@ class Gutenberg_View_Config_Data {
 	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_view_list_items( array $items, $version ) {
+	public function update_view_list_items( array $items, int $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
 
-		$items = $this->migrate( $items, $version, 'view_list' );
-
-		if ( array() === $items ) {
+		if ( empty( $items ) ) {
 			return $this;
 		}
 		if ( array_is_list( $items ) ) {
@@ -238,9 +233,7 @@ class Gutenberg_View_Config_Data {
 				$view_list = array_values(
 					array_filter(
 						$view_list,
-						static function ( $item ) use ( $slug ) {
-							return ! is_array( $item ) || ! isset( $item['slug'] ) || $item['slug'] !== $slug;
-						}
+						static fn( $item ) => ! is_array( $item ) || ! isset( $item['slug'] ) || $item['slug'] !== $slug
 					)
 				);
 				continue;
@@ -249,7 +242,7 @@ class Gutenberg_View_Config_Data {
 			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 				_doing_it_wrong(
 					__METHOD__,
-					esc_html__( 'Each view patch must be an object of view properties, or null to remove the view.', 'gutenberg' ),
+					esc_html__( 'Each view patch must be an associative array of view properties, or null to remove the view.', 'gutenberg' ),
 					'7.1.0'
 				);
 				continue;
@@ -307,14 +300,12 @@ class Gutenberg_View_Config_Data {
 	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_form_fields( array $fields, $version ) {
+	public function update_form_fields( array $fields, int $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
 
-		$fields = $this->migrate( $fields, $version, 'form_fields' );
-
-		if ( array() === $fields ) {
+		if ( empty( $fields ) ) {
 			return $this;
 		}
 		if ( array_is_list( $fields ) ) {
@@ -337,49 +328,25 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Migrates a patch from its declared version up to the latest version.
-	 *
-	 * The latest version is the only version so far, so this is an identity
-	 * transform for now. Version-specific steps dispatch on the declared
-	 * version and the part of the configuration the patch targets as the
-	 * schema evolves.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param array  $patch   The patch to migrate.
-	 * @param int    $version The schema version the patch was authored against.
-	 * @param string $scope   The part of the configuration the patch targets: 'properties', 'view_list', or 'form_fields'.
-	 * @return array The migrated patch.
-	 */
-	private function migrate( array $patch, $version, $scope ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return $patch;
-	}
-
-	/**
 	 * Validates a declared patch version, reporting misuse against the given
 	 * public method.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed  $version The declared version.
+	 * @param int    $version The declared version.
 	 * @param string $method  The public method the patch was passed to.
 	 * @return bool Whether the version can be migrated to the latest version.
 	 */
-	private function check_version( $version, $method ) {
-		if ( is_int( $version ) && $version >= 1 && $version <= self::LATEST_VERSION ) {
+	private function check_version( int $version, $method ) {
+		if ( $version >= 1 && $version <= self::LATEST_VERSION ) {
 			return true;
 		}
 
-		if ( self::LATEST_VERSION > 1 ) {
-			$message = sprintf(
-				/* translators: %d: the latest supported version. */
-				esc_html__( 'A view configuration contribution must declare a version between 1 and %d.', 'gutenberg' ),
-				self::LATEST_VERSION
-			);
-		} else {
-			$message = esc_html__( 'A view configuration contribution must declare version 1.', 'gutenberg' );
-		}
-		_doing_it_wrong( esc_html( $method ), $message, '7.1.0' );
+		_doing_it_wrong(
+			esc_html( $method ),
+			esc_html__( 'A view configuration contribution must declare a supported schema version.', 'gutenberg' ),
+			'7.1.0'
+		);
 
 		return false;
 	}
@@ -398,7 +365,7 @@ class Gutenberg_View_Config_Data {
 		if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 			_doing_it_wrong(
 				'Gutenberg_View_Config_Data::update_properties',
-				esc_html__( 'A "form" patch must be an object of form properties, not a list.', 'gutenberg' ),
+				esc_html__( 'A "form" patch must be an associative array of form properties.', 'gutenberg' ),
 				'7.1.0'
 			);
 			return null;
@@ -486,7 +453,7 @@ class Gutenberg_View_Config_Data {
 			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 				_doing_it_wrong(
 					'Gutenberg_View_Config_Data::update_form_fields',
-					esc_html__( 'Each field patch must be an object of field properties, or null to remove the field.', 'gutenberg' ),
+					esc_html__( 'Each field patch must be an associative array of field properties, or null to remove the field.', 'gutenberg' ),
 					'7.1.0'
 				);
 				continue;
@@ -575,7 +542,7 @@ class Gutenberg_View_Config_Data {
 				if ( ! is_array( $item ) ) {
 					_doing_it_wrong(
 						'Gutenberg_View_Config_Data::update_form_fields',
-						esc_html__( 'A "children" patch must be an object keyed by field id to merge, a list to replace the children wholesale, or null to delete the key.', 'gutenberg' ),
+						esc_html__( 'A "children" patch must be an associative array keyed by field id to merge, a numerically indexed array to replace the children wholesale, or null to delete the key.', 'gutenberg' ),
 						'7.1.0'
 					);
 					continue;

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -1,0 +1,589 @@
+<?php
+/**
+ * Gutenberg_View_Config_Data class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Mutable container passed through the `get_entity_view_config_{$kind}_{$name}`
+ * filter so core and third parties can contribute to an entity's view
+ * configuration as versioned patches instead of mutating a raw array.
+ *
+ * Two kinds of contribution are supported:
+ *
+ * - Base definition (`set()`): replaces a whole top-level key. Intended for the
+ *   entity's authoritative definition (core's per-post-type callbacks). Because
+ *   it replaces rather than merges, a third party using it stops inheriting
+ *   core's future changes to that key (a "freeze"), so third parties should
+ *   prefer the layering verbs below.
+ * - Versioned layering (`update_with()` and the `remove_*` helpers): additive
+ *   patches that survive future shape changes. Each `update_with()` contribution
+ *   declares the schema version it was authored against and is migrated forward
+ *   to the latest version before it merges: identity-keyed lists (`view_list` by
+ *   `slug`, `form` fields by `id`) merge a matching member in place and append an
+ *   unknown one to the end; the object-shaped keys (`default_view`,
+ *   `default_layouts`) merge recursively; and a patch value of `null` deletes
+ *   that key (e.g. a nested layout property or a field's `label`). Dropping a
+ *   whole list member instead
+ *   goes through `remove_view_list_items()` (by `slug`) and `remove_fields()`
+ *   (by `id`, recursing into group `children`): they name identities and core
+ *   walks its own current structure to drop them, which keeps inheritance intact
+ *   and version-safe.
+ *
+ * @since 7.1.0
+ */
+class Gutenberg_View_Config_Data {
+
+	/**
+	 * The latest supported configuration schema version.
+	 *
+	 * @since 7.1.0
+	 * @var int
+	 */
+	const LATEST_VERSION = 1;
+
+	/**
+	 * The documented top-level configuration keys.
+	 *
+	 * @since 7.1.0
+	 * @var string[]
+	 */
+	const CONFIG_KEYS = array( 'default_view', 'default_layouts', 'view_list', 'form' );
+
+	/**
+	 * The configuration being contributed to.
+	 *
+	 * @since 7.1.0
+	 * @var array
+	 */
+	private $config;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $config The base configuration to contribute to.
+	 */
+	public function __construct( array $config ) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Returns the current configuration array.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array The configuration.
+	 */
+	public function get_config() {
+		return $this->config;
+	}
+
+	/**
+	 * Replaces a whole top-level key with a new value.
+	 *
+	 * Intended for the entity's base definition (core's per-post-type callbacks).
+	 * Third parties should prefer update_with() and the remove_* helpers so they
+	 * keep inheriting core's future changes.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $key   The configuration key to replace.
+	 * @param mixed  $value The new value.
+	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 */
+	public function set( $key, $value ) {
+		if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: the configuration key. */
+					esc_html__( '"%s" is not a documented view configuration key.', 'gutenberg' ),
+					esc_html( $key )
+				),
+				'7.1.0'
+			);
+			return $this;
+		}
+
+		$this->config[ $key ] = $value;
+		return $this;
+	}
+
+	/**
+	 * Merges a versioned patch into the configuration.
+	 *
+	 * The patch is migrated from the declared version up to the latest version
+	 * and then merged by identity: matching collection members merge in place and
+	 * unknown ones append to the end. A patch value of `null` deletes that key
+	 * rather than assigning `null`: a nested value (a `default_view` property, a
+	 * `default_layouts` entry or nested layout property, a field's `label`) is
+	 * unset, and a whole top-level key is dropped from the container —
+	 * `gutenberg_get_entity_view_config()` backfills a dropped documented key
+	 * from the defaults, so that reads as a reset. Null never removes list
+	 * content: a `null` inside a list member is kept as a literal value, and
+	 * nulling the `fields`/`children` lists themselves is rejected; use
+	 * `remove_view_list_items()` / `remove_fields()` to drop list members.
+	 *
+	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is rejected
+	 * (it cannot be migrated) and does not merge.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array    $patch   The partial configuration to merge.
+	 * @param int|null $version The schema version the patch was authored against.
+	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 */
+	public function update_with( array $patch, $version = null ) {
+		if ( ! $this->is_valid_version( $version ) ) {
+			if ( self::LATEST_VERSION > 1 ) {
+				$message = sprintf(
+					/* translators: %d: the latest supported version. */
+					esc_html__( 'A view configuration contribution must declare a version between 1 and %d.', 'gutenberg' ),
+					self::LATEST_VERSION
+				);
+			} else {
+				$message = esc_html__( 'A view configuration contribution must declare version 1.', 'gutenberg' );
+			}
+			_doing_it_wrong( __METHOD__, $message, '7.1.0' );
+			return $this;
+		}
+
+		$patch = $this->migrate( $patch );
+
+		foreach ( $patch as $key => $value ) {
+			// Keys outside the documented shape are discarded, so the container
+			// only ever exposes the documented keys.
+			if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
+				continue;
+			}
+			// A null patch value drops the whole key from the container rather
+			// than assigning null.
+			if ( null === $value ) {
+				unset( $this->config[ $key ] );
+				continue;
+			}
+			// A documented key that is not yet present merges onto an empty base.
+			$current              = array_key_exists( $key, $this->config ) ? $this->config[ $key ] : array();
+			$this->config[ $key ] = $this->merge_value( $key, $current, $value );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Removes one or more `view_list` entries by `slug`.
+	 *
+	 * Core walks its own current view list to drop the named entries, so the
+	 * caller only needs the stable slug.
+	 *
+	 * An entry that is not found is left untouched without warning: it may have
+	 * been removed by another filter or simply not apply to this entity, which is
+	 * a legitimate outcome rather than misuse.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string|string[] $slugs A single slug to remove, or an array of slugs.
+	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 */
+	public function remove_view_list_items( $slugs ) {
+		$slugs = (array) $slugs;
+
+		if ( isset( $this->config['view_list'] ) && is_array( $this->config['view_list'] ) ) {
+			$this->config['view_list'] = array_values(
+				array_filter(
+					$this->config['view_list'],
+					static function ( $item ) use ( $slugs ) {
+						$slug = is_array( $item ) && isset( $item['slug'] ) ? $item['slug'] : null;
+						return ! in_array( $slug, $slugs, true );
+					}
+				)
+			);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Removes one or more `form` fields by `id`, recursing into group children.
+	 *
+	 * Core walks its own current form structure to find and drop the named
+	 * fields, including ones nested inside a group's `children`, so the caller
+	 * only needs the stable id.
+	 *
+	 * A field that is not found is left untouched without warning: it may have
+	 * been removed by another filter or simply not apply to this entity, which is
+	 * a legitimate outcome rather than misuse.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string|string[] $ids A single field id to remove, or an array of ids.
+	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 */
+	public function remove_fields( $ids ) {
+		$ids = (array) $ids;
+
+		if ( isset( $this->config['form']['fields'] ) && is_array( $this->config['form']['fields'] ) ) {
+			$this->config['form']['fields'] = $this->reject_fields( $this->config['form']['fields'], $ids );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Migrates a patch up to the latest version.
+	 *
+	 * The latest version is the only version so far, so this is an identity
+	 * transform for now. Version-specific steps — and the source version they
+	 * migrate from — are added here as the schema evolves.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $patch The patch to migrate.
+	 * @return array The migrated patch.
+	 */
+	private function migrate( array $patch ) {
+		return $patch;
+	}
+
+	/**
+	 * Determines whether a declared version can be migrated to the latest version.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $version The declared version.
+	 * @return bool Whether the version is a supported integer.
+	 */
+	private function is_valid_version( $version ) {
+		return is_int( $version )
+			&& $version >= 1
+			&& $version <= self::LATEST_VERSION;
+	}
+
+	/**
+	 * Merges an incoming value for a top-level key into the current value.
+	 *
+	 * Dispatches the identity-keyed collections to their dedicated mergers and
+	 * falls back to a recursive value merge for object-shaped keys.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $key      The top-level key being merged.
+	 * @param mixed  $current  The current value.
+	 * @param mixed  $incoming The incoming value.
+	 * @return mixed The merged value.
+	 */
+	private function merge_value( $key, $current, $incoming ) {
+		if ( 'view_list' === $key ) {
+			return $this->merge_view_list( $current, $incoming );
+		}
+		if ( 'form' === $key ) {
+			return $this->merge_form( $current, $incoming );
+		}
+		return $this->deep_merge( $current, $incoming );
+	}
+
+	/**
+	 * Recursively merges two values.
+	 *
+	 * Associative arrays (maps) merge key by key; lists and scalars are replaced
+	 * wholesale by the incoming value, since lists without a defined identity
+	 * cannot be merged member by member.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $current  The current value.
+	 * @param mixed $incoming The incoming value.
+	 * @return mixed The merged value.
+	 */
+	private function deep_merge( $current, $incoming ) {
+		// Only a map patch merges; scalars and lists replace wholesale. An
+		// empty array counts as a list, so patching with array() empties the
+		// key (e.g. 'filters' => array() clears the filters) rather than
+		// being a no-op map merge.
+		if ( ! is_array( $incoming ) || array_is_list( $incoming ) ) {
+			return $incoming;
+		}
+
+		// Merge onto the current map, or onto an empty base when the current
+		// value is absent, empty, or not a map, so null delete-markers in the
+		// patch are consumed rather than stored as literal values (e.g.
+		// array( 'layout' => null ) merged into an empty layouts entry yields
+		// array(), not array( 'layout' => null )).
+		$result = is_array( $current ) && ! array_is_list( $current ) ? $current : array();
+		foreach ( $incoming as $key => $value ) {
+			if ( null === $value ) {
+				// A null patch value deletes the key.
+				unset( $result[ $key ] );
+				continue;
+			}
+			$result[ $key ] = $this->deep_merge(
+				array_key_exists( $key, $result ) ? $result[ $key ] : array(),
+				$value
+			);
+		}
+		return $result;
+	}
+
+	/**
+	 * Merges an incoming view list into the current one, keyed by `slug`.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $current  The current view list.
+	 * @param mixed $incoming The incoming view list.
+	 * @return mixed The merged view list.
+	 */
+	private function merge_view_list( $current, $incoming ) {
+		if ( ! is_array( $incoming ) || ! array_is_list( $incoming ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'A "view_list" patch must be a list of view objects.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return $current;
+		}
+		if ( ! is_array( $current ) ) {
+			$current = array();
+		}
+
+		$result  = $current;
+		$by_slug = array();
+		foreach ( $result as $index => $item ) {
+			if ( is_array( $item ) && isset( $item['slug'] ) ) {
+				$by_slug[ $item['slug'] ] = $index;
+			}
+		}
+
+		foreach ( $incoming as $item ) {
+			// A member without a slug could never be matched, merged, or
+			// removed afterwards, so it is rejected rather than appended.
+			$slug = is_array( $item ) && isset( $item['slug'] ) ? $item['slug'] : null;
+			if ( null === $slug ) {
+				_doing_it_wrong(
+					'Gutenberg_View_Config_Data::update_with',
+					esc_html__( 'Each view in a "view_list" patch must declare a "slug".', 'gutenberg' ),
+					'7.1.0'
+				);
+				continue;
+			}
+			if ( isset( $by_slug[ $slug ] ) ) {
+				$index            = $by_slug[ $slug ];
+				$result[ $index ] = $this->deep_merge( $result[ $index ], $item );
+			} else {
+				$result[]         = $item;
+				$by_slug[ $slug ] = array_key_last( $result );
+			}
+		}
+
+		return array_values( $result );
+	}
+
+	/**
+	 * Merges an incoming form into the current one.
+	 *
+	 * The `fields` list is merged by field identity; every other key (e.g.
+	 * `layout`) is merged recursively as a value.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $current  The current form.
+	 * @param mixed $incoming The incoming form.
+	 * @return mixed The merged form.
+	 */
+	private function merge_form( $current, $incoming ) {
+		if ( ! is_array( $incoming ) || ( array() !== $incoming && array_is_list( $incoming ) ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'A "form" patch must be an object of form properties, not a list.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return $current;
+		}
+		if ( ! is_array( $current ) ) {
+			$current = array();
+		}
+
+		return $this->merge_map( $current, $incoming, 'fields' );
+	}
+
+	/**
+	 * Merges an incoming map into the current one, routing one identity-keyed
+	 * field list key to the field-list merger.
+	 *
+	 * Shared by the `form` key (whose `fields` are an identity-keyed list) and
+	 * a single field (whose `children` are). Every other key merges recursively
+	 * as a value, and a null patch value deletes the key — except the identity
+	 * list itself, whose content only `remove_fields()` may remove.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array  $current  The current map.
+	 * @param array  $incoming The incoming map patch.
+	 * @param string $list_key The key holding the identity-keyed field list.
+	 * @return array The merged map.
+	 */
+	private function merge_map( array $current, array $incoming, $list_key ) {
+		$result = $current;
+		foreach ( $incoming as $key => $value ) {
+			if ( $list_key === $key ) {
+				// The identity-keyed list cannot be deleted with null: that
+				// would drop list members without naming them, which is what
+				// remove_fields() is for.
+				if ( null === $value ) {
+					_doing_it_wrong(
+						'Gutenberg_View_Config_Data::update_with',
+						sprintf(
+							/* translators: %s: the patch key holding the field list. */
+							esc_html__( 'The "%s" list cannot be deleted with a null patch value. Use remove_fields() to remove fields.', 'gutenberg' ),
+							esc_html( $list_key )
+						),
+						'7.1.0'
+					);
+					continue;
+				}
+				$current_list   = isset( $result[ $key ] ) && is_array( $result[ $key ] ) ? $result[ $key ] : array();
+				$result[ $key ] = $this->merge_field_list( $current_list, $value );
+				continue;
+			}
+			if ( null === $value ) {
+				// A null patch value deletes the key.
+				unset( $result[ $key ] );
+				continue;
+			}
+			$result[ $key ] = $this->deep_merge(
+				array_key_exists( $key, $result ) ? $result[ $key ] : array(),
+				$value
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Merges an incoming list of form fields into the current one, keyed by `id`.
+	 *
+	 * A field whose identity matches an existing one merges in place; an unknown
+	 * one appends to the end.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $current  The current list of fields.
+	 * @param mixed $incoming The incoming list of fields.
+	 * @return mixed The merged list of fields.
+	 */
+	private function merge_field_list( $current, $incoming ) {
+		if ( ! is_array( $incoming ) || ! array_is_list( $incoming ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'A fields patch must be a list of fields.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return $current;
+		}
+
+		$result = $current;
+		$by_id  = array();
+		foreach ( $result as $index => $field ) {
+			$identity = $this->field_identity( $field );
+			if ( null !== $identity ) {
+				$by_id[ $identity ] = $index;
+			}
+		}
+
+		foreach ( $incoming as $field ) {
+			// A field without an identity could never be matched, merged, or
+			// removed afterwards, so it is rejected rather than appended.
+			$identity = $this->field_identity( $field );
+			if ( null === $identity ) {
+				_doing_it_wrong(
+					'Gutenberg_View_Config_Data::update_with',
+					esc_html__( 'Each field in a patch must be a string reference or declare a string "id".', 'gutenberg' ),
+					'7.1.0'
+				);
+				continue;
+			}
+			if ( isset( $by_id[ $identity ] ) ) {
+				$index            = $by_id[ $identity ];
+				$result[ $index ] = $this->merge_field_item( $result[ $index ], $field );
+			} else {
+				$result[]           = $field;
+				$by_id[ $identity ] = array_key_last( $result );
+			}
+		}
+
+		return array_values( $result );
+	}
+
+	/**
+	 * Merges an incoming form field into an existing one.
+	 *
+	 * A field may be a bare string (a reference with no overrides) or an object.
+	 * The nested `children` list is merged by identity like any field list.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $existing The existing field.
+	 * @param mixed $incoming The incoming field.
+	 * @return mixed The merged field.
+	 */
+	private function merge_field_item( $existing, $incoming ) {
+		// A bare string reference carries no overrides, so the richer existing
+		// definition wins.
+		if ( ! is_array( $incoming ) ) {
+			return $existing;
+		}
+		// Promote a bare string reference so the incoming object's overrides apply.
+		if ( ! is_array( $existing ) ) {
+			$existing = array( 'id' => $existing );
+		}
+
+		return $this->merge_map( $existing, $incoming, 'children' );
+	}
+
+	/**
+	 * Returns a field list with the fields matching the given identities removed,
+	 * recursing into group children.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array    $fields The list of fields.
+	 * @param string[] $ids    The identities of the fields to remove.
+	 * @return array The list with the matching fields removed.
+	 */
+	private function reject_fields( array $fields, array $ids ) {
+		$result = array();
+		foreach ( $fields as $field ) {
+			if ( in_array( $this->field_identity( $field ), $ids, true ) ) {
+				continue;
+			}
+			if ( is_array( $field ) && isset( $field['children'] ) && is_array( $field['children'] ) ) {
+				$field['children'] = $this->reject_fields( $field['children'], $ids );
+			}
+			$result[] = $field;
+		}
+		return $result;
+	}
+
+	/**
+	 * Resolves the identity of a form field.
+	 *
+	 * A bare string is its own identity; an object is identified by its `id`.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $field The field.
+	 * @return string|null The identity, or null if it cannot be resolved.
+	 */
+	private function field_identity( $field ) {
+		if ( is_string( $field ) ) {
+			return $field;
+		}
+		if ( is_array( $field ) && isset( $field['id'] ) && is_string( $field['id'] ) ) {
+			return $field['id'];
+		}
+		return null;
+	}
+}

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -6,30 +6,33 @@
  */
 
 /**
- * Mutable container passed through the `get_entity_view_config_{$kind}_{$name}`
- * filter so core and third parties can contribute to an entity's view
- * configuration as versioned patches instead of mutating a raw array.
+ * Holds an entity's view configuration while it is being built.
  *
- * Two kinds of contribution are supported:
+ * An instance of this class is what `get_entity_view_config_{$kind}_{$name}`
+ * filter callbacks receive: a callback changes the configuration by calling
+ * methods on the instance and returning it. The configuration has four
+ * top-level keys — `default_view`, `default_layouts`, `view_list`, and
+ * `form` — and there are two ways to contribute:
  *
- * - Base definition (`set()`): replaces a whole top-level key. Intended for the
- *   entity's authoritative definition (core's per-post-type callbacks). Because
- *   it replaces rather than merges, a third party using it stops inheriting
- *   core's future changes to that key (a "freeze"), so third parties should
- *   prefer the layering functions below.
- * - Versioned layering: additive patches that survive future shape changes.
- *   Each contribution declares the schema version it was authored against so it
- *   can be migrated forward to the latest version before it merges, and each
- *   function covers one part of the configuration. `update_properties()` merges the
- *   object-shaped keys: `default_view`, `default_layouts`, and `form` minus its
- *   `fields`. `update_view_list_items()` patches `view_list` entries by `slug`,
- *   and `update_form_fields()` patches `form` fields by `id`, finding a field
- *   wherever it lives — at the top level or nested in a group's `children`.
- *   All the update functions follow the same rules: a map value merges key by key, a list
- *   value replaces wholesale, and `null` deletes what it names — a property, a
- *   whole member, or a whole top-level key, which
- *   `gutenberg_get_entity_view_config()` backfills from the defaults so it
- *   reads as a reset.
+ * - The `update_*()` methods merge partial changes (patches) into what is
+ *   already there, each covering one part of the configuration:
+ *   `update_properties()` for `default_view`, `default_layouts`, and the
+ *   `form` settings other than its `fields`; `update_view_list_items()` for
+ *   the `view_list` entries, keyed by view `slug`; and `update_form_fields()`
+ *   for the `form` fields, keyed by field `id`. This is what plugins should
+ *   use: patches compose with core's configuration and with other plugins'.
+ * - `set()` replaces a whole top-level key. It shouldn't be the default
+ *   choice — a callback using it stops inheriting core's future changes to
+ *   that key — but it's useful for cases like a post type that doesn't
+ *   want the default form at all.
+ *
+ * Patches follow three shared rules: an associative array merges key by
+ * key, a numerically indexed array replaces the current value wholesale,
+ * and `null` deletes what it names — deleting a whole top-level key resets
+ * it to its default. Each patch also declares the configuration schema
+ * version it was written against (currently 1), so a future WordPress
+ * release that changes the configuration shape can migrate existing patches
+ * forward instead of breaking them.
  *
  * @since 7.1.0
  */
@@ -84,9 +87,9 @@ class Gutenberg_View_Config_Data {
 	/**
 	 * Replaces a whole top-level key with a new value.
 	 *
-	 * Intended for the entity's base definition (core's per-post-type callbacks).
-	 * Third parties should prefer the update_* functions so they keep inheriting
-	 * core's future changes.
+	 * It shouldn't be the default choice — a callback using it stops
+	 * inheriting core's future changes to that key — but it's useful for
+	 * cases like a post type that doesn't want the default form at all.
 	 *
 	 * @since 7.1.0
 	 *
@@ -113,24 +116,21 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Merges a versioned patch into the object-shaped configuration keys.
+	 * Merges a partial configuration into `default_view`, `default_layouts`,
+	 * and the `form` settings other than its `fields`.
 	 *
-	 * Covers `default_view`, `default_layouts`, and `form` except its `fields`.
-	 * A map value merges key by key, a list value replaces wholesale, and a
-	 * `null` value deletes the key it names: a nested value (a `default_view`
-	 * property, a `default_layouts` entry or nested layout property) is unset,
-	 * and a whole top-level key — any documented key, including `view_list` —
-	 * is dropped from the container. `gutenberg_get_entity_view_config()`
-	 * backfills a dropped documented key from the defaults, so that reads as a
-	 * reset.
+	 * An associative array merges key by key, a numerically indexed array
+	 * replaces the current value wholesale, and `null` deletes the key it
+	 * names; deleting a whole top-level key (any documented key, including
+	 * `view_list`) resets it to its default.
 	 *
-	 * The identity-keyed collections are managed by their own functions and are
-	 * rejected here: a non-null `view_list` value must go through
-	 * `update_view_list_items()`, and a `fields` key inside a `form` value must
-	 * go through `update_form_fields()`.
+	 * The keyed collections have dedicated methods and are rejected here: a
+	 * non-null `view_list` value must go through `update_view_list_items()`,
+	 * and a `fields` key inside a `form` value must go through
+	 * `update_form_fields()`.
 	 *
-	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
-	 * cannot be migrated) and does not merge.
+	 * A patch that declares an unsupported schema version is rejected and
+	 * does not merge.
 	 *
 	 * @since 7.1.0
 	 *
@@ -178,7 +178,6 @@ class Gutenberg_View_Config_Data {
 					continue;
 				}
 			}
-			// A documented key that is not yet present merges onto an empty base.
 			$this->config[ $key ] = $this->deep_merge( $this->config[ $key ] ?? array(), $value );
 		}
 
@@ -186,19 +185,19 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Merges a versioned patch into the `view_list`, keyed by `slug`.
+	 * Adds, updates, or removes `view_list` entries, keyed by view `slug`.
 	 *
-	 * Each patch key names the `slug` of the view it patches: a matching view
-	 * merges in place and keeps its position (a map value merges key by key, a
-	 * list value — e.g. the view's `filters` — replaces wholesale), an unknown
-	 * slug appends a new view to the end, and a `null` value removes the view.
-	 * The patch key is the identity: a `slug` property inside the value is
-	 * ignored. A `null` for a slug that is not found is a silent no-op: the
-	 * view may have been removed by another filter or simply not apply to this
-	 * entity, which is a legitimate outcome rather than misuse.
+	 * Each patch key names the `slug` of the view it targets: a matching view
+	 * merges in place and keeps its position (following the shared rules —
+	 * e.g. the view's `filters`, being numerically indexed, replace
+	 * wholesale), an unknown slug appends a new view to the end, and `null`
+	 * removes the view. The patch key is the identity: a `slug` property
+	 * inside the value is ignored. A `null` for a slug that is not found is a
+	 * silent no-op — the view may have been removed by another callback or
+	 * simply not apply to this entity.
 	 *
-	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
-	 * cannot be migrated) and does not merge.
+	 * A patch that declares an unsupported schema version is rejected and
+	 * does not merge.
 	 *
 	 * @since 7.1.0
 	 *
@@ -276,23 +275,26 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Merges a versioned patch into the `form` fields, keyed by field `id`.
+	 * Adds, updates, or removes `form` fields, keyed by field `id`.
 	 *
-	 * Each patch key names the `id` of the field it patches, and the field is
+	 * Each patch key names the `id` of the field it targets, and the field is
 	 * found wherever it lives — at the top level or nested inside a group's
 	 * `children`. Fields are visited in document order and a group is checked
 	 * before its own children, so when an id appears at both levels the group
 	 * wins. A matching field merges in place, an unknown id appends a new field
-	 * to the end of the top-level list, and a `null` value removes the field.
-	 * The patch key is the identity: an `id` property inside the value is
-	 * ignored.
+	 * to the end of the top-level fields, and `null` removes the field. The
+	 * patch key is the identity: an `id` property inside the value is ignored.
+	 * A `null` for an id that is not found is a silent no-op — the field may
+	 * have been removed by another callback or simply not apply to this
+	 * entity.
 	 *
-	 * Inside a field patch, `children` follows the same rules: a map merges
-	 * into the group's children by id (appending unknown ones), a list replaces
-	 * the children wholesale, and `null` deletes the key.
+	 * Inside a field patch, `children` follows the shared rules: an associative
+	 * array merges into the group's children by id (appending unknown ones), a
+	 * numerically indexed array replaces the children wholesale, and `null`
+	 * deletes the key.
 	 *
-	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
-	 * cannot be migrated) and does not merge.
+	 * A patch that declares an unsupported schema version is rejected and
+	 * does not merge.
 	 *
 	 * @since 7.1.0
 	 *
@@ -335,7 +337,7 @@ class Gutenberg_View_Config_Data {
 	 *
 	 * @param int    $version The declared version.
 	 * @param string $method  The public method the patch was passed to.
-	 * @return bool Whether the version can be migrated to the latest version.
+	 * @return bool Whether the declared version is a supported schema version.
 	 */
 	private function check_version( int $version, $method ) {
 		if ( $version >= 1 && $version <= self::LATEST_VERSION ) {
@@ -396,9 +398,8 @@ class Gutenberg_View_Config_Data {
 	 * @return mixed The merged value.
 	 */
 	private function deep_merge( $current, $incoming ) {
-		// Only a map patch merges; scalars and lists replace wholesale. An
-		// empty array counts as a list, so patching with array() empties the
-		// key (e.g. 'filters' => array() clears the filters) rather than
+		// An empty array counts as a list, so patching with array() empties
+		// the key (e.g. 'filters' => array() clears the filters) rather than
 		// being a no-op map merge.
 		if ( ! is_array( $incoming ) || array_is_list( $incoming ) ) {
 			return $incoming;
@@ -431,9 +432,7 @@ class Gutenberg_View_Config_Data {
 	 * value removes the matching field (recursing into children), a map value
 	 * merges into the matching field wherever it lives, and an unknown id
 	 * appends a new field to the end of this list. A `null` for an id that is
-	 * not found is a silent no-op: the field may have been removed by another
-	 * filter or simply not apply to this entity, which is a legitimate outcome
-	 * rather than misuse.
+	 * not found is a silent no-op.
 	 *
 	 * @since 7.1.0
 	 *
@@ -468,7 +467,7 @@ class Gutenberg_View_Config_Data {
 				continue;
 			}
 			// An unknown id appends: as a bare string reference when the patch
-			// carries no overrides, as an object otherwise.
+			// carries no overrides, as an array otherwise.
 			$current[] = array() === $value ? $id : $this->merge_field_item( $id, $id, $value );
 		}
 
@@ -510,11 +509,10 @@ class Gutenberg_View_Config_Data {
 	/**
 	 * Merges a field patch into an existing field.
 	 *
-	 * A bare string reference is promoted to an object so the overrides apply.
+	 * A bare string reference is promoted to an array so the overrides apply.
 	 * The `children` key follows the same rules — a map merges into the
 	 * group's children by id, a list replaces them wholesale, and `null`
-	 * deletes the key — and every other key merges as a value: a map merges
-	 * key by key, a list or scalar replaces, and `null` deletes the key.
+	 * deletes the key — and every other key merges via deep_merge().
 	 *
 	 * @since 7.1.0
 	 *

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -16,20 +16,20 @@
  *   entity's authoritative definition (core's per-post-type callbacks). Because
  *   it replaces rather than merges, a third party using it stops inheriting
  *   core's future changes to that key (a "freeze"), so third parties should
- *   prefer the layering verbs below.
- * - Versioned layering (`update_with()` and the `remove_*` helpers): additive
- *   patches that survive future shape changes. Each `update_with()` contribution
- *   declares the schema version it was authored against and is migrated forward
- *   to the latest version before it merges: identity-keyed lists (`view_list` by
- *   `slug`, `form` fields by `id`) merge a matching member in place and append an
- *   unknown one to the end; the object-shaped keys (`default_view`,
- *   `default_layouts`) merge recursively; and a patch value of `null` deletes
- *   that key (e.g. a nested layout property or a field's `label`). Dropping a
- *   whole list member instead
- *   goes through `remove_view_list_items()` (by `slug`) and `remove_fields()`
- *   (by `id`, recursing into group `children`): they name identities and core
- *   walks its own current structure to drop them, which keeps inheritance intact
- *   and version-safe.
+ *   prefer the layering functions below.
+ * - Versioned layering: additive patches that survive future shape changes.
+ *   Each contribution declares the schema version it was authored against so it
+ *   can be migrated forward to the latest version before it merges, and each
+ *   function covers one part of the configuration. `update_properties()` merges the
+ *   object-shaped keys: `default_view`, `default_layouts`, and `form` minus its
+ *   `fields`. `update_view_list_items()` patches `view_list` entries by `slug`,
+ *   and `update_form_fields()` patches `form` fields by `id`, finding a field
+ *   wherever it lives — at the top level or nested in a group's `children`.
+ *   All the update functions follow the same rules: a map value merges key by key, a list
+ *   value replaces wholesale, and `null` deletes what it names — a property, a
+ *   whole member, or a whole top-level key, which
+ *   `gutenberg_get_entity_view_config()` backfills from the defaults so it
+ *   reads as a reset.
  *
  * @since 7.1.0
  */
@@ -85,8 +85,8 @@ class Gutenberg_View_Config_Data {
 	 * Replaces a whole top-level key with a new value.
 	 *
 	 * Intended for the entity's base definition (core's per-post-type callbacks).
-	 * Third parties should prefer update_with() and the remove_* helpers so they
-	 * keep inheriting core's future changes.
+	 * Third parties should prefer the update_* functions so they keep inheriting
+	 * core's future changes.
 	 *
 	 * @since 7.1.0
 	 *
@@ -113,22 +113,24 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Merges a versioned patch into the configuration.
+	 * Merges a versioned patch into the object-shaped configuration keys.
 	 *
-	 * The patch is migrated from the declared version up to the latest version
-	 * and then merged by identity: matching collection members merge in place and
-	 * unknown ones append to the end. A patch value of `null` deletes that key
-	 * rather than assigning `null`: a nested value (a `default_view` property, a
-	 * `default_layouts` entry or nested layout property, a field's `label`) is
-	 * unset, and a whole top-level key is dropped from the container —
-	 * `gutenberg_get_entity_view_config()` backfills a dropped documented key
-	 * from the defaults, so that reads as a reset. Null never removes list
-	 * content: a `null` inside a list member is kept as a literal value, and
-	 * nulling the `fields`/`children` lists themselves is rejected; use
-	 * `remove_view_list_items()` / `remove_fields()` to drop list members.
+	 * Covers `default_view`, `default_layouts`, and `form` except its `fields`.
+	 * A map value merges key by key, a list value replaces wholesale, and a
+	 * `null` value deletes the key it names: a nested value (a `default_view`
+	 * property, a `default_layouts` entry or nested layout property) is unset,
+	 * and a whole top-level key — any documented key, including `view_list` —
+	 * is dropped from the container. `gutenberg_get_entity_view_config()`
+	 * backfills a dropped documented key from the defaults, so that reads as a
+	 * reset.
 	 *
-	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is rejected
-	 * (it cannot be migrated) and does not merge.
+	 * The identity-keyed collections are managed by their own functions and are
+	 * rejected here: a non-null `view_list` value must go through
+	 * `update_view_list_items()`, and a `fields` key inside a `form` value must
+	 * go through `update_form_fields()`.
+	 *
+	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
+	 * rejected (it cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
@@ -136,27 +138,24 @@ class Gutenberg_View_Config_Data {
 	 * @param int|null $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_with( array $patch, $version = null ) {
-		if ( ! $this->is_valid_version( $version ) ) {
-			if ( self::LATEST_VERSION > 1 ) {
-				$message = sprintf(
-					/* translators: %d: the latest supported version. */
-					esc_html__( 'A view configuration contribution must declare a version between 1 and %d.', 'gutenberg' ),
-					self::LATEST_VERSION
-				);
-			} else {
-				$message = esc_html__( 'A view configuration contribution must declare version 1.', 'gutenberg' );
-			}
-			_doing_it_wrong( __METHOD__, $message, '7.1.0' );
+	public function update_properties( array $patch, $version = null ) {
+		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
 
-		$patch = $this->migrate( $patch );
+		$patch = $this->migrate( $patch, $version, 'properties' );
 
 		foreach ( $patch as $key => $value ) {
-			// Keys outside the documented shape are discarded, so the container
-			// only ever exposes the documented keys.
 			if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: the configuration key. */
+						esc_html__( '"%s" is not a documented view configuration key.', 'gutenberg' ),
+						esc_html( $key )
+					),
+					'7.1.0'
+				);
 				continue;
 			}
 			// A null patch value drops the whole key from the container rather
@@ -165,132 +164,263 @@ class Gutenberg_View_Config_Data {
 				unset( $this->config[ $key ] );
 				continue;
 			}
+			if ( 'view_list' === $key ) {
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html__( 'The "view_list" entries are patched by identity. Use update_view_list_items() instead.', 'gutenberg' ),
+					'7.1.0'
+				);
+				continue;
+			}
+			if ( 'form' === $key ) {
+				$value = $this->extract_form_properties( $value );
+				// Nothing left to merge: the value was off-shape, or held only
+				// the rejected `fields` key.
+				if ( null === $value || array() === $value ) {
+					continue;
+				}
+			}
 			// A documented key that is not yet present merges onto an empty base.
 			$current              = array_key_exists( $key, $this->config ) ? $this->config[ $key ] : array();
-			$this->config[ $key ] = $this->merge_value( $key, $current, $value );
+			$this->config[ $key ] = $this->deep_merge( $current, $value );
 		}
 
 		return $this;
 	}
 
 	/**
-	 * Removes one or more `view_list` entries by `slug`.
+	 * Merges a versioned patch into the `view_list`, keyed by `slug`.
 	 *
-	 * Core walks its own current view list to drop the named entries, so the
-	 * caller only needs the stable slug.
+	 * Each patch key names the `slug` of the view it patches: a matching view
+	 * merges in place and keeps its position (a map value merges key by key, a
+	 * list value — e.g. the view's `filters` — replaces wholesale), an unknown
+	 * slug appends a new view to the end, and a `null` value removes the view.
+	 * The patch key is the identity: a `slug` property inside the value is
+	 * ignored. A `null` for a slug that is not found is a silent no-op: the
+	 * view may have been removed by another filter or simply not apply to this
+	 * entity, which is a legitimate outcome rather than misuse.
 	 *
-	 * An entry that is not found is left untouched without warning: it may have
-	 * been removed by another filter or simply not apply to this entity, which is
-	 * a legitimate outcome rather than misuse.
+	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
+	 * rejected (it cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string|string[] $slugs A single slug to remove, or an array of slugs.
+	 * @param array    $items   The view patches, keyed by slug.
+	 * @param int|null $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function remove_view_list_items( $slugs ) {
-		$slugs = (array) $slugs;
+	public function update_view_list_items( array $items, $version = null ) {
+		if ( ! $this->check_version( $version, __METHOD__ ) ) {
+			return $this;
+		}
 
-		if ( isset( $this->config['view_list'] ) && is_array( $this->config['view_list'] ) ) {
-			$this->config['view_list'] = array_values(
-				array_filter(
-					$this->config['view_list'],
-					static function ( $item ) use ( $slugs ) {
-						$slug = is_array( $item ) && isset( $item['slug'] ) ? $item['slug'] : null;
-						return ! in_array( $slug, $slugs, true );
-					}
-				)
+		$items = $this->migrate( $items, $version, 'view_list' );
+
+		if ( array() === $items ) {
+			return $this;
+		}
+		if ( array_is_list( $items ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'A view list patch must be keyed by view "slug".', 'gutenberg' ),
+				'7.1.0'
 			);
+			return $this;
 		}
+
+		$view_list = isset( $this->config['view_list'] ) && is_array( $this->config['view_list'] ) ? $this->config['view_list'] : array();
+
+		foreach ( $items as $slug => $value ) {
+			// PHP casts numeric-string array keys to integers; identities are strings.
+			$slug = (string) $slug;
+
+			if ( null === $value ) {
+				$view_list = array_values(
+					array_filter(
+						$view_list,
+						static function ( $item ) use ( $slug ) {
+							return ! is_array( $item ) || ! isset( $item['slug'] ) || $item['slug'] !== $slug;
+						}
+					)
+				);
+				continue;
+			}
+
+			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html__( 'Each view patch must be an object of view properties, or null to remove the view.', 'gutenberg' ),
+					'7.1.0'
+				);
+				continue;
+			}
+
+			// The patch key is the identity.
+			unset( $value['slug'] );
+
+			$index = null;
+			foreach ( $view_list as $i => $item ) {
+				if ( is_array( $item ) && isset( $item['slug'] ) && $item['slug'] === $slug ) {
+					$index = $i;
+					break;
+				}
+			}
+
+			if ( null === $index ) {
+				$view_list[] = array_merge( array( 'slug' => $slug ), $value );
+				continue;
+			}
+			// An empty patch value has nothing to merge (and deep_merge would
+			// treat an empty array as a list, replacing the whole view).
+			if ( array() !== $value ) {
+				$view_list[ $index ] = $this->deep_merge( $view_list[ $index ], $value );
+			}
+		}
+
+		$this->config['view_list'] = array_values( $view_list );
 
 		return $this;
 	}
 
 	/**
-	 * Removes one or more `form` fields by `id`, recursing into group children.
+	 * Merges a versioned patch into the `form` fields, keyed by field `id`.
 	 *
-	 * Core walks its own current form structure to find and drop the named
-	 * fields, including ones nested inside a group's `children`, so the caller
-	 * only needs the stable id.
+	 * Each patch key names the `id` of the field it patches, and the field is
+	 * found wherever it lives — at the top level or nested inside a group's
+	 * `children`. Fields are visited in document order and a group is checked
+	 * before its own children, so when an id appears at both levels the group
+	 * wins. A matching field merges in place, an unknown id appends a new field
+	 * to the end of the top-level list, and a `null` value removes the field.
+	 * The patch key is the identity: an `id` property inside the value is
+	 * ignored.
 	 *
-	 * A field that is not found is left untouched without warning: it may have
-	 * been removed by another filter or simply not apply to this entity, which is
-	 * a legitimate outcome rather than misuse.
+	 * Inside a field patch, `children` follows the same rules: a map merges
+	 * into the group's children by id (appending unknown ones), a list replaces
+	 * the children wholesale, and `null` deletes the key.
+	 *
+	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
+	 * rejected (it cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string|string[] $ids A single field id to remove, or an array of ids.
+	 * @param array    $fields  The field patches, keyed by field id.
+	 * @param int|null $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function remove_fields( $ids ) {
-		$ids = (array) $ids;
-
-		if ( isset( $this->config['form']['fields'] ) && is_array( $this->config['form']['fields'] ) ) {
-			$this->config['form']['fields'] = $this->reject_fields( $this->config['form']['fields'], $ids );
+	public function update_form_fields( array $fields, $version = null ) {
+		if ( ! $this->check_version( $version, __METHOD__ ) ) {
+			return $this;
 		}
+
+		$fields = $this->migrate( $fields, $version, 'form_fields' );
+
+		if ( array() === $fields ) {
+			return $this;
+		}
+		if ( array_is_list( $fields ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'A fields patch must be keyed by field "id".', 'gutenberg' ),
+				'7.1.0'
+			);
+			return $this;
+		}
+
+		if ( ! isset( $this->config['form'] ) || ! is_array( $this->config['form'] ) ) {
+			$this->config['form'] = array();
+		}
+		$current = isset( $this->config['form']['fields'] ) && is_array( $this->config['form']['fields'] ) ? $this->config['form']['fields'] : array();
+
+		$this->config['form']['fields'] = $this->merge_fields_by_identity( $current, $fields );
 
 		return $this;
 	}
 
 	/**
-	 * Migrates a patch up to the latest version.
+	 * Migrates a patch from its declared version up to the latest version.
 	 *
 	 * The latest version is the only version so far, so this is an identity
-	 * transform for now. Version-specific steps — and the source version they
-	 * migrate from — are added here as the schema evolves.
+	 * transform for now. Version-specific steps dispatch on the declared
+	 * version and the part of the configuration the patch targets as the
+	 * schema evolves.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array $patch The patch to migrate.
+	 * @param array  $patch   The patch to migrate.
+	 * @param int    $version The schema version the patch was authored against.
+	 * @param string $scope   The part of the configuration the patch targets: 'properties', 'view_list', or 'form_fields'.
 	 * @return array The migrated patch.
 	 */
-	private function migrate( array $patch ) {
+	private function migrate( array $patch, $version, $scope ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $patch;
 	}
 
 	/**
-	 * Determines whether a declared version can be migrated to the latest version.
+	 * Validates a declared patch version, reporting misuse against the given
+	 * public method.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed $version The declared version.
-	 * @return bool Whether the version is a supported integer.
+	 * @param mixed  $version The declared version.
+	 * @param string $method  The public method the patch was passed to.
+	 * @return bool Whether the version can be migrated to the latest version.
 	 */
-	private function is_valid_version( $version ) {
-		return is_int( $version )
-			&& $version >= 1
-			&& $version <= self::LATEST_VERSION;
+	private function check_version( $version, $method ) {
+		if ( is_int( $version ) && $version >= 1 && $version <= self::LATEST_VERSION ) {
+			return true;
+		}
+
+		if ( self::LATEST_VERSION > 1 ) {
+			$message = sprintf(
+				/* translators: %d: the latest supported version. */
+				esc_html__( 'A view configuration contribution must declare a version between 1 and %d.', 'gutenberg' ),
+				self::LATEST_VERSION
+			);
+		} else {
+			$message = esc_html__( 'A view configuration contribution must declare version 1.', 'gutenberg' );
+		}
+		_doing_it_wrong( esc_html( $method ), $message, '7.1.0' );
+
+		return false;
 	}
 
 	/**
-	 * Merges an incoming value for a top-level key into the current value.
-	 *
-	 * Dispatches the identity-keyed collections to their dedicated mergers and
-	 * falls back to a recursive value merge for object-shaped keys.
+	 * Validates a `form` patch value for update_properties() and strips the
+	 * `fields` key, which is managed by update_form_fields().
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $key      The top-level key being merged.
-	 * @param mixed  $current  The current value.
-	 * @param mixed  $incoming The incoming value.
-	 * @return mixed The merged value.
+	 * @param mixed $value The incoming `form` patch value.
+	 * @return array|null The form properties to merge, or null when the value
+	 *                    is off-shape.
 	 */
-	private function merge_value( $key, $current, $incoming ) {
-		if ( 'view_list' === $key ) {
-			return $this->merge_view_list( $current, $incoming );
+	private function extract_form_properties( $value ) {
+		if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_properties',
+				esc_html__( 'A "form" patch must be an object of form properties, not a list.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return null;
 		}
-		if ( 'form' === $key ) {
-			return $this->merge_form( $current, $incoming );
+		if ( array_key_exists( 'fields', $value ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_properties',
+				esc_html__( 'The form "fields" are patched by identity. Use update_form_fields() instead.', 'gutenberg' ),
+				'7.1.0'
+			);
+			unset( $value['fields'] );
 		}
-		return $this->deep_merge( $current, $incoming );
+
+		return $value;
 	}
 
 	/**
 	 * Recursively merges two values.
 	 *
-	 * Associative arrays (maps) merge key by key; lists and scalars are replaced
-	 * wholesale by the incoming value, since lists without a defined identity
-	 * cannot be merged member by member.
+	 * Associative arrays (maps) merge key by key and a null patch value deletes
+	 * the key; lists and scalars are replaced wholesale by the incoming value,
+	 * since lists without a defined identity cannot be merged member by member.
 	 *
 	 * @since 7.1.0
 	 *
@@ -328,219 +458,151 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Merges an incoming view list into the current one, keyed by `slug`.
+	 * Merges a map of field patches into a field list by identity.
+	 *
+	 * Shared by the top-level `form` fields and a group's `children`: a `null`
+	 * value removes the matching field (recursing into children), a map value
+	 * merges into the matching field wherever it lives, and an unknown id
+	 * appends a new field to the end of this list. A `null` for an id that is
+	 * not found is a silent no-op: the field may have been removed by another
+	 * filter or simply not apply to this entity, which is a legitimate outcome
+	 * rather than misuse.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed $current  The current view list.
-	 * @param mixed $incoming The incoming view list.
-	 * @return mixed The merged view list.
+	 * @param array $current The current list of fields.
+	 * @param array $patches The field patches, keyed by field id.
+	 * @return array The merged list of fields.
 	 */
-	private function merge_view_list( $current, $incoming ) {
-		if ( ! is_array( $incoming ) || ! array_is_list( $incoming ) ) {
-			_doing_it_wrong(
-				'Gutenberg_View_Config_Data::update_with',
-				esc_html__( 'A "view_list" patch must be a list of view objects.', 'gutenberg' ),
-				'7.1.0'
-			);
-			return $current;
-		}
-		if ( ! is_array( $current ) ) {
-			$current = array();
-		}
+	private function merge_fields_by_identity( array $current, array $patches ) {
+		foreach ( $patches as $id => $value ) {
+			// PHP casts numeric-string array keys to integers; identities are strings.
+			$id = (string) $id;
 
-		$result  = $current;
-		$by_slug = array();
-		foreach ( $result as $index => $item ) {
-			if ( is_array( $item ) && isset( $item['slug'] ) ) {
-				$by_slug[ $item['slug'] ] = $index;
+			if ( null === $value ) {
+				$current = $this->reject_fields( $current, array( $id ) );
+				continue;
 			}
-		}
-
-		foreach ( $incoming as $item ) {
-			// A member without a slug could never be matched, merged, or
-			// removed afterwards, so it is rejected rather than appended.
-			$slug = is_array( $item ) && isset( $item['slug'] ) ? $item['slug'] : null;
-			if ( null === $slug ) {
+			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 				_doing_it_wrong(
-					'Gutenberg_View_Config_Data::update_with',
-					esc_html__( 'Each view in a "view_list" patch must declare a "slug".', 'gutenberg' ),
+					'Gutenberg_View_Config_Data::update_form_fields',
+					esc_html__( 'Each field patch must be an object of field properties, or null to remove the field.', 'gutenberg' ),
 					'7.1.0'
 				);
 				continue;
 			}
-			if ( isset( $by_slug[ $slug ] ) ) {
-				$index            = $by_slug[ $slug ];
-				$result[ $index ] = $this->deep_merge( $result[ $index ], $item );
-			} else {
-				$result[]         = $item;
-				$by_slug[ $slug ] = array_key_last( $result );
+
+			// The patch key is the identity.
+			unset( $value['id'] );
+
+			$merged = $this->merge_field_in_tree( $current, $id, $value );
+			if ( null !== $merged ) {
+				$current = $merged;
+				continue;
+			}
+			// An unknown id appends: as a bare string reference when the patch
+			// carries no overrides, as an object otherwise.
+			$current[] = array() === $value ? $id : $this->merge_field_item( $id, $id, $value );
+		}
+
+		return $current;
+	}
+
+	/**
+	 * Merges a field patch into the field carrying the given identity, wherever
+	 * it lives in the tree.
+	 *
+	 * Fields are visited in document order and a group is checked before its
+	 * own children, so when an id appears at both levels the group wins.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array  $fields The list of fields to search.
+	 * @param string $id     The identity of the field to patch.
+	 * @param array  $value  The field patch.
+	 * @return array|null The updated list, or null when the id was not found.
+	 */
+	private function merge_field_in_tree( array $fields, $id, array $value ) {
+		foreach ( $fields as $index => $field ) {
+			if ( $this->field_identity( $field ) === $id ) {
+				$fields[ $index ] = $this->merge_field_item( $field, $id, $value );
+				return $fields;
+			}
+			if ( is_array( $field ) && isset( $field['children'] ) && is_array( $field['children'] ) ) {
+				$children = $this->merge_field_in_tree( $field['children'], $id, $value );
+				if ( null !== $children ) {
+					$fields[ $index ]['children'] = $children;
+					return $fields;
+				}
 			}
 		}
 
-		return array_values( $result );
+		return null;
 	}
 
 	/**
-	 * Merges an incoming form into the current one.
+	 * Merges a field patch into an existing field.
 	 *
-	 * The `fields` list is merged by field identity; every other key (e.g.
-	 * `layout`) is merged recursively as a value.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param mixed $current  The current form.
-	 * @param mixed $incoming The incoming form.
-	 * @return mixed The merged form.
-	 */
-	private function merge_form( $current, $incoming ) {
-		if ( ! is_array( $incoming ) || ( array() !== $incoming && array_is_list( $incoming ) ) ) {
-			_doing_it_wrong(
-				'Gutenberg_View_Config_Data::update_with',
-				esc_html__( 'A "form" patch must be an object of form properties, not a list.', 'gutenberg' ),
-				'7.1.0'
-			);
-			return $current;
-		}
-		if ( ! is_array( $current ) ) {
-			$current = array();
-		}
-
-		return $this->merge_map( $current, $incoming, 'fields' );
-	}
-
-	/**
-	 * Merges an incoming map into the current one, routing one identity-keyed
-	 * field list key to the field-list merger.
-	 *
-	 * Shared by the `form` key (whose `fields` are an identity-keyed list) and
-	 * a single field (whose `children` are). Every other key merges recursively
-	 * as a value, and a null patch value deletes the key — except the identity
-	 * list itself, whose content only `remove_fields()` may remove.
+	 * A bare string reference is promoted to an object so the overrides apply.
+	 * The `children` key follows the same rules — a map merges into the
+	 * group's children by id, a list replaces them wholesale, and `null`
+	 * deletes the key — and every other key merges as a value: a map merges
+	 * key by key, a list or scalar replaces, and `null` deletes the key.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array  $current  The current map.
-	 * @param array  $incoming The incoming map patch.
-	 * @param string $list_key The key holding the identity-keyed field list.
-	 * @return array The merged map.
+	 * @param array|string $existing The existing field.
+	 * @param string       $id       The field identity.
+	 * @param array        $value    The field patch.
+	 * @return array|string The merged field.
 	 */
-	private function merge_map( array $current, array $incoming, $list_key ) {
-		$result = $current;
-		foreach ( $incoming as $key => $value ) {
-			if ( $list_key === $key ) {
-				// The identity-keyed list cannot be deleted with null: that
-				// would drop list members without naming them, which is what
-				// remove_fields() is for.
-				if ( null === $value ) {
+	private function merge_field_item( $existing, $id, array $value ) {
+		if ( ! is_array( $existing ) ) {
+			// Nothing to apply: keep the bare string reference.
+			if ( array() === $value ) {
+				return $existing;
+			}
+			// Promote the reference so the incoming overrides apply.
+			$existing = array( 'id' => $id );
+		}
+
+		foreach ( $value as $key => $item ) {
+			if ( 'children' === $key ) {
+				if ( null === $item ) {
+					unset( $existing['children'] );
+					continue;
+				}
+				if ( ! is_array( $item ) ) {
 					_doing_it_wrong(
-						'Gutenberg_View_Config_Data::update_with',
-						sprintf(
-							/* translators: %s: the patch key holding the field list. */
-							esc_html__( 'The "%s" list cannot be deleted with a null patch value. Use remove_fields() to remove fields.', 'gutenberg' ),
-							esc_html( $list_key )
-						),
+						'Gutenberg_View_Config_Data::update_form_fields',
+						esc_html__( 'A "children" patch must be an object keyed by field id to merge, a list to replace the children wholesale, or null to delete the key.', 'gutenberg' ),
 						'7.1.0'
 					);
 					continue;
 				}
-				$current_list   = isset( $result[ $key ] ) && is_array( $result[ $key ] ) ? $result[ $key ] : array();
-				$result[ $key ] = $this->merge_field_list( $current_list, $value );
+				// A list replaces the children wholesale (an empty array counts
+				// as a list, clearing them)...
+				if ( array_is_list( $item ) ) {
+					$existing['children'] = $item;
+					continue;
+				}
+				// ...and a map merges into them by identity.
+				$children             = isset( $existing['children'] ) && is_array( $existing['children'] ) ? $existing['children'] : array();
+				$existing['children'] = $this->merge_fields_by_identity( $children, $item );
 				continue;
 			}
-			if ( null === $value ) {
+			if ( null === $item ) {
 				// A null patch value deletes the key.
-				unset( $result[ $key ] );
+				unset( $existing[ $key ] );
 				continue;
 			}
-			$result[ $key ] = $this->deep_merge(
-				array_key_exists( $key, $result ) ? $result[ $key ] : array(),
-				$value
+			$existing[ $key ] = $this->deep_merge(
+				array_key_exists( $key, $existing ) ? $existing[ $key ] : array(),
+				$item
 			);
 		}
 
-		return $result;
-	}
-
-	/**
-	 * Merges an incoming list of form fields into the current one, keyed by `id`.
-	 *
-	 * A field whose identity matches an existing one merges in place; an unknown
-	 * one appends to the end.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param array $current  The current list of fields.
-	 * @param mixed $incoming The incoming list of fields.
-	 * @return mixed The merged list of fields.
-	 */
-	private function merge_field_list( $current, $incoming ) {
-		if ( ! is_array( $incoming ) || ! array_is_list( $incoming ) ) {
-			_doing_it_wrong(
-				'Gutenberg_View_Config_Data::update_with',
-				esc_html__( 'A fields patch must be a list of fields.', 'gutenberg' ),
-				'7.1.0'
-			);
-			return $current;
-		}
-
-		$result = $current;
-		$by_id  = array();
-		foreach ( $result as $index => $field ) {
-			$identity = $this->field_identity( $field );
-			if ( null !== $identity ) {
-				$by_id[ $identity ] = $index;
-			}
-		}
-
-		foreach ( $incoming as $field ) {
-			// A field without an identity could never be matched, merged, or
-			// removed afterwards, so it is rejected rather than appended.
-			$identity = $this->field_identity( $field );
-			if ( null === $identity ) {
-				_doing_it_wrong(
-					'Gutenberg_View_Config_Data::update_with',
-					esc_html__( 'Each field in a patch must be a string reference or declare a string "id".', 'gutenberg' ),
-					'7.1.0'
-				);
-				continue;
-			}
-			if ( isset( $by_id[ $identity ] ) ) {
-				$index            = $by_id[ $identity ];
-				$result[ $index ] = $this->merge_field_item( $result[ $index ], $field );
-			} else {
-				$result[]           = $field;
-				$by_id[ $identity ] = array_key_last( $result );
-			}
-		}
-
-		return array_values( $result );
-	}
-
-	/**
-	 * Merges an incoming form field into an existing one.
-	 *
-	 * A field may be a bare string (a reference with no overrides) or an object.
-	 * The nested `children` list is merged by identity like any field list.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param mixed $existing The existing field.
-	 * @param mixed $incoming The incoming field.
-	 * @return mixed The merged field.
-	 */
-	private function merge_field_item( $existing, $incoming ) {
-		// A bare string reference carries no overrides, so the richer existing
-		// definition wins.
-		if ( ! is_array( $incoming ) ) {
-			return $existing;
-		}
-		// Promote a bare string reference so the incoming object's overrides apply.
-		if ( ! is_array( $existing ) ) {
-			$existing = array( 'id' => $existing );
-		}
-
-		return $this->merge_map( $existing, $incoming, 'children' );
+		return $existing;
 	}
 
 	/**

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -129,16 +129,16 @@ class Gutenberg_View_Config_Data {
 	 * `update_view_list_items()`, and a `fields` key inside a `form` value must
 	 * go through `update_form_fields()`.
 	 *
-	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
-	 * rejected (it cannot be migrated) and does not merge.
+	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
+	 * cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array    $patch   The partial configuration to merge.
-	 * @param int|null $version The schema version the patch was authored against.
+	 * @param array $patch   The partial configuration to merge.
+	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_properties( array $patch, $version = null ) {
+	public function update_properties( array $patch, $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
@@ -200,16 +200,16 @@ class Gutenberg_View_Config_Data {
 	 * view may have been removed by another filter or simply not apply to this
 	 * entity, which is a legitimate outcome rather than misuse.
 	 *
-	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
-	 * rejected (it cannot be migrated) and does not merge.
+	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
+	 * cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array    $items   The view patches, keyed by slug.
-	 * @param int|null $version The schema version the patch was authored against.
+	 * @param array $items   The view patches, keyed by slug.
+	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_view_list_items( array $items, $version = null ) {
+	public function update_view_list_items( array $items, $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}
@@ -298,16 +298,16 @@ class Gutenberg_View_Config_Data {
 	 * into the group's children by id (appending unknown ones), a list replaces
 	 * the children wholesale, and `null` deletes the key.
 	 *
-	 * A patch whose version is missing or outside `[1, LATEST_VERSION]` is
-	 * rejected (it cannot be migrated) and does not merge.
+	 * A patch whose version is outside `[1, LATEST_VERSION]` is rejected (it
+	 * cannot be migrated) and does not merge.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array    $fields  The field patches, keyed by field id.
-	 * @param int|null $version The schema version the patch was authored against.
+	 * @param array $fields  The field patches, keyed by field id.
+	 * @param int   $version The schema version the patch was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function update_form_fields( array $fields, $version = null ) {
+	public function update_form_fields( array $fields, $version ) {
 		if ( ! $this->check_version( $version, __METHOD__ ) ) {
 			return $this;
 		}

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -29,10 +29,10 @@
  * Patches follow three shared rules: an associative array merges key by
  * key, a numerically indexed array replaces the current value wholesale,
  * and `null` deletes what it names — deleting a whole top-level key resets
- * it to its default. Each patch also declares the configuration schema
- * version it was written against (currently 1), so a future WordPress
- * release that changes the configuration shape can migrate existing patches
- * forward instead of breaking them.
+ * it to its default. Each patch and each `set()` value also declares the
+ * configuration schema version it was written against (currently 1), so a
+ * future WordPress release that changes the configuration shape can migrate
+ * existing patches forward instead of breaking them.
  *
  * @since 7.1.0
  */
@@ -91,13 +91,21 @@ class Gutenberg_View_Config_Data {
 	 * inheriting core's future changes to that key — but it's useful for
 	 * cases like a post type that doesn't want the default form at all.
 	 *
+	 * A value that declares an unsupported schema version is rejected and
+	 * does not replace anything.
+	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $key   The configuration key to replace.
-	 * @param mixed  $value The new value.
+	 * @param string $key     The configuration key to replace.
+	 * @param mixed  $value   The new value.
+	 * @param int    $version The schema version the value was authored against.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function set( $key, $value ) {
+	public function set( $key, $value, int $version ) {
+		if ( ! $this->check_version( $version, __METHOD__ ) ) {
+			return $this;
+		}
+
 		if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -788,11 +788,16 @@ function gutenberg_register_entity_view_config_filters() {
 		$wp_callback = "_wp_get_entity_view_config_post_type_{$post_type}";
 		$gb_callback = "_gutenberg_get_entity_view_config_post_type_{$post_type}";
 
-		if ( has_filter( $hook, $wp_callback ) ) {
-			remove_filter( $hook, $wp_callback );
+		// has_filter() returns the priority the callback was registered at.
+		$wp_priority = has_filter( $hook, $wp_callback );
+		if ( false !== $wp_priority ) {
+			remove_filter( $hook, $wp_callback, $wp_priority );
 		}
 		if ( function_exists( $gb_callback ) ) {
-			add_filter( $hook, $gb_callback, 10, 1 );
+			// Base definitions run before the default priority, so third-party
+			// callbacks registered at the default compose on top of them
+			// regardless of registration order.
+			add_filter( $hook, $gb_callback, 5, 1 );
 		}
 	}
 }

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -328,8 +328,8 @@ function _gutenberg_get_entity_view_config_post_type_page( $data ) {
 		),
 	);
 
-	$data->set( 'default_layouts', $default_layouts );
-	$data->set( 'default_view', $default_view );
+	$data->set( 'default_layouts', $default_layouts, 1 );
+	$data->set( 'default_view', $default_view, 1 );
 	// Append the status views onto the inherited base "all items" view rather
 	// than replacing it, so its post-type-specific title is kept. The version
 	// is pinned to the literal this patch was authored against as an extra guard,
@@ -373,8 +373,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
 		'layout'     => $default_layouts['grid']['layout'],
 	);
 
-	$data->set( 'default_layouts', $default_layouts );
-	$data->set( 'default_view', $default_view );
+	$data->set( 'default_layouts', $default_layouts, 1 );
+	$data->set( 'default_view', $default_view, 1 );
 
 	$view_list = array(
 		array(
@@ -423,7 +423,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
 		);
 	}
 
-	$data->set( 'view_list', $view_list );
+	$data->set( 'view_list', $view_list, 1 );
 
 	$data->set(
 		'form',
@@ -447,7 +447,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
 				'sync-status',
 				'revisions',
 			),
-		)
+		),
+		1
 	);
 
 	return $data;
@@ -485,8 +486,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
 		'layout'     => $default_layouts['grid']['layout'],
 	);
 
-	$data->set( 'default_layouts', $default_layouts );
-	$data->set( 'default_view', $default_view );
+	$data->set( 'default_layouts', $default_layouts, 1 );
+	$data->set( 'default_view', $default_view, 1 );
 
 	$view_list = array(
 		array(
@@ -529,7 +530,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
 		);
 	}
 
-	$data->set( 'view_list', $view_list );
+	$data->set( 'view_list', $view_list, 1 );
 
 	$data->set(
 		'form',
@@ -545,7 +546,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
 				),
 				'revisions',
 			),
-		)
+		),
+		1
 	);
 
 	return $data;
@@ -579,8 +581,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
 		'list'  => array( 'showMedia' => false ),
 	);
 
-	$data->set( 'default_view', $default_view );
-	$data->set( 'default_layouts', $default_layouts );
+	$data->set( 'default_view', $default_view, 1 );
+	$data->set( 'default_layouts', $default_layouts, 1 );
 
 	$view_list = array(
 		array(
@@ -720,7 +722,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
 		}
 	}
 
-	$data->set( 'view_list', array_merge( $view_list, $registered_authors, $user_authors ) );
+	$data->set( 'view_list', array_merge( $view_list, $registered_authors, $user_authors ), 1 );
 
 	$data->set(
 		'form',
@@ -757,7 +759,8 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
 				'posts_per_page',
 				'default_comment_status',
 			),
-		)
+		),
+		1
 	);
 
 	return $data;

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -154,11 +154,11 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 	 * The dynamic portions of the hook name, `$kind` and `$name`, refer to the
 	 * entity kind (e.g. `postType`) and the entity name (e.g. `page`).
 	 *
-	 * Callbacks receive a Gutenberg_View_Config_Data object and contribute
-	 * through it: `set()` replaces a whole top-level key (the entity's base
-	 * definition), while the `update_*` functions layer versioned, identity-aware
-	 * patches that survive future shape changes. Callbacks must return the
-	 * object they were given.
+	 * Callbacks receive a Gutenberg_View_Config_Data object and change the
+	 * configuration through its methods: the `update_*()` methods merge
+	 * partial changes into the current configuration, while `set()` replaces
+	 * a whole top-level key. Callbacks must return the object they were
+	 * given.
 	 *
 	 * @param Gutenberg_View_Config_Data $data   The view configuration container
 	 *                                           for the entity, exposing the

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -146,7 +146,7 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		'form'            => 'postType' === $kind ? _gutenberg_get_default_post_type_form() : array(),
 	);
 
-	$data = new Gutenberg_View_Config_Data( $config, $kind, $name );
+	$data = new Gutenberg_View_Config_Data( $config );
 
 	/**
 	 * Filters the view configuration for a given entity.
@@ -156,9 +156,9 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 	 *
 	 * Callbacks receive a Gutenberg_View_Config_Data object and contribute
 	 * through it: `set()` replaces a whole top-level key (the entity's base
-	 * definition), while `update_with()` and the `remove_*` helpers layer
-	 * versioned, identity-aware patches that survive future shape changes.
-	 * Callbacks must return the object they were given.
+	 * definition), while the `update_*` functions layer versioned, identity-aware
+	 * patches that survive future shape changes. Callbacks must return the
+	 * object they were given.
 	 *
 	 * @param Gutenberg_View_Config_Data $data   The view configuration container
 	 *                                           for the entity, exposing the
@@ -195,8 +195,8 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		return $config;
 	}
 
-	// The verbs keep the container close to the documented shape (set() rejects
-	// unknown keys and update_with() discards them), but a documented key may
+	// The functions keep the container close to the documented shape (set() and
+	// update_properties() reject unknown keys), but a documented key may
 	// still be missing — dropped by a null reset patch, or omitted by a callback
 	// returning its own off-shape container. Normalize either way: drop
 	// undocumented keys and backfill any dropped documented keys from the
@@ -334,7 +334,7 @@ function _gutenberg_get_entity_view_config_post_type_page( $data ) {
 	// than replacing it, so its post-type-specific title is kept. The version
 	// is pinned to the literal this patch was authored against as an extra guard,
 	// so a future LATEST_VERSION bump migrates it instead of silently skipping it.
-	$data->update_with( array( 'view_list' => $view_list ), 1 );
+	$data->update_view_list_items( array_column( $view_list, null, 'slug' ), 1 );
 
 	return $data;
 }

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -146,56 +146,72 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		'form'            => 'postType' === $kind ? _gutenberg_get_default_post_type_form() : array(),
 	);
 
+	$data = new Gutenberg_View_Config_Data( $config, $kind, $name );
+
 	/**
 	 * Filters the view configuration for a given entity.
 	 *
 	 * The dynamic portions of the hook name, `$kind` and `$name`, refer to the
 	 * entity kind (e.g. `postType`) and the entity name (e.g. `page`).
 	 *
-	 * @param array $config {
-	 *     The view configuration for the entity.
+	 * Callbacks receive a Gutenberg_View_Config_Data object and contribute
+	 * through it: `set()` replaces a whole top-level key (the entity's base
+	 * definition), while `update_with()` and the `remove_*` helpers layer
+	 * versioned, identity-aware patches that survive future shape changes.
+	 * Callbacks must return the object they were given.
 	 *
-	 *     @type array $default_view    Default view configuration.
-	 *     @type array $default_layouts Default layouts configuration.
-	 *     @type array $view_list       List of available views.
-	 *     @type array $form            Form configuration.
-	 * }
-	 * @param array $entity {
+	 * @param Gutenberg_View_Config_Data $data   The view configuration container
+	 *                                           for the entity, exposing the
+	 *                                           `default_view`, `default_layouts`,
+	 *                                           `view_list`, and `form` keys.
+	 * @param array                      $entity {
 	 *     The entity the configuration is built for.
 	 *
 	 *     @type string $kind The entity kind.
 	 *     @type string $name The entity name.
 	 * }
 	 */
-	$filtered_config = apply_filters(
+	$filtered = apply_filters(
 		"get_entity_view_config_{$kind}_{$name}",
-		$config,
+		$data,
 		array(
 			'kind' => $kind,
 			'name' => $name,
 		)
 	);
 
-	if ( ! is_array( $filtered_config ) ) {
+	// A well-behaved callback returns the object it was given. Fall back to the
+	// unfiltered config if a callback replaced it with something else.
+	if ( ! $filtered instanceof Gutenberg_View_Config_Data ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: the filter hook name. */
+				esc_html__( 'A "%s" filter callback must return the Gutenberg_View_Config_Data object it was given.', 'gutenberg' ),
+				esc_html( "get_entity_view_config_{$kind}_{$name}" )
+			),
+			'7.1.0'
+		);
 		return $config;
 	}
 
-	// Backfill any dropped keys with their defaults, then discard any keys the
-	// filter introduced that are not part of the documented configuration shape.
-	$filtered_config = array_merge( $config, $filtered_config );
-	return array_intersect_key( $filtered_config, $config );
+	// The verbs keep the container close to the documented shape (set() rejects
+	// unknown keys and update_with() discards them), but a documented key may
+	// still be missing — dropped by a null reset patch, or omitted by a callback
+	// returning its own off-shape container. Normalize either way: drop
+	// undocumented keys and backfill any dropped documented keys from the
+	// defaults.
+	return array_intersect_key( array_merge( $config, $filtered->get_config() ), $config );
 }
 
 /**
  * Provides the view configuration for the `page` post type.
  *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_page( $config ) {
-	$config['default_layouts'] = array(
+function _gutenberg_get_entity_view_config_post_type_page( $data ) {
+	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
 				'styles' => array(
@@ -209,7 +225,7 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 		'list'  => array(),
 	);
 
-	$config['default_view'] = array(
+	$default_view = array(
 		'type'       => 'list',
 		'filters'    => array(),
 		'perPage'    => 20,
@@ -223,10 +239,7 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 		'fields'     => array( 'author', 'status' ),
 	);
 
-	$config['view_list'] = array(
-		// Reuse the base "all items" view, whose title is derived from the post
-		// type's `all_items` label in gutenberg_get_entity_view_config().
-		$config['view_list'][0],
+	$view_list = array(
 		array(
 			'title' => __( 'Published', 'gutenberg' ),
 			'slug'  => 'published',
@@ -302,7 +315,7 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 			'slug'  => 'trash',
 			'view'  => array(
 				'type'    => 'table',
-				'layout'  => $config['default_layouts']['table']['layout'],
+				'layout'  => $default_layouts['table']['layout'],
 				'filters' => array(
 					array(
 						'field'    => 'status',
@@ -315,19 +328,25 @@ function _gutenberg_get_entity_view_config_post_type_page( $config ) {
 		),
 	);
 
-	return $config;
+	$data->set( 'default_layouts', $default_layouts );
+	$data->set( 'default_view', $default_view );
+	// Append the status views onto the inherited base "all items" view rather
+	// than replacing it, so its post-type-specific title is kept. The version
+	// is pinned to the literal this patch was authored against as an extra guard,
+	// so a future LATEST_VERSION bump migrates it instead of silently skipping it.
+	$data->update_with( array( 'view_list' => $view_list ), 1 );
+
+	return $data;
 }
 
 /**
  * Provides the view configuration for the `wp_block` post type.
  *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_block( $config ) {
-	$config['default_layouts'] = array(
+function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
+	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
 				'styles' => array(
@@ -344,15 +363,18 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $config ) {
 		),
 	);
 
-	$config['default_view'] = array(
+	$default_view = array(
 		'type'       => 'grid',
 		'perPage'    => 20,
 		'titleField' => 'title',
 		'mediaField' => 'preview',
 		'fields'     => array( 'sync-status' ),
 		'filters'    => array(),
-		'layout'     => $config['default_layouts']['grid']['layout'],
+		'layout'     => $default_layouts['grid']['layout'],
 	);
+
+	$data->set( 'default_layouts', $default_layouts );
+	$data->set( 'default_view', $default_view );
 
 	$view_list = array(
 		array(
@@ -401,43 +423,44 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $config ) {
 		);
 	}
 
-	$config['view_list'] = $view_list;
+	$data->set( 'view_list', $view_list );
 
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'excerpt',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
+	$data->set(
+		'form',
+		array(
+			'layout' => array( 'type' => 'panel' ),
+			'fields' => array(
+				array(
+					'id'     => 'excerpt',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'top',
+					),
 				),
-			),
-			array(
-				'id'     => 'post-content-info',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
+				array(
+					'id'     => 'post-content-info',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
 				),
+				'sync-status',
+				'revisions',
 			),
-			'sync-status',
-			'revisions',
-		),
+		)
 	);
 
-	return $config;
+	return $data;
 }
 
 /**
  * Provides the view configuration for the `wp_template_part` post type.
  *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_template_part( $config ) {
-	$config['default_layouts'] = array(
+function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
+	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
 				'styles' => array(
@@ -452,15 +475,18 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $config )
 		),
 	);
 
-	$config['default_view'] = array(
+	$default_view = array(
 		'type'       => 'grid',
 		'perPage'    => 20,
 		'titleField' => 'title',
 		'mediaField' => 'preview',
 		'fields'     => array( 'author' ),
 		'filters'    => array(),
-		'layout'     => $config['default_layouts']['grid']['layout'],
+		'layout'     => $default_layouts['grid']['layout'],
 	);
+
+	$data->set( 'default_layouts', $default_layouts );
+	$data->set( 'default_view', $default_view );
 
 	$view_list = array(
 		array(
@@ -503,35 +529,36 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $config )
 		);
 	}
 
-	$config['view_list'] = $view_list;
+	$data->set( 'view_list', $view_list );
 
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'last_edited_date',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'none',
+	$data->set(
+		'form',
+		array(
+			'layout' => array( 'type' => 'panel' ),
+			'fields' => array(
+				array(
+					'id'     => 'last_edited_date',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'none',
+					),
 				),
+				'revisions',
 			),
-			'revisions',
-		),
+		)
 	);
 
-	return $config;
+	return $data;
 }
 
 /**
  * Provides the view configuration for the `wp_template` post type.
  *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
-	$config['default_view'] = array(
+function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
+	$default_view = array(
 		'type'             => 'grid',
 		'perPage'          => 20,
 		'sort'             => array(
@@ -546,11 +573,14 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
 		'showMedia'        => true,
 	);
 
-	$config['default_layouts'] = array(
+	$default_layouts = array(
 		'table' => array( 'showMedia' => false ),
 		'grid'  => array( 'showMedia' => true ),
 		'list'  => array( 'showMedia' => false ),
 	);
+
+	$data->set( 'default_view', $default_view );
+	$data->set( 'default_layouts', $default_layouts );
 
 	$view_list = array(
 		array(
@@ -690,44 +720,47 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $config ) {
 		}
 	}
 
-	$config['view_list'] = array_merge( $view_list, $registered_authors, $user_authors );
+	$data->set( 'view_list', array_merge( $view_list, $registered_authors, $user_authors ) );
 
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'description',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
+	$data->set(
+		'form',
+		array(
+			'layout' => array( 'type' => 'panel' ),
+			'fields' => array(
+				array(
+					'id'     => 'description',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'top',
+					),
 				),
-			),
-			array(
-				'id'     => 'description_readonly',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
+				array(
+					'id'     => 'description_readonly',
+					'layout' => array(
+						'type'          => 'regular',
+						'labelPosition' => 'none',
+					),
 				),
-			),
-			array(
-				'id'     => 'last_edited_date',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'none',
+				array(
+					'id'     => 'last_edited_date',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'none',
+					),
 				),
+				'revisions',
+				// The following fields are only meaningful in the `home`/`index`
+				// template summary. They edit other entities (`root/site` and the
+				// posts page); the editor merges those records into the form data
+				// under a namespace and controls when the fields are shown.
+				'posts_page_title',
+				'posts_per_page',
+				'default_comment_status',
 			),
-			'revisions',
-			// The following fields are only meaningful in the `home`/`index`
-			// template summary. They edit other entities (`root/site` and the
-			// posts page); the editor merges those records into the form data
-			// under a namespace and controls when the fields are shown.
-			'posts_page_title',
-			'posts_per_page',
-			'default_comment_status',
-		),
+		)
 	);
 
-	return $config;
+	return $data;
 }
 
 /**

--- a/lib/load.php
+++ b/lib/load.php
@@ -69,6 +69,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.1 compat.
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php';
+	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-view-config-data.php';
 	require __DIR__ . '/compat/wordpress-7.1/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php';
 	require __DIR__ . '/compat/wordpress-7.1/class-wp-icon-collections-registry.php';

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -337,17 +337,14 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 		wp_set_current_user( self::$editor_id );
 
 		$filter = static function ( $data ) {
-			return $data->update_with(
+			return $data->update_view_list_items(
 				array(
-					'view_list' => array(
-						array(
-							'title' => 'Custom',
-							'slug'  => 'custom',
-							'view'  => array(
-								'type'   => 'table',
-								'layout' => array(
-									'styles' => array(),
-								),
+					'custom' => array(
+						'title' => 'Custom',
+						'view'  => array(
+							'type'   => 'table',
+							'layout' => array(
+								'styles' => array(),
 							),
 						),
 					),

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -271,6 +271,7 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'postType', $data['kind'] );
 		$this->assertSame( 'page', $data['name'] );
+		$this->assertSame( Gutenberg_View_Config_Data::LATEST_VERSION, $data['version'] );
 		$this->assertArrayHasKey( 'default_view', $data );
 		$this->assertArrayHasKey( 'default_layouts', $data );
 		$this->assertArrayHasKey( 'view_list', $data );
@@ -335,18 +336,24 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	public function test_empty_objects_inside_view_list_view_serialize_as_json_objects() {
 		wp_set_current_user( self::$editor_id );
 
-		$filter = static function ( $config ) {
-			$config['view_list'][] = array(
-				'title' => 'Custom',
-				'slug'  => 'custom',
-				'view'  => array(
-					'type'   => 'table',
-					'layout' => array(
-						'styles' => array(),
+		$filter = static function ( $data ) {
+			return $data->update_with(
+				array(
+					'view_list' => array(
+						array(
+							'title' => 'Custom',
+							'slug'  => 'custom',
+							'view'  => array(
+								'type'   => 'table',
+								'layout' => array(
+									'styles' => array(),
+								),
+							),
+						),
 					),
 				),
+				1
 			);
-			return $config;
 		};
 		add_filter( 'get_entity_view_config_custom_kind_custom_name', $filter );
 
@@ -370,7 +377,7 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 
 		$this->assertSame( 'view-config', $schema['title'] );
 		$this->assertSameSets(
-			array( 'kind', 'name', 'default_view', 'default_layouts', 'view_list', 'form' ),
+			array( 'kind', 'name', 'version', 'default_view', 'default_layouts', 'view_list', 'form' ),
 			array_keys( $schema['properties'] )
 		);
 	}

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -184,34 +184,6 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_properties() unsets several default_layouts entries in one patch.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_null_unsets_multiple_default_layouts() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'default_layouts' => array(
-					'table' => array(),
-					'grid'  => array(),
-					'list'  => array(),
-				),
-			)
-		);
-		$data->update_properties(
-			array(
-				'default_layouts' => array(
-					'grid' => null,
-					'list' => null,
-				),
-			),
-			1
-		);
-
-		$this->assertSame( array( 'table' => array() ), $data->get_config()['default_layouts'] );
-	}
-
-	/**
 	 * update_properties() unsets a deeply nested layout property when the value is null.
 	 *
 	 * @covers ::update_properties

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -416,7 +416,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		// Omitted: no version declared.
 		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ) );
 		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ) );
-		$data->update_form_fields( array( 'excerpt' => array( 'label' => 'Summary' ) ) );
+		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ) );
 
 		// Newer than the latest supported version.
 		$data->update_properties(
@@ -586,21 +586,27 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				'form' => array(
 					'fields' => array(
 						array(
-							'id'    => 'excerpt',
-							'label' => 'Excerpt',
+							'id'     => 'excerpt',
+							'layout' => array(
+								'type'          => 'panel',
+								'labelPosition' => 'top',
+							),
 						),
 						'date',
 					),
 				),
 			)
 		);
-		$data->update_form_fields( array( 'excerpt' => array( 'label' => 'Summary' ) ), 1 );
+		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), 1 );
 
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'excerpt',
-					'label' => 'Summary',
+					'id'     => 'excerpt',
+					'layout' => array(
+						'type'          => 'panel',
+						'labelPosition' => 'side',
+					),
 				),
 				'date',
 			),
@@ -628,7 +634,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields( array( 'ping_status' => array( 'label' => 'Pings' ) ), 1 );
+		$data->update_form_fields( array( 'ping_status' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), 1 );
 
 		// comment_status stays a bare string; the matched ping_status child is
 		// promoted from a bare string and merged with the incoming overrides.
@@ -640,8 +646,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 					'children' => array(
 						'comment_status',
 						array(
-							'id'    => 'ping_status',
-							'label' => 'Pings',
+							'id'     => 'ping_status',
+							'layout' => array( 'labelPosition' => 'side' ),
 						),
 					),
 				),
@@ -676,7 +682,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			array(
 				'status' => array(
 					'label'    => 'Visibility',
-					'children' => array( 'status' => array( 'label' => 'State' ) ),
+					'children' => array( 'status' => array( 'layout' => array( 'labelPosition' => 'none' ) ) ),
 				),
 			),
 			1
@@ -689,8 +695,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 					'label'    => 'Visibility',
 					'children' => array(
 						array(
-							'id'    => 'status',
-							'label' => 'State',
+							'id'     => 'status',
+							'layout' => array( 'labelPosition' => 'none' ),
 						),
 						'password',
 					),
@@ -711,7 +717,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
 		$data->update_form_fields(
 			array(
-				'my_field'    => array( 'label' => 'Mine' ),
+				'my_field'    => array( 'layout' => array( 'labelPosition' => 'side' ) ),
 				'other_field' => array(),
 			),
 			1
@@ -721,8 +727,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			array(
 				'date',
 				array(
-					'id'    => 'my_field',
-					'label' => 'Mine',
+					'id'     => 'my_field',
+					'layout' => array( 'labelPosition' => 'side' ),
 				),
 				'other_field',
 			),
@@ -742,8 +748,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				'form' => array(
 					'fields' => array(
 						array(
-							'id'    => 'excerpt',
-							'label' => 'Excerpt',
+							'id'     => 'excerpt',
+							'layout' => array( 'type' => 'panel' ),
 						),
 						array(
 							'id'       => 'discussion',
@@ -800,7 +806,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			array(
 				'discussion' => array(
 					'children' => array(
-						'comment_status' => array( 'label' => 'Comments' ),
+						'comment_status' => array( 'layout' => array( 'labelPosition' => 'none' ) ),
 						'my_field'       => array(),
 					),
 				),
@@ -815,8 +821,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 					'label'    => 'Discussion',
 					'children' => array(
 						array(
-							'id'    => 'comment_status',
-							'label' => 'Comments',
+							'id'     => 'comment_status',
+							'layout' => array( 'labelPosition' => 'none' ),
 						),
 						'ping_status',
 						'my_field',
@@ -913,8 +919,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				'form' => array(
 					'fields' => array(
 						array(
-							'id'    => 'excerpt',
-							'label' => 'Excerpt',
+							'id'     => 'excerpt',
+							'layout' => array( 'labelPosition' => 'top' ),
 						),
 					),
 				),
@@ -923,8 +929,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$data->update_form_fields(
 			array(
 				'excerpt' => array(
-					'id'    => 'other',
-					'label' => 'Summary',
+					'id'     => 'other',
+					'layout' => array( 'labelPosition' => 'side' ),
 				),
 			),
 			1
@@ -933,8 +939,8 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'excerpt',
-					'label' => 'Summary',
+					'id'     => 'excerpt',
+					'layout' => array( 'labelPosition' => 'side' ),
 				),
 			),
 			$data->get_config()['form']['fields']

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -22,7 +22,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->set( 'default_view', array( 'type' => 'grid' ) );
+		$data->set( 'default_view', array( 'type' => 'grid' ), 1 );
 
 		$this->assertSame( array( 'type' => 'grid' ), $data->get_config()['default_view'] );
 	}
@@ -37,7 +37,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 
 		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
-		$data->set( 'not_a_real_key', 'nope' );
+		$data->set( 'not_a_real_key', 'nope', 1 );
 
 		$this->assertSame( $before, $data->get_config() );
 	}
@@ -370,17 +370,19 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Every update function rejects a patch whose version cannot be migrated —
-	 * newer than the latest supported version.
+	 * Every update function and set() reject a patch whose version cannot be
+	 * migrated — newer than the latest supported version.
 	 *
 	 * @covers ::update_properties
 	 * @covers ::update_view_list_items
 	 * @covers ::update_form_fields
+	 * @covers ::set
 	 */
 	public function test_update_functions_reject_unmigratable_version() {
 		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
 		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_view_list_items' );
 		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_form_fields' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::set' );
 
 		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
@@ -389,6 +391,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ), $version );
 		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ), $version );
 		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), $version );
+		$data->set( 'default_view', array( 'type' => 'grid' ), $version );
 
 		$this->assertSame( $before, $data->get_config() );
 	}

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -1,0 +1,756 @@
+<?php
+/**
+ * Tests for the entity view configuration data container.
+ *
+ * @package gutenberg
+ *
+ * @coversDefaultClass Gutenberg_View_Config_Data
+ */
+class Tests_View_Config_Data extends WP_UnitTestCase {
+
+	/**
+	 * Builds a representative view configuration container.
+	 *
+	 * The form intentionally includes a group with nested `children` so identity
+	 * resolution can be exercised across nesting levels.
+	 *
+	 * @return Gutenberg_View_Config_Data A fresh container.
+	 */
+	private function make_data() {
+		$config = array(
+			'default_view'    => array(
+				'type'    => 'table',
+				'perPage' => 20,
+				'sort'    => array(
+					'field'     => 'title',
+					'direction' => 'asc',
+				),
+				'fields'  => array( 'author', 'status' ),
+			),
+			'default_layouts' => array(
+				'table' => array(),
+				'grid'  => array(),
+				'list'  => array(),
+			),
+			'view_list'       => array(
+				array(
+					'title' => 'All',
+					'slug'  => 'all',
+				),
+				array(
+					'title' => 'Published',
+					'slug'  => 'published',
+				),
+			),
+			'form'            => array(
+				'layout' => array( 'type' => 'panel' ),
+				'fields' => array(
+					array(
+						'id'    => 'excerpt',
+						'label' => 'Excerpt',
+					),
+					array(
+						'id'       => 'discussion',
+						'label'    => 'Discussion',
+						'children' => array(
+							'comment_status',
+							'ping_status',
+						),
+					),
+					'date',
+					'slug',
+				),
+			),
+		);
+
+		return new Gutenberg_View_Config_Data( $config );
+	}
+
+	/**
+	 * set() replaces a whole documented key.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_replaces_key() {
+		$data = $this->make_data();
+		$data->set( 'default_view', array( 'type' => 'grid' ) );
+
+		$this->assertSame( array( 'type' => 'grid' ), $data->get_config()['default_view'] );
+	}
+
+	/**
+	 * set() rejects an undocumented key.
+	 *
+	 * @covers ::set
+	 */
+	public function test_set_unknown_key_triggers_doing_it_wrong() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::set' );
+
+		$data   = $this->make_data();
+		$before = $data->get_config();
+		$data->set( 'not_a_real_key', 'nope' );
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * update_with() merges a documented key that is absent from the config.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_a_documented_key_absent_from_config() {
+		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array() ) );
+		$data->update_with( array( 'form' => array( 'fields' => array( 'excerpt' ) ) ), 1 );
+
+		$this->assertSame( array( 'fields' => array( 'excerpt' ) ), $data->get_config()['form'] );
+	}
+
+	/**
+	 * update_with() merges object-shaped keys recursively.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_default_view_recursively() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'default_view' => array(
+					'perPage' => 50,
+					'sort'    => array( 'direction' => 'desc' ),
+				),
+			),
+			1
+		);
+
+		$default_view = $data->get_config()['default_view'];
+		$this->assertSame( 50, $default_view['perPage'] );
+		$this->assertSame(
+			array(
+				'field'     => 'title',
+				'direction' => 'desc',
+			),
+			$default_view['sort']
+		);
+		// Untouched values are preserved.
+		$this->assertSame( 'table', $default_view['type'] );
+	}
+
+	/**
+	 * update_with() merges default_layouts by map key and adds unknown ones.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_default_layouts_by_key() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'default_layouts' => array(
+					'table'    => array( 'density' => 'compact' ),
+					'activity' => array(),
+				),
+			),
+			1
+		);
+
+		$default_layouts = $data->get_config()['default_layouts'];
+		$this->assertSame( array( 'density' => 'compact' ), $default_layouts['table'] );
+		$this->assertArrayHasKey( 'activity', $default_layouts );
+		// Existing keys are preserved.
+		$this->assertArrayHasKey( 'grid', $default_layouts );
+		$this->assertArrayHasKey( 'list', $default_layouts );
+	}
+
+	/**
+	 * update_with() merges a `view_list` entry by matching slug and appends an unknown one.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_view_by_slug_and_appends_unknown() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'published',
+						'title' => 'Live',
+					),
+					array(
+						'slug'  => 'mine',
+						'title' => 'Mine',
+					),
+				),
+			),
+			1
+		);
+
+		$view_list = $data->get_config()['view_list'];
+		$this->assertCount( 3, $view_list );
+		// Matching slug merges in place.
+		$this->assertSame(
+			array(
+				'title' => 'Live',
+				'slug'  => 'published',
+			),
+			$view_list[1]
+		);
+		// Unknown slug appends to the end.
+		$this->assertSame(
+			array(
+				'slug'  => 'mine',
+				'title' => 'Mine',
+			),
+			$view_list[2]
+		);
+	}
+
+	/**
+	 * update_with() merges a form field by matching id.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_existing_field_by_id() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'excerpt',
+							'label' => 'Summary',
+						),
+					),
+				),
+			),
+			1
+		);
+
+		$fields = $data->get_config()['form']['fields'];
+		// No new field is appended.
+		$this->assertCount( 4, $fields );
+		$this->assertSame(
+			array(
+				'id'    => 'excerpt',
+				'label' => 'Summary',
+			),
+			$fields[0]
+		);
+	}
+
+	/**
+	 * update_with() appends a form field with an unknown id to the end.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_appends_unknown_field() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'my_field',
+							'label' => 'Mine',
+						),
+					),
+				),
+			),
+			1
+		);
+
+		$fields = $data->get_config()['form']['fields'];
+		$this->assertCount( 5, $fields );
+		$last = end( $fields );
+		$this->assertSame( 'my_field', $last['id'] );
+	}
+
+	/**
+	 * update_with() reaches a nested group child when the group is targeted.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_nested_group_child_by_id() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'children' => array(
+								array(
+									'id'    => 'ping_status',
+									'label' => 'Pings',
+								),
+							),
+						),
+					),
+				),
+			),
+			1
+		);
+
+		$fields = $data->get_config()['form']['fields'];
+		// The group merges in place rather than being appended.
+		$this->assertCount( 4, $fields );
+		// comment_status stays a bare string; the matched ping_status child is
+		// promoted from a bare string and merged with the incoming overrides.
+		$this->assertSame(
+			array(
+				'id'       => 'discussion',
+				'label'    => 'Discussion',
+				'children' => array(
+					'comment_status',
+					array(
+						'id'    => 'ping_status',
+						'label' => 'Pings',
+					),
+				),
+			),
+			$fields[1]
+		);
+	}
+
+	/**
+	 * update_with() appends at top level when the id only exists nested.
+	 *
+	 * Adding is append-only at the top level; only remove_fields() reaches
+	 * nested members by identity.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_appends_when_id_only_exists_nested() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'ping_status',
+							'label' => 'Pings',
+						),
+					),
+				),
+			),
+			1
+		);
+
+		$fields = $data->get_config()['form']['fields'];
+		$this->assertCount( 5, $fields );
+		$last = end( $fields );
+		$this->assertSame( 'ping_status', $last['id'] );
+		// The nested ping_status is left untouched.
+		$this->assertSame( array( 'comment_status', 'ping_status' ), $fields[1]['children'] );
+	}
+
+	/**
+	 * update_with() discards keys outside the documented shape.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_discards_unknown_keys() {
+		$data = $this->make_data();
+		$data->update_with( array( 'not_a_real_key' => 'nope' ), 1 );
+
+		$this->assertArrayNotHasKey( 'not_a_real_key', $data->get_config() );
+	}
+
+	/**
+	 * update_with() rejects a patch whose version cannot be migrated — omitted, or
+	 * newer than the latest supported version.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_rejects_unmigratable_version() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data   = $this->make_data();
+		$before = $data->get_config();
+
+		// Omitted: no version declared.
+		$data->update_with( array( 'default_view' => array( 'type' => 'grid' ) ) );
+		$this->assertSame( $before, $data->get_config() );
+
+		// Newer than the latest supported version.
+		$data->update_with(
+			array( 'default_view' => array( 'type' => 'grid' ) ),
+			Gutenberg_View_Config_Data::LATEST_VERSION + 1
+		);
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * update_with() unsets a default_view property when the patch value is null.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_unsets_default_view_prop() {
+		$data = $this->make_data();
+		$data->update_with(
+			array( 'default_view' => array( 'perPage' => null ) ),
+			1
+		);
+
+		$default_view = $data->get_config()['default_view'];
+		$this->assertArrayNotHasKey( 'perPage', $default_view );
+		// Sibling properties are preserved.
+		$this->assertSame( 'table', $default_view['type'] );
+		$this->assertSame( array( 'author', 'status' ), $default_view['fields'] );
+	}
+
+	/**
+	 * update_with() unsets a default_layouts entry when the patch value is null.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_unsets_default_layout() {
+		$data = $this->make_data();
+		$data->update_with(
+			array( 'default_layouts' => array( 'grid' => null ) ),
+			1
+		);
+
+		$this->assertSame(
+			array( 'table', 'list' ),
+			array_keys( $data->get_config()['default_layouts'] )
+		);
+	}
+
+	/**
+	 * update_with() unsets several default_layouts entries in one patch.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_unsets_multiple_default_layouts() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'default_layouts' => array(
+					'grid' => null,
+					'list' => null,
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array( 'table' ),
+			array_keys( $data->get_config()['default_layouts'] )
+		);
+	}
+
+	/**
+	 * update_with() unsets a deeply nested layout property when the value is null.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_unsets_nested_layout_prop() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_layouts' => array(
+					'table' => array(
+						'layout' => array(
+							'styles'  => array( 'title' => array( 'width' => '20%' ) ),
+							'density' => 'compact',
+						),
+					),
+				),
+			)
+		);
+		$data->update_with(
+			array( 'default_layouts' => array( 'table' => array( 'layout' => array( 'styles' => null ) ) ) ),
+			1
+		);
+
+		$layout = $data->get_config()['default_layouts']['table']['layout'];
+		$this->assertArrayNotHasKey( 'styles', $layout );
+		// The sibling property is preserved.
+		$this->assertSame( 'compact', $layout['density'] );
+	}
+
+	/**
+	 * update_with() unsets a form field property when the patch value is null,
+	 * finding the field by identity first.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_unsets_field_property() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'excerpt',
+							'label' => null,
+						),
+					),
+				),
+			),
+			1
+		);
+
+		$fields = $data->get_config()['form']['fields'];
+		// The field is merged in place, not appended.
+		$this->assertCount( 4, $fields );
+		$this->assertSame( array( 'id' => 'excerpt' ), $fields[0] );
+	}
+
+	/**
+	 * update_with() drops a whole top-level key when the patch value is null,
+	 * rather than storing a literal null.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_drops_whole_top_level_key() {
+		$data = $this->make_data();
+		$data->update_with(
+			array(
+				'default_view' => null,
+				'view_list'    => null,
+			),
+			1
+		);
+
+		$config = $data->get_config();
+		$this->assertArrayNotHasKey( 'default_view', $config );
+		$this->assertArrayNotHasKey( 'view_list', $config );
+		// Untouched keys are preserved.
+		$this->assertArrayHasKey( 'form', $config );
+	}
+
+	/**
+	 * update_with() consumes a null delete-marker merged into an empty base
+	 * instead of storing it as a literal value.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_into_empty_base_is_consumed() {
+		$data = $this->make_data();
+		// The `table` layout entry is an empty array in the base config.
+		$data->update_with(
+			array( 'default_layouts' => array( 'table' => array( 'layout' => null ) ) ),
+			1
+		);
+
+		$this->assertSame( array(), $data->get_config()['default_layouts']['table'] );
+	}
+
+	/**
+	 * update_with() strips nulls from a subtree assigned to a key absent from
+	 * the base instead of storing them as literal values.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_stripped_from_absent_key_subtree() {
+		$data = $this->make_data();
+		// The base default_view has no `layout` key.
+		$data->update_with(
+			array(
+				'default_view' => array(
+					'layout' => array(
+						'type'        => 'flex',
+						'badgeFields' => null,
+					),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( array( 'type' => 'flex' ), $data->get_config()['default_view']['layout'] );
+	}
+
+	/**
+	 * update_with() rejects a null patch value for the identity-keyed `fields`
+	 * and `children` lists: only remove_fields() may remove list content.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_null_cannot_delete_field_lists() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data   = $this->make_data();
+		$before = $data->get_config();
+
+		$data->update_with( array( 'form' => array( 'fields' => null ) ), 1 );
+		$this->assertSame( $before['form']['fields'], $data->get_config()['form']['fields'] );
+
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'children' => null,
+						),
+					),
+				),
+			),
+			1
+		);
+		$this->assertSame(
+			array( 'comment_status', 'ping_status' ),
+			$data->get_config()['form']['fields'][1]['children']
+		);
+	}
+
+	/**
+	 * update_with() rejects a list member that declares no identity: it could
+	 * never be matched, merged, or removed afterwards.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_rejects_member_without_identity() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data   = $this->make_data();
+		$before = $data->get_config();
+
+		$data->update_with(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => null,
+						'title' => 'Broken',
+					),
+				),
+			),
+			1
+		);
+		$data->update_with(
+			array(
+				'form' => array(
+					'fields' => array(
+						array( 'label' => 'No id' ),
+						null,
+					),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * update_with() rejects patches whose shape does not match the key: a
+	 * map where a list is expected, or a list where a map is expected.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_rejects_shape_mismatched_patches() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data   = $this->make_data();
+		$before = $data->get_config();
+
+		// A map where the view_list list is expected.
+		$data->update_with(
+			array(
+				'view_list' => array(
+					'slug'  => 'mine',
+					'title' => 'Mine',
+				),
+			),
+			1
+		);
+		// A list where the form map is expected.
+		$data->update_with( array( 'form' => array( array( 'id' => 'my_field' ) ) ), 1 );
+		// A map where the fields list is expected.
+		$data->update_with( array( 'form' => array( 'fields' => array( 'id' => 'my_field' ) ) ), 1 );
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * remove_view_list_items() drops a view by slug.
+	 *
+	 * @covers ::remove_view_list_items
+	 */
+	public function test_remove_view_list_items_by_slug() {
+		$data = $this->make_data();
+		$data->remove_view_list_items( 'published' );
+
+		$slugs = wp_list_pluck( $data->get_config()['view_list'], 'slug' );
+		$this->assertSame( array( 'all' ), $slugs );
+	}
+
+	/**
+	 * remove_view_list_items() drops several views when given an array of slugs.
+	 *
+	 * @covers ::remove_view_list_items
+	 */
+	public function test_remove_view_list_items_multiple_by_array() {
+		$data = $this->make_data();
+		$data->remove_view_list_items( array( 'all', 'published' ) );
+
+		$this->assertSame( array(), $data->get_config()['view_list'] );
+	}
+
+	/**
+	 * remove_view_list_items() removes the found slugs in an array and silently
+	 * ignores the rest.
+	 *
+	 * @covers ::remove_view_list_items
+	 */
+	public function test_remove_view_list_items_mixes_found_and_missing_silently() {
+		$data = $this->make_data();
+		$data->remove_view_list_items( array( 'published', 'does_not_exist' ) );
+
+		$slugs = wp_list_pluck( $data->get_config()['view_list'], 'slug' );
+		$this->assertSame( array( 'all' ), $slugs );
+	}
+
+	/**
+	 * remove_fields() drops a nested field by id, walking the current structure.
+	 *
+	 * @covers ::remove_fields
+	 */
+	public function test_remove_fields_nested_by_id() {
+		$data = $this->make_data();
+		$data->remove_fields( 'ping_status' );
+
+		$fields     = $data->get_config()['form']['fields'];
+		$discussion = $fields[1];
+		$this->assertSame( 'discussion', $discussion['id'] );
+		// Only ping_status is dropped from the group's children.
+		$this->assertSame( array( 'comment_status' ), $discussion['children'] );
+	}
+
+	/**
+	 * remove_fields() drops several form fields when given an array of ids.
+	 *
+	 * @covers ::remove_fields
+	 */
+	public function test_remove_fields_multiple_by_array() {
+		$data = $this->make_data();
+		$data->remove_fields( array( 'ping_status', 'comment_status' ) );
+
+		$fields = $data->get_config()['form']['fields'];
+		// Top-level fields are untouched.
+		$this->assertCount( 4, $fields );
+		$this->assertSame( 'excerpt', $fields[0]['id'] );
+		// Both nested children were dropped; the group itself remains.
+		$discussion = $fields[1];
+		$this->assertSame( 'discussion', $discussion['id'] );
+		$this->assertSame( array(), $discussion['children'] );
+	}
+
+	/**
+	 * The remove helpers are a silent no-op when the identity is not found.
+	 *
+	 * A member that is not present may have been removed by another filter or
+	 * simply not apply to this entity, so it is not treated as misuse.
+	 *
+	 * @covers ::remove_fields
+	 * @covers ::remove_view_list_items
+	 */
+	public function test_remove_not_found_is_silent_no_op() {
+		$data   = $this->make_data();
+		$before = $data->get_config();
+
+		$data->remove_fields( 'does_not_exist' );
+		$data->remove_view_list_items( 'does_not_exist' );
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+}

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -9,70 +9,19 @@
 class Tests_View_Config_Data extends WP_UnitTestCase {
 
 	/**
-	 * Builds a representative view configuration container.
-	 *
-	 * The form intentionally includes a group with nested `children` so identity
-	 * resolution can be exercised across nesting levels.
-	 *
-	 * @return Gutenberg_View_Config_Data A fresh container.
-	 */
-	private function make_data() {
-		$config = array(
-			'default_view'    => array(
-				'type'    => 'table',
-				'perPage' => 20,
-				'sort'    => array(
-					'field'     => 'title',
-					'direction' => 'asc',
-				),
-				'fields'  => array( 'author', 'status' ),
-			),
-			'default_layouts' => array(
-				'table' => array(),
-				'grid'  => array(),
-				'list'  => array(),
-			),
-			'view_list'       => array(
-				array(
-					'title' => 'All',
-					'slug'  => 'all',
-				),
-				array(
-					'title' => 'Published',
-					'slug'  => 'published',
-				),
-			),
-			'form'            => array(
-				'layout' => array( 'type' => 'panel' ),
-				'fields' => array(
-					array(
-						'id'    => 'excerpt',
-						'label' => 'Excerpt',
-					),
-					array(
-						'id'       => 'discussion',
-						'label'    => 'Discussion',
-						'children' => array(
-							'comment_status',
-							'ping_status',
-						),
-					),
-					'date',
-					'slug',
-				),
-			),
-		);
-
-		return new Gutenberg_View_Config_Data( $config );
-	}
-
-	/**
 	 * set() replaces a whole documented key.
 	 *
 	 * @covers ::set
 	 */
 	public function test_set_replaces_key() {
-		$data = $this->make_data();
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'type'    => 'table',
+					'perPage' => 20,
+				),
+			)
+		);
 		$data->set( 'default_view', array( 'type' => 'grid' ) );
 
 		$this->assertSame( array( 'type' => 'grid' ), $data->get_config()['default_view'] );
@@ -86,7 +35,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	public function test_set_unknown_key_triggers_doing_it_wrong() {
 		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::set' );
 
-		$data   = $this->make_data();
+		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
 		$data->set( 'not_a_real_key', 'nope' );
 
@@ -94,25 +43,24 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_with() merges a documented key that is absent from the config.
+	 * update_properties() merges object-shaped keys recursively.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_merges_a_documented_key_absent_from_config() {
-		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array() ) );
-		$data->update_with( array( 'form' => array( 'fields' => array( 'excerpt' ) ) ), 1 );
-
-		$this->assertSame( array( 'fields' => array( 'excerpt' ) ), $data->get_config()['form'] );
-	}
-
-	/**
-	 * update_with() merges object-shaped keys recursively.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_merges_default_view_recursively() {
-		$data = $this->make_data();
-		$data->update_with(
+	public function test_update_properties_merges_default_view_recursively() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'type'    => 'table',
+					'perPage' => 20,
+					'sort'    => array(
+						'field'     => 'title',
+						'direction' => 'asc',
+					),
+				),
+			)
+		);
+		$data->update_properties(
 			array(
 				'default_view' => array(
 					'perPage' => 50,
@@ -122,27 +70,34 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			1
 		);
 
-		$default_view = $data->get_config()['default_view'];
-		$this->assertSame( 50, $default_view['perPage'] );
 		$this->assertSame(
 			array(
-				'field'     => 'title',
-				'direction' => 'desc',
+				'type'    => 'table',
+				'perPage' => 50,
+				'sort'    => array(
+					'field'     => 'title',
+					'direction' => 'desc',
+				),
 			),
-			$default_view['sort']
+			$data->get_config()['default_view']
 		);
-		// Untouched values are preserved.
-		$this->assertSame( 'table', $default_view['type'] );
 	}
 
 	/**
-	 * update_with() merges default_layouts by map key and adds unknown ones.
+	 * update_properties() merges default_layouts by map key and adds unknown ones.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_merges_default_layouts_by_key() {
-		$data = $this->make_data();
-		$data->update_with(
+	public function test_update_properties_merges_default_layouts_by_key() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_layouts' => array(
+					'table' => array(),
+					'grid'  => array(),
+				),
+			)
+		);
+		$data->update_properties(
 			array(
 				'default_layouts' => array(
 					'table'    => array( 'density' => 'compact' ),
@@ -152,277 +107,98 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			1
 		);
 
-		$default_layouts = $data->get_config()['default_layouts'];
-		$this->assertSame( array( 'density' => 'compact' ), $default_layouts['table'] );
-		$this->assertArrayHasKey( 'activity', $default_layouts );
-		// Existing keys are preserved.
-		$this->assertArrayHasKey( 'grid', $default_layouts );
-		$this->assertArrayHasKey( 'list', $default_layouts );
-	}
-
-	/**
-	 * update_with() merges a `view_list` entry by matching slug and appends an unknown one.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_merges_view_by_slug_and_appends_unknown() {
-		$data = $this->make_data();
-		$data->update_with(
-			array(
-				'view_list' => array(
-					array(
-						'slug'  => 'published',
-						'title' => 'Live',
-					),
-					array(
-						'slug'  => 'mine',
-						'title' => 'Mine',
-					),
-				),
-			),
-			1
-		);
-
-		$view_list = $data->get_config()['view_list'];
-		$this->assertCount( 3, $view_list );
-		// Matching slug merges in place.
 		$this->assertSame(
 			array(
-				'title' => 'Live',
-				'slug'  => 'published',
+				'table'    => array( 'density' => 'compact' ),
+				'grid'     => array(),
+				'activity' => array(),
 			),
-			$view_list[1]
-		);
-		// Unknown slug appends to the end.
-		$this->assertSame(
-			array(
-				'slug'  => 'mine',
-				'title' => 'Mine',
-			),
-			$view_list[2]
+			$data->get_config()['default_layouts']
 		);
 	}
 
 	/**
-	 * update_with() merges a form field by matching id.
+	 * update_properties() merges the form's plain properties and leaves its
+	 * fields untouched.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_merges_existing_field_by_id() {
-		$data = $this->make_data();
-		$data->update_with(
+	public function test_update_properties_merges_form_layout() {
+		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
-					'fields' => array(
-						array(
-							'id'    => 'excerpt',
-							'label' => 'Summary',
-						),
-					),
+					'layout' => array( 'type' => 'panel' ),
+					'fields' => array( 'date', 'slug' ),
 				),
-			),
-			1
+			)
 		);
-
-		$fields = $data->get_config()['form']['fields'];
-		// No new field is appended.
-		$this->assertCount( 4, $fields );
-		$this->assertSame(
-			array(
-				'id'    => 'excerpt',
-				'label' => 'Summary',
-			),
-			$fields[0]
-		);
-	}
-
-	/**
-	 * update_with() appends a form field with an unknown id to the end.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_appends_unknown_field() {
-		$data = $this->make_data();
-		$data->update_with(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'    => 'my_field',
-							'label' => 'Mine',
-						),
-					),
-				),
-			),
-			1
-		);
-
-		$fields = $data->get_config()['form']['fields'];
-		$this->assertCount( 5, $fields );
-		$last = end( $fields );
-		$this->assertSame( 'my_field', $last['id'] );
-	}
-
-	/**
-	 * update_with() reaches a nested group child when the group is targeted.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_merges_nested_group_child_by_id() {
-		$data = $this->make_data();
-		$data->update_with(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'       => 'discussion',
-							'children' => array(
-								array(
-									'id'    => 'ping_status',
-									'label' => 'Pings',
-								),
-							),
-						),
-					),
-				),
-			),
-			1
-		);
-
-		$fields = $data->get_config()['form']['fields'];
-		// The group merges in place rather than being appended.
-		$this->assertCount( 4, $fields );
-		// comment_status stays a bare string; the matched ping_status child is
-		// promoted from a bare string and merged with the incoming overrides.
-		$this->assertSame(
-			array(
-				'id'       => 'discussion',
-				'label'    => 'Discussion',
-				'children' => array(
-					'comment_status',
-					array(
-						'id'    => 'ping_status',
-						'label' => 'Pings',
-					),
-				),
-			),
-			$fields[1]
-		);
-	}
-
-	/**
-	 * update_with() appends at top level when the id only exists nested.
-	 *
-	 * Adding is append-only at the top level; only remove_fields() reaches
-	 * nested members by identity.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_appends_when_id_only_exists_nested() {
-		$data = $this->make_data();
-		$data->update_with(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'    => 'ping_status',
-							'label' => 'Pings',
-						),
-					),
-				),
-			),
-			1
-		);
-
-		$fields = $data->get_config()['form']['fields'];
-		$this->assertCount( 5, $fields );
-		$last = end( $fields );
-		$this->assertSame( 'ping_status', $last['id'] );
-		// The nested ping_status is left untouched.
-		$this->assertSame( array( 'comment_status', 'ping_status' ), $fields[1]['children'] );
-	}
-
-	/**
-	 * update_with() discards keys outside the documented shape.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_discards_unknown_keys() {
-		$data = $this->make_data();
-		$data->update_with( array( 'not_a_real_key' => 'nope' ), 1 );
-
-		$this->assertArrayNotHasKey( 'not_a_real_key', $data->get_config() );
-	}
-
-	/**
-	 * update_with() rejects a patch whose version cannot be migrated — omitted, or
-	 * newer than the latest supported version.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_rejects_unmigratable_version() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
-
-		$data   = $this->make_data();
-		$before = $data->get_config();
-
-		// Omitted: no version declared.
-		$data->update_with( array( 'default_view' => array( 'type' => 'grid' ) ) );
-		$this->assertSame( $before, $data->get_config() );
-
-		// Newer than the latest supported version.
-		$data->update_with(
-			array( 'default_view' => array( 'type' => 'grid' ) ),
-			Gutenberg_View_Config_Data::LATEST_VERSION + 1
-		);
-		$this->assertSame( $before, $data->get_config() );
-	}
-
-	/**
-	 * update_with() unsets a default_view property when the patch value is null.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_null_unsets_default_view_prop() {
-		$data = $this->make_data();
-		$data->update_with(
-			array( 'default_view' => array( 'perPage' => null ) ),
-			1
-		);
-
-		$default_view = $data->get_config()['default_view'];
-		$this->assertArrayNotHasKey( 'perPage', $default_view );
-		// Sibling properties are preserved.
-		$this->assertSame( 'table', $default_view['type'] );
-		$this->assertSame( array( 'author', 'status' ), $default_view['fields'] );
-	}
-
-	/**
-	 * update_with() unsets a default_layouts entry when the patch value is null.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_null_unsets_default_layout() {
-		$data = $this->make_data();
-		$data->update_with(
-			array( 'default_layouts' => array( 'grid' => null ) ),
+		$data->update_properties(
+			array( 'form' => array( 'layout' => array( 'type' => 'card' ) ) ),
 			1
 		);
 
 		$this->assertSame(
-			array( 'table', 'list' ),
-			array_keys( $data->get_config()['default_layouts'] )
+			array(
+				'layout' => array( 'type' => 'card' ),
+				'fields' => array( 'date', 'slug' ),
+			),
+			$data->get_config()['form']
 		);
 	}
 
 	/**
-	 * update_with() unsets several default_layouts entries in one patch.
+	 * update_properties() merges a documented key that is absent from the config.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_unsets_multiple_default_layouts() {
-		$data = $this->make_data();
-		$data->update_with(
+	public function test_update_properties_merges_a_documented_key_absent_from_config() {
+		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array() ) );
+		$data->update_properties(
+			array( 'default_layouts' => array( 'table' => array( 'density' => 'compact' ) ) ),
+			1
+		);
+
+		$this->assertSame(
+			array( 'table' => array( 'density' => 'compact' ) ),
+			$data->get_config()['default_layouts']
+		);
+	}
+
+	/**
+	 * update_properties() unsets a property when the patch value is null.
+	 *
+	 * @covers ::update_properties
+	 */
+	public function test_update_properties_null_unsets_property() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'type'    => 'table',
+					'perPage' => 20,
+				),
+			)
+		);
+		$data->update_properties( array( 'default_view' => array( 'perPage' => null ) ), 1 );
+
+		$this->assertSame( array( 'type' => 'table' ), $data->get_config()['default_view'] );
+	}
+
+	/**
+	 * update_properties() unsets several default_layouts entries in one patch.
+	 *
+	 * @covers ::update_properties
+	 */
+	public function test_update_properties_null_unsets_multiple_default_layouts() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'default_layouts' => array(
+					'table' => array(),
+					'grid'  => array(),
+					'list'  => array(),
+				),
+			)
+		);
+		$data->update_properties(
 			array(
 				'default_layouts' => array(
 					'grid' => null,
@@ -432,18 +208,15 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			1
 		);
 
-		$this->assertSame(
-			array( 'table' ),
-			array_keys( $data->get_config()['default_layouts'] )
-		);
+		$this->assertSame( array( 'table' => array() ), $data->get_config()['default_layouts'] );
 	}
 
 	/**
-	 * update_with() unsets a deeply nested layout property when the value is null.
+	 * update_properties() unsets a deeply nested layout property when the value is null.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_unsets_nested_layout_prop() {
+	public function test_update_properties_null_unsets_nested_layout_prop() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'default_layouts' => array(
@@ -456,54 +229,40 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_with(
+		$data->update_properties(
 			array( 'default_layouts' => array( 'table' => array( 'layout' => array( 'styles' => null ) ) ) ),
 			1
 		);
 
-		$layout = $data->get_config()['default_layouts']['table']['layout'];
-		$this->assertArrayNotHasKey( 'styles', $layout );
-		// The sibling property is preserved.
-		$this->assertSame( 'compact', $layout['density'] );
+		$this->assertSame(
+			array( 'layout' => array( 'density' => 'compact' ) ),
+			$data->get_config()['default_layouts']['table']
+		);
 	}
 
 	/**
-	 * update_with() unsets a form field property when the patch value is null,
-	 * finding the field by identity first.
+	 * update_properties() drops a whole top-level key when the patch value is
+	 * null — any documented key, including the identity-keyed view_list —
+	 * rather than storing a literal null. gutenberg_get_entity_view_config()
+	 * backfills a dropped documented key from the defaults, so that reads as
+	 * a reset.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_unsets_field_property() {
-		$data = $this->make_data();
-		$data->update_with(
+	public function test_update_properties_null_drops_whole_top_level_key() {
+		$data = new Gutenberg_View_Config_Data(
 			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'    => 'excerpt',
-							'label' => null,
-						),
+				'default_view' => array( 'type' => 'table' ),
+				'view_list'    => array(
+					array(
+						'title' => 'All',
+						'slug'  => 'all',
 					),
 				),
-			),
-			1
+				'form'         => array( 'layout' => array( 'type' => 'panel' ) ),
+			)
 		);
-
-		$fields = $data->get_config()['form']['fields'];
-		// The field is merged in place, not appended.
-		$this->assertCount( 4, $fields );
-		$this->assertSame( array( 'id' => 'excerpt' ), $fields[0] );
-	}
-
-	/**
-	 * update_with() drops a whole top-level key when the patch value is null,
-	 * rather than storing a literal null.
-	 *
-	 * @covers ::update_with
-	 */
-	public function test_update_with_null_drops_whole_top_level_key() {
-		$data = $this->make_data();
-		$data->update_with(
+		$data->update_properties(
 			array(
 				'default_view' => null,
 				'view_list'    => null,
@@ -511,23 +270,21 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			1
 		);
 
-		$config = $data->get_config();
-		$this->assertArrayNotHasKey( 'default_view', $config );
-		$this->assertArrayNotHasKey( 'view_list', $config );
-		// Untouched keys are preserved.
-		$this->assertArrayHasKey( 'form', $config );
+		$this->assertSame(
+			array( 'form' => array( 'layout' => array( 'type' => 'panel' ) ) ),
+			$data->get_config()
+		);
 	}
 
 	/**
-	 * update_with() consumes a null delete-marker merged into an empty base
-	 * instead of storing it as a literal value.
+	 * update_properties() consumes a null delete-marker merged into an empty
+	 * base instead of storing it as a literal value.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_into_empty_base_is_consumed() {
-		$data = $this->make_data();
-		// The `table` layout entry is an empty array in the base config.
-		$data->update_with(
+	public function test_update_properties_null_into_empty_base_is_consumed() {
+		$data = new Gutenberg_View_Config_Data( array( 'default_layouts' => array( 'table' => array() ) ) );
+		$data->update_properties(
 			array( 'default_layouts' => array( 'table' => array( 'layout' => null ) ) ),
 			1
 		);
@@ -536,15 +293,15 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_with() strips nulls from a subtree assigned to a key absent from
-	 * the base instead of storing them as literal values.
+	 * update_properties() strips nulls from a subtree assigned to a key absent
+	 * from the base instead of storing them as literal values.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_stripped_from_absent_key_subtree() {
-		$data = $this->make_data();
+	public function test_update_properties_null_stripped_from_absent_key_subtree() {
+		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		// The base default_view has no `layout` key.
-		$data->update_with(
+		$data->update_properties(
 			array(
 				'default_view' => array(
 					'layout' => array(
@@ -560,197 +317,795 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_with() rejects a null patch value for the identity-keyed `fields`
-	 * and `children` lists: only remove_fields() may remove list content.
+	 * update_properties() rejects the identity-keyed branches: a non-null
+	 * view_list value and form fields belong to their dedicated functions. A
+	 * valid sibling form property still merges.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_null_cannot_delete_field_lists() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+	public function test_update_properties_rejects_identity_keyed_branches() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
 
-		$data   = $this->make_data();
-		$before = $data->get_config();
-
-		$data->update_with( array( 'form' => array( 'fields' => null ) ), 1 );
-		$this->assertSame( $before['form']['fields'], $data->get_config()['form']['fields'] );
-
-		$data->update_with(
+		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
-					'fields' => array(
-						array(
-							'id'       => 'discussion',
-							'children' => null,
-						),
+					'layout' => array( 'type' => 'panel' ),
+					'fields' => array( 'date' ),
+				),
+			)
+		);
+
+		$data->update_properties(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'mine',
+						'title' => 'Mine',
 					),
+				),
+			),
+			1
+		);
+		$this->assertArrayNotHasKey( 'view_list', $data->get_config() );
+
+		$data->update_properties(
+			array(
+				'form' => array(
+					'layout' => array( 'type' => 'card' ),
+					'fields' => array( 'my_field' ),
 				),
 			),
 			1
 		);
 		$this->assertSame(
-			array( 'comment_status', 'ping_status' ),
-			$data->get_config()['form']['fields'][1]['children']
+			array(
+				'layout' => array( 'type' => 'card' ),
+				'fields' => array( 'date' ),
+			),
+			$data->get_config()['form']
 		);
 	}
 
 	/**
-	 * update_with() rejects a list member that declares no identity: it could
-	 * never be matched, merged, or removed afterwards.
+	 * update_properties() rejects an undocumented top-level key. Nested
+	 * properties are not validated: their vocabulary is owned by the
+	 * client-side consumers.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_properties
 	 */
-	public function test_update_with_rejects_member_without_identity() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+	public function test_update_properties_warns_on_unknown_top_level_key() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
 
-		$data   = $this->make_data();
+		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
+		$data->update_properties( array( 'not_a_real_key' => 'nope' ), 1 );
+
+		$this->assertSame( array( 'default_view' => array( 'type' => 'table' ) ), $data->get_config() );
+	}
+
+	/**
+	 * update_properties() rejects a list where the form map is expected.
+	 *
+	 * @covers ::update_properties
+	 */
+	public function test_update_properties_rejects_list_shaped_form_patch() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
+
+		$data   = new Gutenberg_View_Config_Data( array( 'form' => array( 'layout' => array( 'type' => 'panel' ) ) ) );
+		$before = $data->get_config();
+		$data->update_properties( array( 'form' => array( array( 'id' => 'my_field' ) ) ), 1 );
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * Every update function rejects a patch whose version cannot be migrated —
+	 * omitted, or newer than the latest supported version.
+	 *
+	 * @covers ::update_properties
+	 * @covers ::update_view_list_items
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_functions_reject_unmigratable_version() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_view_list_items' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_form_fields' );
+
+		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
 
-		$data->update_with(
-			array(
-				'view_list' => array(
-					array(
-						'slug'  => null,
-						'title' => 'Broken',
-					),
-				),
-			),
-			1
-		);
-		$data->update_with(
-			array(
-				'form' => array(
-					'fields' => array(
-						array( 'label' => 'No id' ),
-						null,
-					),
-				),
-			),
-			1
+		// Omitted: no version declared.
+		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ) );
+		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ) );
+		$data->update_form_fields( array( 'excerpt' => array( 'label' => 'Summary' ) ) );
+
+		// Newer than the latest supported version.
+		$data->update_properties(
+			array( 'default_view' => array( 'type' => 'grid' ) ),
+			Gutenberg_View_Config_Data::LATEST_VERSION + 1
 		);
 
 		$this->assertSame( $before, $data->get_config() );
 	}
 
 	/**
-	 * update_with() rejects patches whose shape does not match the key: a
-	 * map where a list is expected, or a list where a map is expected.
+	 * update_view_list_items() merges a matching slug in place and appends an
+	 * unknown one, injecting the slug from the patch key.
 	 *
-	 * @covers ::update_with
+	 * @covers ::update_view_list_items
 	 */
-	public function test_update_with_rejects_shape_mismatched_patches() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
-
-		$data   = $this->make_data();
-		$before = $data->get_config();
-
-		// A map where the view_list list is expected.
-		$data->update_with(
+	public function test_update_view_list_items_merges_by_slug_and_appends_unknown() {
+		$data = new Gutenberg_View_Config_Data(
 			array(
 				'view_list' => array(
+					array(
+						'title' => 'All',
+						'slug'  => 'all',
+					),
+					array(
+						'title' => 'Published',
+						'slug'  => 'published',
+					),
+				),
+			)
+		);
+		$data->update_view_list_items(
+			array(
+				'published' => array( 'title' => 'Live' ),
+				'mine'      => array( 'title' => 'Mine' ),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'title' => 'All',
+					'slug'  => 'all',
+				),
+				array(
+					'title' => 'Live',
+					'slug'  => 'published',
+				),
+				array(
+					'slug'  => 'mine',
+					'title' => 'Mine',
+				),
+			),
+			$data->get_config()['view_list']
+		);
+	}
+
+	/**
+	 * update_view_list_items() removes a view when the patch value is null.
+	 *
+	 * @covers ::update_view_list_items
+	 */
+	public function test_update_view_list_items_null_removes_view() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'title' => 'All',
+						'slug'  => 'all',
+					),
+					array(
+						'title' => 'Published',
+						'slug'  => 'published',
+					),
+				),
+			)
+		);
+		$data->update_view_list_items( array( 'published' => null ), 1 );
+
+		$this->assertSame(
+			array(
+				array(
+					'title' => 'All',
+					'slug'  => 'all',
+				),
+			),
+			$data->get_config()['view_list']
+		);
+	}
+
+	/**
+	 * The patch key is the identity: a conflicting `slug` property inside the
+	 * value is ignored.
+	 *
+	 * @covers ::update_view_list_items
+	 */
+	public function test_update_view_list_items_patch_key_wins_over_slug_property() {
+		$data = new Gutenberg_View_Config_Data( array( 'view_list' => array() ) );
+		$data->update_view_list_items(
+			array(
+				'mine' => array(
+					'slug'  => 'other',
+					'title' => 'Mine',
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'slug'  => 'mine',
+					'title' => 'Mine',
+				),
+			),
+			$data->get_config()['view_list']
+		);
+	}
+
+	/**
+	 * update_view_list_items() rejects patches that are not keyed by slug and
+	 * members that are not view objects.
+	 *
+	 * @covers ::update_view_list_items
+	 */
+	public function test_update_view_list_items_rejects_off_shape_patches() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_view_list_items' );
+
+		$data   = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'title' => 'All',
+						'slug'  => 'all',
+					),
+				),
+			)
+		);
+		$before = $data->get_config();
+
+		// A positional list where a map keyed by slug is expected.
+		$data->update_view_list_items(
+			array(
+				array(
 					'slug'  => 'mine',
 					'title' => 'Mine',
 				),
 			),
 			1
 		);
-		// A list where the form map is expected.
-		$data->update_with( array( 'form' => array( array( 'id' => 'my_field' ) ) ), 1 );
-		// A map where the fields list is expected.
-		$data->update_with( array( 'form' => array( 'fields' => array( 'id' => 'my_field' ) ) ), 1 );
+		// A scalar where a view object (or null) is expected.
+		$data->update_view_list_items( array( 'all' => 'nope' ), 1 );
 
 		$this->assertSame( $before, $data->get_config() );
 	}
 
 	/**
-	 * remove_view_list_items() drops a view by slug.
+	 * update_form_fields() merges a top-level field by its id: in place, with
+	 * siblings untouched and nothing appended.
 	 *
-	 * @covers ::remove_view_list_items
+	 * @covers ::update_form_fields
 	 */
-	public function test_remove_view_list_items_by_slug() {
-		$data = $this->make_data();
-		$data->remove_view_list_items( 'published' );
+	public function test_update_form_fields_merges_top_level_field_by_id() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'excerpt',
+							'label' => 'Excerpt',
+						),
+						'date',
+					),
+				),
+			)
+		);
+		$data->update_form_fields( array( 'excerpt' => array( 'label' => 'Summary' ) ), 1 );
 
-		$slugs = wp_list_pluck( $data->get_config()['view_list'], 'slug' );
-		$this->assertSame( array( 'all' ), $slugs );
+		$this->assertSame(
+			array(
+				array(
+					'id'    => 'excerpt',
+					'label' => 'Summary',
+				),
+				'date',
+			),
+			$data->get_config()['form']['fields']
+		);
 	}
 
 	/**
-	 * remove_view_list_items() drops several views when given an array of slugs.
+	 * update_form_fields() finds a nested field by its bare id: the caller does
+	 * not need to know (or address) the group the field lives in.
 	 *
-	 * @covers ::remove_view_list_items
+	 * @covers ::update_form_fields
 	 */
-	public function test_remove_view_list_items_multiple_by_array() {
-		$data = $this->make_data();
-		$data->remove_view_list_items( array( 'all', 'published' ) );
+	public function test_update_form_fields_merges_nested_field_without_addressing_group() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields( array( 'ping_status' => array( 'label' => 'Pings' ) ), 1 );
 
-		$this->assertSame( array(), $data->get_config()['view_list'] );
+		// comment_status stays a bare string; the matched ping_status child is
+		// promoted from a bare string and merged with the incoming overrides.
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array(
+						'comment_status',
+						array(
+							'id'    => 'ping_status',
+							'label' => 'Pings',
+						),
+					),
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
 	}
 
 	/**
-	 * remove_view_list_items() removes the found slugs in an array and silently
-	 * ignores the rest.
+	 * Fields are visited in document order and a group matches before its own
+	 * children, so a group and a child sharing an id (as in core's default
+	 * `status` group) resolve to the group; the child is reached through a
+	 * `children` patch on the group.
 	 *
-	 * @covers ::remove_view_list_items
+	 * @covers ::update_form_fields
 	 */
-	public function test_remove_view_list_items_mixes_found_and_missing_silently() {
-		$data = $this->make_data();
-		$data->remove_view_list_items( array( 'published', 'does_not_exist' ) );
+	public function test_update_form_fields_matches_group_before_its_children() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'status',
+							'label'    => 'Status',
+							'children' => array( 'status', 'password' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'status' => array(
+					'label'    => 'Visibility',
+					'children' => array( 'status' => array( 'label' => 'State' ) ),
+				),
+			),
+			1
+		);
 
-		$slugs = wp_list_pluck( $data->get_config()['view_list'], 'slug' );
-		$this->assertSame( array( 'all' ), $slugs );
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'status',
+					'label'    => 'Visibility',
+					'children' => array(
+						array(
+							'id'    => 'status',
+							'label' => 'State',
+						),
+						'password',
+					),
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
 	}
 
 	/**
-	 * remove_fields() drops a nested field by id, walking the current structure.
+	 * update_form_fields() appends an unknown id to the end of the top-level
+	 * list: as an object when the patch carries overrides, as a bare string
+	 * reference otherwise.
 	 *
-	 * @covers ::remove_fields
+	 * @covers ::update_form_fields
 	 */
-	public function test_remove_fields_nested_by_id() {
-		$data = $this->make_data();
-		$data->remove_fields( 'ping_status' );
+	public function test_update_form_fields_appends_unknown_field() {
+		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
+		$data->update_form_fields(
+			array(
+				'my_field'    => array( 'label' => 'Mine' ),
+				'other_field' => array(),
+			),
+			1
+		);
 
-		$fields     = $data->get_config()['form']['fields'];
-		$discussion = $fields[1];
-		$this->assertSame( 'discussion', $discussion['id'] );
-		// Only ping_status is dropped from the group's children.
-		$this->assertSame( array( 'comment_status' ), $discussion['children'] );
+		$this->assertSame(
+			array(
+				'date',
+				array(
+					'id'    => 'my_field',
+					'label' => 'Mine',
+				),
+				'other_field',
+			),
+			$data->get_config()['form']['fields']
+		);
 	}
 
 	/**
-	 * remove_fields() drops several form fields when given an array of ids.
+	 * A null patch value removes the field wherever it lives, including nested
+	 * inside a group's children.
 	 *
-	 * @covers ::remove_fields
+	 * @covers ::update_form_fields
 	 */
-	public function test_remove_fields_multiple_by_array() {
-		$data = $this->make_data();
-		$data->remove_fields( array( 'ping_status', 'comment_status' ) );
+	public function test_update_form_fields_null_removes_field_wherever_it_lives() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'excerpt',
+							'label' => 'Excerpt',
+						),
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+						'date',
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'excerpt'     => null,
+				'ping_status' => null,
+			),
+			1
+		);
 
-		$fields = $data->get_config()['form']['fields'];
-		// Top-level fields are untouched.
-		$this->assertCount( 4, $fields );
-		$this->assertSame( 'excerpt', $fields[0]['id'] );
-		// Both nested children were dropped; the group itself remains.
-		$discussion = $fields[1];
-		$this->assertSame( 'discussion', $discussion['id'] );
-		$this->assertSame( array(), $discussion['children'] );
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array( 'comment_status' ),
+				),
+				'date',
+			),
+			$data->get_config()['form']['fields']
+		);
 	}
 
 	/**
-	 * The remove helpers are a silent no-op when the identity is not found.
+	 * A `children` map merges into the group's children by id, appending
+	 * unknown ones.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_children_map_merges_by_id() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'discussion' => array(
+					'children' => array(
+						'comment_status' => array( 'label' => 'Comments' ),
+						'my_field'       => array(),
+					),
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array(
+						array(
+							'id'    => 'comment_status',
+							'label' => 'Comments',
+						),
+						'ping_status',
+						'my_field',
+					),
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * A `children` list replaces the group's children wholesale while the group
+	 * keeps its position among the other top-level fields.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_children_list_replaces_wholesale() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						'excerpt',
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+						'date',
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array( 'discussion' => array( 'children' => array( 'ping_status', 'my_field' ) ) ),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				'excerpt',
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array( 'ping_status', 'my_field' ),
+				),
+				'date',
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * A null `children` value deletes the key, turning the group into a plain
+	 * field.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_children_null_drops_key() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields( array( 'discussion' => array( 'children' => null ) ), 1 );
+
+		$this->assertSame(
+			array(
+				array(
+					'id'    => 'discussion',
+					'label' => 'Discussion',
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * The patch key is the identity: a conflicting `id` property inside the
+	 * value is ignored.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_patch_key_wins_over_id_property() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'    => 'excerpt',
+							'label' => 'Excerpt',
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'excerpt' => array(
+					'id'    => 'other',
+					'label' => 'Summary',
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'id'    => 'excerpt',
+					'label' => 'Summary',
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * update_form_fields() rejects patches that are not keyed by id and members
+	 * that are not field objects.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_rejects_off_shape_patches() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_form_fields' );
+
+		$data   = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
+		$before = $data->get_config();
+
+		// A positional list where a map keyed by id is expected.
+		$data->update_form_fields( array( array( 'id' => 'my_field' ) ), 1 );
+		// A scalar where a field object (or null) is expected.
+		$data->update_form_fields( array( 'date' => 'nope' ), 1 );
+
+		$this->assertSame( $before, $data->get_config() );
+	}
+
+	/**
+	 * Several null field patches drop several members in one patch: both nested
+	 * children are removed while the group itself remains.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_null_removes_multiple_nested_fields() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						'excerpt',
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'ping_status'    => null,
+				'comment_status' => null,
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				'excerpt',
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array(),
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * Removing a group removes its children with it: they are not hoisted to
+	 * the top level.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_null_removes_group_with_its_children() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+						'date',
+					),
+				),
+			)
+		);
+		$data->update_form_fields( array( 'discussion' => null ), 1 );
+
+		$this->assertSame( array( 'date' ), $data->get_config()['form']['fields'] );
+	}
+
+	/**
+	 * Patch entries apply in order and a null removes every occurrence of the
+	 * id, so a field moves into a group by removing it first and appending it
+	 * to the group's children later in the same patch.
+	 *
+	 * @covers ::update_form_fields
+	 */
+	public function test_update_form_fields_moves_field_into_group_in_one_patch() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						'author',
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status' ),
+						),
+					),
+				),
+			)
+		);
+		$data->update_form_fields(
+			array(
+				'author'     => null,
+				'discussion' => array( 'children' => array( 'author' => array() ) ),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array( 'comment_status', 'author' ),
+				),
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * A null patch for an identity that is not found is a silent no-op.
 	 *
 	 * A member that is not present may have been removed by another filter or
 	 * simply not apply to this entity, so it is not treated as misuse.
 	 *
-	 * @covers ::remove_fields
-	 * @covers ::remove_view_list_items
+	 * @covers ::update_form_fields
+	 * @covers ::update_view_list_items
 	 */
-	public function test_remove_not_found_is_silent_no_op() {
-		$data   = $this->make_data();
-		$before = $data->get_config();
+	public function test_null_patch_for_unknown_identity_is_silent_no_op() {
+		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
+		$data->update_form_fields( array( 'does_not_exist' => null ), 1 );
 
-		$data->remove_fields( 'does_not_exist' );
-		$data->remove_view_list_items( 'does_not_exist' );
+		$this->assertSame( array( 'date' ), $data->get_config()['form']['fields'] );
 
-		$this->assertSame( $before, $data->get_config() );
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'title' => 'All',
+						'slug'  => 'all',
+					),
+				),
+			)
+		);
+		$data->update_view_list_items( array( 'does_not_exist' => null ), 1 );
+
+		$this->assertSame(
+			array(
+				array(
+					'title' => 'All',
+					'slug'  => 'all',
+				),
+			),
+			$data->get_config()['view_list']
+		);
 	}
 }

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -399,7 +399,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 
 	/**
 	 * Every update function rejects a patch whose version cannot be migrated —
-	 * omitted, or newer than the latest supported version.
+	 * newer than the latest supported version.
 	 *
 	 * @covers ::update_properties
 	 * @covers ::update_view_list_items
@@ -413,16 +413,10 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
 
-		// Omitted: no version declared.
-		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ) );
-		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ) );
-		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ) );
-
-		// Newer than the latest supported version.
-		$data->update_properties(
-			array( 'default_view' => array( 'type' => 'grid' ) ),
-			Gutenberg_View_Config_Data::LATEST_VERSION + 1
-		);
+		$version = Gutenberg_View_Config_Data::LATEST_VERSION + 1;
+		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ), $version );
+		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ), $version );
+		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), $version );
 
 		$this->assertSame( $before, $data->get_config() );
 	}

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -165,24 +165,6 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A filter can replace a whole key through set().
-	 */
-	public function test_filter_set_replaces_key() {
-		add_filter(
-			'get_entity_view_config_custom_kind_custom_name',
-			function ( $data ) {
-				return $data->set( 'form', array( 'custom' => true ) );
-			}
-		);
-
-		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
-
-		$this->assertSame( array( 'custom' => true ), $config['form'] );
-		// Untouched keys keep their defaults.
-		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
-	}
-
-	/**
 	 * Successive filters share the same container, so their patches compose and
 	 * a later null field patch reaches a member contributed by an earlier filter.
 	 */
@@ -218,28 +200,6 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 			array( 'comment_status' ),
 			$config['form']['fields'][0]['children']
 		);
-	}
-
-	/**
-	 * Top-level keys introduced through the container that are not part of the
-	 * documented shape are rejected and never reach the response. Nested
-	 * properties are not validated: their vocabulary is owned by the
-	 * client-side consumers.
-	 */
-	public function test_filter_unknown_top_level_keys_warn_and_are_discarded() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
-
-		add_filter(
-			'get_entity_view_config_custom_kind_custom_name',
-			function ( $data ) {
-				return $data->update_properties( array( 'not_a_real_key' => 'nope' ), 1 );
-			}
-		);
-
-		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
-
-		$this->assertArrayNotHasKey( 'not_a_real_key', $config );
-		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
 	}
 
 	/**

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -181,7 +181,8 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 								'children' => array( 'comment_status', 'ping_status' ),
 							),
 						),
-					)
+					),
+					1
 				);
 			},
 			9

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -117,15 +117,17 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The dynamic filter receives the default config and the entity descriptor.
+	 * The dynamic filter receives the data container and the entity descriptor.
 	 */
-	public function test_filter_receives_config_and_entity() {
+	public function test_filter_receives_data_and_entity() {
 		$received_entity = null;
+		$received_data   = null;
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
-			function ( $config, $entity ) use ( &$received_entity ) {
+			function ( $data, $entity ) use ( &$received_entity, &$received_data ) {
 				$received_entity = $entity;
-				return $config;
+				$received_data   = $data;
+				return $data;
 			},
 			10,
 			2
@@ -133,6 +135,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 
 		gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
 
+		$this->assertInstanceOf( 'Gutenberg_View_Config_Data', $received_data );
 		$this->assertSame(
 			array(
 				'kind' => 'custom_kind',
@@ -143,14 +146,16 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A filter can override the configuration values.
+	 * A filter can override configuration values through update_with().
 	 */
-	public function test_filter_can_override_config() {
+	public function test_filter_update_with_overrides_config() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
-			function ( $config ) {
-				$config['default_view']['type'] = 'grid';
-				return $config;
+			function ( $data ) {
+				return $data->update_with(
+					array( 'default_view' => array( 'type' => 'grid' ) ),
+					1
+				);
 			}
 		);
 
@@ -160,37 +165,70 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Dropped keys are backfilled with their defaults.
+	 * A filter can replace a whole key through set().
 	 */
-	public function test_filter_dropped_keys_are_backfilled() {
+	public function test_filter_set_replaces_key() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
-			function () {
-				// Return a config that is missing most of the documented keys.
-				return array( 'form' => array( 'custom' => true ) );
+			function ( $data ) {
+				return $data->set( 'form', array( 'custom' => true ) );
 			}
 		);
 
 		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
 
-		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
 		$this->assertSame( array( 'custom' => true ), $config['form'] );
-		// Backfilled from defaults.
-		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		// Untouched keys keep their defaults.
 		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
-		$this->assertSame( self::DEFAULT_LAYOUTS, $config['default_layouts'] );
-		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
 	}
 
 	/**
-	 * Keys introduced by a filter that are not part of the documented shape are discarded.
+	 * Successive filters share the same container, so their patches compose and
+	 * a later remove_fields() reaches a member contributed by an earlier filter.
+	 */
+	public function test_filters_compose_across_the_chain() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $data ) {
+				return $data->set(
+					'form',
+					array(
+						'fields' => array(
+							array(
+								'id'       => 'discussion',
+								'children' => array( 'comment_status', 'ping_status' ),
+							),
+						),
+					)
+				);
+			},
+			9
+		);
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $data ) {
+				return $data->remove_fields( 'ping_status' );
+			},
+			11
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertSame(
+			array( 'comment_status' ),
+			$config['form']['fields'][0]['children']
+		);
+	}
+
+	/**
+	 * Keys introduced through the container that are not part of the documented
+	 * shape are discarded.
 	 */
 	public function test_filter_unknown_keys_are_discarded() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
-			function ( $config ) {
-				$config['not_a_real_key'] = 'nope';
-				return $config;
+			function ( $data ) {
+				return $data->update_with( array( 'not_a_real_key' => 'nope' ), 1 );
 			}
 		);
 
@@ -201,13 +239,63 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A non-array filter return falls back to the default config.
+	 * A filter that returns its own off-shape container has the result normalized:
+	 * undocumented keys are dropped and dropped documented keys are backfilled
+	 * from the defaults.
 	 */
-	public function test_non_array_filter_return_falls_back_to_default() {
+	public function test_off_shape_container_return_is_normalized() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function () {
-				return 'not an array';
+				return new Gutenberg_View_Config_Data(
+					array(
+						'default_view'   => array( 'type' => 'grid' ),
+						'not_a_real_key' => 'nope',
+					)
+				);
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		// Undocumented key dropped; shape is exactly the documented keys.
+		$this->assertSameSets( self::CONFIG_KEYS, array_keys( $config ) );
+		// The container's own value is respected.
+		$this->assertSame( array( 'type' => 'grid' ), $config['default_view'] );
+		// Documented keys the container omitted are backfilled from the defaults.
+		$this->assertSame( self::DEFAULT_LAYOUTS, $config['default_layouts'] );
+		$this->assertSame( self::DEFAULT_VIEW_LIST, $config['view_list'] );
+		$this->assertSame( self::DEFAULT_FORM, $config['form'] );
+	}
+
+	/**
+	 * A documented key dropped through a null patch value is backfilled from
+	 * the defaults, so a null never reaches the response.
+	 */
+	public function test_filter_null_reset_is_backfilled_from_defaults() {
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function ( $data ) {
+				return $data->update_with( array( 'default_view' => null ), 1 );
+			}
+		);
+
+		$config = gutenberg_get_entity_view_config( 'custom_kind', 'custom_name' );
+
+		$this->assertSame( self::DEFAULT_VIEW, $config['default_view'] );
+	}
+
+	/**
+	 * A filter that returns something other than the container falls back to the
+	 * default config.
+	 */
+	public function test_non_object_filter_return_falls_back_to_default() {
+		$this->setExpectedIncorrectUsage( 'gutenberg_get_entity_view_config' );
+
+		add_filter(
+			'get_entity_view_config_custom_kind_custom_name',
+			function () {
+				return 'not the container';
 			}
 		);
 

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -146,13 +146,13 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A filter can override configuration values through update_with().
+	 * A filter can override configuration values through update_properties().
 	 */
-	public function test_filter_update_with_overrides_config() {
+	public function test_filter_update_properties_overrides_config() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_with(
+				return $data->update_properties(
 					array( 'default_view' => array( 'type' => 'grid' ) ),
 					1
 				);
@@ -184,7 +184,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 
 	/**
 	 * Successive filters share the same container, so their patches compose and
-	 * a later remove_fields() reaches a member contributed by an earlier filter.
+	 * a later null field patch reaches a member contributed by an earlier filter.
 	 */
 	public function test_filters_compose_across_the_chain() {
 		add_filter(
@@ -207,7 +207,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->remove_fields( 'ping_status' );
+				return $data->update_form_fields( array( 'ping_status' => null ), 1 );
 			},
 			11
 		);
@@ -221,14 +221,18 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Keys introduced through the container that are not part of the documented
-	 * shape are discarded.
+	 * Top-level keys introduced through the container that are not part of the
+	 * documented shape are rejected and never reach the response. Nested
+	 * properties are not validated: their vocabulary is owned by the
+	 * client-side consumers.
 	 */
-	public function test_filter_unknown_keys_are_discarded() {
+	public function test_filter_unknown_top_level_keys_warn_and_are_discarded() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
+
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_with( array( 'not_a_real_key' => 'nope' ), 1 );
+				return $data->update_properties( array( 'not_a_real_key' => 'nope' ), 1 );
 			}
 		);
 
@@ -276,7 +280,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_with( array( 'default_view' => null ), 1 );
+				return $data->update_properties( array( 'default_view' => null ), 1 );
 			}
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/76544

This PR adds version handling to the server-side view configuration API (`gutenberg_get_entity_view_config()`).

## Why?

Right now consumers of the filters have to customize the config by walking the raw payload (find the right index, `foreach`, `unset`, etc..), and imperative array manipulation can never be migrated. A later shape change could break existing callbacks in the wild. So even though there is only version `1` today and no migrations exist, this code is the safeguard to keep filters working in a possible shape change.


## How? 

The approach here partially mirrors `theme.json` version handling, where documents declare a `version` and `WP_Theme_JSON_Data->update_with()` migrates older data forward. So instead of mutating a single payload directly, now callbacks receive a `data container` and update the config through the container's specific methods. 

Any update made is marked against the version it was written, and the payload could be migrated in newer versions.

Where it differs from `theme.json` handling is the need for updating configs that are arrays (e.g. `fields and view_list`) and handling index based transforms cannot happen reliably in a filter. These props though have stable identities (`field.id`, `view_list.slug`), so each part of the config has its own update function and patches are keyed by that identity: the key names the member, the value carries only the changes. All the update functions follow the same rules — an associative array merges key by key, a numerically indexed array replaces wholesale, and `null` deletes what it names: a nested key, a whole member, or a whole top-level key (which resets it to its default).




### `update_properties()`

- `update_properties( $patch, $version )` merges partial changes into `default_view`, `default_layouts`, and `form` except its `fields`.
- a `null` patch value unsets a nested key, and `null` for a whole top-level key resets it to its default.

```php
function example_filter_page_view_config( $data ) {
    // Unset a nested value with null: drop the grid layout option. Form
    // properties other than `fields` also merge here
    $data->update_properties(
        array(
            'default_layouts' => array( 'grid' => null ),
            'form'                   => array( 'layout' => array( 'type' => 'regular' ) ),
        ),
        1
    );

    return $data;
}
add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
```

### `update_view_list_items()`

- `update_view_list_items( $items, $version )` patches the `view_list`, keyed by `slug`.
- a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view.

```php
function example_filter_page_view_config( $data ) {
    // Add a saved view, retitle the existing Drafts view — matched by slug,
    // only the given keys change — and remove the Trash view with null.
    $data->update_view_list_items(
        array(
            'my-drafts' => array(
                'title' => __( 'My drafts', 'example' ),
                'view'  => array(
                    'filters' => array(
                        array(
                            'field'    => 'status',
                            'operator' => 'isAny',
                            'value'    => 'draft',
                            'isLocked' => true,
                        ),
                    ),
                ),
            ),
            'drafts'    => array( 'title' => __( 'In progress', 'example' ) ),
            'trash'     => null,
        ),
        1
    );

    return $data;
}
add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
```

### `update_form_fields()`

- `update_form_fields( $fields, $version )` patches the `form` fields, keyed by `id`. A field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id.
- a matching field merges in place, an unknown id appends a new field, and `null` removes the field.
- the id lives in the patch key and the value only carries overrides, so a new field with no overrides is `'my_field' => array()`. Inside a field patch, an associative `children` value merges into the group's children by `id` (unknown ids append to the group), while a numerically indexed one replaces them wholesale.

```php
function example_filter_page_view_config( $data ) {
    // Change label position to post-content-info field, remove the slug and author
    // fields with null, and append a field to the discussion group.
    $data->update_form_fields(
        array(
            'post-content-info' => array(
                'layout' => array( 'labelPosition' => 'side' ),
            ),
            'slug'                        => null,
            'author'                    => null,
            'discussion'             => array(
                'children' => array( 'my_field' => array() ),
            ),
        ),
        1
    );

    return $data;
}
add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
```


### `set()`

Replaces a whole top-level key. It shouldn't be the default choice — a callback using it stops inheriting core's future changes to that key — but it's useful for cases like a CPT that doesn't want the default post form at all.


```php
function example_filter_book_view_config( $data ) {
    // The default post form doesn't fit books; define one from scratch.
    return $data->set(
        'form',
        array(
            'layout' => array( 'type' => 'panel' ),
            'fields' => array( 'isbn', 'publisher' ),
        ),
        1
    );
}
add_filter( 'get_entity_view_config_postType_book', 'example_filter_book_view_config' );
```


## Testing Instructions

1. Add the example callback above in PHP.
2. Open Site Editor → Pages:
    - The "My drafts" view appears in the views list; the Drafts view is retitled "In progress"; the Trash view is gone.
    - The Grid layout option is no longer offered.
3. Open Quick Edit on a page: the Slug and Author fields are gone from the form.
4. Play around with different payloads


## Use of AI Tools
Opus 4.8 and Fable 5 with direction, changes and review