### PR TITLE
Playlist: Update waveform player dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45199,7 +45199,7 @@
 			"version": "10.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@arraypress/waveform-player": "^1.2.1",
+				"@arraypress/waveform-player": "^1.19.0",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/autop": "file:../autop",
@@ -45273,9 +45273,9 @@
 			}
 		},
 		"packages/block-library/node_modules/@arraypress/waveform-player": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.2.1.tgz",
-			"integrity": "sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.19.0.tgz",
+			"integrity": "sha512-HYgheOOoE0+oho5FuCGXwT36uuEiU+azfo9lT0H5N1HeVbOjs/jomwYKOG6bQ9nTsABKOVigzWSd8OwKmjUzUw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -91,7 +91,7 @@
 		"build-module/*/init.mjs"
 	],
 	"dependencies": {
-		"@arraypress/waveform-player": "^1.2.1",
+		"@arraypress/waveform-player": "^1.19.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates `@arraypress/waveform-player` in the block library from `^1.2.1` to `^1.19.0`.

## Why?
Keeps the bundled waveform player dependency current for blocks that render playlist waveforms.

## How?
Updates `packages/block-library/package.json` and the matching `package-lock.json` package metadata.

## Testing Instructions
1. Run `npm install --workspace=@wordpress/block-library --package-lock-only --ignore-scripts`.
2. Confirm the lockfile remains unchanged.

### Testing Instructions for Keyboard
Not applicable; this PR only updates dependency metadata.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Used Codex to update the dependency metadata, run the npm lockfile check, and draft this PR description.
