### PR TITLE
Release: Harden plugin release workflow guardrails

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -74,15 +74,6 @@ jobs:
                   permission-contents: write
                   permission-workflows: write
 
-            - name: Validate GitHub release token
-              env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-              run: |
-                  if ! gh api "repos/${GITHUB_REPOSITORY}" > /dev/null; then
-                    echo "::error::Could not validate the GitHub App release token for ${GITHUB_REPOSITORY}. Check that the GitHub Releases environment exposes APP_CLIENT_ID and APP_PRIVATE_KEY, and that the installed app has contents: write and workflows: write permissions for this repository."
-                    exit 1
-                  fi
-
     bump-version:
         name: Bump version
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -17,9 +17,9 @@ on:
 # Workflow-dispatched release runs must not cancel an in-flight run after it may have
 # pushed version bump commits.
 concurrency:
-    # The concurrency group contains the workflow name and the release type/ref for release
-    # dispatches, the branch name for pull requests, or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format( '{0}-{1}', github.ref, github.event.inputs.version ) || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
+    # The concurrency group contains the workflow name and ref for release dispatches,
+    # the branch name for pull requests, or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.ref || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
     cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # Disable permissions for all available scopes by default.
@@ -93,7 +93,7 @@ jobs:
                   # PATs and GitHub App tokens may omit it, and GitHub does not expose
                   # a non-mutating release-creation permission check. This catches visible
                   # under-scoping while the repository access check remains the fallback.
-                  if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qx 'repo'; then
+                  if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qxE 'repo|public_repo'; then
                     echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."
                     echo "::error::$token_follow_up"
                     rm -f "$headers_file"

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -68,9 +68,12 @@ jobs:
               run: |
                   gh auth status --hostname github.com
 
-                  token_follow_up="Release managers/repository admins must fix this before the next RC day: "
-                  token_follow_up+="either make the default GITHUB_TOKEN with contents: write able to create draft releases and remove this PAT dependency, "
-                  token_follow_up+="or rotate/replace GUTENBERG_TOKEN with a token that can create draft releases in this repository."
+                  # This workflow currently relies on GUTENBERG_TOKEN for release
+                  # branch pushes and draft release creation. If repository policy
+                  # later allows the default GITHUB_TOKEN to create draft releases,
+                  # that can be handled as a separate workflow simplification.
+                  token_follow_up="Release managers should ask repository admins to rotate or replace GUTENBERG_TOKEN before the next RC day "
+                  token_follow_up+="with a token that can create draft releases in ${GITHUB_REPOSITORY}."
 
                   headers_file="$(mktemp)"
                   if ! gh api -i "repos/${GITHUB_REPOSITORY}" > "$headers_file"; then

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -81,6 +81,9 @@ jobs:
                     tail -n 1
                   )"
 
+                  # GitHub only exposes x-oauth-scopes for classic PATs. Fine-grained
+                  # PATs and GitHub App tokens may omit it, so this catches visible
+                  # under-scoping while the repository access check remains the fallback.
                   if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qx 'repo'; then
                     echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."
                     rm -f "$headers_file"
@@ -233,8 +236,14 @@ jobs:
         if: |
             always() && (
               github.event_name == 'pull_request' ||
-              github.event_name == 'workflow_dispatch' ||
-              github.repository == 'WordPress/gutenberg'
+              (
+                github.event_name == 'workflow_dispatch' &&
+                needs.bump-version.result == 'success'
+              ) ||
+              (
+                github.event_name != 'workflow_dispatch' &&
+                github.repository == 'WordPress/gutenberg'
+              )
             )
         strategy:
             matrix:

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -58,49 +58,30 @@ jobs:
     preflight-release-token:
         name: Preflight release token
         runs-on: 'ubuntu-24.04'
+        environment: 'GitHub Releases'
         permissions: {}
         if: ${{ github.event_name == 'workflow_dispatch' }}
 
         steps:
