### PR TITLE
Boot: lazy-load the editor instead of importing it eagerly in the save UI

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Load the editor lazily. The save/"review changes" UI no longer statically imports `@wordpress/editor`, so the editor (and its `block-editor`/`block-library`/`media-utils` dependencies) is only loaded on demand instead of eagerly on every view, including list views that never edit.
+-   Load the editor lazily. The save/"review changes" UI no longer statically imports `@wordpress/editor`, so the editor (and its `block-editor`/`block-library`/`media-utils` dependencies) is only loaded on demand instead of eagerly on every view, including list views that never edit. [#79913](https://github.com/WordPress/gutenberg/pull/79913).
 
 ## 0.17.0 (2026-07-01)
 

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Load the editor lazily. The save/"review changes" UI no longer statically imports `@wordpress/editor`, so the editor (and its `block-editor`/`block-library`/`media-utils` dependencies) is only loaded on demand instead of eagerly on every view, including list views that never edit.
+
 ## 0.17.0 (2026-07-01)
 
 ## 0.16.0 (2026-06-24)

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -1,13 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, Suspense } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
-import { Button, Modal, Spinner } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { Tooltip } from '@wordpress/ui';
 
 /**
@@ -120,12 +120,10 @@ export default function SaveButton() {
 					onRequestClose={ () => setIsSaveViewOpened( false ) }
 					size="small"
 				>
-					<Suspense fallback={ <Spinner /> }>
-						<LazyEntitiesSavedStates
-							close={ () => setIsSaveViewOpened( false ) }
-							variant="inline"
-						/>
-					</Suspense>
+					<LazyEntitiesSavedStates
+						close={ () => setIsSaveViewOpened( false ) }
+						variant="inline"
+					/>
 				</Modal>
 			) }
 		</>

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -1,14 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, Suspense } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
-import { EntitiesSavedStates } from '@wordpress/editor';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, Spinner } from '@wordpress/components';
 import { Tooltip } from '@wordpress/ui';
 
 /**
@@ -16,6 +15,7 @@ import { Tooltip } from '@wordpress/ui';
  */
 import './style.scss';
 import useSaveShortcut from '../save-panel/use-save-shortcut';
+import LazyEntitiesSavedStates from '../save-panel/lazy-entities-saved-states';
 
 export default function SaveButton() {
 	const [ isSaveViewOpen, setIsSaveViewOpened ] = useState( false );
@@ -120,10 +120,12 @@ export default function SaveButton() {
 					onRequestClose={ () => setIsSaveViewOpened( false ) }
 					size="small"
 				>
-					<EntitiesSavedStates
-						close={ () => setIsSaveViewOpened( false ) }
-						variant="inline"
-					/>
+					<Suspense fallback={ <Spinner /> }>
+						<LazyEntitiesSavedStates
+							close={ () => setIsSaveViewOpened( false ) }
+							variant="inline"
+						/>
+					</Suspense>
 				</Modal>
 			) }
 		</>

--- a/packages/boot/src/components/save-panel/index.tsx
+++ b/packages/boot/src/components/save-panel/index.tsx
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useState, Suspense } from '@wordpress/element';
-import { Modal, Spinner } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -26,12 +26,10 @@ export default function SavePanel() {
 			title={ __( 'Review changes' ) }
 			size="small"
 		>
-			<Suspense fallback={ <Spinner /> }>
-				<LazyEntitiesSavedStates
-					close={ () => setIsOpen( false ) }
-					variant="inline"
-				/>
-			</Suspense>
+			<LazyEntitiesSavedStates
+				close={ () => setIsOpen( false ) }
+				variant="inline"
+			/>
 		</Modal>
 	);
 }

