### PR TITLE
Navigation Link: Use dynamic URL and label at render time and sync label in editor

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -8,9 +8,11 @@ import clsx from 'clsx';
  */
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import {
 	BlockControls,
 	InspectorControls,
@@ -95,6 +97,38 @@ export default function NavigationLinkEdit( {
 		__unstableMarkNextChangeAsNotPersistent,
 		selectBlock,
 	} = useDispatch( blockEditorStore );
+
+	// Fetch the live entity title for post-type and taxonomy links so the editor
+	// label stays in sync when a post's title or a term's name changes.
+	const liveEntityTitle = useSelect(
+		( select ) => {
+			if ( ! id || ( kind !== 'post-type' && kind !== 'taxonomy' ) ) {
+				return null;
+			}
+			const isPostType = kind === 'post-type';
+			const entityType = isPostType ? 'postType' : 'taxonomy';
+			const typeForAPI = type === 'tag' ? 'post_tag' : type;
+			const record = select( coreDataStore ).getEntityRecord(
+				entityType,
+				typeForAPI,
+				id
+			);
+			if ( ! record ) {
+				return null;
+			}
+			// Posts/pages expose title as { raw, rendered }; terms expose name.
+			const rawTitle = record?.title;
+			if ( typeof rawTitle === 'string' ) {
+				return rawTitle;
+			}
+			if ( rawTitle && 'rendered' in rawTitle ) {
+				return rawTitle.rendered || null;
+			}
+			return record?.name || null;
+		},
+		[ id, kind, type ]
+	);
+
 	// Have the link editing ui open on mount when lacking a url and selected.
 	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected && ! url );
 	// Use internal state instead of a ref to make sure that the component
@@ -225,6 +259,20 @@ export default function NavigationLinkEdit( {
 		__unstableMarkNextChangeAsNotPersistent,
 		transformToSubmenu,
 	] );
+
+	// Sync the block's stored label with the live entity title.
+	useEffect( () => {
+		if ( ! liveEntityTitle || ! label ) {
+			return;
+		}
+		// Decode HTML entities in the stored label before comparing
+		const decodedLabel = decodeEntities( label ).trim();
+		if ( decodedLabel !== liveEntityTitle.trim() ) {
+			// Mark as non-persistent so label auto-sync doesn't pollute undo history.
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { label: liveEntityTitle } );
+		}
+	}, [ liveEntityTitle ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Handle link UI when a new link is created
 	useEffect( () => {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -114,6 +114,77 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 
 
 /**
+ * Returns the dynamic URL for a navigation link based on its kind and id.
+ *
+ * For non-custom links (those with an id and a recognized kind), retrieves
+ * the current permalink using WordPress core functions so that links stay
+ * up-to-date even when a post's slug or a term's slug is changed after the
+ * menu item was saved.
+ *
+ * Returns null for custom/external links (no id, or unrecognised kind) so
+ * the caller falls back to the stored URL.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes The block attributes.
+ * @return string|null The dynamic URL, or null if one cannot be determined.
+ */
+function block_core_navigation_link_get_dynamic_url( $attributes ) {
+	$kind = isset( $attributes['kind'] ) ? $attributes['kind'] : '';
+	$id   = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
+	$type = isset( $attributes['type'] ) ? $attributes['type'] : '';
+
+	if ( 'post-type' === $kind && $id ) {
+		$url = get_permalink( $id );
+		return $url ? $url : null;
+	}
+
+	if ( 'taxonomy' === $kind && $id ) {
+		$url = get_term_link( $id, $type );
+		return ( ! is_wp_error( $url ) ) ? $url : null;
+	}
+
+	if ( 'post-type-archive' === $kind && $type ) {
+		$url = get_post_type_archive_link( $type );
+		return $url ? $url : null;
+	}
+
+	return null;
+}
+
+/**
+ * Returns the dynamic label for a navigation link based on its kind and id.
+ *
+ * For post-type links the current post title is returned; for taxonomy links
+ * the current term name is returned. Returns null for custom/external links
+ * (no id, or unrecognised kind) so the caller falls back to the stored label.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes The block attributes.
+ * @return string|null The dynamic label, or null if one cannot be determined.
+ */
+function block_core_navigation_link_get_dynamic_label( $attributes ) {
+	$kind = isset( $attributes['kind'] ) ? $attributes['kind'] : '';
+	$id   = isset( $attributes['id'] ) ? (int) $attributes['id'] : 0;
+	$type = isset( $attributes['type'] ) ? $attributes['type'] : '';
+
+	if ( 'post-type' === $kind && $id ) {
+		$title = get_the_title( $id );
+		return $title ? $title : null;
+	}
+
+	if ( 'taxonomy' === $kind && $id ) {
+		$term = get_term( $id, $type );
+		if ( $term && ! is_wp_error( $term ) ) {
+			return $term->name;
+		}
+	}
+
+	return null;
+}
+
+/**
  * Renders the `core/navigation-link` block.
  *
  * @since 5.9.0
@@ -167,7 +238,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		'<a class="wp-block-navigation-item__content" ';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( isset( $attributes['url'] ) ) {
+	// Try to resolve the URL dynamically (keeps links correct after slug changes).
+	$dynamic_url = block_core_navigation_link_get_dynamic_url( $attributes );
+	if ( null !== $dynamic_url ) {
+		$html .= ' href="' . esc_url( $dynamic_url ) . '"';
+	} elseif ( isset( $attributes['url'] ) ) {
 		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $attributes['url'] ) ) . '"';
 	}
 
@@ -196,7 +271,11 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		// Wrap title with span to isolate it from submenu icon.
 		'<span class="wp-block-navigation-item__label">';
 
-	if ( isset( $attributes['label'] ) ) {
+	// Try to resolve the label dynamically (keeps labels correct after title changes).
+	$dynamic_label = block_core_navigation_link_get_dynamic_label( $attributes );
+	if ( null !== $dynamic_label ) {
+		$html .= wp_kses_post( $dynamic_label );
+	} elseif ( isset( $attributes['label'] ) ) {
 		$html .= wp_kses_post( $attributes['label'] );
 	}
 

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -1,308 +1,297 @@
 <?php
 /**
- * Navigation block post type/taxonomies variations tests.
+ * Tests server side rendering of core/navigation-link
  *
- * @package WordPress
- * @subpackage Blocks
+ * @package    Gutenberg
+ * @subpackage block-library
  */
 
 /**
- * Tests for the Navigation block variations for post types.
- *
- * @group blocks
+ * Tests for various cases in Navigation Link rendering
  */
-class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
+class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
+	private static $category;
+	private static $page;
+	private static $draft;
+	private static $custom_draft;
+	private static $custom_post;
 
+	private static $pages;
+	private static $terms;
 	/**
-	 * Whether to use a shim/workaround for WordPress Core versions < 6.5.
-	 * See https://github.com/WordPress/gutenberg/pull/58389 for details.
-	 *
-	 * @var bool
+	 * @var array|null
 	 */
-	private $pre_65_compat = false;
+	private $original_block_supports;
+
+	public static function wpSetUpBeforeClass() {
+
+		self::$draft   = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'draft',
+				'post_name'    => 'ceilingcat',
+				'post_title'   => 'Ceiling Cat',
+				'post_content' => 'Ceiling Cat content',
+				'post_excerpt' => 'Ceiling Cat',
+			)
+		);
+		self::$pages[] = self::$draft;
+
+		self::$custom_draft = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'cats',
+				'post_status'  => 'draft',
+				'post_name'    => 'metalcat',
+				'post_title'   => 'Metal Cat',
+				'post_content' => 'Metal Cat content',
+				'post_excerpt' => 'Metal Cat',
+			)
+		);
+		self::$pages[]      = self::$custom_draft;
+
+		self::$custom_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'dogs',
+				'post_status'  => 'publish',
+				'post_name'    => 'metaldog',
+				'post_title'   => 'Metal Dog',
+				'post_content' => 'Metal Dog content',
+				'post_excerpt' => 'Metal Dog',
+			)
+		);
+		self::$pages[]     = self::$custom_post;
+
+		self::$page    = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_name'    => 'tabby',
+				'post_title'   => 'Tabby cats',
+				'post_content' => 'Tabby cat content',
+				'post_excerpt' => 'Tabby cat',
+			)
+		);
+		self::$pages[] = self::$page;
+
+		self::$category = self::factory()->category->create_and_get(
+			array(
+				'taxonomy'    => 'category',
+				'name'        => 'cats',
+				'slug'        => 'cats',
+				'description' => 'Cats Category',
+			)
+		);
+
+		self::$terms[] = self::$category;
+	}
+
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$pages as $page_to_delete ) {
+			wp_delete_post( $page_to_delete->ID );
+		}
+		foreach ( self::$terms as $term_to_delete ) {
+			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );
+		}
+	}
 
 	public function set_up() {
 		parent::set_up();
 
-		$post_type         = register_post_type(
-			'custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Custom Book',
-				),
-				'public'            => true,
-				'show_in_rest'      => true,
-				'show_in_nav_menus' => true,
-			)
+		$this->original_block_supports      = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'attrs'     => array(),
+			'blockName' => '',
 		);
