### PR TITLE
PHP-only blocks: make them editable in the canvas while keeping the PHP output shown in the editor

### DIFF
--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Pattern-backed PHP-only block registration (prototype, WordPress 7.1+).
+ *
+ * Lets a PHP-only block (`supports.autoRegister`) use a block pattern for its
+ * editable content. The pattern is a block-markup string, like a registered
+ * pattern's `content`. In the editor it becomes real inner blocks locked to the
+ * pattern structure. When saved, it serializes as normal block markup, so it can
+ * render on the frontend without ServerSideRender.
+ *
+ * Gated behind the `gutenberg-pattern-blocks` experiment.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Exposes auto-registered pattern block markup to the editor.
+ *
+ * Auto-registered blocks that declare a `pattern` property (and have no
+ * `render_callback`) are passed to JavaScript as a map of block name to pattern
+ * markup. The client registers each one with an editor view made of real inner
+ * blocks. This complements the ServerSideRender collection in auto-register.php,
+ * which only includes blocks with a `render_callback`.
+ */
+function gutenberg_enqueue_auto_register_pattern_blocks() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-pattern-blocks' ) ) {
+		return;
+	}
+
+	$pattern_blocks    = array();
+	$registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+	foreach ( $registered_blocks as $block_name => $block_type ) {
+		// `pattern` is an arbitrary registration arg, available as a public
+		// property because WP_Block_Type::set_props() assigns unknown args.
+		if ( empty( $block_type->supports['autoRegister'] ) || empty( $block_type->pattern ) || ! is_string( $block_type->pattern ) ) {
+			continue;
+		}
+		// Opt into an SSR preview instead of canvas editing; falls through to the
+		// SSR registration (needs a render_callback).
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
+		if ( isset( $block_type->patternEditorPreview ) && 'ssr' === $block_type->patternEditorPreview ) {
+			continue;
+		}
+		// `lock` mode: 'contentOnly' (default) locks tightly but its section UI
+		// hides the generated controls; `false` keeps them visible with a softer
+		// lock (`'patternLock' => false`).
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
+		$lock = ( isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'contentOnly';
+
+		$pattern_blocks[ $block_name ] = array(
+			'markup'            => $block_type->pattern,
+			'lock'              => $lock,
+			'hasRenderCallback' => ! empty( $block_type->render_callback ),
+		);
+	}
+
+	if ( ! empty( $pattern_blocks ) ) {
+		wp_add_inline_script(
+			'wp-block-library',
+			sprintf( 'window.__unstableAutoRegisterBlockPatterns = %s;', wp_json_encode( $pattern_blocks ) ),
+			'before'
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_auto_register_pattern_blocks' );

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -44,9 +44,11 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 
 		// Structural lock for the editable blocks: 'all' prevents add/move/remove
 		// while keeping the content editable and the generated controls visible.
-		// Soften it with `'patternLock' => false`.
+		// Canvas blocks can soften it with `'patternLock' => false`. SSR-islands
+		// blocks are always locked: the editor portals one block per slot and the
+		// slot count is fixed by the pattern, so the structure cannot change.
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
-		$lock = ( isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'all';
+		$lock = ( 'canvas' === $editor_mode && isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'all';
 
 		$pattern_blocks[ $block_name ] = array(
 			'markup'            => $block_type->pattern,

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -113,10 +113,11 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 
 	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $slot_count, $pattern ) {
 		if ( '' === trim( (string) $content ) ) {
-			if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-				// The editor's SSR preview renders the block bare. Pass the
-				// slots as `$content` so the editor has somewhere to portal the
-				// editable islands.
+			$rest_route = isset( $GLOBALS['wp']->query_vars['rest_route'] ) ? $GLOBALS['wp']->query_vars['rest_route'] : '';
+			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && str_contains( $rest_route, '/block-renderer/' ) ) {
+				// Only the editor's block-renderer preview renders the block
+				// bare on purpose. Pass the slots as `$content` so the editor
+				// has somewhere to portal the editable islands.
 				$slots = '';
 				for ( $index = 0; $index < $slot_count; $index++ ) {
 					$slots .= sprintf(
@@ -126,8 +127,9 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 				}
 				$content = $slots;
 			} else {
-				// An empty block on the front end falls back to the pattern,
-				// matching the default content the editor seeds.
+				// Everywhere else an empty block falls back to the pattern:
+				// the front end, and REST renders like a post's
+				// `content.rendered`, which must match the front end.
 				$content = do_blocks( $pattern );
 			}
 		}

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -36,22 +36,23 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		if ( empty( $block_type->supports['autoRegister'] ) || empty( $block_type->pattern ) || ! is_string( $block_type->pattern ) ) {
 			continue;
 		}
-		// Opt into an SSR preview instead of canvas editing; falls through to the
-		// SSR registration (needs a render_callback).
+		// A pattern block with a `render_callback` renders as SSR-islands: the
+		// editor renders that shell server-side and portals the editable pattern
+		// blocks into its slots (WYSIWYG). Without a render_callback the blocks are
+		// the output and are edited bare.
+		$editor_mode = ! empty( $block_type->render_callback ) ? 'ssr-islands' : 'canvas';
+
+		// Structural lock for the editable blocks: 'all' prevents add/move/remove
+		// while keeping the content editable and the generated controls visible.
+		// Soften it with `'patternLock' => false`.
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
-		if ( isset( $block_type->patternEditorPreview ) && 'ssr' === $block_type->patternEditorPreview ) {
-			continue;
-		}
-		// `lock` mode: 'contentOnly' (default) locks tightly but its section UI
-		// hides the generated controls; `false` keeps them visible with a softer
-		// lock (`'patternLock' => false`).
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
-		$lock = ( isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'contentOnly';
+		$lock = ( isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'all';
 
 		$pattern_blocks[ $block_name ] = array(
 			'markup'            => $block_type->pattern,
 			'lock'              => $lock,
 			'hasRenderCallback' => ! empty( $block_type->render_callback ),
+			'editorMode'        => $editor_mode,
 		);
 	}
 

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -45,8 +45,8 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		// Structural lock for the editable blocks: 'all' prevents add/move/remove
 		// while keeping the content editable and the generated controls visible.
 		// Canvas blocks can soften it with `'patternLock' => false`. SSR-islands
-		// blocks are always locked: the editor portals one block per slot and the
-		// slot count is fixed by the pattern, so the structure cannot change.
+		// blocks keep the lock for now: unlocked structure inside the shell has
+		// no appender yet, so honoring the opt-out there is a follow-up.
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- camelCase matches sibling block-registration args like supports.autoRegister.
 		$lock = ( 'canvas' === $editor_mode && isset( $block_type->patternLock ) && false === $block_type->patternLock ) ? false : 'all';
 
@@ -75,10 +75,10 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_auto_register_patt
  * goes, and only the block's own callback knows where that is. Instead of
  * making every author detect the editor context and emit the marker by hand,
  * this wraps the callback at registration so `$content` is always filled in:
- * the saved blocks when there are any, one slot per top-level pattern block
- * when the editor's SSR preview renders the block bare, or the rendered
- * pattern when an empty block renders on the front end. The callback places
- * `$content` like any other content, with no branches.
+ * the saved blocks when there are any, a content slot when the editor's SSR
+ * preview renders the block bare, or the rendered pattern when an empty block
+ * renders on the front end. The callback places `$content` like any other
+ * content, with no branches.
  *
  * @param array $args Arguments passed to `register_block_type()`.
  * @return array Filtered arguments.
@@ -97,35 +97,18 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 		return $args;
 	}
 
-	// One slot per top-level pattern block; the editable islands portal into
-	// them by index. `parse_blocks()` also returns whitespace nodes with a null
-	// block name; the filter drops them.
-	$top_level_blocks = array_filter(
-		parse_blocks( $args['pattern'] ),
-		static function ( $block ) {
-			return ! empty( $block['blockName'] );
-		}
-	);
-	$slot_count       = max( 1, count( $top_level_blocks ) );
-
 	$original_render_callback = $args['render_callback'];
 	$pattern                  = $args['pattern'];
 
-	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $slot_count, $pattern ) {
+	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $pattern ) {
 		if ( '' === trim( (string) $content ) ) {
 			$rest_route = isset( $GLOBALS['wp']->query_vars['rest_route'] ) ? $GLOBALS['wp']->query_vars['rest_route'] : '';
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && str_contains( $rest_route, '/block-renderer/' ) ) {
 				// Only the editor's block-renderer preview renders the block
-				// bare on purpose. Pass the slots as `$content` so the editor
-				// has somewhere to portal the editable islands.
-				$slots = '';
-				for ( $index = 0; $index < $slot_count; $index++ ) {
-					$slots .= sprintf(
-						'<wp-inner-block-slot data-slot-index="%d" style="display:contents"></wp-inner-block-slot>',
-						$index
-					);
-				}
-				$content = $slots;
+				// bare on purpose. Pass a slot as `$content` so the editor has
+				// somewhere to portal the editable islands: one content area,
+				// matching the single `$content` a callback receives.
+				$content = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
 			} else {
 				// Everywhere else an empty block falls back to the pattern:
 				// the front end, and REST renders like a post's

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -65,3 +65,66 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_auto_register_pattern_blocks' );
+
+/**
+ * Injects editor slot placeholders into an SSR-islands render callback.
+ *
+ * The editor shell needs a `<wp-inner-block-slot>` marker wherever the content
+ * goes, and only the block's own callback knows where that is. Instead of
+ * making every author detect the editor context and emit the marker by hand,
+ * this wraps the callback at registration: when the block renders with no
+ * saved content in a REST request (the editor's SSR preview), the callback
+ * receives one slot per top-level pattern block as `$content` and places it
+ * like any other content.
+ *
+ * @param array $args Arguments passed to `register_block_type()`.
+ * @return array Filtered arguments.
+ */
+function gutenberg_wrap_ssr_islands_render_callback( $args ) {
+	if (
+		empty( $args['supports']['autoRegister'] ) ||
+		empty( $args['pattern'] ) ||
+		! is_string( $args['pattern'] ) ||
+		empty( $args['render_callback'] )
+	) {
+		return $args;
+	}
+
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-pattern-blocks' ) ) {
+		return $args;
+	}
+
+	// One slot per top-level pattern block; the editable islands portal into
+	// them by index. `parse_blocks()` also returns whitespace nodes with a null
+	// block name; the filter drops them.
+	$top_level_blocks = array_filter(
+		parse_blocks( $args['pattern'] ),
+		static function ( $block ) {
+			return ! empty( $block['blockName'] );
+		}
+	);
+	$slot_count       = max( 1, count( $top_level_blocks ) );
+
+	$original_render_callback = $args['render_callback'];
+
+	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $slot_count ) {
+		// Empty content in a REST request is the editor's SSR preview, which
+		// renders the block bare. Pass the slots as `$content` so the editor
+		// has somewhere to portal the editable islands.
+		if ( '' === trim( (string) $content ) && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			$slots = '';
+			for ( $index = 0; $index < $slot_count; $index++ ) {
+				$slots .= sprintf(
+					'<wp-inner-block-slot data-slot-index="%d" style="display:contents"></wp-inner-block-slot>',
+					$index
+				);
+			}
+			$content = $slots;
+		}
+
+		return call_user_func( $original_render_callback, $attributes, $content, $block );
+	};
+
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_wrap_ssr_islands_render_callback' );

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -67,15 +67,16 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_auto_register_pattern_blocks' );
 
 /**
- * Injects editor slot placeholders into an SSR-islands render callback.
+ * Guarantees an SSR-islands render callback a non-empty `$content`.
  *
  * The editor shell needs a `<wp-inner-block-slot>` marker wherever the content
  * goes, and only the block's own callback knows where that is. Instead of
  * making every author detect the editor context and emit the marker by hand,
- * this wraps the callback at registration: when the block renders with no
- * saved content in a REST request (the editor's SSR preview), the callback
- * receives one slot per top-level pattern block as `$content` and places it
- * like any other content.
+ * this wraps the callback at registration so `$content` is always filled in:
+ * the saved blocks when there are any, one slot per top-level pattern block
+ * when the editor's SSR preview renders the block bare, or the rendered
+ * pattern when an empty block renders on the front end. The callback places
+ * `$content` like any other content, with no branches.
  *
  * @param array $args Arguments passed to `register_block_type()`.
  * @return array Filtered arguments.
@@ -106,20 +107,27 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 	$slot_count       = max( 1, count( $top_level_blocks ) );
 
 	$original_render_callback = $args['render_callback'];
+	$pattern                  = $args['pattern'];
 
-	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $slot_count ) {
-		// Empty content in a REST request is the editor's SSR preview, which
-		// renders the block bare. Pass the slots as `$content` so the editor
-		// has somewhere to portal the editable islands.
-		if ( '' === trim( (string) $content ) && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-			$slots = '';
-			for ( $index = 0; $index < $slot_count; $index++ ) {
-				$slots .= sprintf(
-					'<wp-inner-block-slot data-slot-index="%d" style="display:contents"></wp-inner-block-slot>',
-					$index
-				);
+	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $slot_count, $pattern ) {
+		if ( '' === trim( (string) $content ) ) {
+			if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+				// The editor's SSR preview renders the block bare. Pass the
+				// slots as `$content` so the editor has somewhere to portal the
+				// editable islands.
+				$slots = '';
+				for ( $index = 0; $index < $slot_count; $index++ ) {
+					$slots .= sprintf(
+						'<wp-inner-block-slot data-slot-index="%d" style="display:contents"></wp-inner-block-slot>',
+						$index
+					);
+				}
+				$content = $slots;
+			} else {
+				// An empty block on the front end falls back to the pattern,
+				// matching the default content the editor seeds.
+				$content = do_blocks( $pattern );
 			}
-			$content = $slots;
 		}
 
 		return call_user_func( $original_render_callback, $attributes, $content, $block );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -130,6 +130,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'React 19', 'gutenberg' ),
 					'description' => __( 'Registers React 19 as the bundled React version, replacing the default React 18 scripts.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-pattern-blocks',
+					'label'       => __( 'Pattern-based PHP blocks', 'gutenberg' ),
+					'description' => __( 'Lets PHP-only blocks use a block pattern as editable canvas content, without requiring a render callback.', 'gutenberg' ),
+				),
 			),
 		),
 	);

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,6 +126,7 @@ require __DIR__ . '/compat/wordpress-7.1/media.php';
 require __DIR__ . '/compat/wordpress-7.1/preload.php';
 require __DIR__ . '/compat/wordpress-7.1/classic-block.php';
 require __DIR__ . '/compat/wordpress-7.1/icons.php';
+require __DIR__ . '/compat/wordpress-7.1/pattern-blocks.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -39,17 +39,22 @@ const LAYOUT = { type: 'default', alignments: [] };
  * elements. Inner blocks are locked: they can be edited in place but not
  * moved, removed, or added to.
  *
- * @param {Object} props          Component props.
- * @param {string} props.clientId Client ID of the block whose inner content
- *                                should be rendered.
- * @param {string} [props.html]   Slot-bearing markup to use verbatim instead of
- *                                building it from the block's `innerContent`.
- *                                The markup must already contain
- *                                `<wp-inner-block-slot data-slot-index>` elements
- *                                (e.g. a server-rendered shell). When omitted, the
- *                                markup is derived from `innerContent` as usual.
+ * @param {Object}  props            Component props.
+ * @param {string}  props.clientId   Client ID of the block whose inner content
+ *                                   should be rendered.
+ * @param {string}  [props.html]     Slot-bearing markup to use verbatim instead of
+ *                                   building it from the block's `innerContent`.
+ *                                   The markup must already contain
+ *                                   `<wp-inner-block-slot data-slot-index>` elements
+ *                                   (e.g. a server-rendered shell). When omitted, the
+ *                                   markup is derived from `innerContent` as usual.
+ * @param {Element} [props.children] Pre-rendered inner-blocks children to portal
+ *                                   wholesale into the first slot, instead of one
+ *                                   portal per block. Required for controlled
+ *                                   trees: their store sync lives in these
+ *                                   children, so they must stay mounted.
  */
-export default function InnerContent( { clientId, html: htmlProp } ) {
+export default function InnerContent( { clientId, html: htmlProp, children } ) {
 	const { innerContent, order, selectedClientIds } = useSelect(
 		( select ) => {
 			const { getBlock, getBlockOrder, getSelectedBlockClientIds } =
@@ -80,7 +85,9 @@ export default function InnerContent( { clientId, html: htmlProp } ) {
 
 	const registry = useRegistry();
 	const containerRef = useRef();
-	const [ slots, setSlots ] = useState( [] );
+	// `null` until the injected markup has been scanned: provided children
+	// wait for it so they mount straight into their portal, once.
+	const [ slots, setSlots ] = useState( null );
 
 	// Moving a slot node into re-injected markup drops DOM focus, even though
 	// the block selection survives in the store. Remember whether the caret
@@ -147,6 +154,46 @@ export default function InnerContent( { clientId, html: htmlProp } ) {
 			?.focus();
 	}, [ slots, registry ] );
 
+	// Provided children carry their own rendering (and, for controlled trees,
+	// the store sync), so they portal wholesale into the first slot. Until
+	// the slot is discovered (pre-paint) they stay unmounted; rendering them
+	// inline first and swapping into the portal would remount them. The
+	// inline fallback only remains for markup without any slot.
+	let portals;
+	if ( children !== undefined ) {
+		if ( slots === null ) {
+			portals = null;
+		} else if ( slots[ 0 ] ) {
+			portals = createPortal(
+				children,
+				slots[ 0 ],
+				'inner-content-children'
+			);
+		} else {
+			portals = children;
+		}
+	} else {
+		portals = order.map( ( childClientId, index ) =>
+			slots?.[ index ]
+				? createPortal(
+						// Render the selected block synchronously, as the block list does.
+						<AsyncModeProvider
+							value={
+								! selectedClientIds.includes( childClientId )
+							}
+						>
+							<BlockListBlock
+								rootClientId={ clientId }
+								clientId={ childClientId }
+							/>
+						</AsyncModeProvider>,
+						slots[ index ],
+						childClientId
+				  )
+				: null
+		);
+	}
+
 	return (
 		<LayoutProvider value={ LAYOUT }>
 			<div
@@ -154,27 +201,7 @@ export default function InnerContent( { clientId, html: htmlProp } ) {
 				className="block-editor-inner-content"
 				style={ { display: 'contents' } }
 			/>
-			{ order.map( ( childClientId, index ) =>
-				slots[ index ]
-					? createPortal(
-							// Render the selected block synchronously, as the block list does.
-							<AsyncModeProvider
-								value={
-									! selectedClientIds.includes(
-										childClientId
-									)
-								}
-							>
-								<BlockListBlock
-									rootClientId={ clientId }
-									clientId={ childClientId }
-								/>
-							</AsyncModeProvider>,
-							slots[ index ],
-							childClientId
-					  )
-					: null
-			) }
+			{ portals }
 		</LayoutProvider>
 	);
 }

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -3,12 +3,13 @@
  */
 import {
 	createPortal,
+	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { AsyncModeProvider, useSelect } from '@wordpress/data';
+import { AsyncModeProvider, useSelect, useRegistry } from '@wordpress/data';
 import { safeHTML } from '@wordpress/dom';
 
 /**
@@ -41,8 +42,14 @@ const LAYOUT = { type: 'default', alignments: [] };
  * @param {Object} props          Component props.
  * @param {string} props.clientId Client ID of the block whose inner content
  *                                should be rendered.
+ * @param {string} [props.html]   Slot-bearing markup to use verbatim instead of
+ *                                building it from the block's `innerContent`.
+ *                                The markup must already contain
+ *                                `<wp-inner-block-slot data-slot-index>` elements
+ *                                (e.g. a server-rendered shell). When omitted, the
+ *                                markup is derived from `innerContent` as usual.
  */
-export default function InnerContent( { clientId } ) {
+export default function InnerContent( { clientId, html: htmlProp } ) {
 	const { innerContent, order, selectedClientIds } = useSelect(
 		( select ) => {
 			const { getBlock, getBlockOrder, getSelectedBlockClientIds } =
@@ -56,6 +63,11 @@ export default function InnerContent( { clientId } ) {
 		[ clientId ]
 	);
 	const html = useMemo( () => {
+		// An externally supplied shell (e.g. server-rendered) already carries its
+		// own slot placeholders, so it is used as-is.
+		if ( htmlProp !== undefined ) {
+			return htmlProp;
+		}
 		let slotIndex = 0;
 		return ( innerContent ?? [] )
 			.map( ( item ) =>
@@ -64,13 +76,24 @@ export default function InnerContent( { clientId } ) {
 					: item
 			)
 			.join( '' );
-	}, [ innerContent ] );
+	}, [ htmlProp, innerContent ] );
 
+	const registry = useRegistry();
 	const containerRef = useRef();
 	const [ slots, setSlots ] = useState( [] );
 
+	// When the markup changes (e.g. a re-rendered server shell), re-injecting it
+	// remounts the portalled inner blocks and drops DOM focus, even though the
+	// block selection survives in the store. Remember whether the caret was
+	// inside an island so it can be restored after the re-portal.
+	const restoreFocusRef = useRef( false );
+
 	useLayoutEffect( () => {
 		const container = containerRef.current;
+
+		restoreFocusRef.current = container.contains(
+			container.ownerDocument.activeElement
+		);
 
 		// Sanitize before injecting into the canvas: `safeHTML` removes
 		// `<script>` elements and inline event handlers, matching how block
@@ -85,6 +108,29 @@ export default function InnerContent( { clientId } ) {
 			)
 		);
 	}, [ html ] );
+
+	// After the inner blocks re-portal into the freshly injected slots, refocus
+	// the selected child's editable so RichText restores the caret from the
+	// store. Best effort: a no-op when the caret was not inside this block.
+	useEffect( () => {
+		if ( ! restoreFocusRef.current ) {
+			return;
+		}
+		restoreFocusRef.current = false;
+
+		const selectedClientId = registry
+			.select( blockEditorStore )
+			.getSelectedBlockClientId();
+		if ( ! selectedClientId ) {
+			return;
+		}
+
+		containerRef.current
+			?.querySelector(
+				`[data-block="${ selectedClientId }"] [contenteditable="true"]`
+			)
+			?.focus();
+	}, [ slots, registry ] );
 
 	return (
 		<LayoutProvider value={ LAYOUT }>

--- a/packages/block-editor/src/components/inner-content/index.js
+++ b/packages/block-editor/src/components/inner-content/index.js
@@ -82,10 +82,9 @@ export default function InnerContent( { clientId, html: htmlProp } ) {
 	const containerRef = useRef();
 	const [ slots, setSlots ] = useState( [] );
 
-	// When the markup changes (e.g. a re-rendered server shell), re-injecting it
-	// remounts the portalled inner blocks and drops DOM focus, even though the
-	// block selection survives in the store. Remember whether the caret was
-	// inside an island so it can be restored after the re-portal.
+	// Moving a slot node into re-injected markup drops DOM focus, even though
+	// the block selection survives in the store. Remember whether the caret
+	// was inside an island so it can be restored afterwards.
 	const restoreFocusRef = useRef( false );
 
 	useLayoutEffect( () => {
@@ -95,18 +94,34 @@ export default function InnerContent( { clientId, html: htmlProp } ) {
 			container.ownerDocument.activeElement
 		);
 
-		// Sanitize before injecting into the canvas: `safeHTML` removes
+		// Parse the new markup off-DOM. Sanitize it first: `safeHTML` removes
 		// `<script>` elements and inline event handlers, matching how block
 		// save content is rendered elsewhere in the editor.
-		container.innerHTML = safeHTML( html );
+		const template = container.ownerDocument.createElement( 'template' );
+		template.innerHTML = safeHTML( html );
 
-		setSlots(
-			Array.from( container.querySelectorAll( SLOT_TAG_NAME ) ).sort(
-				( a, b ) =>
-					Number( a.dataset.slotIndex ) -
-					Number( b.dataset.slotIndex )
-			)
+		const nextSlots = Array.from(
+			template.content.querySelectorAll( SLOT_TAG_NAME )
+		).sort(
+			( a, b ) =>
+				Number( a.dataset.slotIndex ) - Number( b.dataset.slotIndex )
 		);
+
+		// Carry the current slot nodes over into the new markup: the portalled
+		// blocks move with them instead of remounting, so a re-rendered shell
+		// doesn't flash the islands or reset their DOM state.
+		container.querySelectorAll( SLOT_TAG_NAME ).forEach( ( slot ) => {
+			const index = nextSlots.findIndex(
+				( next ) => next.dataset.slotIndex === slot.dataset.slotIndex
+			);
+			if ( index !== -1 ) {
+				nextSlots[ index ].replaceWith( slot );
+				nextSlots[ index ] = slot;
+			}
+		} );
+
+		container.replaceChildren( template.content );
+		setSlots( nextSlots );
 	}, [ html ] );
 
 	// After the inner blocks re-portal into the freshly injected slots, refocus

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -76,6 +76,29 @@ describe( 'InnerContent', () => {
 		expect( root.querySelector( '[onclick]' ) ).toBeNull();
 		expect( root.querySelector( 'button' ) ).toHaveTextContent( 'Click' );
 	} );
+
+	it( 'uses the `html` prop verbatim instead of building from innerContent', () => {
+		const block = createBlock(
+			BLOCK_NAME,
+			{},
+			[],
+			[ '<p class="from-inner-content">derived</p>' ]
+		);
+		const shell =
+			'<div class="ssr-shell"><wp-inner-block-slot data-slot-index="0"></wp-inner-block-slot></div>';
+		const { container } = render(
+			<BlockEditorProvider value={ [ block ] }>
+				<InnerContent clientId={ block.clientId } html={ shell } />
+			</BlockEditorProvider>
+		);
+		const root = container.querySelector( '.block-editor-inner-content' );
+
+		// The provided shell (and its slot) is injected as-is...
+		expect( root.querySelector( '.ssr-shell' ) ).not.toBeNull();
+		expect( root.querySelector( 'wp-inner-block-slot' ) ).not.toBeNull();
+		// ...and the innerContent-derived markup is ignored.
+		expect( root.querySelector( '.from-inner-content' ) ).toBeNull();
+	} );
 } );
 
 /* eslint-enable testing-library/no-node-access, testing-library/no-container, testing-library/render-result-naming-convention */

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -77,6 +77,33 @@ describe( 'InnerContent', () => {
 		expect( root.querySelector( 'button' ) ).toHaveTextContent( 'Click' );
 	} );
 
+	it( 'keeps the slot nodes when the shell re-renders', () => {
+		const block = createBlock( BLOCK_NAME, {}, [], [] );
+		const shellA =
+			'<div class="shell-a"><wp-inner-block-slot data-slot-index="0"></wp-inner-block-slot></div>';
+		const shellB =
+			'<div class="shell-b"><wp-inner-block-slot data-slot-index="0"></wp-inner-block-slot></div>';
+		const { container, rerender } = render(
+			<BlockEditorProvider value={ [ block ] }>
+				<InnerContent clientId={ block.clientId } html={ shellA } />
+			</BlockEditorProvider>
+		);
+		const root = container.querySelector( '.block-editor-inner-content' );
+		const slot = root.querySelector( 'wp-inner-block-slot' );
+
+		rerender(
+			<BlockEditorProvider value={ [ block ] }>
+				<InnerContent clientId={ block.clientId } html={ shellB } />
+			</BlockEditorProvider>
+		);
+
+		// The new shell is injected, but the slot node survives, so the
+		// portalled blocks move with it instead of remounting.
+		expect( root.querySelector( '.shell-b' ) ).not.toBeNull();
+		expect( root.querySelector( '.shell-a' ) ).toBeNull();
+		expect( root.querySelector( 'wp-inner-block-slot' ) ).toBe( slot );
+	} );
+
 	it( 'uses the `html` prop verbatim instead of building from innerContent', () => {
 		const block = createBlock(
 			BLOCK_NAME,

--- a/packages/block-editor/src/components/inner-content/test/index.js
+++ b/packages/block-editor/src/components/inner-content/test/index.js
@@ -11,6 +11,7 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 } from '@wordpress/blocks';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -102,6 +103,34 @@ describe( 'InnerContent', () => {
 		expect( root.querySelector( '.shell-b' ) ).not.toBeNull();
 		expect( root.querySelector( '.shell-a' ) ).toBeNull();
 		expect( root.querySelector( 'wp-inner-block-slot' ) ).toBe( slot );
+	} );
+
+	it( 'mounts provided children only once, inside the slot', () => {
+		const block = createBlock( BLOCK_NAME, {}, [], [] );
+		const onMount = jest.fn();
+		function Probe() {
+			useEffect( () => {
+				onMount();
+			}, [] );
+			return <span className="probe" />;
+		}
+		const shell =
+			'<div class="shell"><wp-inner-block-slot data-slot-index="0"></wp-inner-block-slot></div>';
+		const { container } = render(
+			<BlockEditorProvider value={ [ block ] }>
+				<InnerContent clientId={ block.clientId } html={ shell }>
+					<Probe />
+				</InnerContent>
+			</BlockEditorProvider>
+		);
+		const root = container.querySelector( '.block-editor-inner-content' );
+
+		// Mounting inline first and swapping into the portal would call the
+		// mount effect twice.
+		expect( onMount ).toHaveBeenCalledTimes( 1 );
+		expect(
+			root.querySelector( 'wp-inner-block-slot .probe' )
+		).not.toBeNull();
 	} );
 
 	it( 'uses the `html` prop verbatim instead of building from innerContent', () => {

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -7,11 +7,18 @@ import {
 	setUnregisteredTypeHandlerName,
 	setGroupingBlockName,
 	registerBlockType,
+	parse,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useDisabled } from '@wordpress/compose';
-import { select } from '@wordpress/data';
-import { useBlockProps } from '@wordpress/block-editor';
+import { select, useDispatch, useRegistry } from '@wordpress/data';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InnerBlocks,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useLayoutEffect } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -312,6 +319,76 @@ export const __experimentalGetCoreBlocks = () =>
 	);
 
 /**
+ * Builds `edit`/`save` for a PHP-only block that uses a `pattern` markup string.
+ * On first insert the pattern becomes real inner blocks (content blocks stay
+ * editable in the canvas) and the block saves as normal block markup.
+ *
+ * Gotchas:
+ * - `lock: 'contentOnly'` locks the structure but makes the block a content-only
+ *   section, whose UI hides the generated Inspector controls (#73845).
+ *   `lock: false` keeps the controls visible with a softer lock.
+ * - With a `render_callback`, `save` emits only the inner blocks; PHP renders
+ *   the wrapper, so saving one too would double-wrap.
+ *
+ * @param {string}       markup              Block-markup string from the `pattern` registration property.
+ * @param {string|false} [lock]              Locking mode: `'contentOnly'` (default) or `false`.
+ * @param {boolean}      [hasRenderCallback] Whether the PHP block has a render_callback.
+ * @return {{ edit: Function, save: Function }} The edit and save components.
+ */
+function createPatternBlockComponents(
+	markup,
+	lock = 'contentOnly',
+	hasRenderCallback = false
+) {
+	function Edit( { clientId } ) {
+		const registry = useRegistry();
+		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+			useDispatch( blockEditorStore );
+
+		// Seed inner blocks from the markup only when empty; on reload they come
+		// from the saved post, so reseeding would overwrite edits.
+		useLayoutEffect( () => {
+			const seeded = parse( markup );
+			if ( ! seeded.length ) {
+				return;
+			}
+			if (
+				registry.select( blockEditorStore ).getBlocks( clientId ).length
+			) {
+				return;
+			}
+			__unstableMarkNextChangeAsNotPersistent();
+			replaceInnerBlocks( clientId, seeded, false );
+		}, [
+			clientId,
+			registry,
+			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
+		] );
+
+		// No `template`, so template sync stays inert; `templateLock` only locks
+		// the structure.
+		const innerBlocksProps = useInnerBlocksProps( useBlockProps(), {
+			templateLock: lock === false ? false : 'contentOnly',
+			renderAppender: false,
+		} );
+
+		return <div { ...innerBlocksProps } />;
+	}
+
+	function save() {
+		// PHP renders the wrapper; save only the inner blocks to avoid double-
+		// wrapping. Without a callback the saved wrapper is the output.
+		if ( hasRenderCallback ) {
+			return <InnerBlocks.Content />;
+		}
+		return <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
+	}
+
+	return { edit: Edit, save };
+}
+
+/**
  * Function to register core blocks provided by the block editor.
  *
  * @param {Array} blocks An optional array of the core blocks being registered.
@@ -331,6 +408,12 @@ export const registerCoreBlocks = (
 	// Auto-register PHP-only blocks with ServerSideRender
 	if ( window.__unstableAutoRegisterBlocks ) {
 		window.__unstableAutoRegisterBlocks.forEach( ( blockName ) => {
+			// A block with both `pattern` and `render_callback` registers as a
+			// pattern block below; skip its SSR registration here.
+			if ( window.__unstableAutoRegisterBlockPatterns?.[ blockName ] ) {
+				return;
+			}
+
 			const bootstrappedBlockType = unlock(
 				select( blocksStore )
 			).getBootstrappedBlockType( blockName );
@@ -382,6 +465,30 @@ export const registerCoreBlocks = (
 				save: () => null,
 			} );
 		} );
+	}
+
+	// Auto-register PHP-only `pattern` blocks as real, locked inner blocks.
+	if ( window.__unstableAutoRegisterBlockPatterns ) {
+		Object.entries( window.__unstableAutoRegisterBlockPatterns ).forEach(
+			( [ blockName, { markup, lock, hasRenderCallback } ] ) => {
+				const bootstrappedBlockType = unlock(
+					select( blocksStore )
+				).getBootstrappedBlockType( blockName );
+
+				registerBlockType( blockName, {
+					...bootstrappedBlockType,
+					title: bootstrappedBlockType?.title || blockName,
+					...( ( bootstrappedBlockType?.apiVersion ?? 0 ) < 3 && {
+						apiVersion: 3,
+					} ),
+					...createPatternBlockComponents(
+						markup,
+						lock,
+						hasRenderCallback
+					),
+				} );
+			}
+		);
 	}
 
 	setDefaultBlockName( paragraph.name );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -422,6 +422,11 @@ function createPatternBlockComponents(
  * @return {{ edit: Function, save: Function }} The edit and save components.
  */
 function createSsrIslandsComponents( blockName, markup ) {
+	// A bare slot stands in until the server shell arrives. The slot node is
+	// carried over between injections, so the portalled islands never remount.
+	const INITIAL_SHELL =
+		'<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
+
 	function Edit( { clientId, attributes } ) {
 		useSeedPatternBlocks( clientId, markup );
 
@@ -439,25 +444,24 @@ function createSsrIslandsComponents( blockName, markup ) {
 			}
 		}, [ status, content ] );
 
-		// The hook call applies the structural lock even when the portal path
-		// below ignores its output. The lock is `'all'` rather than
-		// `'contentOnly'` so the generated inspector controls stay visible to
-		// drive the shell re-fetch.
+		// The hook call applies the structural lock and renders the islands
+		// as its children, portalled into the shell's single content slot.
+		// The lock is `'all'` rather than `'contentOnly'` so the generated
+		// inspector controls stay visible to drive the shell re-fetch.
 		const blockProps = useBlockProps();
 		const innerBlocksProps = useInnerBlocksProps( blockProps, {
 			templateLock: 'all',
 			renderAppender: false,
 		} );
 
-		// The islands must stay visible while the shell is missing, whether
-		// that's the first load or an error.
-		if ( ! shell ) {
-			return <div { ...innerBlocksProps } />;
-		}
-
 		return (
 			<div { ...blockProps }>
-				<InnerContent clientId={ clientId } html={ shell } />
+				<InnerContent
+					clientId={ clientId }
+					html={ shell ?? INITIAL_SHELL }
+				>
+					{ innerBlocksProps.children }
+				</InnerContent>
 			</div>
 		);
 	}

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -388,15 +388,15 @@ function createPatternBlockComponents(
 }
 
 /**
- * Builds `edit`/`save` for a PHP-only `pattern` block in SSR-islands mode
- * (`patternEditorPreview: 'ssr'`).
+ * Builds `edit`/`save` for a PHP-only `pattern` block with a `render_callback`
+ * (SSR-islands mode).
  *
  * The editor renders the PHP `render_callback` shell server-side and portals the
  * editable pattern inner blocks (the islands) into its slots, so the editor
  * matches the frontend (WYSIWYG) while the islands stay editable in the canvas.
- * In the editor SSR context the block renders with no inner content, so the
- * `render_callback` receives `$content === ''` and emits its wrapper with
- * `<wp-inner-block-slot>` placeholders instead of the saved content.
+ * In the editor SSR context the block renders with no inner content, and the
+ * PHP side passes `<wp-inner-block-slot>` placeholders as `$content`, so the
+ * shell arrives with slots where the saved content would go.
  *
  * @param {string} blockName Block name, used to fetch the server-rendered shell.
  * @param {string} markup    Pattern markup seeded as the editable inner blocks.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -17,8 +17,9 @@ import {
 	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -318,26 +319,24 @@ export const __experimentalGetCoreBlocks = () =>
 		( { metadata } ) => ! isBlockMetadataExperimental( metadata )
 	);
 
+const { InnerContent } = unlock( blockEditorPrivateApis );
+
 /**
  * Builds `edit`/`save` for a PHP-only block that uses a `pattern` markup string.
  * On first insert the pattern becomes real inner blocks (content blocks stay
  * editable in the canvas) and the block saves as normal block markup.
  *
- * Gotchas:
- * - `lock: 'contentOnly'` locks the structure but makes the block a content-only
- *   section, whose UI hides the generated Inspector controls (#73845).
- *   `lock: false` keeps the controls visible with a softer lock.
- * - With a `render_callback`, `save` emits only the inner blocks; PHP renders
- *   the wrapper, so saving one too would double-wrap.
+ * Gotcha: with a `render_callback`, `save` emits only the inner blocks; PHP
+ * renders the wrapper, so saving one too would double-wrap.
  *
  * @param {string}       markup              Block-markup string from the `pattern` registration property.
- * @param {string|false} [lock]              Locking mode: `'contentOnly'` (default) or `false`.
+ * @param {string|false} [lock]              Locking mode: `'all'` (default) or `false`.
  * @param {boolean}      [hasRenderCallback] Whether the PHP block has a render_callback.
  * @return {{ edit: Function, save: Function }} The edit and save components.
  */
 function createPatternBlockComponents(
 	markup,
-	lock = 'contentOnly',
+	lock = 'all',
 	hasRenderCallback = false
 ) {
 	function Edit( { clientId } ) {
@@ -369,7 +368,7 @@ function createPatternBlockComponents(
 		// No `template`, so template sync stays inert; `templateLock` only locks
 		// the structure.
 		const innerBlocksProps = useInnerBlocksProps( useBlockProps(), {
-			templateLock: lock === false ? false : 'contentOnly',
+			templateLock: lock === false ? false : 'all',
 			renderAppender: false,
 		} );
 
@@ -383,6 +382,93 @@ function createPatternBlockComponents(
 			return <InnerBlocks.Content />;
 		}
 		return <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />;
+	}
+
+	return { edit: Edit, save };
+}
+
+/**
+ * Builds `edit`/`save` for a PHP-only `pattern` block in SSR-islands mode
+ * (`patternEditorPreview: 'ssr'`).
+ *
+ * The editor renders the PHP `render_callback` shell server-side and portals the
+ * editable pattern inner blocks (the islands) into its slots, so the editor
+ * matches the frontend (WYSIWYG) while the islands stay editable in the canvas.
+ * In the editor SSR context the block renders with no inner content, so the
+ * `render_callback` receives `$content === ''` and emits its wrapper with
+ * `<wp-inner-block-slot>` placeholders instead of the saved content.
+ *
+ * @param {string} blockName Block name, used to fetch the server-rendered shell.
+ * @param {string} markup    Pattern markup seeded as the editable inner blocks.
+ * @return {{ edit: Function, save: Function }} The edit and save components.
+ */
+function createSsrIslandsComponents( blockName, markup ) {
+	function Edit( { clientId, attributes } ) {
+		const registry = useRegistry();
+		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+			useDispatch( blockEditorStore );
+
+		// Seed the pattern as editable inner blocks once, when empty (same as the
+		// canvas-editable pattern mode). On reload they come from the saved post.
+		useLayoutEffect( () => {
+			const seeded = parse( markup );
+			if ( ! seeded.length ) {
+				return;
+			}
+			if (
+				registry.select( blockEditorStore ).getBlocks( clientId ).length
+			) {
+				return;
+			}
+			__unstableMarkNextChangeAsNotPersistent();
+			replaceInnerBlocks( clientId, seeded, false );
+		}, [
+			clientId,
+			registry,
+			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
+		] );
+
+		const { content, status } = useServerSideRender( {
+			block: blockName,
+			attributes,
+		} );
+
+		// Hold the last good shell: `useServerSideRender` drops `content` while
+		// loading, and the islands must never disappear mid-edit.
+		const shellRef = useRef();
+		if ( status === 'success' && typeof content === 'string' ) {
+			shellRef.current = content;
+		}
+		const shell = shellRef.current;
+
+		// Lock the island structure with `'all'`: no add/move/remove, but the
+		// content stays editable and the generated `variant`/`featured` controls
+		// stay visible (SSR-islands needs them to drive the shell re-fetch). The
+		// `useInnerBlocksProps` side effect applies the lock; the blocks render
+		// either inline (fallback) or portalled into the shell.
+		const blockProps = useBlockProps();
+		const innerBlocksProps = useInnerBlocksProps( blockProps, {
+			templateLock: 'all',
+			renderAppender: false,
+		} );
+
+		// Until the first shell arrives (or on error), show the editable islands
+		// plainly so they are never hidden.
+		if ( ! shell ) {
+			return <div { ...innerBlocksProps } />;
+		}
+
+		return (
+			<div { ...blockProps }>
+				<InnerContent clientId={ clientId } html={ shell } />
+			</div>
+		);
+	}
+
+	function save() {
+		// PHP wraps the saved islands on the frontend; save only the inner blocks.
+		return <InnerBlocks.Content />;
 	}
 
 	return { edit: Edit, save };
@@ -470,7 +556,10 @@ export const registerCoreBlocks = (
 	// Auto-register PHP-only `pattern` blocks as real, locked inner blocks.
 	if ( window.__unstableAutoRegisterBlockPatterns ) {
 		Object.entries( window.__unstableAutoRegisterBlockPatterns ).forEach(
-			( [ blockName, { markup, lock, hasRenderCallback } ] ) => {
+			( [
+				blockName,
+				{ markup, lock, hasRenderCallback, editorMode },
+			] ) => {
 				const bootstrappedBlockType = unlock(
 					select( blocksStore )
 				).getBootstrappedBlockType( blockName );
@@ -481,11 +570,16 @@ export const registerCoreBlocks = (
 					...( ( bootstrappedBlockType?.apiVersion ?? 0 ) < 3 && {
 						apiVersion: 3,
 					} ),
-					...createPatternBlockComponents(
-						markup,
-						lock,
-						hasRenderCallback
-					),
+					// `ssr-islands` renders the PHP shell server-side and portals
+					// the editable islands into it (WYSIWYG); the default mode
+					// edits the pattern blocks directly in the canvas.
+					...( editorMode === 'ssr-islands'
+						? createSsrIslandsComponents( blockName, markup )
+						: createPatternBlockComponents(
+								markup,
+								lock,
+								hasRenderCallback
+						  ) ),
 				} );
 			}
 		);

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -324,14 +324,18 @@ const { InnerContent } = unlock( blockEditorPrivateApis );
 /**
  * Seeds a pattern block's inner blocks from its `pattern` markup.
  *
- * Seeds only freshly inserted empty blocks: a reloaded empty block is a
- * saved state (the pattern deleted under `patternLock: false`), and
- * reseeding it would resurrect the deleted content.
+ * A locked block cannot be emptied in the editor, so an empty one always
+ * means "never seeded" and seeds on mount, wherever it came from: a CPT or
+ * InnerBlocks template, an inserted pattern, or a bare paste. An unlockable
+ * block (`patternLock: false`) can be legitimately emptied and saved, so it
+ * only seeds when it (or an ancestor) was just inserted; a reloaded empty
+ * block is a saved state and stays empty.
  *
- * @param {string} clientId Client ID of the pattern block.
- * @param {string} markup   Block-markup string from the `pattern` registration property.
+ * @param {string}  clientId     Client ID of the pattern block.
+ * @param {string}  markup       Block-markup string from the `pattern` registration property.
+ * @param {boolean} [isUnlocked] Whether the block registered `patternLock: false`.
  */
-function useSeedPatternBlocks( clientId, markup ) {
+function useSeedPatternBlocks( clientId, markup, isUnlocked = false ) {
 	const registry = useRegistry();
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -341,19 +345,27 @@ function useSeedPatternBlocks( clientId, markup ) {
 		if ( ! seeded.length ) {
 			return;
 		}
-		const { getBlocks, wasBlockJustInserted } =
+		const { getBlocks, getBlockParents, wasBlockJustInserted } =
 			registry.select( blockEditorStore );
-		if (
-			getBlocks( clientId ).length ||
-			! wasBlockJustInserted( clientId )
-		) {
+		if ( getBlocks( clientId ).length ) {
 			return;
+		}
+		if ( isUnlocked ) {
+			const justInserted =
+				wasBlockJustInserted( clientId ) ||
+				getBlockParents( clientId ).some( ( parentId ) =>
+					wasBlockJustInserted( parentId )
+				);
+			if ( ! justInserted ) {
+				return;
+			}
 		}
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, seeded, false );
 	}, [
 		clientId,
 		markup,
+		isUnlocked,
 		registry,
 		replaceInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
@@ -375,7 +387,7 @@ function createPatternBlockComponents(
 	hasRenderCallback = false
 ) {
 	function Edit( { clientId } ) {
-		useSeedPatternBlocks( clientId, markup );
+		useSeedPatternBlocks( clientId, markup, lock === false );
 
 		// No `template`, so template sync stays inert; `templateLock` only locks
 		// the structure.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -322,12 +322,8 @@ export const __experimentalGetCoreBlocks = () =>
 const { InnerContent } = unlock( blockEditorPrivateApis );
 
 /**
- * Builds `edit`/`save` for a PHP-only block that uses a `pattern` markup string.
- * On first insert the pattern becomes real inner blocks (content blocks stay
- * editable in the canvas) and the block saves as normal block markup.
- *
- * Gotcha: with a `render_callback`, `save` emits only the inner blocks; PHP
- * renders the wrapper, so saving one too would double-wrap.
+ * Builds `edit`/`save` for a PHP-only block whose editable content is seeded
+ * from a `pattern` markup string.
  *
  * @param {string}       markup              Block-markup string from the `pattern` registration property.
  * @param {string|false} [lock]              Locking mode: `'all'` (default) or `false`.
@@ -344,8 +340,8 @@ function createPatternBlockComponents(
 		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 			useDispatch( blockEditorStore );
 
-		// Seed inner blocks from the markup only when empty; on reload they come
-		// from the saved post, so reseeding would overwrite edits.
+		// Seed only when empty: on reload the inner blocks come from the saved
+		// post, and reseeding would overwrite edits.
 		useLayoutEffect( () => {
 			const seeded = parse( markup );
 			if ( ! seeded.length ) {
@@ -376,8 +372,8 @@ function createPatternBlockComponents(
 	}
 
 	function save() {
-		// PHP renders the wrapper; save only the inner blocks to avoid double-
-		// wrapping. Without a callback the saved wrapper is the output.
+		// With a render_callback PHP renders the wrapper, so saving one too
+		// would double-wrap. Without one the saved wrapper is the output.
 		if ( hasRenderCallback ) {
 			return <InnerBlocks.Content />;
 		}
@@ -389,14 +385,9 @@ function createPatternBlockComponents(
 
 /**
  * Builds `edit`/`save` for a PHP-only `pattern` block with a `render_callback`
- * (SSR-islands mode).
- *
- * The editor renders the PHP `render_callback` shell server-side and portals the
- * editable pattern inner blocks (the islands) into its slots, so the editor
- * matches the frontend (WYSIWYG) while the islands stay editable in the canvas.
- * In the editor SSR context the block renders with no inner content, and the
- * PHP side passes `<wp-inner-block-slot>` placeholders as `$content`, so the
- * shell arrives with slots where the saved content would go.
+ * (SSR-islands). The editor shows the server-rendered shell and portals the
+ * editable pattern blocks into its `<wp-inner-block-slot>` placeholders, so it
+ * matches the frontend while the content stays editable in the canvas.
  *
  * @param {string} blockName Block name, used to fetch the server-rendered shell.
  * @param {string} markup    Pattern markup seeded as the editable inner blocks.
@@ -408,8 +399,8 @@ function createSsrIslandsComponents( blockName, markup ) {
 		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 			useDispatch( blockEditorStore );
 
-		// Seed the pattern as editable inner blocks once, when empty (same as the
-		// canvas-editable pattern mode). On reload they come from the saved post.
+		// Seed only when empty: on reload the inner blocks come from the saved
+		// post, and reseeding would overwrite edits.
 		useLayoutEffect( () => {
 			const seeded = parse( markup );
 			if ( ! seeded.length ) {
@@ -442,19 +433,18 @@ function createSsrIslandsComponents( blockName, markup ) {
 		}
 		const shell = shellRef.current;
 
-		// Lock the island structure with `'all'`: no add/move/remove, but the
-		// content stays editable and the generated `variant`/`featured` controls
-		// stay visible (SSR-islands needs them to drive the shell re-fetch). The
-		// `useInnerBlocksProps` side effect applies the lock; the blocks render
-		// either inline (fallback) or portalled into the shell.
+		// The hook call applies the structural lock even when the portal path
+		// below ignores its output. The lock is `'all'` rather than
+		// `'contentOnly'` so the generated inspector controls stay visible to
+		// drive the shell re-fetch.
 		const blockProps = useBlockProps();
 		const innerBlocksProps = useInnerBlocksProps( blockProps, {
 			templateLock: 'all',
 			renderAppender: false,
 		} );
 
-		// Until the first shell arrives (or on error), show the editable islands
-		// plainly so they are never hidden.
+		// The islands must stay visible while the shell is missing, whether
+		// that's the first load or an error.
 		if ( ! shell ) {
 			return <div { ...innerBlocksProps } />;
 		}
@@ -467,7 +457,8 @@ function createSsrIslandsComponents( blockName, markup ) {
 	}
 
 	function save() {
-		// PHP wraps the saved islands on the frontend; save only the inner blocks.
+		// PHP wraps the saved islands on the frontend; saving the wrapper too
+		// would double-wrap.
 		return <InnerBlocks.Content />;
 	}
 
@@ -494,8 +485,8 @@ export const registerCoreBlocks = (
 	// Auto-register PHP-only blocks with ServerSideRender
 	if ( window.__unstableAutoRegisterBlocks ) {
 		window.__unstableAutoRegisterBlocks.forEach( ( blockName ) => {
-			// A block with both `pattern` and `render_callback` registers as a
-			// pattern block below; skip its SSR registration here.
+			// Pattern blocks register below; a second registration here would
+			// clobber theirs.
 			if ( window.__unstableAutoRegisterBlockPatterns?.[ blockName ] ) {
 				return;
 			}
@@ -553,7 +544,7 @@ export const registerCoreBlocks = (
 		} );
 	}
 
-	// Auto-register PHP-only `pattern` blocks as real, locked inner blocks.
+	// Auto-register PHP-only `pattern` blocks as editable inner blocks.
 	if ( window.__unstableAutoRegisterBlockPatterns ) {
 		Object.entries( window.__unstableAutoRegisterBlockPatterns ).forEach(
 			( [
@@ -575,9 +566,6 @@ export const registerCoreBlocks = (
 					example: bootstrappedBlockType?.example ?? {
 						innerBlocks: parse( markup ),
 					},
-					// `ssr-islands` renders the PHP shell server-side and portals
-					// the editable islands into it (WYSIWYG); the default mode
-					// edits the pattern blocks directly in the canvas.
 					...( editorMode === 'ssr-islands'
 						? createSsrIslandsComponents( blockName, markup )
 						: createPatternBlockComponents(

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -570,6 +570,11 @@ export const registerCoreBlocks = (
 					...( ( bootstrappedBlockType?.apiVersion ?? 0 ) < 3 && {
 						apiVersion: 3,
 					} ),
+					// The pattern is the natural inserter preview; an `example`
+					// provided at registration still wins.
+					example: bootstrappedBlockType?.example ?? {
+						innerBlocks: parse( markup ),
+					},
 					// `ssr-islands` renders the PHP shell server-side and portals
 					// the editable islands into it (WYSIWYG); the default mode
 					// edits the pattern blocks directly in the canvas.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -19,7 +19,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import { useLayoutEffect, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -322,6 +322,45 @@ export const __experimentalGetCoreBlocks = () =>
 const { InnerContent } = unlock( blockEditorPrivateApis );
 
 /**
+ * Seeds a pattern block's inner blocks from its `pattern` markup.
+ *
+ * Seeds only freshly inserted empty blocks: a reloaded empty block is a
+ * saved state (the pattern deleted under `patternLock: false`), and
+ * reseeding it would resurrect the deleted content.
+ *
+ * @param {string} clientId Client ID of the pattern block.
+ * @param {string} markup   Block-markup string from the `pattern` registration property.
+ */
+function useSeedPatternBlocks( clientId, markup ) {
+	const registry = useRegistry();
+	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	useLayoutEffect( () => {
+		const seeded = parse( markup );
+		if ( ! seeded.length ) {
+			return;
+		}
+		const { getBlocks, wasBlockJustInserted } =
+			registry.select( blockEditorStore );
+		if (
+			getBlocks( clientId ).length ||
+			! wasBlockJustInserted( clientId )
+		) {
+			return;
+		}
+		__unstableMarkNextChangeAsNotPersistent();
+		replaceInnerBlocks( clientId, seeded, false );
+	}, [
+		clientId,
+		markup,
+		registry,
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
+}
+
+/**
  * Builds `edit`/`save` for a PHP-only block whose editable content is seeded
  * from a `pattern` markup string.
  *
@@ -336,34 +375,7 @@ function createPatternBlockComponents(
 	hasRenderCallback = false
 ) {
 	function Edit( { clientId } ) {
-		const registry = useRegistry();
-		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-			useDispatch( blockEditorStore );
-
-		// Seed only freshly inserted empty blocks: a reloaded empty block is a
-		// saved state (the pattern deleted under `patternLock: false`), and
-		// reseeding it would resurrect the deleted content.
-		useLayoutEffect( () => {
-			const seeded = parse( markup );
-			if ( ! seeded.length ) {
-				return;
-			}
-			const { getBlocks, wasBlockJustInserted } =
-				registry.select( blockEditorStore );
-			if (
-				getBlocks( clientId ).length ||
-				! wasBlockJustInserted( clientId )
-			) {
-				return;
-			}
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, seeded, false );
-		}, [
-			clientId,
-			registry,
-			replaceInnerBlocks,
-			__unstableMarkNextChangeAsNotPersistent,
-		] );
+		useSeedPatternBlocks( clientId, markup );
 
 		// No `template`, so template sync stays inert; `templateLock` only locks
 		// the structure.
@@ -399,34 +411,7 @@ function createPatternBlockComponents(
  */
 function createSsrIslandsComponents( blockName, markup ) {
 	function Edit( { clientId, attributes } ) {
-		const registry = useRegistry();
-		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-			useDispatch( blockEditorStore );
-
-		// Seed only freshly inserted empty blocks: a reloaded empty block is a
-		// saved state (the pattern deleted under `patternLock: false`), and
-		// reseeding it would resurrect the deleted content.
-		useLayoutEffect( () => {
-			const seeded = parse( markup );
-			if ( ! seeded.length ) {
-				return;
-			}
-			const { getBlocks, wasBlockJustInserted } =
-				registry.select( blockEditorStore );
-			if (
-				getBlocks( clientId ).length ||
-				! wasBlockJustInserted( clientId )
-			) {
-				return;
-			}
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, seeded, false );
-		}, [
-			clientId,
-			registry,
-			replaceInnerBlocks,
-			__unstableMarkNextChangeAsNotPersistent,
-		] );
+		useSeedPatternBlocks( clientId, markup );
 
 		const { content, status } = useServerSideRender( {
 			block: blockName,
@@ -435,11 +420,12 @@ function createSsrIslandsComponents( blockName, markup ) {
 
 		// Hold the last good shell: `useServerSideRender` drops `content` while
 		// loading, and the islands must never disappear mid-edit.
-		const shellRef = useRef();
-		if ( status === 'success' && typeof content === 'string' ) {
-			shellRef.current = content;
-		}
-		const shell = shellRef.current;
+		const [ shell, setShell ] = useState();
+		useLayoutEffect( () => {
+			if ( status === 'success' && typeof content === 'string' ) {
+				setShell( content );
+			}
+		}, [ status, content ] );
 
 		// The hook call applies the structural lock even when the portal path
 		// below ignores its output. The lock is `'all'` rather than

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -340,15 +340,19 @@ function createPatternBlockComponents(
 		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 			useDispatch( blockEditorStore );
 
-		// Seed only when empty: on reload the inner blocks come from the saved
-		// post, and reseeding would overwrite edits.
+		// Seed only freshly inserted empty blocks: a reloaded empty block is a
+		// saved state (the pattern deleted under `patternLock: false`), and
+		// reseeding it would resurrect the deleted content.
 		useLayoutEffect( () => {
 			const seeded = parse( markup );
 			if ( ! seeded.length ) {
 				return;
 			}
+			const { getBlocks, wasBlockJustInserted } =
+				registry.select( blockEditorStore );
 			if (
-				registry.select( blockEditorStore ).getBlocks( clientId ).length
+				getBlocks( clientId ).length ||
+				! wasBlockJustInserted( clientId )
 			) {
 				return;
 			}
@@ -399,15 +403,19 @@ function createSsrIslandsComponents( blockName, markup ) {
 		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 			useDispatch( blockEditorStore );
 
-		// Seed only when empty: on reload the inner blocks come from the saved
-		// post, and reseeding would overwrite edits.
+		// Seed only freshly inserted empty blocks: a reloaded empty block is a
+		// saved state (the pattern deleted under `patternLock: false`), and
+		// reseeding it would resurrect the deleted content.
 		useLayoutEffect( () => {
 			const seeded = parse( markup );
 			if ( ! seeded.length ) {
 				return;
 			}
+			const { getBlocks, wasBlockJustInserted } =
+				registry.select( blockEditorStore );
 			if (
-				registry.select( blockEditorStore ).getBlocks( clientId ).length
+				getBlocks( clientId ).length ||
+				! wasBlockJustInserted( clientId )
 			) {
 				return;
 			}

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -174,5 +174,91 @@ add_action(
 				),
 			)
 		);
+
+		// The three pattern blocks below share content/attributes/render_callback
+		// and differ only in how the editor locks and previews the structure.
+		$pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
+			. '<!-- wp:heading --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Body text.</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->';
+
+		$pattern_attributes = array(
+			'variant'  => array(
+				'type'    => 'string',
+				'enum'    => array( 'default', 'highlight' ),
+				'default' => 'default',
+				'label'   => 'Variant',
+			),
+			'featured' => array(
+				'type'    => 'boolean',
+				'default' => false,
+				'label'   => 'Featured',
+			),
+		);
+
+		// $content is the rendered inner blocks. It is empty in the editor SSR
+		// context (the block-renderer REST endpoint builds the block with no inner
+		// content): there, SSR-islands mode emits a slot placeholder so the editor
+		// can portal the editable islands into the shell. One slot per top-level
+		// pattern block; this pattern is a single group, so one slot at index 0.
+		// On the frontend (not a REST request) an empty block falls back to the
+		// pattern, so the raw slot never leaks. `variant` sets a class, `featured`
+		// a ribbon.
+		$render_pattern_block = static function ( $attributes, $content ) use ( $pattern_markup ) {
+			if ( '' !== trim( (string) $content ) ) {
+				$body = $content;
+			} elseif ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+				$body = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
+			} else {
+				$body = do_blocks( $pattern_markup );
+			}
+			$variant  = isset( $attributes['variant'] ) ? sanitize_html_class( $attributes['variant'] ) : 'default';
+			$featured = ! empty( $attributes['featured'] );
+			$classes  = 'pattern-block-demo is-variant-' . $variant . ( $featured ? ' is-featured' : '' );
+			$wrapper  = get_block_wrapper_attributes( array( 'class' => $classes ) );
+			$ribbon   = $featured ? '<p class="pattern-block-demo__ribbon"><strong>Featured</strong></p>' : '';
+
+			return sprintf( '<div %1$s>%2$s%3$s</div>', $wrapper, $ribbon, $body );
+		};
+
+		// SSR-islands: a pattern block with a render_callback renders its PHP shell
+		// server-side in the editor and portals the editable pattern blocks into its
+		// slots, so the editor matches the frontend (WYSIWYG) while the islands stay
+		// editable in the canvas.
+		register_block_type(
+			'test/php-only-pattern-ssr',
+			array(
+				'title'           => 'PHP-only pattern: SSR-islands (WYSIWYG, editable)',
+				'icon'            => 'layout',
+				'category'        => 'widgets',
+				'description'     => 'The PHP wrapper is rendered server-side in the editor with the editable pattern blocks portalled into it, so the editor matches the frontend while the content stays editable in the canvas.',
+				'keywords'        => array( 'pattern', 'autotest' ),
+				'attributes'      => $pattern_attributes,
+				'supports'        => array(
+					'autoRegister' => true,
+					'color'        => array(
+						'background' => true,
+						'text'       => true,
+					),
+				),
+				'pattern'         => $pattern_markup,
+				'render_callback' => $render_pattern_block,
+			)
+		);
+
+		// Demo styles for the `variant`/`featured` output, in editor and frontend.
+		add_action(
+			'enqueue_block_assets',
+			static function () {
+				wp_register_style( 'pattern-block-demo', false );
+				wp_enqueue_style( 'pattern-block-demo' );
+				wp_add_inline_style(
+					'pattern-block-demo',
+					'.pattern-block-demo.is-variant-highlight{background:#fffbe6;border:2px solid #f0b849;padding:1em;}'
+					. '.pattern-block-demo.is-featured{box-shadow:0 0 0 3px #3858e9;}'
+					. '.pattern-block-demo__ribbon{margin:0 0 .5em;color:#3858e9;}'
+				);
+			}
+		);
 	}
 );

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -183,16 +183,21 @@ add_action(
 			. '</div><!-- /wp:group -->';
 
 		$pattern_attributes = array(
-			'variant'  => array(
+			'variant'     => array(
 				'type'    => 'string',
 				'enum'    => array( 'default', 'highlight' ),
 				'default' => 'default',
 				'label'   => 'Variant',
 			),
-			'featured' => array(
+			'featured'    => array(
 				'type'    => 'boolean',
 				'default' => false,
 				'label'   => 'Featured',
+			),
+			'membersOnly' => array(
+				'type'    => 'boolean',
+				'default' => false,
+				'label'   => 'Members only',
 			),
 		);
 
@@ -200,7 +205,10 @@ add_action(
 		// editor-specific code and no empty check: the framework guarantees a
 		// non-empty $content (saved blocks, editor slot placeholders, or the
 		// pattern as fallback; see gutenberg_wrap_ssr_islands_render_callback).
-		// `variant` sets a class, `featured` a ribbon.
+		// `variant` sets a class, `featured` a ribbon, and `membersOnly` swaps
+		// the content for a login notice when the visitor is logged out, the
+		// job enclosing shortcodes used to do. The footer is computed on the
+		// server on every render.
 		$render_pattern_block = static function ( $attributes, $content ) {
 			$variant  = isset( $attributes['variant'] ) ? sanitize_html_class( $attributes['variant'] ) : 'default';
 			$featured = ! empty( $attributes['featured'] );
@@ -208,7 +216,19 @@ add_action(
 			$wrapper  = get_block_wrapper_attributes( array( 'class' => $classes ) );
 			$ribbon   = $featured ? '<p class="pattern-block-demo__ribbon"><strong>Featured</strong></p>' : '';
 
-			return sprintf( '<div %1$s>%2$s%3$s</div>', $wrapper, $ribbon, $content );
+			if ( ! empty( $attributes['membersOnly'] ) && ! is_user_logged_in() ) {
+				$content = '<p class="pattern-block-demo__gate">This content is for members only. Please log in.</p>';
+			}
+
+			$viewer = is_user_logged_in() ? wp_get_current_user()->display_name : 'guest';
+			$meta   = sprintf(
+				'<p class="pattern-block-demo__meta">Rendered by PHP at %1$s for %2$s · %3$d published posts</p>',
+				esc_html( wp_date( 'H:i:s' ) ),
+				esc_html( $viewer ),
+				(int) wp_count_posts()->publish
+			);
+
+			return sprintf( '<div %1$s>%2$s%3$s%4$s</div>', $wrapper, $ribbon, $content, $meta );
 		};
 
 		// SSR-islands: a pattern block with a render_callback renders its PHP shell
@@ -236,7 +256,7 @@ add_action(
 			)
 		);
 
-		// Demo styles for the `variant`/`featured` output, in editor and frontend.
+		// Demo styles for the wrapper output, in editor and frontend.
 		add_action(
 			'enqueue_block_assets',
 			static function () {
@@ -247,6 +267,8 @@ add_action(
 					'.pattern-block-demo.is-variant-highlight{background:#fffbe6;border:2px solid #f0b849;padding:1em;}'
 					. '.pattern-block-demo.is-featured{box-shadow:0 0 0 3px #3858e9;}'
 					. '.pattern-block-demo__ribbon{margin:0 0 .5em;color:#3858e9;}'
+					. '.pattern-block-demo__gate{background:#f6f7f7;border:1px dashed #949494;padding:1em;}'
+					. '.pattern-block-demo__meta{margin:.5em 0 0;font-size:12px;color:#757575;}'
 				);
 			}
 		);

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -175,8 +175,8 @@ add_action(
 			)
 		);
 
-		// The three pattern blocks below share content/attributes/render_callback
-		// and differ only in how the editor locks and previews the structure.
+		// Content, attributes, and render callback for the editable PHP-only
+		// demo block below.
 		$pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
 			. '<!-- wp:heading --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
 			. '<!-- wp:paragraph --><p>Body text.</p><!-- /wp:paragraph -->'
@@ -216,9 +216,9 @@ add_action(
 		// slots, so the editor matches the frontend (WYSIWYG) while the islands stay
 		// editable in the canvas.
 		register_block_type(
-			'test/php-only-pattern-ssr',
+			'test/php-only-editable-block',
 			array(
-				'title'           => 'PHP-only pattern: SSR-islands (WYSIWYG, editable)',
+				'title'           => 'Editable PHP-only block (SSR-islands)',
 				'icon'            => 'layout',
 				'category'        => 'widgets',
 				'description'     => 'The PHP wrapper is rendered server-side in the editor with the editable pattern blocks portalled into it, so the editor matches the frontend while the content stays editable in the canvas.',

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -196,22 +196,14 @@ add_action(
 			),
 		);
 
-		// $content is the rendered inner blocks. It is empty in the editor SSR
-		// context (the block-renderer REST endpoint builds the block with no inner
-		// content): there, SSR-islands mode emits a slot placeholder so the editor
-		// can portal the editable islands into the shell. One slot per top-level
-		// pattern block; this pattern is a single group, so one slot at index 0.
-		// On the frontend (not a REST request) an empty block falls back to the
-		// pattern, so the raw slot never leaks. `variant` sets a class, `featured`
-		// a ribbon.
+		// An ordinary dynamic-block callback: it wraps $content and falls back
+		// to the pattern when empty, with no editor-specific code. In the
+		// editor's SSR preview the framework passes slot placeholders as
+		// $content (see gutenberg_wrap_ssr_islands_render_callback) and the
+		// editor swaps them for the editable pattern blocks. `variant` sets a
+		// class, `featured` a ribbon.
 		$render_pattern_block = static function ( $attributes, $content ) use ( $pattern_markup ) {
-			if ( '' !== trim( (string) $content ) ) {
-				$body = $content;
-			} elseif ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-				$body = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
-			} else {
-				$body = do_blocks( $pattern_markup );
-			}
+			$body     = ( '' !== trim( (string) $content ) ) ? $content : do_blocks( $pattern_markup );
 			$variant  = isset( $attributes['variant'] ) ? sanitize_html_class( $attributes['variant'] ) : 'default';
 			$featured = ! empty( $attributes['featured'] );
 			$classes  = 'pattern-block-demo is-variant-' . $variant . ( $featured ? ' is-featured' : '' );

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -196,21 +196,19 @@ add_action(
 			),
 		);
 
-		// An ordinary dynamic-block callback: it wraps $content and falls back
-		// to the pattern when empty, with no editor-specific code. In the
-		// editor's SSR preview the framework passes slot placeholders as
-		// $content (see gutenberg_wrap_ssr_islands_render_callback) and the
-		// editor swaps them for the editable pattern blocks. `variant` sets a
-		// class, `featured` a ribbon.
-		$render_pattern_block = static function ( $attributes, $content ) use ( $pattern_markup ) {
-			$body     = ( '' !== trim( (string) $content ) ) ? $content : do_blocks( $pattern_markup );
+		// An ordinary dynamic-block callback that wraps $content, with no
+		// editor-specific code and no empty check: the framework guarantees a
+		// non-empty $content (saved blocks, editor slot placeholders, or the
+		// pattern as fallback; see gutenberg_wrap_ssr_islands_render_callback).
+		// `variant` sets a class, `featured` a ribbon.
+		$render_pattern_block = static function ( $attributes, $content ) {
 			$variant  = isset( $attributes['variant'] ) ? sanitize_html_class( $attributes['variant'] ) : 'default';
 			$featured = ! empty( $attributes['featured'] );
 			$classes  = 'pattern-block-demo is-variant-' . $variant . ( $featured ? ' is-featured' : '' );
 			$wrapper  = get_block_wrapper_attributes( array( 'class' => $classes ) );
 			$ribbon   = $featured ? '<p class="pattern-block-demo__ribbon"><strong>Featured</strong></p>' : '';
 
-			return sprintf( '<div %1$s>%2$s%3$s</div>', $wrapper, $ribbon, $body );
+			return sprintf( '<div %1$s>%2$s%3$s</div>', $wrapper, $ribbon, $content );
 		};
 
 		// SSR-islands: a pattern block with a render_callback renders its PHP shell

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -333,3 +333,66 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		} );
 	} );
 } );
+
+test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-pattern-blocks',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'renders the PHP shell in the editor with editable islands, keeps controls, and saves clean inner blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'test/php-only-pattern-ssr' } );
+
+		// The server-rendered PHP shell is shown in the canvas, with the
+		// pattern's editable blocks portalled in place inside it (WYSIWYG). In the
+		// editor the heading/paragraph are editable RichText (role `textbox`), so
+		// assert on their text being inside the shell.
+		const shell = editor.canvas.locator( '.pattern-block-demo' );
+		await expect( shell ).toBeVisible();
+		await expect( shell ).toContainText( 'Title' );
+		await expect( shell ).toContainText( 'Body text' );
+
+		// Unlike a content-only section, the auto-generated controls stay
+		// visible — SSR-islands needs them to drive the re-fetch.
+		await editor.openDocumentSettingsSidebar();
+		await expect( page.getByLabel( 'Variant' ) ).toBeVisible();
+		const featured = page.getByLabel( 'Featured' );
+		await expect( featured ).toBeVisible();
+
+		// Toggling an attribute re-renders the shell server-side: the ribbon the
+		// render_callback adds for `featured` appears, and the island survives.
+		await featured.check();
+		await expect(
+			shell.locator( '.pattern-block-demo__ribbon' )
+		).toBeVisible();
+		await expect( shell ).toContainText( 'Title' );
+
+		// The PHP wrapper is editor-only: the block saves just the inner blocks,
+		// which the render_callback wraps on the frontend.
+		const content = await editor.getEditedPostContent();
+		// Opening delimiter carries the toggled attributes, so match its prefix.
+		expect( content ).toContain( '<!-- wp:test/php-only-pattern-ssr' );
+		expect( content ).toContain(
+			'<h2 class="wp-block-heading">Title</h2>'
+		);
+		expect( content ).not.toContain( 'pattern-block-demo' );
+	} );
+} );

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -334,7 +334,7 @@ test.describe( 'PHP-only auto-register blocks', () => {
 	} );
 } );
 
-test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
+test.describe( 'Editable PHP-only blocks (SSR-islands)', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
 			'gutenberg-test-server-side-rendered-block'
@@ -359,7 +359,7 @@ test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.insertBlock( { name: 'test/php-only-pattern-ssr' } );
+		await editor.insertBlock( { name: 'test/php-only-editable-block' } );
 
 		// The server-rendered PHP shell is shown in the canvas, with the
 		// pattern's editable blocks portalled in place inside it (WYSIWYG). In the
@@ -371,7 +371,7 @@ test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
 		await expect( shell ).toContainText( 'Body text' );
 
 		// Unlike a content-only section, the auto-generated controls stay
-		// visible — SSR-islands needs them to drive the re-fetch.
+		// visible; SSR-islands needs them to drive the re-fetch.
 		await editor.openDocumentSettingsSidebar();
 		await expect( page.getByLabel( 'Variant' ) ).toBeVisible();
 		const featured = page.getByLabel( 'Featured' );
@@ -389,7 +389,7 @@ test.describe( 'PHP-only pattern blocks (SSR-islands)', () => {
 		// which the render_callback wraps on the frontend.
 		const content = await editor.getEditedPostContent();
 		// Opening delimiter carries the toggled attributes, so match its prefix.
-		expect( content ).toContain( '<!-- wp:test/php-only-pattern-ssr' );
+		expect( content ).toContain( '<!-- wp:test/php-only-editable-block' );
 		expect( content ).toContain(
 			'<h2 class="wp-block-heading">Title</h2>'
 		);


### PR DESCRIPTION
## What

Part of #79330. Consolidates and supersedes #79598 and #79705, which explored this in separate steps.

Adds experimental support for PHP-only auto-registered blocks that provide a `pattern`, allowing the pattern's blocks to be editable in the canvas.

## Why

As of WP 7.0, PHP-only blocks appear in the editor as a preview you can't edit on the canvas; you change their settings in the sidebar instead. This PR makes their content editable in the canvas by registering the block's `pattern` as real inner blocks, saved as normal block markup.

But why not just use a plain block pattern? A plain block pattern would also allow you to add editable content in pure PHP (`register_block_pattern`), but doing it as a registered block adds what a pattern can't: a name and namespace that CSS, `theme.json`, and filters can target, and an optional `render_callback` to process the content at render time.

With a `render_callback`, PHP wraps or transforms the content at render time, and that wrapper only lives on the front end, so the editor and the front end no longer match. SSR-islands fixes that: the editor renders the same wrapper with the editable blocks inside it, so the block stays dynamic and what you see is what you get.

## How

The block provides a `pattern` (the editable content) and, optionally, a `render_callback` (the PHP wrapper). The editor turns the pattern into real, editable blocks, which are saved as normal block markup.

When there's a `render_callback`, the editor renders that PHP wrapper server-side and places the editable blocks inside it, reusing the new `InnerContent` component from #79115. On save, it stores just the blocks, and the front end runs the `render_callback` to wrap them.

The callback needs no editor-specific code: the framework always hands it a non-empty `$content`, whether that's the saved blocks, the editor's placeholders, or the pattern when an empty block renders on the front end.

For the block author, the whole thing looks like this:

```php
register_block_type( 'my-plugin/promo-box', array(
	'supports'        => array( 'autoRegister' => true ),
	'pattern'         => $pattern_markup,
	'render_callback' => static function ( $attributes, $content ) {
		$wrapper = get_block_wrapper_attributes( array( 'class' => 'promo-box' ) );
		return sprintf( '<div %s>%s</div>', $wrapper, $content );
	},
) );
```

## Testing Instructions

1. Enable the "Pattern-based PHP blocks" experiment (Gutenberg → Experiments).
2. With the server-side-rendered-block test plugin active, open a new post.
3. Insert the "Editable PHP-only block (SSR-islands)" block. Confirm the editor shows the PHP wrapper (variant class, plus the "Featured" ribbon when enabled) with the heading and paragraph editable in place.
4. Change Variant or toggle Featured in the sidebar. Confirm the wrapper updates and the edited content survives.
5. Save and view the post on the front end. Confirm it matches the editor.

## Screen recording

https://github.com/user-attachments/assets/84fca8a7-7e69-4669-8a73-2b27fa3fc868

---
Code implemented by Claude while designed, tested, and reviewed by me