### PR TITLE
Table: Add Arrow Down writing flow escape from the last table row

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -13,6 +13,8 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { isVerticalEdge } from '@wordpress/dom';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import {
 	InspectorControls,
 	BlockControls,
@@ -412,6 +414,39 @@ function TableEdit( {
 		},
 	];
 
+	// Determine the last section and its last row index so we can provide
+	// Arrow Down escape behaviour for cells in that position.
+	const lastSectionName = sections[ sections.length - 1 ];
+	const lastSectionRows = lastSectionName
+		? attributes[ lastSectionName ]
+		: [];
+	const lastRowIndex = lastSectionRows.length - 1;
+
+	/**
+	 * Handles Arrow Down key press in the last row of the table. When the
+	 * caret is at the bottom vertical edge of the cell, insert a new default
+	 * block after the table so keyboard-only users can escape the block.
+	 *
+	 * @param {KeyboardEvent} event The keyboard event.
+	 */
+	function onLastRowKeyDown( event ) {
+		if ( event.defaultPrevented ) {
+			return;
+		}
+
+		if ( event.key !== 'ArrowDown' ) {
+			return;
+		}
+
+		if ( ! isVerticalEdge( event.currentTarget, false ) ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+	}
+
 	const renderedSections = sections.map( ( name ) => (
 		<TSection name={ name } key={ name }>
 			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
@@ -421,6 +456,12 @@ function TableEdit( {
 							selectedCell?.sectionName === name &&
 							selectedCell?.rowIndex === rowIndex &&
 							selectedCell?.columnIndex === columnIndex;
+
+						// Determine if this cell is in the last row of the last
+						// section so we can attach the Arrow Down escape handler.
+						const isLastRowOfLastSection =
+							name === lastSectionName &&
+							rowIndex === lastRowIndex;
 
 						// Important - the Cell component is memoized to improve typing performance.
 						// ensure all props passed have stable references.
@@ -438,6 +479,11 @@ function TableEdit( {
 									isSelected ? onChange : undefined
 								}
 								setSelectedCell={ setSelectedCell }
+								onArrowDownFromLastRow={
+									isLastRowOfLastSection
+										? onLastRowKeyDown
+										: undefined
+								}
 								{ ...cellProps }
 							/>
 						);
@@ -615,6 +661,7 @@ const Cell = memo( function ( {
 	content,
 	onChange,
 	setSelectedCell,
+	onArrowDownFromLastRow,
 } ) {
 	return (
 		<CellTag
@@ -642,6 +689,7 @@ const Cell = memo( function ( {
 				} }
 				aria-label={ cellAriaLabel[ name ] }
 				placeholder={ placeholder[ name ] }
+				onKeyDown={ onArrowDownFromLastRow }
 			/>
 		</CellTag>
 	);

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -13,7 +13,6 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { isVerticalEdge } from '@wordpress/dom';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import {
 	InspectorControls,
@@ -414,39 +413,6 @@ function TableEdit( {
 		},
 	];
 
-	// Determine the last section and its last row index so we can provide
-	// Arrow Down escape behaviour for cells in that position.
-	const lastSectionName = sections[ sections.length - 1 ];
-	const lastSectionRows = lastSectionName
-		? attributes[ lastSectionName ]
-		: [];
-	const lastRowIndex = lastSectionRows.length - 1;
-
-	/**
-	 * Handles Arrow Down key press in the last row of the table. When the
-	 * caret is at the bottom vertical edge of the cell, insert a new default
-	 * block after the table so keyboard-only users can escape the block.
-	 *
-	 * @param {KeyboardEvent} event The keyboard event.
-	 */
-	function onLastRowKeyDown( event ) {
-		if ( event.defaultPrevented ) {
-			return;
-		}
-
-		if ( event.key !== 'ArrowDown' ) {
-			return;
-		}
-
-		if ( ! isVerticalEdge( event.currentTarget, false ) ) {
-			return;
-		}
-
-		event.preventDefault();
-
-		insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-	}
-
 	const renderedSections = sections.map( ( name ) => (
 		<TSection name={ name } key={ name }>
 			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
@@ -456,12 +422,6 @@ function TableEdit( {
 							selectedCell?.sectionName === name &&
 							selectedCell?.rowIndex === rowIndex &&
 							selectedCell?.columnIndex === columnIndex;
-
-						// Determine if this cell is in the last row of the last
-						// section so we can attach the Arrow Down escape handler.
-						const isLastRowOfLastSection =
-							name === lastSectionName &&
-							rowIndex === lastRowIndex;
 
 						// Important - the Cell component is memoized to improve typing performance.
 						// ensure all props passed have stable references.
@@ -479,11 +439,7 @@ function TableEdit( {
 									isSelected ? onChange : undefined
 								}
 								setSelectedCell={ setSelectedCell }
-								onArrowDownFromLastRow={
-									isLastRowOfLastSection
-										? onLastRowKeyDown
-										: undefined
-								}
+								insertBlocksAfter={ insertBlocksAfter }
 								{ ...cellProps }
 							/>
 						);
@@ -661,7 +617,7 @@ const Cell = memo( function ( {
 	content,
 	onChange,
 	setSelectedCell,
-	onArrowDownFromLastRow,
+	insertBlocksAfter,
 } ) {
 	return (
 		<CellTag
@@ -689,7 +645,13 @@ const Cell = memo( function ( {
 				} }
 				aria-label={ cellAriaLabel[ name ] }
 				placeholder={ placeholder[ name ] }
-				onKeyDown={ onArrowDownFromLastRow }
+				__unstableOnSplitAtDoubleLineEnd={ () => {
+					if ( insertBlocksAfter ) {
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						);
+					}
+				} }
 			/>
 		</CellTag>
 	);


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/79277

## What?

Fixes a keyboard navigation trap in the Table block. When the table is the last block on the page, pressing Arrow Down in any cell of the last row now inserts a new paragraph block after the table, allowing keyboard-only users
to continue writing naturally.

## Why?

Unlike paragraph or heading blocks, the Table block reserves the Enter key for inserting line breaks within cells. This means keyboard users had no way to exit the table downward, Arrow Down did nothing, and Tab jumped directly
to the meta fields, bypassing the editor entirely.

## How?

Added an `onKeyDown` handler (`onLastRowKeyDown`) attached exclusively to cells in the **last row of the last section** (body or foot). The handler:

1. Checks for `event.key === 'ArrowDown'`
2. Checks `isVerticalEdge(event.currentTarget, false)` to confirm the caret is at the bottom of the cell — so multi-line cells still allow natural downward movement within the cell before triggering
3. Calls `insertBlocksAfter( createBlock( getDefaultBlockName() ) )`

Cells in all other rows are completely unaffected, and Arrow Down continues to move through rows normally via the browser's native table navigation.

## Testing Instructions

1. Create a Table block
2. Click into any cell in the **last row** and press Arrow Down → A new paragraph block should appear below the table with focus
3. Click into a cell in the **first row** and press Arrow Down → Focus moves to the cell below (standard behavior, unchanged)
4. In a last-row cell with multi-line content, press Arrow Down when the caret is NOT on the last line → caret moves down within the cell (no escape)

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/3a1968a0-4cd2-4f9e-af80-bd5c414967b1


### After



https://github.com/user-attachments/assets/8a6d2b5f-725f-4dfc-8c10-f42d716f7d38

