### PR TITLE
Vips: Add positional-crop test for high-bit-depth AVIF

### DIFF
--- a/packages/vips/src/test/resize-image.ts
+++ b/packages/vips/src/test/resize-image.ts
@@ -281,6 +281,30 @@ describe( 'resizeImage', () => {
 			);
 		} );
 
+		it( 'crops a 10-bit AVIF to a position while preserving bit depth', async () => {
+			mockBitdepth = 10;
+			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
+				type: 'image/avif',
+			} );
+			const buffer = await avifFile.arrayBuffer();
+
+			await resizeImage( 'itemId', buffer, 'image/avif', {
+				width: 50,
+				height: 50,
+				crop: [ 'right', 'top' ],
+			} );
+
+			// Positional crops resize on the precision-preserving path and
+			// then crop the offset region directly on the 16-bit image.
+			expect( mockResize ).toHaveBeenCalled();
+			expect( mockThumbnailBuffer ).not.toHaveBeenCalled();
+			expect( mockCrop ).toHaveBeenCalledWith( 50, 0, 50, 50 );
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.avif',
+				expect.objectContaining( { bitdepth: 10 } )
+			);
+		} );
+
 		it( 'uses the standard thumbnail path for an 8-bit AVIF', async () => {
 			mockBitdepth = 8;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {


### PR DESCRIPTION
## What?

Adds a unit test covering positional crops (e.g. `['right', 'top']`) on the high-bit-depth AVIF resize path.

## Why?

Follow-up to #79556, where @andrewserong [asked](https://github.com/WordPress/gutenberg/pull/79556#discussion_r3479463624) whether crop position arrays were covered. The existing tests only exercised no-crop and centre-weighted (`crop: true`) variants.

## How?

The new test resizes a 10-bit AVIF with `crop: [ 'right', 'top' ]` and asserts:

- the precision-preserving `resize` path is used (not `thumbnail`, which flattens to 8-bit),
- the positional crop is applied with the expected offsets (`crop( 50, 0, 50, 50 )` for a 50×50 target on the 100×100 mock),
- the output is written with `bitdepth: 10` so the sub-size stays 10-bit.

## Testing Instructions

```
npm run test:unit -- packages/vips/src/test/resize-image.ts
```
