### PR TITLE
Editor: add editor.headingBlockTypes filter

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -444,6 +444,24 @@ wp.hooks.addFilter(
 );
 ```
 
+### `editor.headingBlockTypes`
+
+Used to modify the list of blocks that are treated as headings by the Document Outline panel and the Table of Contents block. By default, only the Heading block (`core/heading`) is included. A block added here must have a numeric `level` attribute and a `content` attribute containing the heading text, the same attribute names the Heading block uses, or it won't appear correctly in the Document Outline or Table of Contents.
+
+The following example adds the fictitious block `namespace/example-heading`.
+
+```js
+const addExampleBlockToHeadingBlockTypes = ( blockTypes ) => {
+	return [ ...blockTypes, 'namespace/example-heading' ];
+};
+
+wp.hooks.addFilter(
+	'editor.headingBlockTypes',
+	'my-plugin/heading-block-types',
+	addExampleBlockToHeadingBlockTypes
+);
+```
+
 ## Removing Blocks
 
 ### Using a deny list

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Table of Contents: Recognize custom heading block types registered via the new `editor.headingBlockTypes` filter.
+
 ## 10.1.0 (2026-07-01)
 
 ## 10.0.0 (2026-06-24)

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -9,16 +9,28 @@ import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 import { useRegistry } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-function getLatestHeadings( select, clientId ) {
+// Can't import `useHeadingBlockTypes` from `@wordpress/editor`: this package
+// must not depend on it (see the `core/editor` string-store access below for
+// the same reason). Blocks added through the `editor.headingBlockTypes`
+// filter must have `level` and `content` attributes, same as `core/heading`.
+const HEADING_BLOCK_TYPES = [ 'core/heading' ];
+
+export function getLatestHeadings( select, clientId ) {
 	const {
 		getBlockAttributes,
 		getBlockName,
 		getBlocksByName,
 		getClientIdsOfDescendants,
 	} = select( blockEditorStore );
+
+	const headingBlockTypes = applyFilters(
+		'editor.headingBlockTypes',
+		HEADING_BLOCK_TYPES
+	);
 
 	// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
 	// Blocks can be loaded into a *non-post* block editor, so to avoid
@@ -97,7 +109,7 @@ function getLatestHeadings( select, clientId ) {
 		// the same page as the Table of Contents block, add them to the
 		// list.
 		else if ( ! onlyIncludeCurrentPage || headingPage === tocPage ) {
-			if ( blockName === 'core/heading' ) {
+			if ( headingBlockTypes.includes( blockName ) ) {
 				const headingAttributes = getBlockAttributes( blockClientId );
 
 				// Skip headings that are deeper than maxLevel

--- a/packages/block-library/src/table-of-contents/test/hooks.js
+++ b/packages/block-library/src/table-of-contents/test/hooks.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { getLatestHeadings } from '../hooks';
+
+function makeSelect( blocks ) {
+	return ( storeNameOrDescriptor ) => {
+		if ( storeNameOrDescriptor === 'core/editor' ) {
+			return { getPermalink: () => null };
+		}
+
+		return {
+			getBlockAttributes: ( clientId ) =>
+				blocks[ clientId ]?.attributes ?? {},
+			getBlockName: ( clientId ) => blocks[ clientId ]?.name,
+			getBlocksByName: ( names ) =>
+				Object.entries( blocks )
+					.filter( ( [ , block ] ) =>
+						[].concat( names ).includes( block.name )
+					)
+					.map( ( [ clientId ] ) => clientId ),
+			getClientIdsOfDescendants: () =>
+				Object.keys( blocks ).filter(
+					( clientId ) => clientId !== 'toc-1'
+				),
+		};
+	};
+}
+
+describe( 'getLatestHeadings', () => {
+	afterEach( () => {
+		removeFilter( 'editor.headingBlockTypes', 'test/heading-block-types' );
+	} );
+
+	const blocks = {
+		'toc-1': { name: 'core/table-of-contents', attributes: {} },
+		'heading-1': {
+			name: 'core/heading',
+			attributes: { level: 2, content: 'Core Heading' },
+		},
+		'custom-1': {
+			name: 'my-plugin/section-heading',
+			attributes: { level: 3, content: 'Custom Heading' },
+		},
+	};
+
+	it( 'only includes core/heading blocks by default', () => {
+		const headings = getLatestHeadings( makeSelect( blocks ), 'toc-1' );
+
+		expect( headings ).toEqual( [
+			{ content: 'Core Heading', level: 2, link: null },
+		] );
+	} );
+
+	it( 'includes blocks added via the editor.headingBlockTypes filter', () => {
+		addFilter(
+			'editor.headingBlockTypes',
+			'test/heading-block-types',
+			( blockTypes ) => [ ...blockTypes, 'my-plugin/section-heading' ]
+		);
+
+		const headings = getLatestHeadings( makeSelect( blocks ), 'toc-1' );
+
+		expect( headings ).toEqual( [
+			{ content: 'Core Heading', level: 2, link: null },
+			{ content: 'Custom Heading', level: 3, link: null },
+		] );
+	} );
+} );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 -   Add an "Attachments" source to the block inserter's Media tab, listing images attached to the current post with the ability to attach and detach them ([#79336](https://github.com/WordPress/gutenberg/pull/79336)).
+-   Add `editor.headingBlockTypes` filter to let third-party blocks register as headings for the Document Outline panel and heading count.
 
 ### Bug Fixes
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -280,7 +280,7 @@ _Returns_
 
 ### DocumentOutlineCheck
 
-Component check if there are any headings (core/heading blocks) present in the document.
+Component check if there are any headings (core/heading blocks, or blocks added via the `editor.headingBlockTypes` filter) present in the document.
 
 _Parameters_
 

--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -5,7 +5,13 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
- * Component check if there are any headings (core/heading blocks) present in the document.
+ * Internal dependencies
+ */
+import useHeadingBlockTypes from './use-heading-block-types';
+
+/**
+ * Component check if there are any headings (core/heading blocks, or blocks
+ * added via the `editor.headingBlockTypes` filter) present in the document.
  *
  * @param {Object}          props          Props.
  * @param {React.ReactNode} props.children Children to be rendered.
@@ -13,11 +19,15 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * @return {React.ReactNode} The component to be rendered or null if there are headings.
  */
 export default function DocumentOutlineCheck( { children } ) {
-	const hasHeadings = useSelect( ( select ) => {
-		const { getGlobalBlockCount } = select( blockEditorStore );
+	const headingBlockTypes = useHeadingBlockTypes();
+	const hasHeadings = useSelect(
+		( select ) => {
+			const { getBlocksByName } = select( blockEditorStore );
 
-		return getGlobalBlockCount( 'core/heading' ) > 0;
-	} );
+			return getBlocksByName( headingBlockTypes ).length > 0;
+		},
+		[ headingBlockTypes ]
+	);
 
 	if ( ! hasHeadings ) {
 		return null;

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -13,6 +13,7 @@ import { Path, SVG, Line, Rect } from '@wordpress/components';
  * Internal dependencies
  */
 import DocumentOutlineItem from './item';
+import useHeadingBlockTypes from './use-heading-block-types';
 import { store as editorStore } from '../../store';
 
 /**
@@ -78,13 +79,20 @@ function EmptyOutlineIllustration() {
  * level   - An integer with the heading level.
  * isEmpty - Flag indicating if the heading has no content.
  *
- * @param {?Array} blocks An array of blocks.
+ * Blocks registered via the `editor.headingBlockTypes` filter are expected
+ * to have `level` and `content` attributes, the same as `core/heading`.
+ *
+ * @param {?Array}    blocks            An array of blocks.
+ * @param {?string[]} headingBlockTypes Block type names considered headings.
  *
  * @return {Array} An array of heading blocks enhanced with the properties described above.
  */
-const computeOutlineHeadings = ( blocks = [] ) => {
+export const computeOutlineHeadings = (
+	blocks = [],
+	headingBlockTypes = []
+) => {
 	return blocks
-		.filter( ( block ) => block.name === 'core/heading' )
+		.filter( ( block ) => headingBlockTypes.includes( block.name ) )
 		.map( ( block ) => ( {
 			...block,
 			level: block.attributes.level,
@@ -110,6 +118,7 @@ export default function DocumentOutline( {
 	hasOutlineItemsDisabled,
 } ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
+	const headingBlockTypes = useHeadingBlockTypes();
 	const { title, isTitleSupported } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( editorStore );
 		const { getPostType } = select( coreStore );
@@ -148,8 +157,8 @@ export default function DocumentOutline( {
 	const prevHeadingLevelRef = useRef( 1 );
 
 	const headings = useMemo(
-		() => computeOutlineHeadings( blocks ),
-		[ blocks ]
+		() => computeOutlineHeadings( blocks, headingBlockTypes ),
+		[ blocks, headingBlockTypes ]
 	);
 
 	if ( headings.length < 1 ) {

--- a/packages/editor/src/components/document-outline/test/check.js
+++ b/packages/editor/src/components/document-outline/test/check.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+/**
+ * Internal dependencies
+ */
+import DocumentOutlineCheck from '../check';
+import useHeadingBlockTypes from '../use-heading-block-types';
+
+jest.mock( '../use-heading-block-types' );
+
+function setupMockSelect( headingBlockNames, blocks ) {
+	useHeadingBlockTypes.mockReturnValue( headingBlockNames );
+	useSelect.mockImplementation( ( mapSelect ) => {
+		return mapSelect( () => ( {
+			getBlocksByName: ( names ) =>
+				blocks
+					.filter( ( block ) => names.includes( block.name ) )
+					.map( ( block ) => block.clientId ),
+		} ) );
+	} );
+}
+
+describe( 'DocumentOutlineCheck', () => {
+	it( 'does not render if there are no headings', () => {
+		setupMockSelect( [ 'core/heading' ], [] );
+		render( <DocumentOutlineCheck>content</DocumentOutlineCheck> );
+		expect( screen.queryByText( 'content' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders if there is a block added via the editor.headingBlockTypes filter, even without a core/heading block', () => {
+		setupMockSelect(
+			[ 'core/heading', 'my-plugin/section-heading' ],
+			[ { clientId: '1', name: 'my-plugin/section-heading' } ]
+		);
+		render( <DocumentOutlineCheck>content</DocumentOutlineCheck> );
+		expect( screen.getByText( 'content' ) ).toBeVisible();
+	} );
+} );

--- a/packages/editor/src/components/document-outline/test/index.js
+++ b/packages/editor/src/components/document-outline/test/index.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import { computeOutlineHeadings } from '../';
+
+describe( 'computeOutlineHeadings', () => {
+	const blocks = [
+		{
+			clientId: '1',
+			name: 'core/heading',
+			attributes: { level: 2, content: 'Heading' },
+		},
+		{
+			clientId: '2',
+			name: 'core/paragraph',
+			attributes: { content: 'Paragraph' },
+		},
+		{
+			clientId: '3',
+			name: 'my-plugin/section-heading',
+			attributes: { level: 3, content: 'Custom heading' },
+		},
+	];
+
+	it( 'only includes core/heading blocks by default', () => {
+		const headings = computeOutlineHeadings( blocks, [ 'core/heading' ] );
+
+		expect( headings ).toHaveLength( 1 );
+		expect( headings[ 0 ] ).toMatchObject( {
+			clientId: '1',
+			level: 2,
+			isEmpty: false,
+		} );
+	} );
+
+	it( 'includes any block name passed in headingBlockTypes', () => {
+		const headingBlockTypes = [
+			'core/heading',
+			'my-plugin/section-heading',
+		];
+		const headings = computeOutlineHeadings( blocks, headingBlockTypes );
+
+		expect( headings ).toHaveLength( 2 );
+		expect( headings[ 1 ] ).toMatchObject( {
+			clientId: '3',
+			level: 3,
+			isEmpty: false,
+		} );
+	} );
+} );

--- a/packages/editor/src/components/document-outline/test/use-heading-block-types.js
+++ b/packages/editor/src/components/document-outline/test/use-heading-block-types.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import useHeadingBlockTypes from '../use-heading-block-types';
+
+describe( 'useHeadingBlockTypes', () => {
+	afterEach( () => {
+		removeFilter( 'editor.headingBlockTypes', 'test/heading-block-types' );
+	} );
+
+	it( 'defaults to core/heading only', () => {
+		const { result } = renderHook( () => useHeadingBlockTypes() );
+
+		expect( result.current ).toEqual( [ 'core/heading' ] );
+	} );
+
+	it( 'includes block types added via the editor.headingBlockTypes filter', () => {
+		addFilter(
+			'editor.headingBlockTypes',
+			'test/heading-block-types',
+			( blockTypes ) => [ ...blockTypes, 'my-plugin/section-heading' ]
+		);
+
+		const { result } = renderHook( () => useHeadingBlockTypes() );
+
+		expect( result.current ).toEqual( [
+			'core/heading',
+			'my-plugin/section-heading',
+		] );
+	} );
+} );

--- a/packages/editor/src/components/document-outline/use-heading-block-types.js
+++ b/packages/editor/src/components/document-outline/use-heading-block-types.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+
+const HEADING_BLOCK_TYPES = [ 'core/heading' ];
+
+/**
+ * Returns the list of block types considered headings for the Document
+ * Outline and Table of Contents, including any added via the
+ * `editor.headingBlockTypes` filter. The result is memoized so it can be
+ * used as a stable dependency in `useSelect` calls.
+ *
+ * Blocks added through the filter must expose a numeric `level` attribute
+ * and a `content` attribute (heading text/HTML), the same attribute names
+ * `core/heading` uses, since that's what the outline and Table of Contents
+ * block read.
+ *
+ * @return {string[]} Block type names considered headings.
+ */
+export default function useHeadingBlockTypes() {
+	return useMemo(
+		() => [
+			...applyFilters( 'editor.headingBlockTypes', HEADING_BLOCK_TYPES ),
+		],
+		[]
+	);
+}

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -12,18 +12,21 @@ import WordCount from '../word-count';
 import TimeToRead from '../time-to-read';
 import DocumentOutline from '../document-outline';
 import CharacterCount from '../character-count';
+import useHeadingBlockTypes from '../document-outline/use-heading-block-types';
 
 function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
+	const headingBlockTypes = useHeadingBlockTypes();
 	const { headingCount, paragraphCount, numberOfBlocks } = useSelect(
 		( select ) => {
-			const { getGlobalBlockCount } = select( blockEditorStore );
+			const { getBlocksByName, getGlobalBlockCount } =
+				select( blockEditorStore );
 			return {
-				headingCount: getGlobalBlockCount( 'core/heading' ),
+				headingCount: getBlocksByName( headingBlockTypes ).length,
 				paragraphCount: getGlobalBlockCount( 'core/paragraph' ),
 				numberOfBlocks: getGlobalBlockCount(),
 			};
 		},
-		[]
+		[ headingBlockTypes ]
 	);
 	return (
 		/*


### PR DESCRIPTION
## What?

Closes #71699, #28607

Adds an `editor.headingBlockTypes` filter so third-party blocks can register themselves as headings for the Document Outline panel and the Table of Contents block.

## Why?

Right now `core/heading` is hardcoded as the only heading source, independently in four places (Document Outline, its visibility check, the Details panel heading count, and the Table of Contents block). Custom blocks that render heading markup are invisible to all of them. The issue thread has several proposals for a bigger API (post type schema, block-support flags); this PR ships the smallest useful piece: a JS filter, mirroring the existing `editor.postContentBlockTypes` pattern already used in this same package.

## How?

- New `useHeadingBlockTypes()` hook in `packages/editor/src/components/document-outline/`, same shape as `usePostContentBlockTypes`: a `['core/heading']` default array run through `applyFilters('editor.headingBlockTypes', ...)`, memoized.
- Document Outline, its check component, and the Table of Contents panel now use this hook instead of hardcoding `core/heading`. Two of them switch from `getGlobalBlockCount(name)` to `getBlocksByName(names).length` since the count now needs to cover more than one block name.
- The Table of Contents block (`block-library`) can't depend on `@wordpress/editor`, so it applies the same filter locally instead of importing the hook.
- A block registered through the filter needs `level` (number) and `content` (string) attributes, same as `core/heading` — documented in code comments and in `docs/reference-guides/filters/block-filters.md`.
- No behavior change when the filter isn't used: default array is still just `core/heading`.

## Testing Instructions

1. Register a block with `level` and `content` attributes (matching `core/heading`'s attribute names) and add it to `editor.headingBlockTypes`:
   ```js
   wp.hooks.addFilter(
   	'editor.headingBlockTypes',
   	'my-plugin/heading-block-types',
   	( blockTypes ) => [ ...blockTypes, 'my-plugin/section-heading' ]
   );
   ```
2. Add a Heading block and your custom block to a post.
3. Open the editor's Details panel (the "i" icon) — heading count and the Document Outline list should include both blocks.
4. Insert a Table of Contents block — both should appear in its nested list.
5. Remove the filter (or deactivate the plugin) — outline/count/ToC should revert to counting only `core/heading`.

Automated:
```
npm run test:unit -- packages/editor/src/components/document-outline packages/block-library/src/table-of-contents
npm run lint:js -- packages/editor/src/components/document-outline packages/editor/src/components/table-of-contents packages/block-library/src/table-of-contents
```

### Testing Instructions for Keyboard

No new interactive UI, existing keyboard behavior for the Document Outline and Table of Contents block panel is unchanged.

### Screenshot
<img width="1386" height="574" alt="SCR-20260706-ctqh" src="https://github.com/user-attachments/assets/8dd6eadd-1a41-479f-9114-0cd486675929"/>

## Use of AI Tools

Used Claude Code to help implement this change (filter hook, wiring into the four call sites, tests, docs). I reviewed the diff, ran the test suite and linter, and manually tested the filter in a local WordPress instance before opening this PR.