+            # Request the same elevated permissions as create-release so a
+            # misconfigured GitHub App fails before version bump commits are pushed.
+            - name: Generate application token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              id: app-token
+              with:
+                  client-id: ${{ vars.APP_CLIENT_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-workflows: write
+
             - name: Validate GitHub release token
               env:
-                  GH_TOKEN: ${{ secrets.GUTENBERG_TOKEN }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  gh auth status --hostname github.com
-
-                  # This workflow currently relies on GUTENBERG_TOKEN for release
-                  # branch pushes and draft release creation. If repository policy
-                  # later allows the default GITHUB_TOKEN to create draft releases,
-                  # that can be handled as a separate workflow simplification.
-                  token_follow_up="Release managers should ask repository admins to rotate or replace GUTENBERG_TOKEN before the next RC day "
-                  token_follow_up+="with a token that can create draft releases in ${GITHUB_REPOSITORY}."
-
-                  headers_file="$(mktemp)"
-                  if ! gh api -i "repos/${GITHUB_REPOSITORY}" > "$headers_file"; then
-                    echo "::error::GUTENBERG_TOKEN cannot access ${GITHUB_REPOSITORY}. The release workflow token must be able to create draft releases in this repository."
-                    echo "::error::$token_follow_up"
-                    rm -f "$headers_file"
+                  if ! gh api "repos/${GITHUB_REPOSITORY}" > /dev/null; then
+                    echo "::error::Could not validate the GitHub App release token for ${GITHUB_REPOSITORY}. Check that the GitHub Releases environment exposes APP_CLIENT_ID and APP_PRIVATE_KEY, and that the installed app has contents: write and workflows: write permissions for this repository."
                     exit 1
                   fi
-
-                  oauth_scopes="$(
-                    awk -F': ' 'tolower($1) == "x-oauth-scopes" { print tolower($2) }' "$headers_file" |
-                    tr -d '\r' |
-                    tail -n 1
-                  )"
-
-                  # GitHub only exposes x-oauth-scopes for classic PATs. Fine-grained
-                  # PATs and GitHub App tokens may omit it, and GitHub does not expose
-                  # a non-mutating release-creation permission check. This catches visible
-                  # under-scoping while the repository access check remains the fallback.
-                  if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qxE 'repo|public_repo'; then
-                    echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."
-                    echo "::error::$token_follow_up"
-                    rm -f "$headers_file"
-                    exit 1
-                  fi
-
-                  rm -f "$headers_file"
 
     bump-version:
         name: Bump version

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -82,7 +82,8 @@ jobs:
                   )"
 
                   # GitHub only exposes x-oauth-scopes for classic PATs. Fine-grained
-                  # PATs and GitHub App tokens may omit it, so this catches visible
+                  # PATs and GitHub App tokens may omit it, and GitHub does not expose
+                  # a non-mutating release-creation permission check. This catches visible
                   # under-scoping while the repository access check remains the fallback.
                   if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qx 'repo'; then
                     echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -63,8 +63,9 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
 
         steps:
-            # Request the same elevated permissions as create-release so a
-            # misconfigured GitHub App fails before version bump commits are pushed.
+            # Request the same elevated permissions as create-release so invalid
+            # credentials or unavailable requested permissions fail before version
+            # bump commits are pushed.
             - name: Generate application token
               uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               id: app-token

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -13,12 +13,14 @@ on:
                 description: 'rc or stable?'
                 required: true
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Cancels previous non-release workflow runs that have not completed.
+# Workflow-dispatched release runs must not cancel an in-flight run after it may have
+# pushed version bump commits.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+    # The concurrency group contains the workflow name and the release type/ref for release
+    # dispatches, the branch name for pull requests, or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format( '{0}-{1}', github.ref, github.event.inputs.version ) || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
+    cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -53,11 +55,45 @@ jobs:
                     echo "next_stable_branch=release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))" >> "$GITHUB_OUTPUT"
                   fi
 
+    preflight-release-token:
+        name: Preflight release token
+        runs-on: 'ubuntu-24.04'
+        permissions: {}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+
+        steps:
+            - name: Validate GitHub release token
+              env:
+                  GH_TOKEN: ${{ secrets.GUTENBERG_TOKEN }}
+              run: |
+                  gh auth status --hostname github.com
+
+                  headers_file="$(mktemp)"
+                  if ! gh api -i "repos/${GITHUB_REPOSITORY}" > "$headers_file"; then
+                    echo "::error::GUTENBERG_TOKEN cannot access ${GITHUB_REPOSITORY}. The release workflow token must be able to create draft releases in this repository."
+                    rm -f "$headers_file"
+                    exit 1
+                  fi
+
+                  oauth_scopes="$(
+                    awk -F': ' 'tolower($1) == "x-oauth-scopes" { print tolower($2) }' "$headers_file" |
+                    tr -d '\r' |
+                    tail -n 1
+                  )"
+
+                  if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qx 'repo'; then
+                    echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."
+                    rm -f "$headers_file"
+                    exit 1
+                  fi
+
+                  rm -f "$headers_file"
+
     bump-version:
         name: Bump version
         runs-on: 'ubuntu-24.04'
         environment: 'GitHub Releases'
