### PR TITLE
Editor: allow selecting which block styles to apply globally

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New Features
 
 -   Add an "Attachments" source to the block inserter's Media tab, listing images attached to the current post with the ability to attach and detach them ([#79336](https://github.com/WordPress/gutenberg/pull/79336)).
--   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value.
+-   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
 
 ### Enhancements
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### New Features
+
+-   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
+
 ## 14.51.0 (2026-07-14)
 
 ### New Features
 
 -   Add an "Attachments" source to the block inserter's Media tab, listing images attached to the current post with the ability to attach and detach them ([#79336](https://github.com/WordPress/gutenberg/pull/79336)).
--   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
 
 ### Enhancements
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 -   Add an "Attachments" source to the block inserter's Media tab, listing images attached to the current post with the ability to attach and detach them ([#79336](https://github.com/WordPress/gutenberg/pull/79336)).
+-   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value.
 
 ### Enhancements
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
@@ -6,7 +6,6 @@ import { DataViewsPicker } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useMemo, useState } from '@wordpress/element';
-import { Icon, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,12 +16,6 @@ import { useReviewRows } from './index';
 // Only the table layout is offered so the modal always renders a compact list
 // of styles with a leading selection checkbox.
 const DEFAULT_LAYOUTS = { pickerTable: {} };
-
-// A dedicated, centered column for the subdued arrow between the current and
-// new value columns.
-const SEPARATOR_COLUMN_STYLES = {
-	separator: { align: 'center', width: '32px' },
-};
 
 const getItemId = ( row ) => row.id;
 
@@ -56,10 +49,10 @@ export default function ApplyGloballyModal( {
 	const [ view, setView ] = useState( () => ( {
 		type: 'pickerTable',
 		titleField: 'label',
-		fields: [ 'current', 'separator', 'new' ],
+		fields: [ 'current', 'new' ],
 		page: 1,
 		perPage: reviewRows.length,
-		layout: { enableMoving: false, styles: SEPARATOR_COLUMN_STYLES },
+		layout: { enableMoving: false },
 	} ) );
 
 	const fields = useMemo(
@@ -84,24 +77,6 @@ export default function ApplyGloballyModal( {
 					<span className="editor-push-changes-to-global-styles-modal__value">
 						{ item.formattedCurrentValue }
 					</span>
-				),
-			},
-			{
-				id: 'separator',
-				// The chevron conveys the direction, so the column needs no
-				// header. An empty string can't be used because DataViews treats
-				// a falsy header as unset and falls back to the label/id, so an
-				// empty element is passed instead.
-				header: <span aria-hidden="true" />,
-				enableSorting: false,
-				enableHiding: false,
-				filterBy: false,
-				render: () => (
-					<Icon
-						className="editor-push-changes-to-global-styles-modal__arrow"
-						icon={ chevronRight }
-						aria-hidden="true"
-					/>
 				),
 			},
 			{

--- a/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
@@ -1,0 +1,184 @@
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { DataViewsPicker } from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import { getBlockType } from '@wordpress/blocks';
+import { useMemo, useState } from '@wordpress/element';
+import { Icon, chevronRight } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useGlobalStyles } from '../../components/global-styles/hooks';
+import { useReviewRows } from './index';
+
+// Only the table layout is offered so the modal always renders a compact list
+// of styles with a leading selection checkbox.
+const DEFAULT_LAYOUTS = { pickerTable: {} };
+
+// A dedicated, centered column for the subdued arrow between the current and
+// new value columns.
+const SEPARATOR_COLUMN_STYLES = {
+	separator: { align: 'center', width: '32px' },
+};
+
+const getItemId = ( row ) => row.id;
+
+/**
+ * Modal that lets the user review the modified block-instance styles and choose
+ * which ones to push to Global Styles for the block type.
+ *
+ * The styles are presented in a `DataViewsPicker` table with all rows selected
+ * by default. The footer `Apply` action pushes only the selected subset and is
+ * disabled when nothing is selected. Dismissing the modal (close button or
+ * Escape) leaves the block unchanged.
+ *
+ * @param {Object}   props                Component props.
+ * @param {string}   props.name           Block name.
+ * @param {Array}    props.rows           Grouped change rows from `useChangesToPush`.
+ * @param {Function} props.onApply        Called with the selected rows to push.
+ * @param {Function} props.onRequestClose Called to dismiss the modal.
+ */
+export default function ApplyGloballyModal( {
+	name,
+	rows,
+	onApply,
+	onRequestClose,
+} ) {
+	const { merged } = useGlobalStyles();
+	const reviewRows = useReviewRows( rows, merged, name );
+
+	const [ selection, setSelection ] = useState( () =>
+		reviewRows.map( ( row ) => row.id )
+	);
+	const [ view, setView ] = useState( () => ( {
+		type: 'pickerTable',
+		titleField: 'label',
+		fields: [ 'current', 'separator', 'new' ],
+		page: 1,
+		perPage: reviewRows.length,
+		layout: { enableMoving: false, styles: SEPARATOR_COLUMN_STYLES },
+	} ) );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'label',
+				label: __( 'Style' ),
+				enableSorting: false,
+				enableHiding: false,
+				filterBy: false,
+				getValue: ( { item } ) => item.label,
+				render: ( { item } ) => item.label,
+			},
+			{
+				id: 'current',
+				label: __( 'Current' ),
+				enableSorting: false,
+				enableHiding: false,
+				filterBy: false,
+				getValue: ( { item } ) => item.formattedCurrentValue,
+				render: ( { item } ) => (
+					<span className="editor-push-changes-to-global-styles-modal__value">
+						{ item.formattedCurrentValue }
+					</span>
+				),
+			},
+			{
+				id: 'separator',
+				// The chevron conveys the direction, so the column needs no
+				// header. An empty string can't be used because DataViews treats
+				// a falsy header as unset and falls back to the label/id, so an
+				// empty element is passed instead.
+				header: <span aria-hidden="true" />,
+				enableSorting: false,
+				enableHiding: false,
+				filterBy: false,
+				render: () => (
+					<Icon
+						className="editor-push-changes-to-global-styles-modal__arrow"
+						icon={ chevronRight }
+						aria-hidden="true"
+					/>
+				),
+			},
+			{
+				id: 'new',
+				label: __( 'New' ),
+				enableSorting: false,
+				enableHiding: false,
+				filterBy: false,
+				getValue: ( { item } ) => item.formattedNewValue,
+				render: ( { item } ) => (
+					<span className="editor-push-changes-to-global-styles-modal__value">
+						{ item.formattedNewValue }
+					</span>
+				),
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'apply',
+				label: __( 'Apply' ),
+				isPrimary: true,
+				supportsBulk: true,
+				callback( items ) {
+					onApply( items );
+					onRequestClose();
+				},
+			},
+		],
+		[ onApply, onRequestClose ]
+	);
+
+	const blockTitle = getBlockType( name )?.title;
+
+	return (
+		<Modal
+			title={ sprintf(
+				// translators: %s: Title of the block e.g. 'Heading'.
+				__( 'Apply %s styles globally' ),
+				blockTitle
+			) }
+			onRequestClose={ onRequestClose }
+			size="large"
+			className="editor-push-changes-to-global-styles-modal"
+		>
+			<p>
+				{ sprintf(
+					// translators: %s: Title of the block e.g. 'Heading'.
+					__(
+						'Choose which styles to make default for all %s blocks.'
+					),
+					blockTitle
+				) }
+			</p>
+			<DataViewsPicker
+				data={ reviewRows }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ getItemId }
+				paginationInfo={ {
+					totalItems: reviewRows.length,
+					totalPages: 1,
+				} }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				search={ false }
+				itemListLabel={ __( 'Styles to apply' ) }
+			>
+				<DataViewsPicker.Layout />
+				<DataViewsPicker.Footer />
+			</DataViewsPicker>
+		</Modal>
+	);
+}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
@@ -13,26 +13,24 @@ import { useMemo, useState } from '@wordpress/element';
 import { useGlobalStyles } from '../../components/global-styles/hooks';
 import { useReviewRows } from './use-review-rows';
 
