### PR TITLE
Command Palette: show the search icon on desktop as well

### DIFF
--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -67,20 +67,15 @@ function gutenberg_add_admin_bar_styles() {
 			return;
 	}
 	$css = <<<CSS
-		#wpadminbar #wp-admin-bar-command-palette .ab-icon {
-			display: none; /* Icon displayed only on mobile */
-		}
 		#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
 			content: "\\f179";
 			content: "\\f179" / '';
+			top: 3px;
 		}
 		#wpadminbar #wp-admin-bar-command-palette kbd {
 			background: transparent;
 		}
 		@media screen and (max-width: 782px) {
-			#wpadminbar #wp-admin-bar-command-palette .ab-icon {
-				display: block; /* Icon is only shown on mobile, while the keyboard shortcut is hidden */
-			}
 			#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
 				text-indent: 0;
 				font: normal 32px/1 dashicons;


### PR DESCRIPTION
## What?

This PR shows the command palette search icon in in admin bar desktop resolution as expected.

## Why?

This is based on Core discussion https://core.trac.wordpress.org/ticket/64672#comment:69 which was already applied to 7.0 but we didn't reapply the changes in the GB backport.

## How?

Applied this changeset in the backport file https://core.trac.wordpress.org/changeset/62092.

## Testing Instructions

1. Open wp-admin in desktop resolution; verify the search icon in the command palette is shown.
1. Open wp-admin in mobile resolution; verify the search icon in the command palette is shown.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before
<img width="352" height="32" alt="image" src="https://github.com/user-attachments/assets/88fc73d7-a1eb-4ed3-8375-38a079ca0bf0" />

After
<img width="352" height="32" alt="image" src="https://github.com/user-attachments/assets/2a0f4c25-e9b5-4f93-a064-9bb55cd7d1ce" />


## Use of AI Tools

Used Opus 4.8 to help apply the Trac changeset to trunk.