### PR TITLE
Design system MCP: Document Codex CLI prerequisite for MCP setup

### DIFF
--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -24,6 +24,8 @@ claude mcp add wordpress-design-system -- npx -y --ignore-scripts --min-release-
 
 ### OpenAI Codex
 
+The [Codex CLI](https://developers.openai.com/codex/cli) must be installed first. Having the Codex desktop app alone is not sufficient.
+
 ```bash
 codex mcp add wordpress-design-system -- npx -y --ignore-scripts --min-release-age=2 @wordpress/design-system-mcp@latest
 ```

--- a/packages/design-system-mcp/README.md
+++ b/packages/design-system-mcp/README.md
@@ -24,7 +24,7 @@ claude mcp add wordpress-design-system -- npx -y --ignore-scripts --min-release-
 
 ### OpenAI Codex
 
-The [Codex CLI](https://developers.openai.com/codex/cli) must be installed first. Having the Codex desktop app alone is not sufficient.
+The [Codex CLI](https://developers.openai.com/codex/cli) must be installed first.
 
 ```bash
 codex mcp add wordpress-design-system -- npx -y --ignore-scripts --min-release-age=2 @wordpress/design-system-mcp@latest


### PR DESCRIPTION
## What?

Adds a note to the design system MCP setup instructions clarifying that OpenAI Codex users need the Codex CLI installed before running `codex mcp add`.

## Why?

It might not be obvious to a non-technical reader.

## Testing Instructions

1. Open [`packages/design-system-mcp/README.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/design-system-mcp/README.md).
2. Confirm the OpenAI Codex section mentions the Codex CLI prerequisite and links to the setup guide.