### PR TITLE
Pullquote block: add background gradient support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -807,7 +807,7 @@ Give special visual emphasis to a quote from your text.
 
 -	**Name:** [core/pullquote](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-pullquote/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
+-	**Supports:** align (full, left, right, wide), anchor, background (backgroundImage, backgroundSize, gradient), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign)
 -	**Attributes:** citation, value
 
 ## Query Loop

--- a/packages/block-library/src/pullquote/README.md
+++ b/packages/block-library/src/pullquote/README.md
@@ -26,6 +26,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):
   - `backgroundImage`: `true`
   - `backgroundSize`: `true`
+  - `gradient`: `true`
 - [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
   - [`gradients`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-gradients): `true`
   - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-background): `true`

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -26,8 +26,10 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
-				"backgroundImage": true
+				"backgroundImage": true,
+				"gradient": true
 			}
 		},
 		"color": {


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75859

Adds `background.gradient` support to the Pullquote block so background gradients are handled by the background support path when used with background images.

This also updates the generated block docs.

## Why?

The Pullquote block already supported background images through `supports.background.backgroundImage`, but gradients were still only declared through legacy `supports.color.gradients`. That meant the gradient was serialized as `background: ...` while the image was serialized as `background-image: ...`, causing the image declaration to override the gradient.

With `supports.background.gradient` enabled, the editor writes the gradient to `style.background.gradient`, and the background support code emits a single combined declaration:

```css
background-image: linear-gradient(...), url(...);
```

The gradient control keeps its current default visibility: Pullquote has `color.__experimentalDefaultControls.background: true`, so the gradient control was already shown by default and `gradient: true` is added to `background.__experimentalDefaultControls` to preserve that.

## Testing Instructions

Playground link: https://playground.wordpress.net/gutenberg.html?pr=79841

1. Upload your favourite image.
2. Open the post editor and insert a Pullquote block.
3. Select the Pullquote block and open the block Styles panel.
4. In Background, set a gradient.
5. In Background, set a background image using your favourite image.
6. Save the post.
7. View the post on the frontend and inspect the Pullquote block markup in dev tools.
8. Confirm the Pullquote block has one combined `background-image` declaration containing both the gradient and image, for example:
   ```css
   background-image: linear-gradient(...), url(...);
   ```
9. Confirm the Pullquote block does not output the old conflicting pair:
   ```css
   background: linear-gradient(...);
   background-image: url(...);
   ```

For regressions:

1. Open a post containing existing Pullquote blocks created before this change, including blocks with existing color/gradient styles.
2. Confirm those blocks still render correctly in the editor and frontend, with no validation errors and no visual regression.

<img width="1152" height="647" alt="Screenshot 2026-07-03 at 2 30 31 pm" src="https://github.com/user-attachments/assets/88f21dcd-1e52-4163-a5d4-a2f86b800ef0" />

