### PR TITLE
fix(block-editor): handle paste across blocks for single-line text

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -175,7 +175,10 @@ export default function useClipboardHandler() {
 					blocks = pasteHandler( {
 						HTML: html,
 						plainText,
-						mode: isFullySelected ? 'BLOCKS' : 'AUTO',
+						mode:
+							isFullySelected || hasMultiSelection()
+								? 'BLOCKS'
+								: 'AUTO',
 						canUserUseUnfilteredHTML,
 					} );
 				}

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -374,6 +374,33 @@ test.describe( 'Copy/cut/paste', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	test( 'should paste single line text over partial cross-block selection', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'first paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second paragraph' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		// Partial select: " paragraph" from the first block and "second"
+		// from the second block.
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 7 } );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 8 } );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await pageUtils.pressKeys( 'shift+ArrowRight', { times: 6 } );
+		// Paste a single line of plain text over the partial selection.
+		pageUtils.setClipboardData( {
+			html: 'REPLACEMENT',
+			plainText: 'REPLACEMENT',
+		} );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	test( 'should cut partial selection and merge like a normal `delete` - not forward', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## Summary

Fixes #79865

When a partial Rich Text selection spans two blocks (e.g. "some text" from the end of paragraph 1 and "This is the" from the start of paragraph 2), pasting a single line of plain text fails or produces unexpected results. The pasted content doesn't replace the selected text.

The paste handler in `use-clipboard-handler.js` only forces `'BLOCKS'` mode for fully-selected whole blocks. For partial cross-block selections, it stays in `'AUTO'` mode, which makes `pasteHandler()` return a string for simple plain text. The handler then bails out to the per-block RichText paste listener, but that listener only touches whichever single DOM element contains `event.target`, so the other half of the cross-block selection is left untouched and `__unstableSplitSelection` (which already knows how to merge content across two blocks) never runs.

## Changes

### use-clipboard-handler.js
**Before:**
```js
mode: isFullySelected ? 'BLOCKS' : 'AUTO',
```

**After:**
```js
mode: isFullySelected || hasMultiSelection() ? 'BLOCKS' : 'AUTO',
```

**Why:** Forces `pasteHandler()` to return an array of blocks whenever there's a multi-block selection (partial or full). That routes cross-block partial selections through the existing `__unstableSplitSelection` path further down in the handler, which correctly splits and merges content across two blocks. Single-block paste is unaffected.

### copy-cut-paste.spec.js
Added an e2e test: partial cross-block selection on two paragraphs, paste single-line plain text, assert both blocks merge correctly.

## Testing
1. Create two paragraph blocks with text
2. Select text spanning the end of block 1 and the start of block 2
3. Copy "REPLACEMENT TEXT" to clipboard
4. Press Ctrl+V to paste
Result: selected text is replaced, two blocks merge into one with the pasted text

## Screen recording

https://github.com/user-attachments/assets/ab92c826-7928-4a1e-b67a-8e581a232d6d

