### PR TITLE
PHP-only blocks: try supporting synced patterns

### DIFF
--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -132,6 +132,12 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 			$args['provides_context'] = array();
 		}
 		$args['provides_context']['pattern/overrides'] = 'content';
+
+		// There is no saved HTML to edit (the markup lives in the
+		// registration), so hide "Edit as HTML" like `core/block` does.
+		if ( ! isset( $args['supports']['html'] ) ) {
+			$args['supports']['html'] = false;
+		}
 	}
 
 	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $pattern, $is_synced ) {

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -121,7 +121,9 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 
 	// The overrides binding resolves through the `pattern/overrides` context,
 	// so the block stores them in a `content` attribute and provides it as
-	// that context, like `core/block` does.
+	// that context, like `core/block` does. The `{}` default is added on the
+	// JS side: an empty PHP array would bootstrap as `[]`, and stdClass would
+	// break the PHP bindings source, which array-accesses the context.
 	if ( $is_synced ) {
 		if ( ! isset( $args['attributes']['content'] ) ) {
 			$args['attributes']['content'] = array( 'type' => 'object' );

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -145,12 +145,17 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 				$content = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
 			} elseif ( $is_synced ) {
 				// The pattern renders as the block's inner blocks so the
-				// instance context (the overrides) reaches the bindings,
-				// mirroring render_block_core_block().
+				// instance context (the overrides) reaches the bindings.
+				// Rendering the children directly, rather than re-entering
+				// $block->render(), keeps the block's own `render_block`
+				// filters (layout, typography, plugins) from running twice.
 				$block->parsed_block['innerBlocks']  = parse_blocks( $pattern );
 				$block->parsed_block['innerContent'] = array_fill( 0, count( $block->parsed_block['innerBlocks'] ), null );
 				$block->refresh_context_dependents();
-				$content = $block->render( array( 'dynamic' => false ) );
+				$content = '';
+				foreach ( $block->inner_blocks as $inner_block ) {
+					$content .= $inner_block->render();
+				}
 			} else {
 				// Everywhere else an empty block falls back to the pattern:
 				// the front end, and REST renders like a post's

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -36,17 +36,18 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		if ( empty( $block_type->supports['autoRegister'] ) || empty( $block_type->pattern ) || ! is_string( $block_type->pattern ) ) {
 			continue;
 		}
-		// A pattern block with a `render_callback` renders as SSR-islands: the
-		// editor renders that shell server-side and portals the editable pattern
-		// blocks into its slots (WYSIWYG). Without a render_callback the blocks are
-		// the output and are edited bare.
-		// SPIKE: a pattern that declares `core/pattern-overrides` bindings opts
-		// into synced mode: the registration owns the structure, the instance
-		// stores only the overrides, and only bound fields are editable.
-		if ( empty( $block_type->render_callback ) ) {
-			$editor_mode = 'canvas';
-		} elseif ( str_contains( $block_type->pattern, 'core/pattern-overrides' ) ) {
+		// Two independent axes. Bindings decide the content model: a pattern
+		// that declares `core/pattern-overrides` bindings opts into synced
+		// mode (SPIKE), where the registration owns the structure, the
+		// instance stores only the overrides, and only bound fields are
+		// editable. Otherwise the `render_callback` decides the editing mode:
+		// with one, SSR-islands (the editor renders that shell server-side
+		// and portals the editable pattern blocks into its slots); without
+		// one, the blocks are the output and are edited bare.
+		if ( str_contains( $block_type->pattern, 'core/pattern-overrides' ) ) {
 			$editor_mode = 'synced-islands';
+		} elseif ( empty( $block_type->render_callback ) ) {
+			$editor_mode = 'canvas';
 		} else {
 			$editor_mode = 'ssr-islands';
 		}
@@ -96,14 +97,25 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 	if (
 		empty( $args['supports']['autoRegister'] ) ||
 		empty( $args['pattern'] ) ||
-		! is_string( $args['pattern'] ) ||
-		empty( $args['render_callback'] )
+		! is_string( $args['pattern'] )
 	) {
 		return $args;
 	}
 
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-pattern-blocks' ) ) {
 		return $args;
+	}
+
+	// SPIKE: a synced pattern must render server-side (the post stores only
+	// the overrides), so a block that doesn't bring a render_callback gets
+	// the identity one: the pattern with the overrides applied, unwrapped.
+	if ( empty( $args['render_callback'] ) ) {
+		if ( ! str_contains( $args['pattern'], 'core/pattern-overrides' ) ) {
+			return $args;
+		}
+		$args['render_callback'] = static function ( $attributes, $content ) {
+			return $content;
+		};
 	}
 
 	$original_render_callback = $args['render_callback'];

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -40,7 +40,16 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		// editor renders that shell server-side and portals the editable pattern
 		// blocks into its slots (WYSIWYG). Without a render_callback the blocks are
 		// the output and are edited bare.
-		$editor_mode = ! empty( $block_type->render_callback ) ? 'ssr-islands' : 'canvas';
+		// SPIKE: a pattern that declares `core/pattern-overrides` bindings opts
+		// into synced mode: the registration owns the structure, the instance
+		// stores only the overrides, and only bound fields are editable.
+		if ( empty( $block_type->render_callback ) ) {
+			$editor_mode = 'canvas';
+		} elseif ( str_contains( $block_type->pattern, 'core/pattern-overrides' ) ) {
+			$editor_mode = 'synced-islands';
+		} else {
+			$editor_mode = 'ssr-islands';
+		}
 
 		// Structural lock for the editable blocks: 'all' prevents add/move/remove
 		// while keeping the content editable and the generated controls visible.
@@ -99,8 +108,22 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 
 	$original_render_callback = $args['render_callback'];
 	$pattern                  = $args['pattern'];
+	$is_synced                = str_contains( $pattern, 'core/pattern-overrides' );
 
-	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $pattern ) {
+	// SPIKE: synced pattern blocks store per-instance overrides in `content`
+	// and provide them as the `pattern/overrides` context, like `core/block`,
+	// so the pattern-overrides binding resolves in both editor and frontend.
+	if ( $is_synced ) {
+		if ( ! isset( $args['attributes']['content'] ) ) {
+			$args['attributes']['content'] = array( 'type' => 'object' );
+		}
+		if ( ! isset( $args['provides_context'] ) ) {
+			$args['provides_context'] = array();
+		}
+		$args['provides_context']['pattern/overrides'] = 'content';
+	}
+
+	$args['render_callback'] = static function ( $attributes, $content, $block ) use ( $original_render_callback, $pattern, $is_synced ) {
 		if ( '' === trim( (string) $content ) ) {
 			$rest_route = isset( $GLOBALS['wp']->query_vars['rest_route'] ) ? $GLOBALS['wp']->query_vars['rest_route'] : '';
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && str_contains( $rest_route, '/block-renderer/' ) ) {
@@ -109,6 +132,14 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 				// somewhere to portal the editable islands: one content area,
 				// matching the single `$content` a callback receives.
 				$content = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
+			} elseif ( $is_synced ) {
+				// SPIKE: render the registration pattern as the block's inner
+				// blocks so the instance context (the overrides) reaches the
+				// bindings, mirroring render_block_core_block().
+				$block->parsed_block['innerBlocks']  = parse_blocks( $pattern );
+				$block->parsed_block['innerContent'] = array_fill( 0, count( $block->parsed_block['innerBlocks'] ), null );
+				$block->refresh_context_dependents();
+				$content = $block->render( array( 'dynamic' => false ) );
 			} else {
 				// Everywhere else an empty block falls back to the pattern:
 				// the front end, and REST renders like a post's

--- a/lib/compat/wordpress-7.1/pattern-blocks.php
+++ b/lib/compat/wordpress-7.1/pattern-blocks.php
@@ -36,14 +36,11 @@ function gutenberg_enqueue_auto_register_pattern_blocks() {
 		if ( empty( $block_type->supports['autoRegister'] ) || empty( $block_type->pattern ) || ! is_string( $block_type->pattern ) ) {
 			continue;
 		}
-		// Two independent axes. Bindings decide the content model: a pattern
-		// that declares `core/pattern-overrides` bindings opts into synced
-		// mode (SPIKE), where the registration owns the structure, the
-		// instance stores only the overrides, and only bound fields are
-		// editable. Otherwise the `render_callback` decides the editing mode:
-		// with one, SSR-islands (the editor renders that shell server-side
-		// and portals the editable pattern blocks into its slots); without
-		// one, the blocks are the output and are edited bare.
+		// Bindings decide the content model: with `core/pattern-overrides`
+		// bindings the registration owns the structure, only bound fields are
+		// editable, and instances store just their overrides. Otherwise the
+		// `render_callback` decides how the pattern is edited: inside its
+		// server-rendered shell (SSR-islands) or bare (canvas).
 		if ( str_contains( $block_type->pattern, 'core/pattern-overrides' ) ) {
 			$editor_mode = 'synced-islands';
 		} elseif ( empty( $block_type->render_callback ) ) {
@@ -106,9 +103,9 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 		return $args;
 	}
 
-	// SPIKE: a synced pattern must render server-side (the post stores only
-	// the overrides), so a block that doesn't bring a render_callback gets
-	// the identity one: the pattern with the overrides applied, unwrapped.
+	// A synced pattern must render server-side (the post stores only the
+	// overrides), so a block that doesn't bring a render_callback gets the
+	// identity one: the pattern with the overrides applied, unwrapped.
 	if ( empty( $args['render_callback'] ) ) {
 		if ( ! str_contains( $args['pattern'], 'core/pattern-overrides' ) ) {
 			return $args;
@@ -122,9 +119,9 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 	$pattern                  = $args['pattern'];
 	$is_synced                = str_contains( $pattern, 'core/pattern-overrides' );
 
-	// SPIKE: synced pattern blocks store per-instance overrides in `content`
-	// and provide them as the `pattern/overrides` context, like `core/block`,
-	// so the pattern-overrides binding resolves in both editor and frontend.
+	// The overrides binding resolves through the `pattern/overrides` context,
+	// so the block stores them in a `content` attribute and provides it as
+	// that context, like `core/block` does.
 	if ( $is_synced ) {
 		if ( ! isset( $args['attributes']['content'] ) ) {
 			$args['attributes']['content'] = array( 'type' => 'object' );
@@ -145,9 +142,9 @@ function gutenberg_wrap_ssr_islands_render_callback( $args ) {
 				// matching the single `$content` a callback receives.
 				$content = '<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
 			} elseif ( $is_synced ) {
-				// SPIKE: render the registration pattern as the block's inner
-				// blocks so the instance context (the overrides) reaches the
-				// bindings, mirroring render_block_core_block().
+				// The pattern renders as the block's inner blocks so the
+				// instance context (the overrides) reaches the bindings,
+				// mirroring render_block_core_block().
 				$block->parsed_block['innerBlocks']  = parse_blocks( $pattern );
 				$block->parsed_block['innerContent'] = array_fill( 0, count( $block->parsed_block['innerBlocks'] ), null );
 				$block->refresh_context_dependents();

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2594,12 +2594,11 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 			templatePartClientIds.push( clientId );
 		}
 
+		// Any block type that provides the `pattern/overrides` context hosts
+		// synced-pattern overrides; `core/block` is the canonical one.
 		if (
-			block?.name === 'core/block' ||
-			// SPIKE: PHP-only pattern blocks in synced mode behave like synced
-			// pattern instances. TODO: derive this from the block type
-			// providing the `pattern/overrides` context instead of a name.
-			block?.name === 'test/php-only-synced-block'
+			select( blocksStore ).getBlockType( block?.name )
+				?.providesContext?.[ 'pattern/overrides' ]
 		) {
 			syncedPatternClientIds.push( clientId );
 		}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2594,7 +2594,13 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 			templatePartClientIds.push( clientId );
 		}
 
-		if ( block?.name === 'core/block' ) {
+		if (
+			block?.name === 'core/block' ||
+			// SPIKE: PHP-only pattern blocks in synced mode behave like synced
+			// pattern instances. TODO: derive this from the block type
+			// providing the `pattern/overrides` context instead of a name.
+			block?.name === 'test/php-only-editable-block'
+		) {
 			syncedPatternClientIds.push( clientId );
 		}
 	} );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2599,7 +2599,7 @@ function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 			// SPIKE: PHP-only pattern blocks in synced mode behave like synced
 			// pattern instances. TODO: derive this from the block type
 			// providing the `pattern/overrides` context instead of a name.
-			block?.name === 'test/php-only-editable-block'
+			block?.name === 'test/php-only-synced-block'
 		) {
 			syncedPatternClientIds.push( clientId );
 		}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4236,8 +4236,26 @@ describe( 'state', () => {
 			);
 		} );
 
+		// Synced pattern hosts are detected through the block type providing
+		// the `pattern/overrides` context, so the type must be registered.
+		beforeAll( () => {
+			registerBlockType( 'core/block', {
+				apiVersion: 3,
+				save: noop,
+				edit: noop,
+				category: 'reusable',
+				title: 'Pattern',
+				attributes: {
+					ref: { type: 'number' },
+					content: { type: 'object' },
+				},
+				providesContext: { 'pattern/overrides': 'content' },
+			} );
+		} );
+
 		afterAll( () => {
 			isContentBlock.mockRestore();
+			unregisterBlockType( 'core/block' );
 		} );
 
 		describe( 'edit mode', () => {

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -478,8 +478,8 @@ function createSsrIslandsComponents( blockName, markup ) {
 const NOOP = () => {};
 
 /**
- * SPIKE: builds `edit`/`save` for a PHP-only `pattern` block whose pattern
- * declares `core/pattern-overrides` bindings (synced mode).
+ * Builds `edit`/`save` for a PHP-only `pattern` block whose pattern declares
+ * `core/pattern-overrides` bindings (synced mode).
  *
  * The registration owns the structure: the editor renders the pattern as a
  * controlled, read-only tree where only bound fields are editable (the derived

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -651,6 +651,17 @@ export const registerCoreBlocks = (
 					example: bootstrappedBlockType?.example ?? {
 						innerBlocks: parse( markup ),
 					},
+					// A fresh synced instance must already provide a truthy
+					// `pattern/overrides` context: gates like RichText's
+					// isInsidePatternOverrides check the value. The `{}`
+					// default lives here because PHP can't express it (an
+					// empty PHP array bootstraps as `[]`).
+					...( editorMode === 'synced-islands' && {
+						attributes: {
+							...bootstrappedBlockType?.attributes,
+							content: { type: 'object', default: {} },
+						},
+					} ),
 					...( () => {
 						if ( editorMode === 'synced-islands' ) {
 							return createSyncedPatternComponents(

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -19,7 +19,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useLayoutEffect, useState } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -475,6 +475,50 @@ function createSsrIslandsComponents( blockName, markup ) {
 	return { edit: Edit, save };
 }
 
+const NOOP = () => {};
+
+/**
+ * SPIKE: builds `edit`/`save` for a PHP-only `pattern` block whose pattern
+ * declares `core/pattern-overrides` bindings (synced mode).
+ *
+ * The registration owns the structure: the editor renders the pattern as a
+ * controlled, read-only tree where only bound fields are editable (the derived
+ * block editing modes disable the rest), and the instance saves just the
+ * overrides in its `content` attribute. The SSR shell composes on top like in
+ * ssr-islands mode.
+ *
+ * @param {string} blockName Block name, used to fetch the server-rendered shell.
+ * @param {string} markup    Pattern markup rendered as the controlled tree.
+ * @return {{ edit: Function, save: Function }} The edit and save components.
+ */
+function createSyncedPatternComponents( blockName, markup ) {
+	function Edit() {
+		const blocks = useMemo( () => parse( markup ), [] );
+
+		// SPIKE limitation: the controlled tree renders inline, without the
+		// SSR shell. The controlled sync lives in the children rendered by
+		// `useInnerBlocksProps`, so portalling them away (InnerContent)
+		// unmounts the sync and empties the tree. Composing both needs the
+		// portal to reuse these children instead of mounting its own.
+		const innerBlocksProps = useInnerBlocksProps( useBlockProps(), {
+			value: blocks,
+			onInput: NOOP,
+			onChange: NOOP,
+			renderAppender: false,
+		} );
+
+		return <div { ...innerBlocksProps } />;
+	}
+
+	function save() {
+		// The pattern lives in the registration and the overrides in the
+		// `content` attribute; there are no inner blocks to save.
+		return null;
+	}
+
+	return { edit: Edit, save };
+}
+
 /**
  * Function to register core blocks provided by the block editor.
  *
@@ -576,13 +620,25 @@ export const registerCoreBlocks = (
 					example: bootstrappedBlockType?.example ?? {
 						innerBlocks: parse( markup ),
 					},
-					...( editorMode === 'ssr-islands'
-						? createSsrIslandsComponents( blockName, markup )
-						: createPatternBlockComponents(
-								markup,
-								lock,
-								hasRenderCallback
-						  ) ),
+					...( () => {
+						if ( editorMode === 'synced-islands' ) {
+							return createSyncedPatternComponents(
+								blockName,
+								markup
+							);
+						}
+						if ( editorMode === 'ssr-islands' ) {
+							return createSsrIslandsComponents(
+								blockName,
+								markup
+							);
+						}
+						return createPatternBlockComponents(
+							markup,
+							lock,
+							hasRenderCallback
+						);
+					} )(),
 				} );
 			}
 		);

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -492,22 +492,53 @@ const NOOP = () => {};
  * @return {{ edit: Function, save: Function }} The edit and save components.
  */
 function createSyncedPatternComponents( blockName, markup ) {
-	function Edit() {
+	// A bare slot stands in until the server shell arrives. The slot node is
+	// carried over between injections, so the portalled children (and the
+	// controlled-tree sync living in them) never remount.
+	const INITIAL_SHELL =
+		'<wp-inner-block-slot data-slot-index="0" style="display:contents"></wp-inner-block-slot>';
+
+	function Edit( { clientId, attributes } ) {
 		const blocks = useMemo( () => parse( markup ), [] );
 
-		// SPIKE limitation: the controlled tree renders inline, without the
-		// SSR shell. The controlled sync lives in the children rendered by
-		// `useInnerBlocksProps`, so portalling them away (InnerContent)
-		// unmounts the sync and empties the tree. Composing both needs the
-		// portal to reuse these children instead of mounting its own.
-		const innerBlocksProps = useInnerBlocksProps( useBlockProps(), {
+		// The shell only depends on the block's own attributes; the overrides
+		// live inside the islands, so leaving them out keeps typing in a
+		// bound field from refetching the shell.
+		const { content: overrides, ...shellAttributes } = attributes;
+		const { content, status } = useServerSideRender( {
+			block: blockName,
+			attributes: shellAttributes,
+		} );
+
+		// Hold the last good shell: `useServerSideRender` drops `content`
+		// while loading, and the islands must never disappear mid-edit.
+		const [ shell, setShell ] = useState();
+		useLayoutEffect( () => {
+			if ( status === 'success' && typeof content === 'string' ) {
+				setShell( content );
+			}
+		}, [ status, content ] );
+
+		const blockProps = useBlockProps();
+		// The controlled tree's store sync lives in these children; they are
+		// portalled into the shell instead of rendered in place.
+		const innerBlocksProps = useInnerBlocksProps( blockProps, {
 			value: blocks,
 			onInput: NOOP,
 			onChange: NOOP,
 			renderAppender: false,
 		} );
 
-		return <div { ...innerBlocksProps } />;
+		return (
+			<div { ...blockProps }>
+				<InnerContent
+					clientId={ clientId }
+					html={ shell ?? INITIAL_SHELL }
+				>
+					{ innerBlocksProps.children }
+				</InnerContent>
+			</div>
+		);
 	}
 
 	function save() {

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -176,10 +176,13 @@ add_action(
 		);
 
 		// Content, attributes, and render callback for the editable PHP-only
-		// demo block below.
+		// demo block below. SPIKE: the heading and paragraph declare
+		// `core/pattern-overrides` bindings, which opts the block into synced
+		// mode: only these two fields are editable, and instances store just
+		// their overrides.
 		$pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
-			. '<!-- wp:heading --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
-			. '<!-- wp:paragraph --><p>Body text.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:heading {"metadata":{"name":"Title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph {"metadata":{"name":"Body","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><p>Body text.</p><!-- /wp:paragraph -->'
 			. '</div><!-- /wp:group -->';
 
 		$pattern_attributes = array(

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -256,11 +256,10 @@ add_action(
 			)
 		);
 
-		// SPIKE: the synced sibling of the block above, sharing its attributes
-		// and render callback. The Title heading declares a
-		// `core/pattern-overrides` binding, so it is editable per instance;
-		// the paragraph has no binding, so the plugin owns it and edits to
-		// this markup propagate to existing posts.
+		// The synced sibling of the block above, sharing its attributes and
+		// render callback. The bound Title is editable per instance; the
+		// paragraph has no binding, so the plugin owns it and edits to this
+		// markup propagate to existing posts.
 		$synced_pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
 			. '<!-- wp:heading {"metadata":{"name":"Title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Synced title</h2><!-- /wp:heading -->'
 			. '<!-- wp:paragraph --><p>Owned by the plugin: shipped with v1.</p><!-- /wp:paragraph -->'

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -176,13 +176,10 @@ add_action(
 		);
 
 		// Content, attributes, and render callback for the editable PHP-only
-		// demo block below. SPIKE: the heading and paragraph declare
-		// `core/pattern-overrides` bindings, which opts the block into synced
-		// mode: only these two fields are editable, and instances store just
-		// their overrides.
+		// demo block below.
 		$pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
-			. '<!-- wp:heading {"metadata":{"name":"Title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
-			. '<!-- wp:paragraph {"metadata":{"name":"Body","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><p>Body text.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:heading --><h2 class="wp-block-heading">Title</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Body text.</p><!-- /wp:paragraph -->'
 			. '</div><!-- /wp:group -->';
 
 		$pattern_attributes = array(
@@ -255,6 +252,33 @@ add_action(
 					),
 				),
 				'pattern'         => $pattern_markup,
+				'render_callback' => $render_pattern_block,
+			)
+		);
+
+		// SPIKE: the synced sibling of the block above, sharing its attributes
+		// and render callback. The Title heading declares a
+		// `core/pattern-overrides` binding, so it is editable per instance;
+		// the paragraph has no binding, so the plugin owns it and edits to
+		// this markup propagate to existing posts.
+		$synced_pattern_markup = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
+			. '<!-- wp:heading {"metadata":{"name":"Title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><h2 class="wp-block-heading">Synced title</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Owned by the plugin: shipped with v1.</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->';
+
+		register_block_type(
+			'test/php-only-synced-block',
+			array(
+				'title'           => 'Synced PHP-only block (pattern overrides)',
+				'icon'            => 'update',
+				'category'        => 'widgets',
+				'description'     => 'The registration owns the pattern: only the bound Title is editable per instance, and plugin updates to the rest propagate to existing content.',
+				'keywords'        => array( 'pattern', 'autotest' ),
+				'attributes'      => $pattern_attributes,
+				'supports'        => array(
+					'autoRegister' => true,
+				),
+				'pattern'         => $synced_pattern_markup,
 				'render_callback' => $render_pattern_block,
 			)
 		);

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -46,7 +46,11 @@ export default {
 
 		const [ patternClientId ] = getBlockParentsByBlockName(
 			clientId,
-			'core/block',
+			// SPIKE: PHP-only pattern blocks in synced mode store overrides in
+			// their `content` attribute like `core/block` does. TODO: derive
+			// this from the block type providing the `pattern/overrides`
+			// context instead of a name list.
+			[ 'core/block', 'test/php-only-editable-block' ],
 			true
 		);
 

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
-
-const CONTENT = 'content';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * @type {WPBlockBindingsSource}
@@ -36,7 +35,7 @@ export default {
 		return overridesValues;
 	},
 	setValues( { select, dispatch, clientId, bindings } ) {
-		const { getBlockAttributes, getBlockParentsByBlockName, getBlocks } =
+		const { getBlockAttributes, getBlockName, getBlockParents, getBlocks } =
 			select( blockEditorStore );
 		const currentBlockAttributes = getBlockAttributes( clientId );
 		const blockName = currentBlockAttributes?.metadata?.name;
@@ -44,14 +43,15 @@ export default {
 			return;
 		}
 
-		const [ patternClientId ] = getBlockParentsByBlockName(
-			clientId,
-			// SPIKE: PHP-only pattern blocks in synced mode store overrides in
-			// their `content` attribute like `core/block` does. TODO: derive
-			// this from the block type providing the `pattern/overrides`
-			// context instead of a name list.
-			[ 'core/block', 'test/php-only-synced-block' ],
-			true
+		// Overrides live on the closest ancestor whose block type provides
+		// the `pattern/overrides` context; `core/block` is the canonical one.
+		// The context mapping names the attribute that stores them.
+		const { getBlockType } = select( blocksStore );
+		const patternClientId = getBlockParents( clientId, true ).find(
+			( parentId ) =>
+				getBlockType( getBlockName( parentId ) )?.providesContext?.[
+					'pattern/overrides'
+				]
 		);
 
 		// Extract the updated attributes from the source bindings.
@@ -80,11 +80,13 @@ export default {
 			syncBlocksWithSameName( getBlocks() );
 			return;
 		}
+		const contentAttribute = getBlockType( getBlockName( patternClientId ) )
+			.providesContext[ 'pattern/overrides' ];
 		const currentBindingValue =
-			getBlockAttributes( patternClientId )?.[ CONTENT ];
+			getBlockAttributes( patternClientId )?.[ contentAttribute ];
 
 		dispatch( blockEditorStore ).updateBlockAttributes( patternClientId, {
-			[ CONTENT ]: {
+			[ contentAttribute ]: {
 				...currentBindingValue,
 				[ blockName ]: {
 					...currentBindingValue?.[ blockName ],

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -50,7 +50,7 @@ export default {
 			// their `content` attribute like `core/block` does. TODO: derive
 			// this from the block type providing the `pattern/overrides`
 			// context instead of a name list.
-			[ 'core/block', 'test/php-only-editable-block' ],
+			[ 'core/block', 'test/php-only-synced-block' ],
 			true
 		);
 


### PR DESCRIPTION
## What

Part of #79330 and extension of #79831; it explores [this suggestion](https://github.com/WordPress/gutenberg/pull/79831#issuecomment-4890851719): patterns behaving as synced, with only bound fields editable.

When the pattern declares `core/pattern-overrides` bindings, the block opts into synced mode; only the bound fields are editable in the canvas, and each instance saves just its overrides. The editor renders the same PHP wrapper as the front end, with the bound fields editable inside it.

## Why

As suggested in #79831, it makes more sense to rely on synced patterns to have better control as a whole, only allowing the editing of specific fields, providing a better balance than no locks vs content-only.

This also allows plugin/block updates to reach already-published posts (see demo below).

## How

- Declaring bindings in the pattern is the only signal; there is no extra flag.
- Rendering the editable fields inside the PHP wrapper, so updating the wrapper doesn't reset them.
- Generalizing the existing pattern-overrides code, which only expected `core/block`, so any block type providing the `pattern/overrides` context can host overrides.

## Testing Instructions

1. Enable the "Pattern-based PHP blocks" experiment, with the server-side-rendered-block test plugin active.
2. In a new post, insert the "Synced PHP-only block (pattern overrides)" block. The PHP wrapper renders around the content, and only the Title is editable; the paragraph and the structure are not.
3. Edit the Title and open the code editor: the post stores a single line, with your edit as an override.
4. Publish, then change the paragraph text in the test plugin file and reload the post on the front end: the published post picks up the plugin change, and your Title override survives.

## Screen recording

https://github.com/user-attachments/assets/48f2758d-9f80-4698-97f2-026222cc2cbe


---
Code implemented by Claude, tested, and reviewed by me