### PR TITLE
Release: Harden all npm package release paths

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -37,7 +37,6 @@ jobs:
         environment: WordPress packages
         steps:
             - name: Checkout (for CLI)
-              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   path: cli
@@ -121,9 +120,9 @@ jobs:
             - name: Publish packages to npm for WP major version ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
-                  cd publish
+                  cd cli
                   npm ci
-                  npx lerna publish patch --dist-tag "wp-$WP_VERSION" --no-private --yes --no-verify-access
+                  npm exec --no release-cli -- npm-wp --wp-version "$WP_VERSION" --ci --repository-path ../publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -86,6 +86,8 @@ jobs:
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
+                  # Keep the release CLI and publish checkout on one runtime;
+                  # active wp release branches must stay compatible with the trunk release CLI.
                   node-version-file: 'publish/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -82,12 +82,12 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 
+            # Keep the release CLI and publish checkout on one runtime;
+            # active wp release branches must stay compatible with the trunk release CLI.
             - name: Setup Node.js (for WP major version)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  # Keep the release CLI and publish checkout on one runtime;
-                  # active wp release branches must stay compatible with the trunk release CLI.
                   node-version-file: 'publish/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -907,17 +907,6 @@ async function publishPackagesToNpm(
 				stdio: 'inherit',
 			}
 		);
