### PR TITLE
Embed: add custom thumbnail support for video embeds

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -322,7 +322,7 @@ Add a block that displays content pulled from other sites, like Twitter or YouTu
 -	**Name:** [core/embed](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-embed/core-block-embed/)
 -	**Category:** [embed](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-embed/)
 -	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, thumbnail, type, url
 
 ## File
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -44,6 +44,7 @@
 	"wpScript": true,
 	"wpScriptModuleExports": {
 		"./accordion/view": "./build-module/accordion/view.mjs",
+		"./embed/view": "./build-module/embed/view.mjs",
 		"./file/view": "./build-module/file/view.mjs",
 		"./form/view": "./build-module/form/view.mjs",
 		"./image/view": "./build-module/image/view.mjs",

--- a/packages/block-library/src/embed/README.md
+++ b/packages/block-library/src/embed/README.md
@@ -21,6 +21,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `allowResponsive` | `boolean` | `true` | — |
 | `responsive` | `boolean` | `false` | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `previewable` | `boolean` | `true` | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `thumbnail` | `string` | — | — |
 
 ## Supports
 

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,9 @@
 			"type": "boolean",
 			"default": true,
 			"role": "content"
+		},
+		"thumbnail": {
+			"type": "string"
 		}
 	},
 	"supports": {
@@ -51,5 +54,6 @@
 		}
 	},
 	"editorStyle": "wp-block-embed-editor",
-	"style": "wp-block-embed"
+	"style": "wp-block-embed",
+	"viewScriptModule": "@wordpress/block-library/embed/view"
 }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -42,6 +42,7 @@ const EmbedEdit = ( props ) => {
 			previewable,
 			responsive,
 			url: attributesUrl,
+			thumbnail,
 		},
 		attributes,
 		isSelected,
@@ -273,6 +274,9 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
+				thumbnail={ thumbnail }
+				setAttributes={ setAttributes }
+				type={ type }
 			/>
 			<figure
 				{ ...blockProps }
@@ -299,6 +303,7 @@ const EmbedEdit = ( props ) => {
 					insertBlocksAfter={ insertBlocksAfter }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
+					thumbnail={ thumbnail }
 				/>
 				<Caption
 					attributes={ attributes }

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -39,6 +39,7 @@
 	right: 0;
 	bottom: 0;
 	opacity: 0;
+	z-index: 2;
 }
 
 .wp-block[data-align="left"],

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -16,6 +16,7 @@ import { pencil } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import PosterImage from '../utils/poster-image';
 
 function getResponsiveHelp( checked ) {
 	return checked
@@ -34,8 +35,15 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
+	thumbnail,
+	setAttributes,
+	type,
 } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	const showInspector =