-		$private_post_type = register_post_type(
-			'private_custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Custom Book',
-				),
-				'public'            => false,
-				'show_in_rest'      => true,
-				'show_in_nav_menus' => false,
-			)
-		);
-		$taxonomy          = register_taxonomy(
-			'book_type',
-			'custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Book Type',
-				),
-				'show_in_nav_menus' => true,
-			)
-		);
-		$private_taxonomoy = register_taxonomy(
-			'private_book_type',
-			'private_custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Book Type',
-				),
-				'show_in_nav_menus' => false,
-			)
-		);
-
-		$this->pre_65_compat = ! method_exists( 'WP_Block_Type', 'get_variations' );
-
-		/*
-		 * In Core versions < 6.5, variations for post types/taxonomies registered after init#10 (= after the block type was registered)
-		 * need to be manually registered.
-		 * set_up runs after init#10, therefore register the variations here with the old deprecated functions.
-		 *
-		 * TODO: After two WP versions (6.7), we can remove this.
-		 */
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_post_type_variation_registration( $post_type );
-			$this->handle_pre_65_post_type_variation_registration( $private_post_type );
-			$this->handle_pre_65_taxonomy_variation_registration( $taxonomy );
-			$this->handle_pre_65_taxonomy_variation_registration( $private_taxonomoy );
-		}
 	}
 
 	public function tear_down() {
-		unregister_post_type( 'custom_book' );
-		unregister_post_type( 'private_custom_book' );
-		unregister_taxonomy( 'book_type' );
-		unregister_taxonomy( 'private_book_type' );
-		unregister_post_type( 'temp_custom_book' );
-		unregister_taxonomy( 'temp_book_type' );
-
-		// See comment in set_up for explanation.
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_post_type_variation_unregistration( 'custom_book' );
-			$this->handle_pre_65_post_type_variation_unregistration( 'private_custom_book' );
-			$this->handle_pre_65_post_type_variation_unregistration( 'temp_custom_book' );
-			$this->handle_pre_65_taxonomy_variation_unregistration( 'book_type' );
-			$this->handle_pre_65_taxonomy_variation_unregistration( 'private_book_type' );
-			$this->handle_pre_65_taxonomy_variation_unregistration( 'temp_book_type' );
-		}
-
+		WP_Block_Supports::$block_to_render = $this->original_block_supports;
 		parent::tear_down();
 	}
 
-	/**
-	 * @covers ::block_core_navigation_link_register_post_type_variation
-	 */
-	public function test_navigation_link_variations_custom_post_type() {
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'custom_book', $variations );
-		$this->assertIsArray( $variation, 'Block variation does not exist' );
-		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
-		$this->assertEquals( 'Custom Book', $variation['title'], 'Variation title is different than the post type label' );
-	}
+	public function test_returns_link_when_post_is_published() {
+		$page_id = self::$page->ID;
+		$url     = 'http://' . WP_TESTS_DOMAIN;
 
-	/**
-	 * @covers ::block_core_navigation_link_register_post_type_variation
-	 */
-	public function test_navigation_link_variations_private_custom_post_type() {
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'private_custom_book', $variations );
-		$this->assertEmpty( $variation, 'Block variation for private post type exists.' );
-	}
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
 
