### PR TITLE
Skip flakey collaboration e2e test

### DIFF
--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-document-size-lock.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-document-size-lock.spec.ts
@@ -7,7 +7,7 @@ import { SECOND_USER } from '../fixtures/collaboration-utils';
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
 
 test.describe( 'Collaboration with large documents', () => {
-	test( 'shows post-locked modal when document size limit is exceeded', async ( {
+	test.skip( 'shows post-locked modal when document size limit is exceeded', async ( {
 		collaborationUtils,
 		requestUtils,
 		admin,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Proposes to skip the `Collaboration with large documents - shows post-locked modal when document size limit is exceeded`, which is failing with regular occurrence and slowing down time to merge other unrelated PRs.
