### PR TITLE
Query Loop: Normalize inherited perPage/offset context for descendant blocks

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -71,6 +71,46 @@ function register_block_core_query() {
 add_action( 'init', 'register_block_core_query' );
 
 /**
+ * Normalizes the `perPage` and `offset` query context passed down to the
+ * descendants of a Query Loop block that inherits the global query.
+ *
+ * When `inherit` is enabled, the block's own `perPage`/`offset` attributes
+ * are not used to build the query: rendering relies entirely on the main
+ * `$wp_query`, which is paginated according to the site's Reading Settings.
+ * If a block's stored `perPage` attribute has drifted from that value (for
+ * example, content authored outside the block editor, or saved before the
+ * "Items per Page" control was hidden for inheriting queries), any block
+ * reading `context.query.perPage` would see a number that doesn't match
+ * what is actually rendered. This keeps the exposed context truthful.
+ *
+ * @since 6.9.0
+ *
+ * @param array         $context      Prepared block context.
+ * @param array         $parsed_block Block being rendered.
+ * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+ * @return array Filtered block context.
+ */
+function block_core_query_normalize_inherited_context( $context, $parsed_block, $parent_block ) {
+	if ( ! $parent_block instanceof WP_Block || 'core/query' !== $parent_block->name ) {
+		return $context;
+	}
+
+	if ( empty( $context['query']['inherit'] ) ) {
+		return $context;
+	}
+
+	global $wp_query;
+
+	$context['query']['perPage'] = $wp_query instanceof WP_Query
+		? (int) $wp_query->get( 'posts_per_page' )
+		: (int) get_option( 'posts_per_page' );
+	$context['query']['offset']  = 0;
+
+	return $context;
+}
+add_filter( 'render_block_context', 'block_core_query_normalize_inherited_context', 10, 3 );
+
+/**
  * Traverse the tree of blocks looking for any plugin block (i.e., a block from
  * an installed plugin) inside a Query block with the enhanced pagination
  * enabled. If at least one is found, the enhanced pagination is effectively

--- a/phpunit/blocks/render-query-inherited-context-test.php
+++ b/phpunit/blocks/render-query-inherited-context-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for the `core/query` block's inherited context normalization.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderQueryInheritedContext extends WP_UnitTestCase {
+
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'test/query-context-probe',
+			array(
+				'uses_context'    => array( 'query' ),
+				'render_callback' => static function ( $attributes, $content, $block ) {
+					return sprintf(
+						'<div class="query-context-probe" data-per-page="%s" data-offset="%s"></div>',
+						esc_attr( $block->context['query']['perPage'] ?? 'null' ),
+						esc_attr( $block->context['query']['offset'] ?? 'null' )
+					);
+				},
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/query-context-probe' );
+	}
+
+	/**
+	 * When a Query Loop inherits the main query, the block only ever renders
+	 * according to `$wp_query`'s own `posts_per_page`, ignoring its own
+	 * `perPage`/`offset` attributes. Descendant blocks should see that same,
+	 * truthful value via context rather than the block's raw (and possibly
+	 * stale or divergent) attributes.
+	 */
+	public function test_inherited_query_context_reflects_main_query_posts_per_page() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"query":{"inherit":true,"perPage":25,"offset":10}} -->
+		<div class="wp-block-query">
+			<!-- wp:test/query-context-probe /-->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		$wp_query     = new WP_Query( array( 'posts_per_page' => 5 ) );
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( array( 'class_name' => 'query-context-probe' ) );
+
+		$this->assertSame( '5', $p->get_attribute( 'data-per-page' ) );
+		$this->assertSame( '0', $p->get_attribute( 'data-offset' ) );
+	}
+
+	/**
+	 * Non-inheriting queries build their own `WP_Query`, so their declared
+	 * `perPage`/`offset` attributes are the source of truth and must be left
+	 * untouched.
+	 */
+	public function test_non_inherited_query_context_keeps_declared_per_page() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"query":{"inherit":false,"perPage":25,"offset":10,"postType":"post"}} -->
+		<div class="wp-block-query">
+			<!-- wp:test/query-context-probe /-->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		$wp_query     = new WP_Query( array( 'posts_per_page' => 5 ) );
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( array( 'class_name' => 'query-context-probe' ) );
+
+		$this->assertSame( '25', $p->get_attribute( 'data-per-page' ) );
+		$this->assertSame( '10', $p->get_attribute( 'data-offset' ) );
+	}
+}


