### PR TITLE
Media Inserter: Allow core media categories to subscribe to changes

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -84,16 +84,18 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const { createErrorNotice, createSuccessNotice, createWarningNotice } =
 		useDispatch( noticesStore );
 
-	// The attach/detach workflow belongs to WordPress's built-in Attachments
-	// source, which manages images attached to the current post. Any category
+	// Private to core's media categories, these capabilities act on WordPress
+	// attachments:
+	// - `attach`/`detach`/`invalidate` manage the images attached to this post.
+	// - `subscribe` watches the attachment cache backing them.
+	// An external resource can never own a post's attachments, and every category
 	// registered by an extender through the public `registerInserterMediaCategory`
-	// API is always flagged as an external resource, so this guard stops such a
-	// category from opting into that workflow just by setting these props. The
-	// guard also reflects the underlying semantics: an external resource can
-	// never own a post's attachments.
+	// API is flagged as one — so this guard stops such a category from opting into
+	// the workflow just by setting these props.
 	const supportsAttachments = ! category.isExternalResource;
 	const attach = supportsAttachments ? category.attach : undefined;
 	const detach = supportsAttachments ? category.detach : undefined;
+	const subscribe = supportsAttachments ? category.subscribe : undefined;
 
 	// Dim (rather than blank) the populated grid while a refetch is in flight,
 	// but only once it has run long enough to be worth signalling — quick
@@ -109,25 +111,16 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 		setRefreshKey( ( key ) => key + 1 );
 	}, [ category, query, supportsAttachments ] );
 