-        needs: compute-stable-branches
+        needs: [compute-stable-branches, preflight-release-token]
         if: |
             github.event_name == 'workflow_dispatch' && (
               (
@@ -422,6 +458,7 @@ jobs:
         needs: [bump-version, build]
         runs-on: 'ubuntu-24.04'
         environment: 'GitHub Releases'
+        if: ${{ needs.bump-version.outputs.new_version }}
 
         steps:
             - name: Generate application token

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -68,9 +68,14 @@ jobs:
               run: |
                   gh auth status --hostname github.com
 
+                  token_follow_up="Release managers/repository admins must fix this before the next RC day: "
+                  token_follow_up+="either make the default GITHUB_TOKEN with contents: write able to create draft releases and remove this PAT dependency, "
+                  token_follow_up+="or rotate/replace GUTENBERG_TOKEN with a token that can create draft releases in this repository."
+
                   headers_file="$(mktemp)"
                   if ! gh api -i "repos/${GITHUB_REPOSITORY}" > "$headers_file"; then
                     echo "::error::GUTENBERG_TOKEN cannot access ${GITHUB_REPOSITORY}. The release workflow token must be able to create draft releases in this repository."
+                    echo "::error::$token_follow_up"
                     rm -f "$headers_file"
                     exit 1
                   fi
@@ -87,6 +92,7 @@ jobs:
                   # under-scoping while the repository access check remains the fallback.
                   if [[ -n "$oauth_scopes" ]] && ! tr ',' '\n' <<< "$oauth_scopes" | sed 's/^ *//;s/ *$//' | grep -qx 'repo'; then
                     echo "::error::GUTENBERG_TOKEN is visibly under-scoped (${oauth_scopes}). The release workflow token must be able to create draft releases in this repository."
+                    echo "::error::$token_follow_up"
                     rm -f "$headers_file"
                     exit 1
                   fi

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -17,9 +17,9 @@ on:
 # Workflow-dispatched release runs must not cancel an in-flight run after it may have
 # pushed version bump commits.
 concurrency:
-    # The concurrency group contains the workflow name and ref for release dispatches,
+    # The concurrency group contains a shared release group for dispatches,
     # the branch name for pull requests, or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.ref || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
+    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'release' || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
     cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -61,9 +61,15 @@ jobs:
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'
               env:
-                  PLUGIN_VERSION: ${{ github.event.release.name }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
               shell: bash
               run: |
+                  PLUGIN_VERSION="${RELEASE_TAG#v}"
+                  if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+                    echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
+                    exit 1
+                  fi
+
                   IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
                   CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
                   PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -74,6 +74,19 @@ jobs:
                   CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
                   PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
                   PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
+                  if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
+                    echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
+                    exit 1
+                  fi
+                  if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
+                    echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                    exit 1
+                  fi
+                  if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
+                    echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                    exit 1
+                  fi
+
                   WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -46,52 +46,42 @@ jobs:
 
             - name: Confirm release assets exist
               env:
-                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+                  RELEASE_ASSETS: ${{ toJson( github.event.release.assets ) }}
               run: |
-                  if [[ -z "$RELEASE_ASSETS" || "$RELEASE_ASSETS" == "null" ]]; then
-                    echo "::error::Expected release assets payload to include gutenberg.zip, but it was empty."
-                    exit 1
-                  fi
-
-                  asset_count="$(jq 'if type == "array" then length else -1 end' <<< "$RELEASE_ASSETS")"
-                  if [[ "$asset_count" == "-1" ]]; then
-                    echo "::error::Expected release assets payload to be an array."
-                    exit 1
-                  fi
-
+                  asset_count="$(jq 'length' <<< "$RELEASE_ASSETS")"
                   if [[ "$asset_count" -eq 0 ]]; then
-                    echo "::error::Expected release assets payload to include gutenberg.zip, but it was empty."
+                    echo "::error::No assets are attached to the release."
                     exit 1
                   fi
 
             - name: Confirm Gutenberg plugin asset exists
               env:
-                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+                  RELEASE_ASSETS: ${{ toJson( github.event.release.assets ) }}
               run: |
                   asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
                   if [[ "$asset_count" -eq 0 ]]; then
-                    echo "::error::Expected one release asset named gutenberg.zip, but none was found."
+                    echo "::error::The gutenberg.zip asset is missing from the release."
                     exit 1
                   fi
 
-            - name: Confirm Gutenberg plugin asset is not duplicated
+            - name: Confirm a single Gutenberg plugin asset exists
               env:
-                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+                  RELEASE_ASSETS: ${{ toJson( github.event.release.assets ) }}
               run: |
                   asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
                   if [[ "$asset_count" -gt 1 ]]; then
-                    echo "::error::Expected one release asset named gutenberg.zip, but found $asset_count."
+                    echo "::error::More than one gutenberg.zip asset is attached to the release."
                     exit 1
                   fi
 
             - name: Select Gutenberg plugin asset
               id: get_plugin_asset
               env:
-                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+                  RELEASE_ASSETS: ${{ toJson( github.event.release.assets ) }}
               run: |
                   plugin_asset_url="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .browser_download_url // empty' <<< "$RELEASE_ASSETS")"
                   if [[ -z "$plugin_asset_url" ]]; then
-                    echo "::error::Release asset gutenberg.zip is missing browser_download_url."
+                    echo "::error::The gutenberg.zip release asset is missing a download URL."
                     exit 1
                   fi
 

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -44,8 +44,7 @@ jobs:
                   fi
                   echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-            - name: Select Gutenberg plugin asset
-              id: get_plugin_asset
+            - name: Confirm release assets exist
               env:
                   RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
               run: |
@@ -54,17 +53,42 @@ jobs:
                     exit 1
                   fi
 
-                  asset_count="$(jq --arg name 'gutenberg.zip' 'if type == "array" then [.[] | select(.name == $name)] | length else -1 end' <<< "$RELEASE_ASSETS")"
+                  asset_count="$(jq 'if type == "array" then length else -1 end' <<< "$RELEASE_ASSETS")"
                   if [[ "$asset_count" == "-1" ]]; then
                     echo "::error::Expected release assets payload to be an array."
                     exit 1
                   fi
 
-                  if [[ "$asset_count" -ne 1 ]]; then
-                    echo "::error::Expected exactly one release asset named gutenberg.zip, found $asset_count."
+                  if [[ "$asset_count" -eq 0 ]]; then
+                    echo "::error::Expected release assets payload to include gutenberg.zip, but it was empty."
                     exit 1
                   fi
 
+            - name: Confirm Gutenberg plugin asset exists
+              env:
+                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+              run: |
+                  asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
+                  if [[ "$asset_count" -eq 0 ]]; then
+                    echo "::error::Expected one release asset named gutenberg.zip, but none was found."
+                    exit 1
+                  fi
+
+            - name: Confirm Gutenberg plugin asset is not duplicated
+              env:
+                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+              run: |
+                  asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
+                  if [[ "$asset_count" -gt 1 ]]; then
+                    echo "::error::Expected one release asset named gutenberg.zip, but found $asset_count."
+                    exit 1
+                  fi
+
+            - name: Select Gutenberg plugin asset
+              id: get_plugin_asset
+              env:
+                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+              run: |
                   plugin_asset_url="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .browser_download_url // empty' <<< "$RELEASE_ASSETS")"
                   if [[ -z "$plugin_asset_url" ]]; then
                     echo "::error::Release asset gutenberg.zip is missing browser_download_url."

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -144,6 +144,7 @@ jobs:
             needs.get-release-metadata.outputs.plugin_asset_url
         needs: [get-release-branch, get-release-metadata]
         env:
+            RELEASE_BRANCH: ${{ needs.get-release-branch.outputs.release_branch }}
             TAG: ${{ github.event.release.tag_name }}
         strategy:
             matrix:

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -49,13 +49,28 @@ jobs:
               env:
                   RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
               run: |
-                  asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
+                  if [[ -z "$RELEASE_ASSETS" || "$RELEASE_ASSETS" == "null" ]]; then
+                    echo "::error::Expected release assets payload to include gutenberg.zip, but it was empty."
+                    exit 1
+                  fi
+
+                  asset_count="$(jq --arg name 'gutenberg.zip' 'if type == "array" then [.[] | select(.name == $name)] | length else -1 end' <<< "$RELEASE_ASSETS")"
+                  if [[ "$asset_count" == "-1" ]]; then
+                    echo "::error::Expected release assets payload to be an array."
+                    exit 1
+                  fi
+
                   if [[ "$asset_count" -ne 1 ]]; then
                     echo "::error::Expected exactly one release asset named gutenberg.zip, found $asset_count."
                     exit 1
                   fi
 
-                  plugin_asset_url="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .browser_download_url' <<< "$RELEASE_ASSETS")"
+                  plugin_asset_url="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .browser_download_url // empty' <<< "$RELEASE_ASSETS")"
+                  if [[ -z "$plugin_asset_url" ]]; then
+                    echo "::error::Release asset gutenberg.zip is missing browser_download_url."
+                    exit 1
+                  fi
+
                   echo "plugin_asset_url=$plugin_asset_url" >> "$GITHUB_OUTPUT"
 
     compute-should-update-trunk:

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -74,6 +74,17 @@ jobs:
                     exit 1
                   fi
 
+            - name: Confirm Gutenberg plugin asset upload completed
+              env:
+                  RELEASE_ASSETS: ${{ toJson( github.event.release.assets ) }}
+              run: |
+                  asset_state="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .state // empty' <<< "$RELEASE_ASSETS")"
+                  asset_size="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .size // 0' <<< "$RELEASE_ASSETS")"
+                  if [[ "$asset_state" != "uploaded" || "$asset_size" -le 0 ]]; then
+                    echo "::error::The gutenberg.zip release asset upload is incomplete (state: $asset_state, size: $asset_size bytes). Delete the incomplete asset and upload it again."
+                    exit 1
+                  fi
+
             - name: Select Gutenberg plugin asset
               id: get_plugin_asset
               env:

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -22,11 +22,47 @@ jobs:
                   fi
                   echo "github.ref is valid: ${{ github.ref }}"
 
+    get-release-metadata:
+        name: Get release metadata
+        runs-on: 'ubuntu-24.04'
+        permissions: {}
+        needs: validate-github-ref
+        outputs:
+            plugin_asset_url: ${{ steps.get_plugin_asset.outputs.plugin_asset_url }}
+            version: ${{ steps.get_release_version.outputs.version }}
+
+        steps:
+            - name: Validate release tag
+              id: get_release_version
+              env:
+                  TAG: ${{ github.event.release.tag_name }}
+              run: |
+                  VERSION="${TAG#v}"
+                  if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+                    echo "::error::Release tag '$TAG' does not resolve to a valid Gutenberg plugin version."
+                    exit 1
+                  fi
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Select Gutenberg plugin asset
+              id: get_plugin_asset
+              env:
+                  RELEASE_ASSETS: ${{ toJson(github.event.release.assets) }}
+              run: |
+                  asset_count="$(jq --arg name 'gutenberg.zip' '[.[] | select(.name == $name)] | length' <<< "$RELEASE_ASSETS")"
+                  if [[ "$asset_count" -ne 1 ]]; then
+                    echo "::error::Expected exactly one release asset named gutenberg.zip, found $asset_count."
+                    exit 1
+                  fi
+
+                  plugin_asset_url="$(jq -r --arg name 'gutenberg.zip' '.[] | select(.name == $name) | .browser_download_url' <<< "$RELEASE_ASSETS")"
+                  echo "plugin_asset_url=$plugin_asset_url" >> "$GITHUB_OUTPUT"
+
     compute-should-update-trunk:
         name: Decide if trunk or tag
         runs-on: 'ubuntu-24.04'
         permissions: {}
-        needs: validate-github-ref
+        needs: get-release-metadata
         # Skip this job if the release is a release candidate. This will in turn skip
         # the upload jobs, which are only relevant for non-RC releases.
         # We first check if the release is a prerelease, and then if the ref contains
@@ -49,10 +85,10 @@ jobs:
             - name: Decide if it is a trunk or tag update
               id: compute_should_update_trunk
               env:
-                  GITHUB_REF: ${{ github.ref }}
                   LATEST_VERSION: ${{ steps.compute_latest_version_in_core_repo.outputs.version }}
+                  RELEASE_VERSION: ${{ needs.get-release-metadata.outputs.version }}
               run: |
-                  latestPublishedVersion=$(echo "$GITHUB_REF" | sed -E 's/refs\/tags\/(v?)([0-9.]+)/\2/')
+                  latestPublishedVersion="$RELEASE_VERSION"
 
                   # Determines if the first version string is greater than the second version string.
                   #
@@ -85,7 +121,7 @@ jobs:
         name: Get release branch name
         runs-on: 'ubuntu-24.04'
         permissions: {}
-        needs: validate-github-ref
+        needs: get-release-metadata
         outputs:
             release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 
@@ -93,9 +129,9 @@ jobs:
             - name: Compute release branch name
               id: get_release_branch
               env:
-                  TAG: ${{ github.event.release.tag_name }}
+                  VERSION: ${{ needs.get-release-metadata.outputs.version }}
               run: |
-                  IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
+                  IFS='.' read -r -a VERSION_ARRAY <<< "${VERSION}"
                   RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
                   echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
 
@@ -105,8 +141,8 @@ jobs:
         permissions:
             contents: write
         if: |
-            github.event.release.assets[0]
-        needs: get-release-branch
+            needs.get-release-metadata.outputs.plugin_asset_url
+        needs: [get-release-branch, get-release-metadata]
         env:
             TAG: ${{ github.event.release.tag_name }}
         strategy:
@@ -183,15 +219,15 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions: {}
         environment: wp.org plugin
-        needs: [compute-should-update-trunk, update-changelog]
+        needs: [compute-should-update-trunk, update-changelog, get-release-metadata]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'true' && needs.get-release-metadata.outputs.plugin_asset_url
         env:
             PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
-            VERSION: ${{ github.event.release.name }}
+            VERSION: ${{ needs.get-release-metadata.outputs.version }}
 
         steps:
             - name: Install Subversion
@@ -209,7 +245,7 @@ jobs:
 
             - name: Download and unzip Gutenberg plugin asset into trunk folder
               env:
-                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+                  PLUGIN_URL: ${{ needs.get-release-metadata.outputs.plugin_asset_url }}
               run: |
                   curl -L -o gutenberg.zip "$PLUGIN_URL"
                   unzip gutenberg.zip -d trunk
@@ -266,15 +302,15 @@ jobs:
         runs-on: 'ubuntu-24.04'
         permissions: {}
         environment: wp.org plugin
-        needs: [compute-should-update-trunk, update-changelog]
+        needs: [compute-should-update-trunk, update-changelog, get-release-metadata]
         if: |
-            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' && github.event.release.assets[0]
+            needs.compute-should-update-trunk.outputs.should_update_trunk == 'false' && needs.get-release-metadata.outputs.plugin_asset_url
         env:
             PLUGIN_REPO_URL: 'https://plugins.svn.wordpress.org/gutenberg'
             STABLE_VERSION_REGEX: '[0-9]\+\.[0-9]\+\.[0-9]\+\s*'
             SVN_USERNAME: ${{ secrets.svn_username }}
             SVN_PASSWORD: ${{ secrets.svn_password }}
-            VERSION: ${{ github.event.release.name }}
+            VERSION: ${{ needs.get-release-metadata.outputs.version }}
 
         steps:
             - name: Install Subversion
@@ -283,7 +319,7 @@ jobs:
 
             - name: Download and unzip Gutenberg plugin asset into tags folder
               env:
-                  PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}
+                  PLUGIN_URL: ${{ needs.get-release-metadata.outputs.plugin_asset_url }}
               run: |
                   # do the magic here
                   curl -L -o gutenberg.zip "$PLUGIN_URL"
@@ -300,7 +336,7 @@ jobs:
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: changelog trunk
-                  path: ${{ github.event.release.name }}
+                  path: ${{ needs.get-release-metadata.outputs.version }}
 
             - name: Check if SVN tag already exists
               id: check_svn_tag


### PR DESCRIPTION
## What?

Builds on #79912 and follows up on #79804.

Hardens the plugin release workflows around the cheap guardrails from the release failure analysis:

- preflights the same GitHub App token path used for release draft creation before version bump commits are pushed;
- prevents workflow-dispatched release runs from running concurrently or cancelling in-flight release runs, and skips expensive build work when the release preflight/version bump fails;
- skips draft release creation unless a new release version was computed;
- derives release automation versions from `release.tag_name` instead of the editable release name;
- selects the `gutenberg.zip` release asset by name and fails early if it is missing, duplicated, incomplete, or missing a download URL;
- verifies release performance inputs point to expected tags/branches before running the comparison.

> [!NOTE]
> This PR keeps #79912's GitHub App credential model and uses the same app-token minting path for the release preflight; it does not reintroduce `GUTENBERG_TOKEN` for release draft creation.

## Why?

The 23.5 release exposed workflow footguns where human-editable release metadata, asset ordering assumptions, duplicate SVN tags, or late credential failures could leave release automation in a confusing partial state. These fixes make those failures earlier and more explicit without redesigning the full release/SVN recovery flow.

#79912 owns the credential-model change for #79803. This PR keeps the remaining guardrails that are still useful on top of that change, especially for the WP.org plugin upload path in #79804.

## How?

Adds a `preflight-release-token` job to `build-plugin-zip.yml` that requests the same GitHub App token and elevated permissions as the release creation job. Token generation fails on invalid credentials or unavailable permissions before the version bump job can run.

Updates workflow concurrency so release dispatches share a single serialized group without canceling in-flight runs, and guards release-only build/release jobs on a computed version.

Adds a shared release metadata job to `upload-release-to-plugin-repo.yml` that validates the tag-derived version and resolves the `gutenberg.zip` asset URL once, then passes those values to the changelog and SVN upload paths. Named validation steps reject missing, duplicate, incomplete, and malformed assets before any changelog commit or SVN upload. Passing the computed release branch into `update-changelog` restores the existing series-specific changelog insertion path.

Updates `performance.yml` to derive the release branch from `release.tag_name` instead of `release.name`, and verifies the release tag plus current/previous release branches exist before running release performance comparisons.

## Testing Instructions

1. Review the workflow diff in `.github/workflows/build-plugin-zip.yml`, `.github/workflows/upload-release-to-plugin-repo.yml`, and `.github/workflows/performance.yml`.
2. Confirm release-dispatch concurrency uses a shared `release` group with `cancel-in-progress` disabled for dispatch runs.
3. Confirm `preflight-release-token` requests a GitHub App token with `permission-contents: write` and `permission-workflows: write`.
4. Confirm release version derivation uses `github.event.release.tag_name`, not `github.event.release.name`, in the SVN and performance workflows.
5. Confirm `upload-release-to-plugin-repo.yml` rejects missing, duplicate, incomplete, and URL-less `gutenberg.zip` assets before downstream jobs run.
6. Confirm `performance.yml` checks that the release tag plus current/previous release branches exist before running release performance comparisons.

Local checks:

- `git diff --check`
- YAML parsing for all three changed workflows
- `bash -n` for every embedded workflow shell block
- `jq` cases for empty, missing, duplicate, incomplete, URL-less, and valid assets

Additional manual checks:

- Changelog insertion point check: `23.5.1` stays at the current series head, while an older patch release such as `23.4.1` uses the matching `23.4` series head instead of the global top entry.
- Performance tag parsing accepts `v23.5.0` and `v23.5.0-rc.1`, and rejects a release-title-shaped value such as `23.5.0 final`.

### Testing Instructions for Keyboard

Not applicable; this PR only changes release automation workflows.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was prepared with OpenAI Codex. I reviewed the changes and validation output.