### PR DESCRIPTION
## What?

Partially addresses #79822.

When a Query Loop block has "Inherit query from URL" enabled, any block underneath it (built-in, like Post Template or the pagination blocks, or third-party) that reads `context.query.perPage` can receive a value that doesn't match what's actually rendered.

## Why?

Investigating #79822, I traced through every block that consumes an inheriting Query Loop's context (`post-template`, `query-pagination-next`, `query-pagination-previous`, `query-pagination-numbers`, `query-total`, `term-template`). All of them are already internally self-consistent when `inherit: true`: they render exclusively off the main `$wp_query` (which is paginated according to Reading Settings' "Blog pages show at most"), and completely ignore the block's own `perPage`/`offset` attributes. That's intentional, from #49904, specifically to keep a Query Loop's own pagination from diverging from WordPress's main-query/URL routing.

However, `providesContext` maps the block's *raw* `query` attribute straight into descendant context, unmodified. So while core's own blocks never actually use the stale `perPage`, anything else that reads `context.query.perPage` — a custom block, a plugin, a "Showing X of Y" display — gets a number that was never applied. That mismatch can arise because the editor only prevents this client-side (a `useEffect` in `query-content.js` force-syncs `perPage` to Reading Settings whenever `inherit` is `true`, and the "Items per Page" control is hidden while inheriting) — content authored outside the editor (imports, hand-edited template markup, or a block saved before that correction existed) can persist a `perPage` that was never actually applied to anything.

I believe this is very likely what's actually going on in the reporter's repro: a Query Loop with `inherit: true` and a stored `perPage: 25` that doesn't match Reading Settings. I could not reproduce a literal, Gutenberg-generated 404 from the block's own pagination links, since (per the above) they're driven entirely by `$wp_query` and can never point past what `$wp_query` itself will resolve. The `<link rel="next">` in the report is also not something WordPress core or Gutenberg emits for archive pagination (`adjacent_posts_rel_link_wp_head()` is single-post-only and hasn't been hooked to `wp_head` since 5.6) — it's most likely coming from an SEO plugin computing its own rel=next from `$wp_query->max_num_pages`, which is a different problem from anything in this block's PHP.

## How?

Adds a `render_block_context` filter, scoped to direct children of `core/query`, that overwrites `perPage`/`offset` in the propagated `query` context with the values that are actually in effect (`$wp_query`'s resolved `posts_per_page`, falling back to `get_option( 'posts_per_page' )`) whenever `inherit` is `true`. Non-inheriting queries are untouched — their own `perPage`/`offset` remain the source of truth.

## Testing Instructions

- `vendor/bin/phpcs packages/block-library/src/query/index.php phpunit/blocks/render-query-inherited-context-test.php`
- `vendor/bin/phpunit phpunit/blocks/render-query-inherited-context-test.php`

## Scope / what this does *not* fix

This does not change what an inheriting Query Loop actually renders or paginates to — that remains tied to Reading Settings, per #49904's design. Making a Query Loop's own `perPage` genuinely override Reading Settings for the *main* query (the deeper ask in #79822 and the related #63028 discussion) would require hooking `pre_get_posts` with knowledge of the resolved block template before the main query runs, which is a materially larger, main-query-affecting change that I think deserves its own design discussion with maintainers before implementation. Happy to help scope that as a follow-up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)