### PR TITLE
Packages: Update Ariakit to 0.4.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,13 +141,13 @@
 			}
 		},
 		"node_modules/@ariakit/components": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.2.tgz",
-			"integrity": "sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.5.tgz",
+			"integrity": "sha512-LnvU9bcOU2IkQS3jCFm2rxcULNtG55+M+fh66mFf4EEBHJnDoTdN7zNRtm1dyzcFn6hAn/AoLl3Hyg95RIGUOA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/store": "0.1.2",
-				"@ariakit/utils": "0.1.2"
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4"
 			}
 		},
 		"node_modules/@ariakit/core": {
@@ -158,12 +158,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@ariakit/react": {
-			"version": "0.4.29",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
-			"integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
+			"version": "0.4.32",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.32.tgz",
+			"integrity": "sha512-ar5lyS/Pp/+p1TdAqsS8gHzL/E9df8uWXYmEsD/Olpv4hp9LVEtwM6FfOu57sn6qaycs2xWFN9GinmXkMd8LWA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-components": "0.1.2"
+				"@ariakit/react-components": "0.3.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -175,16 +175,16 @@
 			}
 		},
 		"node_modules/@ariakit/react-components": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.1.2.tgz",
-			"integrity": "sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.1.tgz",
+			"integrity": "sha512-SJ/xfL3vj20TX6p/Gx39wbQtfNKL66uQ8MtnW8yU7Mv3DnOr/riFUKZnTuVjl+rMfwCdiGoHK1DdYiFKSaHG5w==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/components": "0.1.2",
-				"@ariakit/react-store": "0.1.2",
-				"@ariakit/react-utils": "0.1.2",
-				"@ariakit/store": "0.1.2",
-				"@ariakit/utils": "0.1.2",
+				"@ariakit/components": "0.1.5",
+				"@ariakit/react-store": "0.1.5",
+				"@ariakit/react-utils": "0.2.0",
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4",
 				"@floating-ui/dom": "^1.0.0"
 			},
 			"peerDependencies": {
@@ -193,14 +193,14 @@
 			}
 		},
 		"node_modules/@ariakit/react-store": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.2.tgz",
-			"integrity": "sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.5.tgz",
+			"integrity": "sha512-EMB7dG0aD+MqI/0M8dzmwPObGYoWx7lvJK4tKmTDDbuGIW+XwrKfG3n1dMkWgg/TEq5lDNE7S3WbpE8mRfXpPA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-utils": "0.1.2",
-				"@ariakit/store": "0.1.2",
-				"@ariakit/utils": "0.1.2",
+				"@ariakit/react-utils": "0.2.0",
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
@@ -208,25 +208,25 @@
 			}
 		},
 		"node_modules/@ariakit/react-utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.2.tgz",
-			"integrity": "sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.0.tgz",
+			"integrity": "sha512-tyIx/qxYY5i8ntGSzDYZ5Olak7zZ58QeEYjbbMNSZEywgtrQlKhZXkVnXK72UkGXmCLg7OrrTsesv8Qh6Bx2LQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/store": "0.1.2",
-				"@ariakit/utils": "0.1.2"
+				"@ariakit/store": "0.1.4",
+				"@ariakit/utils": "0.1.4"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@ariakit/store": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.2.tgz",
-			"integrity": "sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.4.tgz",
+			"integrity": "sha512-VQDtp5eq4MgIjxzo6M/6NN2sVx8WykiSs9HNMv2AnfAGntF1fMA6cxCuBIFFWkHekNMGWwe/utzbTt3J/mtuiA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/utils": "0.1.2"
+				"@ariakit/utils": "0.1.4"
 			}
 		},
 		"node_modules/@ariakit/test": {
@@ -257,9 +257,9 @@
 			}
 		},
 		"node_modules/@ariakit/utils": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.2.tgz",
-			"integrity": "sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.4.tgz",
+			"integrity": "sha512-gIC/FR/gcOtp2FQQDOnRPfxizJjqp4PSQWS7fH2tNr6O6iTwwW8CPao7VUpu8Y8xKeMXrvzHvkOHhBhfBf4OrA==",
 			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -45453,7 +45453,7 @@
 			"version": "36.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.29",
+				"@ariakit/react": "^0.4.32",
 				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.14.0",
 				"@emotion/css": "^11.13.5",
@@ -46512,7 +46512,7 @@
 			"version": "17.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.29",