-// Only offer the table layout: a compact list with a leading selection
-// checkbox.
+// Show a simple table with a checkbox at the start of each row.
 const DEFAULT_LAYOUTS = { pickerTable: {} };
 
 const getItemId = ( row ) => row.id;
 
 /**
- * Modal that lets the user review the modified block-instance styles and choose
- * which ones to push to Global Styles for the block type.
+ * Modal for reviewing a block's changed styles and choosing which ones to apply
+ * to every block of the same type.
  *
- * The styles are presented in a `DataViewsPicker` table with all rows selected
- * by default. The footer `Apply` action pushes only the selected subset and is
- * disabled when nothing is selected. Dismissing the modal (close button or
- * Escape) leaves the block unchanged.
+ * Each style is a row in the table and starts out selected. Apply pushes only
+ * the rows that are still selected, and is turned off when none are. Closing
+ * the modal or pressing Escape leaves the block untouched.
  *
  * @param {Object}   props                Component props.
  * @param {string}   props.name           Block name.
- * @param {Array}    props.rows           Grouped change rows from `useChangesToPush`.
- * @param {Function} props.onApply        Called with the selected rows to push.
- * @param {Function} props.onRequestClose Called to dismiss the modal.
+ * @param {Array}    props.rows           The block's changed styles, grouped into rows.
+ * @param {Function} props.onApply        Called with the selected rows to apply.
+ * @param {Function} props.onRequestClose Called to close the modal.
  */
 export default function ApplyGloballyModal( {
 	name,

--- a/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
@@ -13,8 +13,8 @@ import { useMemo, useState } from '@wordpress/element';
 import { useGlobalStyles } from '../../components/global-styles/hooks';
 import { useReviewRows } from './use-review-rows';
 
-// Only the table layout is offered so the modal always renders a compact list
-// of styles with a leading selection checkbox.
+// Only offer the table layout: a compact list with a leading selection
+// checkbox.
 const DEFAULT_LAYOUTS = { pickerTable: {} };
 
 const getItemId = ( row ) => row.id;

--- a/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/apply-globally-modal.js
@@ -11,7 +11,7 @@ import { useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useGlobalStyles } from '../../components/global-styles/hooks';
-import { useReviewRows } from './index';
+import { useReviewRows } from './use-review-rows';
 
 // Only the table layout is offered so the modal always renders a compact list
 // of styles with a leading selection checkbox.

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -145,7 +145,19 @@ export function formatSpacingShorthand(
 		return [ top, right, bottom, left ].map( format ).join( ' ' );
 	}
 
-	const parts = [ top, right, bottom, left ].filter( isSet ).map( format );
+	if (
+		! isSet( top ) &&
+		! isSet( right ) &&
+		! isSet( bottom ) &&
+		! isSet( left )
+	) {
+		return EMPTY_VALUE_LABEL;
+	}
 
-	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
+	// Keep all four slots so an unset side still shows its position.
+	return [ top, right, bottom, left ]
+		.map( ( value ) =>
+			isSet( value ) ? format( value ) : EMPTY_VALUE_LABEL
+		)
+		.join( ' ' );
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -9,6 +9,10 @@ export const EMPTY_VALUE_LABEL = '\u2014';
 // Matches a preset variable token, e.g. `var:preset|color|vivid-red`.
 const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
 
+// True when a style value is present (not unset or empty).
+const isSet = ( value ) =>
+	value !== undefined && value !== null && value !== '';
+
 /**
  * Formats a raw style value into a human-friendly string for display.
  *
@@ -24,7 +28,7 @@ const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
  * @return {string} A human-friendly representation of the value.
  */
 export function formatStyleValue( value ) {
-	if ( value === undefined || value === null || value === '' ) {
+	if ( ! isSet( value ) ) {
 		return EMPTY_VALUE_LABEL;
 	}
 
@@ -74,9 +78,7 @@ export function formatBorderShorthand( border ) {
 
 	const { width, style, color } = border;
 	const parts = [ width, style, color ]
-		.filter(
-			( part ) => part !== undefined && part !== null && part !== ''
-		)
+		.filter( isSet )
 		.map( ( part ) => formatStyleValue( part ) );
 
 	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
@@ -100,9 +102,7 @@ export function formatBorderRadius( radius ) {
 	if ( radius && typeof radius === 'object' ) {
 		const parts = RADIUS_CORNERS.map(
 			( corner ) => radius[ corner ]
-		).filter(
-			( value ) => value !== undefined && value !== null && value !== ''
-		);
+		).filter( isSet );
 		return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
 	}
 
@@ -136,8 +136,6 @@ export function formatSpacingShorthand(
 		return format( spacing );
 	}
 
-	const isSet = ( value ) =>
-		value !== undefined && value !== null && value !== '';
 	const { top, right, bottom, left } = spacing;
 
 	// Collapse a full axial/uniform object to the shortest CSS shorthand.

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import { capitalCase } from 'change-case';
+
+/**
+ * Em dash used to represent an unset / default value.
+ *
+ * @type {string}
+ */
+export const EMPTY_VALUE_LABEL = '\u2014';
+
+/**
+ * Matches a preset variable token, e.g. `var:preset|color|vivid-red`.
+ *
+ * @type {RegExp}
+ */
+const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
+
+/**
+ * Formats a raw style value into a human-friendly string for display.
+ *
+ * Handles:
+ * - `undefined`/`null`/empty: an em-dash placeholder.
+ * - Preset tokens (`var:preset|type|slug`): the humanized slug.
+ * - Plain strings/numbers: passed through as-is.
+ * - Objects/arrays (e.g. border side objects): safely stringified, or the
+ *   em-dash placeholder when they cannot be represented.
+ *
+ * @param {*} value The raw style value.
+ *
+ * @return {string} A human-friendly representation of the value.
+ */
+export function formatStyleValue( value ) {
+	if ( value === undefined || value === null || value === '' ) {
+		return EMPTY_VALUE_LABEL;
+	}
+
+	if ( typeof value === 'string' ) {
+		const presetMatch = value.match( PRESET_TOKEN_REGEX );
+		if ( presetMatch ) {
+			return capitalCase( presetMatch[ 2 ] );
+		}
+		return value;
+	}
+
+	if ( typeof value === 'number' ) {
+		return String( value );
+	}
+
+	if ( typeof value === 'object' ) {
+		try {
+			const stringified = JSON.stringify( value );
+			return stringified && stringified !== '{}' && stringified !== '[]'
+				? stringified
+				: EMPTY_VALUE_LABEL;
+		} catch {
+			return EMPTY_VALUE_LABEL;
+		}
+	}
+
+	return String( value );
+}
+
+/**
+ * Formats a border scope object into a CSS `border` shorthand for display,
+ * e.g. `2px dashed #000fff`.
+ *
+ * The parts are ordered `width style color` to match the CSS shorthand, unset
+ * parts are omitted, and preset color tokens are humanized (via
+ * `formatStyleValue`). Returns the empty-value placeholder when the scope
+ * carries no values.
+ *
+ * @param {*} border A border scope, e.g. `{ color, width, style }`.
+ *
+ * @return {string} The shorthand representation, or the empty-value placeholder.
+ */
+export function formatBorderShorthand( border ) {
+	if ( ! border || typeof border !== 'object' ) {
+		return formatStyleValue( border );
+	}
+
+	const { width, style, color } = border;
+	const parts = [ width, style, color ]
+		.filter(
+			( part ) => part !== undefined && part !== null && part !== ''
+		)
+		.map( ( part ) => formatStyleValue( part ) );
+
+	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
+}
+
+/**
+ * CSS `border-radius` shorthand corner order (top-left, top-right,
+ * bottom-right, bottom-left).
+ *
+ * @type {string[]}
+ */
+const RADIUS_CORNERS = [ 'topLeft', 'topRight', 'bottomRight', 'bottomLeft' ];
+
+/**
+ * Formats a border radius value for display.
+ *
+ * A string radius is passed through; a per-corner object is joined into a
+ * shorthand in CSS corner order, e.g. `1px 20px 1px 15px`. Returns the
+ * empty-value placeholder when there is nothing to show.
+ *
+ * @param {*} radius A radius string or a per-corner object.
+ *
+ * @return {string} The formatted radius, or the empty-value placeholder.
+ */
+export function formatBorderRadius( radius ) {
+	if ( radius && typeof radius === 'object' ) {
+		const parts = RADIUS_CORNERS.map(
+			( corner ) => radius[ corner ]
+		).filter(
+			( value ) => value !== undefined && value !== null && value !== ''
+		);
+		return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
+	}
+
+	return formatStyleValue( radius );
+}
+
+/**
+ * Formats a spacing value (padding or margin) as a CSS shorthand for display.
+ *
+ * A string value is passed through. A per-side object is collapsed to the
+ * shortest CSS shorthand that represents it: a single value when all sides
+ * match, a `vertical horizontal` pair for axial values, and otherwise the
+ * defined sides in CSS `top right bottom left` order.
+ *
+ * An optional `resolve` callback maps a raw value to its resolved form before
+ * display, e.g. turning a `var:preset|spacing|40` token into its actual size,
+ * which is more meaningful than the preset slug.
+ *
+ * @param {*}        spacing A spacing string or a per-side object.
+ * @param {Function} resolve Optional resolver applied to each raw value.
+ *
+ * @return {string} The formatted spacing, or the empty-value placeholder.
+ */
+export function formatSpacingShorthand(
+	spacing,
+	resolve = ( value ) => value
+) {
+	const format = ( value ) => formatStyleValue( resolve( value ) );
+
+	if ( ! spacing || typeof spacing !== 'object' ) {
+		return format( spacing );
+	}
+
+	const isSet = ( value ) =>
+		value !== undefined && value !== null && value !== '';
+	const { top, right, bottom, left } = spacing;
+
+	// Collapse a full axial/uniform object to the shortest CSS shorthand.
+	if ( isSet( top ) && isSet( right ) && isSet( bottom ) && isSet( left ) ) {
+		if ( top === right && right === bottom && bottom === left ) {
+			return format( top );
+		}
+		if ( top === bottom && left === right ) {
+			return `${ format( top ) } ${ format( left ) }`;
+		}
+		return [ top, right, bottom, left ].map( format ).join( ' ' );
+	}
+
+	// Partial object: show the defined sides in CSS order.
+	const parts = [ top, right, bottom, left ].filter( isSet ).map( format );
+
+	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
+}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -3,18 +3,10 @@
  */
 import { capitalCase } from 'change-case';
 
-/**
- * Em dash used to represent an unset / default value.
- *
- * @type {string}
- */
+// Em dash used to represent an unset / default value.
 export const EMPTY_VALUE_LABEL = '\u2014';
 
-/**
- * Matches a preset variable token, e.g. `var:preset|color|vivid-red`.
- *
- * @type {RegExp}
- */
+// Matches a preset variable token, e.g. `var:preset|color|vivid-red`.
 const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
 
 /**
@@ -90,12 +82,7 @@ export function formatBorderShorthand( border ) {
 	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
 }
 
-/**
- * CSS `border-radius` shorthand corner order (top-left, top-right,
- * bottom-right, bottom-left).
- *
- * @type {string[]}
- */
+// CSS `border-radius` shorthand corner order.
 const RADIUS_CORNERS = [ 'topLeft', 'topRight', 'bottomRight', 'bottomLeft' ];
 
 /**

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -161,3 +161,41 @@ export function formatSpacingShorthand(
 		)
 		.join( ' ' );
 }
+
+/**
+ * Turns a block gap value into readable text.
+ *
+ * A plain string is used as-is. An axial object with a `top` (row) and `left`
+ * (column) gap reads as one value when both match, or `row - column` when they
+ * differ.
+ *
+ * The optional `resolve` callback swaps a raw value for its real one first,
+ * e.g. turning `var:preset|spacing|40` into its actual size.
+ *
+ * @param {*}        gap     A gap string or an axial `{ top, left }` object.
+ * @param {Function} resolve Optional callback to resolve each raw value.
+ *
+ * @return {string} The readable gap, or an em dash.
+ */
+export function formatBlockGap( gap, resolve = ( value ) => value ) {
+	const format = ( value ) => formatStyleValue( resolve( value ) );
+
+	if ( ! gap || typeof gap !== 'object' ) {
+		return format( gap );
+	}
+
+	const { top: row, left: column } = gap;
+
+	if ( ! isSet( row ) && ! isSet( column ) ) {
+		return EMPTY_VALUE_LABEL;
+	}
+
+	if ( row === column ) {
+		return format( row );
+	}
+
+	const rowLabel = isSet( row ) ? format( row ) : EMPTY_VALUE_LABEL;
+	const columnLabel = isSet( column ) ? format( column ) : EMPTY_VALUE_LABEL;
+
+	return `${ rowLabel } - ${ columnLabel }`;
+}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -6,8 +6,28 @@ import { capitalCase } from 'change-case';
 // Em dash shown when a value isn't set.
 export const EMPTY_VALUE_LABEL = '\u2014';
 
-// Matches a preset value, e.g. `var:preset|color|vivid-red`.
-const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
+// Preset values come in two forms: the user form `var:preset|color|vivid-red`
+// and the CSS custom property form `var(--wp--preset--color--vivid-red)`. In
+// both the slug (e.g. `vivid-red`) is the last segment.
+const PRESET_USER_PREFIX = 'var:preset|';
+const PRESET_CSS_VAR_REGEX =
+	/^var\(\s*--wp--preset--[a-z0-9-]+?\s*(?:,[^)]*)?\)$/i;
+
+// Returns a preset's slug from either form, or `undefined` when the value isn't
+// a preset.
+function getPresetSlug( value ) {
+	if ( value.startsWith( PRESET_USER_PREFIX ) ) {
+		return value.split( '|' ).pop();
+	}
+	if ( PRESET_CSS_VAR_REGEX.test( value ) ) {
+		return value
+			.replace( /^var\(\s*/, '' )
+			.replace( /\s*(?:,[^)]*)?\)$/, '' )
+			.split( '--' )
+			.pop();
+	}
+	return undefined;
+}
 
 // True when a value is actually set.
 const isSet = ( value ) =>
@@ -50,7 +70,8 @@ function flattenBorder( border ) {
  * Turns a raw style value into readable text for the modal.
  *
  * - Empty, `null` or `undefined`: an em dash.
- * - Preset values (`var:preset|type|slug`): the readable slug.
+ * - Preset values (`var:preset|type|slug` or `var(--wp--preset--type--slug)`):
+ *   the readable slug.
  * - Strings and numbers: used as-is.
  * - Objects and arrays (like a border side): turned into text, or an em dash
  *   when there's nothing to show.
@@ -65,9 +86,9 @@ export function formatStyleValue( value ) {
 	}
 
 	if ( typeof value === 'string' ) {
-		const presetMatch = value.match( PRESET_TOKEN_REGEX );
-		if ( presetMatch ) {
-			return capitalCase( presetMatch[ 2 ] );
+		const presetSlug = getPresetSlug( value );
+		if ( presetSlug ) {
+			return capitalCase( presetSlug );
 		}
 		return value;
 	}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -3,29 +3,27 @@
  */
 import { capitalCase } from 'change-case';
 
-// Em dash used to represent an unset / default value.
+// Em dash shown when a value isn't set.
 export const EMPTY_VALUE_LABEL = '\u2014';
 
-// Matches a preset variable token, e.g. `var:preset|color|vivid-red`.
+// Matches a preset value, e.g. `var:preset|color|vivid-red`.
 const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
 
-// True when a style value is present (not unset or empty).
 const isSet = ( value ) =>
 	value !== undefined && value !== null && value !== '';
 
 /**
- * Formats a raw style value into a human-friendly string for display.
+ * Turns a raw style value into readable text for the modal.
  *
- * Handles:
- * - `undefined`/`null`/empty: an em-dash placeholder.
- * - Preset tokens (`var:preset|type|slug`): the humanized slug.
- * - Plain strings/numbers: passed through as-is.
- * - Objects/arrays (e.g. border side objects): safely stringified, or the
- *   em-dash placeholder when they cannot be represented.
+ * - Empty, `null` or `undefined`: an em dash.
+ * - Preset values (`var:preset|type|slug`): the readable slug.
+ * - Strings and numbers: used as-is.
+ * - Objects and arrays (like a border side): turned into text, or an em dash
+ *   when there's nothing to show.
  *
  * @param {*} value The raw style value.
  *
- * @return {string} A human-friendly representation of the value.
+ * @return {string} Readable text for the value.
  */
 export function formatStyleValue( value ) {
 	if ( ! isSet( value ) ) {
@@ -59,17 +57,16 @@ export function formatStyleValue( value ) {
 }
 
 /**
- * Formats a border scope object into a CSS `border` shorthand for display,
- * e.g. `2px dashed #000fff`.
+ * Turns a border object into a single CSS `border` value, e.g.
+ * `2px dashed #000fff`.
  *
- * The parts are ordered `width style color` to match the CSS shorthand, unset
- * parts are omitted, and preset color tokens are humanized (via
- * `formatStyleValue`). Returns the empty-value placeholder when the scope
- * carries no values.
+ * The parts follow the CSS order of `width style color`, anything that isn't
+ * set is left out, and preset colors are shown by name. Returns an em dash
+ * when the border has nothing set.
  *
- * @param {*} border A border scope, e.g. `{ color, width, style }`.
+ * @param {*} border A border object, e.g. `{ color, width, style }`.
  *
- * @return {string} The shorthand representation, or the empty-value placeholder.
+ * @return {string} The combined border value, or an em dash.
  */
 export function formatBorderShorthand( border ) {
 	if ( ! border || typeof border !== 'object' ) {
@@ -84,19 +81,19 @@ export function formatBorderShorthand( border ) {
 	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;
 }
 
-// CSS `border-radius` shorthand corner order.
+// Corner order used by the CSS `border-radius` shorthand.
 const RADIUS_CORNERS = [ 'topLeft', 'topRight', 'bottomRight', 'bottomLeft' ];
 
 /**
- * Formats a border radius value for display.
+ * Turns a border radius into readable text.
  *
- * A string radius is passed through; a per-corner object is joined into a
- * shorthand in CSS corner order, e.g. `1px 20px 1px 15px`. Returns the
- * empty-value placeholder when there is nothing to show.
+ * A plain string is used as-is. An object with a value per corner is joined in
+ * CSS corner order, e.g. `1px 20px 1px 15px`. Returns an em dash when there's
+ * nothing to show.
  *
- * @param {*} radius A radius string or a per-corner object.
+ * @param {*} radius A radius string or an object with a value per corner.
  *
- * @return {string} The formatted radius, or the empty-value placeholder.
+ * @return {string} The readable radius, or an em dash.
  */
 export function formatBorderRadius( radius ) {
 	if ( radius && typeof radius === 'object' ) {
@@ -110,21 +107,21 @@ export function formatBorderRadius( radius ) {
 }
 
 /**
- * Formats a spacing value (padding or margin) as a CSS shorthand for display.
+ * Turns a spacing value (padding or margin) into a single CSS value.
  *
- * A string value is passed through. A per-side object is collapsed to the
- * shortest CSS shorthand that represents it: a single value when all sides
- * match, a `vertical horizontal` pair for axial values, and otherwise the
- * defined sides in CSS `top right bottom left` order.
+ * A plain string is used as-is. An object with a value per side is shortened
+ * to the smallest CSS form: one value when every side matches, a
+ * `vertical horizontal` pair when top/bottom and left/right match, otherwise
+ * all four sides in `top right bottom left` order.
  *
- * An optional `resolve` callback maps a raw value to its resolved form before
- * display, e.g. turning a `var:preset|spacing|40` token into its actual size,
- * which is more meaningful than the preset slug.
+ * The optional `resolve` callback swaps a raw value for its real one first,
+ * e.g. turning `var:preset|spacing|40` into its actual size, which reads
+ * better than the preset name.
  *
- * @param {*}        spacing A spacing string or a per-side object.
- * @param {Function} resolve Optional resolver applied to each raw value.
+ * @param {*}        spacing A spacing string or an object with a value per side.
+ * @param {Function} resolve Optional callback to resolve each raw value.
  *
- * @return {string} The formatted spacing, or the empty-value placeholder.
+ * @return {string} The combined spacing, or an em dash.
  */
 export function formatSpacingShorthand(
 	spacing,
@@ -138,7 +135,6 @@ export function formatSpacingShorthand(
 
 	const { top, right, bottom, left } = spacing;
 
-	// Collapse a full axial/uniform object to the shortest CSS shorthand.
 	if ( isSet( top ) && isSet( right ) && isSet( bottom ) && isSet( left ) ) {
 		if ( top === right && right === bottom && bottom === left ) {
 			return format( top );
@@ -149,7 +145,6 @@ export function formatSpacingShorthand(
 		return [ top, right, bottom, left ].map( format ).join( ' ' );
 	}
 
-	// Partial object: show the defined sides in CSS order.
 	const parts = [ top, right, bottom, left ].filter( isSet ).map( format );
 
 	return parts.length ? parts.join( ' ' ) : EMPTY_VALUE_LABEL;

--- a/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/format-style-value.js
@@ -9,8 +9,42 @@ export const EMPTY_VALUE_LABEL = '\u2014';
 // Matches a preset value, e.g. `var:preset|color|vivid-red`.
 const PRESET_TOKEN_REGEX = /^var:preset\|([^|]+)\|(.+)$/;
 
+// True when a value is actually set.
 const isSet = ( value ) =>
 	value !== undefined && value !== null && value !== '';
+
+const BORDER_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+
+// Global Styles stores border style, width and color per side (e.g.
+// `border.top.style`). Collapse a per-side border object to flat
+// `{ width, style, color }`, keeping a value only when every set side agrees.
+function flattenBorder( border ) {
+	if (
+		isSet( border.width ) ||
+		isSet( border.style ) ||
+		isSet( border.color )
+	) {
+		return border;
+	}
+
+	const setSides = BORDER_SIDES.filter( ( side ) => border[ side ] );
+	if ( ! setSides.length ) {
+		return border;
+	}
+
+	const collapse = ( property ) => {
+		const values = setSides.map( ( side ) => border[ side ]?.[ property ] );
+		return values.every( ( value ) => value === values[ 0 ] )
+			? values[ 0 ]
+			: undefined;
+	};
+
+	return {
+		width: collapse( 'width' ),
+		style: collapse( 'style' ),
+		color: collapse( 'color' ),
+	};
+}
 
 /**
  * Turns a raw style value into readable text for the modal.
@@ -61,10 +95,12 @@ export function formatStyleValue( value ) {
  * `2px dashed #000fff`.
  *
  * The parts follow the CSS order of `width style color`, anything that isn't
- * set is left out, and preset colors are shown by name. Returns an em dash
- * when the border has nothing set.
+ * set is left out, and preset colors are shown by name. A per-side object (as
+ * Global Styles stores borders) is collapsed to its shared values first.
+ * Returns an em dash when the border has nothing set.
  *
- * @param {*} border A border object, e.g. `{ color, width, style }`.
+ * @param {*} border A border object, e.g. `{ color, width, style }`, or a
+ *                   per-side object, e.g. `{ top: { style } }`.
  *
  * @return {string} The combined border value, or an em dash.
  */
@@ -73,7 +109,7 @@ export function formatBorderShorthand( border ) {
 		return formatStyleValue( border );
 	}
 
-	const { width, style, color } = border;
+	const { width, style, color } = flattenBorder( border );
 	const parts = [ width, style, color ]
 		.filter( isSet )
 		.map( ( part ) => formatStyleValue( part ) );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -17,10 +17,14 @@ import {
 	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+import {
+	getStyle,
+	getValueFromVariable,
+} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -28,6 +32,14 @@ import { store as coreStore } from '@wordpress/core-data';
 import { unlock } from '../../lock-unlock';
 import setNestedValue from '../../utils/set-nested-value';
 import { useGlobalStyles } from '../../components/global-styles/hooks';
+import { getStyleLabel } from './style-labels';
+import {
+	formatStyleValue,
+	formatBorderShorthand,
+	formatBorderRadius,
+	formatSpacingShorthand,
+} from './format-style-value';
+import ApplyGloballyModal from './apply-globally-modal';
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 
@@ -112,56 +124,271 @@ const getValueFromObjectPath = ( object, path ) => {
 	return value;
 };
 
-const flatBorderProperties = [ 'borderColor', 'borderWidth', 'borderStyle' ];
 const sides = [ 'top', 'right', 'bottom', 'left' ];
 
-function getBorderStyleChanges( border, presetColor, userStyle ) {
-	if ( ! border && ! presetColor ) {
-		return [];
+/**
+ * Builds the border review rows.
+ *
+ * Border styles are grouped by scope so each row reads as a CSS `border`
+ * shorthand rather than one row per longhand: a single "Border" row for the
+ * all-sides shorthand, one row per side for split borders, and a "Border
+ * radius" row. Grouping keeps the modal compact and legible.
+ *
+ * Global Styles requires per-side longhand configuration (to override per-side
+ * theme.json settings) and a border style for a border to render, so the
+ * all-sides shorthand is also written to every side and a `solid` style
+ * fallback is added when a color or width is set without a style.
+ *
+ * @param {string[]} supports        Supported style keys for the block.
+ * @param {Object}   attributes      Block attributes.
+ * @param {Object}   blockUserConfig User Global Styles config for the block.
+ *
+ * @return {Array} Grouped border rows.
+ */
+function getBorderRows( supports, attributes, blockUserConfig ) {
+	const rows = [];
+	const border = attributes.style?.border;
+	const userBorder = blockUserConfig?.border;
+
+	const colorSupported = supports.includes( 'borderColor' );
+	const widthSupported = supports.includes( 'borderWidth' );
+	const styleSupported = supports.includes( 'borderStyle' );
+
+	// All-sides (flat) border shorthand. A preset border color is stored as a
+	// block attribute and pushed as a preset variable token.
+	const presetBorderColor = attributes.borderColor;
+	const flatColor = presetBorderColor
+		? `var:preset|color|${ presetBorderColor }`
+		: border?.color;
+	const flatRow = buildBorderScopeRow( {
+		id: 'border',
+		primaryPath: [ 'border' ],
+		side: null,
+		color: colorSupported ? flatColor : undefined,
+		width: widthSupported ? border?.width : undefined,
+		style: styleSupported ? border?.style : undefined,
+		userBorder,
+		presetAttributes: presetBorderColor ? [ 'borderColor' ] : [],
+	} );
+	if ( flatRow ) {
+		rows.push( flatRow );
 	}
 
-	const changes = [
-		...getFallbackBorderStyleChange( 'top', border, userStyle ),
-		...getFallbackBorderStyleChange( 'right', border, userStyle ),
-		...getFallbackBorderStyleChange( 'bottom', border, userStyle ),
-		...getFallbackBorderStyleChange( 'left', border, userStyle ),
-	];
+	// Per-side borders (split border configuration).
+	sides.forEach( ( side ) => {
+		const sideBorder = border?.[ side ];
+		const sideRow = buildBorderScopeRow( {
+			id: `border.${ side }`,
+			primaryPath: [ 'border', side ],
+			side,
+			color: colorSupported ? sideBorder?.color : undefined,
+			width: widthSupported ? sideBorder?.width : undefined,
+			style: styleSupported ? sideBorder?.style : undefined,
+			userBorder,
+			presetAttributes: [],
+		} );
+		if ( sideRow ) {
+			rows.push( sideRow );
+		}
+	} );
 
-	// Handle a flat border i.e. all sides the same, CSS shorthand.
-	const { color: customColor, style, width } = border || {};
-	const hasColorOrWidth = presetColor || customColor || width;
+	// Border radius. Pushed as-is (a string or per-corner object) since Global
+	// Styles accepts both forms.
+	if (
+		supports.includes( 'borderRadius' ) &&
+		border?.radius !== undefined &&
+		border?.radius !== ''
+	) {
+		rows.push( {
+			id: 'border.radius',
+			primaryPath: [ 'border', 'radius' ],
+			paths: [ { path: [ 'border', 'radius' ], value: border.radius } ],
+			presetAttributes: [],
+			newValue: border.radius,
+			format: 'borderRadius',
+		} );
+	}
 
-	if ( hasColorOrWidth && ! style ) {
-		// Global Styles need individual side configurations to overcome
-		// theme.json configurations which are per side as well.
-		sides.forEach( ( side ) => {
-			// Only add fallback border-style if global styles don't already
-			// have something set.
-			if ( ! userStyle?.[ side ]?.style ) {
-				changes.push( {
-					path: [ 'border', side, 'style' ],
+	return rows;
+}
+
+/**
+ * Builds a single border row (all-sides or one side) that pushes the scope's
+ * color, width, and style together and displays them as a CSS shorthand.
+ *
+ * @param {Object}   options                  Options.
+ * @param {string}   options.id               Row id.
+ * @param {string[]} options.primaryPath      Path used for the current-value lookup.
+ * @param {?string}  options.side             Side name, or `null` for all sides.
+ * @param {*}        options.color            Border color value, if any.
+ * @param {*}        options.width            Border width value, if any.
+ * @param {*}        options.style            Border style value, if any.
+ * @param {Object}   options.userBorder       User Global Styles border config.
+ * @param {string[]} options.presetAttributes Preset block attributes to clear.
+ *
+ * @return {?Object} The border row, or `null` when the scope has no values.
+ */
+function buildBorderScopeRow( {
+	id,
+	primaryPath,
+	side,
+	color,
+	width,
+	style,
+	userBorder,
+	presetAttributes,
+} ) {
+	if ( ! color && ! width && ! style ) {
+		return null;
+	}
+
+	const paths = [];
+	// The all-sides shorthand is also written to each side so it can override
+	// per-side theme.json configuration.
+	const targetSides = side ? [ side ] : sides;
+
+	const addChange = ( property, value ) => {
+		if ( value === undefined ) {
+			return;
+		}
+		if ( ! side ) {
+			// The shorthand entry is cleared from the block and set globally.
+			paths.push( { path: [ 'border', property ], value } );
+		}
+		targetSides.forEach( ( targetSide ) => {
+			paths.push( { path: [ 'border', targetSide, property ], value } );
+		} );
+	};
+
+	addChange( 'color', color );
+	addChange( 'width', width );
+	addChange( 'style', style );
+
+	// A visible border needs a style, so fall back to `solid` when a color or
+	// width is set without one (unless Global Styles already define a style for
+	// that side).
+	let effectiveStyle = style;
+	if ( ! style && ( color || width ) ) {
+		targetSides.forEach( ( targetSide ) => {
+			if ( ! userBorder?.[ targetSide ]?.style ) {
+				paths.push( {
+					path: [ 'border', targetSide, 'style' ],
 					value: 'solid',
 				} );
 			}
 		} );
+		effectiveStyle = 'solid';
 	}
 
-	return changes;
+	return {
+		id,
+		primaryPath,
+		paths,
+		presetAttributes,
+		newValue: { color, width, style: effectiveStyle },
+		format: 'border',
+	};
 }
 
-function getFallbackBorderStyleChange( side, border, globalBorderStyle ) {
-	if ( ! border?.[ side ] || globalBorderStyle?.[ side ]?.style ) {
-		return [];
-	}
+/**
+ * Derives the block-instance style changes that can be pushed to Global Styles,
+ * grouped into logical rows.
+ *
+ * Each row represents a single logical style (e.g. "Font size") and carries all
+ * of its expanded `{ path, value }` pairs so that a selection can push them
+ * atomically. Border styles are grouped by scope into shorthand rows (see
+ * `getBorderRows`).
+ *
+ * @param {Array}  supports        Supported style keys for the block.
+ * @param {Object} attributes      Block attributes.
+ * @param {Object} blockUserConfig User Global Styles config for the block.
+ *
+ * @return {Array<{id: string, primaryPath: string[], paths: Array<{path: string[], value: *}>, presetAttributes: string[], newValue: *, format?: string}>}
+ *   Grouped change rows.
+ */
+export function getChangesToPush( supports, attributes, blockUserConfig ) {
+	const rows = [];
 
-	const { color, style, width } = border[ side ];
-	const hasColorOrWidth = color || width;
+	supports.forEach( ( key ) => {
+		if ( ! STYLE_PROPERTY[ key ] ) {
+			return;
+		}
+		// Border styles are grouped by scope and handled separately below.
+		if ( key.startsWith( 'border' ) ) {
+			return;
+		}
+		// Root-only properties (e.g. `--wp--style--root--padding`) duplicate
+		// their non-root counterpart (`padding`) and only apply to the root,
+		// so they are skipped here.
+		if ( STYLE_PROPERTY[ key ].rootOnly ) {
+			return;
+		}
+		const { value: path } = STYLE_PROPERTY[ key ];
+		const presetAttributeKey = path.join( '.' );
+		const presetAttributeName =
+			STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[ presetAttributeKey ];
+		const presetAttributeValue = presetAttributeName
+			? attributes[ presetAttributeName ]
+			: undefined;
+		const value = presetAttributeValue
+			? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
+			: getValueFromObjectPath( attributes.style, path );
 
-	if ( ! hasColorOrWidth || style ) {
-		return [];
-	}
+		// A preset attribute is only cleared from the block when its
+		// corresponding row is pushed (see `getStylesUpdate`).
+		const presetAttributes = presetAttributeValue
+			? [ presetAttributeName ]
+			: [];
 
-	return [ { path: [ 'border', side, 'style' ], value: 'solid' } ];
+		// Links only have a single support entry but have two element
+		// style properties, color and hover color. The following check
+		// will add the hover color to the changes if required.
+		if ( key === 'linkColor' ) {
+			const paths = value ? [ { path, value } ] : [];
+			const hoverPath = [ 'elements', 'link', ':hover', 'color', 'text' ];
+			const hoverValue = getValueFromObjectPath(
+				attributes.style,
+				hoverPath
+			);
+
+			if ( hoverValue ) {
+				paths.push( { path: hoverPath, value: hoverValue } );
+			}
+
+			if ( paths.length === 0 ) {
+				return;
+			}
+
+			rows.push( {
+				id: presetAttributeKey,
+				primaryPath: path,
+				paths,
+				presetAttributes,
+				newValue: value ?? hoverValue,
+			} );
+			return;
+		}
+
+		if ( value ) {
+			// Padding and margin can be axial or per-side objects; a format
+			// hint lets them render as a single CSS shorthand instead of one
+			// row per side or a raw object.
+			const format =
+				key === 'padding' || key === 'margin' ? 'spacing' : undefined;
+			rows.push( {
+				id: presetAttributeKey,
+				primaryPath: path,
+				paths: [ { path, value } ],
+				presetAttributes,
+				newValue: value,
+				format,
+			} );
+		}
+	} );
+
+	rows.push( ...getBorderRows( supports, attributes, blockUserConfig ) );
+
+	return rows;
 }
 
 function useChangesToPush( name, attributes, userConfig ) {
@@ -173,71 +400,140 @@ function useChangesToPush( name, attributes, userConfig ) {
 	);
 	const blockUserConfig = userConfig?.styles?.blocks?.[ name ];
 
+	return useMemo(
+		() => getChangesToPush( supports, attributes, blockUserConfig ),
+		[ supports, attributes, blockUserConfig ]
+	);
+}
+
+/**
+ * Computes the block attribute and user Global Styles updates for a subset of
+ * grouped rows without applying them.
+ *
+ * Preset block attributes are only cleared for rows that are part of the pushed
+ * subset, so deselected preset styles are neither pushed nor wiped from the
+ * block. Returns `null` when there is nothing to push.
+ *
+ * @param {Object} options            Options.
+ * @param {Array}  options.rowsToPush Grouped rows to push.
+ * @param {Object} options.attributes Current block attributes.
+ * @param {Object} options.userConfig Current user Global Styles config.
+ * @param {string} options.name       Block name.
+ *
+ * @return {?{newBlockAttributes: Object, newUserConfig: Object}} The computed
+ *   updates, or `null` when the subset is empty.
+ */
+export function getStylesUpdate( {
+	rowsToPush,
+	attributes,
+	userConfig,
+	name,
+} ) {
+	if ( ! rowsToPush || rowsToPush.length === 0 ) {
+		return null;
+	}
+
+	const selectedChanges = rowsToPush.flatMap( ( row ) => row.paths );
+
+	if ( selectedChanges.length === 0 ) {
+		return null;
+	}
+
+	const { style: blockStyles } = attributes;
+
+	const newBlockStyles = structuredClone( blockStyles );
+	const newUserConfig = structuredClone( userConfig );
+
+	for ( const { path, value } of selectedChanges ) {
+		setNestedValue( newBlockStyles, path, undefined );
+		setNestedValue(
+			newUserConfig,
+			[ 'styles', 'blocks', name, ...path ],
+			value
+		);
+	}
+
+	// Only clear the preset block attributes that belong to the pushed rows.
+	// Clearing them unconditionally would wipe deselected preset styles from
+	// the block without pushing them to Global Styles.
+	const newBlockAttributes = {
+		style: cleanEmptyObject( newBlockStyles ),
+	};
+	for ( const presetAttribute of rowsToPush.flatMap(
+		( row ) => row.presetAttributes
+	) ) {
+		newBlockAttributes[ presetAttribute ] = undefined;
+	}
+
+	return { newBlockAttributes, newUserConfig };
+}
+
+/**
+ * Formats a raw style value for display, using the row's `format` hint so
+ * border scopes render as CSS shorthands rather than raw objects.
+ *
+ * @param {string}   format  Optional format hint (`border`, `borderRadius`,
+ *                           `spacing`).
+ * @param {*}        value   The raw style value.
+ * @param {Function} resolve Resolver for preset tokens (used for spacing).
+ *
+ * @return {string} A human-friendly representation of the value.
+ */
+function formatReviewValue( format, value, resolve ) {
+	if ( format === 'border' ) {
+		return formatBorderShorthand( value );
+	}
+	if ( format === 'borderRadius' ) {
+		return formatBorderRadius( value );
+	}
+	if ( format === 'spacing' ) {
+		return formatSpacingShorthand( value, resolve );
+	}
+	return formatStyleValue( value );
+}
+
+/**
+ * Enriches grouped change rows with a human-readable label and the current
+ * effective Global Styles value for the block type, plus display-formatted
+ * versions of the current and new values.
+ *
+ * @param {Array}  rows   Grouped rows from `useChangesToPush`.
+ * @param {Object} merged Merged Global Styles config.
+ * @param {string} name   Block name.
+ *
+ * @return {Array} Rows extended with `label`, `currentValue`,
+ *                 `formattedCurrentValue`, and `formattedNewValue`.
+ */
+export function useReviewRows( rows, merged, name ) {
 	return useMemo( () => {
-		const changes = supports.flatMap( ( key ) => {
-			if ( ! STYLE_PROPERTY[ key ] ) {
-				return [];
-			}
-			const { value: path } = STYLE_PROPERTY[ key ];
-			const presetAttributeKey = path.join( '.' );
-			const presetAttributeValue =
-				attributes[
-					STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE[ presetAttributeKey ]
-				];
-			const value = presetAttributeValue
-				? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
-				: getValueFromObjectPath( attributes.style, path );
+		// Resolves preset tokens (e.g. `var:preset|spacing|40`) to their actual
+		// values so spacing reads as a real size rather than a preset slug.
+		const resolve = ( value ) =>
+			getValueFromVariable( merged, name, value );
 
-			// Links only have a single support entry but have two element
-			// style properties, color and hover color. The following check
-			// will add the hover color to the changes if required.
-			if ( key === 'linkColor' ) {
-				const linkChanges = value ? [ { path, value } ] : [];
-				const hoverPath = [
-					'elements',
-					'link',
-					':hover',
-					'color',
-					'text',
-				];
-				const hoverValue = getValueFromObjectPath(
-					attributes.style,
-					hoverPath
-				);
-
-				if ( hoverValue ) {
-					linkChanges.push( { path: hoverPath, value: hoverValue } );
-				}
-
-				return linkChanges;
-			}
-
-			// The shorthand border styles can't be mapped directly as global
-			// styles requires longhand config.
-			if ( flatBorderProperties.includes( key ) && value ) {
-				// The shorthand config path is included to clear the block attribute.
-				const borderChanges = [ { path, value } ];
-				sides.forEach( ( side ) => {
-					const currentPath = [ ...path ];
-					currentPath.splice( -1, 0, side );
-					borderChanges.push( { path: currentPath, value } );
-				} );
-				return borderChanges;
-			}
-
-			return value ? [ { path, value } ] : [];
+		return rows.map( ( row ) => {
+			const currentValue = getStyle(
+				merged,
+				row.primaryPath.join( '.' ),
+				name
+			);
+			return {
+				...row,
+				label: getStyleLabel( row.primaryPath ),
+				currentValue,
+				formattedCurrentValue: formatReviewValue(
+					row.format,
+					currentValue,
+					resolve
+				),
+				formattedNewValue: formatReviewValue(
+					row.format,
+					row.newValue,
+					resolve
+				),
+			};
 		} );
-
-		// To ensure display of a visible border, global styles require a
-		// default border style if a border color or width is present.
-		getBorderStyleChanges(
-			attributes.style?.border,
-			attributes.borderColor,
-			blockUserConfig?.border
-		).forEach( ( change ) => changes.push( change ) );
-
-		return changes;
-	}, [ supports, attributes, blockUserConfig ] );
+	}, [ rows, merged, name ] );
 }
 
 function PushChangesToGlobalStylesControl( {
@@ -247,41 +543,30 @@ function PushChangesToGlobalStylesControl( {
 } ) {
 	const { user: userConfig, setUser: setUserConfig } = useGlobalStyles();
 
-	const changes = useChangesToPush( name, attributes, userConfig );
+	const rows = useChangesToPush( name, attributes, userConfig );
+
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
-	const pushChanges = useCallback( () => {
-		if ( changes.length === 0 ) {
-			return;
-		}
+	// Pushes the given subset of grouped rows to Global Styles. Defaults to all
+	// rows so the caller can push everything without change to prior behaviour.
+	const pushChanges = useCallback(
+		( rowsToPush = rows ) => {
+			const update = getStylesUpdate( {
+				rowsToPush,
+				attributes,
+				userConfig,
+				name,
+			} );
 
-		if ( changes.length > 0 ) {
-			const { style: blockStyles } = attributes;
-
-			const newBlockStyles = structuredClone( blockStyles );
-			const newUserConfig = structuredClone( userConfig );
-
-			for ( const { path, value } of changes ) {
-				setNestedValue( newBlockStyles, path, undefined );
-				setNestedValue(
-					newUserConfig,
-					[ 'styles', 'blocks', name, ...path ],
-					value
-				);
+			if ( ! update ) {
+				return;
 			}
 
-			const newBlockAttributes = {
-				borderColor: undefined,
-				backgroundColor: undefined,
-				textColor: undefined,
-				gradient: undefined,
-				fontSize: undefined,
-				fontFamily: undefined,
-				style: cleanEmptyObject( newBlockStyles ),
-			};
+			const { newBlockAttributes, newUserConfig } = update;
 
 			// @wordpress/core-data doesn't support editing multiple entity types in
 			// a single undo level. So for now, we disable @wordpress/core-data undo
@@ -312,17 +597,18 @@ function PushChangesToGlobalStylesControl( {
 					],
 				}
 			);
-		}
-	}, [
-		__unstableMarkNextChangeAsNotPersistent,
-		attributes,
-		changes,
-		createSuccessNotice,
-		name,
-		setAttributes,
-		setUserConfig,
-		userConfig,
-	] );
+		},
+		[
+			__unstableMarkNextChangeAsNotPersistent,
+			attributes,
+			rows,
+			createSuccessNotice,
+			name,
+			setAttributes,
+			setUserConfig,
+			userConfig,
+		]
+	);
 
 	return (
 		<BaseControl
@@ -330,7 +616,7 @@ function PushChangesToGlobalStylesControl( {
 			help={ sprintf(
 				// translators: %s: Title of the block e.g. 'Heading'.
 				__(
-					'Apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
+					'Review and apply this block’s typography, spacing, dimensions, and color styles to all %s blocks.'
 				),
 				getBlockType( name ).title
 			) }
@@ -342,11 +628,19 @@ function PushChangesToGlobalStylesControl( {
 				__next40pxDefaultSize
 				variant="secondary"
 				accessibleWhenDisabled
-				disabled={ changes.length === 0 }
-				onClick={ pushChanges }
+				disabled={ rows.length === 0 }
+				onClick={ () => setIsModalOpen( true ) }
 			>
 				{ __( 'Apply globally' ) }
 			</Button>
+			{ isModalOpen && (
+				<ApplyGloballyModal
+					name={ name }
+					rows={ rows }
+					onApply={ pushChanges }
+					onRequestClose={ () => setIsModalOpen( false ) }
+				/>
+			) }
 		</BaseControl>
 	);
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -128,25 +128,9 @@ const sides = [ 'top', 'right', 'bottom', 'left' ];
  * @property {string}                            [format]         Display format hint (`border`, `borderRadius`, `spacing`).
  */
 
-/**
- * Builds the border review rows.
- *
- * Border styles are grouped by scope so each row reads as a CSS `border`
- * shorthand rather than one row per longhand: a single "Border" row for the
- * all-sides shorthand, one row per side for split borders, and a "Border
- * radius" row. Grouping keeps the modal compact and legible.
- *
- * Global Styles requires per-side longhand configuration (to override per-side
- * theme.json settings) and a border style for a border to render, so the
- * all-sides shorthand is also written to every side and a `solid` style
- * fallback is added when a color or width is set without a style.
- *
- * @param {string[]} supports        Supported style keys for the block.
- * @param {Object}   attributes      Block attributes.
- * @param {Object}   blockUserConfig User Global Styles config for the block.
- *
- * @return {ChangeRow[]} Grouped border rows.
- */
+// Builds the border review rows, grouped by scope so each row reads as a CSS
+// `border` shorthand (all-sides, per-side, and radius) rather than one row per
+// longhand.
 function getBorderRows( supports, attributes, blockUserConfig ) {
 	const rows = [];
 	const border = attributes.style?.border;
@@ -214,22 +198,9 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 	return rows;
 }
 
-/**
- * Builds a single border row (all-sides or one side) that pushes the scope's
- * color, width, and style together and displays them as a CSS shorthand.
- *
- * @param {Object}   options                  Options.
- * @param {string}   options.id               Row id.
- * @param {string[]} options.primaryPath      Path used for the current-value lookup.
- * @param {?string}  options.side             Side name, or `null` for all sides.
- * @param {*}        options.color            Border color value, if any.
- * @param {*}        options.width            Border width value, if any.
- * @param {*}        options.style            Border style value, if any.
- * @param {Object}   options.userBorder       User Global Styles border config.
- * @param {string[]} options.presetAttributes Preset block attributes to clear.
- *
- * @return {?ChangeRow} The border row, or `null` when the scope has no values.
- */
+// Builds a single border row (all-sides or one side) that pushes the scope's
+// color, width, and style together and displays them as a CSS shorthand.
+// Returns `null` when the scope has no values.
 function buildBorderScopeRow( {
 	id,
 	primaryPath,
@@ -294,12 +265,7 @@ function buildBorderScopeRow( {
 
 /**
  * Derives the block-instance style changes that can be pushed to Global Styles,
- * grouped into logical rows.
- *
- * Each row represents a single logical style (e.g. "Font size") and carries all
- * of its expanded `{ path, value }` pairs so that a selection can push them
- * atomically. Border styles are grouped by scope into shorthand rows (see
- * `getBorderRows`).
+ * grouped into logical rows (see `ChangeRow`).
  *
  * @param {Array}  supports        Supported style keys for the block.
  * @param {Object} attributes      Block attributes.
@@ -409,11 +375,8 @@ function useChangesToPush( name, attributes, userConfig ) {
 
 /**
  * Computes the block attribute and user Global Styles updates for a subset of
- * grouped rows without applying them.
- *
- * Preset block attributes are only cleared for rows that are part of the pushed
- * subset, so deselected preset styles are neither pushed nor wiped from the
- * block. Returns `null` when there is nothing to push.
+ * grouped rows without applying them. Returns `null` when there is nothing to
+ * push.
  *
  * @param {Object} options            Options.
  * @param {Array}  options.rowsToPush Grouped rows to push.

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -21,10 +21,6 @@ import { useMemo, useCallback, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
-import {
-	getStyle,
-	getValueFromVariable,
-} from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
@@ -32,13 +28,6 @@ import {
 import { unlock } from '../../lock-unlock';
 import setNestedValue from '../../utils/set-nested-value';
 import { useGlobalStyles } from '../../components/global-styles/hooks';
-import { getStyleLabel } from './style-labels';
-import {
-	formatStyleValue,
-	formatBorderShorthand,
-	formatBorderRadius,
-	formatSpacingShorthand,
-} from './format-style-value';
 import ApplyGloballyModal from './apply-globally-modal';
 
 const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
@@ -466,74 +455,6 @@ export function getStylesUpdate( {
 	}
 
 	return { newBlockAttributes, newUserConfig };
-}
-
-/**
- * Formats a raw style value for display, using the row's `format` hint so
- * border scopes render as CSS shorthands rather than raw objects.
- *
- * @param {string}   format  Optional format hint (`border`, `borderRadius`,
- *                           `spacing`).
- * @param {*}        value   The raw style value.
- * @param {Function} resolve Resolver for preset tokens (used for spacing).
- *
- * @return {string} A human-friendly representation of the value.
- */
-function formatReviewValue( format, value, resolve ) {
-	if ( format === 'border' ) {
-		return formatBorderShorthand( value );
-	}
-	if ( format === 'borderRadius' ) {
-		return formatBorderRadius( value );
-	}
-	if ( format === 'spacing' ) {
-		return formatSpacingShorthand( value, resolve );
-	}
-	return formatStyleValue( value );
-}
-
-/**
- * Enriches grouped change rows with a human-readable label and the current
- * effective Global Styles value for the block type, plus display-formatted
- * versions of the current and new values.
- *
- * @param {Array}  rows   Grouped rows from `useChangesToPush`.
- * @param {Object} merged Merged Global Styles config.
- * @param {string} name   Block name.
- *
- * @return {Array} Rows extended with `label`, `currentValue`,
- *                 `formattedCurrentValue`, and `formattedNewValue`.
- */
-export function useReviewRows( rows, merged, name ) {
-	return useMemo( () => {
-		// Resolves preset tokens (e.g. `var:preset|spacing|40`) to their actual
-		// values so spacing reads as a real size rather than a preset slug.
-		const resolve = ( value ) =>
-			getValueFromVariable( merged, name, value );
-
-		return rows.map( ( row ) => {
-			const currentValue = getStyle(
-				merged,
-				row.primaryPath.join( '.' ),
-				name
-			);
-			return {
-				...row,
-				label: getStyleLabel( row.primaryPath ),
-				currentValue,
-				formattedCurrentValue: formatReviewValue(
-					row.format,
-					currentValue,
-					resolve
-				),
-				formattedNewValue: formatReviewValue(
-					row.format,
-					row.newValue,
-					resolve
-				),
-			};
-		} );
-	}, [ rows, merged, name ] );
 }
 
 function PushChangesToGlobalStylesControl( {

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -236,18 +236,28 @@ function buildBorderScopeRow( {
 
 	// A border only shows with a style, so use `solid` when a color or width
 	// is set without one (unless Global Styles already sets a style for that
-	// side).
+	// side, which is kept).
 	let effectiveStyle = style;
 	if ( ! style && ( color || width ) ) {
-		targetSides.forEach( ( targetSide ) => {
-			if ( ! userBorder?.[ targetSide ]?.style ) {
+		const sideStyles = targetSides.map(
+			( targetSide ) => userBorder?.[ targetSide ]?.style
+		);
+		targetSides.forEach( ( targetSide, index ) => {
+			if ( ! sideStyles[ index ] ) {
 				paths.push( {
 					path: [ 'border', targetSide, 'style' ],
 					value: 'solid',
 				} );
 			}
 		} );
-		effectiveStyle = 'solid';
+		// Show the style the border will actually have after Apply: the shared
+		// Global Styles style when every side agrees on one, else `solid`.
+		const sharedStyle = sideStyles.every(
+			( sideStyle ) => sideStyle === sideStyles[ 0 ]
+		)
+			? sideStyles[ 0 ]
+			: undefined;
+		effectiveStyle = sharedStyle || 'solid';
 	}
 
 	return {

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -176,7 +176,7 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 		rows.push( flatRow );
 	}
 
-	// Per-side borders (split border configuration).
+	// Per-side borders.
 	sides.forEach( ( side ) => {
 		const sideBorder = border?.[ side ];
 		const sideRow = buildBorderScopeRow( {
@@ -484,10 +484,8 @@ function PushChangesToGlobalStylesControl( {
 		useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
-	// Pushes the given subset of grouped rows to Global Styles. Defaults to all
-	// rows so the caller can push everything without change to prior behaviour.
 	const pushChanges = useCallback(
-		( rowsToPush = rows ) => {
+		( rowsToPush ) => {
 			const update = getStylesUpdate( {
 				rowsToPush,
 				attributes,
@@ -534,7 +532,6 @@ function PushChangesToGlobalStylesControl( {
 		[
 			__unstableMarkNextChangeAsNotPersistent,
 			attributes,
-			rows,
 			createSuccessNotice,
 			name,
 			setAttributes,

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -334,9 +334,13 @@ export function getChangesToPush( supports, attributes, blockUserConfig ) {
 		if ( value ) {
 			// Padding and margin can be axial or per-side objects. The format
 			// hint lets them show as one CSS value instead of a row per side
-			// or a raw object.
-			const format =
-				key === 'padding' || key === 'margin' ? 'spacing' : undefined;
+			// or a raw object. Block gap can be an axial `{ top, left }` object.
+			let format;
+			if ( key === 'padding' || key === 'margin' ) {
+				format = 'spacing';
+			} else if ( key === 'blockGap' ) {
+				format = 'blockGap';
+			}
 			rows.push( {
 				id: presetAttributeKey,
 				primaryPath: path,

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -116,6 +116,19 @@ const getValueFromObjectPath = ( object, path ) => {
 const sides = [ 'top', 'right', 'bottom', 'left' ];
 
 /**
+ * A single logical style change, grouping all the `{ path, value }` pairs it
+ * expands to so a selection can push them atomically.
+ *
+ * @typedef {Object} ChangeRow
+ * @property {string}                            id               Unique row id.
+ * @property {string[]}                          primaryPath      Path used for the current-value lookup.
+ * @property {Array<{path: string[], value: *}>} paths            Expanded path/value pairs to push.
+ * @property {string[]}                          presetAttributes Preset block attributes to clear when pushed.
+ * @property {*}                                 newValue         Value shown in the "New" column.
+ * @property {string}                            [format]         Display format hint (`border`, `borderRadius`, `spacing`).
+ */
+
+/**
  * Builds the border review rows.
  *
  * Border styles are grouped by scope so each row reads as a CSS `border`
@@ -132,7 +145,7 @@ const sides = [ 'top', 'right', 'bottom', 'left' ];
  * @param {Object}   attributes      Block attributes.
  * @param {Object}   blockUserConfig User Global Styles config for the block.
  *
- * @return {Array} Grouped border rows.
+ * @return {ChangeRow[]} Grouped border rows.
  */
 function getBorderRows( supports, attributes, blockUserConfig ) {
 	const rows = [];
@@ -215,7 +228,7 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
  * @param {Object}   options.userBorder       User Global Styles border config.
  * @param {string[]} options.presetAttributes Preset block attributes to clear.
  *
- * @return {?Object} The border row, or `null` when the scope has no values.
+ * @return {?ChangeRow} The border row, or `null` when the scope has no values.
  */
 function buildBorderScopeRow( {
 	id,
@@ -292,8 +305,7 @@ function buildBorderScopeRow( {
  * @param {Object} attributes      Block attributes.
  * @param {Object} blockUserConfig User Global Styles config for the block.
  *
- * @return {Array<{id: string, primaryPath: string[], paths: Array<{path: string[], value: *}>, presetAttributes: string[], newValue: *, format?: string}>}
- *   Grouped change rows.
+ * @return {ChangeRow[]} Grouped change rows.
  */
 export function getChangesToPush( supports, attributes, blockUserConfig ) {
 	const rows = [];

--- a/packages/editor/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/index.js
@@ -116,21 +116,20 @@ const getValueFromObjectPath = ( object, path ) => {
 const sides = [ 'top', 'right', 'bottom', 'left' ];
 
 /**
- * A single logical style change, grouping all the `{ path, value }` pairs it
- * expands to so a selection can push them atomically.
+ * One style change shown as a single row. It holds every `{ path, value }` pair
+ * the change covers so they all get pushed together.
  *
  * @typedef {Object} ChangeRow
  * @property {string}                            id               Unique row id.
- * @property {string[]}                          primaryPath      Path used for the current-value lookup.
- * @property {Array<{path: string[], value: *}>} paths            Expanded path/value pairs to push.
+ * @property {string[]}                          primaryPath      Path used to look up the current value.
+ * @property {Array<{path: string[], value: *}>} paths            The path/value pairs to push.
  * @property {string[]}                          presetAttributes Preset block attributes to clear when pushed.
  * @property {*}                                 newValue         Value shown in the "New" column.
- * @property {string}                            [format]         Display format hint (`border`, `borderRadius`, `spacing`).
+ * @property {string}                            [format]         How to display the value (`border`, `borderRadius`, `spacing`).
  */
 
-// Builds the border review rows, grouped by scope so each row reads as a CSS
-// `border` shorthand (all-sides, per-side, and radius) rather than one row per
-// longhand.
+// Builds the border rows, grouped so each one reads as a single CSS `border`
+// value (all sides, one side, and radius) instead of a row per property.
 function getBorderRows( supports, attributes, blockUserConfig ) {
 	const rows = [];
 	const border = attributes.style?.border;
@@ -140,8 +139,8 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 	const widthSupported = supports.includes( 'borderWidth' );
 	const styleSupported = supports.includes( 'borderStyle' );
 
-	// All-sides (flat) border shorthand. A preset border color is stored as a
-	// block attribute and pushed as a preset variable token.
+	// The all-sides border. A preset border color lives in a block attribute
+	// and is pushed as a preset value.
 	const presetBorderColor = attributes.borderColor;
 	const flatColor = presetBorderColor
 		? `var:preset|color|${ presetBorderColor }`
@@ -160,7 +159,6 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 		rows.push( flatRow );
 	}
 
-	// Per-side borders.
 	sides.forEach( ( side ) => {
 		const sideBorder = border?.[ side ];
 		const sideRow = buildBorderScopeRow( {
@@ -178,8 +176,8 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 		}
 	} );
 
-	// Border radius. Pushed as-is (a string or per-corner object) since Global
-	// Styles accepts both forms.
+	// Border radius, pushed as-is (a string or an object per corner) since
+	// Global Styles takes either.
 	if (
 		supports.includes( 'borderRadius' ) &&
 		border?.radius !== undefined &&
@@ -198,9 +196,9 @@ function getBorderRows( supports, attributes, blockUserConfig ) {
 	return rows;
 }
 
-// Builds a single border row (all-sides or one side) that pushes the scope's
-// color, width, and style together and displays them as a CSS shorthand.
-// Returns `null` when the scope has no values.
+// Builds one border row (all sides or a single side) that pushes its color,
+// width and style together and shows them as one CSS value. Returns `null`
+// when there's nothing set.
 function buildBorderScopeRow( {
 	id,
 	primaryPath,
@@ -216,8 +214,8 @@ function buildBorderScopeRow( {
 	}
 
 	const paths = [];
-	// The all-sides shorthand is also written to each side so it can override
-	// per-side theme.json configuration.
+	// The all-sides value is also written to each side so it can override any
+	// per-side values from theme.json.
 	const targetSides = side ? [ side ] : sides;
 
 	const addChange = ( property, value ) => {
@@ -225,7 +223,6 @@ function buildBorderScopeRow( {
 			return;
 		}
 		if ( ! side ) {
-			// The shorthand entry is cleared from the block and set globally.
 			paths.push( { path: [ 'border', property ], value } );
 		}
 		targetSides.forEach( ( targetSide ) => {
@@ -237,9 +234,9 @@ function buildBorderScopeRow( {
 	addChange( 'width', width );
 	addChange( 'style', style );
 
-	// A visible border needs a style, so fall back to `solid` when a color or
-	// width is set without one (unless Global Styles already define a style for
-	// that side).
+	// A border only shows with a style, so use `solid` when a color or width
+	// is set without one (unless Global Styles already sets a style for that
+	// side).
 	let effectiveStyle = style;
 	if ( ! style && ( color || width ) ) {
 		targetSides.forEach( ( targetSide ) => {
@@ -264,14 +261,14 @@ function buildBorderScopeRow( {
 }
 
 /**
- * Derives the block-instance style changes that can be pushed to Global Styles,
- * grouped into logical rows (see `ChangeRow`).
+ * Works out which of the block's style changes can be pushed to Global Styles,
+ * grouped into rows (see `ChangeRow`).
  *
  * @param {Array}  supports        Supported style keys for the block.
  * @param {Object} attributes      Block attributes.
- * @param {Object} blockUserConfig User Global Styles config for the block.
+ * @param {Object} blockUserConfig The block's user Global Styles config.
  *
- * @return {ChangeRow[]} Grouped change rows.
+ * @return {ChangeRow[]} The changes, grouped into rows.
  */
 export function getChangesToPush( supports, attributes, blockUserConfig ) {
 	const rows = [];
@@ -280,13 +277,12 @@ export function getChangesToPush( supports, attributes, blockUserConfig ) {
 		if ( ! STYLE_PROPERTY[ key ] ) {
 			return;
 		}
-		// Border styles are grouped by scope and handled separately below.
+		// Border styles are grouped and handled separately below.
 		if ( key.startsWith( 'border' ) ) {
 			return;
 		}
-		// Root-only properties (e.g. `--wp--style--root--padding`) duplicate
-		// their non-root counterpart (`padding`) and only apply to the root,
-		// so they are skipped here.
+		// Root-only properties (e.g. `--wp--style--root--padding`) repeat their
+		// normal version (`padding`) and only apply to the root, so skip them.
 		if ( STYLE_PROPERTY[ key ].rootOnly ) {
 			return;
 		}
@@ -301,15 +297,14 @@ export function getChangesToPush( supports, attributes, blockUserConfig ) {
 			? `var:preset|${ STYLE_PATH_TO_CSS_VAR_INFIX[ presetAttributeKey ] }|${ presetAttributeValue }`
 			: getValueFromObjectPath( attributes.style, path );
 
-		// A preset attribute is only cleared from the block when its
-		// corresponding row is pushed (see `getStylesUpdate`).
+		// A preset attribute is only removed from the block when its row is
+		// pushed (see `getStylesUpdate`).
 		const presetAttributes = presetAttributeValue
 			? [ presetAttributeName ]
 			: [];
 
-		// Links only have a single support entry but have two element
-		// style properties, color and hover color. The following check
-		// will add the hover color to the changes if required.
+		// Links have a single support but two styles: color and hover color.
+		// Add the hover color to the changes when it's set.
 		if ( key === 'linkColor' ) {
 			const paths = value ? [ { path, value } ] : [];
 			const hoverPath = [ 'elements', 'link', ':hover', 'color', 'text' ];
@@ -337,9 +332,9 @@ export function getChangesToPush( supports, attributes, blockUserConfig ) {
 		}
 
 		if ( value ) {
-			// Padding and margin can be axial or per-side objects; a format
-			// hint lets them render as a single CSS shorthand instead of one
-			// row per side or a raw object.
+			// Padding and margin can be axial or per-side objects. The format
+			// hint lets them show as one CSS value instead of a row per side
+			// or a raw object.
 			const format =
 				key === 'padding' || key === 'margin' ? 'spacing' : undefined;
 			rows.push( {
@@ -374,18 +369,17 @@ function useChangesToPush( name, attributes, userConfig ) {
 }
 
 /**
- * Computes the block attribute and user Global Styles updates for a subset of
- * grouped rows without applying them. Returns `null` when there is nothing to
- * push.
+ * Works out the block attribute and user Global Styles updates for the chosen
+ * rows, without applying them. Returns `null` when there's nothing to push.
  *
  * @param {Object} options            Options.
- * @param {Array}  options.rowsToPush Grouped rows to push.
+ * @param {Array}  options.rowsToPush The rows to push.
  * @param {Object} options.attributes Current block attributes.
  * @param {Object} options.userConfig Current user Global Styles config.
  * @param {string} options.name       Block name.
  *
- * @return {?{newBlockAttributes: Object, newUserConfig: Object}} The computed
- *   updates, or `null` when the subset is empty.
+ * @return {?{newBlockAttributes: Object, newUserConfig: Object}} The updates,
+ *   or `null` when no rows were chosen.
  */
 export function getStylesUpdate( {
 	rowsToPush,
@@ -417,9 +411,9 @@ export function getStylesUpdate( {
 		);
 	}
 
-	// Only clear the preset block attributes that belong to the pushed rows.
-	// Clearing them unconditionally would wipe deselected preset styles from
-	// the block without pushing them to Global Styles.
+	// Only clear the preset attributes from the rows being pushed. Clearing
+	// them all would wipe unselected preset styles from the block without
+	// pushing them to Global Styles.
 	const newBlockAttributes = {
 		style: cleanEmptyObject( newBlockStyles ),
 	};

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style-labels.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style-labels.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { capitalCase } from 'change-case';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Human-readable labels for style paths, keyed by `path.join( '.' )`.
+ *
+ * The block style property config (`__EXPERIMENTAL_STYLE_PROPERTY`) does not
+ * carry display labels, so they are authored here. Any path without an entry
+ * falls back to a humanized version of its last segment (see `getStyleLabel`).
+ *
+ * @type {Record<string, string>}
+ */
+export const STYLE_LABELS = {
+	// Typography.
+	'typography.fontFamily': __( 'Font family' ),
+	'typography.fontSize': __( 'Font size' ),
+	'typography.fontStyle': __( 'Font style' ),
+	'typography.fontWeight': __( 'Font weight' ),
+	'typography.lineHeight': __( 'Line height' ),
+	'typography.letterSpacing': __( 'Letter spacing' ),
+	'typography.textDecoration': __( 'Text decoration' ),
+	'typography.textTransform': __( 'Letter case' ),
+	'typography.textColumns': __( 'Text columns' ),
+	'typography.writingMode': __( 'Orientation' ),
+
+	// Color.
+	'color.text': __( 'Text color' ),
+	'color.background': __( 'Background color' ),
+	'color.gradient': __( 'Gradient' ),
+	'elements.link.color.text': __( 'Link color' ),
+
+	// Spacing.
+	'spacing.padding': __( 'Padding' ),
+	'spacing.margin': __( 'Margin' ),
+	'spacing.blockGap': __( 'Block spacing' ),
+
+	// Border.
+	border: __( 'Border' ),
+	'border.top': __( 'Border top' ),
+	'border.right': __( 'Border right' ),
+	'border.bottom': __( 'Border bottom' ),
+	'border.left': __( 'Border left' ),
+	'border.color': __( 'Border color' ),
+	'border.width': __( 'Border width' ),
+	'border.style': __( 'Border style' ),
+	'border.radius': __( 'Border radius' ),
+
+	// Dimensions.
+	'dimensions.minHeight': __( 'Minimum height' ),
+	'dimensions.aspectRatio': __( 'Aspect ratio' ),
+};
+
+/**
+ * Returns a human-readable label for a given style path.
+ *
+ * When the path has no authored label it falls back to a humanized version of
+ * the path's last segment so nothing renders blank.
+ *
+ * @param {string[]} path Style path, e.g. `[ 'color', 'background' ]`.
+ *
+ * @return {string} A human-readable label.
+ */
+export function getStyleLabel( path ) {
+	const key = path.join( '.' );
+	if ( STYLE_LABELS[ key ] ) {
+		return STYLE_LABELS[ key ];
+	}
+	return capitalCase( path[ path.length - 1 ] ?? '' );
+}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style-labels.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style-labels.js
@@ -9,11 +9,11 @@ import { capitalCase } from 'change-case';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Human-readable labels for style paths, keyed by `path.join( '.' )`.
+ * Readable labels for style paths, keyed by `path.join( '.' )`.
  *
- * The block style property config (`__EXPERIMENTAL_STYLE_PROPERTY`) does not
- * carry display labels, so they are authored here. Any path without an entry
- * falls back to a humanized version of its last segment (see `getStyleLabel`).
+ * The block style config (`__EXPERIMENTAL_STYLE_PROPERTY`) has no labels of its
+ * own, so they live here. A path with no entry falls back to a readable version
+ * of its last part (see `getStyleLabel`).
  *
  * @type {Record<string, string>}
  */
@@ -58,14 +58,14 @@ export const STYLE_LABELS = {
 };
 
 /**
- * Returns a human-readable label for a given style path.
+ * Returns a readable label for a style path.
  *
- * When the path has no authored label it falls back to a humanized version of
- * the path's last segment so nothing renders blank.
+ * When the path has no label of its own, it falls back to a readable version of
+ * the path's last part so nothing shows up blank.
  *
  * @param {string[]} path Style path, e.g. `[ 'color', 'background' ]`.
  *
- * @return {string} A human-readable label.
+ * @return {string} A readable label.
  */
 export function getStyleLabel( path ) {
 	const key = path.join( '.' );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -1,4 +1,25 @@
+@use "@wordpress/base-styles/colors" as *;
+
 .editor-push-changes-to-global-styles-control .components-button {
 	justify-content: center;
 	width: 100%;
+}
+
+.editor-push-changes-to-global-styles-modal p {
+	margin-top: 0;
+}
+
+.editor-push-changes-to-global-styles-modal {
+	.dataviews-layout__container {
+		overflow-x: hidden;
+	}
+}
+
+.editor-push-changes-to-global-styles-modal__arrow {
+	fill: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.editor-push-changes-to-global-styles-modal__value {
+	color: $gray-900;
+	overflow-wrap: anywhere;
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/breakpoints" as *;
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
 
 .editor-push-changes-to-global-styles-control .components-button {
 	justify-content: center;
@@ -17,6 +18,14 @@
 		@media ( max-width: #{ $break-small } ) {
 			overflow-x: auto;
 		}
+	}
+
+	.components-modal__content {
+		padding-bottom: 0;
+	}
+
+	.dataviews-footer {
+		padding-bottom: $grid-unit-30;
 	}
 }
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/breakpoints" as *;
 @use "@wordpress/base-styles/colors" as *;
 
 .editor-push-changes-to-global-styles-control .components-button {
@@ -12,6 +13,10 @@
 .editor-push-changes-to-global-styles-modal {
 	.dataviews-layout__container {
 		overflow-x: hidden;
+
+		@media ( max-width: #{ $break-small } ) {
+			overflow-x: auto;
+		}
 	}
 }
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/style.scss
@@ -15,10 +15,6 @@
 	}
 }
 
-.editor-push-changes-to-global-styles-modal__arrow {
-	fill: var(--wpds-color-foreground-content-neutral-weak);
-}
-
 .editor-push-changes-to-global-styles-modal__value {
 	color: $gray-900;
 	overflow-wrap: anywhere;

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -137,10 +137,10 @@ describe( 'formatSpacingShorthand', () => {
 		).toBe( '1px 2px 3px 4px' );
 	} );
 
-	it( 'shows only the defined sides for a partial object', () => {
+	it( 'keeps all four slots for a partial object so positions stay clear', () => {
 		expect(
 			formatSpacingShorthand( { top: '10px', bottom: '10px' } )
-		).toBe( '10px 10px' );
+		).toBe( `10px ${ EMPTY_VALUE_LABEL } 10px ${ EMPTY_VALUE_LABEL }` );
 	} );
 
 	it( 'humanizes preset spacing tokens without a resolver', () => {

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -1,0 +1,178 @@
+/**
+ * Internal dependencies
+ */
+import {
+	formatStyleValue,
+	formatBorderShorthand,
+	formatBorderRadius,
+	formatSpacingShorthand,
+	EMPTY_VALUE_LABEL,
+} from '../format-style-value';
+
+describe( 'formatStyleValue', () => {
+	it( 'renders a placeholder for empty values', () => {
+		expect( formatStyleValue( undefined ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatStyleValue( null ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatStyleValue( '' ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+
+	it( 'humanizes preset tokens', () => {
+		expect( formatStyleValue( 'var:preset|color|vivid-red' ) ).toBe(
+			'Vivid Red'
+		);
+		expect( formatStyleValue( 'var:preset|font-size|x-large' ) ).toBe(
+			'X Large'
+		);
+	} );
+
+	it( 'passes plain strings through unchanged', () => {
+		expect( formatStyleValue( 'uppercase' ) ).toBe( 'uppercase' );
+		expect( formatStyleValue( '20px' ) ).toBe( '20px' );
+	} );
+
+	it( 'stringifies numbers', () => {
+		expect( formatStyleValue( 1.5 ) ).toBe( '1.5' );
+		expect( formatStyleValue( 0 ) ).toBe( '0' );
+	} );
+
+	it( 'stringifies non-empty objects and falls back for empty ones', () => {
+		expect( formatStyleValue( { top: '1px' } ) ).toBe(
+			JSON.stringify( { top: '1px' } )
+		);
+		expect( formatStyleValue( {} ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatStyleValue( [] ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+} );
+
+describe( 'formatBorderShorthand', () => {
+	it( 'orders parts as width, style, color', () => {
+		expect(
+			formatBorderShorthand( {
+				width: '2px',
+				style: 'dashed',
+				color: '#000fff',
+			} )
+		).toBe( '2px dashed #000fff' );
+	} );
+
+	it( 'omits unset parts', () => {
+		expect(
+			formatBorderShorthand( { style: 'solid', color: '#ff00ff' } )
+		).toBe( 'solid #ff00ff' );
+	} );
+
+	it( 'humanizes preset color tokens', () => {
+		expect(
+			formatBorderShorthand( {
+				width: '1px',
+				style: 'solid',
+				color: 'var:preset|color|vivid-red',
+			} )
+		).toBe( '1px solid Vivid Red' );
+	} );
+
+	it( 'falls back to a placeholder for empty or non-object values', () => {
+		expect( formatBorderShorthand( {} ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatBorderShorthand( undefined ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+} );
+
+describe( 'formatBorderRadius', () => {
+	it( 'passes a string radius through unchanged', () => {
+		expect( formatBorderRadius( '10px' ) ).toBe( '10px' );
+	} );
+
+	it( 'joins a per-corner object in CSS shorthand order', () => {
+		expect(
+			formatBorderRadius( {
+				topLeft: '1px',
+				topRight: '20px',
+				bottomRight: '1px',
+				bottomLeft: '15px',
+			} )
+		).toBe( '1px 20px 1px 15px' );
+	} );
+
+	it( 'falls back to a placeholder for empty values', () => {
+		expect( formatBorderRadius( {} ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatBorderRadius( undefined ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+} );
+
+describe( 'formatSpacingShorthand', () => {
+	it( 'passes a string value through unchanged', () => {
+		expect( formatSpacingShorthand( '10px' ) ).toBe( '10px' );
+	} );
+
+	it( 'collapses a uniform object to a single value', () => {
+		expect(
+			formatSpacingShorthand( {
+				top: '10px',
+				right: '10px',
+				bottom: '10px',
+				left: '10px',
+			} )
+		).toBe( '10px' );
+	} );
+
+	it( 'collapses axial values to a vertical horizontal pair', () => {
+		expect(
+			formatSpacingShorthand( {
+				top: '10px',
+				right: '20px',
+				bottom: '10px',
+				left: '20px',
+			} )
+		).toBe( '10px 20px' );
+	} );
+
+	it( 'lists all four sides when they differ', () => {
+		expect(
+			formatSpacingShorthand( {
+				top: '1px',
+				right: '2px',
+				bottom: '3px',
+				left: '4px',
+			} )
+		).toBe( '1px 2px 3px 4px' );
+	} );
+
+	it( 'shows only the defined sides for a partial object', () => {
+		expect(
+			formatSpacingShorthand( { top: '10px', bottom: '10px' } )
+		).toBe( '10px 10px' );
+	} );
+
+	it( 'humanizes preset spacing tokens without a resolver', () => {
+		expect(
+			formatSpacingShorthand( {
+				top: 'var:preset|spacing|40',
+				right: 'var:preset|spacing|40',
+				bottom: 'var:preset|spacing|40',
+				left: 'var:preset|spacing|40',
+			} )
+		).toBe( '40' );
+	} );
+
+	it( 'resolves preset spacing tokens with a resolver', () => {
+		const resolve = ( value ) =>
+			value === 'var:preset|spacing|40' ? '1.5rem' : value;
+
+		expect(
+			formatSpacingShorthand(
+				{
+					top: 'var:preset|spacing|40',
+					right: '20px',
+					bottom: 'var:preset|spacing|40',
+					left: '20px',
+				},
+				resolve
+			)
+		).toBe( '1.5rem 20px' );
+	} );
+
+	it( 'falls back to a placeholder for empty values', () => {
+		expect( formatSpacingShorthand( {} ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatSpacingShorthand( undefined ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+} );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -76,6 +76,26 @@ describe( 'formatBorderShorthand', () => {
 		expect( formatBorderShorthand( {} ) ).toBe( EMPTY_VALUE_LABEL );
 		expect( formatBorderShorthand( undefined ) ).toBe( EMPTY_VALUE_LABEL );
 	} );
+
+	it( 'collapses a uniform per-side object to its shared values', () => {
+		expect(
+			formatBorderShorthand( {
+				top: { style: 'dotted' },
+				right: { style: 'dotted' },
+				bottom: { style: 'dotted' },
+				left: { style: 'dotted' },
+			} )
+		).toBe( 'dotted' );
+	} );
+
+	it( 'omits a per-side property when the sides disagree', () => {
+		expect(
+			formatBorderShorthand( {
+				top: { style: 'dotted', width: '1px' },
+				right: { style: 'dashed', width: '1px' },
+			} )
+		).toBe( '1px' );
+	} );
 } );
 
 describe( 'formatBorderRadius', () => {

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -6,6 +6,7 @@ import {
 	formatBorderShorthand,
 	formatBorderRadius,
 	formatSpacingShorthand,
+	formatBlockGap,
 	EMPTY_VALUE_LABEL,
 } from '../format-style-value';
 
@@ -174,5 +175,49 @@ describe( 'formatSpacingShorthand', () => {
 	it( 'falls back to a placeholder for empty values', () => {
 		expect( formatSpacingShorthand( {} ) ).toBe( EMPTY_VALUE_LABEL );
 		expect( formatSpacingShorthand( undefined ) ).toBe( EMPTY_VALUE_LABEL );
+	} );
+} );
+
+describe( 'formatBlockGap', () => {
+	it( 'passes a string value through unchanged', () => {
+		expect( formatBlockGap( '10px' ) ).toBe( '10px' );
+	} );
+
+	it( 'collapses matching axes to a single value', () => {
+		expect( formatBlockGap( { top: '10px', left: '10px' } ) ).toBe(
+			'10px'
+		);
+	} );
+
+	it( 'shows differing axes as a row - column pair', () => {
+		expect( formatBlockGap( { top: '10px', left: '20px' } ) ).toBe(
+			'10px - 20px'
+		);
+	} );
+
+	it( 'keeps a placeholder for an unset axis', () => {
+		expect( formatBlockGap( { top: '10px' } ) ).toBe(
+			`10px - ${ EMPTY_VALUE_LABEL }`
+		);
+		expect( formatBlockGap( { left: '20px' } ) ).toBe(
+			`${ EMPTY_VALUE_LABEL } - 20px`
+		);
+	} );
+
+	it( 'resolves preset gap tokens with a resolver', () => {
+		const resolve = ( value ) =>
+			value === 'var:preset|spacing|40' ? '1.5rem' : value;
+
+		expect(
+			formatBlockGap(
+				{ top: 'var:preset|spacing|40', left: '20px' },
+				resolve
+			)
+		).toBe( '1.5rem - 20px' );
+	} );
+
+	it( 'falls back to a placeholder for empty values', () => {
+		expect( formatBlockGap( {} ) ).toBe( EMPTY_VALUE_LABEL );
+		expect( formatBlockGap( undefined ) ).toBe( EMPTY_VALUE_LABEL );
 	} );
 } );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -26,6 +26,21 @@ describe( 'formatStyleValue', () => {
 		);
 	} );
 
+	it( 'humanizes preset CSS custom property values', () => {
+		expect(
+			formatStyleValue( 'var(--wp--preset--color--vivid-red)' )
+		).toBe( 'Vivid Red' );
+		expect(
+			formatStyleValue( 'var(--wp--preset--font-size--x-large)' )
+		).toBe( 'X Large' );
+	} );
+
+	it( 'humanizes preset CSS custom property values with a fallback', () => {
+		expect(
+			formatStyleValue( 'var(--wp--preset--color--vivid-red, #cf2e2e)' )
+		).toBe( 'Vivid Red' );
+	} );
+
 	it( 'passes plain strings through unchanged', () => {
 		expect( formatStyleValue( 'uppercase' ) ).toBe( 'uppercase' );
 		expect( formatStyleValue( '20px' ) ).toBe( '20px' );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
@@ -1,0 +1,321 @@
+/**
+ * Internal dependencies
+ */
+import { getChangesToPush, getStylesUpdate } from '../index';
+
+describe( 'getChangesToPush', () => {
+	it( 'groups an all-sides border into a single shorthand row', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor' ],
+			{ style: { border: { color: '#ff0000' } } },
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+
+		const [ row ] = rows;
+		expect( row.id ).toBe( 'border' );
+		expect( row.primaryPath ).toEqual( [ 'border' ] );
+		expect( row.format ).toBe( 'border' );
+		expect( row.newValue ).toEqual( {
+			color: '#ff0000',
+			width: undefined,
+			style: 'solid',
+		} );
+
+		// Shorthand entry + four per-side longhands + four `solid` fallbacks.
+		expect( row.paths ).toHaveLength( 9 );
+		expect( row.paths ).toContainEqual( {
+			path: [ 'border', 'color' ],
+			value: '#ff0000',
+		} );
+		expect( row.paths ).toContainEqual( {
+			path: [ 'border', 'top', 'color' ],
+			value: '#ff0000',
+		} );
+		expect( row.paths ).toContainEqual( {
+			path: [ 'border', 'left', 'style' ],
+			value: 'solid',
+		} );
+	} );
+
+	it( 'groups a per-side border into its own shorthand row', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor', 'borderWidth', 'borderStyle' ],
+			{
+				style: {
+					border: {
+						left: {
+							color: '#000fff',
+							width: '2px',
+							style: 'dashed',
+						},
+					},
+				},
+			},
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+
+		const [ row ] = rows;
+		expect( row.id ).toBe( 'border.left' );
+		expect( row.primaryPath ).toEqual( [ 'border', 'left' ] );
+		expect( row.format ).toBe( 'border' );
+		expect( row.newValue ).toEqual( {
+			color: '#000fff',
+			width: '2px',
+			style: 'dashed',
+		} );
+
+		// A per-side row does not write the shorthand entry, only the side.
+		expect( row.paths ).toEqual( [
+			{ path: [ 'border', 'left', 'color' ], value: '#000fff' },
+			{ path: [ 'border', 'left', 'width' ], value: '2px' },
+			{ path: [ 'border', 'left', 'style' ], value: 'dashed' },
+		] );
+	} );
+
+	it( 'adds a solid style fallback for a per-side border without a style', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor' ],
+			{ style: { border: { top: { color: '#00ff00' } } } },
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+
+		const [ row ] = rows;
+		expect( row.id ).toBe( 'border.top' );
+		expect( row.newValue.style ).toBe( 'solid' );
+		expect( row.paths ).toEqual( [
+			{ path: [ 'border', 'top', 'color' ], value: '#00ff00' },
+			{ path: [ 'border', 'top', 'style' ], value: 'solid' },
+		] );
+	} );
+
+	it( 'does not override a border style already set in Global Styles', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor' ],
+			{ style: { border: { color: '#ff0000' } } },
+			{ border: { top: { style: 'dotted' } } }
+		);
+
+		const [ row ] = rows;
+		// The top side keeps the user's dotted style (no `solid` fallback),
+		// while the other three sides still get the fallback.
+		expect( row.paths ).not.toContainEqual( {
+			path: [ 'border', 'top', 'style' ],
+			value: 'solid',
+		} );
+		expect( row.paths ).toContainEqual( {
+			path: [ 'border', 'right', 'style' ],
+			value: 'solid',
+		} );
+	} );
+
+	it( 'emits a border radius row with the raw value', () => {
+		const radius = {
+			topLeft: '1px',
+			topRight: '20px',
+			bottomRight: '1px',
+			bottomLeft: '15px',
+		};
+		const rows = getChangesToPush(
+			[ 'borderRadius' ],
+			{ style: { border: { radius } } },
+			undefined
+		);
+
+		expect( rows ).toEqual( [
+			{
+				id: 'border.radius',
+				primaryPath: [ 'border', 'radius' ],
+				paths: [ { path: [ 'border', 'radius' ], value: radius } ],
+				presetAttributes: [],
+				newValue: radius,
+				format: 'borderRadius',
+			},
+		] );
+	} );
+
+	it( 'tracks the preset attribute for a preset border color', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor' ],
+			{ borderColor: 'vivid-red', style: {} },
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+
+		const [ row ] = rows;
+		expect( row.id ).toBe( 'border' );
+		expect( row.presetAttributes ).toEqual( [ 'borderColor' ] );
+		expect( row.newValue.color ).toBe( 'var:preset|color|vivid-red' );
+		expect( row.paths ).toContainEqual( {
+			path: [ 'border', 'color' ],
+			value: 'var:preset|color|vivid-red',
+		} );
+	} );
+
+	it( 'emits one row per simple style change', () => {
+		const rows = getChangesToPush(
+			[ 'textTransform' ],
+			{ style: { typography: { textTransform: 'uppercase' } } },
+			undefined
+		);
+
+		expect( rows ).toEqual( [
+			{
+				id: 'typography.textTransform',
+				primaryPath: [ 'typography', 'textTransform' ],
+				paths: [
+					{
+						path: [ 'typography', 'textTransform' ],
+						value: 'uppercase',
+					},
+				],
+				presetAttributes: [],
+				newValue: 'uppercase',
+			},
+		] );
+	} );
+
+	it( 'ignores supports without a set value', () => {
+		expect(
+			getChangesToPush( [ 'textTransform' ], { style: {} }, undefined )
+		).toEqual( [] );
+	} );
+
+	it( 'emits a single spacing row tagged for shorthand formatting', () => {
+		const padding = {
+			top: '10px',
+			right: '20px',
+			bottom: '10px',
+			left: '20px',
+		};
+		const rows = getChangesToPush(
+			[ 'padding' ],
+			{ style: { spacing: { padding } } },
+			undefined
+		);
+
+		expect( rows ).toEqual( [
+			{
+				id: 'spacing.padding',
+				primaryPath: [ 'spacing', 'padding' ],
+				paths: [ { path: [ 'spacing', 'padding' ], value: padding } ],
+				presetAttributes: [],
+				newValue: padding,
+				format: 'spacing',
+			},
+		] );
+	} );
+
+	it( 'skips root-only style properties that duplicate padding', () => {
+		const padding = { top: '10px', bottom: '10px' };
+		const rows = getChangesToPush(
+			// Both keys map to `spacing.padding`; the root-only one must be
+			// skipped so padding is not listed twice.
+			[ 'padding', '--wp--style--root--padding' ],
+			{ style: { spacing: { padding } } },
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+		expect( rows[ 0 ].id ).toBe( 'spacing.padding' );
+	} );
+
+	it( 'tracks preset attributes for preset-backed changes', () => {
+		const rows = getChangesToPush(
+			[ 'backgroundColor' ],
+			{ backgroundColor: 'vivid-red', style: {} },
+			undefined
+		);
+
+		expect( rows ).toHaveLength( 1 );
+		expect( rows[ 0 ].newValue ).toBe( 'var:preset|color|vivid-red' );
+		expect( rows[ 0 ].presetAttributes ).toEqual( [ 'backgroundColor' ] );
+	} );
+} );
+
+describe( 'getStylesUpdate', () => {
+	it( 'returns null when there is nothing to push', () => {
+		expect(
+			getStylesUpdate( {
+				rowsToPush: [],
+				attributes: { style: {} },
+				userConfig: {},
+				name: 'core/heading',
+			} )
+		).toBeNull();
+
+		expect(
+			getStylesUpdate( {
+				rowsToPush: [ { paths: [], presetAttributes: [] } ],
+				attributes: { style: {} },
+				userConfig: {},
+				name: 'core/heading',
+			} )
+		).toBeNull();
+	} );
+
+	it( 'clears the pushed style from the block and writes it to Global Styles', () => {
+		const update = getStylesUpdate( {
+			rowsToPush: [
+				{
+					paths: [
+						{
+							path: [ 'typography', 'textTransform' ],
+							value: 'uppercase',
+						},
+					],
+					presetAttributes: [],
+				},
+			],
+			attributes: {
+				style: { typography: { textTransform: 'uppercase' } },
+			},
+			userConfig: {},
+			name: 'core/heading',
+		} );
+
+		expect( update.newBlockAttributes.style ).toBeUndefined();
+		expect(
+			update.newUserConfig.styles.blocks[ 'core/heading' ].typography
+				.textTransform
+		).toBe( 'uppercase' );
+	} );
+
+	it( 'only clears preset attributes belonging to the pushed rows', () => {
+		const update = getStylesUpdate( {
+			rowsToPush: [
+				{
+					paths: [
+						{
+							path: [ 'color', 'background' ],
+							value: 'var:preset|color|vivid-red',
+						},
+					],
+					presetAttributes: [ 'backgroundColor' ],
+				},
+			],
+			attributes: {
+				backgroundColor: 'vivid-red',
+				textColor: 'black',
+				style: {},
+			},
+			userConfig: {},
+			name: 'core/heading',
+		} );
+
+		// The pushed preset attribute is cleared from the block.
+		expect( update.newBlockAttributes.backgroundColor ).toBeUndefined();
+		// The deselected preset attribute is left untouched (not wiped).
+		expect( update.newBlockAttributes ).not.toHaveProperty( 'textColor' );
+		expect(
+			update.newUserConfig.styles.blocks[ 'core/heading' ].color
+				.background
+		).toBe( 'var:preset|color|vivid-red' );
+	} );
+} );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
@@ -114,6 +114,29 @@ describe( 'getChangesToPush', () => {
 		} );
 	} );
 
+	it( 'keeps a uniform Global Styles border style as the new value', () => {
+		const rows = getChangesToPush(
+			[ 'borderColor' ],
+			{ style: { border: { color: '#ff9900' } } },
+			{
+				border: {
+					top: { style: 'dotted' },
+					right: { style: 'dotted' },
+					bottom: { style: 'dotted' },
+					left: { style: 'dotted' },
+				},
+			}
+		);
+
+		const [ row ] = rows;
+		// Every side already has `dotted` in Global Styles, so the border keeps
+		// it after Apply instead of falling back to `solid`.
+		expect( row.newValue.style ).toBe( 'dotted' );
+		expect( row.paths ).not.toContainEqual(
+			expect.objectContaining( { value: 'solid' } )
+		);
+	} );
+
 	it( 'emits a border radius row with the raw value', () => {
 		const radius = {
 			topLeft: '1px',

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
@@ -23,7 +23,7 @@ describe( 'getChangesToPush', () => {
 			style: 'solid',
 		} );
 
-		// Shorthand entry + four per-side longhands + four `solid` fallbacks.
+		// All-sides value + four per-side values + four `solid` fallbacks.
 		expect( row.paths ).toHaveLength( 9 );
 		expect( row.paths ).toContainEqual( {
 			path: [ 'border', 'color' ],
@@ -68,7 +68,7 @@ describe( 'getChangesToPush', () => {
 			style: 'dashed',
 		} );
 
-		// A per-side row does not write the shorthand entry, only the side.
+		// A per-side row writes only that side, not the all-sides value.
 		expect( row.paths ).toEqual( [
 			{ path: [ 'border', 'left', 'color' ], value: '#000fff' },
 			{ path: [ 'border', 'left', 'width' ], value: '2px' },
@@ -102,8 +102,8 @@ describe( 'getChangesToPush', () => {
 		);
 
 		const [ row ] = rows;
-		// The top side keeps the user's dotted style (no `solid` fallback),
-		// while the other three sides still get the fallback.
+		// The top side keeps its dotted style (no `solid` fallback); the other
+		// three sides still get the fallback.
 		expect( row.paths ).not.toContainEqual( {
 			path: [ 'border', 'top', 'style' ],
 			value: 'solid',
@@ -215,8 +215,8 @@ describe( 'getChangesToPush', () => {
 	it( 'skips root-only style properties that duplicate padding', () => {
 		const padding = { top: '10px', bottom: '10px' };
 		const rows = getChangesToPush(
-			// Both keys map to `spacing.padding`; the root-only one must be
-			// skipped so padding is not listed twice.
+			// Both keys map to `spacing.padding`, so the root-only one is
+			// skipped to avoid listing padding twice.
 			[ 'padding', '--wp--style--root--padding' ],
 			{ style: { spacing: { padding } } },
 			undefined
@@ -311,7 +311,7 @@ describe( 'getStylesUpdate', () => {
 
 		// The pushed preset attribute is cleared from the block.
 		expect( update.newBlockAttributes.backgroundColor ).toBeUndefined();
-		// The deselected preset attribute is left untouched (not wiped).
+		// The unselected preset attribute is left alone.
 		expect( update.newBlockAttributes ).not.toHaveProperty( 'textColor' );
 		expect(
 			update.newUserConfig.styles.blocks[ 'core/heading' ].color

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/style-labels.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/style-labels.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { capitalCase } from 'change-case';
+
+/**
+ * Internal dependencies
+ */
+import { getStyleLabel, STYLE_LABELS } from '../style-labels';
+
+describe( 'getStyleLabel', () => {
+	it( 'returns the authored label for a mapped path', () => {
+		expect( getStyleLabel( [ 'color', 'background' ] ) ).toBe(
+			STYLE_LABELS[ 'color.background' ]
+		);
+		expect( getStyleLabel( [ 'typography', 'textTransform' ] ) ).toBe(
+			'Letter case'
+		);
+		expect( getStyleLabel( [ 'border', 'color' ] ) ).toBe( 'Border color' );
+		expect( getStyleLabel( [ 'border' ] ) ).toBe( 'Border' );
+		expect( getStyleLabel( [ 'border', 'left' ] ) ).toBe( 'Border left' );
+	} );
+
+	it( 'humanizes the last segment when the path is unmapped', () => {
+		expect( getStyleLabel( [ 'some', 'unknownProperty' ] ) ).toBe(
+			capitalCase( 'unknownProperty' )
+		);
+	} );
+
+	it( 'returns an empty string for an empty path', () => {
+		expect( getStyleLabel( [] ) ).toBe( '' );
+	} );
+} );

--- a/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import {
+	getStyle,
+	getValueFromVariable,
+} from '@wordpress/global-styles-engine';
+
+/**
+ * Internal dependencies
+ */
+import { getStyleLabel } from './style-labels';
+import {
+	formatStyleValue,
+	formatBorderShorthand,
+	formatBorderRadius,
+	formatSpacingShorthand,
+} from './format-style-value';
+
+/**
+ * Formats a raw style value for display, using the row's `format` hint so
+ * border scopes render as CSS shorthands rather than raw objects.
+ *
+ * @param {string}   format  Optional format hint (`border`, `borderRadius`,
+ *                           `spacing`).
+ * @param {*}        value   The raw style value.
+ * @param {Function} resolve Resolver for preset tokens (used for spacing).
+ *
+ * @return {string} A human-friendly representation of the value.
+ */
+function formatReviewValue( format, value, resolve ) {
+	if ( format === 'border' ) {
+		return formatBorderShorthand( value );
+	}
+	if ( format === 'borderRadius' ) {
+		return formatBorderRadius( value );
+	}
+	if ( format === 'spacing' ) {
+		return formatSpacingShorthand( value, resolve );
+	}
+	return formatStyleValue( value );
+}
+
+/**
+ * Enriches grouped change rows with a human-readable label and the current
+ * effective Global Styles value for the block type, plus display-formatted
+ * versions of the current and new values.
+ *
+ * @param {Array}  rows   Grouped rows from `useChangesToPush`.
+ * @param {Object} merged Merged Global Styles config.
+ * @param {string} name   Block name.
+ *
+ * @return {Array} Rows extended with `label`, `currentValue`,
+ *                 `formattedCurrentValue`, and `formattedNewValue`.
+ */
+export function useReviewRows( rows, merged, name ) {
+	return useMemo( () => {
+		// Resolves preset tokens (e.g. `var:preset|spacing|40`) to their actual
+		// values so spacing reads as a real size rather than a preset slug.
+		const resolve = ( value ) =>
+			getValueFromVariable( merged, name, value );
+
+		return rows.map( ( row ) => {
+			const currentValue = getStyle(
+				merged,
+				row.primaryPath.join( '.' ),
+				name
+			);
+			return {
+				...row,
+				label: getStyleLabel( row.primaryPath ),
+				currentValue,
+				formattedCurrentValue: formatReviewValue(
+					row.format,
+					currentValue,
+					resolve
+				),
+				formattedNewValue: formatReviewValue(
+					row.format,
+					row.newValue,
+					resolve
+				),
+			};
+		} );
+	}, [ rows, merged, name ] );
+}

--- a/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
@@ -65,7 +65,10 @@ export function useReviewRows( rows, merged, name ) {
 			const currentValue = getStyle(
 				merged,
 				row.primaryPath.join( '.' ),
-				name
+				name,
+				// Keep preset values encoded (e.g. `var:preset|color|vivid-red`)
+				// so they show by name, matching the new value.
+				false
 			);
 			return {
 				...row,

--- a/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
@@ -16,6 +16,7 @@ import {
 	formatBorderShorthand,
 	formatBorderRadius,
 	formatSpacingShorthand,
+	formatBlockGap,
 } from './format-style-value';
 
 /**
@@ -23,7 +24,7 @@ import {
  * borders and spacing show as a single CSS value instead of a raw object.
  *
  * @param {string}   format  Optional format hint (`border`, `borderRadius`,
- *                           `spacing`).
+ *                           `spacing`, `blockGap`).
  * @param {*}        value   The raw style value.
  * @param {Function} resolve Callback to resolve preset values (used for spacing).
  *
@@ -38,6 +39,9 @@ function formatReviewValue( format, value, resolve ) {
 	}
 	if ( format === 'spacing' ) {
 		return formatSpacingShorthand( value, resolve );
+	}
+	if ( format === 'blockGap' ) {
+		return formatBlockGap( value, resolve );
 	}
 	return formatStyleValue( value );
 }

--- a/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/use-review-rows.js
@@ -19,15 +19,15 @@ import {
 } from './format-style-value';
 
 /**
- * Formats a raw style value for display, using the row's `format` hint so
- * border scopes render as CSS shorthands rather than raw objects.
+ * Turns a raw style value into readable text, using the row's `format` hint so
+ * borders and spacing show as a single CSS value instead of a raw object.
  *
  * @param {string}   format  Optional format hint (`border`, `borderRadius`,
  *                           `spacing`).
  * @param {*}        value   The raw style value.
- * @param {Function} resolve Resolver for preset tokens (used for spacing).
+ * @param {Function} resolve Callback to resolve preset values (used for spacing).
  *
- * @return {string} A human-friendly representation of the value.
+ * @return {string} Readable text for the value.
  */
 function formatReviewValue( format, value, resolve ) {
 	if ( format === 'border' ) {
@@ -43,21 +43,21 @@ function formatReviewValue( format, value, resolve ) {
 }
 
 /**
- * Enriches grouped change rows with a human-readable label and the current
- * effective Global Styles value for the block type, plus display-formatted
- * versions of the current and new values.
+ * Adds display details to each change row: a readable label, the block type's
+ * current Global Styles value, and readable versions of the current and new
+ * values.
  *
  * @param {Array}  rows   Grouped rows from `useChangesToPush`.
  * @param {Object} merged Merged Global Styles config.
  * @param {string} name   Block name.
  *
- * @return {Array} Rows extended with `label`, `currentValue`,
- *                 `formattedCurrentValue`, and `formattedNewValue`.
+ * @return {Array} Rows with `label`, `currentValue`, `formattedCurrentValue`
+ *                 and `formattedNewValue` added.
  */
 export function useReviewRows( rows, merged, name ) {
 	return useMemo( () => {
-		// Resolves preset tokens (e.g. `var:preset|spacing|40`) to their actual
-		// values so spacing reads as a real size rather than a preset slug.
+		// Swaps preset values (e.g. `var:preset|spacing|40`) for their real
+		// size so spacing reads as a size rather than a preset name.
 		const resolve = ( value ) =>
 			getValueFromVariable( merged, name, value );
 

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -20,40 +20,39 @@ test.describe( 'Push to Global Styles button', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'should apply Heading block styles to all Heading blocks', async ( {
-		page,
-		editor,
-	} ) => {
+	/**
+	 * Returns the review-modal row (a listbox option) for a given style label.
+	 * The row toggles selection on click and reflects it via `aria-selected`.
+	 *
+	 * @param {Object} modal Playwright locator for the review modal.
+	 * @param {string} label Style label, e.g. 'Letter case'.
+	 *
+	 * @return {Object} Playwright locator for the matching row.
+	 */
+	function styleRow( modal, label ) {
+		return modal.getByRole( 'option' ).filter( { hasText: label } );
+	}
+
+	/**
+	 * Adds a Heading block, navigates to its Advanced panel and enables the
+	 * Letter case typography option so that there is a pushable change.
+	 *
+	 * @param {Object} options        Playwright fixtures.
+	 * @param {Object} options.page   Playwright page.
+	 * @param {Object} options.editor Editor utilities.
+	 */
+	async function setupHeadingWithUppercase( { page, editor } ) {
 		// Add a Heading block.
 		await editor.insertBlock( { name: 'core/heading' } );
 		await page.keyboard.type( 'A heading' );
 
-		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
-		const settingsPanel = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-
-		// Navigate to Styles -> Blocks -> Heading -> Typography
-		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
-		await settingsPanel.getByRole( 'button', { name: 'Blocks' } ).click();
-		await settingsPanel
-			.getByRole( 'button', { name: 'Heading', exact: true } )
-			.click();
-
-		// Headings should not have uppercase
-		await expect(
-			page.getByRole( 'button', { name: 'Uppercase' } )
-		).toHaveAttribute( 'aria-pressed', 'false' );
-
-		// Go to block settings and open the Advanced panel
-		await topBar.getByRole( 'button', { name: 'Settings' } ).click();
+		// Go to block settings and open the Advanced panel.
+		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Advanced' } ).click();
 
-		// Push button should be disabled
+		// Push button should be disabled with no changes.
 		await expect(
-			page.getByRole( 'button', {
-				name: 'Apply globally',
-			} )
+			page.getByRole( 'button', { name: 'Apply globally' } )
 		).toBeDisabled();
 
 		// Enable letter case.
@@ -66,20 +65,51 @@ test.describe( 'Push to Global Styles button', () => {
 			.click();
 		await typographyOptions.click();
 
-		// Make the Heading block uppercase
+		// Make the Heading block uppercase.
 		await page.getByRole( 'button', { name: 'Uppercase' } ).click();
 
-		// Push button should now be enabled
+		// Push button should now be enabled.
 		await expect(
-			page.getByRole( 'button', {
-				name: 'Apply globally',
-			} )
+			page.getByRole( 'button', { name: 'Apply globally' } )
 		).toBeEnabled();
+	}
 
-		// Press the Push button
+	test( 'should apply Heading block styles to all Heading blocks', async ( {
+		page,
+		editor,
+	} ) => {
+		const settingsPanel = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		await setupHeadingWithUppercase( { page, editor } );
+
+		// Open the review modal.
 		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
 
-		// Snackbar notification should appear
+		// The modal should be titled after the block and show the lead text.
+		const modal = page.getByRole( 'dialog', {
+			name: 'Apply Heading styles globally',
+		} );
+		await expect( modal ).toBeVisible();
+		await expect(
+			modal.getByText(
+				'Choose which styles to make default for all Heading blocks.'
+			)
+		).toBeVisible();
+
+		// The Letter case row is listed and selected by default.
+		const letterCase = styleRow( modal, 'Letter case' );
+		await expect( letterCase ).toBeVisible();
+		await expect( letterCase ).toHaveAttribute( 'aria-selected', 'true' );
+
+		// Confirm the push.
+		await modal
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
+		await expect( modal ).toBeHidden();
+
+		// Snackbar notification should appear.
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Dismiss this notice',
@@ -87,14 +117,12 @@ test.describe( 'Push to Global Styles button', () => {
 			} )
 		).toBeVisible();
 
-		// Push button should be disabled again
+		// Push button should be disabled again.
 		await expect(
-			page.getByRole( 'button', {
-				name: 'Apply globally',
-			} )
+			page.getByRole( 'button', { name: 'Apply globally' } )
 		).toBeDisabled();
 
-		// Navigate again to Styles -> Blocks -> Heading -> Typography
+		// Navigate to Styles -> Blocks -> Heading -> Typography.
 		await page
 			.getByRole( 'button', { name: 'Styles', exact: true } )
 			.click();
@@ -103,9 +131,128 @@ test.describe( 'Push to Global Styles button', () => {
 			.getByRole( 'button', { name: 'Heading', exact: true } )
 			.click();
 
-		// Headings should now have uppercase
+		// Headings should now have uppercase.
 		await expect(
 			page.getByRole( 'button', { name: 'Uppercase' } )
 		).toHaveAttribute( 'aria-pressed', 'true' );
+	} );
+
+	test( 'should push only the selected subset of styles', async ( {
+		page,
+		editor,
+	} ) => {
+		await setupHeadingWithUppercase( { page, editor } );
+
+		// Enable and set a letter spacing so there is a second pushable change.
+		const typographyOptions = page.getByRole( 'button', {
+			name: 'Typography options',
+		} );
+		await typographyOptions.click();
+		await page
+			.getByRole( 'menuitemcheckbox', { name: 'Letter spacing' } )
+			.click();
+		await typographyOptions.click();
+		await page
+			.getByRole( 'spinbutton', { name: 'Letter spacing' } )
+			.fill( '2' );
+
+		// Open the modal; both styles should be listed.
+		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
+		const modal = page.getByRole( 'dialog', {
+			name: 'Apply Heading styles globally',
+		} );
+		await expect( styleRow( modal, 'Letter case' ) ).toBeVisible();
+		await expect( styleRow( modal, 'Letter spacing' ) ).toBeVisible();
+
+		// Deselect Letter case so only Letter spacing is pushed.
+		const letterCase = styleRow( modal, 'Letter case' );
+		await letterCase.click();
+		await expect( letterCase ).toHaveAttribute( 'aria-selected', 'false' );
+		await modal
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
+		await expect( modal ).toBeHidden();
+
+		// Snackbar notification should appear for the pushed subset.
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Dismiss this notice',
+				text: 'Heading styles applied.',
+			} )
+		).toBeVisible();
+
+		// Letter case remains a local override, so a change is still pending.
+		await expect(
+			page.getByRole( 'button', { name: 'Apply globally' } )
+		).toBeEnabled();
+
+		// Reopening the modal should now list only the unpushed Letter case.
+		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
+		await expect( styleRow( modal, 'Letter case' ) ).toBeVisible();
+		await expect( styleRow( modal, 'Letter spacing' ) ).toBeHidden();
+		await modal.getByRole( 'button', { name: 'Close' } ).click();
+	} );
+
+	test( 'should disable Apply when no styles are selected', async ( {
+		page,
+		editor,
+	} ) => {
+		await setupHeadingWithUppercase( { page, editor } );
+
+		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
+		const modal = page.getByRole( 'dialog', {
+			name: 'Apply Heading styles globally',
+		} );
+
+		// Deselect the only row; Apply becomes disabled.
+		const letterCase = styleRow( modal, 'Letter case' );
+		await letterCase.click();
+		await expect( letterCase ).toHaveAttribute( 'aria-selected', 'false' );
+		await expect(
+			modal.getByRole( 'button', { name: 'Apply', exact: true } )
+		).toBeDisabled();
+
+		// Closing the modal makes no changes.
+		await modal.getByRole( 'button', { name: 'Close' } ).click();
+		await expect( modal ).toBeHidden();
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Dismiss this notice',
+				text: 'Heading styles applied.',
+			} )
+		).toBeHidden();
+
+		// The change is still pending because nothing was pushed.
+		await expect(
+			page.getByRole( 'button', { name: 'Apply globally' } )
+		).toBeEnabled();
+	} );
+
+	test( 'should make no changes when the modal is dismissed', async ( {
+		page,
+		editor,
+	} ) => {
+		await setupHeadingWithUppercase( { page, editor } );
+
+		await page.getByRole( 'button', { name: 'Apply globally' } ).click();
+		const modal = page.getByRole( 'dialog', {
+			name: 'Apply Heading styles globally',
+		} );
+		await expect( modal ).toBeVisible();
+
+		// Dismiss without applying.
+		await modal.getByRole( 'button', { name: 'Close' } ).click();
+		await expect( modal ).toBeHidden();
+
+		// No snackbar, and the change remains pending.
+		await expect(
+			page.getByRole( 'button', {
+				name: 'Dismiss this notice',
+				text: 'Heading styles applied.',
+			} )
+		).toBeHidden();
+		await expect(
+			page.getByRole( 'button', { name: 'Apply globally' } )
+		).toBeEnabled();
 	} );
 } );

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -21,8 +21,8 @@ test.describe( 'Push to Global Styles button', () => {
 	} );
 
 	/**
-	 * Returns the review-modal row (a listbox option) for a given style label.
-	 * The row toggles selection on click and reflects it via `aria-selected`.
+	 * Returns the modal row (a listbox option) for a style label. Clicking the
+	 * row toggles its selection, shown by `aria-selected`.
 	 *
 	 * @param {Object} modal Playwright locator for the review modal.
 	 * @param {string} label Style label, e.g. 'Letter case'.
@@ -34,8 +34,8 @@ test.describe( 'Push to Global Styles button', () => {
 	}
 
 	/**
-	 * Adds a Heading block, navigates to its Advanced panel and enables the
-	 * Letter case typography option so that there is a pushable change.
+	 * Adds a Heading block, opens its Advanced panel and turns on Letter case
+	 * so there's a change to push.
 	 *
 	 * @param {Object} options        Playwright fixtures.
 	 * @param {Object} options.page   Playwright page.
@@ -181,7 +181,7 @@ test.describe( 'Push to Global Styles button', () => {
 			} )
 		).toBeVisible();
 
-		// Letter case remains a local override, so a change is still pending.
+		// Letter case is still only set on the block, so there's a change to push.
 		await expect(
 			page.getByRole( 'button', { name: 'Apply globally' } )
 		).toBeEnabled();


### PR DESCRIPTION
## What?

Alternative to: https://github.com/WordPress/gutenberg/pull/79719

Adds a review step to the block inspector's **Apply globally** action. Instead of immediately pushing every changed style to Global Styles, the button now opens a modal listing each modified style with its current and new value, and only the styles you keep selected are applied.

## Why?

Today the button is all-or-nothing: a single click writes _every_ detected change into Global Styles for that block type, with no chance to see what will change or leave some of it behind. Surfacing the changes as a pre-selected checklist makes the action reviewable and lets you push just the styles you mean to.

## How?

- Reworks `useChangesToPush` to return grouped **rows** rather than a flat list of paths, so border shorthand, its per-side values, and `solid` fallbacks collapse into a single "Border color" row that pushes together.
- Adds a `useReviewRows` hook that decorates each row with a readable label, the effective current Global Styles value for the block type, and formatted current/new values.
- Makes `pushChanges` accept a selected subset and clears preset attributes (`textColor`, `backgroundColor`, `borderColor`, etc.) **conditionally**, so a deselected preset style is neither pushed nor wiped from the block. Early-returns on an empty subset; the existing Undo snackbar is untouched.
- Adds a `style-labels` map (with a `capitalCase` fallback) and a `format-style-value` util that resolves preset tokens to readable slugs and collapses spacing/border/radius objects to CSS shorthand.
- Adds an `ApplyGloballyModal` (using `DataViewsPicker`) with a selection checkbox, style name, current value, a subdued arrow, and the new value. All rows selected by default; **Apply** is disabled with nothing selected; Cancel/close/Escape do nothing.

_Note: The tricky bits — row grouping and the conditional preset clearing — are pulled out into pure `getChangesToPush()`/`getStylesUpdate()` helpers and unit tested directly._

_Note: The "current" value shown is the merged/effective Global Styles value for the block type, i.e. what the block currently resolves to._

## Testing Instructions

1. Add a **Paragraph** to a post and open **Advanced** in the block inspector.
2. Change a few styles on the block, e.g. uppercase text, a text colour, some padding, and a border colour.
3. Click **Apply globally** and confirm the modal lists one row per style with current → new values, all checked.
4. Deselect a row and click **Apply**. Confirm only the checked styles are pushed, the snackbar appears, and **Undo** restores the prior state. The deselected style stays as a local override.
5. Reopen the modal and confirm the still-unpushed style is the only row listed.
6. Deselect every row and confirm **Apply** is disabled.
7. Reopen and dismiss with Cancel/close/Escape, and confirm nothing changes on the block or in Global Styles.
8. Confirm the **Apply globally** button is disabled when there are no changes to push.

## Screenshots or screencast <!-- if applicable -->


<img width="984" height="596" alt="Screenshot 2026-07-13 at 10 44 03 pm" src="https://github.com/user-attachments/assets/1657875e-8bf0-4a26-8048-e98c22199774" />

https://github.com/user-attachments/assets/f4b2c4d8-4fa1-4b93-a11e-a6a5a6dd4cb2

