### PR TITLE
Tabs: fix stale overflow fade as content settles on load

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+-   `Tabs`: Re-measure overflow when the list or its content changes size so the scroll fade stays in sync as labels/badges load or a web font reflows the tabs. ([#79856](https://github.com/WordPress/gutenberg/pull/79856))
 -   `IconButton`: Keep the inline padding override valid when reused in button length calculations ([#79722](https://github.com/WordPress/gutenberg/pull/79722)).
 -   `IconButton`: Restore the default tooltip delay on hover ([#79505](https://github.com/WordPress/gutenberg/pull/79505)).
 -   `Button`: Fix corner artifacts by using `background-clip: border-box` ([#79524](https://github.com/WordPress/gutenberg/pull/79524))

--- a/packages/ui/src/tabs/list.tsx
+++ b/packages/ui/src/tabs/list.tsx
@@ -60,15 +60,34 @@ export const List = forwardRef< HTMLDivElement, TabListProps >(
 						: scrollLeft;
 
 				// Use SCROLL_EPSILON to handle subpixel rendering differences.
-				setOverflow( {
+				const next = {
 					first: scrollFromStart > SCROLL_EPSILON,
 					last: scrollFromStart < maxScroll - SCROLL_EPSILON,
 					isScrolling: scrollWidth > clientWidth,
-				} );
+				};
+				setOverflow( ( prev ) =>
+					prev.first === next.first &&
+					prev.last === next.last &&
+					prev.isScrolling === next.isScrolling
+						? prev
+						: next
+				);
 			};
 
 			const resizeObserver = new ResizeObserver( measureOverflow );
-			resizeObserver.observe( listEl );
+			const observeTabs = () => {
+				resizeObserver.disconnect();
+				resizeObserver.observe( listEl );
+				listEl
+					.querySelectorAll( '[role="tab"]' )
+					.forEach( ( tab ) => resizeObserver.observe( tab ) );
+			};
+
+			const mutationObserver = new MutationObserver( observeTabs );
+			mutationObserver.observe( listEl, {
+				childList: true,
+				subtree: true,
+			} );
 
 			let scrollTick = false;
 			const throttleMeasureOverflowOnScroll = () => {
@@ -86,7 +105,7 @@ export const List = forwardRef< HTMLDivElement, TabListProps >(
 				{ passive: true }
 			);
 
-			// Initial check.
+			observeTabs();
 			measureOverflow();
 
 			return () => {
@@ -95,6 +114,7 @@ export const List = forwardRef< HTMLDivElement, TabListProps >(
 					throttleMeasureOverflowOnScroll
 				);
 				resizeObserver.disconnect();
+				mutationObserver.disconnect();
 			};
 		}, [ listEl ] );
 

--- a/packages/ui/src/tabs/test/overflow.test.tsx
+++ b/packages/ui/src/tabs/test/overflow.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the stale overflow fade: a tab reflowing to fit — with
+ * no resize/mutation/scroll event on the list — must clear the fade.
+ *
+ * The fix mirrors Base UI by observing each tab (not just the list box), so
+ * firing only the observers that watch a tab reproduces the exact case the old
+ * list-only observer missed. Passes with the fix; fails without it.
+ */
+import { act, render, screen } from '@testing-library/react';
+import { Tabs } from '../..';
+
+// The jest preset mocks CSS Modules to `{}`; expose the keys so we can assert
+// on `is-overflowing-last`, the class that drives the fade.
+jest.mock( '../style.module.css', () => ( {
+	__esModule: true,
+	default: new Proxy( {}, { get: ( _target, key ) => key } ),
+} ) );
+
+// The list's fixed visible width. The overflowing width exceeds it by more than
+// the component's 1px SCROLL_EPSILON so overflow registers; the fitting width
+// equals it so the fade clears. The exact pixel values are arbitrary.
+const CLIENT_WIDTH = 173;
+const OVERFLOWING_SCROLL_WIDTH = CLIENT_WIDTH + 2;
+const FITTING_SCROLL_WIDTH = CLIENT_WIDTH;
+
+describe( 'Tabs.List overflow fade', () => {
+	let observers: Array< {
+		callback: ResizeObserverCallback;
+		elements: Set< Element >;
+	} >;
+	let scrollWidth: number;
+
+	beforeEach( () => {
+		observers = [];
+		global.ResizeObserver = class {
+			elements = new Set< Element >();
+			constructor( callback: ResizeObserverCallback ) {
+				observers.push( { callback, elements: this.elements } );
+			}
+			observe( element: Element ) {
+				this.elements.add( element );
+			}
+			unobserve( element: Element ) {
+				this.elements.delete( element );
+			}
+			disconnect() {
+				this.elements.clear();
+			}
+		} as unknown as typeof ResizeObserver;
+
+		// jsdom does no layout, so drive the measured widths ourselves.
+		scrollWidth = OVERFLOWING_SCROLL_WIDTH;
+		Object.defineProperty( HTMLElement.prototype, 'scrollWidth', {
+			configurable: true,
+			get: () => scrollWidth,
+		} );
+		Object.defineProperty( HTMLElement.prototype, 'clientWidth', {
+			configurable: true,
+			get: () => CLIENT_WIDTH,
+		} );
+	} );
+
+	it( 'clears the fade when a tab reflows to fit', () => {
+		render(
+			<Tabs.Root defaultValue="one">
+				<Tabs.List>
+					<Tabs.Tab value="one">One</Tabs.Tab>
+					<Tabs.Tab value="two">Two</Tabs.Tab>
+				</Tabs.List>
+			</Tabs.Root>
+		);
+
+		const tablist = screen.getByRole( 'tablist' );
+		const tabs = screen.getAllByRole( 'tab' );
+		expect( tablist ).toHaveClass( 'is-overflowing-last' );
+
+		// Fire only the observers watching a tab — a tab-box reflow, the case the
+		// old list-only observer never saw.
+		const tabObservers = observers.filter( ( observer ) =>
+			tabs.some( ( tab ) => observer.elements.has( tab ) )
+		);
+		scrollWidth = FITTING_SCROLL_WIDTH;
+		act( () =>
+			tabObservers.forEach( ( observer ) =>
+				observer.callback( [], {} as ResizeObserver )
+			)
+		);
+
+		expect( tablist ).not.toHaveClass( 'is-overflowing-last' );
+	} );
+} );


### PR DESCRIPTION
## What?

Fixes the `Tabs` horizontal-overflow **fade** ("scroll affordance") getting stuck in a stale state as a tab bar's content settles on load — e.g. a fade left covering the trailing tab even though its content has since reflowed to a size that fits.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/enejb/gutenberg/tabs-fade-screenshots/tabs-fade-before.png) | ![after](https://raw.githubusercontent.com/enejb/gutenberg/tabs-fade-screenshots/tabs-fade-after.png) |

_A two-tab bar whose count settles after mount. **Before:** the fade is stuck over the "Responses 2" tab. **After:** the fade clears and both tabs read cleanly._

## Why?

`Tabs.List` decides whether to show the edge fade from a `measureOverflow()` call that re-runs on `scroll` and via a `ResizeObserver` **on the list element**. A `ResizeObserver` only fires when the observed element's own box changes.

When the list is width-constrained, content can reflow after mount without resizing the list or mutating its DOM:

- async labels / count badges resolving to their value, or
- a **web font swapping in** and reflowing the labels — often by a *sub-pixel* amount (e.g. `scrollWidth` 175 → 173 while `clientWidth` stays 173).

Neither is a change to the list's own box, so **no observer fires**, and the overflow state (and the fade) stays frozen at the mount-time measurement — a fade stuck over a tab whose content actually fits.

## How?

Mirror Base UI's own overflow tracking: a single `ResizeObserver` observes the list box **and each individual tab**, with a `MutationObserver` re-syncing the observed tabs as they are added or removed. The reflow a list-only observer misses *does* change each tab's own box — the same size Base UI observes to keep its indicator in sync — so observing the tabs picks it up.

This replaces an earlier frame-based "settle loop" (re-measuring each animation frame until the width held steady). The observer approach is event-driven rather than polling, and there is no longer any change to the native scrollbar — it behaves as the platform default.

Adds a jsdom regression test that fires only the observers watching a tab (a tab-box reflow, with no resize/mutation/scroll event) and asserts `is-overflowing-last` clears; it passes with this change and fails against the list-only observer.

## Testing Instructions

1. Run the unit test: `npm run test:unit packages/ui/src/tabs`. The `Tabs.List overflow fade` regression test passes with this change and fails against the list-only observer on trunk.
2. Confirm scroll/resize behaviour is unchanged in Storybook (`npm run storybook:dev`): **Design System → Components → Tabs → Size and Overflow Playground** — a small container still scrolls via trackpad/keyboard and still shows the edge fade.

## Testing Instructions for Keyboard

No interaction changes. The list stays scrollable and the fade is purely visual; tab focus / roving-tabindex behaviour is unchanged.
