### PR TITLE
Release: Run npm phases in separate jobs

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -524,14 +524,18 @@ jobs:
                         }
                       });
 
-    npm-publish:
-        name: Publish WordPress packages to npm
+    npm-prepare:
+        name: Prepare WordPress packages for npm
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         environment: WordPress packages
         needs: [bump-version, build]
         if: ${{ endsWith( needs.bump-version.outputs.new_version, '-rc.1' ) }}
+        outputs:
+            cli_commit: ${{ steps.release-state.outputs.cli_commit }}
+            prepared_commit: ${{ steps.release-state.outputs.prepared_commit }}
+            release_prepared: ${{ steps.release-state.outputs.release_prepared }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -541,17 +545,16 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
-            - name: Checkout (for publishing)
+            - name: Checkout (for preparation)
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   path: publish
-                  # Later, we switch this branch in the script that publishes packages.
                   ref: trunk
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: true
 
-            - name: Configure git user name and email (for publishing)
+            - name: Configure git user name and email (for preparation)
               run: |
                   cd publish
                   git config user.name "Gutenberg Repository Automation"
@@ -561,13 +564,107 @@ jobs:
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version-file: 'main/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 
-            - name: Publish packages to npm ("latest" dist-tag)
+            - name: Prepare package release
               run: |
                   cd main
                   npm ci
-                  npm exec --no release-cli -- npm-latest --semver minor --ci --repository-path ../publish
+                  npm exec --no release-cli -- npm-latest --semver minor --phase prepare --ci --repository-path ../publish
+
+            - name: Expose prepared release
+              id: release-state
+              run: |
+                  echo "cli_commit=$(git -C main rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+                  PREPARED_COMMIT="$(git -C publish rev-parse HEAD)"
+                  echo "prepared_commit=${PREPARED_COMMIT}" >> "$GITHUB_OUTPUT"
+                  if [[ "$(git -C publish show -s --format=%s "$PREPARED_COMMIT")" == "chore(release): publish" ]]; then
+                    echo "release_prepared=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "release_prepared=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    npm-publish:
+        name: Publish WordPress packages to npm
+        needs: npm-prepare
+        if: ${{ needs.npm-prepare.outputs.release_prepared == 'true' }}
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        environment: WordPress packages
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: main
+                  ref: ${{ needs.npm-prepare.outputs.cli_commit }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Checkout exact prepared commit
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: publish
+                  ref: ${{ needs.npm-prepare.outputs.prepared_commit }}
+                  fetch-depth: 3
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+                  check-latest: true
+
+            - name: Publish prepared packages to npm ("latest" dist-tag)
+              run: |
+                  cd main
+                  npm ci
+                  npm exec --no release-cli -- npm-latest --semver minor --phase publish --ci --repository-path ../publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    npm-finalize:
+        name: Finalize WordPress packages npm release
+        needs: [npm-prepare, npm-publish]
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        environment: WordPress packages
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: main
+                  ref: ${{ needs.npm-prepare.outputs.cli_commit }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Checkout exact published commit
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: publish
+                  ref: ${{ needs.npm-prepare.outputs.prepared_commit }}
+                  fetch-depth: 0
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: true
+
+            - name: Configure git user name and email (for finalization)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  check-latest: true
+
+            - name: Finalize package release
+              run: |
+                  cd main
+                  npm ci
+                  npm exec --no release-cli -- npm-latest --semver minor --phase finalize --ci --repository-path ../publish

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -29,12 +29,16 @@ concurrency:
 permissions: {}
 
 jobs:
-    release:
-        name: Release - ${{ github.event.inputs.release_type }}
+    prepare:
+        name: Prepare - ${{ github.event.inputs.release_type }}
         runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         environment: WordPress packages
+        outputs:
+            cli_commit: ${{ steps.release-state.outputs.cli_commit }}
+            prepared_commit: ${{ steps.release-state.outputs.prepared_commit }}
+            release_prepared: ${{ steps.release-state.outputs.release_prepared }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -44,18 +48,17 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
-            - name: Checkout (for publishing)
+            - name: Checkout (for preparation)
               if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   path: publish
-                  # Later, we switch this branch in the script that publishes packages.
                   ref: trunk
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: true
 
-            - name: Checkout (for publishing WP major version)
+            - name: Checkout (for preparation of WP major version)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
@@ -68,63 +71,143 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: true
 
-            - name: Configure git user name and email (for publishing)
+            - name: Configure git user name and email (for preparation)
               run: |
                   cd publish
                   git config user.name "Gutenberg Repository Automation"
                   git config user.email gutenberg@wordpress.org
 
             - name: Setup Node.js
-              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version-file: 'cli/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
+                  node-version-file: ${{ github.event.inputs.release_type == 'wp' && 'publish/.nvmrc' || 'cli/.nvmrc' }}
                   check-latest: true
 
-            # Keep the release CLI and publish checkout on one runtime;
-            # active wp release branches must stay compatible with the trunk release CLI.
-            - name: Setup Node.js (for WP major version)
-              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version-file: 'publish/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
-                  check-latest: true
-
-            - name: Publish development packages to npm ("next" dist-tag)
-              if: ${{ github.event.inputs.release_type == 'development' }}
-              run: |
-                  cd cli
-                  npm ci
-                  npm exec --no release-cli -- npm-next --ci --repository-path ../publish
+            - name: Prepare package release
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-            - name: Publish packages based on the latest Gutenberg plugin to npm ("latest" dist-tag)
-              if: ${{ github.event.inputs.release_type == 'latest' }}
-              run: |
-                  cd cli
-                  npm ci
-                  npm exec --no release-cli -- npm-latest --semver minor --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-            - name: Publish packages to npm with bug fixes ("latest" dist-tag)
-              if: ${{ github.event.inputs.release_type == 'bugfix' }}
-              run: |
-                  cd cli
-                  npm ci
-                  npm exec --no release-cli -- npm-bugfix --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-            - name: Publish packages to npm for WP major version ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
-              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
-              run: |
-                  cd cli
-                  npm ci
-                  npm exec --no release-cli -- npm-wp --wp-version "$WP_VERSION" --ci --repository-path ../publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}
+              run: |
+                  cd cli
+                  npm ci
+                  case "$RELEASE_TYPE" in
+                    development) RELEASE_COMMAND=(npm-next) ;;
+                    latest) RELEASE_COMMAND=(npm-latest --semver minor) ;;
+                    bugfix) RELEASE_COMMAND=(npm-bugfix) ;;
+                    wp) RELEASE_COMMAND=(npm-wp --wp-version "$WP_VERSION") ;;
+                  esac
+                  npm exec --no release-cli -- "${RELEASE_COMMAND[@]}" --phase prepare --ci --repository-path ../publish
+
+            - name: Expose prepared release
+              id: release-state
+              run: |
+                  echo "cli_commit=$(git -C cli rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+                  PREPARED_COMMIT="$(git -C publish rev-parse HEAD)"
+                  echo "prepared_commit=${PREPARED_COMMIT}" >> "$GITHUB_OUTPUT"
+                  if [[ "$(git -C publish show -s --format=%s "$PREPARED_COMMIT")" == "chore(release): publish" ]]; then
+                    echo "release_prepared=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "release_prepared=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    publish:
+        name: Publish - ${{ github.event.inputs.release_type }}
+        needs: prepare
+        if: ${{ needs.prepare.outputs.release_prepared == 'true' }}
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        environment: WordPress packages
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: cli
+                  ref: ${{ needs.prepare.outputs.cli_commit }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Checkout exact prepared commit
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: publish
+                  ref: ${{ needs.prepare.outputs.prepared_commit }}
+                  fetch-depth: 3
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: ${{ github.event.inputs.release_type == 'wp' && 'publish/.nvmrc' || 'cli/.nvmrc' }}
+                  registry-url: 'https://registry.npmjs.org'
+                  check-latest: true
+
+            - name: Publish prepared packages to npm
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+                  WP_VERSION: ${{ github.event.inputs.wp_version }}
+              run: |
+                  cd cli
+                  npm ci
+                  case "$RELEASE_TYPE" in
+                    development) RELEASE_COMMAND=(npm-next) ;;
+                    latest) RELEASE_COMMAND=(npm-latest --semver minor) ;;
+                    bugfix) RELEASE_COMMAND=(npm-bugfix) ;;
+                    wp) RELEASE_COMMAND=(npm-wp --wp-version "$WP_VERSION") ;;
+                  esac
+                  npm exec --no release-cli -- "${RELEASE_COMMAND[@]}" --phase publish --ci --repository-path ../publish
+
+    finalize:
+        name: Finalize - ${{ github.event.inputs.release_type }}
+        needs: [prepare, publish]
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        environment: WordPress packages
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: cli
+                  ref: ${{ needs.prepare.outputs.cli_commit }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Checkout exact published commit
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  path: publish
+                  ref: ${{ needs.prepare.outputs.prepared_commit }}
+                  fetch-depth: 0
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: true
+
+            - name: Configure git user name and email (for finalization)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: ${{ github.event.inputs.release_type == 'wp' && 'publish/.nvmrc' || 'cli/.nvmrc' }}
+                  check-latest: true
+
+            - name: Finalize package release
+              env:
+                  RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+                  WP_VERSION: ${{ github.event.inputs.wp_version }}
+              run: |
+                  cd cli
+                  npm ci
+                  case "$RELEASE_TYPE" in
+                    development) RELEASE_COMMAND=(npm-next) ;;
+                    latest) RELEASE_COMMAND=(npm-latest --semver minor) ;;
+                    bugfix) RELEASE_COMMAND=(npm-bugfix) ;;
+                    wp) RELEASE_COMMAND=(npm-wp --wp-version "$WP_VERSION") ;;
+                  esac
+                  npm exec --no release-cli -- "${RELEASE_COMMAND[@]}" --phase finalize --ci --repository-path ../publish


### PR DESCRIPTION
Depends on #80202.

## What?

Runs npm release preparation, publication, and finalization in separate GitHub Actions jobs.

## Why?

The npm job must be safely rerunnable on a fresh runner from an exact release commit already stored on GitHub.

## How?

- Preparation pushes the release branch and exposes both the CLI commit and prepared release commit as job outputs.
- Publication checks out those exact commits with read-only repository access and uses only `NPM_TOKEN`.
- Finalization performs Git backports and package-tag writes only after npm succeeds.
- The manual package workflow and the Gutenberg RC1 workflow use the same job boundary.

## Testing Instructions

1. Confirm both changed workflows parse as YAML.
2. Confirm every changed `run` block passes `bash -n`.
3. Confirm `npm run format -- .github/workflows/publish-npm-packages.yml .github/workflows/build-plugin-zip.yml` is clean.
4. Confirm `git diff --check` passes.

## Use of AI Tools

Codex was used to implement and test the changes. The resulting workflow was reviewed, including a separate adversarial self-review pass.