-	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
-		log(
-			'>> Bumping version of public packages changed since the last release.'
-		);
-		await commandFn(
-			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
 	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -830,6 +830,9 @@ async function publishVersionedPackagesToNpm(
 		log(
 			'>> Trying to finish failed publishing of modified npm packages.'
 		);
+		// A failed Lerna publish can leave temporary `gitHead` manifest changes.
+		// Reset to the version commit so `from-package` sees a clean tree on retry.
+		await git.reset( 'hard' );
 		await commandFn(
 			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
 			{

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -777,34 +777,113 @@ async function pushNpmReleaseGitMetadata(
 }
 
 /**
+ * Publishes locally versioned packages, then pushes and verifies Git metadata.
+ *
+ * @param {Object}   options                          Options.
+ * @param {string}   options.distTag                  The dist-tag used for npm publishing.
+ * @param {string}   options.gitWorkingDirectoryPath  Git working directory path.
+ * @param {string}   options.noVerifyAccessFlag       Lerna no-verify-access flag.
+ * @param {string}   options.npmReleaseBranch         Npm release branch.
+ * @param {string}   options.yesFlag                  Lerna yes flag.
+ * @param {Object}   deps                             Dependencies.
+ * @param {Function} deps.commandFn                   Command runner.
+ * @param {Object}   deps.git                         Git client.
+ * @param {Function} deps.getNpmReleasePackagesFn     Gets release package metadata.
+ * @param {Function} deps.pushNpmReleaseGitMetadataFn Pushes Git metadata.
+ * @param {Function} deps.runNpmPublishPreflightFn    Runs npm preflight.
+ */
+async function publishVersionedPackagesToNpm(
+	{
+		distTag,
+		gitWorkingDirectoryPath,
+		noVerifyAccessFlag,
+		npmReleaseBranch,
+		yesFlag,
+	},
+	deps = {}
+) {
+	const {
+		commandFn = command,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		getNpmReleasePackagesFn = getNpmReleasePackages,
+		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
+		runNpmPublishPreflightFn = runNpmPublishPreflight,
+	} = deps;
+	const releasePackages = await getNpmReleasePackagesFn(
+		gitWorkingDirectoryPath
+	);
+	await runNpmPublishPreflightFn( {
+		gitWorkingDirectoryPath,
+		releasePackages,
+	} );
+
+	log( '>> Publishing modified packages to npm.' );
+	try {
+		await commandFn(
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
+	} catch {
+		log(
+			'>> Trying to finish failed publishing of modified npm packages.'
+		);
+		await commandFn(
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
+	}
+
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	await pushNpmReleaseGitMetadataFn( {
+		gitWorkingDirectoryPath,
+		npmReleaseBranch,
+		packageTags: releasePackages.map( ( { tagName } ) => tagName ),
+		publishCommit,
+	} );
+}
+
+/**
  * Publishes all changed packages to npm.
  *
  * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
  *
  * @return {?string} The optional commit's hash when packages published to npm.
  */
-async function publishPackagesToNpm( {
-	distTag,
-	gitWorkingDirectoryPath,
-	interactive,
-	minimumVersionBump,
-	npmReleaseBranch,
-	releaseType,
-} ) {
+async function publishPackagesToNpm(
+	{
+		distTag,
+		gitWorkingDirectoryPath,
+		interactive,
+		minimumVersionBump,
+		npmReleaseBranch,
+		releaseType,
+	},
+	deps = {}
+) {
+	const {
+		commandFn = command,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
+	} = deps;
 	log( '>> Installing npm packages.' );
-	await command( 'npm ci', {
+	await commandFn( 'npm ci', {
 		cwd: gitWorkingDirectoryPath,
 	} );
 
 	log( '>> Current npm user:' );
-	await command( 'npm whoami', {
+	await commandFn( 'npm whoami', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'inherit',
 	} );
 
-	const beforeCommitHash = await SimpleGit(
-		gitWorkingDirectoryPath
-	).revparse( [ '--short', 'HEAD' ] );
+	const beforeCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
 
 	// Timestamp is the current time in `YYYYMMDDHHMM` format.
 	const timestamp = new Date()
@@ -814,111 +893,53 @@ async function publishPackagesToNpm( {
 
 	const yesFlag = interactive ? '' : '--yes';
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
+	// Keep version commits and package tags local until npm publishing succeeds,
+	// then push and verify Git metadata explicitly.
 	if ( releaseType === 'next' ) {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
 		);
 
-		await command(
-			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private ${ yesFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
-
-		log( '>> Publishing modified packages to npm.' );
-		await command(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
+		await commandFn(
+			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private --no-push ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
 	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
-		log( '>> Publishing modified packages to npm.' );
-		try {
-			await command(
-				`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		} catch {
-			log(
-				'>> Trying to finish failed publishing of modified npm packages.'
-			);
-			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
-			await command(
-				`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		}
-	} else {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
 		);
-		// --no-push keeps the version commit and package tags local until
-		// `lerna publish` succeeds, so a failed retry can re-version
-		// without hitting "tag '@wordpress/<pkg>@<version>' already exists"
-		// on origin.
-		await command(
+		await commandFn(
 			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
-
-		const releasePackages = await getNpmReleasePackages(
-			gitWorkingDirectoryPath
+	} else {
+		log(
+			'>> Bumping version of public packages changed since the last release.'
 		);
-		await runNpmPublishPreflight( {
-			gitWorkingDirectoryPath,
-			releasePackages,
-		} );
-
-		log( '>> Publishing modified packages to npm.' );
-		try {
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		} catch {
-			log(
-				'>> Trying to finish failed publishing of modified npm packages.'
-			);
-			await SimpleGit( gitWorkingDirectoryPath ).reset( 'hard' );
-			await command(
-				`npx lerna publish from-package ${ yesFlag } ${ noVerifyAccessFlag }`,
-				{
-					cwd: gitWorkingDirectoryPath,
-					stdio: 'inherit',
-				}
-			);
-		}
-
-		const publishCommit = await SimpleGit(
-			gitWorkingDirectoryPath
-		).revparse( [ 'HEAD' ] );
-		await pushNpmReleaseGitMetadata( {
-			gitWorkingDirectoryPath,
-			npmReleaseBranch,
-			packageTags: releasePackages.map( ( { tagName } ) => tagName ),
-			publishCommit,
-		} );
+		await commandFn(
+			`npx lerna version ${ minimumVersionBump } --no-private --no-push ${ yesFlag }`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'inherit',
+			}
+		);
 	}
 
-	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
-		[ '--short', 'HEAD' ]
-	);
+	await publishVersionedPackagesToNpmFn( {
+		distTag,
+		gitWorkingDirectoryPath,
+		noVerifyAccessFlag,
+		npmReleaseBranch,
+		yesFlag,
+	} );
+
+	const afterCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
 	if ( afterCommitHash === beforeCommitHash ) {
 		return;
 	}
@@ -1153,6 +1174,8 @@ module.exports = {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	publishPackagesToNpm,
+	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	publishNpmGutenbergPlugin,
 	publishNpmBugfixLatest,

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -394,7 +394,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'retries from-package without resetting local version metadata', async () => {
+	it( 'resets temporary manifest changes before retrying from-package', async () => {
 		const commandFn = jest
 			.fn()
 			.mockRejectedValueOnce( new Error( 'partial publish' ) )
@@ -426,7 +426,13 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 
 		expect( commandFn ).toHaveBeenCalledTimes( 2 );
-		expect( git.reset ).not.toHaveBeenCalled();
+		expect( git.reset ).toHaveBeenCalledWith( 'hard' );
+		expect( commandFn.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			git.reset.mock.invocationCallOrder[ 0 ]
+		);
+		expect( git.reset.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			commandFn.mock.invocationCallOrder[ 1 ]
+		);
 		expect( console ).toHaveLogged();
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -8,6 +8,8 @@ import {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	publishPackagesToNpm,
+	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	runNpmPublishPreflight,
 	runNpmReleaseGitPushPhase,
@@ -339,4 +341,176 @@ describe( 'pushNpmReleaseGitMetadata', () => {
 		} );
 		expect( console ).toHaveLogged();
 	} );
+} );
+
+describe( 'publishVersionedPackagesToNpm', () => {
+	it( 'preflights, publishes from package, and pushes metadata', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+		const getNpmReleasePackagesFn = jest
+			.fn()
+			.mockResolvedValue( [
+				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
+			] );
+		const runNpmPublishPreflightFn = jest.fn();
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/latest',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn,
+				git,
+				pushNpmReleaseGitMetadataFn,
+				runNpmPublishPreflightFn,
+			}
+		);
+
+		expect( getNpmReleasePackagesFn ).toHaveBeenCalledWith( '/repo' );
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			releasePackages: [
+				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
+			],
+		} );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npx lerna publish from-package --dist-tag latest --yes --no-verify-access',
+			{ cwd: '/repo', stdio: 'inherit' }
+		);
+		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			packageTags: [ '@wordpress/a11y@4.50.0' ],
+			publishCommit: 'publish-sha',
+		} );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'retries from-package without resetting local version metadata', async () => {
+		const commandFn = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'partial publish' ) )
+			.mockResolvedValueOnce();
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			reset: jest.fn(),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'next',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/next',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn: jest
+					.fn()
+					.mockResolvedValue( [
+						{ tagName: '@wordpress/a11y@4.50.0-next.0' },
+					] ),
+				git,
+				pushNpmReleaseGitMetadataFn: jest.fn(),
+				runNpmPublishPreflightFn: jest.fn(),
+			}
+		);
+
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( git.reset ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'publishPackagesToNpm', () => {
+	const getConfig = ( releaseType ) => ( {
+		distTag: releaseType === 'next' ? 'next' : 'latest',
+		gitWorkingDirectoryPath: '/repo',
+		interactive: false,
+		minimumVersionBump: 'patch',
+		npmReleaseBranch: releaseType === 'next' ? 'wp/next' : 'wp/latest',
+		releaseType,
+	} );
+
+	it.each( [
+		[
+			'latest',
+			'npx lerna version patch --no-private --no-push --yes',
+			'latest',
+			'wp/latest',
+		],
+		[
+			'next',
+			'npx lerna version prepatch --preid next.v.',
+			'next',
+			'wp/next',
+		],
+		[
+			'bugfix',
+			'npx lerna version patch --no-private --no-push --yes',
+			'latest',
+			'wp/latest',
+		],
+		[
+			'wp',
+			'npx lerna version patch --no-private --no-push --yes',
+			'wp-6.9',
+			'wp/6.9',
+		],
+	] )(
+		'routes %s releases through the shared metadata publishing path',
+		async ( releaseType, versionCommand, distTag, npmReleaseBranch ) => {
+			const commandFn = jest.fn().mockResolvedValue();
+			const git = {
+				revparse: jest
+					.fn()
+					.mockResolvedValueOnce( 'before-sha' )
+					.mockResolvedValueOnce( 'after-sha' ),
+			};
+			const publishVersionedPackagesToNpmFn = jest.fn();
+			const config = {
+				...getConfig( releaseType ),
+				distTag,
+				npmReleaseBranch,
+			};
+
+			await publishPackagesToNpm( config, {
+				commandFn,
+				git,
+				publishVersionedPackagesToNpmFn,
+			} );
+
+			expect( commandFn ).toHaveBeenCalledWith( 'npm ci', {
+				cwd: '/repo',
+			} );
+			expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
+				cwd: '/repo',
+				stdio: 'inherit',
+			} );
+			expect(
+				commandFn.mock.calls.some(
+					( [ command ] ) =>
+						command.startsWith( versionCommand ) &&
+						command.includes( '--no-push' )
+				)
+			).toBe( true );
+			expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
+				distTag,
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch,
+				yesFlag: '--yes',
+			} );
+			expect( console ).toHaveLogged();
+		}
+	);
 } );


### PR DESCRIPTION
Follows #79904. Split from #79859.

## What?

Extend the hardened npm metadata publishing flow from `latest` to the remaining workflow-dispatched package release paths.

## Why?

`next`, `bugfix`, and `wp` releases could still couple npm publication to the final Git push. A late Git failure could leave npm published without matching release branches and tags.

## How?

- Route `next`, `bugfix`, and CLI-driven `wp` releases through local `lerna version ... --no-push` and `lerna publish from-package` phases.
- Reuse the npm preflight, phased branch/tag push, verification, and recovery output introduced in #79904.
- Reset Lerna's temporary manifest changes before retrying a partially failed publish, while preserving the committed versions and local tags.
- Update the `wp` workflow path to use `release-cli npm-wp` and keep its runtime expectation explicit.
- Cover all release types and retry ordering with focused unit tests.

## Testing Instructions

1. `npm run test:unit -- tools/release/commands/test/packages.js`
2. `npm run lint:js -- tools/release/cli.js tools/release/commands/packages.js tools/release/commands/test/packages.js`
3. `git diff --check origin/trunk...HEAD`
4. `npm run build`

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast

N/A

## Use of AI Tools

This PR was prepared with assistance from OpenAI Codex.