-	/**
-	 * @covers ::block_core_navigation_link_register_taxonomy_variation
-	 */
-	public function test_navigation_link_variations_custom_taxonomy() {
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'book_type', $variations );
-		$this->assertIsArray( $variation, 'Block variation does not exist' );
-		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
-		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the post type label' );
-	}
-
-	/**
-	 * @covers ::block_core_navigation_link_register_taxonomy_variation
-	 */
-	public function test_navigation_link_variations_private_custom_taxonomy() {
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'private_book_type', $variations );
-		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
-	}
-
-	/**
-	 * @covers ::block_core_navigation_link_unregister_post_type_variation
-	 */
-	public function test_navigation_link_variations_unregister_post_type() {
-		$post_type = register_post_type(
-			'temp_custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Custom Book',
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
 				),
-				'public'            => true,
-				'show_in_rest'      => true,
-				'show_in_nav_menus' => true,
+				'Sample Page'
+			) !== false
+		);
+	}
+
+	public function test_returns_empty_when_label_is_missing() {
+		$page_id = self::$page->ID;
+		$url     = 'http://' . WP_TESTS_DOMAIN;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
 			)
 		);
-
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_post_type_variation_registration( $post_type );
-		}
-
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'temp_custom_book', $variations );
-		$this->assertIsArray( $variation, 'Block variation does not exist' );
-
-		unregister_post_type( $post_type->name );
-
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_post_type_variation_unregistration( $post_type->name );
-		}
-
-		// Update array, since it's an dynamic built array
-		$variations = $nav_link_block->variations;
-		$variation  = $this->get_variation_by_name( 'temp_custom_book', $variations );
-		$this->assertEmpty( $variation, 'Block variation still exists' );
 	}
 
-	/**
-	 * @covers ::block_core_navigation_link_unregister_taxonomy_variation
-	 */
-	public function test_navigation_link_variations_unregister_taxonomy() {
-		$taxonomy = register_taxonomy(
-			'temp_book_type',
-			'custom_book',
-			array(
-				'labels'            => array(
-					'item_link' => 'Book Type',
-				),
-				'show_in_nav_menus' => true,
+	public function test_returns_empty_when_draft() {
+		$page_id = self::$draft->ID;
+		$url     = 'http://' . WP_TESTS_DOMAIN;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Draft Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
 			)
 		);
+	}
 
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_taxonomy_variation_registration( $taxonomy );
+	public function test_returns_link_for_category() {
+		$category_id = self::$category->term_id;
+		$url         = 'http://' . WP_TESTS_DOMAIN;
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"{$url}/?cat={$category_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Cats'
+			) !== false
+		);
+	}
+
+	public function test_returns_link_for_plain_link() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:navigation-link {"label":"My Website","url":"https://example.com"} /-->'
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'My Website'
+			) !== false
+		);
+	}
+
+	public function test_returns_link_for_decoded_link() {
+
+		$urls_before_render = array(
+			'https://example.com/?id=10&data=lzB%252Fzd%252FZA%253D%253D',
+			'https://example.com/?id=10&data=lzB%2Fzd%FZA%3D%3D',
+			'https://example.com/?id=10&data=1234',
+			'https://example.com/?arrayParams[]=1&arrayParams[]=2&arrayParams[]=3',
+		);
+
+		$urls_after_render = array(
+			'https://example.com/?id=10&#038;data=lzB%2Fzd%2FZA%3D%3D',
+			'https://example.com/?id=10&#038;data=lzB%2Fzd%FZA%3D%3D',
+			'https://example.com/?id=10&#038;data=1234',
+			'https://example.com/?arrayParams%5B%5D=1&#038;arrayParams%5B%5D=2&#038;arrayParams%5B%5D=3',
+		);
+
+		foreach ( $urls_before_render as $idx => $link ) {
+				$parsed_blocks = parse_blocks( '<!-- wp:navigation-link {"label":"test label", "url": "' . $link . '"} /-->' );
+			$this->assertEquals( 1, count( $parsed_blocks ) );
+				$block             = $parsed_blocks[0];
+			$navigation_link_block = new WP_Block( $block, array() );
+				$this->assertEquals(
+					true,
+					strpos(
+						gutenberg_render_block_core_navigation_link(
+							$navigation_link_block->attributes,
+							array(),
+							$navigation_link_block
+						),
+						$urls_after_render[ $idx ]
+					) !== false
+				);
 		}
-
-		$registry       = WP_Block_Type_Registry::get_instance();
-		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
-		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
-		$variations = $nav_link_block->variations;
-		$this->assertNotEmpty( $variations, 'Block has no variations' );
-		$variation = $this->get_variation_by_name( 'temp_book_type', $variations );
-		$this->assertIsArray( $variation, 'Block variation does not exist' );
-
-		unregister_taxonomy( $taxonomy->name );
-
-		if ( $this->pre_65_compat ) {
-			$this->handle_pre_65_taxonomy_variation_unregistration( $taxonomy->name );
-		}
-
-		// Update array, since it's an dynamic built array
-		$variations = $nav_link_block->variations;
-		$variation  = $this->get_variation_by_name( 'temp_book_type', $variations );
-		$this->assertEmpty( $variation, 'Block variation still exists' );
 	}
 
