### PR TITLE
Collaboration: only report changed properties from the default sync config

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -345,8 +345,24 @@ function parseCursorSelection( selection?: WPSelection ): MergeCursorPosition {
 		: null;
 }
 
-function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
-	return getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
+function defaultGetChangesFromCRDTDoc(
+	crdtDoc: CRDTDoc,
+	editedRecord: ObjectData
+): ObjectData {
+	const docRecord = getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
+
+	/*
+	 * Only report properties that differ from the edited record. Reporting
+	 * unchanged properties as edits marks the record dirty: `Y.Map.toJSON()`
+	 * returns fresh object instances, so without this comparison every synced
+	 * update (e.g. from another tab) re-dispatches the entire record as edits.
+	 * See https://github.com/WordPress/gutenberg/issues/79907.
+	 */
+	return Object.fromEntries(
+		Object.entries( docRecord ).filter( ( [ key, newValue ] ) =>
+			haveValuesChanged( editedRecord?.[ key ], newValue )
+		)
+	);
 }
 
 /**

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -68,6 +68,7 @@ import { CRDT_RECORD_MAP_KEY } from '../../sync';
 import {
 	applyPostChangesToCRDTDoc,
 	defaultCollectionSyncConfig,
+	defaultSyncConfig,
 	getPostChangesFromCRDTDoc,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 	type PostChanges,
@@ -92,6 +93,52 @@ const defaultSyncedProperties = new Set< string >( [
 	'tags',
 	'title',
 ] );
+
+describe( 'defaultSyncConfig', () => {
+	// Regression test for https://github.com/WordPress/gutenberg/issues/79907:
+	// reporting unchanged properties as changes marks resolved records
+	// (e.g. taxonomy terms) as dirty whenever a synced update arrives.
+	it( 'getChangesFromCRDTDoc returns no changes when the document matches the edited record', () => {
+		const doc = new Y.Doc();
+		const record = {
+			id: 1,
+			name: 'Uncategorized',
+			slug: 'uncategorized',
+			meta: [],
+			_links: { self: [ { href: 'https://example.com' } ] },
+		};
+		defaultSyncConfig.applyChangesToCRDTDoc( doc, record );
+
+		// The edited record deep-equals the document contents, but
+		// `Y.Map.toJSON()` returns fresh object instances.
+		const changes = defaultSyncConfig.getChangesFromCRDTDoc( doc, {
+			...record,
+			meta: [],
+			_links: { self: [ { href: 'https://example.com' } ] },
+		} );
+
+		expect( changes ).toEqual( {} );
+		doc.destroy();
+	} );
+
+	it( 'getChangesFromCRDTDoc returns only the properties that differ from the edited record', () => {
+		const doc = new Y.Doc();
+		defaultSyncConfig.applyChangesToCRDTDoc( doc, {
+			id: 1,
+			name: 'Renamed category',
+			slug: 'uncategorized',
+		} );
+
+		const changes = defaultSyncConfig.getChangesFromCRDTDoc( doc, {
+			id: 1,
+			name: 'Uncategorized',
+			slug: 'uncategorized',
+		} );
+
+		expect( changes ).toEqual( { name: 'Renamed category' } );
+		doc.destroy();
+	} );
+} );
 
 describe( 'defaultCollectionSyncConfig', () => {
 	it( 'has no-op applyChangesToCRDTDoc', () => {

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-taxonomy-record-dirty.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-taxonomy-record-dirty.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+
+/**
+ * Regression test for https://github.com/WordPress/gutenberg/issues/79907.
+ *
+ * Opening the pre-publish panel resolves the default category record, which
+ * loads the term document into the sync manager. When another peer has the
+ * same term document loaded, its updates are relayed to this client. The
+ * default sync config must not report the unchanged record as edits when
+ * those updates arrive. If it does, the term becomes dirty,
+ * `hasNonPostEntityChanges()` returns true, and the Publish button silently
+ * turns into "Save".
+ */
+test.describe( 'Collaboration - synced taxonomy records', () => {
+	test( 'pre-publish panel does not dirty the default category record', async ( {
+		collaborationUtils,
+		requestUtils,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Taxonomy record dirty regression',
+			content:
+				'<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+
+		const publishPanelFor = ( target: Page ) =>
+			target.locator( '.editor-post-publish-panel' );
+
+		/*
+		 * The toggle is aria-disabled while the editor initializes, which
+		 * Playwright's actionability checks don't wait for, so retry the
+		 * click until the panel opens.
+		 */
+		const openPrePublishPanel = async ( target: Page ) => {
+			const toggle = target
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Publish', exact: true } );
+			const panel = publishPanelFor( target );
+			await expect( async () => {
+				if ( ! ( await panel.isVisible() ) ) {
+					await toggle.click();
+				}
+				await expect( panel ).toBeVisible( { timeout: 2000 } );
+			} ).toPass( { timeout: 20000 } );
+		};
+
+		// Session 1: open the post and the pre-publish panel. This resolves
+		// the default category record and loads the term document into the
+		// sync manager, which starts exchanging it with the server.
+		await collaborationUtils.openPost( post.id );
+		await openPrePublishPanel( page );
+
+		// Session 2: a second tab for the same user opens the same post and
+		// panel. Each tab is a distinct sync client, so the term document
+		// updates of one tab are relayed to the other.
+		const page2 = await page.context().newPage();
+		await page2.goto( `/wp-admin/post.php?post=${ post.id }&action=edit` );
+		await collaborationUtils.waitForCollaborationReady( page2 );
+		await openPrePublishPanel( page2 );
+
+		// Wait until both tabs have exchanged sync messages that include the
+		// default category room.
+		const waitForCategorySyncExchange = ( target: Page ) =>
+			target.waitForResponse(
+				( response ) =>
+					response.url().includes( 'wp-sync' ) &&
+					response.status() === 200 &&
+					( response.request().postData() ?? '' ).includes(
+						'taxonomy/category'
+					),
+				{ timeout: 20000 }
+			);
+		await Promise.all( [
+			waitForCategorySyncExchange( page ),
+			waitForCategorySyncExchange( page2 ),
+		] );
+
+		// The relayed updates carry no actual changes, so the term record
+		// must not accumulate edits in either tab. Poll across several sync
+		// cycles; on regression the record turns dirty within one cycle.
+		const watchForDirtyCategory = ( target: Page ) =>
+			target.evaluate(
+				() =>
+					new Promise( ( resolve ) => {
+						const started = Date.now();
+						const interval = setInterval( () => {
+							const hasEdits = window.wp.data
+								.select( 'core' )
+								.hasEditsForEntityRecord(
+									'taxonomy',
+									'category',
+									1
+								);
+							if ( hasEdits ) {
+								clearInterval( interval );
+								resolve( true );
+							} else if ( Date.now() - started > 10000 ) {
+								clearInterval( interval );
+								resolve( false );
+							}
+						}, 200 );
+					} )
+			);
+		const [ becameDirty, becameDirty2 ] = await Promise.all( [
+			watchForDirtyCategory( page ),
+			watchForDirtyCategory( page2 ),
+		] );
+		expect( becameDirty ).toBe( false );
+		expect( becameDirty2 ).toBe( false );
+
+		// The user-visible symptom: the panel button must still read
+		// "Publish", not "Save".
+		await expect(
+			publishPanelFor( page ).locator(
+				'.editor-post-publish-button__button'
+			)
+		).toHaveText( 'Publish' );
+
+		await page2.close();
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-taxonomy-record-dirty.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-taxonomy-record-dirty.spec.ts
@@ -30,6 +30,7 @@ test.describe( 'Collaboration - synced taxonomy records', () => {
 			content:
 				'<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 
 		const publishPanelFor = ( target: Page ) =>


### PR DESCRIPTION
## What?

Fixes #79907.

With real-time collaboration enabled, resolving any synced taxonomy record (for example the default category, which the pre-publish panel resolves via `MaybeCategoryPanel`) marked that record as having edits as soon as a synced update arrived from another peer. `hasNonPostEntityChanges()` then returned true, so the Publish button in the pre-publish panel silently turned into "Save", the post appeared permanently dirty, and reloading triggered the "Changes you made may not be saved" browser warning.

## Why?

`defaultGetChangesFromCRDTDoc` (used by `defaultSyncConfig`, which all taxonomy entities use) returned the entire CRDT record map as "changes" without comparing against the edited record:

```ts
function defaultGetChangesFromCRDTDoc( crdtDoc: CRDTDoc ): ObjectData {
	return getRootMap( crdtDoc, CRDT_RECORD_MAP_KEY ).toJSON();
}
```

`Y.Map.toJSON()` returns fresh object instances, so when the sync manager dispatched these "changes" as edits (via the raw `EDIT_ENTITY_RECORD` handler in the `getEntityRecord` resolver, which bypasses the action creator's unchanged-value filtering), object-valued properties like `meta` and `_links` always registered as edits and the record became permanently dirty. Nothing the user did cleared them, which is why Cancel never restored the Publish button.

The post-specific `getPostChangesFromCRDTDoc` already deep-compares each property against the edited record; the default config did no comparison at all.

## How?

`defaultGetChangesFromCRDTDoc` now uses its (previously ignored) `editedRecord` argument and only reports properties whose values deep-differ from the edited record, using the same `fastDeepEqual`-based comparison as the post-specific implementation. Genuine remote changes still flow through; unchanged records produce no edits.

## Testing Instructions

Automated coverage:

- New e2e test: `test/e2e/specs/editor/collaboration/http-only/collaboration-taxonomy-record-dirty.spec.ts` opens the pre-publish panel in two tabs (two sync clients) and asserts the default category record stays clean and the panel button keeps its "Publish" label. It fails on trunk and passes with this fix.
- New unit tests for `defaultSyncConfig.getChangesFromCRDTDoc` in `packages/core-data/src/utils/test/crdt.ts`.

Manual:

1. Enable real-time collaboration (Settings > Writing > Collaboration, enabled by default on plugin activation when allowed).
2. Open a draft post in two browser tabs.
3. In both tabs, click Publish so the pre-publish panel opens.
4. Without this fix, within a couple of seconds the panel button in one tab changes from "Publish" to "Save" and `wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords()` shows `taxonomy/category/1` dirty. With the fix, the button stays "Publish" and no entity records become dirty.

[![Test in WP Playground](https://img.shields.io/badge/Test%20in-WP%20Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=79908)
