### PR TITLE
Interface: Remove incorrect aria-expanded from pin-to-toolbar button

### DIFF
--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed`.
+
 ### Internal
 
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed`.
+-   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
 
 ### Internal
 

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -336,7 +336,6 @@ function ComplementaryArea( {
 										)
 									}
 									isPressed={ isPinned }
-									aria-expanded={ isPinned }
 									size="compact"
 								/>
 							) }


### PR DESCRIPTION
## What?
See https://github.com/equalizedigital/accessibility-checker/issues/1762 (downstream report)

Removes the incorrect `aria-expanded` attribute from the "Pin to toolbar" / "Unpin from toolbar" button in the `ComplementaryArea` component (`@wordpress/interface`).

## Why?
The pin/unpin button toggles whether the sidebar's icon is pinned to the editor toolbar — it does not expand or collapse anything. Per WCAG 4.1.2 (Name, Role, Value), the exposed state must match the control's actual behavior: with `aria-expanded` present, screen readers announce "expanded"/"collapsed" for a control whose real state is pressed/not pressed, which is misleading. The button already conveys the correct toggle state via `aria-pressed`, through its existing `isPressed={ isPinned }` prop, so `aria-expanded` is both inaccurate and redundant.

This was flagged by an automated accessibility scan and reported in equalizedigital/accessibility-checker#1762.

## How?
Deletes the `aria-expanded={ isPinned }` prop from the pin/unpin `Button` in `packages/interface/src/components/complementary-area/index.js`. The `isPressed` prop remains and provides the accurate `aria-pressed` state. Also adds a Bug Fixes entry to the `@wordpress/interface` changelog.

Note: the pinned-items toolbar toggle in the same component keeps its `aria-expanded={ isActive }`, since that button genuinely controls the sidebar's expanded/collapsed state.

## Testing Instructions
1. Open the post editor.
2. Open a plugin sidebar (any plugin that registers one via `PluginSidebar`), or the block inspector of a pinnable sidebar.
3. Inspect the star button ("Unpin from toolbar" / "Pin to toolbar") in the sidebar header with browser dev tools.
4. Confirm the button exposes `aria-pressed` reflecting the pinned state and no longer has an `aria-expanded` attribute.
5. With a screen reader (VoiceOver, NVDA, or JAWS), confirm the button is announced as a toggle button with pressed/not pressed state, rather than expanded/collapsed.

### Testing Instructions for Keyboard
1. Open a plugin sidebar and press Tab until focus reaches the star pin/unpin button in the sidebar header.
2. Toggle it with Enter or Space.
3. Confirm the announced state changes between pressed and not pressed, with no "expanded"/"collapsed" announcement, and that pin/unpin behavior is unchanged.

## Screenshots or screencast <!-- if applicable -->

No visual changes — this only affects the ARIA attributes exposed to assistive technology.

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools
This PR was prepared with the assistance of Claude Code (Anthropic), which authored the initial code change and changelog entry. I reviewed, tested, and take responsibility for the final change.