--- a/packages/boot/src/components/save-panel/index.tsx
+++ b/packages/boot/src/components/save-panel/index.tsx
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { Modal } from '@wordpress/components';
-import { EntitiesSavedStates } from '@wordpress/editor';
+import { useState, Suspense } from '@wordpress/element';
+import { Modal, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useSaveShortcut from './use-save-shortcut';
+import LazyEntitiesSavedStates from './lazy-entities-saved-states';
 
 export default function SavePanel() {
 	const [ isOpen, setIsOpen ] = useState< boolean >( false );
@@ -26,10 +26,12 @@ export default function SavePanel() {
 			title={ __( 'Review changes' ) }
 			size="small"
 		>
-			<EntitiesSavedStates
-				close={ () => setIsOpen( false ) }
-				variant="inline"
-			/>
+			<Suspense fallback={ <Spinner /> }>
+				<LazyEntitiesSavedStates
+					close={ () => setIsOpen( false ) }
+					variant="inline"
+				/>
+			</Suspense>
 		</Modal>
 	);
 }

--- a/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
+++ b/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { lazy } from '@wordpress/element';
+
+/**
+ * `EntitiesSavedStates` lives in `@wordpress/editor`, a classic script that would
+ * otherwise be pulled into boot's eager dependencies and force the whole editor
+ * (block-editor, block-library, media-utils, …) to load on every view.
+ *
+ * Loading it through `@wordpress/lazy-editor` — a script module — defers the editor
+ * until the "Review changes" modal actually opens, which only happens while editing,
+ * when the editor has already been loaded by the canvas.
+ */
+const LazyEntitiesSavedStates = lazy( () =>
+	import( '@wordpress/lazy-editor' ).then( ( module ) => ( {
+		default: module.EntitiesSavedStates,
+	} ) )
+);
+
+export default LazyEntitiesSavedStates;

--- a/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
+++ b/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentProps } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { lazy, Suspense } from '@wordpress/element';
@@ -19,10 +24,9 @@ const EntitiesSavedStates = lazy( () =>
 	} ) )
 );
 
