### PR TITLE
Editor: Always iframe the post editor for block themes

### DIFF
--- a/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md
+++ b/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md
@@ -25,9 +25,9 @@ The iframed post editor will make life easier for block and theme authors by red
 While most editors, including the template editor, already work as iframes, for backward compatibility, the current post editor only works as an iframe when the following conditions are met (determined by [the useShouldIframe hook](https://github.com/WordPress/gutenberg/blob/cd4fae71551e0ebf27472da1d7bbdfce91a131ec/packages/edit-post/src/components/layout/use-should-iframe.js#L16)):
 
 - **If the Gutenberg plugin is enabled:** The editor always works as an iframe.
-- **If the Gutenberg plugin is not enabled:** The editor always works as an iframe when any of the following is true: the device type is not `Desktop` (e.g., tablet or mobile previews), the current post type is `wp_template` or `wp_block`, zoom-out mode is active, or all blocks present in the post content have `apiVersion` 3 or higher.
+- **If the Gutenberg plugin is not enabled:** The editor always works as an iframe when any of the following is true: the active theme is a block theme, the device type is not `Desktop` (e.g., tablet or mobile previews), the current post type is `wp_template` or `wp_block`, zoom-out mode is active, or all blocks present in the post content have `apiVersion` 3 or higher.
 
-In summary, if you haven't been able to fully test your blocks in the iframe editor yet, by maintaining `apiVersion` 2, you can prevent the post editor from working as an iframe in most cases. Once you've confirmed that your blocks work in the iframe editor, you can then migrate to `apiVersion` 3.
+In summary, **with a classic theme**, if you haven't been able to fully test your blocks in the iframe editor yet, by maintaining `apiVersion` 2, you can prevent the post editor from working as an iframe in most cases. Once you've confirmed that your blocks work in the iframe editor, you can then migrate to `apiVersion` 3.
 
 ### When will the post editor work as an iframe?
 

--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -5,6 +5,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ export function useShouldIframe() {
 		const { getClientIdsWithDescendants, getBlockName } =
 			select( blockEditorStore );
 		const { getBlockType } = select( blocksStore );
+		const { getCurrentTheme } = select( coreStore );
 
 		return (
 			// If the Gutenberg plugin is active, we ALWAYS use the iframe for
@@ -28,6 +30,8 @@ export function useShouldIframe() {
 			// blocks easily. Before GB v22.5, we only enforced it for
 			// block-based themes (classic themes used the same rules as core).
 			isGutenbergPlugin ||
+			// Always iframe the editor for block themes.
+			getCurrentTheme()?.is_block_theme ||
 			// We also still want to iframe all the special
 			// editor features and modes such as device previews, zoom out, and
 			// template/pattern editing.


### PR DESCRIPTION
Alternatives to #74042

## What?

Make the post editor always render inside an iframe when a block theme is active.

## Why?

We aim to always render the post editor's canvas as an iframe in the future. This PR extends the conditions for forcing an iframe as a preliminary step towards a full migration, [in accordance with the explanation in the 7.1 roadmap](https://make.wordpress.org/core/2026/06/19/roadmap-to-7-1/#:~:text=the%20current%20plan%20is%20to%20enforce%20iframing%20for%20block%2Dbased%20themes%20in%20this%20release).

## Testing Instructions

1. Run `IS_GUTENBERG_PLUGIN=false npm run dev`
2. Open the post editor.
3. Register the v2 block using the following code.
  ```javascript
  wp.blocks.registerBlockType( 'my-plugin/v2-block', {
  	apiVersion: 2,
  	title: 'v2 block',
  	edit: function () {
  		return wp.element.createElement( 'p', wp.blockEditor.useBlockProps(), `v2 block` );
  	},
  } );
  ```
4. Insert the v2 block.
5. The editor remains an iframe.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Claude Opus). All changes were reviewed by the author.
