### PR TITLE
Site Editor: Update default theme color from fresh to modern

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -47,7 +47,7 @@ function gutenberg_site_editor_enable_admin_bar() {
 
 	$admin_color = get_user_option( 'admin_color' );
 	if ( empty( $admin_color ) ) {
-		$admin_color = 'fresh';
+		$admin_color = 'modern';
 	}
 	$admin_color_class = 'admin-color-' . sanitize_html_class( $admin_color );
 

--- a/packages/admin-ui/src/admin-theme-colors/index.ts
+++ b/packages/admin-ui/src/admin-theme-colors/index.ts
@@ -5,12 +5,12 @@ type AdminThemeColors = {
 
 const DEFAULT_THEME_COLORS: AdminThemeColors = {
 	primary: '#3858e9',
-	background: '#25292b',
+	background: '#222524',
 };
 
 const ADMIN_THEME_COLORS = new Map< string, AdminThemeColors >( [
-	[ 'fresh', DEFAULT_THEME_COLORS ],
-	[ 'modern', { primary: '#3858e9', background: '#222524' } ],
+	[ 'modern', DEFAULT_THEME_COLORS ],
+	[ 'fresh', { primary: '#3858e9', background: '#25292b' } ],
 	[ 'midnight', { primary: '#cf4339', background: '#3d4042' } ],
 	[ 'coffee', { primary: '#916745', background: '#5b534d' } ],
 	[ 'ocean', { primary: '#567958', background: '#5f787f' } ],
@@ -31,7 +31,7 @@ const ADMIN_THEME_COLORS = new Map< string, AdminThemeColors >( [
 export function getAdminThemeColors(): AdminThemeColors {
 	const scheme =
 		document.body.className.match( /admin-color-([\w-]+)/ )?.[ 1 ] ??
-		'fresh';
+		'modern';
 
 	return ADMIN_THEME_COLORS.get( scheme ) ?? DEFAULT_THEME_COLORS;
 }

--- a/packages/admin-ui/src/admin-theme-colors/test/index.test.ts
+++ b/packages/admin-ui/src/admin-theme-colors/test/index.test.ts
@@ -13,12 +13,12 @@ describe( 'getAdminThemeColors', () => {
 		} );
 	} );
 
-	it( 'should fall back to the fresh scheme colors when no admin-color class is present', () => {
+	it( 'should fall back to the modern scheme colors when no admin-color class is present', () => {
 		document.body.className = 'foo bar';
 
 		expect( getAdminThemeColors() ).toEqual( {
 			primary: '#3858e9',
-			background: '#25292b',
+			background: '#222524',
 		} );
 	} );
 
@@ -27,7 +27,7 @@ describe( 'getAdminThemeColors', () => {
 
 		expect( getAdminThemeColors() ).toEqual( {
 			primary: '#3858e9',
-			background: '#25292b',
+			background: '#222524',
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

When the user has not yet set admin color scheme, or uses non-standard admin color scheme (e.g. provided by certain hosts), the site editor now falls back to the Modern scheme, instead of Fresh.

## Why?

Two reasons:

- It fixes a subtle bug introduced https://github.com/WordPress/gutenberg/pull/78397. Basically, Modern was the (only) color scheme before we follow the admin color scheme via that PR.
- Modern is the default color scheme since 7.0.

## How?

Update `fresh` reference with `modern`.

## Testing Instructions

It's a bit tricky to test this since we need to update the admin color to a non-standard color. For example, we can use the following command:

```
npx wp-env run cli wp user meta update admin admin_color bogus
```

then go to Appearance -> Editor, and verify you see the editor with the Modern color as below screenshot. Also verify that the color is actually set in the `<body>`:

<img width="746" height="233" alt="image" src="https://github.com/user-attachments/assets/e59945bf-4707-47c1-ad7f-85d53b918c4a" />


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Site Editor | Site Editor v2<br>(Extensible Site Editor experiment) |
| - | - |
| <img width="1720" height="1056" alt="image" src="https://github.com/user-attachments/assets/878f085a-d62a-4161-93b8-d7224817166e" /> | <img width="1720" height="1056" alt="image" src="https://github.com/user-attachments/assets/fea97253-0003-4e50-8a55-1b067205ffcc" />


## Use of AI Tools

Used Opus 4.8 to generate the changes.
