### PR TITLE
Accordion block: add background gradient support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -25,7 +25,7 @@ Displays a foldable layout that groups content in collapsible sections.
 -	**Name:** [core/accordion](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/core-block-accordion/)
 -	**Category:** [design](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/)
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize, gradient), color (background, gradients, text), contentRole, interactivity, layout, listView, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/src/accordion/README.md
+++ b/packages/block-library/src/accordion/README.md
@@ -35,6 +35,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):
   - `backgroundImage`: `true`
   - `backgroundSize`: `true`
+  - `gradient`: `true`
 - [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
   - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-background): `true`
   - [`gradients`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-gradients): `true`

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -13,6 +13,7 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
 				"backgroundImage": true
 			}


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75859

Adds `background.gradient` support to the Accordion block so background gradients are handled by the background support path when used with background images.

This also updates the generated block docs.

## Why?

The Accordion block already supported background images through `supports.background.backgroundImage`, but gradients were still only declared through legacy `supports.color.gradients`. That meant the gradient was serialized as `background: ...` while the image was serialized as `background-image: ...`, causing the image declaration to override the gradient.

With `supports.background.gradient` enabled, the editor writes the gradient to `style.background.gradient`, and the background support code emits a single combined declaration:

```css
background-image: linear-gradient(...), url(...);
```

The gradient control keeps its current default visibility: the Accordion block does not define `color.__experimentalDefaultControls`, so the gradient control is not shown by default and no `gradient` key is added to `background.__experimentalDefaultControls`.

## Testing Instructions

Playground link: https://playground.wordpress.net/gutenberg.html?pr=79840

1. Upload your favourite image.
2. Open the post editor and insert an Accordion block.
3. Select the Accordion block and open the block Styles panel.
4. In Background, set a gradient (open the options menu if it is not shown by default).
5. In Background, set a background image using your favourite image.
6. Save the post.
7. View the post on the frontend and inspect the Accordion block markup in dev tools.
8. Confirm the Accordion block has one combined `background-image` declaration containing both the gradient and image, for example:
   ```css
   background-image: linear-gradient(...), url(...);
   ```
9. Confirm the Accordion block does not output the old conflicting pair:
   ```css
   background: linear-gradient(...);
   background-image: url(...);
   ```

For regressions:

1. Open a post containing existing Accordion blocks created before this change, including blocks with existing color/gradient styles.
2. Confirm those blocks still render correctly in the editor and frontend, with no validation errors and no visual regression.


https://github.com/user-attachments/assets/ece4b768-1c14-4506-b201-98db0f629945