-export default function LazyEntitiesSavedStates( props: {
-	close: () => void;
-	variant?: 'inline';
-} ) {
+export default function LazyEntitiesSavedStates(
+	props: ComponentProps< typeof EntitiesSavedStates >
+) {
 	return (
 		<Suspense fallback={ <Spinner /> }>
 			<EntitiesSavedStates { ...props } />

--- a/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
+++ b/packages/boot/src/components/save-panel/lazy-entities-saved-states.tsx
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { lazy } from '@wordpress/element';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * `EntitiesSavedStates` lives in `@wordpress/editor`, a classic script that would
@@ -12,10 +13,19 @@ import { lazy } from '@wordpress/element';
  * until the "Review changes" modal actually opens, which only happens while editing,
  * when the editor has already been loaded by the canvas.
  */
-const LazyEntitiesSavedStates = lazy( () =>
+const EntitiesSavedStates = lazy( () =>
 	import( '@wordpress/lazy-editor' ).then( ( module ) => ( {
 		default: module.EntitiesSavedStates,
 	} ) )
 );
 
-export default LazyEntitiesSavedStates;
+export default function LazyEntitiesSavedStates( props: {
+	close: () => void;
+	variant?: 'inline';
+} ) {
+	return (
+		<Suspense fallback={ <Spinner /> }>
+			<EntitiesSavedStates { ...props } />
+		</Suspense>
+	);
+}

--- a/packages/boot/src/components/save-panel/use-save-shortcut.ts
+++ b/packages/boot/src/components/save-panel/use-save-shortcut.ts
@@ -7,11 +7,16 @@ import {
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
 
 const shortcutName = 'core/boot/save';
+
+// The editor store is provided by the classic @wordpress/editor script, which is
+// loaded lazily (via the canvas / lazy-editor). Referencing it by name here — rather
+// than importing the store descriptor — keeps @wordpress/editor out of boot's eager
+// dependency graph so the editor only loads when there is something to edit.
+const EDITOR_STORE_NAME = 'core/editor';
 
 /**
  * Register the save keyboard shortcut in view mode.
@@ -24,11 +29,9 @@ export default function useSaveShortcut( {
 }: {
 	openSavePanel: () => void;
 } ) {
+	const registry = useRegistry();
 	const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } =
 		useSelect( coreStore );
-	const { hasNonPostEntityChanges, isPostSavingLocked } =
-		useSelect( editorStore );
-	const { savePost } = useDispatch( editorStore );
 	const { registerShortcut, unregisterShortcut } = useDispatch(
 		keyboardShortcutsStore
 	);
@@ -57,10 +60,14 @@ export default function useSaveShortcut( {
 		if ( ! hasDirtyEntities || isSaving ) {
 			return;
 		}
-		if ( hasNonPostEntityChanges() ) {
+		// The editor store is only registered once the editor has been loaded.
+		// When it isn't present there is nothing post-related to save, so fall
+		// back to the entity-only save panel.
+		const editorSelectors = registry.select( EDITOR_STORE_NAME );
+		if ( ! editorSelectors || editorSelectors.hasNonPostEntityChanges() ) {
 			openSavePanel();
-		} else if ( ! isPostSavingLocked() ) {
-			savePost();
+		} else if ( ! editorSelectors.isPostSavingLocked() ) {
+			registry.dispatch( EDITOR_STORE_NAME ).savePost();
 		}
 	} );
 }

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Export `EntitiesSavedStates` so consumers can render the editor's "review changes" UI on demand through this script module instead of statically depending on `@wordpress/editor`.
+-   Export `EntitiesSavedStates` so consumers can render the editor's "review changes" UI on demand through this script module instead of statically depending on `@wordpress/editor`. [#79913](https://github.com/WordPress/gutenberg/pull/79913).
 
 ## 1.16.0 (2026-07-01)
 

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Export `EntitiesSavedStates` so consumers can render the editor's "review changes" UI on demand through this script module instead of statically depending on `@wordpress/editor`.
+
 ## 1.16.0 (2026-07-01)
 
 ## 1.15.0 (2026-06-24)

--- a/packages/lazy-editor/src/index.tsx
+++ b/packages/lazy-editor/src/index.tsx
@@ -1,4 +1,12 @@
 /**
+ * WordPress dependencies
+ */
+// Re-exported through this script module so consumers (e.g. @wordpress/boot) can load
+// the editor-backed "review changes" UI on demand instead of pulling the classic
+// @wordpress/editor script into their eager dependencies.
+export { EntitiesSavedStates } from '@wordpress/editor';
+
+/**
  * Internal dependencies
  */
 export { Editor } from './components/editor';

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Generated pages now enqueue the classic script dependencies declared by each route's content and route modules, merged into the prerequisites script. Previously a route relied on whatever classic scripts `@wordpress/boot` happened to load eagerly, so a route using e.g. `@wordpress/viewport` could break if those were not loaded. [#79913](https://github.com/WordPress/gutenberg/pull/79913).
+
 ### Enhancements
 
 -   Widgets: carry the optional metadata fields from `widget.json` into

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -72,6 +72,47 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
 }
 
 /**
+ * Collect the classic script dependencies for the {{PAGE_SLUG}}-wp-admin prerequisites script.
+ *
+ * Merges @wordpress/boot's classic dependencies with the classic script dependencies
+ * declared by each route's content and route modules. Script modules cannot load
+ * classic-script dependencies themselves, so the page is responsible for enqueuing
+ * them; otherwise a route relies on whatever @wordpress/boot happens to load eagerly.
+ *
+ * @param array $routes            Registered routes (may carry content_module / route_module ids).
+ * @param array $boot_dependencies Classic script dependencies of @wordpress/boot.
+ * @return array De-duplicated list of classic script handles.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies( $routes, $boot_dependencies ) {
+	$dependencies = $boot_dependencies;
+
+	foreach ( $routes as $route ) {
+		foreach ( array( 'content_module', 'route_module' ) as $module_key ) {
+			if ( empty( $route[ $module_key ] ) ) {
+				continue;
+			}
+
+			// Module ids look like "<namespace>/routes/<name>/(content|route)".
+			if ( ! preg_match( '#/routes/([^/]+)/(content|route)$#', $route[ $module_key ], $matches ) ) {
+				continue;
+			}
+
+			$module_asset_path = __DIR__ . '/../../routes/' . $matches[1] . '/' . $matches[2] . '.min.asset.php';
+			if ( ! file_exists( $module_asset_path ) ) {
+				continue;
+			}
+
+			$module_asset = require $module_asset_path;
+			if ( ! empty( $module_asset['dependencies'] ) ) {
+				$dependencies = array_merge( $dependencies, $module_asset['dependencies'] );
+			}
+		}
+	}
+
+	return array_values( array_unique( $dependencies ) );
+}
+
+/**
  * Get all registered menu items for the {{PAGE_SLUG}}-wp-admin page.
  *
  * @return array Array of menu item objects.
@@ -150,10 +191,18 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 	if ( file_exists( $asset_file ) ) {
 		$asset = require $asset_file;
 
+		// Route content/route modules declare their own classic script dependencies
+		// (e.g. wp-viewport) that must be present before the module evaluates. Because
+		// script modules do not load classic-script dependencies themselves, merge each
+		// route's declared dependencies into the prerequisites script. This lets each
+		// route reliably receive its classic dependencies without relying on whatever
+		// @wordpress/boot happens to load eagerly.
+		$prerequisite_dependencies = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies( $routes, $asset['dependencies'] );
+
 		// This script serves two purposes:
 		// 1. It ensures all the globals that are made available to the modules are loaded.
 		// 2. It initializes the boot module as an inline script.
-		wp_register_script( '{{PAGE_SLUG}}-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
+		wp_register_script( '{{PAGE_SLUG}}-wp-admin-prerequisites', '', $prerequisite_dependencies, $asset['version'], true );
 
 		$init_modules = {{INIT_MODULES_JSON}};
 
@@ -193,7 +242,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 
 		// Register prerequisites style by filtering script dependencies to find registered styles
 		$style_dependencies = array_filter(
-			$asset['dependencies'],
+			$prerequisite_dependencies,
 			function ( $handle ) {
 				return wp_style_is( $handle, 'registered' );
 			}

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -10,20 +10,22 @@
  * @package {{PREFIX}}
  */
 
-// Global storage for {{PAGE_SLUG}} routes and menu items
-global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items;
-${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes     = array();
-${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items = array();
+// Global storage for {{PAGE_SLUG}} routes, menu items, and route classic dependencies
+global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies;
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes             = array();
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_items         = array();
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies = array();
 
 /**
  * Register a route for the {{PAGE_SLUG}}-wp-admin page.
  *
- * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
- * @param string|null $content_module Script module ID for content (stage/inspector).
- * @param string|null $route_module   Script module ID for route lifecycle hooks.
+ * @param string      $path                 Route path (e.g., '/types/$type/edit/$id').
+ * @param string|null $content_module       Script module ID for content (stage/inspector).
+ * @param string|null $route_module         Script module ID for route lifecycle hooks.
+ * @param array       $classic_dependencies Classic script handles the route's modules depend on.
  */
-function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $content_module = null, $route_module = null ) {
-	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $content_module = null, $route_module = null, $classic_dependencies = array() ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies;
 
 	$route = array( 'path' => $path );
 	if ( ! empty( $content_module ) ) {
@@ -33,7 +35,11 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route( $path, $co
 		$route['route_module'] = $route_module;
 	}
 
-	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes[] = $route;
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes[]             = $route;
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies = array_merge(
+		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies,
+		$classic_dependencies
+	);
 }
 
 /**
@@ -69,47 +75,6 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_menu_item( $id, $
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes() {
 	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes;
 	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes ?? array();
-}
-
-/**
- * Collect the classic script dependencies for the {{PAGE_SLUG}}-wp-admin prerequisites script.
- *
- * Merges @wordpress/boot's classic dependencies with the classic script dependencies
- * declared by each route's content and route modules. Script modules cannot load
- * classic-script dependencies themselves, so the page is responsible for enqueuing
- * them; otherwise a route relies on whatever @wordpress/boot happens to load eagerly.
- *
- * @param array $routes            Registered routes (may carry content_module / route_module ids).
- * @param array $boot_dependencies Classic script dependencies of @wordpress/boot.
- * @return array De-duplicated list of classic script handles.
- */
-function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies( $routes, $boot_dependencies ) {
-	$dependencies = $boot_dependencies;
-
-	foreach ( $routes as $route ) {
-		foreach ( array( 'content_module', 'route_module' ) as $module_key ) {
-			if ( empty( $route[ $module_key ] ) ) {
-				continue;
-			}
-
-			// Module ids look like "<namespace>/routes/<name>/(content|route)".
-			if ( ! preg_match( '#/routes/([^/]+)/(content|route)$#', $route[ $module_key ], $matches ) ) {
-				continue;
-			}
-
-			$module_asset_path = __DIR__ . '/../../routes/' . $matches[1] . '/' . $matches[2] . '.min.asset.php';
-			if ( ! file_exists( $module_asset_path ) ) {
-				continue;
-			}
-
-			$module_asset = require $module_asset_path;
-			if ( ! empty( $module_asset['dependencies'] ) ) {
-				$dependencies = array_merge( $dependencies, $module_asset['dependencies'] );
-			}
-		}
-	}
-
-	return array_values( array_unique( $dependencies ) );
 }
 
 /**
@@ -192,12 +157,17 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 		$asset = require $asset_file;
 
 		// Route content/route modules declare their own classic script dependencies
-		// (e.g. wp-viewport) that must be present before the module evaluates. Because
-		// script modules do not load classic-script dependencies themselves, merge each
-		// route's declared dependencies into the prerequisites script. This lets each
-		// route reliably receive its classic dependencies without relying on whatever
-		// @wordpress/boot happens to load eagerly.
-		$prerequisite_dependencies = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies( $routes, $asset['dependencies'] );
+		// (e.g. wp-viewport) that must be present before the module evaluates. Script
+		// modules cannot load classic-script dependencies themselves, so the deps
+		// collected during route registration are merged into the prerequisites script.
+		// This lets each route reliably receive its classic dependencies without relying
+		// on whatever @wordpress/boot happens to load eagerly.
+		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies;
+		$prerequisite_dependencies = array_values(
+			array_unique(
+				array_merge( $asset['dependencies'], ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_route_dependencies )
+			)
+		);
 
 		// This script serves two purposes:
 		// 1. It ensures all the globals that are made available to the modules are loaded.

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -7,20 +7,22 @@
  * @package {{PREFIX}}
  */
 
-// Global storage for {{PAGE_SLUG}} routes and menu items
-global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items;
-${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes     = array();
-${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items = array();
+// Global storage for {{PAGE_SLUG}} routes, menu items, and route classic dependencies
+global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies;
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes             = array();
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_menu_items         = array();
+${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies = array();
 
 /**
  * Register a route for the {{PAGE_SLUG}} page.
  *
- * @param string      $path           Route path (e.g., '/types/$type/edit/$id').
- * @param string|null $content_module Script module ID for content (stage/inspector).
- * @param string|null $route_module   Script module ID for route lifecycle hooks.
+ * @param string      $path                 Route path (e.g., '/types/$type/edit/$id').
+ * @param string|null $content_module       Script module ID for content (stage/inspector).
+ * @param string|null $route_module         Script module ID for route lifecycle hooks.
+ * @param array       $classic_dependencies Classic script handles the route's modules depend on.
  */
-function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_module = null, $route_module = null ) {
-	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
+function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_module = null, $route_module = null, $classic_dependencies = array() ) {
+	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes, ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies;
 
 	$route = array( 'path' => $path );
 	if ( ! empty( $content_module ) ) {
@@ -30,7 +32,11 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_route( $path, $content_mod
 		$route['route_module'] = $route_module;
 	}
 
-	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes[] = $route;
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes[]             = $route;
+	${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies = array_merge(
+		${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies,
+		$classic_dependencies
+	);
 }
 
 /**
@@ -70,47 +76,6 @@ function {{PREFIX}}_register_{{PAGE_SLUG_UNDERSCORE}}_menu_item( $id, $label, $t
 function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
 	global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes;
 	return ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_routes ?? array();
-}
-
-/**
- * Collect the classic script dependencies for the {{PAGE_SLUG}} prerequisites script.
- *
- * Merges @wordpress/boot's classic dependencies with the classic script dependencies
- * declared by each route's content and route modules. Script modules cannot load
- * classic-script dependencies themselves, so the page is responsible for enqueuing
- * them; otherwise a route relies on whatever @wordpress/boot happens to load eagerly.
- *
- * @param array $routes            Registered routes (may carry content_module / route_module ids).
- * @param array $boot_dependencies Classic script dependencies of @wordpress/boot.
- * @return array De-duplicated list of classic script handles.
- */
-function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies( $routes, $boot_dependencies ) {
-	$dependencies = $boot_dependencies;
-
-	foreach ( $routes as $route ) {
-		foreach ( array( 'content_module', 'route_module' ) as $module_key ) {
-			if ( empty( $route[ $module_key ] ) ) {
-				continue;
-			}
-
-			// Module ids look like "<namespace>/routes/<name>/(content|route)".
-			if ( ! preg_match( '#/routes/([^/]+)/(content|route)$#', $route[ $module_key ], $matches ) ) {
-				continue;
-			}
-
-			$module_asset_path = __DIR__ . '/../../routes/' . $matches[1] . '/' . $matches[2] . '.min.asset.php';
-			if ( ! file_exists( $module_asset_path ) ) {
-				continue;
-			}
-
-			$module_asset = require $module_asset_path;
-			if ( ! empty( $module_asset['dependencies'] ) ) {
-				$dependencies = array_merge( $dependencies, $module_asset['dependencies'] );
-			}
-		}
-	}
-
-	return array_values( array_unique( $dependencies ) );
 }
 
 /**
@@ -198,12 +163,17 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 		$asset = require $asset_file;
 
 		// Route content/route modules declare their own classic script dependencies
-		// (e.g. wp-viewport) that must be present before the module evaluates. Because
-		// script modules do not load classic-script dependencies themselves, merge each
-		// route's declared dependencies into the prerequisites script. This lets each
-		// route reliably receive its classic dependencies without relying on whatever
-		// @wordpress/boot happens to load eagerly.
-		$prerequisite_dependencies = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies( $routes, $asset['dependencies'] );
+		// (e.g. wp-viewport) that must be present before the module evaluates. Script
+		// modules cannot load classic-script dependencies themselves, so the deps
+		// collected during route registration are merged into the prerequisites script.
+		// This lets each route reliably receive its classic dependencies without relying
+		// on whatever @wordpress/boot happens to load eagerly.
+		global ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies;
+		$prerequisite_dependencies = array_values(
+			array_unique(
+				array_merge( $asset['dependencies'], ${{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies )
+			)
+		);
 
 		// This script serves two purposes:
 		// 1. It ensures all the globals that are made available to the modules are loaded.

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -73,6 +73,47 @@ function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes() {
 }
 
 /**
+ * Collect the classic script dependencies for the {{PAGE_SLUG}} prerequisites script.
+ *
+ * Merges @wordpress/boot's classic dependencies with the classic script dependencies
+ * declared by each route's content and route modules. Script modules cannot load
+ * classic-script dependencies themselves, so the page is responsible for enqueuing
+ * them; otherwise a route relies on whatever @wordpress/boot happens to load eagerly.
+ *
+ * @param array $routes            Registered routes (may carry content_module / route_module ids).
+ * @param array $boot_dependencies Classic script dependencies of @wordpress/boot.
+ * @return array De-duplicated list of classic script handles.
+ */
+function {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies( $routes, $boot_dependencies ) {
+	$dependencies = $boot_dependencies;
+
+	foreach ( $routes as $route ) {
+		foreach ( array( 'content_module', 'route_module' ) as $module_key ) {
+			if ( empty( $route[ $module_key ] ) ) {
+				continue;
+			}
+
+			// Module ids look like "<namespace>/routes/<name>/(content|route)".
+			if ( ! preg_match( '#/routes/([^/]+)/(content|route)$#', $route[ $module_key ], $matches ) ) {
+				continue;
+			}
+
+			$module_asset_path = __DIR__ . '/../../routes/' . $matches[1] . '/' . $matches[2] . '.min.asset.php';
+			if ( ! file_exists( $module_asset_path ) ) {
+				continue;
+			}
+
+			$module_asset = require $module_asset_path;
+			if ( ! empty( $module_asset['dependencies'] ) ) {
+				$dependencies = array_merge( $dependencies, $module_asset['dependencies'] );
+			}
+		}
+	}
+
+	return array_values( array_unique( $dependencies ) );
+}
+
+/**
  * Get all registered menu items for the {{PAGE_SLUG}} page.
  *
  * @return array Array of menu item objects.
@@ -156,10 +197,18 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	if ( file_exists( $asset_file ) ) {
 		$asset = require $asset_file;
 
+		// Route content/route modules declare their own classic script dependencies
+		// (e.g. wp-viewport) that must be present before the module evaluates. Because
+		// script modules do not load classic-script dependencies themselves, merge each
+		// route's declared dependencies into the prerequisites script. This lets each
+		// route reliably receive its classic dependencies without relying on whatever
+		// @wordpress/boot happens to load eagerly.
+		$prerequisite_dependencies = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_route_dependencies( $routes, $asset['dependencies'] );
+
 		// This script serves two purposes:
 		// 1. It ensures all the globals that are made available to the modules are loaded.
 		// 2. It initializes the boot module as an inline script.
-		wp_register_script( '{{PAGE_SLUG}}-prerequisites', '', $asset['dependencies'], $asset['version'], true );
+		wp_register_script( '{{PAGE_SLUG}}-prerequisites', '', $prerequisite_dependencies, $asset['version'], true );
 
 		// Add inline script to initialize the app
 		$init_modules = {{INIT_MODULES_JSON}};
@@ -177,7 +226,7 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 
 		// Register prerequisites style by filtering script dependencies to find registered styles
 		$style_dependencies = array_filter(
-			$asset['dependencies'],
+			$prerequisite_dependencies,
 			function ( $handle ) {
 				return wp_style_is( $handle, 'registered' );
 			}

--- a/packages/wp-build/templates/routes-registration.php.template
+++ b/packages/wp-build/templates/routes-registration.php.template
@@ -46,6 +46,11 @@ function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name 
 		$content_handle = null;
 		$route_handle = null;
 
+		// Classic script dependencies declared by this route's modules. Script modules
+		// cannot load classic-script dependencies themselves, so they are collected here
+		// and enqueued by the page's prerequisites script (see the page render function).
+		$classic_dependencies = array();
+
 		// Register content module if exists
 		if ( $route['has_content'] ) {
 			$content_asset_path = __DIR__ . "/routes/{$route['name']}/content.min.asset.php";
@@ -53,6 +58,7 @@ function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name 
 				$content_asset = require $content_asset_path;
 				$content_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/content';
 				$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+				$classic_dependencies = array_merge( $classic_dependencies, $content_asset['dependencies'] ?? array() );
 				// Deregister first to override any previously registered version
 				// (e.g., Core's default modules when running as a plugin).
 				wp_deregister_script_module( $content_handle );
@@ -72,6 +78,7 @@ function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name 
 				$route_asset = require $route_asset_path;
 				$route_handle = '{{HANDLE_PREFIX}}/routes/' . $route['name'] . '/route';
 				$extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
+				$classic_dependencies = array_merge( $classic_dependencies, $route_asset['dependencies'] ?? array() );
 				// Deregister first to override any previously registered version
 				// (e.g., Core's default modules when running as a plugin).
 				wp_deregister_script_module( $route_handle );
@@ -86,7 +93,7 @@ function {{PREFIX}}_register_page_routes( $page_routes, $register_function_name 
 
 		// Register route with page
 		if ( function_exists( $register_function_name ) ) {
-			call_user_func( $register_function_name, $route['path'], $content_handle, $route_handle );
+			call_user_func( $register_function_name, $route['path'], $content_handle, $route_handle, $classic_dependencies );
 		}
 	}
 }


### PR DESCRIPTION
## What?

Make `@wordpress/boot` load the editor lazily, so the block editor (and its heavy `block-editor` / `block-library` / `media-utils` dependencies) is only loaded on demand instead of eagerly on every boot-powered view. Includes a companion fix in `@wordpress/build` so routes reliably receive their own classic script dependencies.

## Why?

`@wordpress/editor` is a classic script. Boot's `SaveButton`, `SavePanel`, and `use-save-shortcut` are part of the always-mounted shell and statically imported `EntitiesSavedStates` and the `editor` store from it. Because a classic-script import lands in a module's eager `dependencies` regardless of whether it is static or dynamic, this forced the entire editor (~2–3 MB of JS) to load on **every** boot-powered page, including list/dashboard views that never open the editor.

## How?

**1. `@wordpress/boot` + `@wordpress/lazy-editor` — defer the editor.** The only way to defer a classic-script package is through a script-module boundary, which is what `@wordpress/lazy-editor` is:

- `@wordpress/lazy-editor`: re-export `EntitiesSavedStates`.
- boot save UI: render `EntitiesSavedStates` through a `React.lazy` wrapper that dynamically imports `@wordpress/lazy-editor`, behind `<Suspense>`. The "Review changes" modal only opens while editing — when the editor is already loaded by the canvas — so there is no added latency.
- `use-save-shortcut`: reference the editor store by name (`core/editor`) via `useRegistry` instead of importing the store descriptor.

**2. `@wordpress/build` — enqueue route classic dependencies (companion fix).** Removing the eager editor surfaced a latent coupling: the generated boot page registered its prerequisites script with **only `@wordpress/boot`'s** classic dependencies, so a route's own classic dependencies (e.g. `@wordpress/viewport`) were only present because the editor happened to pull them in. Generated pages now merge each route content/route module's declared classic `dependencies` into the prerequisites script, so every route reliably gets its classic dependencies independent of what boot loads.

## Testing Instructions

Verified locally with `wp-env` on the experimental **Dashboard (Beta)** page (`gutenberg-dashboard-widgets` experiment), which mounts `@wordpress/boot`:

1. Enable the "Dashboard (Beta)" experiment and open it.
2. In DevTools → Network, confirm `editor.min.js` / `block-editor.min.js` are **not** requested on load (the editor stays lazy), while the page renders correctly.
3. Confirm `window.wp.editor` is `undefined` on load but `window.wp.viewport` is defined (the route's own classic dep is present).
4. In the Post/Site editor, make an entity change and Save (button and <kbd>Cmd/Ctrl</kbd>+<kbd>S</kbd>): the "Review changes" modal opens and saving works as before (a brief `<Suspense>` spinner may show on first open while `@wordpress/lazy-editor` resolves).

Before the companion fix, the Dashboard (Beta) crashed with *"Cannot read properties of undefined (reading 'name')"* because `wp.viewport` was no longer loaded; with it, the dashboard renders identically to trunk and the editor remains lazy.
