### PR TITLE
wp-build: Cap build phase concurrency at available parallelism

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Cap build phase concurrency (package transpiling and bundling, routes, widgets) at the machine's available parallelism instead of fanning out unbounded, which exhausted memory on projects with many widgets. Override the default with the `--concurrency` flag or the `WP_BUILD_CONCURRENCY` environment variable.
+-   Cap build phase concurrency (package transpiling and bundling, routes, widgets) at the machine's available parallelism instead of fanning out unbounded, which exhausted memory on projects with many widgets. Override the default with the `--concurrency` flag or the `WP_BUILD_CONCURRENCY` environment variable ([#79885](https://github.com/WordPress/gutenberg/pull/79885)).
 
 ## 0.18.0 (2026-07-01)
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Cap build phase concurrency (package transpiling and bundling, routes, widgets) at the machine's available parallelism instead of fanning out unbounded, which exhausted memory on projects with many widgets. Override the default with the `--concurrency` flag or the `WP_BUILD_CONCURRENCY` environment variable.
+
 ## 0.18.0 (2026-07-01)
 
 ## 0.17.0 (2026-06-24)

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -6,11 +6,11 @@ Build tool for WordPress plugins.
 
 `@wordpress/build` is an opinionated build system designed for WordPress plugins. It provides:
 
-- **Transpilation**: Converts TypeScript/JSX source code to both CommonJS (`build/`) and ESM (`build-module/`) formats using esbuild
-- **Style Compilation**: Processes SCSS files and CSS modules, generating LTR and RTL versions
-- **Bundling**: Creates browser-ready bundles for WordPress scripts and modules
-- **PHP Generation**: Automatically generates PHP registration files for scripts, modules, and styles
-- **Watch Mode**: Incremental rebuilds during development
+-   **Transpilation**: Converts TypeScript/JSX source code to both CommonJS (`build/`) and ESM (`build-module/`) formats using esbuild
+-   **Style Compilation**: Processes SCSS files and CSS modules, generating LTR and RTL versions
+-   **Bundling**: Creates browser-ready bundles for WordPress scripts and modules
+-   **PHP Generation**: Automatically generates PHP registration files for scripts, modules, and styles
+-   **Watch Mode**: Incremental rebuilds during development
 
 ## Installation
 
