### PR TITLE
Release: Harden latest npm metadata publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -19,8 +19,9 @@ on:
 
 # Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
-    # Scope package release dispatches by release type, and by WordPress version for wp releases.
-    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || 'all' }}
+    # Scope package release dispatches by target npm release branch.
+    # `latest` and `bugfix` both target wp/latest and must serialize.
+    group: ${{ github.workflow }}-wp-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.event.inputs.release_type == 'development' && 'next' || 'latest' }}
     cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -20,7 +20,7 @@ on:
 # Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
     # Scope package release dispatches by release type, and by WordPress version for wp releases.
-    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.sha }}
+    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || 'all' }}
     cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -17,12 +17,11 @@ on:
                 description: 'WordPress major version (`wp` only)'
                 type: string
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Prevents overlapping package releases without canceling an in-progress release.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+    # Scope package release dispatches by release type, and by WordPress version for wp releases.
+    group: ${{ github.workflow }}-${{ github.event.inputs.release_type }}-${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version || github.sha }}
+    cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -681,6 +681,8 @@ async function runNpmPublishPreflight(
 	} );
 
 	log( '>> Verifying target package versions are not already published.' );
+	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
+	// Keep the first hardening pass sequential so registry errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
 		try {
 			await commandFn( `npm view ${ name }@${ version } version --json`, {

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -28,6 +28,7 @@ const {
 const pluginConfig = require( '../config' );
 
 const NPM_RELEASE_GIT_PUSH_ATTEMPTS = 3;
+// Keep tag pushes small enough that GitHub ruleset validation handles each phase predictably.
 const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
 
 /**
@@ -344,24 +345,27 @@ async function runPushGitChangesStep( {
 /**
  * Returns package metadata for public packages that Lerna tagged at HEAD.
  *
- * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   gitWorkingDirectoryPath Git working directory path.
+ * @param {Object}   deps                    Dependencies.
+ * @param {Object}   deps.git                Git client.
+ * @param {Function} deps.globFn             Glob function.
+ * @param {Function} deps.readJSON           JSON reader.
  *
  * @return {Promise<Array<{ name: string, version: string, tagName: string }>>} Package metadata.
  */
-async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
+async function getNpmReleasePackages( gitWorkingDirectoryPath, deps = {} ) {
+	const {
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		globFn = glob,
+		readJSON = readJSONFile,
+	} = deps;
 	const localTagsAtHead = new Set(
-		(
-			await SimpleGit( gitWorkingDirectoryPath ).raw(
-				'tag',
-				'--points-at',
-				'HEAD'
-			)
-		)
+		( await git.raw( 'tag', '--points-at', 'HEAD' ) )
 			.split( '\n' )
 			.filter( Boolean )
 	);
 
-	const packageJSONPaths = await glob(
+	const packageJSONPaths = await globFn(
 		path.resolve( gitWorkingDirectoryPath, 'packages/*/package.json' )
 	);
 
@@ -371,7 +375,7 @@ async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
 				name,
 				private: isPrivate,
 				version,
-			} = readJSONFile( packageJSONPath );
+			} = readJSON( packageJSONPath );
 			return {
 				isPrivate,
 				name,
@@ -478,10 +482,16 @@ function getNpmReleaseGitRecoveryCommands( {
 /**
  * Runs a release metadata push phase with retry.
  *
- * @param {string}   label Phase label.
- * @param {Function} task  Task to retry.
+ * @param {string}   label     Phase label.
+ * @param {Function} task      Task to retry.
+ * @param {Object}   deps      Dependencies.
+ * @param {Function} deps.wait Wait function.
  */
-async function runNpmReleaseGitPushPhase( label, task ) {
+async function runNpmReleaseGitPushPhase( label, task, deps = {} ) {
+	const {
+		wait = ( delay ) =>
+			new Promise( ( resolve ) => setTimeout( resolve, delay ) ),
+	} = deps;
 	for ( let attempt = 1; ; attempt++ ) {
 		try {
 			await task();
@@ -495,9 +505,7 @@ async function runNpmReleaseGitPushPhase( label, task ) {
 					err.message
 				}, retrying in ${ attempt * 5 }s...`
 			);
-			await new Promise( ( resolve ) =>
-				setTimeout( resolve, attempt * 5000 )
-			);
+			await wait( attempt * 5000 );
 		}
 	}
 }
@@ -507,11 +515,18 @@ async function runNpmReleaseGitPushPhase( label, task ) {
  *
  * @param {string} gitWorkingDirectoryPath Git working directory path.
  * @param {string} branchName              Branch name.
+ * @param {Object} deps                    Dependencies.
+ * @param {Object} deps.git                Git client.
  *
  * @return {Promise<?string>} Remote branch SHA.
  */
-async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
-	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+async function getRemoteBranchSha(
+	gitWorkingDirectoryPath,
+	branchName,
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const output = await git.raw(
 		'ls-remote',
 		'--heads',
 		'origin',
@@ -523,50 +538,67 @@ async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
 }
 
 /**
- * Gets the peeled remote SHA for a tag.
+ * Gets the peeled remote SHA for each tag.
  *
- * @param {string} gitWorkingDirectoryPath Git working directory path.
- * @param {string} tagName                 Tag name.
+ * @param {string}   gitWorkingDirectoryPath Git working directory path.
+ * @param {string[]} tagNames                Tag names.
+ * @param {Object}   deps                    Dependencies.
+ * @param {Object}   deps.git                Git client.
  *
- * @return {Promise<?string>} Remote tag SHA.
+ * @return {Promise<Map<string, string>>} Remote tag SHAs.
  */
-async function getRemoteTagSha( gitWorkingDirectoryPath, tagName ) {
-	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+async function getRemoteTagShas(
+	gitWorkingDirectoryPath,
+	tagNames,
+	{ git = SimpleGit( gitWorkingDirectoryPath ) } = {}
+) {
+	if ( tagNames.length === 0 ) {
+		return new Map();
+	}
+
+	const output = await git.raw(
 		'ls-remote',
 		'--tags',
 		'origin',
-		`refs/tags/${ tagName }`,
-		`refs/tags/${ tagName }^{}`
+		...tagNames.flatMap( ( tagName ) => [
+			`refs/tags/${ tagName }`,
+			`refs/tags/${ tagName }^{}`,
+		] )
 	);
-	const refs = output
+	const remoteTagShas = new Map();
+	output
 		.trim()
 		.split( '\n' )
 		.filter( Boolean )
-		.map( ( line ) => {
-			const [ sha, ref ] = line.split( /\s+/ );
-			return { ref, sha };
+		.forEach( ( line ) => {
+			const [ sha, ref = '' ] = line.split( /\s+/ );
+			const match = ref.match( /^refs\/tags\/(.+?)(\^\{\})?$/ );
+			if ( match ) {
+				const [ , tagName, isPeeled ] = match;
+				if ( isPeeled || ! remoteTagShas.has( tagName ) ) {
+					remoteTagShas.set( tagName, sha );
+				}
+			}
 		} );
-	const peeled = refs.find(
-		( { ref } ) => ref === `refs/tags/${ tagName }^{}`
-	);
-	const direct = refs.find( ( { ref } ) => ref === `refs/tags/${ tagName }` );
-	return peeled?.sha || direct?.sha || null;
+	return remoteTagShas;
 }
 
 /**
  * Verifies that a remote branch points to the expected SHA.
  *
- * @param {Object} options                         Options.
- * @param {string} options.gitWorkingDirectoryPath Git working directory path.
- * @param {string} options.npmReleaseBranch        Npm release branch.
- * @param {string} options.publishCommit           Expected commit SHA.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.npmReleaseBranch        Npm release branch.
+ * @param {string}   options.publishCommit           Expected commit SHA.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.getRemoteBranchShaFn       Gets the remote branch SHA.
  */
-async function verifyRemoteNpmReleaseBranch( {
-	gitWorkingDirectoryPath,
-	npmReleaseBranch,
-	publishCommit,
-} ) {
-	const remoteSha = await getRemoteBranchSha(
+async function verifyRemoteNpmReleaseBranch(
+	{ gitWorkingDirectoryPath, npmReleaseBranch, publishCommit },
+	deps = {}
+) {
+	const { getRemoteBranchShaFn = getRemoteBranchSha } = deps;
+	const remoteSha = await getRemoteBranchShaFn(
 		gitWorkingDirectoryPath,
 		npmReleaseBranch
 	);
@@ -586,18 +618,21 @@ async function verifyRemoteNpmReleaseBranch( {
  * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
  * @param {string[]} options.packageTags             Package tag names.
  * @param {string}   options.publishCommit           Expected commit SHA.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.getRemoteTagShasFn         Gets remote tag SHAs.
  */
-async function verifyRemotePackageTags( {
-	gitWorkingDirectoryPath,
-	packageTags,
-	publishCommit,
-} ) {
+async function verifyRemotePackageTags(
+	{ gitWorkingDirectoryPath, packageTags, publishCommit },
+	deps = {}
+) {
+	const { getRemoteTagShasFn = getRemoteTagShas } = deps;
 	const mismatches = [];
+	const remoteTagShas = await getRemoteTagShasFn(
+		gitWorkingDirectoryPath,
+		packageTags
+	);
 	for ( const tagName of packageTags ) {
-		const remoteSha = await getRemoteTagSha(
-			gitWorkingDirectoryPath,
-			tagName
-		);
+		const remoteSha = remoteTagShas.get( tagName );
 		if ( remoteSha !== publishCommit ) {
 			mismatches.push(
 				`${ tagName }: expected ${ publishCommit }, got ${
@@ -614,18 +649,33 @@ async function verifyRemotePackageTags( {
 }
 
 /**
+ * Checks whether an npm command failed because the target package version is absent.
+ *
+ * @param {Error} error Command error.
+ *
+ * @return {boolean} Whether the package version is absent.
+ */
+function isNpmPackageVersionMissing( error ) {
+	const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
+	return output.includes( 'E404' );
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
- * @param {Object} options                         Options.
- * @param {string} options.gitWorkingDirectoryPath Git working directory path.
- * @param {Array}  options.releasePackages         Packages to publish.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Array}    options.releasePackages         Packages to publish.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.commandFn                  Command runner.
  */
-async function runNpmPublishPreflight( {
-	gitWorkingDirectoryPath,
-	releasePackages,
-} ) {
+async function runNpmPublishPreflight(
+	{ gitWorkingDirectoryPath, releasePackages },
+	deps = {}
+) {
+	const { commandFn = command } = deps;
 	log( '>> Checking npm package access.' );
-	await command( 'npm access ls-packages @wordpress --json', {
+	await commandFn( 'npm access list packages @wordpress --json', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'pipe',
 	} );
@@ -633,55 +683,61 @@ async function runNpmPublishPreflight( {
 	log( '>> Verifying target package versions are not already published.' );
 	for ( const { name, version } of releasePackages ) {
 		try {
-			await command( `npm view ${ name }@${ version } version --json`, {
+			await commandFn( `npm view ${ name }@${ version } version --json`, {
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'pipe',
 			} );
-			throw new Error(
-				`${ name }@${ version } already exists in the npm registry.`
-			);
 		} catch ( error ) {
-			const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
-			if ( ! output.includes( 'E404' ) ) {
-				throw error;
+			if ( isNpmPackageVersionMissing( error ) ) {
+				continue;
 			}
+			throw error;
 		}
+		throw new Error(
+			`${ name }@${ version } already exists in the npm registry.`
+		);
 	}
 }
 
 /**
  * Pushes and verifies Git metadata for an npm release.
  *
- * @param {Object}   options                         Options.
- * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
- * @param {string}   options.npmReleaseBranch        Npm release branch.
- * @param {string[]} options.packageTags             Package tag names.
- * @param {string}   options.publishCommit           Publish commit SHA.
+ * @param {Object}   options                             Options.
+ * @param {string}   options.gitWorkingDirectoryPath     Git working directory path.
+ * @param {string}   options.npmReleaseBranch            Npm release branch.
+ * @param {string[]} options.packageTags                 Package tag names.
+ * @param {string}   options.publishCommit               Publish commit SHA.
+ * @param {Object}   deps                                Dependencies.
+ * @param {Object}   deps.git                            Git client.
+ * @param {Function} deps.runPhase                       Runs a retryable phase.
+ * @param {Function} deps.verifyRemoteNpmReleaseBranchFn Verifies the remote branch.
+ * @param {Function} deps.verifyRemotePackageTagsFn      Verifies remote package tags.
  */
-async function pushNpmReleaseGitMetadata( {
-	gitWorkingDirectoryPath,
-	npmReleaseBranch,
-	packageTags,
-	publishCommit,
-} ) {
-	const repo = SimpleGit( gitWorkingDirectoryPath );
+async function pushNpmReleaseGitMetadata(
+	{ gitWorkingDirectoryPath, npmReleaseBranch, packageTags, publishCommit },
+	deps = {}
+) {
+	const {
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		runPhase = runNpmReleaseGitPushPhase,
+		verifyRemoteNpmReleaseBranchFn = verifyRemoteNpmReleaseBranch,
+		verifyRemotePackageTagsFn = verifyRemotePackageTags,
+	} = deps;
 	try {
-		await runNpmReleaseGitPushPhase( 'Release branch push', async () => {
+		await runPhase( 'Release branch push', async () => {
 			log( '>> Pushing release branch to remote.' );
-			await repo.raw(
+			await git.raw(
 				'push',
 				'origin',
 				`${ publishCommit }:refs/heads/${ npmReleaseBranch }`
 			);
 		} );
-		await runNpmReleaseGitPushPhase(
-			'Release branch verification',
-			async () =>
-				verifyRemoteNpmReleaseBranch( {
-					gitWorkingDirectoryPath,
-					npmReleaseBranch,
-					publishCommit,
-				} )
+		await runPhase( 'Release branch verification', async () =>
+			verifyRemoteNpmReleaseBranchFn( {
+				gitWorkingDirectoryPath,
+				npmReleaseBranch,
+				publishCommit,
+			} )
 		);
 
 		if ( packageTags.length ) {
@@ -689,26 +745,21 @@ async function pushNpmReleaseGitMetadata( {
 				packageTags,
 				NPM_RELEASE_TAG_PUSH_BATCH_SIZE
 			) ) {
-				await runNpmReleaseGitPushPhase(
-					'Package tag push',
-					async () => {
-						log( '>> Pushing package tags to remote.' );
-						await repo.raw(
-							'push',
-							'origin',
-							...packageTagChunk.map( getTagRefspec )
-						);
-					}
-				);
+				await runPhase( 'Package tag push', async () => {
+					log( '>> Pushing package tags to remote.' );
+					await git.raw(
+						'push',
+						'origin',
+						...packageTagChunk.map( getTagRefspec )
+					);
+				} );
 			}
-			await runNpmReleaseGitPushPhase(
-				'Package tag verification',
-				async () =>
-					verifyRemotePackageTags( {
-						gitWorkingDirectoryPath,
-						packageTags,
-						publishCommit,
-					} )
+			await runPhase( 'Package tag verification', async () =>
+				verifyRemotePackageTagsFn( {
+					gitWorkingDirectoryPath,
+					packageTags,
+					publishCommit,
+				} )
 			);
 		}
 	} catch ( error ) {
@@ -1095,11 +1146,17 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	pushNpmReleaseGitMetadata,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,
 	publishNpmBugfixWordPressCore,
 	publishNpmNext,
+	runNpmPublishPreflight,
+	runNpmReleaseGitPushPhase,
+	verifyRemotePackageTags,
 };

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -462,7 +462,7 @@ function getNpmReleaseGitRecoveryCommands( {
 	return [
 		'Push and verify the release branch:',
 		`git push origin "${ publishCommit }:refs/heads/${ npmReleaseBranch }"`,
-		`git ls-remote --heads origin "${ npmReleaseBranch }"`,
+		`git ls-remote --heads origin "refs/heads/${ npmReleaseBranch }"`,
 		...( packageTags.length
 			? [
 					'',
@@ -526,14 +526,13 @@ async function getRemoteBranchSha(
 	deps = {}
 ) {
 	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
-	const output = await git.raw(
-		'ls-remote',
-		'--heads',
-		'origin',
-		branchName
-	);
-	const [ firstLine = '' ] = output.trim().split( '\n' );
-	const [ sha ] = firstLine.split( /\s+/ );
+	const branchRef = `refs/heads/${ branchName }`;
+	const output = await git.raw( 'ls-remote', '--heads', 'origin', branchRef );
+	const matchingLine = output
+		.trim()
+		.split( '\n' )
+		.find( ( line ) => line.split( /\s+/ )[ 1 ] === branchRef );
+	const [ sha ] = ( matchingLine || '' ).split( /\s+/ );
 	return sha || null;
 }
 
@@ -1150,6 +1149,7 @@ async function publishNpmNext( options ) {
 module.exports = {
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -27,6 +27,9 @@ const {
 } = require( './common' );
 const pluginConfig = require( '../config' );
 
+const NPM_RELEASE_GIT_PUSH_ATTEMPTS = 3;
+const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
+
 /**
  * Release type names.
  *
@@ -339,6 +342,389 @@ async function runPushGitChangesStep( {
 }
 
 /**
+ * Returns package metadata for public packages that Lerna tagged at HEAD.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ *
+ * @return {Promise<Array<{ name: string, version: string, tagName: string }>>} Package metadata.
+ */
+async function getNpmReleasePackages( gitWorkingDirectoryPath ) {
+	const localTagsAtHead = new Set(
+		(
+			await SimpleGit( gitWorkingDirectoryPath ).raw(
+				'tag',
+				'--points-at',
+				'HEAD'
+			)
+		)
+			.split( '\n' )
+			.filter( Boolean )
+	);
+
+	const packageJSONPaths = await glob(
+		path.resolve( gitWorkingDirectoryPath, 'packages/*/package.json' )
+	);
+
+	return packageJSONPaths
+		.map( ( packageJSONPath ) => {
+			const {
+				name,
+				private: isPrivate,
+				version,
+			} = readJSONFile( packageJSONPath );
+			return {
+				isPrivate,
+				name,
+				tagName: `${ name }@${ version }`,
+				version,
+			};
+		} )
+		.filter(
+			( { isPrivate, tagName } ) =>
+				isPrivate !== true && localTagsAtHead.has( tagName )
+		)
+		.map( ( { name, tagName, version } ) => ( {
+			name,
+			tagName,
+			version,
+		} ) )
+		.sort( ( a, b ) => a.tagName.localeCompare( b.tagName ) );
+}
+
+/**
+ * Returns a fully qualified tag refspec.
+ *
+ * @param {string} tagName Tag name.
+ *
+ * @return {string} Tag refspec.
+ */
+function getTagRefspec( tagName ) {
+	return `refs/tags/${ tagName }:refs/tags/${ tagName }`;
+}
+
+/**
+ * Splits an array into chunks.
+ *
+ * @param {Array}  items     Items to chunk.
+ * @param {number} chunkSize Chunk size.
+ *
+ * @return {Array[]} Chunks.
+ */
+function chunk( items, chunkSize ) {
+	const chunks = [];
+	for ( let index = 0; index < items.length; index += chunkSize ) {
+		chunks.push( items.slice( index, index + chunkSize ) );
+	}
+	return chunks;
+}
+
+/**
+ * Formats one or more tag push commands.
+ *
+ * @param {string[]} tagNames Tag names.
+ *
+ * @return {string[]} Git push commands.
+ */
+function getTagPushCommands( tagNames ) {
+	return chunk( tagNames, NPM_RELEASE_TAG_PUSH_BATCH_SIZE ).map(
+		( tagNameChunk ) =>
+			[
+				'git push origin \\',
+				...tagNameChunk.map(
+					( tagName, index ) =>
+						`  "${ getTagRefspec( tagName ) }"${
+							index === tagNameChunk.length - 1 ? '' : ' \\'
+						}`
+				),
+			].join( '\n' )
+	);
+}
+
+/**
+ * Formats recovery commands for release Git metadata.
+ *
+ * @param {Object}   options                  Options.
+ * @param {string}   options.npmReleaseBranch Npm release branch.
+ * @param {string[]} options.packageTags      Package tag names.
+ * @param {string}   options.publishCommit    Publish commit SHA.
+ *
+ * @return {string} Recovery commands.
+ */
+function getNpmReleaseGitRecoveryCommands( {
+	npmReleaseBranch,
+	packageTags,
+	publishCommit,
+} ) {
+	return [
+		'Push and verify the release branch:',
+		`git push origin "${ publishCommit }:refs/heads/${ npmReleaseBranch }"`,
+		`git ls-remote --heads origin "${ npmReleaseBranch }"`,
+		...( packageTags.length
+			? [
+					'',
+					'Push the package tags:',
+					...getTagPushCommands( packageTags ),
+					'',
+					'Verify the package tags:',
+					...packageTags.map(
+						( tagName ) =>
+							`git ls-remote --tags origin "refs/tags/${ tagName }" "refs/tags/${ tagName }^{}"`
+					),
+			  ]
+			: [] ),
+	].join( '\n' );
+}
+
+/**
+ * Runs a release metadata push phase with retry.
+ *
+ * @param {string}   label Phase label.
+ * @param {Function} task  Task to retry.
+ */
+async function runNpmReleaseGitPushPhase( label, task ) {
+	for ( let attempt = 1; ; attempt++ ) {
+		try {
+			await task();
+			return;
+		} catch ( err ) {
+			if ( attempt >= NPM_RELEASE_GIT_PUSH_ATTEMPTS ) {
+				throw err;
+			}
+			log(
+				`>> ${ label } failed (attempt ${ attempt }/${ NPM_RELEASE_GIT_PUSH_ATTEMPTS }): ${
+					err.message
+				}, retrying in ${ attempt * 5 }s...`
+			);
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, attempt * 5000 )
+			);
+		}
+	}
+}
+
+/**
+ * Gets the remote SHA for a branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string} branchName              Branch name.
+ *
+ * @return {Promise<?string>} Remote branch SHA.
+ */
+async function getRemoteBranchSha( gitWorkingDirectoryPath, branchName ) {
+	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+		'ls-remote',
+		'--heads',
+		'origin',
+		branchName
+	);
+	const [ firstLine = '' ] = output.trim().split( '\n' );
+	const [ sha ] = firstLine.split( /\s+/ );
+	return sha || null;
+}
+
+/**
+ * Gets the peeled remote SHA for a tag.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string} tagName                 Tag name.
+ *
+ * @return {Promise<?string>} Remote tag SHA.
+ */
+async function getRemoteTagSha( gitWorkingDirectoryPath, tagName ) {
+	const output = await SimpleGit( gitWorkingDirectoryPath ).raw(
+		'ls-remote',
+		'--tags',
+		'origin',
+		`refs/tags/${ tagName }`,
+		`refs/tags/${ tagName }^{}`
+	);
+	const refs = output
+		.trim()
+		.split( '\n' )
+		.filter( Boolean )
+		.map( ( line ) => {
+			const [ sha, ref ] = line.split( /\s+/ );
+			return { ref, sha };
+		} );
+	const peeled = refs.find(
+		( { ref } ) => ref === `refs/tags/${ tagName }^{}`
+	);
+	const direct = refs.find( ( { ref } ) => ref === `refs/tags/${ tagName }` );
+	return peeled?.sha || direct?.sha || null;
+}
+
+/**
+ * Verifies that a remote branch points to the expected SHA.
+ *
+ * @param {Object} options                         Options.
+ * @param {string} options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string} options.npmReleaseBranch        Npm release branch.
+ * @param {string} options.publishCommit           Expected commit SHA.
+ */
+async function verifyRemoteNpmReleaseBranch( {
+	gitWorkingDirectoryPath,
+	npmReleaseBranch,
+	publishCommit,
+} ) {
+	const remoteSha = await getRemoteBranchSha(
+		gitWorkingDirectoryPath,
+		npmReleaseBranch
+	);
+	if ( remoteSha !== publishCommit ) {
+		throw new Error(
+			`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit }, got ${
+				remoteSha || 'nothing'
+			}.`
+		);
+	}
+}
+
+/**
+ * Verifies that remote tags peel to the expected SHA.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string[]} options.packageTags             Package tag names.
+ * @param {string}   options.publishCommit           Expected commit SHA.
+ */
+async function verifyRemotePackageTags( {
+	gitWorkingDirectoryPath,
+	packageTags,
+	publishCommit,
+} ) {
+	const mismatches = [];
+	for ( const tagName of packageTags ) {
+		const remoteSha = await getRemoteTagSha(
+			gitWorkingDirectoryPath,
+			tagName
+		);
+		if ( remoteSha !== publishCommit ) {
+			mismatches.push(
+				`${ tagName }: expected ${ publishCommit }, got ${
+					remoteSha || 'nothing'
+				}`
+			);
+		}
+	}
+	if ( mismatches.length ) {
+		throw new Error(
+			`Package tag verification failed:\n${ mismatches.join( '\n' ) }`
+		);
+	}
+}
+
+/**
+ * Runs a pragmatic npm preflight before publishing.
+ *
+ * @param {Object} options                         Options.
+ * @param {string} options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Array}  options.releasePackages         Packages to publish.
+ */
+async function runNpmPublishPreflight( {
+	gitWorkingDirectoryPath,
+	releasePackages,
+} ) {
+	log( '>> Checking npm package access.' );
+	await command( 'npm access ls-packages @wordpress --json', {
+		cwd: gitWorkingDirectoryPath,
+		stdio: 'pipe',
+	} );
+
+	log( '>> Verifying target package versions are not already published.' );
+	for ( const { name, version } of releasePackages ) {
+		try {
+			await command( `npm view ${ name }@${ version } version --json`, {
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'pipe',
+			} );
+			throw new Error(
+				`${ name }@${ version } already exists in the npm registry.`
+			);
+		} catch ( error ) {
+			const output = `${ error.stdout || '' }\n${ error.stderr || '' }`;
+			if ( ! output.includes( 'E404' ) ) {
+				throw error;
+			}
+		}
+	}
+}
+
+/**
+ * Pushes and verifies Git metadata for an npm release.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.npmReleaseBranch        Npm release branch.
+ * @param {string[]} options.packageTags             Package tag names.
+ * @param {string}   options.publishCommit           Publish commit SHA.
+ */
+async function pushNpmReleaseGitMetadata( {
+	gitWorkingDirectoryPath,
+	npmReleaseBranch,
+	packageTags,
+	publishCommit,
+} ) {
+	const repo = SimpleGit( gitWorkingDirectoryPath );
+	try {
+		await runNpmReleaseGitPushPhase( 'Release branch push', async () => {
+			log( '>> Pushing release branch to remote.' );
+			await repo.raw(
+				'push',
+				'origin',
+				`${ publishCommit }:refs/heads/${ npmReleaseBranch }`
+			);
+		} );
+		await runNpmReleaseGitPushPhase(
+			'Release branch verification',
+			async () =>
+				verifyRemoteNpmReleaseBranch( {
+					gitWorkingDirectoryPath,
+					npmReleaseBranch,
+					publishCommit,
+				} )
+		);
+
+		if ( packageTags.length ) {
+			for ( const packageTagChunk of chunk(
+				packageTags,
+				NPM_RELEASE_TAG_PUSH_BATCH_SIZE
+			) ) {
+				await runNpmReleaseGitPushPhase(
+					'Package tag push',
+					async () => {
+						log( '>> Pushing package tags to remote.' );
+						await repo.raw(
+							'push',
+							'origin',
+							...packageTagChunk.map( getTagRefspec )
+						);
+					}
+				);
+			}
+			await runNpmReleaseGitPushPhase(
+				'Package tag verification',
+				async () =>
+					verifyRemotePackageTags( {
+						gitWorkingDirectoryPath,
+						packageTags,
+						publishCommit,
+					} )
+			);
+		}
+	} catch ( error ) {
+		log(
+			'>> npm publication completed, but Git metadata did not finish. Use these recovery commands after checking the remote state:\n\n' +
+				getNpmReleaseGitRecoveryCommands( {
+					npmReleaseBranch,
+					packageTags,
+					publishCommit,
+				} )
+		);
+		throw error;
+	}
+}
+
+/**
  * Publishes all changed packages to npm.
  *
  * @param {WPPackagesConfig} config Command config.
@@ -436,6 +822,14 @@ async function publishPackagesToNpm( {
 			}
 		);
 
+		const releasePackages = await getNpmReleasePackages(
+			gitWorkingDirectoryPath
+		);
+		await runNpmPublishPreflight( {
+			gitWorkingDirectoryPath,
+			releasePackages,
+		} );
+
 		log( '>> Publishing modified packages to npm.' );
 		try {
 			await command(
@@ -459,34 +853,15 @@ async function publishPackagesToNpm( {
 			);
 		}
 
-		// Retry the push so a transient network/auth blip between a successful
-		// publish and a failed push doesn't leave npm-published versions
-		// without their tags on origin. The push is idempotent: tags already
-		// present on origin (same SHA) are a no-op.
-		log( '>> Pushing version commit and tags to remote.' );
-		const maxPushAttempts = 3;
-		for ( let attempt = 1; ; attempt++ ) {
-			try {
-				await SimpleGit( gitWorkingDirectoryPath ).push(
-					'origin',
-					npmReleaseBranch,
-					[ '--follow-tags' ]
-				);
-				break;
-			} catch ( err ) {
-				if ( attempt >= maxPushAttempts ) {
-					throw err;
-				}
-				log(
-					`>> Push failed (attempt ${ attempt }/${ maxPushAttempts }): ${
-						err.message
-					}, retrying in ${ attempt * 5 }s…`
-				);
-				await new Promise( ( resolve ) =>
-					setTimeout( resolve, attempt * 5000 )
-				);
-			}
-		}
+		const publishCommit = await SimpleGit(
+			gitWorkingDirectoryPath
+		).revparse( [ 'HEAD' ] );
+		await pushNpmReleaseGitMetadata( {
+			gitWorkingDirectoryPath,
+			npmReleaseBranch,
+			packageTags: releasePackages.map( ( { tagName } ) => tagName ),
+			publishCommit,
+		} );
 	}
 
 	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
@@ -720,6 +1095,9 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	getNpmReleaseGitRecoveryCommands,
+	getTagPushCommands,
+	getTagRefspec,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,
 	publishNpmBugfixWordPressCore,

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -4,6 +4,7 @@
 import {
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
@@ -115,7 +116,35 @@ describe( 'getNpmReleaseGitRecoveryCommands', () => {
 			'git push origin "abc123:refs/heads/wp/latest"'
 		);
 		expect( commands ).toContain(
+			'git ls-remote --heads origin "refs/heads/wp/latest"'
+		);
+		expect( commands ).toContain(
 			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
+		);
+	} );
+} );
+
+describe( 'getRemoteBranchSha', () => {
+	it( 'returns the exact remote branch ref SHA', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'wrong-sha\trefs/heads/backport/wp/latest',
+						'expected-sha\trefs/heads/wp/latest',
+					].join( '\n' )
+				),
+		};
+
+		await expect(
+			getRemoteBranchSha( '/repo', 'wp/latest', { git } )
+		).resolves.toBe( 'expected-sha' );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'ls-remote',
+			'--heads',
+			'origin',
+			'refs/heads/wp/latest'
 		);
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getNpmReleaseGitRecoveryCommands,
+	getTagPushCommands,
+	getTagRefspec,
+} from '../packages';
+
+describe( 'getTagRefspec', () => {
+	it( 'returns a fully qualified package tag refspec', () => {
+		expect( getTagRefspec( '@wordpress/a11y@4.50.0' ) ).toBe(
+			'refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0'
+		);
+	} );
+} );
+
+describe( 'getTagPushCommands', () => {
+	it( 'quotes fully qualified tag refspecs', () => {
+		expect(
+			getTagPushCommands( [
+				'@wordpress/a11y@4.50.0',
+				'@wordpress/blocks@14.20.0',
+			] )
+		).toEqual( [
+			[
+				'git push origin \\',
+				'  "refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0" \\',
+				'  "refs/tags/@wordpress/blocks@14.20.0:refs/tags/@wordpress/blocks@14.20.0"',
+			].join( '\n' ),
+		] );
+	} );
+} );
+
+describe( 'getNpmReleaseGitRecoveryCommands', () => {
+	it( 'includes branch, tag push, and tag verification commands', () => {
+		const commands = getNpmReleaseGitRecoveryCommands( {
+			npmReleaseBranch: 'wp/latest',
+			packageTags: [ '@wordpress/a11y@4.50.0' ],
+			publishCommit: 'abc123',
+		} );
+
+		expect( commands ).toContain( 'git push origin \\' );
+		expect( commands ).toContain(
+			'"refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0"'
+		);
+		expect( commands ).toContain(
+			'git push origin "abc123:refs/heads/wp/latest"'
+		);
+		expect( commands ).toContain(
+			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
+		);
+	} );
+} );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -2,10 +2,77 @@
  * Internal dependencies
  */
 import {
+	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	pushNpmReleaseGitMetadata,
+	runNpmPublishPreflight,
+	runNpmReleaseGitPushPhase,
+	verifyRemotePackageTags,
 } from '../packages';
+
+describe( 'getNpmReleasePackages', () => {
+	it( 'returns public packages tagged at HEAD', async () => {
+		const files = [
+			'/repo/packages/blocks/package.json',
+			'/repo/packages/a11y/package.json',
+			'/repo/packages/private/package.json',
+			'/repo/packages/untagged/package.json',
+		];
+		const packageJsonByPath = {
+			'/repo/packages/blocks/package.json': {
+				name: '@wordpress/blocks',
+				version: '2.0.0',
+			},
+			'/repo/packages/a11y/package.json': {
+				name: '@wordpress/a11y',
+				version: '1.0.0',
+			},
+			'/repo/packages/private/package.json': {
+				name: '@wordpress/private',
+				private: true,
+				version: '3.0.0',
+			},
+			'/repo/packages/untagged/package.json': {
+				name: '@wordpress/untagged',
+				version: '4.0.0',
+			},
+		};
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'@wordpress/blocks@2.0.0',
+						'@wordpress/a11y@1.0.0',
+						'@wordpress/private@3.0.0',
+					].join( '\n' )
+				),
+		};
+
+		await expect(
+			getNpmReleasePackages( '/repo', {
+				git,
+				globFn: jest.fn().mockResolvedValue( files ),
+				readJSON: ( file ) => packageJsonByPath[ file ],
+			} )
+		).resolves.toEqual( [
+			{
+				name: '@wordpress/a11y',
+				tagName: '@wordpress/a11y@1.0.0',
+				version: '1.0.0',
+			},
+			{
+				name: '@wordpress/blocks',
+				tagName: '@wordpress/blocks@2.0.0',
+				version: '2.0.0',
+			},
+		] );
+		expect( git.raw ).toHaveBeenCalledWith( 'tag', '--points-at', 'HEAD' );
+	} );
+} );
 
 describe( 'getTagRefspec', () => {
 	it( 'returns a fully qualified package tag refspec', () => {
@@ -50,5 +117,197 @@ describe( 'getNpmReleaseGitRecoveryCommands', () => {
 		expect( commands ).toContain(
 			'git ls-remote --tags origin "refs/tags/@wordpress/a11y@4.50.0" "refs/tags/@wordpress/a11y@4.50.0^{}"'
 		);
+	} );
+} );
+
+describe( 'getRemoteTagShas', () => {
+	it( 'fetches tag refs in one call and prefers peeled SHAs', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					[
+						'direct-a11y\trefs/tags/@wordpress/a11y@4.50.0',
+						'peeled-a11y\trefs/tags/@wordpress/a11y@4.50.0^{}',
+						'direct-blocks\trefs/tags/@wordpress/blocks@14.20.0',
+					].join( '\n' )
+				),
+		};
+
+		const result = await getRemoteTagShas(
+			'/repo',
+			[ '@wordpress/a11y@4.50.0', '@wordpress/blocks@14.20.0' ],
+			{ git }
+		);
+
+		expect( git.raw ).toHaveBeenCalledWith(
+			'ls-remote',
+			'--tags',
+			'origin',
+			'refs/tags/@wordpress/a11y@4.50.0',
+			'refs/tags/@wordpress/a11y@4.50.0^{}',
+			'refs/tags/@wordpress/blocks@14.20.0',
+			'refs/tags/@wordpress/blocks@14.20.0^{}'
+		);
+		expect( result.get( '@wordpress/a11y@4.50.0' ) ).toBe( 'peeled-a11y' );
+		expect( result.get( '@wordpress/blocks@14.20.0' ) ).toBe(
+			'direct-blocks'
+		);
+	} );
+} );
+
+describe( 'verifyRemotePackageTags', () => {
+	it( 'throws when a remote tag is missing or points to another commit', async () => {
+		await expect(
+			verifyRemotePackageTags(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					packageTags: [
+						'@wordpress/a11y@4.50.0',
+						'@wordpress/blocks@14.20.0',
+					],
+					publishCommit: 'expected-sha',
+				},
+				{
+					getRemoteTagShasFn: jest.fn().mockResolvedValue(
+						new Map( [
+							[ '@wordpress/a11y@4.50.0', 'expected-sha' ],
+							[ '@wordpress/blocks@14.20.0', 'other-sha' ],
+						] )
+					),
+				}
+			)
+		).rejects.toThrow(
+			'@wordpress/blocks@14.20.0: expected expected-sha, got other-sha'
+		);
+	} );
+} );
+
+describe( 'runNpmPublishPreflight', () => {
+	it( 'uses the npm access command supported by current npm versions', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockRejectedValueOnce( {
+				stderr: 'npm ERR! code E404',
+			} );
+
+		await runNpmPublishPreflight(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releasePackages: [
+					{ name: '@wordpress/a11y', version: '4.50.0' },
+				],
+			},
+			{ commandFn }
+		);
+
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			1,
+			'npm access list packages @wordpress --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( commandFn ).toHaveBeenNthCalledWith(
+			2,
+			'npm view @wordpress/a11y@4.50.0 version --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when a target package version already exists', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'@wordpress/a11y@4.50.0 already exists in the npm registry.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'runNpmReleaseGitPushPhase', () => {
+	it( 'retries a failed phase before surfacing success', async () => {
+		const task = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'transient failure' ) )
+			.mockResolvedValueOnce();
+		const wait = jest.fn();
+
+		await runNpmReleaseGitPushPhase( 'Package tag push', task, { wait } );
+
+		expect( task ).toHaveBeenCalledTimes( 2 );
+		expect( wait ).toHaveBeenCalledWith( 5000 );
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'pushNpmReleaseGitMetadata', () => {
+	it( 'pushes the branch before pushing and verifying package tags', async () => {
+		const git = { raw: jest.fn().mockResolvedValue() };
+		const runPhase = jest.fn( async ( _label, task ) => task() );
+		const verifyRemoteNpmReleaseBranchFn = jest.fn();
+		const verifyRemotePackageTagsFn = jest.fn();
+
+		await pushNpmReleaseGitMetadata(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				npmReleaseBranch: 'wp/latest',
+				packageTags: [
+					'@wordpress/a11y@4.50.0',
+					'@wordpress/blocks@14.20.0',
+				],
+				publishCommit: 'publish-sha',
+			},
+			{
+				git,
+				runPhase,
+				verifyRemoteNpmReleaseBranchFn,
+				verifyRemotePackageTagsFn,
+			}
+		);
+
+		expect( runPhase.mock.calls.map( ( [ label ] ) => label ) ).toEqual( [
+			'Release branch push',
+			'Release branch verification',
+			'Package tag push',
+			'Package tag verification',
+		] );
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			1,
+			'push',
+			'origin',
+			'publish-sha:refs/heads/wp/latest'
+		);
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			2,
+			'push',
+			'origin',
+			'refs/tags/@wordpress/a11y@4.50.0:refs/tags/@wordpress/a11y@4.50.0',
+			'refs/tags/@wordpress/blocks@14.20.0:refs/tags/@wordpress/blocks@14.20.0'
+		);
+		expect( verifyRemoteNpmReleaseBranchFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			publishCommit: 'publish-sha',
+		} );
+		expect( verifyRemotePackageTagsFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			packageTags: [
+				'@wordpress/a11y@4.50.0',
+				'@wordpress/blocks@14.20.0',
+			],
+			publishCommit: 'publish-sha',
+		} );
+		expect( console ).toHaveLogged();
 	} );
 } );


### PR DESCRIPTION
Split from #79859. Followed by #79905 and #79906.

## What?
Harden the `npm-latest` release path so npm publication and Git metadata publication are separate, recoverable phases.

## Why?
The Gutenberg 23.5 package release changed npm state before a later Git push failed. A separate workflow dispatch could also cancel an active publish.

## How?
- Queue releases by target npm release branch without canceling an active run.
- Run local Lerna versioning with `--no-push`, then publish with `lerna publish from-package`.
- Retry a partial npm publish using Lerna's unpublished-package detection.
- Push the release branch and package tags explicitly after npm publication.
- Verify the exact remote branch and tag refs.
- Print copy-pasteable Git recovery commands if metadata publication fails.
- Add focused unit coverage for preflight, retry, push, verification, and recovery behavior.

## Testing Instructions
1. `npm run test:unit -- tools/release/commands/test/packages.js`
2. `npm run lint:js -- tools/release/commands/packages.js tools/release/commands/test/packages.js`
3. `npm run build`
4. `git diff --check origin/trunk...HEAD`

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
N/A

## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex.
