### PR TITLE
Release: Harden npm package release paths

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -19,8 +19,9 @@ on:
 
 # Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
-    # Scope package release dispatches by release type, and by WordPress version for wp releases.
-    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || 'all' }}
+    # Scope package release dispatches by target npm release branch.
+    # `latest` and `bugfix` both target wp/latest and must serialize.
+    group: ${{ github.workflow }}-wp-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.event.inputs.release_type == 'development' && 'next' || 'latest' }}
     cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -20,7 +20,7 @@ on:
 # Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
     # Scope package release dispatches by release type, and by WordPress version for wp releases.
-    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.sha }}
+    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || 'all' }}
     cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -17,12 +17,11 @@ on:
                 description: 'WordPress major version (`wp` only)'
                 type: string
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+    # Scope package release dispatches by release type, and by WordPress version for wp releases.
+    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.sha }}
+    cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -85,6 +85,8 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
+                  # Keep the release CLI and publish checkout on one runtime;
+                  # active wp release branches must stay compatible with the trunk release CLI.
                   node-version-file: 'publish/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -36,7 +36,6 @@ jobs:
         environment: WordPress packages
         steps:
             - name: Checkout (for CLI)
-              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   path: cli
@@ -120,9 +119,9 @@ jobs:
             - name: Publish packages to npm for WP major version ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
-                  cd publish
+                  cd cli
                   npm ci
-                  npx lerna publish patch --dist-tag "wp-$WP_VERSION" --no-private --yes --no-verify-access
+                  npm exec --no release-cli -- npm-wp --wp-version "$WP_VERSION" --ci --repository-path ../publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -30,6 +30,10 @@ const { runPerformanceTests } = require( './commands/performance' );
 
 const semverOption = [ '--semver <semver>', 'Semantic Versioning', 'patch' ];
 const ciOption = [ '-c, --ci', 'Run in CI (non interactive)' ];
