### PR TITLE
Docs: Clarify release recovery steps

### DIFF
--- a/docs/contributors/code/release/package-release-and-core-updates.md
+++ b/docs/contributors/code/release/package-release-and-core-updates.md
@@ -41,14 +41,28 @@ Behind the scenes, all steps are automated via `npm exec release-cli -- npm-late
 
 If npm publishing fails part-way through, do not assume every target package version is still unpublished. Some expected versions may already exist on npm while the release branch, package tags, or dist-tags still need recovery.
 
-Before restarting any mutating step, inspect the npm registry state for the packages listed in the failed job:
+Before restarting any mutating step, inspect the npm registry state for the packages listed in the failed job. Do not infer the remaining work from the package where the job stopped; retries or manual recovery attempts can leave a non-contiguous set of package versions published.
+
+For one package:
 
 ```sh
 npm view @wordpress/components@X.Y.Z version
 npm dist-tag ls @wordpress/components
 ```
 
-Resume from the package versions that already exist on npm. If the expected versions exist and the expected dist-tags point to them, continue with `npx lerna publish from-package` or the workflow's generated recovery command when one is printed.
+To inspect all package versions from the current release branch:
+
+```sh
+npx lerna list --json --no-private | jq -r '.[] | "\(.name)@\(.version)"' | while read package_version; do
+	package="${package_version%@*}"
+	version="${package_version##*@}"
+	echo "$package@$version"
+	npm view "$package@$version" version || true
+	npm dist-tag ls "$package"
+done
+```
+
+Resume from the package versions that already exist on npm. If the expected versions exist and the expected dist-tags point to them, continue either with [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package), which publishes local package versions that are not yet on npm and skips the ones that already made it, or the workflow's generated recovery command when one is printed.
 
 When a workflow run prints branch or package-tag recovery commands after npm publishing succeeds but Git metadata publication fails, prefer those run-specific commands over starting a fresh release.
 

--- a/docs/contributors/code/release/package-release-and-core-updates.md
+++ b/docs/contributors/code/release/package-release-and-core-updates.md
@@ -34,8 +34,23 @@ Behind the scenes, all steps are automated via `npm exec release-cli -- npm-late
 10. Run the script `npx lerna publish --no-private`.
     - When asked for the version numbers to choose for each package pick the values of the updated CHANGELOG files.
     - You'll be asked for your One-Time Password (OTP) a couple of times. This is the code from the 2FA authenticator app you use. Depending on how many packages are to be released you may be asked for more than one OTP, as they tend to expire before all packages are released.
