### PR TITLE
Global Styles: Show skeleton placeholder while previews load

### DIFF
--- a/packages/global-styles-ui/src/preview-wrapper.tsx
+++ b/packages/global-styles-ui/src/preview-wrapper.tsx
@@ -107,7 +107,7 @@ function PreviewWrapper( {
 				<Skeleton
 					className="global-styles-ui-preview__wrapper"
 					style={ {
-						aspectRatio: `${ normalizedWidth } / ${ normalizedHeight }`,
+						aspectRatio: normalizedWidth / normalizedHeight,
 					} }
 				/>
 			) }

--- a/packages/global-styles-ui/src/preview-wrapper.tsx
+++ b/packages/global-styles-ui/src/preview-wrapper.tsx
@@ -13,6 +13,7 @@ import {
 	useResizeObserver,
 } from '@wordpress/compose';
 import { useLayoutEffect, useState } from '@wordpress/element';
+import { Skeleton } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -101,6 +102,15 @@ function PreviewWrapper( {
 			<div style={ { position: 'relative' } }>
 				{ containerResizeListener }
 			</div>
+			{ ! isReady && (
+				// Match the preview aspect ratio so layout doesn't jump once width is measured.
+				<Skeleton
+					className="global-styles-ui-preview__wrapper"
+					style={ {
+						aspectRatio: `${ normalizedWidth } / ${ normalizedHeight }`,
+					} }
+				/>
+			) }
 			{ isReady && (
 				<div
 					className={ clsx( 'global-styles-ui-preview__wrapper', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/79284

Show the new `Skeleton` placeholder in `PreviewWrapper` while the container width is being calculated, instead of rendering nothing until the preview is ready.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As described in [the issue](https://github.com/WordPress/gutenberg/issues/79284), global styles previews (style variations, color/typography previews, etc.) wait on a resize observer before rendering. Until the width of each element is known, the preview area has no height, and then it suddenly expands to its full size. That layout jump happens fast but it is noticeable (especially in the Site Editor, where these previews are among the first things users see)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

While still loading (`! isReady`), we render the new [Skeleton](https://github.com/WordPress/gutenberg/pull/79671) from `@wordpress/ui` with the same wrapper class and aspect ratio as the real preview. That "reserves" the proper height immediately, so when the measured preview replaces it there is no jump.

## Testing Instructions

The best way to test this out would be opening the chrome dev tools, going to performance and set the "Environment"settings to have a CPU slowdown.

1. Open Site Editor > Styles
2. Click on "Browse styles" (test with TT5, that has different variations, palettes, typography)
3. Confirm preview areas no longer jump in height on load.
4. Resize the styles panel and confirm previews still scale correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/47191c76-6395-444e-8efc-78e090564870


Previous behavior:

https://github.com/user-attachments/assets/bda49a5c-15b5-4c37-af23-d56f387e613f

