### PR TITLE
fix(block-editor): add sticky offset control

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -8,10 +8,15 @@ import clsx from 'clsx';
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
-import { BaseControl, CustomSelectControl } from '@wordpress/components';
+import {
+	BaseControl,
+	BoxControl,
+	CustomSelectControl,
+} from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { __experimentalUseCustomUnits as useCustomUnits } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -201,6 +206,10 @@ export function PositionPanelPure( {
 	const allowFixed = hasFixedPositionSupport( blockName );
 	const allowSticky = hasStickyPositionSupport( blockName );
 	const value = style?.position?.type;
+	const [ spacingUnits ] = useSettings( 'spacing.units' );
+	const units = useCustomUnits( {
+		availableUnits: spacingUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
+	} );
 
 	const { firstParentClientId } = useSelect(
 		( select ) => {
@@ -263,6 +272,20 @@ export function PositionPanelPure( {
 		? options.find( ( option ) => option.value === value ) || DEFAULT_OPTION
 		: DEFAULT_OPTION;
 
+	const onChangeSides = ( next ) => {
+		const newStyle = {
+			...style,
+			position: {
+				...style?.position,
+				...next,
+			},
+		};
+
+		setAttributes( {
+			style: cleanEmptyObject( newStyle ),
+		} );
+	};
+
 	// Only display position controls if there is at least one option to choose from.
 	return options.length > 1 ? (
 		<InspectorControls group="position">
@@ -281,6 +304,15 @@ export function PositionPanelPure( {
 						onChangeType( selectedItem.value );
 					} }
 				/>
+				{ value === STICKY_OPTION.value && (
+					<BoxControl
+						label={ __( 'Sticky offset' ) }
+						values={ style?.position }
+						onChange={ onChangeSides }
+						units={ units }
+						sides={ POSITION_SIDES }
+					/>
+				) }
 			</BaseControl>
 		</InspectorControls>
 	) : null;


### PR DESCRIPTION
## What?
Closes #79732

Adds a Sticky offset control to the Position panel, shown when a block's position is set to Sticky. Lets users set top/right/bottom/left offset values instead of the fixed 0px.

## Why?
Blocks with Sticky position had no way to configure their offset from the viewport without custom CSS. The `style.position.{top,right,bottom,left}` attribute path already flowed through to CSS (editor) and PHP render, but no UI existed to set anything but `0px`.

## How?
Added a `BoxControl` (same component used for spacing/padding) inside `PositionPanelPure` in `packages/block-editor/src/hooks/position.js`, shown only when position is Sticky. Writes to the existing `style.position` attribute keys, so no CSS or PHP renderer changes were needed.

## Testing Instructions
1. Add a Group block (or any block supporting position).
2. In the block inspector (Styles tab > Position), set Position to "Sticky".
3. The new "Sticky offset" control appears below the position dropdown.
4. Set values for top/right/bottom/left.
5. Save and view the post; confirm the CSS reflects the offsets on the `.wp-container-*` class.
6. Confirm resetting the Position panel clears the offset values.
7. Confirm the control does not appear for Fixed position.

### Testing Instructions for Keyboard
Tab to the Position panel, use arrow keys / typing to set offset values in the BoxControl inputs; all fields reachable and operable via keyboard.

## Screenshots or screencast

|Before|After|
|-|-|
|No offset control|Sticky offset BoxControl visible|

## Use of AI Tools
This PR was developed with the assistance of Claude Code (Anthropic). AI was used to help draft the implementation, which was reviewed before submission.
