### PR TITLE
Quote block: add background gradient support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -894,7 +894,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** [core/quote](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-quote/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize, gradient), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** citation, textAlign, value
 
 ## Read More

--- a/packages/block-library/src/quote/README.md
+++ b/packages/block-library/src/quote/README.md
@@ -29,6 +29,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):
   - `backgroundImage`: `true`
   - `backgroundSize`: `true`
+  - `gradient`: `true`
 - [`dimensions`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#dimensions):
   - `minHeight`: `true`
 - [`typography`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography):

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -33,8 +33,10 @@
 		"background": {
 			"backgroundImage": true,
 			"backgroundSize": true,
+			"gradient": true,
 			"__experimentalDefaultControls": {
-				"backgroundImage": true
+				"backgroundImage": true,
+				"gradient": true
 			}
 		},
 		"__experimentalBorder": {


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/75859

Adds `background.gradient` support to the Quote block so background gradients are handled by the background support path when used with background images.

This also updates the generated block docs.

## Why?

The Quote block already supported background images through `supports.background.backgroundImage`, but gradients were still only declared through legacy `supports.color.gradients`. That meant the gradient was serialized as `background: ...` while the image was serialized as `background-image: ...`, causing the image declaration to override the gradient.

With `supports.background.gradient` enabled, the editor writes the gradient to `style.background.gradient`, and the background support code emits a single combined declaration:

```css
background-image: linear-gradient(...), url(...);
```

The gradient control keeps its current default visibility: Quote has `color.__experimentalDefaultControls.background: true`, so the gradient control was already shown by default and `gradient: true` is added to `background.__experimentalDefaultControls` to preserve that.

## Testing Instructions

Playground link: https://playground.wordpress.net/gutenberg.html?pr=79843

1. Upload your favourite image.
2. Open the post editor and insert a Quote block.
3. Select the Quote block and open the block Styles panel.
4. In Background, set a gradient.
5. In Background, set a background image using your favourite image.
6. Save the post.
7. View the post on the frontend and inspect the Quote block markup in dev tools.
8. Confirm the Quote block has one combined `background-image` declaration containing both the gradient and image, for example:
   ```css
   background-image: linear-gradient(...), url(...);
   ```
9. Confirm the Quote block does not output the old conflicting pair:
   ```css
   background: linear-gradient(...);
   background-image: url(...);
   ```

For regressions:

1. Open a post containing existing Quote blocks created before this change, including blocks with existing color/gradient styles.
2. Confirm those blocks still render correctly in the editor and frontend, with no validation errors and no visual regression.

<img width="1088" height="590" alt="Screenshot 2026-07-03 at 2 37 24 pm" src="https://github.com/user-attachments/assets/08a7e1fb-f4bf-4ee0-985c-8e2bfd7e20bd" />