-	/**
-	 * Get a variation by its name from an array of variations.
-	 *
-	 * @param string $variation_name The name (= slug) of the variation.
-	 * @param array  $variations An array of variations.
-	 * @return array|null The found variation or null.
-	 */
-	private function get_variation_by_name( $variation_name, $variations ) {
-		$found_variation = null;
-		foreach ( $variations as $variation ) {
-			if ( $variation['name'] === $variation_name ) {
-				$found_variation = $variation;
-			}
-		}
+	public function test_returns_empty_when_custom_post_type_draft() {
+		$page_id = self::$custom_draft->ID;
+		$url     = 'http://' . WP_TESTS_DOMAIN;
 
-		return $found_variation;
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Draft Custom Post Type\",\"type\":\"cats\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+
+		$this->assertEquals(
+			'',
+			gutenberg_render_block_core_navigation_link(
+				$navigation_link_block->attributes,
+				array(),
+				$navigation_link_block
+			)
+		);
 	}
 
-	/**
-	 * Registers a block variation for a post type with the deprecated methods for Core versions < 6.5.
-	 * See comment in set_up for dexplanation.
-	 *
-	 * @param WP_Post_Type $post_type
-	 */
-	private function handle_pre_65_post_type_variation_registration( $post_type ) {
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_post_type_variation' );
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_variation' );
-		gutenberg_block_core_navigation_link_register_post_type_variation( $post_type->name, $post_type );
-	}
+	public function test_returns_link_when_custom_post_is_published() {
+		$page_id = self::$custom_post->ID;
+		$url     = 'http://' . WP_TESTS_DOMAIN;
 
-	/**
-	 * Unregisters a block variation for a post type with the deprecated methods for Core versions < 6.5.
-	 * See comment in set_up for dexplanation.
-	 *
-	 * @param string $post_type
-	 */
-	private function handle_pre_65_post_type_variation_unregistration( $post_type ) {
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_post_type_variation' );
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_variation' );
-		gutenberg_block_core_navigation_link_unregister_post_type_variation( $post_type );
-	}
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"dogs\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
 
-	/**
-	 * Registers a block variation for a taxonomy with the deprecated methods for Core versions < 6.5.
-	 * See comment in set_up for dexplanation.
-	 *
-	 * @param WP_Taxonomy $post_type
-	 */
-	private function handle_pre_65_taxonomy_variation_registration( $taxonomy ) {
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_taxonomy_variation' );
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_variation' );
-		gutenberg_block_core_navigation_link_register_taxonomy_variation( $taxonomy->name, $taxonomy->object_type, (array) $taxonomy );
-	}
-
-	/**
-	 * Unregisters a block variation for a taxonomy with the deprecated methods for Core versions < 6.5.
-	 * See comment in set_up for dexplanation.
-	 *
-	 * @param string $post_type
-	 */
-	private function handle_pre_65_taxonomy_variation_unregistration( $taxonomy ) {
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_taxonomy_variation' );
-		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_variation' );
-		gutenberg_block_core_navigation_link_unregister_taxonomy_variation( $taxonomy );
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$this->assertEquals(
+			true,
+			strpos(
+				gutenberg_render_block_core_navigation_link(
+					$navigation_link_block->attributes,
+					array(),
+					$navigation_link_block
+				),
+				'Metal Dogs'
+			) !== false
+		);
 	}
 }

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -114,11 +114,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$url     = 'http://' . WP_TESTS_DOMAIN;
 
 		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
+			"<!-- wp:navigation-link {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\",\"kind\":\"post-type\"} /-->"
 		);
 		$this->assertEquals( 1, count( $parsed_blocks ) );
 
 		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		// Dynamic label: uses the actual post title ('Tabby cats'), not the stored label.
 		$this->assertEquals(
 			true,
 			strpos(
@@ -127,7 +128,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 					array(),
 					$navigation_link_block
 				),
-				'Sample Page'
+				self::$page->post_title
 			) !== false
 		);
 	}
@@ -178,11 +179,12 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$url         = 'http://' . WP_TESTS_DOMAIN;
 
 		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"{$url}/?cat={$category_id}\"} /-->"
+			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"{$url}/?cat={$category_id}\",\"kind\":\"taxonomy\"} /-->"
 		);
 		$this->assertEquals( 1, count( $parsed_blocks ) );
 
 		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		// Dynamic label: uses the actual term name.
 		$this->assertEquals(
 			true,
 			strpos(
@@ -191,7 +193,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 					array(),
 					$navigation_link_block
 				),
-				'Cats'
+				self::$category->name
 			) !== false
 		);
 	}
@@ -282,6 +284,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, count( $parsed_blocks ) );
 
 		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		// Dynamic label: uses the actual post title ('Metal Dog'), not the stored label.
 		$this->assertEquals(
 			true,
 			strpos(
@@ -290,8 +293,184 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 					array(),
 					$navigation_link_block
 				),
-				'Metal Dogs'
+				self::$custom_post->post_title
 			) !== false