+		( themeSupportsResponsive && blockSupportsResponsive ) ||
+		type === 'video';
 
 	return (
 		<>
@@ -51,31 +59,51 @@ const EmbedControls = ( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			{ themeSupportsResponsive && blockSupportsResponsive && (
+			{ showInspector && (
 				<InspectorControls>
-					<ToolsPanel
-						label={ __( 'Media settings' ) }
-						resetAll={ () => {
-							toggleResponsive( true );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						<ToolsPanelItem
-							label={ __( 'Media settings' ) }
-							isShownByDefault
-							hasValue={ () => ! allowResponsive }
-							onDeselect={ () => {
-								toggleResponsive( ! allowResponsive );
+					{ type === 'video' && (
+						<ToolsPanel
+							label={ __( 'Thumbnail settings' ) }
+							resetAll={ () => {
+								setAttributes( { thumbnail: undefined } );
 							} }
+							dropdownMenuProps={ dropdownMenuProps }
 						>
-							<ToggleControl
-								label={ __( 'Resize for smaller devices' ) }
-								checked={ allowResponsive }
-								help={ getResponsiveHelp }
-								onChange={ toggleResponsive }
+							<PosterImage
+								poster={ thumbnail }
+								onChange={ ( posterImage ) =>
+									setAttributes( {
+										thumbnail: posterImage?.url,
+									} )
+								}
 							/>
-						</ToolsPanelItem>
-					</ToolsPanel>
+						</ToolsPanel>
+					) }
+					{ themeSupportsResponsive && blockSupportsResponsive && (
+						<ToolsPanel
+							label={ __( 'Media settings' ) }
+							resetAll={ () => {
+								toggleResponsive( true );
+							} }
+							dropdownMenuProps={ dropdownMenuProps }
+						>
+							<ToolsPanelItem
+								label={ __( 'Media settings' ) }
+								isShownByDefault
+								hasValue={ () => ! allowResponsive }
+								onDeselect={ () => {
+									toggleResponsive( ! allowResponsive );
+								} }
+							>
+								<ToggleControl
+									label={ __( 'Resize for smaller devices' ) }
+									checked={ allowResponsive }
+									help={ getResponsiveHelp }
+									onChange={ toggleResponsive }
+								/>
+							</ToolsPanelItem>
+						</ToolsPanel>
+					) }
 				</InspectorControls>
 			) }
 		</>

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -31,6 +31,7 @@ export default function EmbedPreview( {
 	className,
 	icon,
 	label,
+	thumbnail,
 } ) {
 	const [ interactive, setInteractive ] = useState( false );
 
@@ -82,6 +83,16 @@ export default function EmbedPreview( {
 					type={ sandboxClassnames }
 					onFocus={ hideOverlay }
 				/>
+				{ thumbnail && 'video' === type && ! interactive && (
+					<div className="wp-block-embed__thumbnail-overlay">
+						<img
+							src={ thumbnail }
+							alt={ __( 'Custom thumbnail' ) }
+							className="wp-block-embed__thumbnail-image"
+						/>
+						<div className="wp-block-embed__play-indicator" />
+					</div>
+				) }
 				{ ! interactive && (
 					<div
 						className="block-library-embed__interactive-overlay"

--- a/packages/block-library/src/embed/save.js
+++ b/packages/block-library/src/embed/save.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { url, caption, type, providerNameSlug } = attributes;
+	const { url, caption, type, providerNameSlug, thumbnail } = attributes;
 
 	if ( ! url ) {
 		return null;
@@ -25,10 +25,31 @@ export default function save( { attributes } ) {
 		[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
 	} );
 
+	const blockProps = useBlockProps.save( { className } );
+
+	if ( thumbnail ) {
+		blockProps[ 'data-thumbnail' ] = thumbnail;
+	}
+
+	const showThumbnail = thumbnail && 'video' === type;
+
 	return (
-		<figure { ...useBlockProps.save( { className } ) }>
+		<figure { ...blockProps }>
 			<div className="wp-block-embed__wrapper">
 				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+				{ showThumbnail && (
+					<button
+						type="button"
+						className="wp-block-embed__thumbnail-overlay"
+					>
+						<img
+							src={ thumbnail }
+							alt=""
+							className="wp-block-embed__thumbnail-image"
+						/>
+						<div className="wp-block-embed__play-indicator" />
+					</button>
+				) }
 			</div>
 			{ ! RichText.isEmpty( caption ) && (
 				<RichText.Content

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -48,6 +48,38 @@
 	position: relative;
 }
 
+.wp-block-embed__thumbnail-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 1;
+	background-color: rgba(0, 0, 0, 0.85);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	cursor: pointer;
+	border: none;
+	padding: 0;
+}
+
+.wp-block-embed__thumbnail-image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.wp-block-embed__play-indicator {
+	position: absolute;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-width: 12px 0 12px 20px;
+	border-color: transparent transparent transparent rgba(255, 255, 255, 0.9);
+}
+
 // Add responsiveness to embeds with aspect ratios.
 .wp-embed-responsive .wp-has-aspect-ratio {
 	.wp-block-embed__wrapper::before {

--- a/packages/block-library/src/embed/view.js
+++ b/packages/block-library/src/embed/view.js
@@ -1,0 +1,24 @@
+document
+	.querySelectorAll( '.wp-block-embed__thumbnail-overlay' )
+	.forEach( ( overlay ) => {
+		// `@wordpress/i18n` has no script module build, and translation
+		// functions aren't allowed in save.js, so this label can't be
+		// translated in this context.
+		overlay.setAttribute( 'aria-label', 'Play' );
+		overlay.addEventListener( 'click', () => {
+			// Auto-start playback so a single click both dismisses the
+			// poster and plays the video, instead of leaving the user to
+			// find the provider's own play button underneath.
+			const iframe = overlay.parentElement?.querySelector( 'iframe' );
+			if ( iframe?.src ) {
+				try {
+					const src = new URL( iframe.src );
+					src.searchParams.set( 'autoplay', '1' );
+					iframe.src = src.toString();
+				} catch {
+					// Malformed src: skip autoplay, still reveal the embed.
+				}
+			}
+			overlay.remove();
+		} );
+	} );


### PR DESCRIPTION
## What?
Closes #46976

Adds a `thumbnail` attribute to the Embed block so users can set a custom poster image for video-type embeds (YouTube, Vimeo, etc.) instead of relying on the provider's default thumbnail.

## Why?
The embed block currently shows whatever thumbnail the video host provides, with no way to override it in the editor. #46976 requests the ability to manually set a custom thumbnail.

## How?
- Added a `thumbnail` attribute to `block.json`.
- Reused the existing `PosterImage` component (already used by the Video block) in a new "Thumbnail settings" panel, shown only when the embed `type` is `video`.
- Editor preview shows the custom thumbnail as an overlay over the embed sandbox.
- `save.js` outputs the poster image as a click-to-reveal overlay, sibling to the URL text inside the wrapper, so it survives WordPress core's frontend oEmbed replacement.
- New `view.js` script module handles the frontend click: removes the overlay and starts playback by appending `autoplay` to the embed iframe's src, so one click both dismisses the poster and plays the video.

## Testing Instructions
1. Insert an Embed block, paste a YouTube URL (e.g. `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
2. Open the block inspector, find "Thumbnail settings", click "Set poster image" and pick an image
3. Verify the custom thumbnail overlays the preview in the editor
4. Publish the post, view it on the frontend
5. Verify the poster image renders fully opaque with a play indicator
6. Click the poster, verify it starts playing immediately (no console errors)
7. Repeat with an embed that has no thumbnail set, verify it still renders normally (no overlay, no regression)
8. Repeat with a non-video embed (e.g. Twitter), verify no "Thumbnail settings" panel appears

### Testing Instructions for Keyboard
The "Set poster image" / "Replace" / "Remove" buttons in the Thumbnail settings panel are standard `MediaUpload`/`Button` components, reachable and operable via Tab and Enter/Space like the rest of the block inspector.

## Screenshots or screencast
|Before|After|
|-|-|
|No thumbnail control, default provider thumbnail only|Custom poster image with play overlay, playable on click|
|<img width="1107" height="698" alt="SCR-20260706-bzsh" src="https://github.com/user-attachments/assets/f38ef21f-2f93-4d3f-9b7d-d0386f1b0007" />|<img width="1009" height="716" alt="SCR-20260706-bkzn" src="https://github.com/user-attachments/assets/5caf368d-18ca-4c6e-906e-e0941f70ed72" />|
|<img width="1527" height="727" alt="SCR-20260706-caey" src="https://github.com/user-attachments/assets/371027bd-facd-4112-b26c-665fc56e88b9" />|<img width="1552" height="832" alt="SCR-20260706-cabb" src="https://github.com/user-attachments/assets/ce38921e-b33e-454a-928b-35424b5d8b21" />|


## Use of AI Tools
Used an AI coding assistant (Claude Code) to help implement this change. I reviewed, tested, and take responsibility for the code in this PR.