### PR TITLE
Post Content block: add background gradient support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -717,7 +717,7 @@ Displays the contents of a post or page.
 
 -	**Name:** [core/post-content](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-post-content/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
--	**Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, background (backgroundImage, backgroundSize, gradient), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName
 
 ## Date

--- a/packages/block-library/src/post-content/README.md
+++ b/packages/block-library/src/post-content/README.md
@@ -27,6 +27,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):
   - `backgroundImage`: `true`
   - `backgroundSize`: `true`
+  - `gradient`: `true`
 - [`dimensions`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#dimensions):
   - `minHeight`: `true`
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -24,6 +24,7 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
 				"backgroundImage": true
 			}


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75859

Adds `background.gradient` support to the Post Content block so background gradients are handled by the background support path when used with background images.

This also updates the generated block docs.

## Why?

The Post Content block already supported background images through `supports.background.backgroundImage`, but gradients were still only declared through legacy `supports.color.gradients`. That meant the gradient was serialized as `background: ...` while the image was serialized as `background-image: ...`, causing the image declaration to override the gradient.

With `supports.background.gradient` enabled, the editor writes the gradient to `style.background.gradient`, and the background support code emits a single combined declaration:

```css
background-image: linear-gradient(...), url(...);
```

The gradient control keeps its current default visibility: Post Content has `color.__experimentalDefaultControls.background: false`, so the gradient control is not shown by default and no `gradient` key is added to `background.__experimentalDefaultControls`.

## Testing Instructions

Playground link: https://playground.wordpress.net/gutenberg.html?pr=79842

1. Upload your favourite image.
2. In the Site Editor, edit a template that includes the Post Content block (e.g. Single).
3. Select the Post Content block and open the block Styles panel.
4. In Background, set a gradient (open the options menu, as it is not shown by default).
5. In Background, set a background image using your favourite image.
6. Save.
7. View a post on the frontend and inspect the Post Content block markup in dev tools.
8. Confirm the Post Content block has one combined `background-image` declaration containing both the gradient and image, for example:
   ```css
   background-image: linear-gradient(...), url(...);
   ```
9. Confirm the Post Content block does not output the old conflicting pair:
   ```css
   background: linear-gradient(...);
   background-image: url(...);
   ```

For regressions:

1. Open a template containing an existing Post Content block created before this change, including one with existing color/gradient styles.
2. Confirm it still renders correctly in the editor and frontend, with no validation errors and no visual regression.

<img width="1157" height="609" alt="Screenshot 2026-07-03 at 2 41 51 pm" src="https://github.com/user-attachments/assets/5c29e891-405e-4e9b-90c1-f5b68123a08b" />