-	// A media modal can be opened from anywhere in the editor (a block in the
-	// canvas, the featured-image panel, this panel's own "Attach images"
-	// button), and uploading in it attaches media to the current post. Closing
-	// such a modal invalidates the cached attachment queries; subscribe so this
-	// grid refetches and reflects the newly attached images. Categories that
-	// aren't core-data-backed (e.g. Openverse) expose no `subscribe` and opt out.
+	// A media modal opened anywhere in the editor (a canvas block, the featured
+	// image panel, the "Attach images" button) attaches its uploads to the current
+	// post, and invalidates the cached attachment queries when it closes. Refetch
+	// so the grid reflects the newly attached images.
 	useEffect( () => {
-		if ( ! category.subscribe ) {
+		if ( ! subscribe ) {
 			return undefined;
 		}
-		// The returned unsubscribe is React's cleanup: it runs on unmount (e.g.
-		// switching category, since only the active panel is mounted) and before
-		// each re-subscribe when `category`/`query` change, so there's only ever
-		// one live subscription per panel.
-		return category.subscribe(
-			() => setRefreshKey( ( key ) => key + 1 ),
-			query
-		);
-	}, [ category, query ] );
+		return subscribe( () => setRefreshKey( ( key ) => key + 1 ), query );
+	}, [ subscribe, query ] );
 
 	const handleAttach = useCallback(
 		async ( selectedMedia ) => {

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -117,7 +117,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	// so the grid reflects the newly attached images.
 	useEffect( () => {
 		if ( ! subscribe ) {
-			return undefined;
+			return;
 		}
 		return subscribe( () => setRefreshKey( ( key ) => key + 1 ), query );
 	}, [ subscribe, query ] );

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -113,12 +113,16 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	// canvas, the featured-image panel, this panel's own "Attach images"
 	// button), and uploading in it attaches media to the current post. Closing
 	// such a modal invalidates the cached attachment queries; subscribe so this
-	// grid refetches and reflects the newly attached images. Categories without
-	// `subscribe` (Images, Videos, Audio, Openverse) simply opt out.
+	// grid refetches and reflects the newly attached images. Categories that
+	// aren't core-data-backed (e.g. Openverse) expose no `subscribe` and opt out.
 	useEffect( () => {
 		if ( ! category.subscribe ) {
 			return undefined;
 		}
+		// The returned unsubscribe is React's cleanup: it runs on unmount (e.g.
+		// switching category, since only the active panel is mounted) and before
+		// each re-subscribe when `category`/`query` change, so there's only ever
+		// one live subscription per panel.
 		return category.subscribe(
 			() => setRefreshKey( ( key ) => key + 1 ),
 			query

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { Button, Modal, Spinner, SearchControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useDebouncedInput } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -108,6 +108,22 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 		}
 		setRefreshKey( ( key ) => key + 1 );
 	}, [ category, query, supportsAttachments ] );
+
+	// A media modal can be opened from anywhere in the editor (a block in the
+	// canvas, the featured-image panel, this panel's own "Attach images"
+	// button), and uploading in it attaches media to the current post. Closing
+	// such a modal invalidates the cached attachment queries; subscribe so this
+	// grid refetches and reflects the newly attached images. Categories without
+	// `subscribe` (Images, Videos, Audio, Openverse) simply opt out.
+	useEffect( () => {
+		if ( ! category.subscribe ) {
+			return undefined;
+		}
+		return category.subscribe(
+			() => setRefreshKey( ( key ) => key + 1 ),
+			query
+		);
+	}, [ category, query ] );
 
 	const handleAttach = useCallback(
 		async ( selectedMedia ) => {

--- a/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
@@ -92,3 +92,36 @@ describe( 'MediaCategoryPanel attach/detach gating', () => {
 		);
 	} );
 } );
+
+describe( 'MediaCategoryPanel subscription gating', () => {
+	it( 'subscribes a local source to media changes and unsubscribes on unmount', () => {
+		const unsubscribe = jest.fn();
+		const subscribe = jest.fn( () => unsubscribe );
+
+		const { unmount } = renderPanel( { ...baseCategory, subscribe } );
+
+		// The panel hands its own query over, so the source can watch the exact
+		// results the grid is showing.
+		expect( subscribe ).toHaveBeenCalledTimes( 1 );
+		expect( subscribe ).toHaveBeenCalledWith(
+			expect.any( Function ),
+			expect.objectContaining( { per_page: expect.any( Number ) } )
+		);
+		expect( unsubscribe ).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect( unsubscribe ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'ignores subscribe when the source is an external resource', () => {
+		// `subscribe` is core-only, gated like `attach`/`detach`: an
+		// extender-registered source is always external, so it cannot hook into
+		// the panel's refresh cycle just by setting the prop.
+		const subscribe = jest.fn();
+
+		renderPanel( { ...baseCategory, subscribe, isExternalResource: true } );
+
+		expect( subscribe ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -10,7 +10,7 @@
  * WordPress dependencies
  */
 import { __, sprintf, _x } from '@wordpress/i18n';
-import { dispatch, resolveSelect } from '@wordpress/data';
+import { dispatch, resolveSelect, select, subscribe } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -212,96 +212,137 @@ const invalidateAttachedImagesQueries = ( postId, query = {} ) => {
 	] );
 };
 
+// A media modal opened anywhere in the editor (a canvas block, the featured
+// image panel, the "Attach images" button) attaches its uploads to the current
+// post and, on close, invalidates every cached attachment `getEntityRecords`
+// resolution. The inserter panel fetches imperatively into local state, so it
+// can't react to that on its own. This watches the exact resolution the visible
+// grid reads and calls `onChange` on the resolved -> unresolved edge — i.e. when
+// that cache is invalidated — so the panel can refetch. The args must match what
+// `coreMediaFetch` resolves byte-for-byte, since `invalidateResolution` keys on
+// deep argument equality.
+const subscribeToMediaInvalidation = ( args, onChange ) => {
+	const isResolved = () =>
+		select( coreStore ).hasFinishedResolution( 'getEntityRecords', args );
+	let wasResolved = isResolved();
+	// Scoped to `coreStore` so the listener only runs on core-data changes.
+	return subscribe( () => {
+		const nowResolved = isResolved();
+		if ( wasResolved && ! nowResolved ) {
+			onChange();
+		}
+		wasResolved = nowResolved;
+	}, coreStore );
+};
+
+// Builds a core-data-backed inserter media category from a single `getQuery`
+// mapper, so `fetch` and `subscribe` always agree on the resolution args (they
+// would otherwise drift). `coreMediaFetch` applies `getCoreMediaQuery`
+// internally, so `subscribe` mirrors that to watch the same resolution. External
+// sources (e.g. Openverse) don't use this and simply omit `subscribe`.
+const createCoreMediaCategory = ( { getQuery, ...category } ) => ( {
+	...category,
+	async fetch( query = {} ) {
+		return coreMediaFetch( getQuery( query ) );
+	},
+	subscribe( onChange, query = {} ) {
+		return subscribeToMediaInvalidation(
+			[
+				'postType',
+				'attachment',
+				getCoreMediaQuery( getQuery( query ) ),
+			],
+			onChange
+		);
+	},
+} );
+
 /**
  * Builds the "Attachments" media category for a given post. It behaves like
  * any other inserter media source (e.g. Openverse): it appears in the tab list
  * and renders through the shared media panel. In addition to `fetch`, it exposes
  * optional `attach`/`detach`/`invalidate` capabilities that the shared panel
  * picks up to offer an "Attach images" button and a per-item "Detach from post"
- * action in the same dropdown Openverse uses for "Report image".
+ * action in the same dropdown Openverse uses for "Report image". It also
+ * exposes an optional `subscribe` capability so the panel can refetch when the
+ * attachment cache is invalidated externally (e.g. a media modal opened
+ * elsewhere closing after an upload).
  *
  * @param {number}      postId      The current post id.
  * @param {string|null} [typeLabel] The post type's singular label to use in copy (e.g. "Page"),
  *                                  or null to fall back to the generic "post".
  * @return {InserterMediaCategory} The Attachments media category.
  */
-const getAttachedImagesCategory = ( postId, typeLabel ) => ( {
-	name: 'attached-images',
-	labels: {
-		name: __( 'Attached images' ),
-		search_items: __( 'Search attachments' ),
-	},
-	mediaType: 'image',
-	// The post type's singular label (e.g. "Page"), threaded through so the
-	// shared panel can word its attach/detach copy for the current post type.
-	postTypeLabel: typeLabel,
-	// Empty-state message. Providing this also keeps the source in the tab list
-	// when it has no items, so it stays discoverable and the first image can be
-	// attached even with none yet.
-	emptyMessage: typeLabel
-		? sprintf(
-				// translators: %s: Name of the post type e.g: "Page".
-				__( 'No images attached to this %s.' ),
-				typeLabel
-		  )
-		: __( 'No images attached to this post.' ),
-	async fetch( query = {} ) {
-		return coreMediaFetch( getAttachedImagesQuery( postId, query ) );
-	},
-	async attach( mediaItems ) {
-		const attachmentIds = getImageAttachmentIds( mediaItems );
+const getAttachedImagesCategory = ( postId, typeLabel ) =>
+	createCoreMediaCategory( {
+		name: 'attached-images',
+		labels: {
+			name: __( 'Attached images' ),
+			search_items: __( 'Search attachments' ),
+		},
+		mediaType: 'image',
+		getQuery: ( query ) => getAttachedImagesQuery( postId, query ),
+		// The post type's singular label (e.g. "Page"), threaded through so the
+		// shared panel can word its attach/detach copy for the current post type.
+		postTypeLabel: typeLabel,
+		// Empty-state message. Providing this also keeps the source in the tab
+		// list when it has no items, so it stays discoverable and the first
+		// image can be attached even with none yet.
+		emptyMessage: typeLabel
+			? sprintf(
+					// translators: %s: Name of the post type e.g: "Page".
+					__( 'No images attached to this %s.' ),
+					typeLabel
+			  )
+			: __( 'No images attached to this post.' ),
+		async attach( mediaItems ) {
+			const attachmentIds = getImageAttachmentIds( mediaItems );
 
-		await Promise.all(
-			attachmentIds.map( ( attachmentId ) =>
-				saveAttachmentParent( attachmentId, postId )
-			)
-		);
+			await Promise.all(
+				attachmentIds.map( ( attachmentId ) =>
+					saveAttachmentParent( attachmentId, postId )
+				)
+			);
 
-		return attachmentIds.length;
-	},
-	async detach( mediaItem ) {
-		await saveAttachmentParent( mediaItem.id, 0 );
-	},
-	invalidate( query = {} ) {
-		invalidateAttachedImagesQueries( postId, query );
-	},
-} );
+			return attachmentIds.length;
+		},
+		async detach( mediaItem ) {
+			await saveAttachmentParent( mediaItem.id, 0 );
+		},
+		invalidate( query = {} ) {
+			invalidateAttachedImagesQueries( postId, query );
+		},
+	} );
 
 /** @type {InserterMediaCategory[]} */
 const inserterMediaCategories = [
-	{
+	createCoreMediaCategory( {
 		name: 'images',
 		labels: {
 			name: __( 'Images' ),
 			search_items: __( 'Search images' ),
 		},
 		mediaType: 'image',
-		async fetch( query = {} ) {
-			return coreMediaFetch( { ...query, media_type: 'image' } );
-		},
-	},
-	{
+		getQuery: ( query ) => ( { ...query, media_type: 'image' } ),
+	} ),
+	createCoreMediaCategory( {
 		name: 'videos',
 		labels: {
 			name: __( 'Videos' ),
 			search_items: __( 'Search videos' ),
 		},
 		mediaType: 'video',
-		async fetch( query = {} ) {
-			return coreMediaFetch( { ...query, media_type: 'video' } );
-		},
-	},
-	{
+		getQuery: ( query ) => ( { ...query, media_type: 'video' } ),
+	} ),
+	createCoreMediaCategory( {
 		name: 'audio',
 		labels: {
 			name: __( 'Audio' ),
 			search_items: __( 'Search audio' ),
 		},
 		mediaType: 'audio',
-		async fetch( query = {} ) {
-			return coreMediaFetch( { ...query, media_type: 'audio' } );
-		},
-	},
+		getQuery: ( query ) => ( { ...query, media_type: 'audio' } ),
+	} ),
 	{
 		name: 'openverse',
 		labels: {

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -212,15 +212,11 @@ const invalidateAttachedImagesQueries = ( postId, query = {} ) => {
 	] );
 };
 
-// A media modal opened anywhere in the editor (a canvas block, the featured
-// image panel, the "Attach images" button) attaches its uploads to the current
-// post and, on close, invalidates every cached attachment `getEntityRecords`
-// resolution. The inserter panel fetches imperatively into local state, so it
-// can't react to that on its own. This watches the exact resolution the visible
-// grid reads and calls `onChange` on the resolved -> unresolved edge — i.e. when
-// that cache is invalidated — so the panel can refetch. The args must match what
-// `coreMediaFetch` resolves byte-for-byte, since `invalidateResolution` keys on
-// deep argument equality.
+// The inserter panel fetches imperatively into local state, so it can't react to
+// attachment cache invalidation on its own. Calls `onChange` on the resolved ->
+// unresolved edge of the resolution the grid reads, i.e. when that cache is
+// invalidated. `args` must match what `coreMediaFetch` resolves byte-for-byte,
+// since `invalidateResolution` keys on deep argument equality.
 const subscribeToMediaInvalidation = ( args, onChange ) => {
 	const isResolved = () =>
 		select( coreStore ).hasFinishedResolution( 'getEntityRecords', args );
@@ -235,10 +231,9 @@ const subscribeToMediaInvalidation = ( args, onChange ) => {
 	}, coreStore );
 };
 
-// Builds a core-data-backed inserter media category from a single `getQuery`
-// mapper, so `fetch` and `subscribe` always agree on the resolution args (they
-// would otherwise drift). `coreMediaFetch` applies `getCoreMediaQuery`
-// internally, so `subscribe` mirrors that to watch the same resolution. External
+// Builds a core-data-backed category from a single `getQuery` mapper, so `fetch`
+// and `subscribe` can't drift apart on the resolution args. `coreMediaFetch`
+// applies `getCoreMediaQuery` internally, so `subscribe` mirrors it. External
 // sources (e.g. Openverse) don't use this and simply omit `subscribe`.
 const createCoreMediaCategory = ( { getQuery, ...category } ) => ( {
 	...category,
@@ -263,10 +258,9 @@ const createCoreMediaCategory = ( { getQuery, ...category } ) => ( {
  * and renders through the shared media panel. In addition to `fetch`, it exposes
  * optional `attach`/`detach`/`invalidate` capabilities that the shared panel
  * picks up to offer an "Attach images" button and a per-item "Detach from post"
- * action in the same dropdown Openverse uses for "Report image". It also
- * exposes an optional `subscribe` capability so the panel can refetch when the
- * attachment cache is invalidated externally (e.g. a media modal opened
- * elsewhere closing after an upload).
+ * action in the same dropdown Openverse uses for "Report image". It also exposes
+ * `subscribe`, so the panel can refetch when the attachment cache is invalidated
+ * elsewhere (e.g. a media modal closing after an upload).
  *
  * @param {number}      postId      The current post id.
  * @param {string|null} [typeLabel] The post type's singular label to use in copy (e.g. "Page"),

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, resolveSelect } from '@wordpress/data';
+import { dispatch, resolveSelect, select, subscribe } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,6 +11,8 @@ import getInserterMediaCategories from '..';
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn(),
 	resolveSelect: jest.fn(),
+	select: jest.fn(),
+	subscribe: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/core-data', () => ( {
@@ -175,6 +177,115 @@ describe( 'getInserterMediaCategories', () => {
 			expect.anything()
 		);
 		expect( saveEntityRecord ).toHaveBeenCalledTimes( 5 );
+	} );
+
+	it( 'refetches on the resolved -> unresolved edge and unsubscribes', () => {
+		let listener;
+		const unsubscribe = jest.fn();
+		subscribe.mockImplementation( ( cb ) => {
+			listener = cb;
+			return unsubscribe;
+		} );
+		// Starts resolved: the grid has already fetched this query.
+		let resolved = true;
+		const hasFinishedResolution = jest
+			.fn()
+			.mockImplementation( () => resolved );
+		select.mockReturnValue( { hasFinishedResolution } );
+
+		const [ attachedImagesCategory ] = getInserterMediaCategories(
+			42,
+			'Post'
+		);
+		const onChange = jest.fn();
+		const returnedUnsubscribe = attachedImagesCategory.subscribe(
+			onChange,
+			{ per_page: 20 }
+		);
+
+		// The watched query args must match what `fetch`/`coreMediaFetch`
+		// resolves, since `invalidateResolution` keys on deep argument equality.
+		expect( hasFinishedResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[
+				'postType',
+				'attachment',
+				{
+					per_page: 20,
+					media_type: 'image',
+					parent: 42,
+					orderBy: 'date',
+				},
+			]
+		);
+
+		// Invalidation (resolved -> unresolved) triggers a single refetch.
+		resolved = false;
+		listener();
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+		// Still unresolved: no new edge, so no extra refetch.
+		listener();
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+		// Refetch resolves it again (unresolved -> resolved): still no refetch,
+		// so there's no loop.
+		resolved = true;
+		listener();
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+		// A subsequent invalidation fires again.
+		resolved = false;
+		listener();
+		expect( onChange ).toHaveBeenCalledTimes( 2 );
+
+		expect( returnedUnsubscribe ).toBe( unsubscribe );
+	} );
+
+	it( 'subscribes plain core-media categories and opts external sources out', () => {
+		let listener;
+		subscribe.mockImplementation( ( cb ) => {
+			listener = cb;
+			return jest.fn();
+		} );
+		let resolved = true;
+		const hasFinishedResolution = jest
+			.fn()
+			.mockImplementation( () => resolved );
+		select.mockReturnValue( { hasFinishedResolution } );
+
+		const categories = getInserterMediaCategories( 42, 'Post' );
+		const images = categories.find(
+			( category ) => category.name === 'images'
+		);
+		const openverse = categories.find(
+			( category ) => category.name === 'openverse'
+		);
+
+		const onChange = jest.fn();
+		images.subscribe( onChange, { per_page: 20 } );
+
+		// The Images source watches its own query (no `parent`) and still
+		// refetches on invalidation, since uploads land in the attachment cache.
+		expect( hasFinishedResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[
+				'postType',
+				'attachment',
+				{
+					per_page: 20,
+					media_type: 'image',
+					orderBy: 'date',
+				},
+			]
+		);
+		resolved = false;
+		listener();
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+		// Openverse is an external resource, not core-data-backed, so it exposes
+		// no `subscribe` and the panel leaves it alone.
+		expect( openverse.subscribe ).toBeUndefined();
 	} );
 
 	it( 'words the empty state from the post type label', () => {


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/76955
* https://github.com/WordPress/gutenberg/issues/77117
* https://github.com/WordPress/gutenberg/issues/73085

Allow core media categories in the Media inserter to subscribe to changes

## Why?

Currently, if you make changes to the media library in other contexts with the media inserter open, the category (usually) doesn't automatically update to pull in the latest changes.

This is most noticeable when opening the media library modal in another part of the editor (or via the "Open Media Library" button in the media inserter) and then uploading an image via the modal.

On trunk, the category would remain stale until you close and reopen the media inserter. Whereas with this PR, when you close the media modal, the area should refresh and update to show the latest changes.

## How?

Because categories need to be able to work with the block-editor package without exposing core-data we need a slightly clever way to update them to react to changes. This PR proposes:

* Add an optional `subscribe` method to media categories.
* Add a utility function to create the core media categories that adds a `subscribe` callback  that checks the resolution for attachment queries used by the category. (This is the core bit of this PR, it's what ensures that the invalidation added in #79844 flows through to the category)
* In the block-editor media panel add a useEffect that calls the category's subscribe method if the category or query changes. When a change occurs we increment the refresh key to force the category to refetch.

## Testing Instructions

* In a post or page (especially one that already has some media), open up the Media Inserter
* Click the Attached images category to expand it
* Click on the Open Media Library button at the bottom of the left pane of the Media Inserter
* Go to the Upload tab of the media modal
* Drag or upload an image (or images) to the modal
* Once the upload has completed, close the modal without selecting anything
* With this PR applied the Attached images category should automatically refresh and display your newly uploaded image(s)

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8c48a68e-1090-4051-89c7-da75abef5b6c

## Use of AI Tools

Claude Code
