### PR TITLE
Block Style Variations: Simplify block style variation selector regex

### DIFF
--- a/backport-changelog/7.1/12429.md
+++ b/backport-changelog/7.1/12429.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12429
+
+* https://github.com/WordPress/gutenberg/pull/79924

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -5610,11 +5610,22 @@ class WP_Theme_JSON_Gutenberg {
 		$selector_parts = static::split_selector_list( $block_selector );
 		$result         = array();
 
+		/*
+		 * Append the variation class to each selector's ancestor: the first
+		 * run of characters before any combinator (whitespace) or pseudo-class
+		 * (`:`). Only the first match is replaced.
+		 *
+		 * Examples ("custom" variation):
+		 * - `.wp-block`              => `.wp-block.is-style-custom`
+		 * - `.wp-block .inner`       => `.wp-block.is-style-custom .inner`
+		 * - `.wp-block:where(.a .b)` => `.wp-block.is-style-custom:where(.a .b)`
+		 * - `:where(.outer .inner)`  => `:where(.outer.is-style-custom .inner)`
+		 */
 		foreach ( $selector_parts as $part ) {
 			$result[] = preg_replace_callback(
-				'/((?::\([^)]+\))?\s*)([^\s:]+)/',
+				'/[^\s:]+/',
 				function ( $matches ) use ( $variation_class ) {
-					return $matches[1] . $matches[2] . $variation_class;
+					return $matches[0] . $variation_class;
 				},
 				$part,
 				$limit

--- a/packages/global-styles-engine/src/utils/common.ts
+++ b/packages/global-styles-engine/src/utils/common.ts
@@ -317,14 +317,19 @@ export function getBlockStyleVariationSelector(
 		return variationClass;
 	}
 
-	const ancestorRegex = /((?::\([^)]+\))?\s*)([^\s:]+)/;
-	const addVariationClass = (
-		_match: string,
-		group1: string,
-		group2: string
-	) => {
-		return group1 + group2 + variationClass;
-	};
+	/*
+	 * Append the variation class to each selector's ancestor: the first run
+	 * of characters before any combinator (whitespace) or pseudo-class (`:`).
+	 * `String.prototype.replace` only replaces the first match.
+	 *
+	 * Examples ("custom" variation):
+	 * - `.wp-block`              => `.wp-block.is-style-custom`
+	 * - `.wp-block .inner`       => `.wp-block.is-style-custom .inner`
+	 * - `.wp-block:where(.a .b)` => `.wp-block.is-style-custom:where(.a .b)`
+	 * - `:where(.outer .inner)`  => `:where(.outer.is-style-custom .inner)`
+	 */
+	const ancestorRegex = /[^\s:]+/;
+	const addVariationClass = ( match: string ) => match + variationClass;
 
 	const result = splitSelectorList( blockSelector ).map( ( part ) =>
 		part.replace( ancestorRegex, addVariationClass )

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -7024,6 +7024,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'selector' => '.wp-block:is(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:is(.outer .inner:first-child)',
 			),
+			':is selector list'        => array(
+				'selector' => '.wp-block:is(.outer, .inner:first-child) .content, .wp-block-alternative',
+				'expected' => '.wp-block.is-style-custom:is(.outer, .inner:first-child) .content, .wp-block-alternative.is-style-custom',
+			),
 			':not selector'            => array(
 				'selector' => '.wp-block:not(.outer .inner:first-child)',
 				'expected' => '.wp-block.is-style-custom:not(.outer .inner:first-child)',


### PR DESCRIPTION
## What?

Related: #58051
Follow up to: https://github.com/WordPress/gutenberg/pull/58051#discussion_r3495363569

Tidies up the regex used to add a block style variation's class (e.g. `.is-style-custom`) to a block's selector.

## Why?

The regex is hard to follow and its first capture group is effectively dead. It only matches a literal `:(...)`, which isn't valid selector syntax (functional pseudo-classes like `:is()` and `:where()` always have a name between the colon and the parenthesis), so `$matches[1]` is always empty. The second group does all the work, so dropping the dead group gives identical output and is much easier to follow.

## How?

- Simplifies the pattern from `/((?::\([^)]+\))?\s*)([^\s:]+)/` to `/[^\s:]+/` and adds a comment with examples.
- Keeps the replacement callback rather than switching to backreferences, so the variation name is always treated as a literal (no chance of `$`/`\` being interpreted).
- Mirrors the change in the JS equivalent (`@wordpress/global-styles-engine`) and backfills a missing `:is` selector-list test case in the PHP suite for parity.

## Testing Instructions

This is a behaviour-preserving change, so the output should be identical to `trunk`.

1. Confirm the PHP tests pass: `npm run test:unit:php:base -- --filter test_get_block_style_variation_selector`
2. Confirm the JS tests pass: `npm run test:unit packages/global-styles-engine/src/test/utils.test.ts`
3. Apply a block style variation to a block (e.g. a Quote or a section Group) and confirm the styles still render correctly in the editor and on the front end.
