### PR TITLE
Widget Dashboard: make Actions a compound component

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `WidgetHeader`: surface the widget type's `help` note as an infotip
     beside the title: a click-open popover with the note and its links.
+-   `WidgetDashboard.Actions`: accept `children` to recompose the customize
+    toolbar from the new `Actions.*` triggers: `AddWidget`, `LayoutSettings`,
+    `Divider`, `Cancel`, `Done`. Omitting `children` keeps the default
+    arrangement.
 
 ## 0.2.0 (2026-07-01)
 

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -4,6 +4,7 @@
 This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes. While it is published as 0.x, breaking changes may ship in minor releases.
 
 This prerelease depends on WordPress core-private APIs and is built to run inside WordPress core. It is not yet safe to install and run as a standalone npm dependency from an external plugin.
+
 </div>
 
 Stateless rendering engine for widget dashboards. `WidgetDashboard` renders an editable grid of widget instances behind a consumer-controlled edit mode: drag-to-reorder, resize, a modal inserter, per-widget and grid-level settings, and command-palette integration.
@@ -145,7 +146,29 @@ Renders its children only when `layout` is empty. Pair it with `<WidgetDashboard
 
 #### `<WidgetDashboard.Actions />`
 
-Edit-mode toggle: a "Customize" button while `editMode` is off, and "Add widget", "Layout settings" (when `onGridSettingsChange` is provided), "Cancel", "Done" while it is on. The buttons and the more-actions menu are triggers: "Customize" and "Done" fire `onEditChange`, "Add widget" opens the inserter, "Layout settings" opens the layout-settings editor, and "Reset to default" opens the reset confirmation. Returns `null` when the dashboard is mounted without `onEditChange`, so surfaces that don't expose edit mode can keep `Actions` in their tree unconditionally.
+Edit-mode toggle: a "Customize" button while `editMode` is off, the customize toolbar while it is on, and an overflow menu with "Reset to default". Returns `null` without `onEditChange`, so surfaces without edit mode can keep `Actions` mounted unconditionally.
+
+Pass `children` to recompose the customize toolbar. The default arrangement is:
+
+```tsx
+<WidgetDashboard.Actions>
+	<WidgetDashboard.Actions.AddWidget />
+	<WidgetDashboard.Actions.LayoutSettings />
+	<WidgetDashboard.Actions.Divider />
+	<WidgetDashboard.Actions.Cancel />
+	<WidgetDashboard.Actions.Done />
+</WidgetDashboard.Actions>
+```
+
+Drop a trigger, reorder them, or mix in custom controls. The Customize button and the overflow menu render either way.
+
+-   `Actions.AddWidget` opens the widget inserter.
+-   `Actions.LayoutSettings` opens the layout-settings editor. Hidden without `onGridSettingsChange`.
+-   `Actions.Divider` renders the vertical rule between trigger clusters.
+-   `Actions.Cancel` discards staged edits and exits customize mode.
+-   `Actions.Done` publishes staged edits and exits customize mode. Disabled with nothing to publish.
+
+The triggers read the dashboard contexts, so they also work anywhere else in the `WidgetDashboard` subtree. Outside `Actions`, mode gating is up to the consumer.
 
 #### `<WidgetDashboard.Commands />`
 

--- a/packages/widget-dashboard/src/components/actions/actions-triggers.tsx
+++ b/packages/widget-dashboard/src/components/actions/actions-triggers.tsx
@@ -1,0 +1,128 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { layout as layoutIcon, plus } from '@wordpress/icons';
+import { store as viewportStore } from '@wordpress/viewport';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Button } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { useDashboardInternalContext } from '../../context/dashboard-context';
+import { useDashboardUIContext } from '../../context/ui-context';
+import styles from './actions.module.css';
+
+// @TODO: switch to using Admin UI declaratively for mobile viewport support once available.
+// https://github.com/WordPress/gutenberg/issues/77628
+function useIsMobileViewport(): boolean {
+	return useSelect(
+		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
+		[]
+	);
+}
+
+/**
+ * Trigger that opens the widget inserter.
+ */
+export function AddWidget(): React.ReactNode {
+	const { setInserterOpen } = useDashboardUIContext();
+	const isMobileViewport = useIsMobileViewport();
+
+	const insert = useCallback( () => {
+		setInserterOpen( true );
+	}, [ setInserterOpen ] );
+
+	return (
+		<Button
+			variant="minimal"
+			tone="brand"
+			size="compact"
+			onClick={ insert }
+		>
+			{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
+			{ __( 'Add widget' ) }
+		</Button>
+	);
+}
+
+/**
+ * Trigger that opens the layout-settings editor. Hidden when grid settings
+ * are not editable.
+ */
+export function LayoutSettings(): React.ReactNode {
+	const { canEditGridSettings } = useDashboardInternalContext();
+	const { setLayoutSettingsOpen } = useDashboardUIContext();
+	const isMobileViewport = useIsMobileViewport();
+
+	const open = useCallback( () => {
+		setLayoutSettingsOpen( true );
+	}, [ setLayoutSettingsOpen ] );
+
+	if ( ! canEditGridSettings ) {
+		return null;
+	}
+
+	return (
+		<Button variant="minimal" tone="brand" size="compact" onClick={ open }>
+			{ ! isMobileViewport && <Button.Icon icon={ layoutIcon } /> }
+			{ __( 'Layout settings' ) }
+		</Button>
+	);
+}
+
+/**
+ * Vertical rule separating trigger clusters in the customize toolbar.
+ */
+export function Divider(): React.ReactNode {
+	return <div className={ styles.editActionsDivider } aria-hidden="true" />;
+}
+
+/**
+ * Trigger that discards staged edits and exits customize mode.
+ */
+export function Cancel(): React.ReactNode {
+	const { cancel: cancelStaging } = useDashboardInternalContext();
+
+	const cancel = useCallback( () => {
+		cancelStaging();
+	}, [ cancelStaging ] );
+
+	return (
+		<Button
+			variant="minimal"
+			tone="brand"
+			size="compact"
+			onClick={ cancel }
+		>
+			{ __( 'Cancel' ) }
+		</Button>
+	);
+}
+
+/**
+ * Trigger that publishes staged edits and exits customize mode. Disabled
+ * while staging matches the committed state.
+ */
+export function Done(): React.ReactNode {
+	const { commit, hasUncommittedChanges } = useDashboardInternalContext();
+
+	const done = useCallback( () => {
+		commit();
+	}, [ commit ] );
+
+	return (
+		<Button
+			variant="solid"
+			tone="brand"
+			size="compact"
+			onClick={ done }
+			disabled={ ! hasUncommittedChanges }
+		>
+			{ __( 'Done' ) }
+		</Button>
+	);
+}

--- a/packages/widget-dashboard/src/components/actions/actions.tsx
+++ b/packages/widget-dashboard/src/components/actions/actions.tsx
@@ -1,11 +1,13 @@
 /**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+/**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { layout as layoutIcon, plus } from '@wordpress/icons';
-import { store as viewportStore } from '@wordpress/viewport';
 // eslint-disable-next-line @wordpress/use-recommended-components
 import { Button, Stack } from '@wordpress/ui';
 
@@ -16,165 +18,117 @@ import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { useDashboardUIContext } from '../../context/ui-context';
 import { ActionsMenu } from '../actions-menu';
 import type { ActionsMenuItem } from '../actions-menu';
+import {
+	AddWidget,
+	Cancel,
+	Divider,
+	Done,
+	LayoutSettings,
+} from './actions-triggers';
 import styles from './actions.module.css';
 
-/**
- * Edit toolbar for the dashboard. In customize mode it surfaces Add widget,
- * Layout settings (when grid settings are editable), Cancel, and Done;
- * otherwise a single Customize button. Buttons and the overflow menu are
- * triggers that flip the shared UI state the overlays react to.
- *
- * Returns `null` when mounted without `onEditChange`, so hosts that don't
- * expose edit mode can keep `Actions` in their tree unconditionally.
- */
-export function Actions(): React.ReactNode {
-	const {
-		editMode,
-		onEditChange,
-		onLayoutReset,
-		commit,
-		cancel: cancelStaging,
-		hasUncommittedChanges,
-		canEditGridSettings,
-	} = useDashboardInternalContext();
-
-	const [ isEditActionsMounted, setIsEditActionsMounted ] =
-		useState( editMode );
-	const [ isExitingEditActions, setIsExitingEditActions ] = useState( false );
-
-	useEffect( () => {
-		if ( editMode ) {
-			setIsEditActionsMounted( true );
-			setIsExitingEditActions( false );
-			return;
-		}
-
-		if ( ! isEditActionsMounted ) {
-			return;
-		}
-
-		setIsExitingEditActions( true );
-		const exitTimeout = setTimeout( () => {
-			setIsEditActionsMounted( false );
-			setIsExitingEditActions( false );
-		}, 220 );
-
-		return () => clearTimeout( exitTimeout );
-	}, [ editMode, isEditActionsMounted ] );
-
-	const { setInserterOpen, setLayoutSettingsOpen, setResetDialogOpen } =
-		useDashboardUIContext();
-	// @TODO: switch to using Admin UI declaratively for mobile viewport support once available.
-	// https://github.com/WordPress/gutenberg/issues/77628
-	const isMobileViewport = useSelect(
-		( select ) => select( viewportStore ).isViewportMatch( '< small' ),
-		[]
-	);
-
-	const handleEditMode = useCallback( () => {
-		onEditChange?.( ! editMode );
-	}, [ editMode, onEditChange ] );
-
-	const insert = useCallback( () => {
-		setInserterOpen( true );
-	}, [ setInserterOpen ] );
-
-	const cancel = useCallback( () => {
-		cancelStaging();
-	}, [ cancelStaging ] );
-
-	const done = useCallback( () => {
-		commit();
-	}, [ commit ] );
-
-	const openLayoutSettings = useCallback( () => {
-		setLayoutSettingsOpen( true );
-	}, [ setLayoutSettingsOpen ] );
-
-	const menuItems: ActionsMenuItem[] = [
-		{
-			label: __( 'Reset to default' ),
-			onClick: () => setResetDialogOpen( true ),
-			disabled: ! onLayoutReset,
-		},
-	];
-
-	if ( ! onEditChange ) {
-		return null;
-	}
-
-	return (
-		<Stack direction="row" gap="sm">
-			{ isEditActionsMounted ? (
-				<Stack
-					direction="row"
-					gap="sm"
-					className={
-						isExitingEditActions
-							? styles.editActionsExit
-							: styles.editActionsEnter
-					}
-				>
-					<Button
-						variant="minimal"
-						tone="brand"
-						size="compact"
-						onClick={ insert }
-					>
-						{ ! isMobileViewport && <Button.Icon icon={ plus } /> }
-						{ __( 'Add widget' ) }
-					</Button>
-
-					{ canEditGridSettings && (
-						<Button
-							variant="minimal"
-							tone="brand"
-							size="compact"
-							onClick={ openLayoutSettings }
-						>
-							{ ! isMobileViewport && (
-								<Button.Icon icon={ layoutIcon } />
-							) }
-							{ __( 'Layout settings' ) }
-						</Button>
-					) }
-
-					<div
-						className={ styles.editActionsDivider }
-						aria-hidden="true"
-					/>
-
-					<Button
-						variant="minimal"
-						tone="brand"
-						size="compact"
-						onClick={ cancel }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-
-					<Button
-						variant="solid"
-						tone="brand"
-						size="compact"
-						onClick={ done }
-						disabled={ ! hasUncommittedChanges }
-					>
-						{ __( 'Done' ) }
-					</Button>
-				</Stack>
-			) : (
-				<Button
-					variant="minimal"
-					tone="brand"
-					size="compact"
-					onClick={ handleEditMode }
-				>
-					{ __( 'Customize' ) }
-				</Button>
-			) }
-
-			<ActionsMenu items={ menuItems } />
-		</Stack>
-	);
+export interface ActionsProps {
+	/**
+	 * Composition slot for the customize-mode toolbar. Defaults to
+	 * `AddWidget`, `LayoutSettings`, `Divider`, `Cancel`, `Done`.
+	 */
+	children?: ReactNode;
 }
+
+/**
+ * Edit-mode toggle: a Customize button while `editMode` is off, the
+ * customize toolbar while it is on, and an overflow menu. `children`
+ * recompose the toolbar from the `Actions.*` triggers; the Customize button
+ * and the menu render either way. Triggers read the dashboard contexts and
+ * also work outside `Actions`, anywhere in the `WidgetDashboard` subtree.
+ *
+ * Returns `null` without `onEditChange`, so hosts without edit mode can
+ * keep `Actions` mounted unconditionally.
+ */
+export const Actions = Object.assign(
+	function Actions( { children }: ActionsProps ): React.ReactNode {
+		const { editMode, onEditChange, onLayoutReset } =
+			useDashboardInternalContext();
+
+		const [ isEditActionsMounted, setIsEditActionsMounted ] =
+			useState( editMode );
+		const [ isExitingEditActions, setIsExitingEditActions ] =
+			useState( false );
+
+		useEffect( () => {
+			if ( editMode ) {
+				setIsEditActionsMounted( true );
+				setIsExitingEditActions( false );
+				return;
+			}
+
+			if ( ! isEditActionsMounted ) {
+				return;
+			}
+
+			setIsExitingEditActions( true );
+			const exitTimeout = setTimeout( () => {
+				setIsEditActionsMounted( false );
+				setIsExitingEditActions( false );
+			}, 220 );
+
+			return () => clearTimeout( exitTimeout );
+		}, [ editMode, isEditActionsMounted ] );
+
+		const { setResetDialogOpen } = useDashboardUIContext();
+
+		const handleEditMode = useCallback( () => {
+			onEditChange?.( ! editMode );
+		}, [ editMode, onEditChange ] );
+
+		const menuItems: ActionsMenuItem[] = [
+			{
+				label: __( 'Reset to default' ),
+				onClick: () => setResetDialogOpen( true ),
+				disabled: ! onLayoutReset,
+			},
+		];
+
+		if ( ! onEditChange ) {
+			return null;
+		}
+
+		return (
+			<Stack direction="row" gap="sm">
+				{ isEditActionsMounted ? (
+					<Stack
+						direction="row"
+						gap="sm"
+						className={
+							isExitingEditActions
+								? styles.editActionsExit
+								: styles.editActionsEnter
+						}
+					>
+						{ children ?? (
+							<>
+								<AddWidget />
+								<LayoutSettings />
+								<Divider />
+								<Cancel />
+								<Done />
+							</>
+						) }
+					</Stack>
+				) : (
+					<Button
+						variant="minimal"
+						tone="brand"
+						size="compact"
+						onClick={ handleEditMode }
+					>
+						{ __( 'Customize' ) }
+					</Button>
+				) }
+
+				<ActionsMenu items={ menuItems } />
+			</Stack>
+		);
+	},
+	{ AddWidget, LayoutSettings, Divider, Cancel, Done }
+);

--- a/packages/widget-dashboard/src/test/actions.test.tsx
+++ b/packages/widget-dashboard/src/test/actions.test.tsx
@@ -36,6 +36,7 @@ interface HarnessProps {
 	onEditChange?: ( next: boolean ) => void;
 	onLayoutChange?: ( next: DashboardWidget[] ) => void;
 	onGridSettingsChange?: ( next: WidgetGridSettings ) => void;
+	children?: React.ReactNode;
 }
 
 function Harness( {
@@ -43,6 +44,7 @@ function Harness( {
 	onEditChange,
 	onLayoutChange = () => {},
 	onGridSettingsChange,
+	children = <WidgetDashboard.Actions />,
 }: HarnessProps ) {
 	const [ editMode, setEditMode ] = useState( initialEditMode );
 
@@ -59,7 +61,7 @@ function Harness( {
 				onEditChange?.( next );
 			} }
 		>
-			<WidgetDashboard.Actions />
+			{ children }
 		</WidgetDashboard>
 	);
 }
@@ -211,6 +213,88 @@ describe( 'WidgetDashboard.Actions', () => {
 			expect(
 				screen.queryByRole( 'menuitem', { name: 'Layout settings' } )
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'composition', () => {
+		it( 'renders only the composed triggers in the edit toolbar', () => {
+			render(
+				<Harness initialEditMode onGridSettingsChange={ () => {} }>
+					<WidgetDashboard.Actions>
+						<WidgetDashboard.Actions.AddWidget />
+						<WidgetDashboard.Actions.Divider />
+						<WidgetDashboard.Actions.Cancel />
+						<WidgetDashboard.Actions.Done />
+					</WidgetDashboard.Actions>
+				</Harness>
+			);
+
+			// Editable grid settings, but the trigger is not composed.
+			expect(
+				screen.queryByRole( 'button', { name: 'Layout settings' } )
+			).not.toBeInTheDocument();
+
+			expect(
+				screen.getByRole( 'button', { name: 'Add widget' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Cancel' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { name: 'Done' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'keeps the Customize button when composed with children', () => {
+			render(
+				<Harness>
+					<WidgetDashboard.Actions>
+						<WidgetDashboard.Actions.AddWidget />
+					</WidgetDashboard.Actions>
+				</Harness>
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: 'Customize' } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Add widget' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'opens the layout settings drawer from a composed trigger', async () => {
+			render(
+				<Harness initialEditMode onGridSettingsChange={ () => {} }>
+					<WidgetDashboard.Actions>
+						<WidgetDashboard.Actions.LayoutSettings />
+						<WidgetDashboard.Actions.Done />
+					</WidgetDashboard.Actions>
+				</Harness>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Layout settings' } )
+			);
+
+			expect(
+				await screen.findByRole( 'dialog', { name: 'Layout settings' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'supports triggers composed outside Actions', async () => {
+			render(
+				<Harness>
+					<WidgetDashboard.Actions.AddWidget />
+				</Harness>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add widget' } )
+			);
+
+			expect(
+				await screen.findByRole( 'dialog', { name: 'Add widget' } )
+			).toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
## What

`WidgetDashboard.Actions` accepts `children` to recompose the customize toolbar from five new triggers: `Actions.AddWidget`, `Actions.LayoutSettings`, `Actions.Divider`, `Actions.Cancel`, `Actions.Done`.

Omitting `children` renders the same toolbar as before. No visual or behavioral changes for existing consumers.

Part of #77626

## Why

The customize toolbar was a monolith.

A host that wants to drop or relocate one entry, layout settings being the concrete case, had to rebuild the whole toolbar and its edit-mode plumbing.

The dashboard already exposes its contexts to the whole subtree and mounts the overlays at the root, so triggers only need to flip shared UI state. Composition falls out of that contract.

## How

- Extract each toolbar button into a context-driven trigger in `actions-triggers.tsx`.
- `Actions` keeps the container concerns.
The Customize button, the overflow menu, mode gating, and the toolbar enter/exit animation.
Its `children` slot falls back to the previous arrangement.
- `Actions.LayoutSettings` keeps the `canEditGridSettings` gating
`Actions.Done` stays disabled without staged changes.
- Triggers read the shared contexts, so they also work composed outside `Actions`, anywhere in the `WidgetDashboard` subtree.

## Testing

1. Open the dashboard and click Customize: the toolbar is unchanged (Add widget, Layout settings, divider, Cancel, Done, overflow menu).
2. Verify each button still works: inserter opens, layout-settings drawer opens, Cancel reverts, Done commits.
3. Recompose the toolbar in `routes/dashboard/stage.tsx` and verify only the composed triggers render:

```tsx
actions={
	<WidgetDashboard.Actions>
		<WidgetDashboard.Actions.AddWidget />
		<WidgetDashboard.Actions.Cancel />
		<WidgetDashboard.Actions.Done />
	</WidgetDashboard.Actions>
}
```

4. Run the package tests:

```bash
npx jest --config test/unit/jest.config.js packages/widget-dashboard
```

## Follow-ups

- [ ] Decouple the layout-settings drawer lifecycle from `editMode` (close on the customize-exit transition only) so the trigger can live outside customize mode.
- [ ] Enter customize mode when the inserter confirms from normal mode: insertion stages layout changes that need the session's Done/Cancel to resolve.