-    - If the publishing process ends up incomplete (perhaps because it timed-out or a bad OTP was introduced) you can resume it via [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package).
+    - If the publishing process ends up incomplete (perhaps because it timed-out or a bad OTP was introduced), inspect npm state before resuming with [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package). See [Recovering from a partial npm publish](#recovering-from-a-partial-npm-publish).
 11. Finally, now that the npm packages are published, cherry-pick the commits created by lerna ("Publish" and the CHANGELOG update) into the `trunk` branch of Gutenberg.
+
+### Recovering from a partial npm publish
+
+If npm publishing fails part-way through, do not assume every target package version is still unpublished. Some expected versions may already exist on npm while the release branch, package tags, or dist-tags still need recovery.
+
+Before restarting any mutating step, inspect the npm registry state for the packages listed in the failed job:
+
+```sh
+npm view @wordpress/components@X.Y.Z version
+npm dist-tag ls @wordpress/components
+```
+
+Resume from the package versions that already exist on npm. If the expected versions exist and the expected dist-tags point to them, continue with `npx lerna publish from-package` or the workflow's generated recovery command when one is printed.
+
+When a workflow run prints branch or package-tag recovery commands after npm publishing succeeds but Git metadata publication fails, prefer those run-specific commands over starting a fresh release.
 
 ## WordPress releases
 
@@ -127,7 +142,7 @@ Behind the scenes, the rest of the process is automated with `npm exec --no rele
 5. Run the script `npx lerna publish --no-private`.
     - When asked for the version numbers to choose for each package pick the values of the updated CHANGELOG files.
     - You'll be asked for your One-Time Password (OTP) a couple of times. This is the code from the 2FA authenticator app you use. Depending on how many packages are to be released you may be asked for more than one OTP, as they tend to expire before all packages are released.
-    - If the publishing process ends up incomplete (perhaps because it timed-out or a bad OTP was introduced) you can resume it via [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package).
+    - If the publishing process ends up incomplete (perhaps because it timed-out or a bad OTP was introduced), inspect npm state before resuming with [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package). See [Recovering from a partial npm publish](#recovering-from-a-partial-npm-publish).
 6. Finally, now that the npm packages are published, cherry-pick the commits created by lerna ("Publish" and the CHANGELOG update) into the `trunk` branch of Gutenberg.
 
 ## Development releases

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -320,15 +320,16 @@ It's important to check that:
 
 -   the plugin from the directory works as expected
 -   the ZIP contents (see [Downloads](https://plugins.trac.wordpress.org/browser/gutenberg/)) looks correct (doesn't have anything obvious missing)
--   the [Gutenberg SVN repo](https://plugins.trac.wordpress.org/browser/gutenberg/) has two new commits (see [the log](https://plugins.trac.wordpress.org/browser/gutenberg/)):
-    -   the `trunk` folder should have "Committing version X.Y.Z"
-    -   there is a new `tags/X.Y.Z` folder with the same contents as `trunk` whose latest commit is "Tagging version X.Y.Z"
+-   the [Gutenberg SVN repo](https://plugins.trac.wordpress.org/browser/gutenberg/) has the expected `trunk` contents and a matching `tags/X.Y.Z` folder (see [the log](https://plugins.trac.wordpress.org/browser/gutenberg/))
 
-Most likely, the tag folder couldn't be created. This is a [known issue](https://github.com/WordPress/gutenberg/issues/55295) that [can be fixed manually](https://github.com/WordPress/gutenberg/issues/55295#issuecomment-1759292978).
+The current WordPress.org upload workflow replaces SVN `trunk`, copies that local `trunk` checkout to `tags/$VERSION`, then commits `trunk` and `tags/$VERSION` together. Before rerunning the workflow or any mutating SVN command, inspect the existing SVN state and avoid creating a second tag for the same version.
 
 Either substitute `SVN_USERNAME`, `SVN_PASSWORD`, and `VERSION` for the proper values or set them as global environment variables first:
 
 ```sh
+# CHECK WHETHER THE TAG ALREADY EXISTS
+svn list https://plugins.svn.wordpress.org/gutenberg/tags/$VERSION --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
 # CHECKOUT THE REPOSITORY
 svn checkout https://plugins.svn.wordpress.org/gutenberg/trunk --username "$SVN_USERNAME" --password "$SVN_PASSWORD" gutenberg-svn
 
@@ -338,9 +339,13 @@ cd gutenberg-svn
 # IF YOU HAPPEN TO HAVE ALREADY THE REPO LOCALLY
 # AND DIDN'T CHECKOUT, MAKE SURE IT IS UPDATED
 svn up .
+```
 
+If `trunk` already contains the intended release but `tags/$VERSION` is missing, create the tag from the current SVN `trunk`:
+
+```sh
 # COPY CURRENT TRUNK INTO THE NEW TAGS FOLDER
-svn copy https://plugins.svn.wordpress.org/gutenberg/trunk https://plugins.svn.wordpress.org/gutenberg/tags/$VERSION -m 'Tagging version $VERSION' --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+svn copy https://plugins.svn.wordpress.org/gutenberg/trunk https://plugins.svn.wordpress.org/gutenberg/tags/$VERSION -m "Tagging version $VERSION" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 ```
 
 Ask around if you need help with any of this.

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -338,7 +338,7 @@ svn cat https://plugins.svn.wordpress.org/gutenberg/trunk/readme.txt | grep "Sta
 svn cat https://plugins.svn.wordpress.org/gutenberg/trunk/gutenberg.php | grep "Version: $VERSION"
 ```
 
-Also confirm the matching GitHub release and `v$VERSION` tag still exist. The following SVN recovery command only repairs WordPress.org plugin repository state.
+Also confirm the matching GitHub release and `v$VERSION` tag still exist. If either is missing, stop and restore the GitHub release state before running SVN recovery commands; the SVN commands below only repair WordPress.org plugin repository state.
 
 If SVN `trunk` already contains the intended release but `tags/$VERSION` is missing, create the tag from the current SVN `trunk`:
 

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -327,21 +327,20 @@ The current WordPress.org upload workflow replaces SVN `trunk`, copies that loca
 Either substitute `SVN_USERNAME`, `SVN_PASSWORD`, and `VERSION` for the proper values or set them as global environment variables first:
 
 ```sh
-# CHECK WHETHER THE TAG ALREADY EXISTS
+# CHECK WHETHER THE SVN TAG ALREADY EXISTS
+# A file listing means YES.
+# An error mentioning a "non-existent" path (W160013/E200009) means NO,
+# and means you can safely create the tag.
 svn list https://plugins.svn.wordpress.org/gutenberg/tags/$VERSION --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
-# CHECKOUT THE REPOSITORY
-svn checkout https://plugins.svn.wordpress.org/gutenberg/trunk --username "$SVN_USERNAME" --password "$SVN_PASSWORD" gutenberg-svn
-
-# MOVE TO THE LOCAL FOLDER
-cd gutenberg-svn
-
-# IF YOU HAPPEN TO HAVE ALREADY THE REPO LOCALLY
-# AND DIDN'T CHECKOUT, MAKE SURE IT IS UPDATED
-svn up .
+# CHECK WHETHER SVN TRUNK ALREADY CONTAINS THE INTENDED RELEASE
+svn cat https://plugins.svn.wordpress.org/gutenberg/trunk/readme.txt | grep "Stable tag: $VERSION"
+svn cat https://plugins.svn.wordpress.org/gutenberg/trunk/gutenberg.php | grep "Version: $VERSION"
 ```
 
-If `trunk` already contains the intended release but `tags/$VERSION` is missing, create the tag from the current SVN `trunk`:
+Also confirm the matching GitHub release and `v$VERSION` tag still exist. The following SVN recovery command only repairs WordPress.org plugin repository state.
+
+If SVN `trunk` already contains the intended release but `tags/$VERSION` is missing, create the tag from the current SVN `trunk`:
 
 ```sh
 # COPY CURRENT TRUNK INTO THE NEW TAGS FOLDER


### PR DESCRIPTION
## What?
Follow-up to #79858 and #79859.

Updates the release documentation for plugin SVN recovery and partial npm package publish recovery.

## Why?
The current docs implied some stale recovery behavior after the 23.5 release workflow failures. Release maintainers need recovery steps that match the current workflow shape and avoid rerunning mutating steps before checking existing SVN or npm state.

> [!NOTE]
> This PR documents and reconciles the current release procedure and recovery paths. It does not redesign the release process; it aligns the docs with the workflows and conventions currently used by Gutenberg, including the hardening work in #79858 and #79859.

## How?
- Clarifies that the WordPress.org plugin upload path updates SVN `trunk`, copies local `trunk` to `tags/$VERSION`, then commits both together.
- Adds inspection-first guidance before rerunning SVN recovery commands.
- Adds a partial npm publish recovery note that expects some target versions may already exist and points maintainers at npm version/dist-tag inspection before resuming.
- Notes that generated branch/package-tag recovery commands should be preferred when workflow runs print them.

## Testing Instructions
1. Confirm the docs-only diff is limited to:
   - `docs/contributors/code/release/plugin-release.md`
   - `docs/contributors/code/release/package-release-and-core-updates.md`
2. Confirm the documented release behavior matches:
   - `.github/workflows/build-plugin-zip.yml`
   - `.github/workflows/upload-release-to-plugin-repo.yml`
   - `.github/workflows/publish-npm-packages.yml`
   - `tools/release/commands/packages.js`
3. Run `git diff --check`.

No full test suite was run because this PR only changes Markdown release docs.

### Testing Instructions for Keyboard
Not applicable; this PR only changes documentation.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex. I reviewed the changes and validation output.