+		);
+	}
+
+	/**
+	 * Tests that the render function uses the current permalink when a post's
+	 * slug has been changed after the menu item was saved.
+	 *
+	 * This is the core scenario reported in GitHub issue #38253.
+	 */
+	public function test_uses_dynamic_permalink_after_post_slug_changes() {
+		// Create a published page.
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_name'   => 'test-page',
+				'post_title'  => 'Test Page',
+			)
+		);
+		self::$pages[] = $post;
+
+		$page_id    = $post->ID;
+		$stored_url = 'http://' . WP_TESTS_DOMAIN . '/?page_id=' . $page_id;
+
+		// Simulate the block as saved with the original URL.
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Test Page\",\"type\":\"page\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$stored_url}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		// Now change the slug (simulating a post update after menu item was saved).
+		wp_update_post(
+			array(
+				'ID'        => $page_id,
+				'post_name' => 'my-changed-page',
+			)
+		);
+
+		$new_permalink = get_permalink( $page_id );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$rendered              = gutenberg_render_block_core_navigation_link(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		// The rendered href should use the NEW dynamic permalink, not the stale stored one.
+		$this->assertStringContainsString(
+			'href="' . esc_url( $new_permalink ) . '"',
+			$rendered,
+			'Expected the rendered href to use the new dynamic permalink after slug change.'
+		);
+		$this->assertStringNotContainsString(
+			$stored_url,
+			$rendered,
+			'Expected the rendered href NOT to use the old stored URL after slug change.'
+		);
+	}
+
+	/**
+	 * Tests that the render function uses the current post title when it has
+	 * been changed after the menu item was saved.
+	 *
+	 * This is the label update part of GitHub issue #38253.
+	 */
+	public function test_uses_dynamic_label_after_post_title_changes() {
+		// Create a published page.
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_name'   => 'original-title-page',
+				'post_title'  => 'Original Title',
+			)
+		);
+		self::$pages[] = $post;
+
+		$page_id    = $post->ID;
+		$stored_url = 'http://' . WP_TESTS_DOMAIN . '/?page_id=' . $page_id;
+
+		// Simulate block saved with the original label.
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Original Title\",\"type\":\"page\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$stored_url}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		// Now change the post title.
+		wp_update_post(
+			array(
+				'ID'         => $page_id,
+				'post_title' => 'My Changed Page',
+			)
+		);
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$rendered              = gutenberg_render_block_core_navigation_link(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		// The rendered label should use the NEW title, not the stale stored label.
+		$this->assertStringContainsString(
+			'My Changed Page',
+			$rendered,
+			'Expected rendered label to use the new post title after it changed.'
+		);
+		$this->assertStringNotContainsString(
+			'Original Title',
+			$rendered,
+			'Expected rendered label NOT to use the old stored label after title change.'
+		);
+	}
+
+	/**
+	 * Tests that the render function uses the current term link when a
+	 * taxonomy term's slug has been changed after the menu item was saved.
+	 */
+	public function test_uses_dynamic_term_link_after_term_slug_changes() {
+		$category_id = self::$category->term_id;
+		$stored_url  = 'http://' . WP_TESTS_DOMAIN . '/?cat=' . $category_id;
+
+		// Simulate block saved with old URL.
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"kind\":\"taxonomy\",\"id\":{$category_id},\"url\":\"{$stored_url}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$current_term_link = get_term_link( $category_id, 'category' );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$rendered              = gutenberg_render_block_core_navigation_link(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		// The rendered href should use the dynamic term link.
+		$this->assertStringContainsString(
+			'href="' . esc_url( $current_term_link ) . '"',
+			$rendered,
+			'Expected the rendered href to use the dynamic term link.'
+		);
+	}
+
+	/**
+	 * Tests that for a plain custom link (no id), the render function falls
+	 * back to the stored URL and label.
+	 */
+	public function test_falls_back_to_stored_url_for_custom_link() {
+		$custom_url   = 'https://example.com/custom';
+		$custom_label = 'My Custom Link';
+
+		$parsed_blocks = parse_blocks(
+			"<!-- wp:navigation-link {\"label\":\"{$custom_label}\",\"url\":\"{$custom_url}\"} /-->"
+		);
+		$this->assertEquals( 1, count( $parsed_blocks ) );
+
+		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
+		$rendered              = gutenberg_render_block_core_navigation_link(
+			$navigation_link_block->attributes,
+			array(),
+			$navigation_link_block
+		);
+
+		// Custom links should use stored URL and label unchanged.
+		$this->assertStringContainsString(
+			'href="' . esc_url( $custom_url ) . '"',
+			$rendered,
+			'Expected custom link to use stored URL as href.'
+		);
+		$this->assertStringContainsString(
+			$custom_label,
+			$rendered,
+			'Expected custom link to use stored label.'
 		);
 	}
 }

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -1,476 +1,308 @@
 <?php
 /**
- * Tests server side rendering of core/navigation-link
+ * Navigation block post type/taxonomies variations tests.
  *
- * @package    Gutenberg
- * @subpackage block-library
+ * @package WordPress
+ * @subpackage Blocks
  */
 
 /**
- * Tests for various cases in Navigation Link rendering
+ * Tests for the Navigation block variations for post types.
+ *
+ * @group blocks
  */
