### PR TITLE
Lint-staged: Match lint:css file globs

### DIFF
--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
 		() => 'npm run prelint:js',
 		'node ./tools/eslint/lint-js.cjs --config eslint.config.strict.cjs',
 	],
-	'**/*.{scss,module.css}': [ 'wp-scripts lint-style' ],
+	'*.{scss,module.css}': [ 'wp-scripts lint-style' ],
 	'package-lock.json': [ 'npm run lint:lockfile' ],
 	'packages/*/package.json': [ 'wp-scripts lint-pkg-json' ],
 	'{docs/toc.json,tools/docs/*.cjs,packages/{*/README.md,components/src/*/**/README.md,block-library/src/*/README.md}}':

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
 		() => 'npm run prelint:js',
 		'node ./tools/eslint/lint-js.cjs --config eslint.config.strict.cjs',
 	],
-	'*.scss': [ 'wp-scripts lint-style' ],
+	'**/*.{scss,module.css}': [ 'wp-scripts lint-style' ],
 	'package-lock.json': [ 'npm run lint:lockfile' ],
 	'packages/*/package.json': [ 'wp-scripts lint-pkg-json' ],
 	'{docs/toc.json,tools/docs/*.cjs,packages/{*/README.md,components/src/*/**/README.md,block-library/src/*/README.md}}':


### PR DESCRIPTION
## What?

Updates the lint-staged CSS matcher to cover the same file types as `lint:css`: SCSS and CSS module stylesheets.

## Why?

Pre-commit stylelint only ran on `*.scss`, which missed `.module.css` files. CI already lints both via `npm run lint:css`, so this closes a gap between local hooks and CI.

## How?

Replace the `*.scss` lint-staged pattern with `*.{scss,module.css}`.

## Testing Instructions

Stage a change to a CSS module file (e.g. `packages/ui/src/button/style.module.css`) and run `npx lint-staged`. Confirm stylelint runs.