### PR TITLE
DimensionControl: Include styles in stylesheet

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `DimensionControl`: Include component styles in the block editor stylesheet so the fieldset reset is applied in Storybook and other contexts without WordPress core styles ([#79916](https://github.com/WordPress/gutenberg/pull/79916)).
 -   `InnerContent`: Render the selected inner block synchronously so its rich text selection stays current while typing; otherwise a stale selection offset could place a typed character at the wrong position in editable static inner blocks ([#79726](https://github.com/WordPress/gutenberg/pull/79726)).
 -   `useTypingObserver`: Capture the window reference at mount and reuse it during cleanup so the ref cleanup no longer reads `node.ownerDocument.defaultView` (which is `null` once the iframe-hosted editor has been detached from its window) and throws, which was also leaking the `removeEventListener` calls that follow it ([#78772](https://github.com/WordPress/gutenberg/pull/78772)).
 

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -30,6 +30,7 @@
 @use "./components/border-radius-control/style.scss" as *;
 @use "./components/colors-gradients/style.scss" as *;
 @use "./components/date-format-picker/style.scss" as *;
+@use "./components/dimension-control/style.scss" as *;
 @use "./components/duotone-control/style.scss" as *;
 @use "./components/fit-text-size-warning/style.scss" as *;
 @use "./components/font-appearance-control/style.scss" as *;


### PR DESCRIPTION
## What?

Includes [`packages/block-editor/src/components/dimension-control/style.scss`](packages/block-editor/src/components/dimension-control/style.scss) in the block editor stylesheet.

## Why?

The `DimensionControl` component renders a `<fieldset>` with the `block-editor-dimension-control` class, but its stylesheet was never imported in [`packages/block-editor/src/style.scss`](packages/block-editor/src/style.scss). The missing fieldset reset was masked in the editor because WordPress core `common.css` applies the same reset, but it is visibly broken in Storybook when core styles are not loaded.

## How?

Add the missing `@use` import alongside the other component stylesheets.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open the `BlockEditor/DimensionControl` story.
3. Confirm the fieldset no longer shows a default browser border around the control.

## Screenshots or screencast

| Before | After |
|--------|-------|
|<img width="800" height="400" alt="Fieldset shows a default browser border around the control" src="https://github.com/user-attachments/assets/fa27a8f4-a649-4a92-b211-a215d9cc0c6d" />|<img width="800" height="400" alt="Fieldset border is removed; control matches other dimension controls like `HeightControl`" src="https://github.com/user-attachments/assets/bcf330ca-a318-4234-bb18-a46bfc74e819" />|