### PR TITLE
HTML Block: Preserve innerContent when transforming to group, columns

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -267,9 +267,9 @@ export default function useOnBlockDrop(
 					blocks.unshift( targetBlock );
 				}
 
-				const groupInnerBlocks = blocks.map( ( block ) => {
-					return __experimentalCloneSanitizedBlock( block );
-				} );
+				const groupInnerBlocks = blocks.map( ( block ) =>
+					__experimentalCloneSanitizedBlock( block )
+				);
 
 				const areAllImages = blocks.every( ( block ) => {
 					return block.name === 'core/image';

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -5,6 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	cloneBlock,
 	createBlock,
+	__experimentalCloneSanitizedBlock,
 	findTransform,
 	getBlockTransforms,
 	pasteHandler,
@@ -267,7 +268,7 @@ export default function useOnBlockDrop(
 				}
 
 				const groupInnerBlocks = blocks.map( ( block ) => {
-					return cloneBlock( block );
+					return __experimentalCloneSanitizedBlock( block );
 				} );
 
 				const areAllImages = blocks.every( ( block ) => {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -267,11 +267,7 @@ export default function useOnBlockDrop(
 				}
 
 				const groupInnerBlocks = blocks.map( ( block ) => {
-					return createBlock(
-						block.name,
-						block.attributes,
-						block.innerBlocks
-					);
+					return cloneBlock( block );
 				} );
 
 				const areAllImages = blocks.every( ( block ) => {

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -68,10 +68,17 @@ const transforms = {
 			__experimentalConvert: ( blocks ) => {
 				const columnWidth = +( 100 / blocks.length ).toFixed( 2 );
 				const innerBlocksTemplate = blocks.map(
-					( { name, attributes, innerBlocks } ) => [
+					( { name, attributes, innerBlocks, innerContent } ) => [
 						'core/column',
 						{ width: `${ columnWidth }%` },
-						[ [ name, { ...attributes }, innerBlocks ] ],
+						[
+							[
+								name,
+								{ ...attributes },
+								innerBlocks,
+								innerContent,
+							],
+						],
 					]
 				);
 				return createBlock(

--- a/packages/block-library/src/details/transforms.js
+++ b/packages/block-library/src/details/transforms.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, cloneBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	__experimentalCloneSanitizedBlock,
+} from '@wordpress/blocks';
 
 export default {
 	from: [
@@ -18,7 +21,9 @@ export default {
 				return createBlock(
 					'core/details',
 					{},
-					blocks.map( ( block ) => cloneBlock( block ) )
+					blocks.map( ( block ) =>
+						__experimentalCloneSanitizedBlock( block )
+					)
 				);
 			},
 		},

--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, cloneBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	__experimentalCloneSanitizedBlock,
+} from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -30,7 +33,7 @@ const transforms = {
 				// are removed both from their original location and within the
 				// new group block.
 				const groupInnerBlocks = blocks.map( ( block ) =>
-					cloneBlock( block )
+					__experimentalCloneSanitizedBlock( block )
 				);
 
 				return createBlock(

--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -29,13 +29,9 @@ const transforms = {
 				// to be replaced in the switchToBlockType call thereby meaning they
 				// are removed both from their original location and within the
 				// new group block.
-				const groupInnerBlocks = blocks.map( ( block ) => {
-					return createBlock(
-						block.name,
-						block.attributes,
-						block.innerBlocks
-					);
-				} );
+				const groupInnerBlocks = blocks.map( ( block ) =>
+					cloneBlock( block )
+				);
 
 				return createBlock(
 					'core/group',

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import { cloneBlock, createBlock, switchToBlockType } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -92,13 +92,7 @@ const transforms = {
 				createBlock(
 					'core/quote',
 					{},
-					blocks.map( ( block ) =>
-						createBlock(
-							block.name,
-							block.attributes,
-							block.innerBlocks
-						)
-					)
+					blocks.map( ( block ) => cloneBlock( block ) )
 				),
 		},
 	],

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { cloneBlock, createBlock, switchToBlockType } from '@wordpress/blocks';
+import {
+	createBlock,
+	__experimentalCloneSanitizedBlock,
+	switchToBlockType,
+} from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -92,7 +96,9 @@ const transforms = {
 				createBlock(
 					'core/quote',
 					{},
-					blocks.map( ( block ) => cloneBlock( block ) )
+					blocks.map( ( block ) =>
+						__experimentalCloneSanitizedBlock( block )
+					)
 				),
 		},
 	],

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -57,7 +57,7 @@ Given an array of InnerBlocks templates or Block Objects, returns an array of cr
 
 _Parameters_
 
--   _innerBlocksOrTemplate_ `Array< Block | [ string, Record< string, unknown >?, Array< unknown >? ] >`: Nested blocks or InnerBlocks templates.
+-   _innerBlocksOrTemplate_ `Array< Block | TemplateBlock >`: Nested blocks or InnerBlocks templates.
 
 _Returns_
 

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -28,6 +28,13 @@ type BlockTypeWithTransformMetadata = BlockType & {
 	variationName?: string;
 };
 
+type TemplateBlock = [
+	string,
+	Record< string, unknown >?,
+	Array< unknown >?,
+	Array< string | null >?,
+];
+
 const getBlockTypeWithTransformMetadata = (
 	blockType: BlockType,
 	transform: BlockTransform
@@ -105,28 +112,26 @@ export function createBlock(
  * @return Array of Block objects.
  */
 export function createBlocksFromInnerBlocksTemplate(
-	innerBlocksOrTemplate: Array<
-		Block | [ string, Record< string, unknown >?, Array< unknown >? ]
-	> = []
+	innerBlocksOrTemplate: Array< Block | TemplateBlock > = []
 ): Block[] {
 	return innerBlocksOrTemplate.map( ( innerBlock ) => {
-		const innerBlockTemplate = Array.isArray( innerBlock )
+		const innerBlockTemplate: TemplateBlock = Array.isArray( innerBlock )
 			? innerBlock
 			: [
 					innerBlock.name,
 					innerBlock.attributes,
 					innerBlock.innerBlocks,
+					innerBlock.innerContent,
 			  ];
-		const [ name, attributes, innerBlocks = [] ] = innerBlockTemplate;
+		const [ name, attributes, innerBlocks = [], innerContent ] =
+			innerBlockTemplate;
 		return createBlock(
 			name as string,
 			attributes as Record< string, unknown >,
 			createBlocksFromInnerBlocksTemplate(
-				innerBlocks as Array<
-					| Block
-					| [ string, Record< string, unknown >?, Array< unknown >? ]
-				>
-			)
+				innerBlocks as Array< Block | TemplateBlock >
+			),
+			innerContent
 		);
 	} );
 }

--- a/packages/widgets/src/blocks/widget-group/index.js
+++ b/packages/widgets/src/blocks/widget-group/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { cloneBlock, createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	__experimentalCloneSanitizedBlock,
+} from '@wordpress/blocks';
 import { group as icon } from '@wordpress/icons';
 
 /**
@@ -40,7 +43,7 @@ export const settings = {
 				__experimentalConvert( blocks ) {
 					// Put the selected blocks inside the new Widget Group's innerBlocks.
 					let innerBlocks = blocks.map( ( block ) => {
-						return cloneBlock( block );
+						return __experimentalCloneSanitizedBlock( block );
 					} );
 
 					// If the first block is a heading then assume this is intended

--- a/packages/widgets/src/blocks/widget-group/index.js
+++ b/packages/widgets/src/blocks/widget-group/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
+import { cloneBlock, createBlock } from '@wordpress/blocks';
 import { group as icon } from '@wordpress/icons';
 
 /**
@@ -39,15 +39,9 @@ export const settings = {
 				},
 				__experimentalConvert( blocks ) {
 					// Put the selected blocks inside the new Widget Group's innerBlocks.
-					let innerBlocks = [
-						...blocks.map( ( block ) => {
-							return createBlock(
-								block.name,
-								block.attributes,
-								block.innerBlocks
-							);
-						} ),
-					];
+					let innerBlocks = blocks.map( ( block ) => {
+						return cloneBlock( block );
+					} );
 
 					// If the first block is a heading then assume this is intended
 					// to be the Widget's "title".

--- a/packages/widgets/src/blocks/widget-group/index.js
+++ b/packages/widgets/src/blocks/widget-group/index.js
@@ -42,9 +42,9 @@ export const settings = {
 				},
 				__experimentalConvert( blocks ) {
 					// Put the selected blocks inside the new Widget Group's innerBlocks.
-					let innerBlocks = blocks.map( ( block ) => {
-						return __experimentalCloneSanitizedBlock( block );
-					} );
+					let innerBlocks = blocks.map( ( block ) =>
+						__experimentalCloneSanitizedBlock( block )
+					);
 
 					// If the first block is a heading then assume this is intended
 					// to be the Widget's "title".


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Recently several block APIs started supporting a new `innerContent` param which is used by the html block for its content.

The block transforms for columns and group (those that apply to any other block type) haven't been updated to use `innerContent`. The result is that if the user tries transforming an HTML block to group or columns, the `innerContent` is lost.

## How?
I've switched the group block over to using `cloneBlock` instead of `createBlock` as it's more succinct, already handles `innerContent`, and copies what the details block does (which has a transform that already works ok in trunk).

Columns is a bit more complex, but I've made sure to pass `innerContent` around. I've also updated the utility function `createBlocksFromInnerBlocksTemplate` that's used by columns so that it supports `innerContent`.

## Testing Instructions
1. Insert an HTML block and add some basic HTML content
2. Try the following:
- Using the 'group' option from the block options dropdown
- Using the 'group' command from the command center
- Using the 'Transform' > 'Group' option
- Using the 'Transform' > 'Columns' option

In this PR - the html block retains its content
In trunk - the html block loses its content

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="634" height="279" alt="Screenshot 2026-07-06 at 4 16 14 pm" src="https://github.com/user-attachments/assets/a2399154-756d-47b3-9b67-d4ec66514af2" /> | <img width="637" height="270" alt="Screenshot 2026-07-06 at 4 15 44 pm" src="https://github.com/user-attachments/assets/23151746-d864-44c6-b69f-a903a531a329" /> |

## Use of AI Tools
OpenCode / Codex