-class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
-	private static $category;
-	private static $page;
-	private static $draft;
-	private static $custom_draft;
-	private static $custom_post;
+class Block_Navigation_Link_Variations_Test extends WP_UnitTestCase {
 
-	private static $pages;
-	private static $terms;
 	/**
-	 * @var array|null
+	 * Whether to use a shim/workaround for WordPress Core versions < 6.5.
+	 * See https://github.com/WordPress/gutenberg/pull/58389 for details.
+	 *
+	 * @var bool
 	 */
-	private $original_block_supports;
-
-	public static function wpSetUpBeforeClass() {
-
-		self::$draft   = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'page',
-				'post_status'  => 'draft',
-				'post_name'    => 'ceilingcat',
-				'post_title'   => 'Ceiling Cat',
-				'post_content' => 'Ceiling Cat content',
-				'post_excerpt' => 'Ceiling Cat',
-			)
-		);
-		self::$pages[] = self::$draft;
-
-		self::$custom_draft = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'cats',
-				'post_status'  => 'draft',
-				'post_name'    => 'metalcat',
-				'post_title'   => 'Metal Cat',
-				'post_content' => 'Metal Cat content',
-				'post_excerpt' => 'Metal Cat',
-			)
-		);
-		self::$pages[]      = self::$custom_draft;
-
-		self::$custom_post = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'dogs',
-				'post_status'  => 'publish',
-				'post_name'    => 'metaldog',
-				'post_title'   => 'Metal Dog',
-				'post_content' => 'Metal Dog content',
-				'post_excerpt' => 'Metal Dog',
-			)
-		);
-		self::$pages[]     = self::$custom_post;
-
-		self::$page    = self::factory()->post->create_and_get(
-			array(
-				'post_type'    => 'page',
-				'post_status'  => 'publish',
-				'post_name'    => 'tabby',
-				'post_title'   => 'Tabby cats',
-				'post_content' => 'Tabby cat content',
-				'post_excerpt' => 'Tabby cat',
-			)
-		);
-		self::$pages[] = self::$page;
-
-		self::$category = self::factory()->category->create_and_get(
-			array(
-				'taxonomy'    => 'category',
-				'name'        => 'cats',
-				'slug'        => 'cats',
-				'description' => 'Cats Category',
-			)
-		);
-
-		self::$terms[] = self::$category;
-	}
-
-	public static function wpTearDownAfterClass() {
-		foreach ( self::$pages as $page_to_delete ) {
-			wp_delete_post( $page_to_delete->ID );
-		}
-		foreach ( self::$terms as $term_to_delete ) {
-			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );
-		}
-	}
+	private $pre_65_compat = false;
 
 	public function set_up() {
 		parent::set_up();
 
-		$this->original_block_supports      = WP_Block_Supports::$block_to_render;
-		WP_Block_Supports::$block_to_render = array(
-			'attrs'     => array(),
-			'blockName' => '',
-		);
-	}
-
-	public function tear_down() {
-		WP_Block_Supports::$block_to_render = $this->original_block_supports;
-		parent::tear_down();
-	}
-
-	public function test_returns_link_when_post_is_published() {
-		$page_id = self::$page->ID;
-		$url     = 'http://' . WP_TESTS_DOMAIN;
-
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Sample Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\",\"kind\":\"post-type\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		// Dynamic label: uses the actual post title ('Tabby cats'), not the stored label.
-		$this->assertEquals(
-			true,
-			strpos(
-				gutenberg_render_block_core_navigation_link(
-					$navigation_link_block->attributes,
-					array(),
-					$navigation_link_block
+		$post_type         = register_post_type(
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
 				),
-				self::$page->post_title
-			) !== false
-		);
-	}
-
-	public function test_returns_empty_when_label_is_missing() {
-		$page_id = self::$page->ID;
-		$url     = 'http://' . WP_TESTS_DOMAIN;
-
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$this->assertEquals(
-			'',
-			gutenberg_render_block_core_navigation_link(
-				$navigation_link_block->attributes,
-				array(),
-				$navigation_link_block
+				'public'            => true,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => true,
 			)
 		);
-	}
-
-	public function test_returns_empty_when_draft() {
-		$page_id = self::$draft->ID;
-		$url     = 'http://' . WP_TESTS_DOMAIN;
-
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Draft Page\",\"type\":\"page\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-
-		$this->assertEquals(
-			'',
-			gutenberg_render_block_core_navigation_link(
-				$navigation_link_block->attributes,
-				array(),
-				$navigation_link_block
+		$private_post_type = register_post_type(
+			'private_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
+				),
+				'public'            => false,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => false,
 			)
 		);
-	}
-
-	public function test_returns_link_for_category() {
-		$category_id = self::$category->term_id;
-		$url         = 'http://' . WP_TESTS_DOMAIN;
-
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"id\":{$category_id},\"url\":\"{$url}/?cat={$category_id}\",\"kind\":\"taxonomy\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		// Dynamic label: uses the actual term name.
-		$this->assertEquals(
-			true,
-			strpos(
-				gutenberg_render_block_core_navigation_link(
-					$navigation_link_block->attributes,
-					array(),
-					$navigation_link_block
+		$taxonomy          = register_taxonomy(
+			'book_type',
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
 				),
-				self::$category->name
-			) !== false
+				'show_in_nav_menus' => true,
+			)
 		);
-	}
-
-	public function test_returns_link_for_plain_link() {
-		$parsed_blocks = parse_blocks(
-			'<!-- wp:navigation-link {"label":"My Website","url":"https://example.com"} /-->'
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$this->assertEquals(
-			true,
-			strpos(
-				gutenberg_render_block_core_navigation_link(
-					$navigation_link_block->attributes,
-					array(),
-					$navigation_link_block
+		$private_taxonomoy = register_taxonomy(
+			'private_book_type',
+			'private_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
 				),
-				'My Website'
-			) !== false
-		);
-	}
-
-	public function test_returns_link_for_decoded_link() {
-
-		$urls_before_render = array(
-			'https://example.com/?id=10&data=lzB%252Fzd%252FZA%253D%253D',
-			'https://example.com/?id=10&data=lzB%2Fzd%FZA%3D%3D',
-			'https://example.com/?id=10&data=1234',
-			'https://example.com/?arrayParams[]=1&arrayParams[]=2&arrayParams[]=3',
+				'show_in_nav_menus' => false,
+			)
 		);
 
-		$urls_after_render = array(
-			'https://example.com/?id=10&#038;data=lzB%2Fzd%2FZA%3D%3D',
-			'https://example.com/?id=10&#038;data=lzB%2Fzd%FZA%3D%3D',
-			'https://example.com/?id=10&#038;data=1234',
-			'https://example.com/?arrayParams%5B%5D=1&#038;arrayParams%5B%5D=2&#038;arrayParams%5B%5D=3',
-		);
+		$this->pre_65_compat = ! method_exists( 'WP_Block_Type', 'get_variations' );
 
-		foreach ( $urls_before_render as $idx => $link ) {
-				$parsed_blocks = parse_blocks( '<!-- wp:navigation-link {"label":"test label", "url": "' . $link . '"} /-->' );
-			$this->assertEquals( 1, count( $parsed_blocks ) );
-				$block             = $parsed_blocks[0];
-			$navigation_link_block = new WP_Block( $block, array() );
-				$this->assertEquals(
-					true,
-					strpos(
-						gutenberg_render_block_core_navigation_link(
-							$navigation_link_block->attributes,
-							array(),
-							$navigation_link_block
-						),
-						$urls_after_render[ $idx ]
-					) !== false
-				);
+		/*
+		 * In Core versions < 6.5, variations for post types/taxonomies registered after init#10 (= after the block type was registered)
+		 * need to be manually registered.
+		 * set_up runs after init#10, therefore register the variations here with the old deprecated functions.
+		 *
+		 * TODO: After two WP versions (6.7), we can remove this.
+		 */
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_post_type_variation_registration( $post_type );
+			$this->handle_pre_65_post_type_variation_registration( $private_post_type );
+			$this->handle_pre_65_taxonomy_variation_registration( $taxonomy );
+			$this->handle_pre_65_taxonomy_variation_registration( $private_taxonomoy );
 		}
 	}
 
-	public function test_returns_empty_when_custom_post_type_draft() {
-		$page_id = self::$custom_draft->ID;
-		$url     = 'http://' . WP_TESTS_DOMAIN;
+	public function tear_down() {
+		unregister_post_type( 'custom_book' );
+		unregister_post_type( 'private_custom_book' );
+		unregister_taxonomy( 'book_type' );
+		unregister_taxonomy( 'private_book_type' );
+		unregister_post_type( 'temp_custom_book' );
+		unregister_taxonomy( 'temp_book_type' );
 
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Draft Custom Post Type\",\"type\":\"cats\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
+		// See comment in set_up for explanation.
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_post_type_variation_unregistration( 'custom_book' );
+			$this->handle_pre_65_post_type_variation_unregistration( 'private_custom_book' );
+			$this->handle_pre_65_post_type_variation_unregistration( 'temp_custom_book' );
+			$this->handle_pre_65_taxonomy_variation_unregistration( 'book_type' );
+			$this->handle_pre_65_taxonomy_variation_unregistration( 'private_book_type' );
+			$this->handle_pre_65_taxonomy_variation_unregistration( 'temp_book_type' );
+		}
 
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-
-		$this->assertEquals(
-			'',
-			gutenberg_render_block_core_navigation_link(
-				$navigation_link_block->attributes,
-				array(),
-				$navigation_link_block
-			)
-		);
+		parent::tear_down();
 	}
 
-	public function test_returns_link_when_custom_post_is_published() {
-		$page_id = self::$custom_post->ID;
-		$url     = 'http://' . WP_TESTS_DOMAIN;
+	/**
+	 * @covers ::block_core_navigation_link_register_post_type_variation
+	 */
+	public function test_navigation_link_variations_custom_post_type() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'custom_book', $variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
+		$this->assertEquals( 'Custom Book', $variation['title'], 'Variation title is different than the post type label' );
+	}
 
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Metal Dogs\",\"type\":\"dogs\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$url}/?page_id={$page_id}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
+	/**
+	 * @covers ::block_core_navigation_link_register_post_type_variation
+	 */
+	public function test_navigation_link_variations_private_custom_post_type() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'private_custom_book', $variations );
+		$this->assertEmpty( $variation, 'Block variation for private post type exists.' );
+	}
 
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		// Dynamic label: uses the actual post title ('Metal Dog'), not the stored label.
-		$this->assertEquals(
-			true,
-			strpos(
-				gutenberg_render_block_core_navigation_link(
-					$navigation_link_block->attributes,
-					array(),
-					$navigation_link_block
+	/**
+	 * @covers ::block_core_navigation_link_register_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_custom_taxonomy() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'book_type', $variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+		$this->assertArrayHasKey( 'title', $variation, 'Block variation has no title' );
+		$this->assertEquals( 'Book Type', $variation['title'], 'Variation title is different than the post type label' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_register_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_private_custom_taxonomy() {
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'private_book_type', $variations );
+		$this->assertEmpty( $variation, 'Block variation for private taxonomy exists.' );
+	}
+
+	/**
+	 * @covers ::block_core_navigation_link_unregister_post_type_variation
+	 */
+	public function test_navigation_link_variations_unregister_post_type() {
+		$post_type = register_post_type(
+			'temp_custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Custom Book',
 				),
-				self::$custom_post->post_title
-			) !== false
+				'public'            => true,
+				'show_in_rest'      => true,
+				'show_in_nav_menus' => true,
+			)
 		);
+
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_post_type_variation_registration( $post_type );
+		}
+
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'temp_custom_book', $variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+
+		unregister_post_type( $post_type->name );
+
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_post_type_variation_unregistration( $post_type->name );
+		}
+
+		// Update array, since it's an dynamic built array
+		$variations = $nav_link_block->variations;
+		$variation  = $this->get_variation_by_name( 'temp_custom_book', $variations );
+		$this->assertEmpty( $variation, 'Block variation still exists' );
 	}
 
 	/**
-	 * Tests that the render function uses the current permalink when a post's
-	 * slug has been changed after the menu item was saved.
+	 * @covers ::block_core_navigation_link_unregister_taxonomy_variation
+	 */
+	public function test_navigation_link_variations_unregister_taxonomy() {
+		$taxonomy = register_taxonomy(
+			'temp_book_type',
+			'custom_book',
+			array(
+				'labels'            => array(
+					'item_link' => 'Book Type',
+				),
+				'show_in_nav_menus' => true,
+			)
+		);
+
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_taxonomy_variation_registration( $taxonomy );
+		}
+
+		$registry       = WP_Block_Type_Registry::get_instance();
+		$nav_link_block = $registry->get_registered( 'core/navigation-link' );
+		// Use property and let __get handle it, so it works for core versions before adding get_variations as well
+		$variations = $nav_link_block->variations;
+		$this->assertNotEmpty( $variations, 'Block has no variations' );
+		$variation = $this->get_variation_by_name( 'temp_book_type', $variations );
+		$this->assertIsArray( $variation, 'Block variation does not exist' );
+
+		unregister_taxonomy( $taxonomy->name );
+
+		if ( $this->pre_65_compat ) {
+			$this->handle_pre_65_taxonomy_variation_unregistration( $taxonomy->name );
+		}
+
+		// Update array, since it's an dynamic built array
+		$variations = $nav_link_block->variations;
+		$variation  = $this->get_variation_by_name( 'temp_book_type', $variations );
+		$this->assertEmpty( $variation, 'Block variation still exists' );
+	}
+
+	/**
+	 * Get a variation by its name from an array of variations.
 	 *
-	 * This is the core scenario reported in GitHub issue #38253.
+	 * @param string $variation_name The name (= slug) of the variation.
+	 * @param array  $variations An array of variations.
+	 * @return array|null The found variation or null.
 	 */