+				"@ariakit/react": "^0.4.32",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",
 				"@wordpress/compose": "file:../compose",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### Internal
 
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
+-   Update `@ariakit/react` to `0.4.32` ([#79860](https://github.com/WordPress/gutenberg/pull/79860)).
 -   `Surface`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#79445](https://github.com/WordPress/gutenberg/pull/79445)).
 -   `Truncate`: Migrate styles from Emotion to SCSS Modules ([#79446](https://github.com/WordPress/gutenberg/pull/79446)).
 -   `View`: Migrate away from Emotion while preserving polymorphic `as` behavior and style cascade order ([#79443](https://github.com/WordPress/gutenberg/pull/79443)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@ariakit/react": "^0.4.29",
+		"@ariakit/react": "^0.4.32",
 		"@date-fns/utc": "^2.1.1",
 		"@emotion/cache": "^11.14.0",
 		"@emotion/css": "^11.13.5",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer's visibility no longer depends on the loading state, so it no longer mounts mid-load (resizing the scroll container). [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
+### Internal
+
+-   Update `@ariakit/react` to `0.4.32` ([#79860](https://github.com/WordPress/gutenberg/pull/79860)).
+
 ## 17.1.0 (2026-07-01)
 
 ## 17.0.0 (2026-06-24)

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -51,7 +51,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@ariakit/react": "^0.4.29",
+		"@ariakit/react": "^0.4.32",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION
Fixes #79727.
Includes the upstream fix from ariakit/ariakit#6585.

## What?
Updates `@ariakit/react` from `0.4.29` to `0.4.32` in `@wordpress/components` and `@wordpress/dataviews`.

## Why?
`0.4.32` fixes Ariakit's pressed-state handling for `Command`-based widgets, which resolves #79727. The intervening patch releases also include focus, keyboard, portal, dialog/popover, composite, combobox, menu, radio, toolbar, tooltip, and tab fixes relevant to our wrappers.

## How?
No Gutenberg runtime code changes were needed. This updates package metadata, the root lockfile, and changelog entries.

<details>
<summary>Ariakit release impact for Gutenberg components</summary>

Reviewed upstream Ariakit changes from `0.4.30`, `0.4.31`, and `0.4.32`.

### ToggleGroupControl / RadioControl / radio-backed options

- `0.4.32`: `Command`-based items now clear their pressed state when focus moves away mid-press and no longer dispatch an unwanted synthetic click on Space keyup from a focused child. This is the ariakit/ariakit#6585 fix behind #79727.
- `0.4.32`: radio arrow-key movement dispatches a real `change` event after the radio is checked, and radio item `onClick` handlers run consistently.
- `0.4.31`: `RadioGroup` tabbing back into a checked item was fixed.

### Toolbar

- `0.4.32`: `ToolbarContainer` no longer treats IME Enter as an item click.
- `0.4.31`: Backspace/Delete handling in toolbar containers no longer steals focus from text controls.
- `0.4.31`: text-field detection works in iframes.

### Tabs

- `0.4.32`: `TabPanel` now updates its `tabIndex` when a dynamic `tabId` changes.
- `0.4.32`: tab state is restored correctly after focus has moved through a select or combobox popover.
- `0.4.31`: hidden tabs no longer block form submit/validation flows.

### Menu / DropdownMenu

- `0.4.31`: `Menu` renders less often and `MenuItemCheckbox` initializes correctly.
- `0.4.30`: dialog/disclosure performance work also benefits menu popovers and animated menu content.

### Popover / Dropdown / Tooltip

- `0.4.32`: `PopoverArrow` positioning handles RTL detachment and ring detection; this also applies to tooltip/menu/hovercard arrows.
- `0.4.32`: dialog/popover backdrop and persistent-element closing edge cases were fixed.
- `0.4.31`: popovers/dialogs no longer focus a hidden element when it is first in tab order.
- `0.4.31`: hovercards close correctly on Escape in shadow-root scenarios.
- `0.4.30`: modal dialog opening and scroll-lock/backdrop setup were made more efficient.
- `0.4.30`: `TooltipAnchor` avoids an unnecessary render.
- `0.4.30`: `DisclosureContent` unmount timing works correctly when mixing CSS transitions and animations.

### Combobox / CustomSelectControl / DataViews search

- `0.4.32`: combobox item value matching handles Unicode normalization.
- `0.4.32`: closed selects no longer freeze on arrow-key navigation, and `focusOnMove` is fixed.
- `0.4.31`: `ComboboxDisclosure` prevents unwanted focus movement on mouse down.
- `0.4.31`: combobox item shortcuts, inline autocomplete with Unicode, iframe scrolling, and overlapping item-value rendering were fixed.
- `0.4.31`: select typeahead skips disabled placeholder items.
- `0.4.30`: grouped combobox error messages and `ComboboxItemValue` performance were improved.

### Composite-based lists and grids

- `0.4.32`: roving `tabIndex` updates avoid unnecessary re-renders, and directional navigation is faster.
- `0.4.32`: virtual focus, row id, and invalid `aria-posinset`/`aria-setsize` edge cases were fixed.
- `0.4.31`: RTL composite navigation and paging/scroll behavior in iframes were fixed.
- `0.4.31`: `CompositeSeparator` gets explicit orientation metadata.

### Portal / form / hidden utility behavior

- `0.4.32`: portals avoid duplicate containers in StrictMode and no longer remount when `portalRef` changes.
- `0.4.31`: `useFormStore` ignores `__proto__`/`constructor` keys and avoids symbol-access crashes.
- `0.4.30`: `VisuallyHidden` now uses `clip-path: inset(50%)`.
- `0.4.30`: `CheckboxCheck` handles non-renderable/function children more safely.
</details>

## Testing Instructions

- `npm run lint:pkg-json`
- `npm run lint:lockfile`
- `npm run lint:deps`
- `./node_modules/.bin/dependency-audit packages/components packages/dataviews`
- `npm run test:unit`

Note: `npm audit --audit-level=high --min-release-age=0` and `npm run lint:published-deps` still report existing repo-wide findings unrelated to this PR.

## Testing Instructions for Keyboard

Smoke test the Ariakit-backed controls above, especially toggle/radio options with Space/Enter, toolbar text inputs, menus, popovers, tabs, custom selects, and DataViews search.

## Use of AI Tools

This PR was prepared with AI assistance for release-note review, dependency update, verification, and PR description drafting.