### PR TITLE
Media Modals: Invalidate attachment caches when closing the modal

### DIFF
--- a/packages/media-utils/src/components/media-upload-modal/use-invalidate-attachment-resolutions.ts
+++ b/packages/media-utils/src/components/media-upload-modal/use-invalidate-attachment-resolutions.ts
@@ -18,8 +18,12 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
 import { useRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { invalidateAttachmentResolutions } from '../../utils/invalidate-attachment-resolutions';
 
 /**
  * Returns a stable callback that invalidates all cached `getEntityRecords`
@@ -29,22 +33,8 @@ import { useRegistry } from '@wordpress/data';
 export function useInvalidateAttachmentResolutions() {
 	const registry = useRegistry();
 
-	return useCallback( () => {
-		const resolvers = registry.select( coreStore ).getCachedResolvers();
-
-		// getCachedResolvers() is typed as Record<string, unknown> but the
-		// values are EquivalentKeyMap instances (Map-like). Cast the same
-		// way the resolvers-cache-middleware does internally.
-		const entityRecordResolutions = resolvers.getEntityRecords as
-			| Map< string[], { status: string } >
-			| undefined;
-
-		entityRecordResolutions?.forEach( ( _value, args ) => {
-			if ( args[ 0 ] === 'postType' && args[ 1 ] === 'attachment' ) {
-				registry
-					.dispatch( coreStore )
-					.invalidateResolution( 'getEntityRecords', args );
-			}
-		} );
-	}, [ registry ] );
+	return useCallback(
+		() => invalidateAttachmentResolutions( registry ),
+		[ registry ]
+	);
 }

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -3,6 +3,12 @@
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { invalidateAttachmentResolutions } from '../../utils/invalidate-attachment-resolutions';
 
 const DEFAULT_EMPTY_GALLERY = [];
 
@@ -481,6 +487,14 @@ class MediaUpload extends Component {
 		if ( onClose ) {
 			onClose();
 		}
+
+		// Uploads performed inside the legacy wp.media modal attach media to the
+		// current post but never reach @wordpress/core-data, so views listing
+		// attached media (e.g. the Gallery block's dynamic mode) would stay stale
+		// until the editor reloads. Invalidate the cached attachment queries on
+		// close so they refetch — mirroring the core-data-native media modal,
+		// which does the same on upload completion.
+		invalidateAttachmentResolutions( { select, dispatch } );
 
 		this.frame.detach();
 	}

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -494,6 +494,15 @@ class MediaUpload extends Component {
 		// until the editor reloads. Invalidate the cached attachment queries on
 		// close so they refetch — mirroring the core-data-native media modal,
 		// which does the same on upload completion.
+		//
+		// This targets the default registry via the module-level `select` and
+		// `dispatch` rather than the contextual one. As a class component
+		// extended by plugins through the `editor.MediaUpload` filter, it can't
+		// read the contextual registry without `withRegistry`/`useRegistry`,
+		// which would break that subclassing contract (see
+		// https://github.com/WordPress/gutenberg/pull/70648). The editor runs on
+		// the default registry in practice, so the only case this misses is a
+		// custom registry, where the invalidation is effectively a no-op.
 		invalidateAttachmentResolutions( { select, dispatch } );
 
 		this.frame.detach();

--- a/packages/media-utils/src/components/media-upload/test/index.js
+++ b/packages/media-utils/src/components/media-upload/test/index.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import MediaUpload from '../index';
+import { invalidateAttachmentResolutions } from '../../../utils/invalidate-attachment-resolutions';
+
+jest.mock( '../../../utils/invalidate-attachment-resolutions' );
+
+describe( 'MediaUpload', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'onClose', () => {
+		it( 'invalidates the cached attachment resolutions against the default registry', () => {
+			const instance = new MediaUpload( { onClose: jest.fn() } );
+			// `onClose` detaches the underlying wp.media frame; stub it so the
+			// method can run without the global media library being present.
+			instance.frame = { detach: jest.fn() };
+
+			instance.onClose();
+
+			expect( invalidateAttachmentResolutions ).toHaveBeenCalledTimes(
+				1
+			);
+			expect( invalidateAttachmentResolutions ).toHaveBeenCalledWith( {
+				select,
+				dispatch,
+			} );
+			// The frame is still detached after invalidating.
+			expect( instance.frame.detach ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'invalidates even when no onClose prop is provided', () => {
+			const instance = new MediaUpload( {} );
+			instance.frame = { detach: jest.fn() };
+
+			instance.onClose();
+
+			expect( invalidateAttachmentResolutions ).toHaveBeenCalledTimes(
+				1
+			);
+			expect( invalidateAttachmentResolutions ).toHaveBeenCalledWith( {
+				select,
+				dispatch,
+			} );
+		} );
+
+		it( 'calls the onClose prop before detaching the frame', () => {
+			const onClose = jest.fn();
+			const instance = new MediaUpload( { onClose } );
+			instance.frame = { detach: jest.fn() };
+
+			instance.onClose();
+
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+			expect( instance.frame.detach ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/media-utils/src/utils/invalidate-attachment-resolutions.ts
+++ b/packages/media-utils/src/utils/invalidate-attachment-resolutions.ts
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import type { DataRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Invalidates every cached `getEntityRecords` resolution for the `attachment`
+ * post type, so components listing media attached to the current post (e.g. the
+ * Gallery block's dynamic mode) re-resolve against the server after an upload.
+ *
+ * `invalidateResolution` only clears the exact query passed to it — on a
+ * paginated grid, page 1 (where a new upload lands) would stay stale — while
+ * `invalidateResolutionForStoreSelector` clears every `getEntityRecords`
+ * resolution, unrelated entity types included. This walks the cached
+ * resolutions and invalidates only the `['postType', 'attachment', …]` entries.
+ *
+ * @param registry A `@wordpress/data` registry (`useRegistry()`), or the
+ *                 default-registry `{ select, dispatch }` exports.
+ */
+export function invalidateAttachmentResolutions(
+	registry: Pick< DataRegistry, 'select' | 'dispatch' >
+) {
+	const resolvers = registry.select( coreStore ).getCachedResolvers();
+
+	// getCachedResolvers() is typed as Record<string, unknown> but the values
+	// are EquivalentKeyMap instances (Map-like). Cast the same way the
+	// resolvers-cache-middleware does internally.
+	const entityRecordResolutions = resolvers.getEntityRecords as
+		| Map< string[], { status: string } >
+		| undefined;
+
+	entityRecordResolutions?.forEach( ( _value, args ) => {
+		if ( args[ 0 ] === 'postType' && args[ 1 ] === 'attachment' ) {
+			registry
+				.dispatch( coreStore )
+				.invalidateResolution( 'getEntityRecords', args );
+		}
+	} );
+}

--- a/packages/media-utils/src/utils/test/invalidate-attachment-resolutions.ts
+++ b/packages/media-utils/src/utils/test/invalidate-attachment-resolutions.ts
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { invalidateAttachmentResolutions } from '../invalidate-attachment-resolutions';
+
+type Registry = Parameters< typeof invalidateAttachmentResolutions >[ 0 ];
+
+/**
+ * Builds a minimal registry stub whose `getCachedResolvers().getEntityRecords`
+ * returns the supplied map, and captures the `invalidateResolution` calls.
+ *
+ * @param entityRecords The cached `getEntityRecords` resolutions (or undefined).
+ */
+function createRegistryStub(
+	entityRecords: Map< unknown[], { status: string } > | undefined
+) {
+	const invalidateResolution = jest.fn();
+	const registry = {
+		select: () => ( {
+			getCachedResolvers: () => ( { getEntityRecords: entityRecords } ),
+		} ),
+		dispatch: () => ( { invalidateResolution } ),
+	} as unknown as Registry;
+
+	return { registry, invalidateResolution };
+}
+
+describe( 'invalidateAttachmentResolutions', () => {
+	it( 'invalidates only the postType/attachment getEntityRecords resolutions', () => {
+		const attachmentPage1 = [ 'postType', 'attachment', { parent: 1 } ];
+		const attachmentPage2 = [
+			'postType',
+			'attachment',
+			{ parent: 1, page: 2 },
+		];
+		const postQuery = [ 'postType', 'post', { per_page: 10 } ];
+		const rootMediaQuery = [ 'root', 'media', {} ];
+
+		const { registry, invalidateResolution } = createRegistryStub(
+			new Map( [
+				[ attachmentPage1, { status: 'finished' } ],
+				[ attachmentPage2, { status: 'finished' } ],
+				[ postQuery, { status: 'finished' } ],
+				[ rootMediaQuery, { status: 'finished' } ],
+			] )
+		);
+
+		invalidateAttachmentResolutions( registry );
+
+		// Both attachment queries (including the paginated one) are invalidated,
+		// with their exact args, and nothing else is touched.
+		expect( invalidateResolution ).toHaveBeenCalledTimes( 2 );
+		expect( invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			attachmentPage1
+		);
+		expect( invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			attachmentPage2
+		);
+		expect( invalidateResolution ).not.toHaveBeenCalledWith(
+			'getEntityRecords',
+			postQuery
+		);
+		expect( invalidateResolution ).not.toHaveBeenCalledWith(
+			'getEntityRecords',
+			rootMediaQuery
+		);
+	} );
+
+	it( 'does nothing when there are no cached getEntityRecords resolutions', () => {
+		const { registry, invalidateResolution } =
+			createRegistryStub( undefined );
+
+		invalidateAttachmentResolutions( registry );
+
+		expect( invalidateResolution ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Part of:

* #76955
* #77117
* #73085

## What?

Invalidate `getEntityRecords` resolutions for attachments when closing the media modal. This newly introduces invalidation for the existing core media library modal. The experimental DataViews-powered one was already doing this after upload, so the change in this PR proposes rolling it out to the core / existing media library.

Note: this PR does _not_ handle refreshing the media categories in the media inserter. That will be handled in a follow-up PR (#79921) if/when this one lands.

## Why?

Flagged in testing of the new Dynamic Gallery block variation (tracked in #77117), currently if a user uploads media _from within the media modal_, then the editor doesn't refresh to consider the newly uploaded media as attachments to display in the Dynamic Gallery block (or other areas, too, I assume).

This is unique to the media modal — if a user uses the "Upload" button from the placeholder of the Image block, it currently works fine. So the change here is to ensure that when the media modal closes, we tell the editor "hey, refresh anything that's looking at lists of attachments, because they might have changed and may need to be refreshed".

Of course, this is an opinionated change, and means that some things will necessarily reload whenever a user closes the media modal. The trade-off here is ensuring consistency and fresh data in the editor versus avoiding refetching data.

## How?

* Take the existing logic from the new media modal experiment and place it in a utility function.
* Call that common utility function when the existing core media modal closes.

## Testing Instructions

* Add a Gallery block to a post or page, and select the "Use attached images" button
* Open up the media inserter (I.e. the block inserter and then switch to the Media tab)
* Click "Open Media Library" to open the media library, and go to the Upload tab
* Upload a couple of images
* Close the media modal
* The Gallery block should automatically update to reflect that the newly uploaded images are attached to this post
* (If you notice that the media categories do not refresh, don't worry, that'll be handled in a follow-up PR if this one lands)
* You can also test the above with a different control, like the placeholder media library button on an Image block

If you want to smoke test the refactor, you can also test that uploading to the experimental media upload modal refreshes the view of the modal, too.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/78ca3e1a-161d-4aa5-89ef-d62d4b792639

## Use of AI Tools

Claude Code