-	public function test_uses_dynamic_permalink_after_post_slug_changes() {
-		// Create a published page.
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_name'   => 'test-page',
-				'post_title'  => 'Test Page',
-			)
-		);
-		self::$pages[] = $post;
+	private function get_variation_by_name( $variation_name, $variations ) {
+		$found_variation = null;
+		foreach ( $variations as $variation ) {
+			if ( $variation['name'] === $variation_name ) {
+				$found_variation = $variation;
+			}
+		}
 
-		$page_id    = $post->ID;
-		$stored_url = 'http://' . WP_TESTS_DOMAIN . '/?page_id=' . $page_id;
-
-		// Simulate the block as saved with the original URL.
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Test Page\",\"type\":\"page\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$stored_url}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		// Now change the slug (simulating a post update after menu item was saved).
-		wp_update_post(
-			array(
-				'ID'        => $page_id,
-				'post_name' => 'my-changed-page',
-			)
-		);
-
-		$new_permalink = get_permalink( $page_id );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$rendered              = gutenberg_render_block_core_navigation_link(
-			$navigation_link_block->attributes,
-			array(),
-			$navigation_link_block
-		);
-
-		// The rendered href should use the NEW dynamic permalink, not the stale stored one.
-		$this->assertStringContainsString(
-			'href="' . esc_url( $new_permalink ) . '"',
-			$rendered,
-			'Expected the rendered href to use the new dynamic permalink after slug change.'
-		);
-		$this->assertStringNotContainsString(
-			$stored_url,
-			$rendered,
-			'Expected the rendered href NOT to use the old stored URL after slug change.'
-		);
+		return $found_variation;
 	}
 
 	/**
-	 * Tests that the render function uses the current post title when it has
-	 * been changed after the menu item was saved.
+	 * Registers a block variation for a post type with the deprecated methods for Core versions < 6.5.
+	 * See comment in set_up for dexplanation.
 	 *
-	 * This is the label update part of GitHub issue #38253.
+	 * @param WP_Post_Type $post_type
 	 */
