### PR TITLE
MediaUpload: Fix "Edit Image" throwing a JS error in Add to Gallery view

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -170,12 +170,23 @@ const getGalleryDetailsMediaFrame = () => {
 		/**
 		 * Handle the edit state requirements of selected media item.
 		 *
+		 * Uses the selection of the currently active state (e.g. `gallery`,
+		 * `gallery-edit`, or `gallery-library` when adding more images to an
+		 * existing gallery) rather than always assuming the `gallery` state,
+		 * since the selected image may live in a different state's selection.
+		 *
 		 * @return {void}
 		 */
 		editState() {
-			const selection = this.state( 'gallery' ).get( 'selection' );
+			const selection = this.state().get( 'selection' );
+			const model = selection && selection.single();
+
+			if ( ! model ) {
+				return;
+			}
+
 			const view = new wp.media.view.EditImage( {
-				model: selection.single(),
+				model,
 				controller: this,
 			} ).render();
 


### PR DESCRIPTION
## What?
Closes #38363

Fixes a JavaScript error that's thrown when clicking "Edit Image" for a selected image in the Gallery block's "Add to Gallery" media library view.

## Why?
When adding images to an existing gallery via the Gallery block's "Add" toolbar button, selecting an image and clicking "Edit Image" throws JS error: Uncaught TypeError: Cannot read properties of undefined (reading 'toJSON')
at constructor.prepare (media-views.js:5412:21)

This happens because `GalleryDetailsMediaFrame`'s `editState()` handler (in `packages/media-utils`) always reads the selected image from the hardcoded `'gallery'` state:

```js
const selection = this.state( 'gallery' ).get( 'selection' );
```

The `'gallery'` state is only the Library state used when creating a *new* gallery. When the frame is in the `'gallery-library'` state (the `GalleryAdd` state used for "Add to Gallery"), the actual selection lives on that state instead, so `this.state('gallery').get('selection')` is empty and `.single()` returns `undefined`. That `undefined` is then passed as the `model` to core's `wp.media.view.EditImage`, whose `prepare()` calls `this.model.toJSON()` and throws.

## Testing Instructions
1. Insert a Gallery block and add a few images.
2. Select the Gallery block.
3. Click "Add" in the block toolbar to open the media library.
4. Select one of the images so it gets a blue border.
5. Click "Edit Image".
6. Confirm the image editor opens instead of throwing a console error.
7. As a regression check, also verify "Edit Image" still works from:
   - The initial "Create Gallery" library view (inserting a brand-new gallery).
   - The "Edit Gallery" view (editing an already-inserted gallery).

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/36ecead9-d685-4d14-af90-c6213ac6dbcd

