### PR TITLE
Global Styles: Don't type classic theme global styles as 'theme' in editor settings

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -43,7 +43,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	$block_classes = array(
 		'css'            => 'styles',
-		'__unstableType' => 'theme',
+		'__unstableType' => wp_theme_has_theme_json() ? 'theme' : 'base-layout',
 		'isGlobalStyles' => true,
 	);
 	$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );


### PR DESCRIPTION
## What?

Closes #79815

Restores the default editor styles (`default-editor-styles.css`) in the post editor for themes that provide no editor styling of their own — no `theme.json` and no `editor-styles` support. This is done by typing the generated global stylesheet entry as `'base-layout'` instead of `'theme'` in `gutenberg_get_block_editor_settings()` for themes without `theme.json`. Themes that opt into `editor-styles` keep their own styles in the editor exactly as before.

## Why?

Since WordPress 7.0 (and Gutenberg plugin versions including #73971), the editor canvas for classic themes without `theme.json` and without `editor-styles` support renders with raw browser defaults (serif, 16px), because the default editor styles are no longer applied.

The editor applies `defaultEditorStyles` only when **no** `'theme'`-typed entry exists in `settings.styles`. #73971 removed the branch that typed the generated global stylesheet as `'base-layout'` for themes without `theme.json` — the entry is now unconditionally `'theme'`, so the editor believes every classic theme provides its own styles and skips the defaults. Since the generated stylesheet for these themes contains no base typography, the canvas is left unstyled.

This is a reintroduction of #42902, which was fixed in #42906 by introducing the `'base-layout'` type precisely so the entry *"isn't considered as theme styles by the check"*. This PR restores that guard as a condition.

## How?

`lib/block-editor-settings.php`: type the generated global stylesheet entry `wp_theme_has_theme_json() ? 'theme' : 'base-layout'`.

Why this is safe for the features #73971 enabled:

- The retyped entry still reaches the editor through the non-theme styles path, so the generated global styles CSS continues to load, with the default typography applied underneath it. Verified on WP 7.0 with this change applied: a user global styles font shows in the editor canvas together with the default typography, and a Font Library font renders correctly in both the editor and the front end.
- Themes *with* a `theme.json` (block and hybrid themes) are unaffected: `wp_theme_has_theme_json()` returns `true` for them.

## Testing Instructions

1. Activate **Twenty Twenty-One** and comment out `add_theme_support( 'editor-styles' );` in `twenty_twenty_one_setup()` (simulates the many classic themes that never opted into editor styles).
2. Open a post in the block editor and inspect a paragraph in the editor canvas.
3. Without this PR: content renders in browser-default serif, 16px. With this PR: content renders in the default editor styles (system font stack, 18px).
4. Verify Font Library CSS still loads: install/activate a font and confirm it is usable in the editor.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1536" height="630" alt="before" src="https://github.com/user-attachments/assets/2326abe8-7335-4681-af20-ab0203444121" />|<img width="1538" height="812" alt="after" src="https://github.com/user-attachments/assets/49da2df2-aaa9-4b29-818c-d9ca52f09f86" />|

## Use of AI Tools

The investigation and this fix were developed with the assistance of Claude Code (Anthropic): diagnosing the root cause, tracing the regression history, and drafting the patch and this PR description. All changes and claims were reviewed and manually verified by the author (measured computed styles in the editor on WP 6.9.4 and 7.0, and verified on WP 7.0 that with this change the default editor styles return, user global styles CSS still reaches the editor canvas, and Font Library fonts render correctly in both the editor and the front end), and I take responsibility for the contribution.