-	public function test_uses_dynamic_label_after_post_title_changes() {
-		// Create a published page.
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_name'   => 'original-title-page',
-				'post_title'  => 'Original Title',
-			)
-		);
-		self::$pages[] = $post;
-
-		$page_id    = $post->ID;
-		$stored_url = 'http://' . WP_TESTS_DOMAIN . '/?page_id=' . $page_id;
-
-		// Simulate block saved with the original label.
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Original Title\",\"type\":\"page\",\"kind\":\"post-type\",\"id\":{$page_id},\"url\":\"{$stored_url}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		// Now change the post title.
-		wp_update_post(
-			array(
-				'ID'         => $page_id,
-				'post_title' => 'My Changed Page',
-			)
-		);
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$rendered              = gutenberg_render_block_core_navigation_link(
-			$navigation_link_block->attributes,
-			array(),
-			$navigation_link_block
-		);
-
-		// The rendered label should use the NEW title, not the stale stored label.
-		$this->assertStringContainsString(
-			'My Changed Page',
-			$rendered,
-			'Expected rendered label to use the new post title after it changed.'
-		);
-		$this->assertStringNotContainsString(
-			'Original Title',
-			$rendered,
-			'Expected rendered label NOT to use the old stored label after title change.'
-		);
+	private function handle_pre_65_post_type_variation_registration( $post_type ) {
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_post_type_variation' );
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_variation' );
+		gutenberg_block_core_navigation_link_register_post_type_variation( $post_type->name, $post_type );
 	}
 
 	/**
-	 * Tests that the render function uses the current term link when a
-	 * taxonomy term's slug has been changed after the menu item was saved.
+	 * Unregisters a block variation for a post type with the deprecated methods for Core versions < 6.5.
+	 * See comment in set_up for dexplanation.
+	 *
+	 * @param string $post_type
 	 */
-	public function test_uses_dynamic_term_link_after_term_slug_changes() {
-		$category_id = self::$category->term_id;
-		$stored_url  = 'http://' . WP_TESTS_DOMAIN . '/?cat=' . $category_id;
-
-		// Simulate block saved with old URL.
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"Cats\",\"type\":\"category\",\"kind\":\"taxonomy\",\"id\":{$category_id},\"url\":\"{$stored_url}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$current_term_link = get_term_link( $category_id, 'category' );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$rendered              = gutenberg_render_block_core_navigation_link(
-			$navigation_link_block->attributes,
-			array(),
-			$navigation_link_block
-		);
-
-		// The rendered href should use the dynamic term link.
-		$this->assertStringContainsString(
-			'href="' . esc_url( $current_term_link ) . '"',
-			$rendered,
-			'Expected the rendered href to use the dynamic term link.'
-		);
+	private function handle_pre_65_post_type_variation_unregistration( $post_type ) {
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_post_type_variation' );
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_variation' );
+		gutenberg_block_core_navigation_link_unregister_post_type_variation( $post_type );
 	}
 
 	/**
-	 * Tests that for a plain custom link (no id), the render function falls
-	 * back to the stored URL and label.
+	 * Registers a block variation for a taxonomy with the deprecated methods for Core versions < 6.5.
+	 * See comment in set_up for dexplanation.
+	 *
+	 * @param WP_Taxonomy $post_type
 	 */
-	public function test_falls_back_to_stored_url_for_custom_link() {
-		$custom_url   = 'https://example.com/custom';
-		$custom_label = 'My Custom Link';
+	private function handle_pre_65_taxonomy_variation_registration( $taxonomy ) {
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_taxonomy_variation' );
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_register_variation' );
+		gutenberg_block_core_navigation_link_register_taxonomy_variation( $taxonomy->name, $taxonomy->object_type, (array) $taxonomy );
+	}
 
-		$parsed_blocks = parse_blocks(
-			"<!-- wp:navigation-link {\"label\":\"{$custom_label}\",\"url\":\"{$custom_url}\"} /-->"
-		);
-		$this->assertEquals( 1, count( $parsed_blocks ) );
-
-		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
-		$rendered              = gutenberg_render_block_core_navigation_link(
-			$navigation_link_block->attributes,
-			array(),
-			$navigation_link_block
-		);
-
-		// Custom links should use stored URL and label unchanged.
-		$this->assertStringContainsString(
-			'href="' . esc_url( $custom_url ) . '"',
-			$rendered,
-			'Expected custom link to use stored URL as href.'
-		);
-		$this->assertStringContainsString(
-			$custom_label,
-			$rendered,
-			'Expected custom link to use stored label.'
-		);
+	/**
+	 * Unregisters a block variation for a taxonomy with the deprecated methods for Core versions < 6.5.
+	 * See comment in set_up for dexplanation.
+	 *
+	 * @param string $post_type
+	 */
+	private function handle_pre_65_taxonomy_variation_unregistration( $taxonomy ) {
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_taxonomy_variation' );
+		$this->setExpectedDeprecated( 'gutenberg_block_core_navigation_link_unregister_variation' );
+		gutenberg_block_core_navigation_link_unregister_taxonomy_variation( $taxonomy );
 	}
 }


### PR DESCRIPTION
## What?
Closes #38253
This PR fixes the `core/navigation-link` block so that navigation menu items always reflect the **current** permalink and title of the linked post, page, or taxonomy term, both on the frontend and in the Site Editor.

## Why?
When a navigation menu item is added via the Site Editor, its `url` and `label` are stored as block attributes at save time. If a post's title or slug is later changed, the menu item continued to show the old URL and label, with no automatic update. This was reported in #38253.

Even when WordPress could redirect the old URL, it is better to output the correct link from the start so it works without relying on redirects.

## Testing Instructions

1. Create a new Page titled "Test Page" with slug test-page and publish it.
2. Go to Appearance → Editor → Navigation and add "Test Page" as a navigation menu item.
3. Save the navigation menu.
4. Go back and edit the page: change its title to "My Changed Page" and its slug to my-changed-page. Update/publish.
5. Confirm the changed page title in frontend and site editor as well.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/eaafd4e6-5eac-4f81-b0ff-2ff46efd0bbe