### PR TITLE
Fix Details block Backspace behavior

### DIFF
--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -15,8 +15,13 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import {
+	isHorizontalEdge,
+	isTextField,
+	placeCaretAtHorizontalEdge,
+} from '@wordpress/dom';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -36,10 +41,40 @@ const TEMPLATE = [
 	],
 ];
 
-function DetailsEdit( { attributes, setAttributes, clientId } ) {
+function DetailsEdit( { attributes, setAttributes, clientId, onRemove } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
-	const blockProps = useBlockProps();
+	const summaryRef = useRef();
+	const { getBlockOrder, getSelectionStart } = useSelect( blockEditorStore );
+
+	const handleDetailsKeyDownCapture = ( event ) => {
+		const { key, target } = event;
+
+		if (
+			event.defaultPrevented ||
+			key !== 'Backspace' ||
+			! isTextField( target ) ||
+			! isHorizontalEdge( target, true )
+		) {
+			return;
+		}
+
+		const shouldMoveToSummary =
+			summaryRef.current &&
+			! summaryRef.current.contains( target ) &&
+			getSelectionStart()?.clientId === getBlockOrder( clientId )[ 0 ];
+
+		if ( ! shouldMoveToSummary ) {
+			return;
+		}
+
+		event.preventDefault();
+		placeCaretAtHorizontalEdge( summaryRef.current, true );
+	};
+
+	const blockProps = useBlockProps( {
+		onKeyDownCapture: handleDetailsKeyDownCapture,
+	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		__experimentalCaptureToolbars: true,
@@ -126,6 +161,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 					onKeyUp={ handleSummaryKeyUp }
 				>
 					<RichText
+						ref={ summaryRef }
 						identifier="summary"
 						aria-label={ __(
 							'Write summary. Press Enter to expand or collapse the details.'
@@ -136,6 +172,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 						onChange={ ( newSummary ) =>
 							setAttributes( { summary: newSummary } )
 						}
+						onRemove={ onRemove }
 					/>
 				</summary>
 				{ innerBlocksProps.children }

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -117,7 +117,6 @@ test.describe( 'Details', () => {
 			name: 'core/details',
 			attributes: {
 				summary: 'Details summary',
-				showContent: true,
 			},
 			innerBlocks: [
 				{
@@ -129,9 +128,13 @@ test.describe( 'Details', () => {
 			],
 		} );
 
+		await page.keyboard.press( 'Enter' );
+
 		const paragraph = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
+
+		await expect( paragraph ).toContainText( 'Details content' );
 
 		await paragraph.getByRole( 'textbox' ).click();
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -90,6 +90,72 @@ test.describe( 'Details', () => {
 		).toBeHidden();
 	} );
 
+	test( 'removes the block when pressing Backspace in an empty summary', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/details',
+		} );
+
+		const summary = editor.canvas.getByRole( 'textbox', {
+			name: 'Write summary',
+		} );
+
+		await summary.click();
+		await page.keyboard.press( 'Backspace' );
+
+		await expect.poll( editor.getBlocks ).toEqual( [] );
+	} );
+
+	test( 'moves focus to the summary when pressing Backspace at the start of body content', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/details',
+			attributes: {
+				summary: 'Details summary',
+				showContent: true,
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Details content',
+					},
+				},
+			],
+		} );
+
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+
+		await paragraph.getByRole( 'textbox' ).click();
+		await pageUtils.pressKeys( 'primary+ArrowLeft' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( ' updated' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/details',
+				attributes: {
+					summary: 'Details summary updated',
+				},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content: 'Details content',
+						},
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'selecting hidden blocks in list view expands details and focuses content', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -3,6 +3,9 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const LINE_START_KEY =
+	process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Home';
+
 test.describe( 'Details', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -111,7 +114,6 @@ test.describe( 'Details', () => {
 	test( 'moves focus to the summary when pressing Backspace at the start of body content', async ( {
 		editor,
 		page,
-		pageUtils,
 	} ) => {
 		await editor.insertBlock( {
 			name: 'core/details',
@@ -138,7 +140,7 @@ test.describe( 'Details', () => {
 
 		await paragraph.click();
 		await expect( paragraph ).toBeFocused();
-		await pageUtils.pressKeys( 'primary+ArrowLeft' );
+		await page.keyboard.press( LINE_START_KEY );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( ' updated' );
 

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -136,7 +136,8 @@ test.describe( 'Details', () => {
 
 		await expect( paragraph ).toContainText( 'Details content' );
 
-		await paragraph.getByRole( 'textbox' ).click();
+		await paragraph.click();
+		await expect( paragraph ).toBeFocused();
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( ' updated' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #79869

Fixes Backspace behavior in the Details block when editing the summary or the first body block.

## Why?
The Details block summary did not pass the block `onRemove` handler to `RichText`, so pressing Backspace in an empty summary did not reliably remove the whole block.

When the caret was at the start of the Details body, Backspace could also skip the summary and move selection to the previous block. This made deletion behavior inconsistent depending on where focus was when Backspace was pressed.

## How?
- Pass `onRemove` to the Details summary `RichText`.
- Capture Backspace at the start of the first inner block and move the caret back to the summary before default merge behavior runs.
- Add e2e coverage for empty-summary removal and body-to-summary Backspace behavior.

## Testing Instructions
1. Open a post or page.
2. Insert a Details block.
3. Leave the summary empty and press Backspace.
4. Confirm the whole Details block is removed.
5. Insert another Details block with summary and body text.
6. Move the caret to the start of the body text and press Backspace.
7. Confirm the caret moves to the summary instead of jumping to the previous block.

## Screenshots or screencast

https://github.com/user-attachments/assets/0b68e556-1f26-4f41-b941-6b17891a5919



## Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5.5
Used for: Ticket analysis, root-cause investigation, and test updates. Final code changes were reviewed by me.