+const resumeOption = [
+	'--resume',
+	'Resume a partial npm package publish from existing local version metadata.',
+];
 const repositoryPathOption = [
 	'--repository-path <repository-path>',
 	'Relative path to the git repository.',
@@ -40,6 +44,7 @@ program
 	.alias( 'npm-latest' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...resumeOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm packages synced from the Gutenberg plugin (latest dist-tag, production version)'
@@ -50,6 +55,7 @@ program
 	.command( 'publish-npm-packages-bugfix-latest' )
 	.alias( 'npm-bugfix' )
 	.option( ...ciOption )
+	.option( ...resumeOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm bugfixes for packages (latest dist-tag, production version)'
@@ -61,6 +67,7 @@ program
 	.alias( 'npm-wp' )
 	.requiredOption( '--wp-version <wpVersion>', 'WordPress version' )
 	.option( ...ciOption )
+	.option( ...resumeOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm bugfixes targeting WordPress core (wp-X.Y dist-tag, production version)'
@@ -72,6 +79,7 @@ program
 	.alias( 'npm-next' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...resumeOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm development version of packages (next dist-tag, prerelease version)'

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -48,6 +48,7 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
  *
  * @property {boolean} [ci]             Disables interactive mode when executed in CI mode.
  * @property {string}  [repositoryPath] Relative path to the git repository.
+ * @property {boolean} [resume]         Whether to resume a partial npm package publish.
  * @property {SemVer}  [semver]         The selected semantic versioning. Defaults to `patch`.
  * @property {string}  [wpVersion]      The major WordPress version number, example: `6.0`.
  */
@@ -62,6 +63,7 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
  * @property {SemVer}      minimumVersionBump      The selected minimum version bump.
  * @property {string}      npmReleaseBranch        The selected branch for npm release.
  * @property {ReleaseType} releaseType             The selected release type.
+ * @property {boolean}     resume                  Whether to resume a partial npm package publish.
  */
 
 /**
@@ -661,16 +663,36 @@ function isNpmPackageVersionMissing( error ) {
 }
 
 /**
+ * Parses npm JSON command output.
+ *
+ * @param {string} output      Command stdout.
+ * @param {string} description Output description for error messages.
+ *
+ * @return {*} Parsed JSON output.
+ */
+function parseNpmJsonOutput( output, description ) {
+	try {
+		return JSON.parse( output );
+	} catch {
+		throw new Error(
+			`Unable to parse npm registry ${ description }: ${ output }`
+		);
+	}
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
+ * @param {string}   options.distTag                 The dist-tag used for npm publishing.
  * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
  * @param {Array}    options.releasePackages         Packages to publish.
+ * @param {boolean}  options.resume                  Whether to resume a partial npm package publish.
  * @param {Object}   deps                            Dependencies.
  * @param {Function} deps.commandFn                  Command runner.
  */
 async function runNpmPublishPreflight(
-	{ gitWorkingDirectoryPath, releasePackages },
+	{ distTag, gitWorkingDirectoryPath, releasePackages, resume = false },
 	deps = {}
 ) {
 	const { commandFn = command } = deps;
@@ -684,20 +706,53 @@ async function runNpmPublishPreflight(
 	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
 	// Keep the first hardening pass sequential so registry errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
+		let registryVersion;
 		try {
-			await commandFn( `npm view ${ name }@${ version } version --json`, {
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'pipe',
-			} );
+			const { stdout } = await commandFn(
+				`npm view ${ name }@${ version } version --json`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'pipe',
+				}
+			);
+			registryVersion = parseNpmJsonOutput(
+				stdout,
+				`${ name }@${ version } version`
+			);
 		} catch ( error ) {
 			if ( isNpmPackageVersionMissing( error ) ) {
 				continue;
 			}
 			throw error;
 		}
-		throw new Error(
-			`${ name }@${ version } already exists in the npm registry.`
+
+		if ( registryVersion !== version ) {
+			throw new Error(
+				`Expected npm registry lookup for ${ name }@${ version } to return version ${ version }, got ${ registryVersion }.`
+			);
+		}
+
+		if ( ! resume ) {
+			throw new Error(
+				`${ name }@${ version } already exists in the npm registry.`
+			);
+		}
+
+		const { stdout } = await commandFn(
+			`npm view ${ name } dist-tags --json`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'pipe',
+			}
 		);
+		const distTags = parseNpmJsonOutput( stdout, `${ name } dist-tags` );
+		if ( distTags[ distTag ] !== version ) {
+			throw new Error(
+				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${
+					distTags[ distTag ] || 'nothing'
+				}.`
+			);
+		}
 	}
 }
 
@@ -785,6 +840,7 @@ async function pushNpmReleaseGitMetadata(
  * @param {string}   options.gitWorkingDirectoryPath  Git working directory path.
  * @param {string}   options.noVerifyAccessFlag       Lerna no-verify-access flag.
  * @param {string}   options.npmReleaseBranch         Npm release branch.
+ * @param {boolean}  options.resume                   Whether to resume a partial npm package publish.
  * @param {string}   options.yesFlag                  Lerna yes flag.
  * @param {Object}   deps                             Dependencies.
  * @param {Function} deps.commandFn                   Command runner.
@@ -799,6 +855,7 @@ async function publishVersionedPackagesToNpm(
 		gitWorkingDirectoryPath,
 		noVerifyAccessFlag,
 		npmReleaseBranch,
+		resume = false,
 		yesFlag,
 	},
 	deps = {}
@@ -814,8 +871,10 @@ async function publishVersionedPackagesToNpm(
 		gitWorkingDirectoryPath
 	);
 	await runNpmPublishPreflightFn( {
+		distTag,
 		gitWorkingDirectoryPath,
 		releasePackages,
+		resume,
 	} );
 
 	log( '>> Publishing modified packages to npm.' );
@@ -865,6 +924,7 @@ async function publishPackagesToNpm(
 		minimumVersionBump,
 		npmReleaseBranch,
 		releaseType,
+		resume,
 	},
 	deps = {}
 ) {
@@ -896,7 +956,11 @@ async function publishPackagesToNpm(
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
 	// Keep version commits and package tags local until npm publishing succeeds,
 	// then push and verify Git metadata explicitly.
-	if ( releaseType === 'next' ) {
+	if ( resume ) {
+		log(
+			'>> Resuming npm publishing from the existing local version commit and package tags.'
+		);
+	} else if ( releaseType === 'next' ) {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
 		);
@@ -926,11 +990,12 @@ async function publishPackagesToNpm(
 		gitWorkingDirectoryPath,
 		noVerifyAccessFlag,
 		npmReleaseBranch,
+		resume,
 		yesFlag,
 	} );
 
 	const afterCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
-	if ( afterCommitHash === beforeCommitHash ) {
+	if ( afterCommitHash === beforeCommitHash && ! resume ) {
 		return;
 	}
 
@@ -1006,6 +1071,11 @@ async function runPackagesRelease( config, customMessages ) {
 	}
 
 	const temporaryFolders = [];
+	if ( config.resume && ! config.gitWorkingDirectoryPath ) {
+		throw new Error(
+			'Resuming a partial npm package publish requires --repository-path pointing to the checkout with the local version commit and package tags.'
+		);
+	}
 	if ( ! config.gitWorkingDirectoryPath ) {
 		const gitPath = getRandomTemporaryPath();
 		config.gitWorkingDirectoryPath = gitPath;
@@ -1028,7 +1098,11 @@ async function runPackagesRelease( config, customMessages ) {
 	}
 
 	let pluginReleaseBranch;
-	if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
+	if ( config.resume ) {
+		log(
+			'>> Resuming npm publishing; skipping release branch preparation and changelog processing.'
+		);
+	} else if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
 		pluginReleaseBranch =
 			config.releaseType === 'next'
 				? 'trunk'
@@ -1040,11 +1114,16 @@ async function runPackagesRelease( config, customMessages ) {
 		await checkoutNpmReleaseBranch( config );
 	}
 
-	const commitHashChangelogUpdates = await updatePackages( config );
+	const commitHashChangelogUpdates = config.resume
+		? undefined
+		: await updatePackages( config );
 
 	const commitHashNpmPublish = await publishPackagesToNpm( config );
 
-	if ( [ 'latest', 'bugfix' ].includes( config.releaseType ) ) {
+	if (
+		! config.resume &&
+		[ 'latest', 'bugfix' ].includes( config.releaseType )
+	) {
 		const commits = [
 			commitHashChangelogUpdates,
 			commitHashNpmPublish,
@@ -1087,7 +1166,7 @@ async function runPackagesRelease( config, customMessages ) {
  */
 function getConfig(
 	releaseType,
-	{ ci, repositoryPath, semver = 'patch', wpVersion }
+	{ ci, repositoryPath, resume = false, semver = 'patch', wpVersion }
 ) {
 	let distTag = 'latest';
 	let npmReleaseBranch = 'wp/latest';
@@ -1108,6 +1187,7 @@ function getConfig(
 		minimumVersionBump: semver,
 		npmReleaseBranch,
 		releaseType,
+		resume,
 	};
 }
 

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -681,6 +681,8 @@ async function runNpmPublishPreflight(
 	} );
 
 	log( '>> Verifying target package versions are not already published.' );
+	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
+	// Keep the first hardening pass sequential so registry errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
 		try {
 			await commandFn( `npm view ${ name }@${ version } version --json`, {

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -778,34 +778,113 @@ async function pushNpmReleaseGitMetadata(
 }
 
 /**
+ * Publishes locally versioned packages, then pushes and verifies Git metadata.
+ *
+ * @param {Object}   options                          Options.
+ * @param {string}   options.distTag                  The dist-tag used for npm publishing.
+ * @param {string}   options.gitWorkingDirectoryPath  Git working directory path.
+ * @param {string}   options.noVerifyAccessFlag       Lerna no-verify-access flag.
+ * @param {string}   options.npmReleaseBranch         Npm release branch.
+ * @param {string}   options.yesFlag                  Lerna yes flag.
+ * @param {Object}   deps                             Dependencies.
+ * @param {Function} deps.commandFn                   Command runner.
+ * @param {Object}   deps.git                         Git client.
+ * @param {Function} deps.getNpmReleasePackagesFn     Gets release package metadata.
+ * @param {Function} deps.pushNpmReleaseGitMetadataFn Pushes Git metadata.
+ * @param {Function} deps.runNpmPublishPreflightFn    Runs npm preflight.
+ */
+async function publishVersionedPackagesToNpm(
+	{
+		distTag,
+		gitWorkingDirectoryPath,
+		noVerifyAccessFlag,
+		npmReleaseBranch,
+		yesFlag,
+	},
+	deps = {}
+) {
+	const {
+		commandFn = command,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		getNpmReleasePackagesFn = getNpmReleasePackages,
+		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
+		runNpmPublishPreflightFn = runNpmPublishPreflight,
+	} = deps;
+	const releasePackages = await getNpmReleasePackagesFn(
+		gitWorkingDirectoryPath
+	);
+	await runNpmPublishPreflightFn( {
+		gitWorkingDirectoryPath,
+		releasePackages,
+	} );
+
+	log( '>> Publishing modified packages to npm.' );
+	try {
+		await commandFn(
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
+	} catch {
+		log(
+			'>> Trying to finish failed publishing of modified npm packages.'
+		);
+		await commandFn(
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
+	}
+
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	await pushNpmReleaseGitMetadataFn( {
+		gitWorkingDirectoryPath,
+		npmReleaseBranch,
+		packageTags: releasePackages.map( ( { tagName } ) => tagName ),
+		publishCommit,
+	} );
+}
+
+/**
  * Publishes all changed packages to npm.
  *
  * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
  *
  * @return {?string} The optional commit's hash when packages published to npm.
  */
-async function publishPackagesToNpm( {
-	distTag,
-	gitWorkingDirectoryPath,
-	interactive,
-	minimumVersionBump,
-	npmReleaseBranch,
-	releaseType,
-} ) {
+async function publishPackagesToNpm(
+	{
+		distTag,
+		gitWorkingDirectoryPath,
+		interactive,
+		minimumVersionBump,
+		npmReleaseBranch,
+		releaseType,
+	},
+	deps = {}
+) {
+	const {
+		commandFn = command,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
+	} = deps;
 	log( '>> Installing npm packages.' );
-	await command( 'npm ci', {
+	await commandFn( 'npm ci', {
 		cwd: gitWorkingDirectoryPath,
 	} );
 
 	log( '>> Current npm user:' );
-	await command( 'npm whoami', {
+	await commandFn( 'npm whoami', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'inherit',
 	} );
 
-	const beforeCommitHash = await SimpleGit(
-		gitWorkingDirectoryPath
-	).revparse( [ '--short', 'HEAD' ] );
+	const beforeCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
 
 	// Timestamp is the current time in `YYYYMMDDHHMM` format.
 	const timestamp = new Date()
@@ -815,111 +894,53 @@ async function publishPackagesToNpm( {
 
 	const yesFlag = interactive ? '' : '--yes';
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
+	// Keep version commits and package tags local until npm publishing succeeds,
+	// then push and verify Git metadata explicitly.
 	if ( releaseType === 'next' ) {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
 		);
 
-		await command(
-			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
-
-		log( '>> Publishing modified packages to npm.' );
-		await command(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+		await commandFn(
+			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private --no-push ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
 	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
-		log( '>> Publishing modified packages to npm.' );
-		try {
-			await command(
-				`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		} catch {
-			log(
-				'>> Trying to finish failed publishing of modified npm packages.'
-			);
-			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
-			await command(
-				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		}
-	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
 		);
-		// --no-push keeps the version commit and package tags local until
-		// `lerna publish` succeeds, so a failed retry can re-version
-		// without hitting "tag '@wordpress/<pkg>@<version>' already exists"
-		// on origin.
-		await command(
+		await commandFn(
 			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
-
-		const releasePackages = await getNpmReleasePackages(
-			gitWorkingDirectoryPath
+	} else {
+		log(
+			'>> Bumping version of public packages changed since the last release.'
 		);
-		await runNpmPublishPreflight( {
-			gitWorkingDirectoryPath,
-			releasePackages,
-		} );
-
-		log( '>> Publishing modified packages to npm.' );
-		try {
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		} catch {
-			log(
-				'>> Trying to finish failed publishing of modified npm packages.'
-			);
-			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		}
-
-		const publishCommit = await SimpleGit(
-			gitWorkingDirectoryPath
-		).revparse( [ 'HEAD' ] );
-		await pushNpmReleaseGitMetadata( {
-			gitWorkingDirectoryPath,
-			npmReleaseBranch,
-			packageTags: releasePackages.map( ( { tagName } ) => tagName ),
-			publishCommit,
-		} );
+		await commandFn(
+			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
 	}
 
-	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
-		[ '--short', 'HEAD' ]
-	);
+	await publishVersionedPackagesToNpmFn( {
+		distTag,
+		gitWorkingDirectoryPath,
+		noVerifyAccessFlag,
+		npmReleaseBranch,
+		yesFlag,
+	} );
+
+	const afterCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
 	if ( afterCommitHash === beforeCommitHash ) {
 		return;
 	}
@@ -1153,6 +1174,8 @@ module.exports = {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	publishPackagesToNpm,
+	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -409,6 +409,18 @@ function getTagRefspec( tagName ) {
 }
 
 /**
+ * Returns a fully qualified branch refspec.
+ *
+ * @param {string} commitHash Commit hash to push.
+ * @param {string} branchName Branch name.
+ *
+ * @return {string} Branch refspec.
+ */
+function getBranchRefspec( commitHash, branchName ) {
+	return `${ commitHash }:refs/heads/${ branchName }`;
+}
+
+/**
  * Splits an array into chunks.
  *
  * @param {Array}  items     Items to chunk.
@@ -463,8 +475,11 @@ function getNpmReleaseGitRecoveryCommands( {
 } ) {
 	return [
 		'Push and verify the release branch:',
-		`git push origin "${ publishCommit }:refs/heads/${ npmReleaseBranch }"`,
-		`git ls-remote --heads origin "${ npmReleaseBranch }"`,
+		`git push origin "${ getBranchRefspec(
+			publishCommit,
+			npmReleaseBranch
+		) }"`,
+		`git ls-remote --heads origin "refs/heads/${ npmReleaseBranch }"`,
 		...( packageTags.length
 			? [
 					'',
@@ -528,14 +543,13 @@ async function getRemoteBranchSha(
 	deps = {}
 ) {
 	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
-	const output = await git.raw(
-		'ls-remote',
-		'--heads',
-		'origin',
-		branchName
-	);
-	const [ firstLine = '' ] = output.trim().split( '\n' );
-	const [ sha ] = firstLine.split( /\s+/ );
+	const branchRef = `refs/heads/${ branchName }`;
+	const output = await git.raw( 'ls-remote', '--heads', 'origin', branchRef );
+	const matchingLine = output
+		.trim()
+		.split( '\n' )
+		.find( ( line ) => line.split( /\s+/ )[ 1 ] === branchRef );
+	const [ sha ] = ( matchingLine || '' ).split( /\s+/ );
 	return sha || null;
 }
 
@@ -681,6 +695,20 @@ function parseNpmJsonOutput( output, description ) {
 }
 
 /**
+ * Gets the version string npm stores in the registry.
+ *
+ * npm strips SemVer build metadata on publish. Local prerelease versions can
+ * include build metadata, so registry comparisons must ignore the `+...` part.
+ *
+ * @param {string} version Local package version.
+ *
+ * @return {string} Registry-comparable package version.
+ */
+function getNpmRegistryVersion( version ) {
+	return version.split( '+' )[ 0 ];
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
@@ -721,6 +749,7 @@ async function runNpmPublishPreflight(
 	// Keep the first hardening pass sequential so registry errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
 		let registryVersion;
+		const expectedRegistryVersion = getNpmRegistryVersion( version );
 		try {
 			const { stdout } = await commandFn(
 				`npm view ${ name }@${ version } version --json`,
@@ -740,9 +769,9 @@ async function runNpmPublishPreflight(
 			throw error;
 		}
 
-		if ( registryVersion !== version ) {
+		if ( registryVersion !== expectedRegistryVersion ) {
 			throw new Error(
-				`Expected npm registry lookup for ${ name }@${ version } to return version ${ version }, got ${ registryVersion }.`
+				`Expected npm registry lookup for ${ name }@${ version } to return version ${ expectedRegistryVersion }, got ${ registryVersion }.`
 			);
 		}
 
@@ -760,7 +789,7 @@ async function runNpmPublishPreflight(
 			}
 		);
 		const distTags = parseNpmJsonOutput( stdout, `${ name } dist-tags` );
-		if ( distTags[ distTag ] !== version ) {
+		if ( distTags[ distTag ] !== expectedRegistryVersion ) {
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${
 					distTags[ distTag ] || 'nothing'
@@ -800,7 +829,7 @@ async function pushNpmReleaseGitMetadata(
 			await git.raw(
 				'push',
 				'origin',
-				`${ publishCommit }:refs/heads/${ npmReleaseBranch }`
+				getBranchRefspec( publishCommit, npmReleaseBranch )
 			);
 		} );
 		await runPhase( 'Release branch verification', async () =>
@@ -884,6 +913,11 @@ async function publishVersionedPackagesToNpm(
 	const releasePackages = await getNpmReleasePackagesFn(
 		gitWorkingDirectoryPath
 	);
+	if ( resume && releasePackages.length === 0 ) {
+		throw new Error(
+			'Resuming a partial npm package publish requires local package version tags at HEAD.'
+		);
+	}
 	await runNpmPublishPreflightFn( {
 		distTag,
 		gitWorkingDirectoryPath,
@@ -1264,8 +1298,10 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	getBranchRefspec,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -28,6 +28,7 @@ const {
 const pluginConfig = require( '../config' );
 
 const NPM_RELEASE_GIT_PUSH_ATTEMPTS = 3;
+// Keep tag pushes small enough that GitHub ruleset validation handles each phase predictably.
 const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
 
 /**
@@ -344,24 +345,27 @@ async function runPushGitChangesStep( {
 /**
  * Returns package metadata for public packages that Lerna tagged at HEAD.
  *
- * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   gitWorkingDirectoryPath Git working directory path.
+ * @param {Object}   deps                    Dependencies.
+ * @param {Object}   deps.git                Git client.
+ * @param {Function} deps.globFn             Glob function.
+ * @param {Function} deps.readJSON           JSON reader.
  *
  * @return {Promise<Array<{ name: string, version: string, tagName: string }>>} Package metadata.
  */
-async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
+async function getNpmReleasePackages( gitWorkingDirectoryPath, deps = {} ) {
+	const {
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		globFn = glob,
+		readJSON = readJSONFile,
+	} = deps;
 	const localTagsAtHead = new Set(
-		(
-			await SimpleGit( gitWorkingDirectoryPath ).raw(
-				'tag',
-				'--points-at',
-				'HEAD'
-			)
-		)
+		( await git.raw( 'tag', '--points-at', 'HEAD' ) )
 			.split( '\n' )
 			.filter( Boolean )
 	);
 
-	const packageJSONPaths = await glob(
+	const packageJSONPaths = await globFn(
 		path.resolve( gitWorkingDirectoryPath, 'packages/*/package.json' )
 	);
 
@@ -371,7 +375,7 @@ async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
 				name,
 				private: isPrivate,
 				version,
-			} = readJSONFile( packageJSONPath );
+			} = readJSON( packageJSONPath );
 			return {
 				isPrivate,
 				name,
@@ -478,10 +482,16 @@ function getNpmReleaseGitRecoveryCommands( {
 /**
  * Runs a release metadata push phase with retry.
  *
- * @param {string}   label Phase label.
- * @param {Function} task  Task to retry.
+ * @param {string}   label     Phase label.
+ * @param {Function} task      Task to retry.
+ * @param {Object}   deps      Dependencies.
+ * @param {Function} deps.wait Wait function.
  */
-async function runNpmReleaseGitPushPhase( label, task ) {
+async function runNpmReleaseGitPushPhase( label, task, deps = {} ) {
+	const {
+		wait = ( delay ) =>
+			new Promise( ( resolve ) => setTimeout( resolve, delay ) ),
+	} = deps;
 	for ( let attempt = 1; ; attempt++ ) {
 		try {
 			await task();
@@ -495,9 +505,7 @@ async function runNpmReleaseGitPushPhase( label, task ) {
 					err.message
 				}, retrying in ${ attempt * 5 }s...`
 			);
-			await new Promise( ( resolve ) =>
-				setTimeout( resolve, attempt * 5000 )
-			);
+			await wait( attempt * 5000 );
 		}
 	}
 }
@@ -507,11 +515,18 @@ async function runNpmReleaseGitPushPhase( label, task ) {
  *
  * @param {string} gitWorkingDirectoryPath Git working directory path.
  * @param {string} branchName              Branch name.
+ * @param {Object} deps                    Dependencies.
+ * @param {Object} deps.git                Git client.
  *
  * @return {Promise<?string>} Remote branch SHA.
  */
-async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
-	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+async function getRemoteBranchSha(
+	gitWorkingDirectoryPath,
+	branchName,
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const output = await git.raw(
 		'ls-remote',
 		'--heads',
 		'origin',
@@ -523,50 +538,67 @@ async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
 }
 
 /**
- * Gets the peeled remote SHA for a tag.
+ * Gets the peeled remote SHA for each tag.
  *
- * @param {string} gitWorkingDirectoryPath Git working directory path.
- * @param {string} tagName                 Tag name.
+ * @param {string}   gitWorkingDirectoryPath Git working directory path.
+ * @param {string[]} tagNames                Tag names.
+ * @param {Object}   deps                    Dependencies.
+ * @param {Object}   deps.git                Git client.
  *
- * @return {Promise<?string>} Remote tag SHA.
+ * @return {Promise<Map<string, string>>} Remote tag SHAs.
  */
-async function getRemoteTagSha( gitWorkingDirectoryPath, tagName ) {
-	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+async function getRemoteTagShas(
+	gitWorkingDirectoryPath,
+	tagNames,
+	{ git = SimpleGit( gitWorkingDirectoryPath ) } = {}
+) {
+	if ( tagNames.length === 0 ) {
+		return new Map();
+	}
+
+	const output = await git.raw(
 		'ls-remote',
 		'--tags',
 		'origin',
-		`refs/tags/${ tagName }`,
-		`refs/tags/${ tagName }^{}`
+		...tagNames.flatMap( ( tagName ) => [
+			`refs/tags/${ tagName }`,
+			`refs/tags/${ tagName }^{}`,
+		] )
 	);
-	const refs = output
+	const remoteTagShas = new Map();
+	output
 		.trim()
 		.split( '\n' )
 		.filter( Boolean )
-		.map( ( line ) => {
-			const [ sha, ref ] = line.split( /\s+/ );
-			return { ref, sha };
+		.forEach( ( line ) => {
+			const [ sha, ref = '' ] = line.split( /\s+/ );
+			const match = ref.match( /^refs\/tags\/(.+?)(\^\{\})?$/ );
+			if ( match ) {
+				const [ , tagName, isPeeled ] = match;
+				if ( isPeeled || ! remoteTagShas.has( tagName ) ) {
+					remoteTagShas.set( tagName, sha );
+				}
+			}
 		} );
-	const peeled = refs.find(
-		( { ref } ) => ref === `refs/tags/${ tagName }^{}`
-	);
-	const direct = refs.find( ( { ref } ) => ref === `refs/tags/${ tagName }` );
-	return peeled?.sha || direct?.sha || null;
+	return remoteTagShas;
 }
 
 /**
  * Verifies that a remote branch points to the expected SHA.
  *
- * @param {Object} options                         Options.
- * @param {string} options.gitWorkingDirectoryPath Git working directory path.
- * @param {string} options.npmReleaseBranch        Npm release branch.
- * @param {string} options.publishCommit           Expected commit SHA.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.npmReleaseBranch        Npm release branch.
+ * @param {string}   options.publishCommit           Expected commit SHA.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.getRemoteBranchShaFn       Gets the remote branch SHA.
  */
-async function verifyRemoteNpmReleaseBranch( {
-	gitWorkingDirectoryPath,
-	npmReleaseBranch,
-	publishCommit,
-} ) {
-	const remoteSha = await getRemoteBranchSha(
+async function verifyRemoteNpmReleaseBranch(
+	{ gitWorkingDirectoryPath, npmReleaseBranch, publishCommit },
+	deps = {}
+) {
+	const { getRemoteBranchShaFn = getRemoteBranchSha } = deps;
+	const remoteSha = await getRemoteBranchShaFn(
 		gitWorkingDirectoryPath,
 		npmReleaseBranch
 	);
@@ -586,18 +618,21 @@ async function verifyRemoteNpmReleaseBranch( {
  * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
  * @param {string[]} options.packageTags             Package tag names.
  * @param {string}   options.publishCommit           Expected commit SHA.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.getRemoteTagShasFn         Gets remote tag SHAs.
  */
-async function verifyRemotePackageTags( {
-	gitWorkingDirectoryPath,
-	packageTags,
-	publishCommit,
-} ) {
+async function verifyRemotePackageTags(
+	{ gitWorkingDirectoryPath, packageTags, publishCommit },
+	deps = {}
+) {
+	const { getRemoteTagShasFn = getRemoteTagShas } = deps;
 	const mismatches = [];
+	const remoteTagShas = await getRemoteTagShasFn(
+		gitWorkingDirectoryPath,
+		packageTags
+	);
 	for ( const tagName of packageTags ) {
-		const remoteSha = await getRemoteTagSha(
-			gitWorkingDirectoryPath,
-			tagName
-		);
+		const remoteSha = remoteTagShas.get( tagName );
 		if ( remoteSha !== publishCommit ) {
 			mismatches.push(
 				`${ tagName }: expected ${ publishCommit }, got ${
@@ -614,18 +649,33 @@ async function verifyRemotePackageTags( {
 }
 
 /**
+ * Checks whether an npm command failed because the target package version is absent.
+ *
+ * @param {Error} error Command error.
+ *
+ * @return {boolean} Whether the package version is absent.
+ */
+function isNpmPackageVersionMissing( error ) {
+	const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
+	return output.includes( 'E404' );
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
- * @param {Object} options                         Options.
- * @param {string} options.gitWorkingDirectoryPath Git working directory path.
- * @param {Array}  options.releasePackages         Packages to publish.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Array}    options.releasePackages         Packages to publish.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.commandFn                  Command runner.
  */
-async function runNpmPublishPreflight( {
-	gitWorkingDirectoryPath,
-	releasePackages,
-} ) {
+async function runNpmPublishPreflight(
+	{ gitWorkingDirectoryPath, releasePackages },
+	deps = {}
+) {
+	const { commandFn = command } = deps;
 	log( '>> Checking npm package access.' );
-	await command( 'npm access ls-packages @wordpress --json', {
+	await commandFn( 'npm access list packages @wordpress --json', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'pipe',
 	} );
@@ -633,55 +683,61 @@ async function runNpmPublishPreflight( {
 	log( '>> Verifying target package versions are not already published.' );
 	for ( const { name, version } of releasePackages ) {
 		try {
-			await command( `npm view ${ name }@${ version } version --json`, {
+			await commandFn( `npm view ${ name }@${ version } version --json`, {
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'pipe',
 			} );
-			throw new Error(
-				`${ name }@${ version } already exists in the npm registry.`
-			);
 		} catch ( error ) {
-			const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
-			if ( ! output.includes( 'E404' ) ) {
-				throw error;
+			if ( isNpmPackageVersionMissing( error ) ) {
+				continue;
 			}
+			throw error;
 		}
+		throw new Error(
+			`${ name }@${ version } already exists in the npm registry.`
+		);
 	}
 }
 
 /**
  * Pushes and verifies Git metadata for an npm release.
  *
- * @param {Object}   options                         Options.
- * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
- * @param {string}   options.npmReleaseBranch        Npm release branch.
- * @param {string[]} options.packageTags             Package tag names.
- * @param {string}   options.publishCommit           Publish commit SHA.
+ * @param {Object}   options                             Options.
+ * @param {string}   options.gitWorkingDirectoryPath     Git working directory path.
+ * @param {string}   options.npmReleaseBranch            Npm release branch.
+ * @param {string[]} options.packageTags                 Package tag names.
+ * @param {string}   options.publishCommit               Publish commit SHA.
+ * @param {Object}   deps                                Dependencies.
+ * @param {Object}   deps.git                            Git client.
+ * @param {Function} deps.runPhase                       Runs a retryable phase.
+ * @param {Function} deps.verifyRemoteNpmReleaseBranchFn Verifies the remote branch.
+ * @param {Function} deps.verifyRemotePackageTagsFn      Verifies remote package tags.
  */
-async function pushNpmReleaseGitMetadata( {
-	gitWorkingDirectoryPath,
-	npmReleaseBranch,
-	packageTags,
-	publishCommit,
-} ) {
-	const repo = SimpleGit( gitWorkingDirectoryPath );
+async function pushNpmReleaseGitMetadata(
+	{ gitWorkingDirectoryPath, npmReleaseBranch, packageTags, publishCommit },
+	deps = {}
+) {
+	const {
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		runPhase = runNpmReleaseGitPushPhase,
+		verifyRemoteNpmReleaseBranchFn = verifyRemoteNpmReleaseBranch,
+		verifyRemotePackageTagsFn = verifyRemotePackageTags,
+	} = deps;
 	try {
-		await runNpmReleaseGitPushPhase( 'Release branch push', async () => {
+		await runPhase( 'Release branch push', async () => {
 			log( '>> Pushing release branch to remote.' );
-			await repo.raw(
+			await git.raw(
 				'push',
 				'origin',
 				`${ publishCommit }:refs/heads/${ npmReleaseBranch }`
 			);
 		} );
-		await runNpmReleaseGitPushPhase(
-			'Release branch verification',
-			async () =>
-				verifyRemoteNpmReleaseBranch( {
-					gitWorkingDirectoryPath,
-					npmReleaseBranch,
-					publishCommit,
-				} )
+		await runPhase( 'Release branch verification', async () =>
+			verifyRemoteNpmReleaseBranchFn( {
+				gitWorkingDirectoryPath,
+				npmReleaseBranch,
+				publishCommit,
+			} )
 		);
 
 		if ( packageTags.length ) {
@@ -689,26 +745,21 @@ async function pushNpmReleaseGitMetadata( {
 				packageTags,
 				NPM_RELEASE_TAG_PUSH_BATCH_SIZE
 			) ) {
-				await runNpmReleaseGitPushPhase(
-					'Package tag push',
-					async () => {
-						log( '>> Pushing package tags to remote.' );
-						await repo.raw(
-							'push',
-							'origin',
-							...packageTagChunk.map( getTagRefspec )
-						);
-					}
-				);
+				await runPhase( 'Package tag push', async () => {
+					log( '>> Pushing package tags to remote.' );
+					await git.raw(
+						'push',
+						'origin',
+						...packageTagChunk.map( getTagRefspec )
+					);
+				} );
 			}
-			await runNpmReleaseGitPushPhase(
-				'Package tag verification',
-				async () =>
-					verifyRemotePackageTags( {
-						gitWorkingDirectoryPath,
-						packageTags,
-						publishCommit,
-					} )
+			await runPhase( 'Package tag verification', async () =>
+				verifyRemotePackageTagsFn( {
+					gitWorkingDirectoryPath,
+					packageTags,
+					publishCommit,
+				} )
 			);
 		}
 	} catch ( error ) {
@@ -1095,11 +1146,17 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	pushNpmReleaseGitMetadata,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,
 	publishNpmBugfixWordPressCore,
 	publishNpmNext,
+	runNpmPublishPreflight,
+	runNpmReleaseGitPushPhase,
+	verifyRemotePackageTags,
 };

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -697,10 +697,24 @@ async function runNpmPublishPreflight(
 ) {
 	const { commandFn = command } = deps;
 	log( '>> Checking npm package access.' );
-	await commandFn( 'npm access list packages @wordpress --json', {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'pipe',
-	} );
+	try {
+		await commandFn( 'npm access list packages @wordpress --json', {
+			cwd: gitWorkingDirectoryPath,
+			stdio: 'pipe',
+		} );
+	} catch ( error ) {
+		log(
+			formats.warning(
+				'>> Unable to list npm package access. Continuing because `npm whoami` already verified credentials.'
+			)
+		);
+		const output = `${ error.stdout || '' }\n${
+			error.stderr || ''
+		}`.trim();
+		if ( output ) {
+			log( output );
+		}
+	}
 
 	log( '>> Verifying target package versions are not already published.' );
 	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
@@ -890,13 +904,25 @@ async function publishVersionedPackagesToNpm(
 		log(
 			'>> Trying to finish failed publishing of modified npm packages.'
 		);
-		await commandFn(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
+		try {
+			await commandFn(
+				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'inherit',
+				}
+			);
+		} catch ( error ) {
+			log(
+				formats.warning(
+					'>> npm publishing did not finish. Some package versions may already be published.'
+				)
+			);
+			log(
+				`>> Do not start a fresh release. After checking npm registry state, rerun the same release command from this checkout with --resume --repository-path ${ gitWorkingDirectoryPath }.`
+			);
+			throw error;
+		}
 	}
 
 	const publishCommit = await git.revparse( [ 'HEAD' ] );

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -908,17 +908,6 @@ async function publishPackagesToNpm(
 				stdio: 'inherit',
 			}
 		);
-	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
-		log(
-			'>> Bumping version of public packages changed since the last release.'
-		);
-		await commandFn(
-			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
 	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -27,6 +27,9 @@ const {
 } = require( './common' );
 const pluginConfig = require( '../config' );
 
+const NPM_RELEASE_GIT_PUSH_ATTEMPTS = 3;
+const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
+
 /**
  * Release type names.
  *
@@ -339,6 +342,389 @@ async function runPushGitChangesStep( {
 }
 
 /**
+ * Returns package metadata for public packages that Lerna tagged at HEAD.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ *
+ * @return {Promise<Array<{ name: string, version: string, tagName: string }>>} Package metadata.
+ */
+async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
+	const localTagsAtHead = new Set(
+		(
+			await SimpleGit( gitWorkingDirectoryPath ).raw(
+				'tag',
+				'--points-at',
+				'HEAD'
+			)
+		)
+			.split( '\n' )
+			.filter( Boolean )
+	);
+
+	const packageJSONPaths = await glob(
+		path.resolve( gitWorkingDirectoryPath, 'packages/*/package.json' )
+	);
+
+	return packageJSONPaths
+		.map( ( packageJSONPath ) => {
+			const {
+				name,
+				private: isPrivate,
+				version,
+			} = readJSONFile( packageJSONPath );
+			return {
+				isPrivate,
+				name,
+				tagName: `${ name }@${ version }`,
+				version,
+			};
+		} )
+		.filter(
+			( { isPrivate, tagName } ) =>
+				isPrivate !== true && localTagsAtHead.has( tagName )
+		)
+		.map( ( { name, tagName, version } ) => ( {
+			name,
+			tagName,
+			version,
+		} ) )
+		.sort( ( a, b ) => a.tagName.localeCompare( b.tagName ) );
+}
+
+/**
+ * Returns a fully qualified tag refspec.
+ *
+ * @param {string} tagName Tag name.
+ *
+ * @return {string} Tag refspec.
+ */
+function getTagRefspec( tagName ) {
+	return `refs/tags/${ tagName }:refs/tags/${ tagName }`;
+}
+
+/**
+ * Splits an array into chunks.
+ *
+ * @param {Array}  items     Items to chunk.
+ * @param {number} chunkSize Chunk size.
+ *
+ * @return {Array[]} Chunks.
+ */
+function chunk( items, chunkSize ) {
+	const chunks = [];
+	for ( let index = 0; index < items.length; index += chunkSize ) {
+		chunks.push( items.slice( index, index + chunkSize ) );
+	}
+	return chunks;
+}
+
+/**
+ * Formats one or more tag push commands.
+ *
+ * @param {string[]} tagNames Tag names.
+ *
+ * @return {string[]} Git push commands.
+ */
+function getTagPushCommands( tagNames ) {
+	return chunk( tagNames, NPM_RELEASE_TAG_PUSH_BATCH_SIZE ).map(
+		( tagNameChunk ) =>
+			[
+				'git push origin \\',
+				...tagNameChunk.map(
+					( tagName, index ) =>
+						`  "${ getTagRefspec( tagName ) }"${
+							index === tagNameChunk.length - 1 ? '' : ' \\'
+						}`
+				),
+			].join( '\n' )
+	);
+}
+
+/**
+ * Formats recovery commands for release Git metadata.
+ *
+ * @param {Object}   options                  Options.
+ * @param {string}   options.npmReleaseBranch Npm release branch.
+ * @param {string[]} options.packageTags      Package tag names.
+ * @param {string}   options.publishCommit    Publish commit SHA.
+ *
+ * @return {string} Recovery commands.
+ */
+function getNpmReleaseGitRecoveryCommands( {
+	npmReleaseBranch,
+	packageTags,
+	publishCommit,
+} ) {
+	return [
+		'Push and verify the release branch:',
+		`git push origin "${ publishCommit }:refs/heads/${ npmReleaseBranch }"`,
+		`git ls-remote --heads origin "${ npmReleaseBranch }"`,
+		...( packageTags.length
+			? [
+					'',
+					'Push the package tags:',
+					...getTagPushCommands( packageTags ),
+					'',
+					'Verify the package tags:',
+					...packageTags.map(
+						( tagName ) =>
+							`git ls-remote --tags origin "refs/tags/${ tagName }" "refs/tags/${ tagName }^{}"`
+					),
+			  ]
+			: [] ),
+	].join( '\n' );
+}
+
+/**
+ * Runs a release metadata push phase with retry.
+ *
+ * @param {string}   label Phase label.
+ * @param {Function} task  Task to retry.
+ */
+async function runNpmReleaseGitPushPhase( label, task ) {
+	for ( let attempt = 1; ; attempt++ ) {
+		try {
+			await task();
+			return;
+		} catch ( err ) {
+			if ( attempt >= NPM_RELEASE_GIT_PUSH_ATTEMPTS ) {
+				throw err;
+			}
+			log(
+				`>> ${ label } failed (attempt ${ attempt }/${ NPM_RELEASE_GIT_PUSH_ATTEMPTS }): ${
+					err.message
+				}, retrying in ${ attempt * 5 }s...`
+			);
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, attempt * 5000 )
+			);
+		}
+	}
+}
+
+/**
+ * Gets the remote SHA for a branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string} branchName              Branch name.
+ *
+ * @return {Promise<?string>} Remote branch SHA.
+ */
+async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
+	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+		'ls-remote',
+		'--heads',
+		'origin',
+		branchName
+	);
+	const [ firstLine = '' ] = output.trim().split( '\n' );
+	const [ sha ] = firstLine.split( /\s+/ );
+	return sha || null;
+}
+
+/**
+ * Gets the peeled remote SHA for a tag.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string} tagName                 Tag name.
+ *
+ * @return {Promise<?string>} Remote tag SHA.
+ */
+async function getRemoteTagSha( gitWorkingDirectoryPath, tagName ) {
+	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+		'ls-remote',
+		'--tags',
+		'origin',
+		`refs/tags/${ tagName }`,
+		`refs/tags/${ tagName }^{}`
+	);
+	const refs = output
+		.trim()
+		.split( '\n' )
+		.filter( Boolean )
+		.map( ( line ) => {
+			const [ sha, ref ] = line.split( /\s+/ );
+			return { ref, sha };
+		} );
+	const peeled = refs.find(
+		( { ref } ) => ref === `refs/tags/${ tagName }^{}`
+	);
+	const direct = refs.find( ( { ref } ) => ref === `refs/tags/${ tagName }` );
+	return peeled?.sha || direct?.sha || null;
+}
+
+/**
+ * Verifies that a remote branch points to the expected SHA.
+ *
+ * @param {Object} options                         Options.
+ * @param {string} options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string} options.npmReleaseBranch        Npm release branch.
+ * @param {string} options.publishCommit           Expected commit SHA.
+ */
+async function verifyRemoteNpmReleaseBranch( {
+	gitWorkingDirectoryPath,
+	npmReleaseBranch,
+	publishCommit,
+} ) {
+	const remoteSha = await getRemoteBranchSha(
+		gitWorkingDirectoryPath,
+		npmReleaseBranch
+	);
+	if ( remoteSha !== publishCommit ) {
+		throw new Error(
+			`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit }, got ${
+				remoteSha || 'nothing'
+			}.`
+		);
+	}
+}
+
+/**
+ * Verifies that remote tags peel to the expected SHA.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string[]} options.packageTags             Package tag names.
+ * @param {string}   options.publishCommit           Expected commit SHA.
+ */
+async function verifyRemotePackageTags( {
+	gitWorkingDirectoryPath,
+	packageTags,
+	publishCommit,
+} ) {
+	const mismatches = [];
+	for ( const tagName of packageTags ) {
+		const remoteSha = await getRemoteTagSha(
+			gitWorkingDirectoryPath,
+			tagName
+		);
+		if ( remoteSha !== publishCommit ) {
+			mismatches.push(
+				`${ tagName }: expected ${ publishCommit }, got ${
+					remoteSha || 'nothing'
+				}`
+			);
+		}
+	}
+	if ( mismatches.length ) {
+		throw new Error(
+			`Package tag verification failed:\n${ mismatches.join( '\n' ) }`
+		);
+	}
+}
+
+/**
+ * Runs a pragmatic npm preflight before publishing.
+ *
+ * @param {Object} options                         Options.
+ * @param {string} options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Array}  options.releasePackages         Packages to publish.
+ */
+async function runNpmPublishPreflight( {
+	gitWorkingDirectoryPath,
+	releasePackages,
+} ) {
+	log( '>> Checking npm package access.' );
+	await command( 'npm access ls-packages @wordpress --json', {
+		cwd: gitWorkingDirectoryPath,
+		stdio: 'pipe',
+	} );
+
+	log( '>> Verifying target package versions are not already published.' );
+	for ( const { name, version } of releasePackages ) {
+		try {
+			await command( `npm view ${ name }@${ version } version --json`, {
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'pipe',
+			} );
+			throw new Error(
+				`${ name }@${ version } already exists in the npm registry.`
+			);
+		} catch ( error ) {
+			const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
+			if ( ! output.includes( 'E404' ) ) {
+				throw error;
+			}
+		}
+	}
+}
+
+/**
+ * Pushes and verifies Git metadata for an npm release.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.npmReleaseBranch        Npm release branch.
+ * @param {string[]} options.packageTags             Package tag names.
+ * @param {string}   options.publishCommit           Publish commit SHA.
+ */
+async function pushNpmReleaseGitMetadata( {
+	gitWorkingDirectoryPath,
+	npmReleaseBranch,
+	packageTags,
+	publishCommit,
+} ) {
+	const repo = SimpleGit( gitWorkingDirectoryPath );
+	try {
+		await runNpmReleaseGitPushPhase( 'Release branch push', async () => {
+			log( '>> Pushing release branch to remote.' );
+			await repo.raw(
+				'push',
+				'origin',
+				`${ publishCommit }:refs/heads/${ npmReleaseBranch }`
+			);
+		} );
+		await runNpmReleaseGitPushPhase(
+			'Release branch verification',
+			async () =>
+				verifyRemoteNpmReleaseBranch( {
+					gitWorkingDirectoryPath,
+					npmReleaseBranch,
+					publishCommit,
+				} )
+		);
+
+		if ( packageTags.length ) {
+			for ( const packageTagChunk of chunk(
+				packageTags,
+				NPM_RELEASE_TAG_PUSH_BATCH_SIZE
+			) ) {
+				await runNpmReleaseGitPushPhase(
+					'Package tag push',
+					async () => {
+						log( '>> Pushing package tags to remote.' );
+						await repo.raw(
+							'push',
+							'origin',
+							...packageTagChunk.map( getTagRefspec )
+						);
+					}
+				);
+			}
+			await runNpmReleaseGitPushPhase(
+				'Package tag verification',
+				async () =>
+					verifyRemotePackageTags( {
+						gitWorkingDirectoryPath,
+						packageTags,
+						publishCommit,
+					} )
+			);
+		}
+	} catch ( error ) {
+		log(
+			'>> npm publication completed, but Git metadata did not finish. Use these recovery commands after checking the remote state:\n\n' +
+				getNpmReleaseGitRecoveryCommands( {
+					npmReleaseBranch,
+					packageTags,
+					publishCommit,
+				} )
+		);
+		throw error;
+	}
+}
+
+/**
  * Publishes all changed packages to npm.
  *
  * @param {WPPackagesConfig} config Command config.
@@ -436,6 +822,14 @@ async function publishPackagesToNpm( {
 			}
 		);
 
+		const releasePackages = await getNpmReleasePackages(
+			gitWorkingDirectoryPath
+		);
+		await runNpmPublishPreflight( {
+			gitWorkingDirectoryPath,
+			releasePackages,
+		} );
+
 		log( '>> Publishing modified packages to npm.' );
 		try {
 			await command(
@@ -459,34 +853,15 @@ async function publishPackagesToNpm( {
 			);
 		}
 
-		// Retry the push so a transient network/auth blip between a successful
-		// publish and a failed push doesn't leave npm-published versions
-		// without their tags on origin. The push is idempotent: tags already
-		// present on origin (same SHA) are a no-op.
-		log( '>> Pushing version commit and tags to remote.' );
-		const maxPushAttempts = 3;
-		for ( let attempt = 1; ; attempt++ ) {
-			try {
-				await SimpleGit( gitWorkingDirectoryPath ).push(
-					'origin',
-					npmReleaseBranch,
-					[ '--follow-tags' ]
-				);
-				break;
-			} catch ( err ) {
-				if ( attempt >= maxPushAttempts ) {
-					throw err;
-				}
-				log(
-					`>> Push failed (attempt ${ attempt }/${ maxPushAttempts }): ${
-						err.message
-					}, retrying in ${ attempt * 5 }s…`
-				);
-				await new Promise( ( resolve ) =>
-					setTimeout( resolve, attempt * 5000 )
-				);
-			}
-		}
+		const publishCommit = await SimpleGit(
+			gitWorkingDirectoryPath
+		).revparse( [ 'HEAD' ] );
+		await pushNpmReleaseGitMetadata( {
+			gitWorkingDirectoryPath,
+			npmReleaseBranch,
+			packageTags: releasePackages.map( ( { tagName } ) => tagName ),
+			publishCommit,
+		} );
 	}
 
 	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
@@ -720,6 +1095,9 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	getNpmReleaseGitRecoveryCommands,
+	getTagPushCommands,
+	getTagRefspec,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,
 	publishNpmBugfixWordPressCore,

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -2,8 +2,10 @@
  * Internal dependencies
  */
 import {
+	getBranchRefspec,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
@@ -84,6 +86,14 @@ describe( 'getTagRefspec', () => {
 	} );
 } );
 
+describe( 'getBranchRefspec', () => {
+	it( 'returns a fully qualified branch refspec', () => {
+		expect( getBranchRefspec( 'abc123', 'wp/latest' ) ).toBe(
+			'abc123:refs/heads/wp/latest'
+		);
+	} );
+} );
+
 describe( 'getTagPushCommands', () => {
 	it( 'quotes fully qualified tag refspecs', () => {
 		expect(
@@ -117,7 +127,35 @@ describe( 'getNpmReleaseGitRecoveryCommands', () => {
 			'git push origin "abc123:refs/heads/wp/latest"'
 		);
 		expect( commands ).toContain(
+			'git ls-remote --heads origin "refs/heads/wp/latest"'
+		);
+		expect( commands ).toContain(
 			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
+		);
+	} );
+} );
+
+describe( 'getRemoteBranchSha', () => {
+	it( 'returns the exact remote branch ref SHA', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'wrong-sha\trefs/heads/backport/wp/latest',
+						'expected-sha\trefs/heads/wp/latest',
+					].join( '\n' )
+				),
+		};
+
+		await expect(
+			getRemoteBranchSha( '/repo', 'wp/latest', { git } )
+		).resolves.toBe( 'expected-sha' );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'ls-remote',
+			'--heads',
+			'origin',
+			'refs/heads/wp/latest'
 		);
 	} );
 } );
@@ -308,6 +346,35 @@ describe( 'runNpmPublishPreflight', () => {
 			'npm view @wordpress/blocks@14.20.0 version --json',
 			{ cwd: '/repo', stdio: 'pipe' }
 		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'allows npm-stripped build metadata when resuming a partial next publish', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( {
+				stdout: '"4.50.0-next.v.202607060000"',
+			} )
+			.mockResolvedValueOnce( {
+				stdout: '{"next":"4.50.0-next.v.202607060000"}',
+			} );
+
+		await runNpmPublishPreflight(
+			{
+				distTag: 'next',
+				gitWorkingDirectoryPath: '/repo',
+				releasePackages: [
+					{
+						name: '@wordpress/a11y',
+						version: '4.50.0-next.v.202607060000+abc123',
+					},
+				],
+				resume: true,
+			},
+			{ commandFn }
+		);
+
 		expect( console ).toHaveLogged();
 	} );
 
@@ -567,6 +634,34 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		expect( console ).toHaveLoggedWith(
 			'>> Do not start a fresh release. After checking npm registry state, rerun the same release command from this checkout with --resume --repository-path /repo.'
 		);
+	} );
+
+	it( 'fails resume before npm work when HEAD has no local package tags', async () => {
+		const commandFn = jest.fn();
+
+		await expect(
+			publishVersionedPackagesToNpm(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					noVerifyAccessFlag: '--no-verify-access',
+					npmReleaseBranch: 'wp/latest',
+					resume: true,
+					yesFlag: '--yes',
+				},
+				{
+					commandFn,
+					git: {
+						revparse: jest.fn(),
+					},
+					getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [] ),
+				}
+			)
+		).rejects.toThrow(
+			'Resuming a partial npm package publish requires local package version tags at HEAD.'
+		);
+
+		expect( commandFn ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -218,6 +218,40 @@ describe( 'runNpmPublishPreflight', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'continues when the npm access listing check fails', async () => {
+		const commandFn = jest
+			.fn()
+			.mockRejectedValueOnce( {
+				stderr: 'npm ERR! access denied',
+			} )
+			.mockRejectedValueOnce( {
+				stderr: 'npm ERR! code E404',
+			} );
+
+		await runNpmPublishPreflight(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				releasePackages: [
+					{ name: '@wordpress/a11y', version: '4.50.0' },
+				],
+			},
+			{ commandFn }
+		);
+
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			1,
+			'npm access list packages @wordpress --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			2,
+			'npm view @wordpress/a11y@4.50.0 version --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
 	it( 'fails when a target package version already exists', async () => {
 		const commandFn = jest
 			.fn()
@@ -496,6 +530,43 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 		expect( git.reset ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
+	} );
+
+	it( 'prints resume guidance when from-package retry fails', async () => {
+		const commandFn = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'partial publish' ) )
+			.mockRejectedValueOnce( new Error( 'still failing' ) );
+
+		await expect(
+			publishVersionedPackagesToNpm(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					noVerifyAccessFlag: '--no-verify-access',
+					npmReleaseBranch: 'wp/latest',
+					yesFlag: '--yes',
+				},
+				{
+					commandFn,
+					git: {
+						revparse: jest.fn(),
+					},
+					getNpmReleasePackagesFn: jest
+						.fn()
+						.mockResolvedValue( [
+							{ tagName: '@wordpress/a11y@4.50.0' },
+						] ),
+					pushNpmReleaseGitMetadataFn: jest.fn(),
+					runNpmPublishPreflightFn: jest.fn(),
+				}
+			)
+		).rejects.toThrow( 'still failing' );
+
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( console ).toHaveLoggedWith(
+			'>> Do not start a fresh release. After checking npm registry state, rerun the same release command from this checkout with --resume --repository-path /repo.'
+		);
 	} );
 } );
 

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getNpmReleaseGitRecoveryCommands,
+	getTagPushCommands,
+	getTagRefspec,
+} from '../packages';
+
+describe( 'getTagRefspec', () => {
+	it( 'returns a fully qualified package tag refspec', () => {
+		expect( getTagRefspec( '@wordpress/a11y@4.50.0' ) ).toBe(
+			'refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0'
+		);
+	} );
+} );
+
+describe( 'getTagPushCommands', () => {
+	it( 'quotes fully qualified tag refspecs', () => {
+		expect(
+			getTagPushCommands( [
+				'@wordpress/a11y@4.50.0',
+				'@wordpress/blocks@14.20.0',
+			] )
+		).toEqual( [
+			[
+				'git push origin \\',
+				'  "refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0" \\',
+				'  "refs/tags/@wordpress/blocks@14.20.0:refs/tags/@wordpress/blocks@14.20.0"',
+			].join( '\n' ),
+		] );
+	} );
+} );
+
+describe( 'getNpmReleaseGitRecoveryCommands', () => {
+	it( 'includes branch, tag push, and tag verification commands', () => {
+		const commands = getNpmReleaseGitRecoveryCommands( {
+			npmReleaseBranch: 'wp/latest',
+			packageTags: [ '@wordpress/a11y@4.50.0' ],
+			publishCommit: 'abc123',
+		} );
+
+		expect( commands ).toContain( 'git push origin \\' );
+		expect( commands ).toContain(
+			'"refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0"'
+		);
+		expect( commands ).toContain(
+			'git push origin "abc123:refs/heads/wp/latest"'
+		);
+		expect( commands ).toContain(
+			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
+		);
+	} );
+} );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -2,10 +2,77 @@
  * Internal dependencies
  */
 import {
+	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	pushNpmReleaseGitMetadata,
+	runNpmPublishPreflight,
+	runNpmReleaseGitPushPhase,
+	verifyRemotePackageTags,
 } from '../packages';
+
+describe( 'getNpmReleasePackages', () => {
+	it( 'returns public packages tagged at HEAD', async () => {
+		const files = [
+			'/repo/packages/blocks/package.json',
+			'/repo/packages/a11y/package.json',
+			'/repo/packages/private/package.json',
+			'/repo/packages/untagged/package.json',
+		];
+		const packageJsonByPath = {
+			'/repo/packages/blocks/package.json': {
+				name: '@wordpress/blocks',
+				version: '2.0.0',
+			},
+			'/repo/packages/a11y/package.json': {
+				name: '@wordpress/a11y',
+				version: '1.0.0',
+			},
+			'/repo/packages/private/package.json': {
+				name: '@wordpress/private',
+				private: true,
+				version: '3.0.0',
+			},
+			'/repo/packages/untagged/package.json': {
+				name: '@wordpress/untagged',
+				version: '4.0.0',
+			},
+		};
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'@wordpress/blocks@2.0.0',
+						'@wordpress/a11y@1.0.0',
+						'@wordpress/private@3.0.0',
+					].join( '\n' )
+				),
+		};
+
+		await expect(
+			getNpmReleasePackages( '/repo', {
+				git,
+				globFn: jest.fn().mockResolvedValue( files ),
+				readJSON: ( file ) => packageJsonByPath[ file ],
+			} )
+		).resolves.toEqual( [
+			{
+				name: '@wordpress/a11y',
+				tagName: '@wordpress/a11y@1.0.0',
+				version: '1.0.0',
+			},
+			{
+				name: '@wordpress/blocks',
+				tagName: '@wordpress/blocks@2.0.0',
+				version: '2.0.0',
+			},
+		] );
+		expect( git.raw ).toHaveBeenCalledWith( 'tag', '--points-at', 'HEAD' );
+	} );
+} );
 
 describe( 'getTagRefspec', () => {
 	it( 'returns a fully qualified package tag refspec', () => {
@@ -50,5 +117,197 @@ describe( 'getNpmReleaseGitRecoveryCommands', () => {
 		expect( commands ).toContain(
 			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
 		);
+	} );
+} );
+
+describe( 'getRemoteTagShas', () => {
+	it( 'fetches tag refs in one call and prefers peeled SHAs', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'direct-a11y\trefs/tags/@wordpress/a11y@4.50.0',
+						'peeled-a11y\trefs/tags/@wordpress/a11y@4.50.0^{}',
+						'direct-blocks\trefs/tags/@wordpress/blocks@14.20.0',
+					].join( '\n' )
+				),
+		};
+
+		const result = await getRemoteTagShas(
+			'/repo',
+			[ '@wordpress/a11y@4.50.0', '@wordpress/blocks@14.20.0' ],
+			{ git }
+		);
+
+		expect( git.raw ).toHaveBeenCalledWith(
+			'ls-remote',
+			'--tags',
+			'origin',
+			'refs/tags/@wordpress/a11y@4.50.0',
+			'refs/tags/@wordpress/a11y@4.50.0^{}',
+			'refs/tags/@wordpress/blocks@14.20.0',
+			'refs/tags/@wordpress/blocks@14.20.0^{}'
+		);
+		expect( result.get( '@wordpress/a11y@4.50.0' ) ).toBe( 'peeled-a11y' );
+		expect( result.get( '@wordpress/blocks@14.20.0' ) ).toBe(
+			'direct-blocks'
+		);
+	} );
+} );
+
+describe( 'verifyRemotePackageTags', () => {
+	it( 'throws when a remote tag is missing or points to another commit', async () => {
+		await expect(
+			verifyRemotePackageTags(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					packageTags: [
+						'@wordpress/a11y@4.50.0',
+						'@wordpress/blocks@14.20.0',
+					],
+					publishCommit: 'expected-sha',
+				},
+				{
+					getRemoteTagShasFn: jest.fn().mockResolvedValue(
+						new Map( [
+							[ '@wordpress/a11y@4.50.0', 'expected-sha' ],
+							[ '@wordpress/blocks@14.20.0', 'other-sha' ],
+						] )
+					),
+				}
+			)
+		).rejects.toThrow(
+			'@wordpress/blocks@14.20.0: expected expected-sha, got other-sha'
+		);
+	} );
+} );
+
+describe( 'runNpmPublishPreflight', () => {
+	it( 'uses the npm access command supported by current npm versions', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockRejectedValueOnce( {
+				stderr: 'npm ERR! code E404',
+			} );
+
+		await runNpmPublishPreflight(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releasePackages: [
+					{ name: '@wordpress/a11y', version: '4.50.0' },
+				],
+			},
+			{ commandFn }
+		);
+
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			1,
+			'npm access list packages @wordpress --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			2,
+			'npm view @wordpress/a11y@4.50.0 version --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when a target package version already exists', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'@wordpress/a11y@4.50.0 already exists in the npm registry.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'runNpmReleaseGitPushPhase', () => {
+	it( 'retries a failed phase before surfacing success', async () => {
+		const task = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'transient failure' ) )
+			.mockResolvedValueOnce();
+		const wait = jest.fn();
+
+		await runNpmReleaseGitPushPhase( 'Package tag push', task, { wait } );
+
+		expect( task ).toHaveBeenCalledTimes( 2 );
+		expect( wait ).toHaveBeenCalledWith( 5000 );
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'pushNpmReleaseGitMetadata', () => {
+	it( 'pushes the branch before pushing and verifying package tags', async () => {
+		const git = { raw: jest.fn().mockResolvedValue() };
+		const runPhase = jest.fn( async ( _label, task ) => task() );
+		const verifyRemoteNpmReleaseBranchFn = jest.fn();
+		const verifyRemotePackageTagsFn = jest.fn();
+
+		await pushNpmReleaseGitMetadata(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				npmReleaseBranch: 'wp/latest',
+				packageTags: [
+					'@wordpress/a11y@4.50.0',
+					'@wordpress/blocks@14.20.0',
+				],
+				publishCommit: 'publish-sha',
+			},
+			{
+				git,
+				runPhase,
+				verifyRemoteNpmReleaseBranchFn,
+				verifyRemotePackageTagsFn,
+			}
+		);
+
+		expect( runPhase.mock.calls.map( ( [ label ] ) => label ) ).toEqual( [
+			'Release branch push',
+			'Release branch verification',
+			'Package tag push',
+			'Package tag verification',
+		] );
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			1,
+			'push',
+			'origin',
+			'publish-sha:refs/heads/wp/latest'
+		);
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			2,
+			'push',
+			'origin',
+			'refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0',
+			'refs/tags/@wordpress/blocks@14.20.0:refs/tags/@wordpress/blocks@14.20.0'
+		);
+		expect( verifyRemoteNpmReleaseBranchFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			publishCommit: 'publish-sha',
+		} );
+		expect( verifyRemotePackageTagsFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			packageTags: [
+				'@wordpress/a11y@4.50.0',
+				'@wordpress/blocks@14.20.0',
+			],
+			publishCommit: 'publish-sha',
+		} );
+		expect( console ).toHaveLogged();
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -196,6 +196,7 @@ describe( 'runNpmPublishPreflight', () => {
 
 		await runNpmPublishPreflight(
 			{
+				distTag: 'latest',
 				gitWorkingDirectoryPath: '/repo',
 				releasePackages: [
 					{ name: '@wordpress/a11y', version: '4.50.0' },
@@ -218,11 +219,15 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails when a target package version already exists', async () => {
-		const commandFn = jest.fn().mockResolvedValue();
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } );
 
 		await expect(
 			runNpmPublishPreflight(
 				{
+					distTag: 'latest',
 					gitWorkingDirectoryPath: '/repo',
 					releasePackages: [
 						{ name: '@wordpress/a11y', version: '4.50.0' },
@@ -232,6 +237,91 @@ describe( 'runNpmPublishPreflight', () => {
 			)
 		).rejects.toThrow(
 			'@wordpress/a11y@4.50.0 already exists in the npm registry.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'allows expected published versions when resuming a partial publish', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '{"latest":"4.50.0"}' } )
+			.mockRejectedValueOnce( {
+				stderr: 'npm ERR! code E404',
+			} );
+
+		await runNpmPublishPreflight(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				releasePackages: [
+					{ name: '@wordpress/a11y', version: '4.50.0' },
+					{ name: '@wordpress/blocks', version: '14.20.0' },
+				],
+				resume: true,
+			},
+			{ commandFn }
+		);
+
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			3,
+			'npm view @wordpress/a11y dist-tags --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			4,
+			'npm view @wordpress/blocks@14.20.0 version --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails during resume when a published version has the wrong dist-tag', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '{"latest":"4.49.0"}' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+					resume: true,
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails during resume when the registry returns a mismatched version', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.49.0"' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+					resume: true,
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'Expected npm registry lookup for @wordpress/a11y@4.50.0 to return version 4.50.0, got 4.49.0.'
 		);
 		expect( console ).toHaveLogged();
 	} );
@@ -347,10 +437,12 @@ describe( 'publishVersionedPackagesToNpm', () => {
 
 		expect( getNpmReleasePackagesFn ).toHaveBeenCalledWith( '/repo' );
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			distTag: 'latest',
 			gitWorkingDirectoryPath: '/repo',
 			releasePackages: [
 				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
 			],
+			resume: false,
 		} );
 		expect( commandFn ).toHaveBeenCalledWith(
 			'npx lerna publish from-package --dist-tag latest --yes --no-verify-access',
@@ -381,6 +473,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
 				npmReleaseBranch: 'wp/next',
+				resume: true,
 				yesFlag: '--yes',
 			},
 			{
@@ -397,6 +490,10 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 
 		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npx lerna publish from-package --dist-tag next --yes --no-verify-access',
+			{ cwd: '/repo', stdio: 'inherit' }
+		);
 		expect( git.reset ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
@@ -410,6 +507,7 @@ describe( 'publishPackagesToNpm', () => {
 		minimumVersionBump: 'patch',
 		npmReleaseBranch: releaseType === 'next' ? 'wp/next' : 'wp/latest',
 		releaseType,
+		resume: false,
 	} );
 
 	it.each( [
@@ -479,9 +577,50 @@ describe( 'publishPackagesToNpm', () => {
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
 				npmReleaseBranch,
+				resume: false,
 				yesFlag: '--yes',
 			} );
 			expect( console ).toHaveLogged();
 		}
 	);
+
+	it( 'resumes from existing local version metadata without versioning again', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+		const git = {
+			revparse: jest
+				.fn()
+				.mockResolvedValueOnce( 'publish-sha' )
+				.mockResolvedValueOnce( 'publish-sha' ),
+		};
+		const publishVersionedPackagesToNpmFn = jest.fn();
+
+		await expect(
+			publishPackagesToNpm(
+				{
+					...getConfig( 'latest' ),
+					resume: true,
+				},
+				{
+					commandFn,
+					git,
+					publishVersionedPackagesToNpmFn,
+				}
+			)
+		).resolves.toBe( 'publish-sha' );
+
+		expect(
+			commandFn.mock.calls.some( ( [ command ] ) =>
+				command.startsWith( 'npx lerna version' )
+			)
+		).toBe( false );
+		expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
+			distTag: 'latest',
+			gitWorkingDirectoryPath: '/repo',
+			noVerifyAccessFlag: '--no-verify-access',
+			npmReleaseBranch: 'wp/latest',
+			resume: true,
+			yesFlag: '--yes',
+		} );
+		expect( console ).toHaveLogged();
+	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -7,6 +7,8 @@ import {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	publishPackagesToNpm,
+	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	runNpmPublishPreflight,
 	runNpmReleaseGitPushPhase,
@@ -310,4 +312,176 @@ describe( 'pushNpmReleaseGitMetadata', () => {
 		} );
 		expect( console ).toHaveLogged();
 	} );
+} );
+
+describe( 'publishVersionedPackagesToNpm', () => {
+	it( 'preflights, publishes from package, and pushes metadata', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+		const getNpmReleasePackagesFn = jest
+			.fn()
+			.mockResolvedValue( [
+				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
+			] );
+		const runNpmPublishPreflightFn = jest.fn();
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/latest',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn,
+				git,
+				pushNpmReleaseGitMetadataFn,
+				runNpmPublishPreflightFn,
+			}
+		);
+
+		expect( getNpmReleasePackagesFn ).toHaveBeenCalledWith( '/repo' );
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			releasePackages: [
+				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
+			],
+		} );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npx lerna publish from-package --dist-tag latest --yes --no-verify-access',
+			{ cwd: '/repo', stdio: 'inherit' }
+		);
+		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			packageTags: [ '@wordpress/a11y@4.50.0' ],
+			publishCommit: 'publish-sha',
+		} );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'retries from-package without resetting local version metadata', async () => {
+		const commandFn = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'partial publish' ) )
+			.mockResolvedValueOnce();
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			reset: jest.fn(),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'next',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/next',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn: jest
+					.fn()
+					.mockResolvedValue( [
+						{ tagName: '@wordpress/a11y@4.50.0-next.0' },
+					] ),
+				git,
+				pushNpmReleaseGitMetadataFn: jest.fn(),
+				runNpmPublishPreflightFn: jest.fn(),
+			}
+		);
+
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( git.reset ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'publishPackagesToNpm', () => {
+	const getConfig = ( releaseType ) => ( {
+		distTag: releaseType === 'next' ? 'next' : 'latest',
+		gitWorkingDirectoryPath: '/repo',
+		interactive: false,
+		minimumVersionBump: 'patch',
+		npmReleaseBranch: releaseType === 'next' ? 'wp/next' : 'wp/latest',
+		releaseType,
+	} );
+
+	it.each( [
+		[
+			'latest',
+			'npx lerna version patch --no-private --no-push --yes',
+			'latest',
+			'wp/latest',
+		],
+		[
+			'next',
+			'npx lerna version prepatch --preid next.v.',
+			'next',
+			'wp/next',
+		],
+		[
+			'bugfix',
+			'npx lerna version patch --no-private --no-push --yes',
+			'latest',
+			'wp/latest',
+		],
+		[
+			'wp',
+			'npx lerna version patch --no-private --no-push --yes',
+			'wp-6.9',
+			'wp/6.9',
+		],
+	] )(
+		'routes %s releases through the shared metadata publishing path',
+		async ( releaseType, versionCommand, distTag, npmReleaseBranch ) => {
+			const commandFn = jest.fn().mockResolvedValue();
+			const git = {
+				revparse: jest
+					.fn()
+					.mockResolvedValueOnce( 'before-sha' )
+					.mockResolvedValueOnce( 'after-sha' ),
+			};
+			const publishVersionedPackagesToNpmFn = jest.fn();
+			const config = {
+				...getConfig( releaseType ),
+				distTag,
+				npmReleaseBranch,
+			};
+
+			await publishPackagesToNpm( config, {
+				commandFn,
+				git,
+				publishVersionedPackagesToNpmFn,
+			} );
+
+			expect( commandFn ).toHaveBeenCalledWith( 'npm ci', {
+				cwd: '/repo',
+			} );
+			expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
+				cwd: '/repo',
+				stdio: 'inherit',
+			} );
+			expect(
+				commandFn.mock.calls.some(
+					( [ command ] ) =>
+						command.startsWith( versionCommand ) &&
+						command.includes( '--no-push' )
+				)
+			).toBe( true );
+			expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
+				distTag,
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch,
+				yesFlag: '--yes',
+			} );
+			expect( console ).toHaveLogged();
+		}
+	);
 } );


### PR DESCRIPTION
## What?
Follow-up to the Gutenberg 23.5 npm package release failure.

This PR makes every workflow-dispatched npm package release path (`latest`, `development`/`next`, `bugfix`, and `wp`) push Git metadata in explicit phases after npm publication succeeds.

## Why?
The previous Git push behavior coupled release branch updates with package tag publication. When that late push failed, npm had already been changed and the workflow did not print exact recovery commands. The same failure mode existed outside the original `npm-latest` path, so all npm release types now use the same hardened implementation.

> [!NOTE]
> This PR intentionally hardens the existing npm package release procedure. It keeps the current release conventions in place: packages are still published through Lerna, release metadata is still pushed back to the existing npm release branches, and per-package Git tags are still produced. Bigger process decisions, such as whether those package tags are still needed, are follow-ups.

## How?
- Create Lerna version commits and package tags locally with `--no-push` for `latest`, `next`, `bugfix`, and CLI-driven `wp` releases.
- Publish npm packages with `lerna publish from-package` after preflight checks.
- Add an explicit `--resume` mode for partial-publish recovery from an existing local version commit and package tags.
- Require `--resume` runs to have local package version tags at `HEAD` before doing npm work.
- Keep fresh-publish preflight strict: target npm versions must be absent.
- Let resume preflight continue when expected versions already exist, but fail on mismatched versions or wrong dist-tags.
- Compare npm registry versions without SemVer build metadata, matching npm's published version behavior for `next` releases.
- Treat `npm whoami` as the hard credential gate and keep `npm access list packages` as a warning-only diagnostic.
- Preserve local version metadata during retry/recovery instead of resetting it away after a partial publish.
- Print explicit resume guidance when npm publication still fails after retry, so releasers do not start a fresh release after possible partial publication.
- Push and verify the npm release branch by expected publish commit SHA using exact `refs/heads/...` refs.
- Push only the package tags created for the current release using fully qualified tag refspecs.
- Verify remote package tags peel to the publish commit.
- Print copy-pasteable branch/tag recovery commands when npm publication succeeds but Git metadata publication fails.
- Route the workflow `wp` dispatch through `release-cli npm-wp` instead of inline raw Lerna.
- Scope package release workflow concurrency by target npm release branch, so `latest` and `bugfix` serialize on `wp/latest`.

## TODO / Follow-ups
- The npm package-version preflight intentionally checks target versions sequentially in this PR. A bounded-concurrency pass could reduce release latency for full releases, but it is deferred so the first hardening change keeps npm registry errors ordered and easy to diagnose.

## Testing Instructions
1. `npm run test:unit -- tools/release/commands/test/packages.js`
2. `npm run lint:js -- tools/release/cli.js tools/release/commands/packages.js tools/release/commands/test/packages.js`
3. Confirm the `latest`, `development`/`next`, `bugfix`, and `wp` release paths all use local `lerna version ... --no-push`, `lerna publish from-package`, and the shared metadata push/recovery flow.
4. Confirm `--resume` skips versioning, requires local package tags at `HEAD`, and allows already-published expected versions only when the expected dist-tag points at that version.
5. Confirm npm access-list failures warn but do not abort after `npm whoami` succeeds, and failed publish retries print resume guidance.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
N/A

## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex.
