### PR TITLE
Fix: DataForm inspector shows raw "auto-draft" status for new posts

### DIFF
--- a/packages/fields/src/fields/status/index.tsx
+++ b/packages/fields/src/fields/status/index.tsx
@@ -18,6 +18,10 @@ const statusField: Field< BasePost > = {
 	id: 'status',
 	type: 'text',
 	elements: STATUSES,
+	// An auto-draft is a draft that hasn't been saved yet, so treat it as
+	// one for display, selection, and filtering.
+	getValue: ( { item } ) =>
+		item.status === 'auto-draft' ? 'draft' : item.status,
 	render: StatusView,
 	Edit: 'radio',
 	enableSorting: false,

--- a/packages/fields/src/fields/status/status-view.tsx
+++ b/packages/fields/src/fields/status/status-view.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalHStack as HStack,
 	Icon as WCIcon,
 } from '@wordpress/components';
+import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -12,9 +13,10 @@ import {
 import type { BasePost } from '../../types';
 import STATUSES from './status-elements';
 
-function StatusView( { item }: { item: BasePost } ) {
-	const status = STATUSES.find( ( { value } ) => value === item.status );
-	const label = status?.label || item.status;
+function StatusView( { item, field }: DataViewRenderFieldProps< BasePost > ) {
+	const currentStatus = field.getValue( { item } );
+	const status = STATUSES.find( ( { value } ) => value === currentStatus );
+	const label = status?.label || currentStatus;
 	const icon = status?.icon;
 	return (
 		<HStack alignment="left" spacing={ 0 }>

--- a/test/e2e/specs/editor/various/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary.spec.js
@@ -275,4 +275,32 @@ test.describe( 'Post Summary', () => {
 			};
 		}
 	} );
+
+	test.describe( 'post status', () => {
+		test( 'shows Draft for a new post before it has been saved', async ( {
+			admin,
+			editor,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await editor.openDocumentSettingsSidebar();
+
+			const summary = page.locator( '.editor-post-summary' );
+			await expect( summary ).toBeVisible();
+
+			// A new post is an `auto-draft`, which should be presented as
+			// a Draft.
+			const editButton = summary.getByRole( 'button', {
+				name: 'Edit Status',
+			} );
+			await expect(
+				editButton.locator( '..' ).getByText( 'Draft', { exact: true } )
+			).toBeVisible();
+
+			await editButton.click();
+			await expect(
+				page.getByRole( 'radio', { name: 'Draft' } )
+			).toBeChecked();
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/various/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary.spec.js
@@ -293,9 +293,7 @@ test.describe( 'Post Summary', () => {
 			const editButton = summary.getByRole( 'button', {
 				name: 'Edit Status',
 			} );
-			await expect(
-				editButton.locator( '..' ).getByText( 'Draft', { exact: true } )
-			).toBeVisible();
+			await expect( editButton ).toHaveAccessibleDescription( 'Draft' );
 
 			await editButton.click();
 			await expect(


### PR DESCRIPTION
## What?

Part of: https://github.com/WordPress/gutenberg/issues/76076


- Normalizes `auto-draft` to `draft` in the shared status field so DataForm display, radio selection, filtering, and sorting semantics all see Draft.
- Updates `StatusView` to render from the field's normalized value instead of raw `item.status`.
- Adds e2e coverage for a new post showing Draft in the DataForm inspector and pre-selecting the Draft radio.

## Before
<img width="620" height="618" alt="Screenshot 2026-07-06 at 18 12 17" src="https://github.com/user-attachments/assets/bea9553f-f294-45aa-8518-1a92290fb364" />


## After
<img width="561" height="564" alt="Screenshot 2026-07-06 at 20 47 00" src="https://github.com/user-attachments/assets/f5535f0c-3e55-455c-b68c-ef2a07080686" />

## Testing
- Verify the end to end tests pass.
- Enable Experiment: Editor Inspector: Use DataForm.
- Create a new post and verify status is draft and not auto-draft.