@@ -52,6 +52,28 @@ or via npm script:
 }
 ```
 
+### Build Concurrency
+
+Build phases process their units (packages, routes, widgets) concurrently,
+capped at the machine's available parallelism by default. Each unit in flight
+spawns its own esbuild and Sass compiler work, so raising the cap trades
+memory for throughput.
+
+Override the default with the `--concurrency` flag:
+
+```bash
+wp-build --concurrency 4
+```
+
+or with the `WP_BUILD_CONCURRENCY` environment variable, which is handy in CI
+where the build command is often wrapped in npm scripts:
+
+```bash
+WP_BUILD_CONCURRENCY=4 npm run build
+```
+
+The flag takes precedence over the environment variable.
+
 ### Testing Generated Styles
 
 Generated CSS module output skips automatic style injection when `NODE_ENV` is
@@ -67,9 +89,9 @@ Configure your `package.json` with the following optional fields:
 
 Controls whether the package is exposed as a bundled WordPress script/module and accessible via the configured global variable.
 
-- **`true`**: The package will be bundled and exposed as a WordPress script. It will be available in WordPress as part of the configured global (e.g., `wp.blockEditor`, `wp.data`, or a custom global name if configured differently).
+-   **`true`**: The package will be bundled and exposed as a WordPress script. It will be available in WordPress as part of the configured global (e.g., `wp.blockEditor`, `wp.data`, or a custom global name if configured differently).
 
-- **Omitted or `false` (default)**: The package will not be exposed as a WordPress script. Use this for packages designed solely as dependencies for other packages. The package can still be used as a dependency via npm imports by other packages.
+-   **Omitted or `false` (default)**: The package will not be exposed as a WordPress script. Use this for packages designed solely as dependencies for other packages. The package can still be used as a dependency via npm imports by other packages.
 
 ```json
 {
@@ -107,7 +129,7 @@ Additional script dependencies:
 
 ```json
 {
-	"wpScriptExtraDependencies": ["wp-polyfill"]
+	"wpScriptExtraDependencies": [ "wp-polyfill" ]
 }
 ```
 
@@ -232,8 +254,8 @@ The prefix used for WordPress script handles in `.asset.php` files (e.g., `wp-da
 
 With this configuration:
 
-- `@my-plugin/editor` → `window.myPlugin.editor` with handle `mp-editor`
-- `@my-plugin/data` → `window.myPlugin.data` with handle `mp-data`
+-   `@my-plugin/editor` → `window.myPlugin.editor` with handle `mp-editor`
+-   `@my-plugin/data` → `window.myPlugin.data` with handle `mp-data`
 
 ### `wpPlugin.externalNamespaces`
 
@@ -258,9 +280,9 @@ Additional package namespaces to externalize (consume as externals, not expose).
 
 This allows your packages to consume third-party dependencies as externals:
 
-- `import { Cart } from '@woo/cart'` → `window.woo.cart` with handle `woocommerce-cart`
-- `import { Button } from '@acme/ui'` → `window.acme.ui` with handle `acme-plugin-ui`
-- Dependencies are tracked in `.asset.php` files
+-   `import { Cart } from '@woo/cart'` → `window.woo.cart` with handle `woocommerce-cart`
+-   `import { Button } from '@acme/ui'` → `window.acme.ui` with handle `acme-plugin-ui`
+-   Dependencies are tracked in `.asset.php` files
 
 If `handlePrefix` is omitted, it defaults to the namespace key (e.g., `"woo"` → `woo-cart`).
 
@@ -277,7 +299,7 @@ Pages can be defined as simple strings or as objects with initialization modules
 			"my-admin-page",
 			{
 				"id": "my-other-page",
-				"init": ["@my-plugin/my-page-init"]
+				"init": [ "@my-plugin/my-page-init" ]
 			}
 		]
 	}
@@ -286,19 +308,19 @@ Pages can be defined as simple strings or as objects with initialization modules
 
 **Page Configuration:**
 
-- **String format**: `"my-admin-page"` - Simple page with no init modules
-- **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "experimental": true }` - Page with optional init modules
-    - **`id`** (required): The page slug used in WordPress admin URLs
-    - **`init`** (optional): Array of script module IDs to execute during page initialization
-    - **`experimental`** (optional, default `false`): When `true`, the page is excluded from WordPress Core builds (`IS_WORDPRESS_CORE=true`), along with any route that belongs only to experimental pages.
+-   **String format**: `"my-admin-page"` - Simple page with no init modules
+-   **Object format**: `{ "id": "page-slug", "init": ["@scope/package"], "experimental": true }` - Page with optional init modules
+    -   **`id`** (required): The page slug used in WordPress admin URLs
+    -   **`init`** (optional): Array of script module IDs to execute during page initialization
+    -   **`experimental`** (optional, default `false`): When `true`, the page is excluded from WordPress Core builds (`IS_WORDPRESS_CORE=true`), along with any route that belongs only to experimental pages.
 
 **Generated Files:**
 
 This generates two page modes:
 
-- `build/pages/my-admin-page/page.php` - Full-page mode (takes over entire admin screen with custom sidebar)
-- `build/pages/my-admin-page/page-wp-admin.php` - WP-Admin mode (integrates within standard wp-admin interface)
-- `build/pages.php` - Loader for all pages
+-   `build/pages/my-admin-page/page.php` - Full-page mode (takes over entire admin screen with custom sidebar)
+-   `build/pages/my-admin-page/page-wp-admin.php` - WP-Admin mode (integrates within standard wp-admin interface)
+-   `build/pages.php` - Loader for all pages
 
 Each mode provides route/menu registration functions and a render callback. Routes are automatically registered for both modes.
 
@@ -343,8 +365,8 @@ add_menu_page( 'Title', 'Menu', 'capability', 'my-admin-page', 'my_plugin_my_adm
 **Init Modules:**
 Init modules are JavaScript packages that execute during page initialization, after menu items and routes are registered and before the app renders. They're ideal for:
 
-- Adding icons to menu items (icons can't be passed from PHP)
-- Registering command palette entries
+-   Adding icons to menu items (icons can't be passed from PHP)
+-   Registering command palette entries
 
 **Creating an Init Module:**
 
@@ -395,9 +417,9 @@ The `init()` function is **mandatory** - all init modules must export this named
 
 This configuration:
 
-- Packages like `@wordpress/data` expose `window.wp.data`
-- Packages like `@wordpress/block-editor` expose `window.wp.blockEditor`
-- All packages can consume `@wordpress/*` as externals
+-   Packages like `@wordpress/data` expose `window.wp.data`
+-   Packages like `@wordpress/block-editor` expose `window.wp.blockEditor`
+-   All packages can consume `@wordpress/*` as externals
 
 ### Example: Third-Party Plugin
 
@@ -413,18 +435,18 @@ This configuration:
 
 This configuration:
 
-- Packages like `@acme/editor` expose `window.acme.editor`
-- Packages like `@acme/data` expose `window.acme.data`
-- All packages can still consume `@wordpress/*` → `window.wp.*`
-- All packages can still consume vendors (react, lodash) → `window.React`, `window.lodash`
+-   Packages like `@acme/editor` expose `window.acme.editor`
+-   Packages like `@acme/data` expose `window.acme.data`
+-   All packages can still consume `@wordpress/*` → `window.wp.*`
+-   All packages can still consume vendors (react, lodash) → `window.React`, `window.lodash`
 
 ### Behavior
 
-- **Packages with `wpScript: true` matching the namespace**: Bundled with global exposure
-- **Packages with `wpScript: true` not matching the namespace**: Bundled without global exposure
-- **Dependencies**: `@wordpress/*` packages are always externalized to `wp.*` globals
-- **Vendors**: React, lodash, jQuery, moment are always externalized to their standard globals
-- **Asset files**: `.asset.php` files are always generated for WordPress dependency management
+-   **Packages with `wpScript: true` matching the namespace**: Bundled with global exposure
+-   **Packages with `wpScript: true` not matching the namespace**: Bundled without global exposure
+-   **Dependencies**: `@wordpress/*` packages are always externalized to `wp.*` globals
+-   **Vendors**: React, lodash, jQuery, moment are always externalized to their standard globals
+-   **Asset files**: `.asset.php` files are always generated for WordPress dependency management
 
 ## Output Structure
 
@@ -471,15 +493,15 @@ For routes that should appear on multiple pages:
 {
 	"route": {
 		"path": "/settings",
-		"page": ["my-admin-page", "other-page"]
+		"page": [ "my-admin-page", "other-page" ]
 	}
 }
 ```
 
 The `page` field can be either:
 
-- **String**: Route belongs to a single page
-- **Array**: Route appears on multiple pages (the build system will register the route for each page)
+-   **String**: Route belongs to a single page
+-   **Array**: Route appears on multiple pages (the build system will register the route for each page)
 
 Each page ID must match one of the pages defined in `wpPlugin.pages` in your root `package.json`. This tells the build system which page(s) this route belongs to. It can also map to existing pages registered by other plugins.
 
@@ -513,22 +535,22 @@ The canvas is a full-screen area typically used for editor previews. To use a cu
 
 Export a `route` object with optional hooks. Each hook receives `{ params, search }` — path parameters and query string values from the URL.
 
-- **`beforeLoad`** — Runs before navigation completes. Use for auth checks, validation, or redirects. Throw `redirect()` or `notFound()` from `@wordpress/route` to abort navigation.
-- **`loader`** — Runs while the route is loading. Use to preload data (for example, `resolveSelect` from `@wordpress/data`) so `stage` components can read from the store without a loading state. May return an object whose properties are merged into the route's loader data. For data that must be available before the JavaScript application loads, use [`rest_preload_api_request()`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) in your page's PHP render callback instead.
-- **`canvas`** — Runs in parallel with `loader`. Controls which canvas is rendered depending on return values:
-    - `CanvasData` (`{ postType, postId, isPreview?, editLink? }`) → default WordPress editor canvas
-    - `null` → custom `canvas.tsx` component (if provided)
-    - `undefined` or omitted → no canvas
+-   **`beforeLoad`** — Runs before navigation completes. Use for auth checks, validation, or redirects. Throw `redirect()` or `notFound()` from `@wordpress/route` to abort navigation.
+-   **`loader`** — Runs while the route is loading. Use to preload data (for example, `resolveSelect` from `@wordpress/data`) so `stage` components can read from the store without a loading state. May return an object whose properties are merged into the route's loader data. For data that must be available before the JavaScript application loads, use [`rest_preload_api_request()`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) in your page's PHP render callback instead.
+-   **`canvas`** — Runs in parallel with `loader`. Controls which canvas is rendered depending on return values:
+    -   `CanvasData` (`{ postType, postId, isPreview?, editLink? }`) → default WordPress editor canvas
+    -   `null` → custom `canvas.tsx` component (if provided)
+    -   `undefined` or omitted → no canvas
 
 ```tsx
 export const route = {
-	beforeLoad: ({ params, search }) => {
+	beforeLoad: ( { params, search } ) => {
 		// Pre-navigation validation, auth checks
 	},
-	loader: ({ params, search }) => {
+	loader: ( { params, search } ) => {
 		// Data preloading
 	},
-	canvas: ({ params, search }) => {
+	canvas: ( { params, search } ) => {
 		// Return CanvasData to use default canvas (editor)
 		return {
 			postType: params.type,
@@ -542,7 +564,7 @@ export const route = {
 
 		// Return undefined to show no canvas
 		// return undefined;
-	}
+	},
 };
 ```
 
@@ -550,10 +572,10 @@ export const route = {
 
 The build system generates:
 
-- `build/routes/{route-name}/content.js` - Bundled stage/inspector/canvas components
-- `build/routes/{route-name}/route.js` - Bundled lifecycle hooks (if present)
-- `build/routes/registry.php` - Route registry data
-- `build/routes.php` - Route registration logic
+-   `build/routes/{route-name}/content.js` - Bundled stage/inspector/canvas components
+-   `build/routes/{route-name}/route.js` - Bundled lifecycle hooks (if present)
+-   `build/routes/registry.php` - Route registry data
+-   `build/routes.php` - Route registration logic
 
 The boot package in Gutenberg will automatically use these routes and make them available.
 
@@ -580,13 +602,13 @@ widgets/
 
 Widgets use a dual-entry pattern, similar in spirit to how blocks split metadata between `block.json` and `edit.js`:
 
-| Concern | Lives in | Reason |
-| --- | --- | --- |
-| Identity (`name`) | both (must match) | server needs it to register; client uses it to resolve the runtime entry |
-| Translatable metadata (`title`, `description`, `keywords`) | `widget.json` | translated server-side via `textdomain`, so the host receives localized strings without a JS runtime |
-| Framing (`category`, `presentation`) | `widget.json` | plain JSON the host reads without a JS runtime |
-| Attribute schema (types, options, labels) | `widget.ts` | needs TypeScript coupling with `render` props; labels are translated with `__()` |
-| Icon and `example` | `widget.ts` | runtime values co-located with the attribute schema |
+| Concern                                                    | Lives in          | Reason                                                                                               |
+| ---------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| Identity (`name`)                                          | both (must match) | server needs it to register; client uses it to resolve the runtime entry                             |
+| Translatable metadata (`title`, `description`, `keywords`) | `widget.json`     | translated server-side via `textdomain`, so the host receives localized strings without a JS runtime |
+| Framing (`category`, `presentation`)                       | `widget.json`     | plain JSON the host reads without a JS runtime                                                       |
+| Attribute schema (types, options, labels)                  | `widget.ts`       | needs TypeScript coupling with `render` props; labels are translated with `__()`                     |
+| Icon and `example`                                         | `widget.ts`       | runtime values co-located with the attribute schema                                                  |
 
 Rule of thumb: anything the host needs before loading a widget's module — identity, translatable copy, framing — goes in `widget.json`, which the build forwards to `build/widgets/registry.php` and exposes through the REST API. Anything that needs TypeScript or runtime values (attribute schema, icon, `example`) goes in `widget.ts`.
 
@@ -604,13 +626,13 @@ Rule of thumb: anything the host needs before loading a widget's module — iden
 
 **Fields:**
 
-- **`name`** (required): Namespaced identifier (e.g., `"my-plugin/hello-world"`)
-- **`title`** (optional): Human-readable title. Translated server-side using `textdomain`.
-- **`description`** (optional): Short description. Translated server-side using `textdomain`.
-- **`keywords`** (optional): Search aliases. Translated server-side using `textdomain`.
-- **`category`** (optional): Grouping category for filtering
-- **`presentation`** (optional): Rendering intent (`framed`, `content-bleed`, `full-bleed`)
-- **`textdomain`** (optional): Gettext text domain for translating `title`, `description`, and `keywords`
+-   **`name`** (required): Namespaced identifier (e.g., `"my-plugin/hello-world"`)
+-   **`title`** (optional): Human-readable title. Translated server-side using `textdomain`.
+-   **`description`** (optional): Short description. Translated server-side using `textdomain`.
+-   **`keywords`** (optional): Search aliases. Translated server-side using `textdomain`.
+-   **`category`** (optional): Grouping category for filtering
+-   **`presentation`** (optional): Rendering intent (`framed`, `content-bleed`, `full-bleed`)
+-   **`textdomain`** (optional): Gettext text domain for translating `title`, `description`, and `keywords`
 
 ### `widget.ts` — runtime schema
 
@@ -667,7 +689,9 @@ export default function HelloWorld( { attributes }: HelloWorldRenderProps ) {
 	return (
 		<div>
 			Hello, { attributes.greeting ?? 'World' }!
-			{ attributes.showDate && <time>{ new Date().toLocaleDateString() }</time> }
+			{ attributes.showDate && (
+				<time>{ new Date().toLocaleDateString() }</time>
+			) }
 		</div>
 	);
 }
@@ -679,12 +703,12 @@ All non-JSON entries are optional. The build system checks for files with extens
 
 The build system generates:
 
-- `build/widgets/{widget-name}/render.min.js` + `render.js` — Bundled UI component (ESM)
-- `build/widgets/{widget-name}/render.min.asset.php` — Asset metadata for render module
-- `build/widgets/{widget-name}/widget.min.js` + `widget.js` — Bundled metadata (ESM)
-- `build/widgets/{widget-name}/widget.min.asset.php` — Asset metadata for widget module
-- `build/widgets/registry.php` — Widget registry data
-- `build/widgets.php` — Script module registration logic
+-   `build/widgets/{widget-name}/render.min.js` + `render.js` — Bundled UI component (ESM)
+-   `build/widgets/{widget-name}/render.min.asset.php` — Asset metadata for render module
+-   `build/widgets/{widget-name}/widget.min.js` + `widget.js` — Bundled metadata (ESM)
+-   `build/widgets/{widget-name}/widget.min.asset.php` — Asset metadata for widget module
+-   `build/widgets/registry.php` — Widget registry data
+-   `build/widgets.php` — Script module registration logic
 
 ### PHP Registration
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -50,6 +50,7 @@ import {
 	findScriptsToRebundle,
 	findRoutesToRebuild,
 } from './dependency-graph.mjs';
+import { createLimiter, resolveConcurrency } from './concurrency.mjs';
 import {
 	generatePhpFromTemplate,
 	getPhpReplacements,
@@ -1828,10 +1829,11 @@ async function buildRoute( routeName ) {
  * Routes whose pages are all in `experimentalPageIds` are skipped. Pass an
  * empty set (the default) to build every route.
  *
- * @param {Set<string>} experimentalPageIds Page ids marked experimental.
+ * @param {Set<string>}                                experimentalPageIds Page ids marked experimental.
+ * @param {(task: () => Promise<any>) => Promise<any>} runLimited          Concurrency-limited task scheduler.
  * @return {Promise<void>}
  */
-async function buildRoutes( experimentalPageIds = new Set() ) {
+async function buildRoutes( experimentalPageIds = new Set(), runLimited ) {
 	console.log( '\n🚦 Phase 3: Building routes...\n' );
 
 	const allRoutes = getAllRoutes( ROOT_DIR );
@@ -1855,12 +1857,14 @@ async function buildRoutes( experimentalPageIds = new Set() ) {
 	}
 
 	await Promise.all(
-		routes.map( async ( routeName ) => {
-			const buildTime = await buildRoute( routeName );
-			console.log(
-				`   ✔ Built route ${ routeName } (${ buildTime }ms)`
-			);
-		} )
+		routes.map( ( routeName ) =>
+			runLimited( async () => {
+				const buildTime = await buildRoute( routeName );
+				console.log(
+					`   ✔ Built route ${ routeName } (${ buildTime }ms)`
+				);
+			} )
+		)
 	);
 }
 
@@ -1986,9 +1990,10 @@ async function buildWidget( widgetName ) {
 /**
  * Build all discovered widgets.
  *
+ * @param {(task: () => Promise<any>) => Promise<any>} runLimited Concurrency-limited task scheduler.
  * @return {Promise<void>}
  */
-async function buildAllWidgets() {
+async function buildAllWidgets( runLimited ) {
 	console.log( '\n🧩 Phase 4: Building widgets...\n' );
 
 	const widgets = getAllWidgets( ROOT_DIR );
@@ -2003,12 +2008,14 @@ async function buildAllWidgets() {
 	);
 
 	await Promise.all(
-		widgets.map( async ( widgetName ) => {
-			const buildTime = await buildWidget( widgetName );
-			console.log(
-				`   ✔ Built widget ${ widgetName } (${ buildTime }ms)`
-			);
-		} )
+		widgets.map( ( widgetName ) =>
+			runLimited( async () => {
+				const buildTime = await buildWidget( widgetName );
+				console.log(
+					`   ✔ Built widget ${ widgetName } (${ buildTime }ms)`
+				);
+			} )
+		)
 	);
 }
 
@@ -2156,11 +2163,14 @@ async function generateWidgetsPhp( widgets, replacements ) {
  * Main build function.
  *
  * @param {string?} baseUrlExpression
+ * @param {number}  concurrency       Maximum number of build units (package,
+ *                                    route, widget) processed at the same time.
  */
-async function buildAll( baseUrlExpression ) {
-	console.log( '🔨 Building packages...\n' );
+async function buildAll( baseUrlExpression, concurrency ) {
+	console.log( `🔨 Building packages (concurrency: ${ concurrency })...\n` );
 
 	const startTime = Date.now();
+	const runLimited = createLimiter( concurrency );
 
 	// Build maps: short name ↔ full name ↔ package.json from package.json files
 	const shortToFull = new Map();
@@ -2181,13 +2191,15 @@ async function buildAll( baseUrlExpression ) {
 
 	for ( const level of levels ) {
 		await Promise.all(
-			level.map( async ( fullName ) => {
-				const packageName = fullToShort.get( fullName );
-				const buildTime = await transpilePackage( packageName );
-				console.log(
-					`   ✔ Transpiled ${ packageName } (${ buildTime }ms)`
-				);
-			} )
+			level.map( ( fullName ) =>
+				runLimited( async () => {
+					const packageName = fullToShort.get( fullName );
+					const buildTime = await transpilePackage( packageName );
+					console.log(
+						`   ✔ Transpiled ${ packageName } (${ buildTime }ms)`
+					);
+				} )
+			)
 		);
 	}
 
@@ -2196,26 +2208,28 @@ async function buildAll( baseUrlExpression ) {
 	const scripts = [];
 	const styles = [];
 	await Promise.all(
-		PACKAGES.map( async ( packageName ) => {
-			const startBundleTime = Date.now();
-			const ret = await bundlePackage( packageName );
-			const buildTime = Date.now() - startBundleTime;
-			if ( ret ) {
-				console.log(
-					`   ✔ Bundled ${ packageName } (${ buildTime }ms)`
-				);
+		PACKAGES.map( ( packageName ) =>
+			runLimited( async () => {
+				const startBundleTime = Date.now();
+				const ret = await bundlePackage( packageName );
+				const buildTime = Date.now() - startBundleTime;
+				if ( ret ) {
+					console.log(
+						`   ✔ Bundled ${ packageName } (${ buildTime }ms)`
+					);
 
-				if ( ret.modules ) {
-					modules.push( ...ret.modules );
+					if ( ret.modules ) {
+						modules.push( ...ret.modules );
+					}
+					if ( ret.scripts ) {
+						scripts.push( ...ret.scripts );
+					}
+					if ( ret.styles ) {
+						styles.push( ...ret.styles );
+					}
 				}
-				if ( ret.scripts ) {
-					scripts.push( ...ret.scripts );
-				}
-				if ( ret.styles ) {
-					styles.push( ...ret.styles );
-				}
-			}
-		} )
+			} )
+		)
 	);
 
 	// Normalize PAGES config to support both string and object formats
@@ -2247,10 +2261,10 @@ async function buildAll( baseUrlExpression ) {
 					.map( ( page ) => page.id )
 		  )
 		: new Set();
-	await buildRoutes( experimentalPageIds );
+	await buildRoutes( experimentalPageIds, runLimited );
 
 	// Build widgets
-	await buildAllWidgets();
+	await buildAllWidgets( runLimited );
 
 	// Collect widget data for PHP generation
 	const widgets = collectWidgets();
@@ -2683,13 +2697,17 @@ async function main() {
 						? "includes_url( 'build/' )"
 						: 'plugin_dir_url( __FILE__ )',
 			},
+			concurrency: {
+				type: 'string',
+			},
 		},
 		strict: false,
 	} );
 
 	const baseUrlExpression = values[ 'base-url' ];
+	const concurrency = resolveConcurrency( values.concurrency );
 
-	await buildAll( baseUrlExpression );
+	await buildAll( baseUrlExpression, concurrency );
 
 	if ( values.watch ) {
 		console.log( '\n👀 Watching for changes...\n' );

--- a/packages/wp-build/lib/concurrency.mjs
+++ b/packages/wp-build/lib/concurrency.mjs
@@ -1,0 +1,83 @@
+/**
+ * Concurrency utilities for build phases.
+ *
+ * Build phases fan out one task per unit (package, route, widget). Each unit
+ * spawns its own esbuild/sass work, so unbounded fan-out exhausts memory on
+ * projects with many units; these helpers bound how many run at once.
+ */
+
+/**
+ * External dependencies
+ */
+import os from 'node:os';
+
+/**
+ * Create a scheduler that runs async tasks with a concurrency limit.
+ *
+ * Tasks start immediately while fewer than `limit` are running; the rest
+ * queue and start as slots free up.
+ *
+ * @param {number} limit Maximum number of tasks running at the same time.
+ * @return {(task: () => Promise<any>) => Promise<any>} Schedules a task and
+ * resolves with its result.
+ */
+export function createLimiter( limit ) {
+	let active = 0;
+	/** @type {Array<() => void>} */
+	const queue = [];
+
+	const runNext = () => {
+		if ( active >= limit ) {
+			return;
+		}
+		const start = queue.shift();
+		if ( ! start ) {
+			return;
+		}
+		active++;
+		start();
+	};
+
+	return function runLimited( task ) {
+		return new Promise( ( resolve, reject ) => {
+			queue.push( () => {
+				Promise.resolve()
+					.then( task )
+					.then( resolve, reject )
+					.finally( () => {
+						active--;
+						runNext();
+					} );
+			} );
+			runNext();
+		} );
+	};
+}
+
+/**
+ * Resolve the concurrency limit for build phases.
+ *
+ * Precedence: `--concurrency` CLI flag, then the `WP_BUILD_CONCURRENCY`
+ * environment variable, then the machine's available parallelism. The limit
+ * is machine-specific, which is why it is not read from `wpPlugin` config.
+ *
+ * @param {string|undefined}                 [flagValue] Raw value of the `--concurrency` CLI flag.
+ * @param {Record<string, string|undefined>} [env]       Environment variables. Defaults to `process.env`.
+ * @return {number} Concurrency limit (a positive integer).
+ */
+export function resolveConcurrency( flagValue, env = process.env ) {
+	const rawValue = flagValue ?? env.WP_BUILD_CONCURRENCY;
+
+	if ( rawValue === undefined || rawValue === '' ) {
+		return os.availableParallelism();
+	}
+
+	const parsed = Number( String( rawValue ) );
+	if ( ! Number.isInteger( parsed ) || parsed < 1 ) {
+		throw new Error(
+			`Invalid concurrency value "${ rawValue }". Expected a positive integer.`
+		);
+	}
+
+	return parsed;
+}

--- a/packages/wp-build/lib/test/concurrency.js
+++ b/packages/wp-build/lib/test/concurrency.js
@@ -1,0 +1,96 @@
+/**
+ * Internal dependencies
+ */
+import { createLimiter, resolveConcurrency } from '../concurrency.mjs';
+
+describe( 'createLimiter()', () => {
+	it( 'never runs more tasks than the limit at once', async () => {
+		const runLimited = createLimiter( 2 );
+		let active = 0;
+		let maxActive = 0;
+
+		await Promise.all(
+			Array.from( { length: 8 }, () =>
+				runLimited( async () => {
+					active++;
+					maxActive = Math.max( maxActive, active );
+					await new Promise( ( resolve ) =>
+						setTimeout( resolve, 5 )
+					);
+					active--;
+				} )
+			)
+		);
+
+		expect( maxActive ).toBe( 2 );
+	} );
+
+	it( 'resolves with each task return value', async () => {
+		const runLimited = createLimiter( 1 );
+
+		const results = await Promise.all(
+			[ 1, 2, 3 ].map( ( value ) => runLimited( async () => value * 10 ) )
+		);
+
+		expect( results ).toEqual( [ 10, 20, 30 ] );
+	} );
+
+	it( 'keeps scheduling after a task rejects', async () => {
+		const runLimited = createLimiter( 1 );
+
+		const failing = runLimited( async () => {
+			throw new Error( 'boom' );
+		} );
+		const following = runLimited( async () => 'ok' );
+
+		await expect( failing ).rejects.toThrow( 'boom' );
+		await expect( following ).resolves.toBe( 'ok' );
+	} );
+
+	it( 'propagates synchronous task throws as rejections', async () => {
+		const runLimited = createLimiter( 1 );
+
+		await expect(
+			runLimited( () => {
+				throw new Error( 'sync boom' );
+			} )
+		).rejects.toThrow( 'sync boom' );
+	} );
+} );
+
+describe( 'resolveConcurrency()', () => {
+	it( 'prefers the CLI flag over the environment variable', () => {
+		expect( resolveConcurrency( '3', { WP_BUILD_CONCURRENCY: '7' } ) ).toBe(
+			3
+		);
+	} );
+
+	it( 'falls back to WP_BUILD_CONCURRENCY when no flag is given', () => {
+		expect(
+			resolveConcurrency( undefined, { WP_BUILD_CONCURRENCY: '7' } )
+		).toBe( 7 );
+	} );
+
+	it( 'defaults to the available parallelism when nothing is set', () => {
+		const resolved = resolveConcurrency( undefined, {} );
+
+		expect( Number.isInteger( resolved ) ).toBe( true );
+		expect( resolved ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'treats an empty environment value as unset', () => {
+		const resolved = resolveConcurrency( undefined, {
+			WP_BUILD_CONCURRENCY: '',
+		} );
+
+		expect( resolved ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'rejects values that are not positive integers', () => {
+		for ( const value of [ '0', '-2', '1.5', 'abc' ] ) {
+			expect( () => resolveConcurrency( value, {} ) ).toThrow(
+				'Invalid concurrency value'
+			);
+		}
+	} );
+} );


### PR DESCRIPTION
## What

Bounds how many build units (packages, routes, widgets) `wp-build` processes at the same time. The cap defaults to `os.availableParallelism()` and can be overridden with a new `--concurrency` flag or the `WP_BUILD_CONCURRENCY` environment variable (the flag wins).

Previously every phase fanned out with an unbounded `Promise.all`, so a project with N widgets put all N in flight at once.

## Why

Each unit in flight spawns real resources: up to 4 `esbuild.build()` calls, and each build with style processing eagerly starts 2 dedicated Sass compiler processes. With dozens of widgets this peaks at hundreds of compiler processes and several GB of memory, which can kill memory-constrained CI runners.

Benchmarking a synthetic project (50 widgets, each bundling a shared 360KB dependency plus a CSS module) shows memory scales linearly with concurrency while throughput is flat past concurrency 2-4:

| concurrency | build time | peak Sass processes | peak RSS |
|---|---|---|---|
| 1 | ~1.9s | 4 | ~0.6GB |
| 4 | ~1.5s | 16 | ~0.9GB |
| 16 | ~1.4s | 64 | ~1.9GB |
| unbounded | ~1.5s | 200 | ~5.1GB |

Unbounded fan-out buys no speed: per-CSS PostCSS work serializes on the Node event loop and the shared esbuild service already parallelizes across cores internally. Capping only removes the memory blow-up.

## How

- New `lib/concurrency.mjs` with `createLimiter()` (FIFO queue, fixed slots) and `resolveConcurrency()` (flag, then env var, then `os.availableParallelism()`; rejects non-positive-integer values with a clear error).
- `buildAll()` creates one shared limiter and applies it to the four fan-out points: package transpiling (within each dependency level), package bundling, routes, and widgets.
- `main()` parses the `--concurrency` flag; the build banner logs the resolved limit.
- The concurrency knob is intentionally not read from `wpPlugin` config: the right value is a property of the machine running the build, not of the project.
- Watch mode is untouched (rebuilds were already sequential).
- Unit tests for the limiter and the resolution precedence in `lib/test/concurrency.js`.

Note for reviewers: the README diff looks large because the repo formatter re-wrapped the whole file on commit; the content change is the new "Build Concurrency" section (27 lines with `git diff -w`).

## Testing

1. In a project built with `wp-build` (or this repo, where flags pass through the build script), run a build and check the banner shows the machine default:

```bash
npm run build -- --skip-types
# 🔨 Building packages (concurrency: <availableParallelism>)...
```

2. Override with the flag and confirm the banner reflects it:

```bash
npm run build -- --skip-types --concurrency 2
# 🔨 Building packages (concurrency: 2)...
```

3. Override with the environment variable, then with both, and confirm the flag wins:

```bash
WP_BUILD_CONCURRENCY=3 npm run build -- --skip-types
# concurrency: 3
WP_BUILD_CONCURRENCY=3 npm run build -- --skip-types --concurrency 5
# concurrency: 5
```

4. Pass an invalid value and confirm the build fails fast with exit code 1:

```bash
npm run build -- --skip-types --concurrency abc
# ❌ Build failed: Error: Invalid concurrency value "abc". Expected a positive integer.
```

5. Confirm build output is unchanged: generated `build/` artifacts (scripts, modules, styles, routes, widgets, PHP registries) match a build from trunk.

6. Optional, to observe the cap at the process level: watch `pgrep -fc dart-sass` during a build of a project with several widgets; the peak stays at ~4x the configured concurrency instead of 4x the widget count.

## Follow-ups

- [ ] Reduce per-unit cost: reuse a shared Sass compiler across builds instead of eagerly spawning two per `esbuild.build()`.
- [ ] Cache the inline CSS transform by content hash; the minified and non-minified variants currently run PostCSS/cssnano over identical CSS twice per entry.
