### PR TITLE
Editor: saveDirtyEntities: don't allow onSave to filter records

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -67,9 +67,8 @@ const EntitiesSavedStatesForPreview = ( {
 	);
 
 	const activateTheme = useActivateTheme();
-	const onSave = async ( values ) => {
+	const onSave = async () => {
 		await activateTheme();
-		return values;
 	};
 
 	return (

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -27,10 +27,6 @@ import { useIsDirty } from './hooks/use-is-dirty';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-function identity( values ) {
-	return values;
-}
-
 /**
  * Renders the component for managing saved states of entities.
  *
@@ -79,7 +75,7 @@ export default function EntitiesSavedStates( {
 export function EntitiesSavedStatesExtensible( {
 	additionalPrompt = undefined,
 	close,
-	onSave = identity,
+	onSave = undefined,
 	saveEnabled: saveEnabledProp = undefined,
 	saveLabel = __( 'Save' ),
 	renderDialog,

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -211,9 +211,9 @@ export const saveDirtyEntities =
 			.__unstableMarkLastChangeAsPersistent();
 
 		Promise.all( pendingSavedRecords )
-			.then( ( values ) => {
+			.then( async ( values ) => {
 				if ( onSave ) {
-					onSave();
+					await onSave();
 				}
 				return values;
 			} )

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -209,9 +209,13 @@ export const saveDirtyEntities =
 		registry
 			.dispatch( blockEditorStore )
 			.__unstableMarkLastChangeAsPersistent();
+
 		Promise.all( pendingSavedRecords )
 			.then( ( values ) => {
-				return onSave ? onSave( values ) : values;
+				if ( onSave ) {
+					onSave();
+				}
+				return values;
 			} )
 			.then( ( values ) => {
 				if (


### PR DESCRIPTION
## What?

Originally, #50030 introduced an optional argument for `saveDirtyEntities` called `onSave`:

https://github.com/WordPress/gutenberg/blob/30bb0b0b1250c6b101342f4de02afe874fe2bdc7/packages/editor/src/store/private-actions.js#L234-L237

This was done to support a specific use case:

https://github.com/WordPress/gutenberg/blob/d9a0ca10f042078b768f98c58aa3f38f7c74903f/packages/edit-site/src/components/save-panel/index.js#L38-L41

However, the exposed surface doesn't need to be quite so wide, so this PR limits the role of `onSave` to a simple callback with no arguments and whose return value is ignored.

## Why?

The most important thing was to ignore the return value of `onSave`. This is to ensure that the latter stage of `saveDirtyEntities` is manipulating the results of those `saveEditedEntityRecord` and `__experimentalSaveSpecifiedEntityEdits` action dispatches, and not some unverified value returned by `onSave`.

The second change was to no longer pass those results to `onSave` in the first place. Since we currently have no use case for it, there's no good reason to tie implementation details of `saveDirtyEntities` with an API.

This PR is a precursor to simplifications to be made in #77447.

## Testing Instructions

Try saving different entities, including with failures.
Nothing should break, nothing should behave differently.