### PR TITLE
Prevent white screen crash during undo operations when Media Modal is open

### DIFF
--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent editor block removal by stopping undo/redo event propagation when the Media Library modal is open ([#79898](https://github.com/WordPress/gutenberg/pull/79898)).
+
 ### Internal
 
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81514](https://github.com/WordPress/gutenberg/pull/81514))

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -270,6 +270,19 @@ class MediaUpload extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onClose = this.onClose.bind( this );
+		this.stopUndoRedoPropagation =
+			this.stopUndoRedoPropagation.bind( this );
+	}
+
+	stopUndoRedoPropagation( event ) {
+		const isUndoRedo =
+			( event.metaKey || event.ctrlKey ) &&
+			event.key &&
+			event.key.toLowerCase() === 'z';
+
+		if ( isUndoRedo ) {
+			event.stopPropagation();
+		}
 	}
 
 	initializeListeners() {
@@ -405,7 +418,19 @@ class MediaUpload extends Component {
 	}
 
 	componentWillUnmount() {
+		this.detachUndoRedoGuard();
 		this.frame?.remove();
+		this.frame?.close();
+	}
+
+	detachUndoRedoGuard() {
+		if ( this.frame?.el ) {
+			this.frame.el.removeEventListener(
+				'keydown',
+				this.stopUndoRedoPropagation,
+				true
+			);
+		}
 	}
 
 	onUpdate( selections ) {
@@ -439,6 +464,14 @@ class MediaUpload extends Component {
 		const { wp } = window;
 		const { value } = this.props;
 		this.updateCollection();
+
+		if ( this.frame?.el ) {
+			this.frame.el.addEventListener(
+				'keydown',
+				this.stopUndoRedoPropagation,
+				true
+			);
+		}
 
 		//Handle active tab in media model on model open.
 		if ( this.props.mode ) {
@@ -476,6 +509,7 @@ class MediaUpload extends Component {
 
 	onClose() {
 		const { onClose } = this.props;
+		this.detachUndoRedoGuard();
 
 		if ( onClose ) {
 			onClose();

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -275,14 +275,22 @@ class MediaUpload extends Component {
 	}
 
 	stopUndoRedoPropagation( event ) {
-		const isUndoRedo =
-			( event.metaKey || event.ctrlKey ) &&
-			event.key &&
-			event.key.toLowerCase() === 'z';
-
-		if ( isUndoRedo ) {
-			event.stopPropagation();
+		if ( ! event.metaKey && ! event.ctrlKey ) {
+			return;
 		}
+
+		// Undo is primary+z, redo is primary+shift+z with a primary+y alias on
+		// non-Apple platforms. Matching both characters covers every variant
+		// without needing to know the platform here.
+		const character = event.key?.toLowerCase();
+		if ( character !== 'z' && character !== 'y' ) {
+			return;
+		}
+
+		// Only stop the editor from acting on the keystroke. The event still
+		// reaches the focused field, so native text undo keeps working inside
+		// the modal's inputs.
+		event.stopPropagation();
 	}
 
 	initializeListeners() {
@@ -419,13 +427,14 @@ class MediaUpload extends Component {
 
 	componentWillUnmount() {
 		this.detachUndoRedoGuard();
-		this.frame?.remove();
 		this.frame?.close();
+		this.frame?.modal?.remove();
+		this.frame?.remove();
 	}
 
 	detachUndoRedoGuard() {
-		if ( this.frame?.el ) {
-			this.frame.el.removeEventListener(
+		if ( this.frame?.modal?.el ) {
+			this.frame.modal.el.removeEventListener(
 				'keydown',
 				this.stopUndoRedoPropagation,
 				true
@@ -465,8 +474,8 @@ class MediaUpload extends Component {
 		const { value } = this.props;
 		this.updateCollection();
 
-		if ( this.frame?.el ) {
-			this.frame.el.addEventListener(
+		if ( this.frame?.modal?.el ) {
+			this.frame.modal.el.addEventListener(
 				'keydown',
 				this.stopUndoRedoPropagation,
 				true

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -692,6 +692,42 @@ test.describe( 'undo', () => {
 	} );
 } );
 
+test.describe( 'Media Library modal undo', () => {
+	test( 'does not remove block on undo while media modal is open', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock( { name: 'core/image' } );
+
+		await editor.canvas
+			.getByRole( 'button', { name: 'Media Library' } )
+			.click();
+
+		const modal = page.locator( '.media-modal' );
+		await expect( modal ).toBeVisible();
+
+		const searchInput = page.locator( '#media-search-input' );
+		await expect( searchInput ).toBeVisible();
+		await searchInput.click();
+
+		await pageUtils.pressKeys( 'primary+z' );
+
+		await expect( modal ).toBeVisible();
+		await expect( modal ).not.toBeEmpty();
+
+		await page.keyboard.press( 'Escape' );
+		await expect( modal ).toBeHidden();
+
+		await expect(
+			editor.canvas.locator( '[data-type="core/image"]' )
+		).toHaveCount( 1 );
+	} );
+} );
+
 class UndoUtils {
 	constructor( { page } ) {
 		this.page = page;

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -697,7 +697,7 @@ test.describe( 'Media Library modal undo', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'does not remove block on undo while media modal is open, but allows native input undo', async ( {
+	test( 'does not remove block on undo while media modal is open', async ( {
 		editor,
 		page,
 		pageUtils,

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -714,20 +714,6 @@ test.describe( 'Media Library modal undo', () => {
 		await expect( modal ).toBeVisible();
 		await expect( modal.locator( '.media-frame-content' ) ).toBeVisible();
 
-		const searchInput = page.locator( '#media-search-input' );
-		await expect( searchInput ).toBeVisible();
-		await searchInput.focus();
-		await page.keyboard.press( 'T' );
-		await page.keyboard.press( 'e' );
-		await page.keyboard.press( 's' );
-		await page.keyboard.press( 't' );
-
-		await expect( searchInput ).toHaveValue( 'Test' );
-
-		await pageUtils.pressKeys( 'primary+z' );
-		await expect( searchInput ).not.toHaveValue( 'Test' );
-		await expect( modal ).toBeVisible();
-
 		const closeButton = page.locator( '.media-modal-close' );
 		await expect( closeButton ).toBeVisible();
 		await closeButton.focus();

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -693,16 +693,16 @@ test.describe( 'undo', () => {
 } );
 
 test.describe( 'Media Library modal undo', () => {
-	test( 'does not remove block on undo while media modal is open', async ( {
-		admin,
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'does not remove block on undo while media modal is open, but allows native input undo', async ( {
 		editor,
 		page,
 		pageUtils,
 	} ) => {
-		await admin.createNewPost();
-
 		await editor.insertBlock( { name: 'core/image' } );
-
 		await editor.canvas
 			.getByRole( 'button', { name: 'Media Library' } )
 			.click();
@@ -710,21 +710,70 @@ test.describe( 'Media Library modal undo', () => {
 		const modal = page.locator( '.media-modal' );
 		await expect( modal ).toBeVisible();
 
+		await pageUtils.pressKeys( 'primary+z' );
+		await expect( modal ).toBeVisible();
+		await expect( modal.locator( '.media-frame-content' ) ).toBeVisible();
+
 		const searchInput = page.locator( '#media-search-input' );
 		await expect( searchInput ).toBeVisible();
-		await searchInput.click();
+		await searchInput.focus();
+		await page.keyboard.press( 'T' );
+		await page.keyboard.press( 'e' );
+		await page.keyboard.press( 's' );
+		await page.keyboard.press( 't' );
 
+		await expect( searchInput ).toHaveValue( 'Test' );
+
+		await pageUtils.pressKeys( 'primary+z' );
+		await expect( searchInput ).not.toHaveValue( 'Test' );
+		await expect( modal ).toBeVisible();
+
+		const closeButton = page.locator( '.media-modal-close' );
+		await expect( closeButton ).toBeVisible();
+		await closeButton.focus();
 		await pageUtils.pressKeys( 'primary+z' );
 
 		await expect( modal ).toBeVisible();
-		await expect( modal ).not.toBeEmpty();
 
-		await page.keyboard.press( 'Escape' );
+		await closeButton.click();
 		await expect( modal ).toBeHidden();
 
 		await expect(
 			editor.canvas.locator( '[data-type="core/image"]' )
 		).toHaveCount( 1 );
+	} );
+
+	test( 'cleans up modal and backdrop when component unmounts', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Media Library' } )
+			.click();
+
+		const modal = page.locator( '.media-modal' );
+		const backdrop = page.locator( '.media-modal-backdrop' );
+
+		await expect( modal ).toBeVisible();
+		await expect( backdrop ).toBeVisible();
+
+		await page.evaluate( () => {
+			const { select, dispatch } = window.wp.data;
+			const blocks = select( 'core/block-editor' ).getBlocks();
+			const imageBlock = blocks.find(
+				( block ) => block.name === 'core/image'
+			);
+
+			if ( imageBlock ) {
+				dispatch( 'core/block-editor' ).removeBlock(
+					imageBlock.clientId
+				);
+			}
+		} );
+
+		await expect( modal ).toHaveCount( 0 );
+		await expect( backdrop ).toHaveCount( 0 );
 	} );
 } );
 


### PR DESCRIPTION
## What?
Closes #71755

Implements a dual layer fix to stabilize the media modal during undo operations, protecting the underlying block from deletion and preventing UI crashes.

## Why?
When a user presses `Ctrl/Cmd+Z` while the legacy Media Library modal is open, the keystroke is intercepted by the block editor's global shortcut listener. This undoes the block insertion, deleting the underlying block and violently unmounting the `MediaUpload` React component.

This caused two distinct issues:
1. The user unintentionally loses their active block while trying to interact with the modal.
2. The abrupt React unmount bypassed Backbone's formal teardown. This left the `.media-modal-backdrop` orphaned on the `document.body`, blocking the UI with a "white screen".

## How?

- Added a capture phase `keydown` listener (`stopUndoRedoPropagation`) to the legacy `MediaUpload` frame to catch and stop undo/redo keystrokes before they reach the global editor.
- Explicitly called `this.frame?.close()` *before* `this.frame?.remove()`. This ensures Backbone properly cleans up the DOM overlay if the component is ever forcefully unmounted via external state changes. This will also cover crashes using RTC.

## Testing Instructions
1. Open a new post or page.
2. Insert an Image block.
3. Click the "Media Library" button to open the legacy modal.
4. Press `Cmd/Ctrl + Z` to trigger an undo operation.
5. Verify that the image block is **not** removed (the event is blocked).
6. Verify the editor remains fully interactive and no white screen appears.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3b6ad8a6-e3f0-4ff1-b577-dd27c58fe099

