### PR TITLE
Use modern PHP string functions instead of strpos/substr

### DIFF
--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -34,7 +34,7 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 			return false;
 		}
 
-		if ( !str_contains( $icon_name, '/' ) ) {
+		if ( ! str_contains( $icon_name, '/' ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Icon name must be namespaced in the form "collection/icon-name".', 'gutenberg' ),
@@ -289,7 +289,7 @@ function gutenberg_override_wp_icons_registry() {
 	// the `core/` namespace onto the Gutenberg registry so they are not lost.
 	if ( null !== $original_registry ) {
 		foreach ( $original_registry->get_registered_icons() as $icon ) {
-			if ( str_starts_with($icon['name'], 'core/') ) {
+			if ( str_starts_with( $icon['name'], 'core/' ) ) {
 				continue;
 			}
 			$icon_properties = array( 'label' => $icon['label'] );

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -34,7 +34,7 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 			return false;
 		}
 
-		if ( false === strpos( $icon_name, '/' ) ) {
+		if ( !str_contains( $icon_name, '/' ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Icon name must be namespaced in the form "collection/icon-name".', 'gutenberg' ),
@@ -289,7 +289,7 @@ function gutenberg_override_wp_icons_registry() {
 	// the `core/` namespace onto the Gutenberg registry so they are not lost.
 	if ( null !== $original_registry ) {
 		foreach ( $original_registry->get_registered_icons() as $icon ) {
-			if ( strpos( $icon['name'], 'core/' ) === 0 ) {
+			if ( str_starts_with($icon['name'], 'core/') ) {
 				continue;
 			}
 			$icon_properties = array( 'label' => $icon['label'] );

--- a/lib/experimental/knowledge/knowledge.php
+++ b/lib/experimental/knowledge/knowledge.php
@@ -179,7 +179,7 @@ if ( ! function_exists( 'wp_knowledge_ensure_default_type_term' ) ) {
 			return;
 		}
 
-		if ( str_starts_with($post->post_name, 'guideline-') ) {
+		if ( str_starts_with( $post->post_name, 'guideline-' ) ) {
 			$term_id = wp_knowledge_get_or_create_type_term( 'guideline' );
 			if ( null !== $term_id ) {
 				wp_set_object_terms( $post_id, $term_id, 'wp_knowledge_type' );
@@ -337,7 +337,7 @@ if ( ! function_exists( 'wp_guideline_scope_from_slug' ) ) {
 	 * @return string|null Scope key, or null if not a registry scope.
 	 */
 	function wp_guideline_scope_from_slug( string $slug ): ?string {
-		if ( !str_starts_with($slug, 'guideline-') || str_starts_with($slug, 'guideline-block-') ) {
+		if ( ! str_starts_with( $slug, 'guideline-' ) || str_starts_with( $slug, 'guideline-block-' ) ) {
 			return null;
 		}
 
@@ -383,7 +383,7 @@ if ( ! function_exists( 'wp_knowledge_guard_guideline_row' ) ) {
 			}
 		}
 
-		if ( !str_starts_with((string) $slug, 'guideline-') ) {
+		if ( ! str_starts_with( (string) $slug, 'guideline-' ) ) {
 			return $prepared_post;
 		}
 

--- a/lib/experimental/knowledge/knowledge.php
+++ b/lib/experimental/knowledge/knowledge.php
@@ -179,7 +179,7 @@ if ( ! function_exists( 'wp_knowledge_ensure_default_type_term' ) ) {
 			return;
 		}
 
-		if ( 0 === strpos( $post->post_name, 'guideline-' ) ) {
+		if ( str_starts_with($post->post_name, 'guideline-') ) {
 			$term_id = wp_knowledge_get_or_create_type_term( 'guideline' );
 			if ( null !== $term_id ) {
 				wp_set_object_terms( $post_id, $term_id, 'wp_knowledge_type' );
@@ -337,7 +337,7 @@ if ( ! function_exists( 'wp_guideline_scope_from_slug' ) ) {
 	 * @return string|null Scope key, or null if not a registry scope.
 	 */
 	function wp_guideline_scope_from_slug( string $slug ): ?string {
-		if ( 0 !== strpos( $slug, 'guideline-' ) || 0 === strpos( $slug, 'guideline-block-' ) ) {
+		if ( !str_starts_with($slug, 'guideline-') || str_starts_with($slug, 'guideline-block-') ) {
 			return null;
 		}
 
@@ -383,7 +383,7 @@ if ( ! function_exists( 'wp_knowledge_guard_guideline_row' ) ) {
 			}
 		}
 
-		if ( 0 !== strpos( (string) $slug, 'guideline-' ) ) {
+		if ( !str_starts_with((string) $slug, 'guideline-') ) {
 			return $prepared_post;
 		}
 

--- a/lib/experimental/rest-api-overrides.php
+++ b/lib/experimental/rest-api-overrides.php
@@ -32,7 +32,7 @@ function gutenberg_boot_allow_auto_draft_in_rest_api() {
 	foreach ( $post_types as $post_type ) {
 		$supports_editor   = post_type_supports( $post_type->name, 'editor' );
 		$supports_title    = post_type_supports( $post_type->name, 'title' );
-		$is_wp_core_system = strpos( $post_type->name, 'wp_' ) === 0;
+		$is_wp_core_system = str_starts_with($post_type->name, 'wp_');
 		$is_attachment     = 'attachment' === $post_type->name;
 
 		// Only add auto-draft to content post types:

--- a/lib/experimental/rest-api-overrides.php
+++ b/lib/experimental/rest-api-overrides.php
@@ -32,7 +32,7 @@ function gutenberg_boot_allow_auto_draft_in_rest_api() {
 	foreach ( $post_types as $post_type ) {
 		$supports_editor   = post_type_supports( $post_type->name, 'editor' );
 		$supports_title    = post_type_supports( $post_type->name, 'title' );
-		$is_wp_core_system = str_starts_with($post_type->name, 'wp_');
+		$is_wp_core_system = str_starts_with( $post_type->name, 'wp_' );
 		$is_attachment     = 'attachment' === $post_type->name;
 
 		// Only add auto-draft to content post types:

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -97,7 +97,7 @@ function render_block_core_rss( $attributes ) {
 			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
 
 			// Change existing [...] to [&hellip;].
-			if ( str_ends_with($excerpt, '[...]') ) {
+			if ( str_ends_with( $excerpt, '[...]' ) ) {
 				$excerpt = substr( $excerpt, 0, -5 ) . '[&hellip;]';
 			}
 

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -97,7 +97,7 @@ function render_block_core_rss( $attributes ) {
 			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
 
 			// Change existing [...] to [&hellip;].
-			if ( '[...]' === substr( $excerpt, -5 ) ) {
+			if ( str_ends_with($excerpt, '[...]') ) {
 				$excerpt = substr( $excerpt, 0, -5 ) . '[&hellip;]';
 			}
 


### PR DESCRIPTION
## What?
Replaces legacy `strpos()` and `substr()` string checks with the modern PHP functions `str_contains()`, `str_starts_with()` and `str_ends_with()`.

## Why?
These PHP 8.0 functions express intent more clearly than the older `strpos() === 0` / `substr( $x, -5 )` idioms and read better at a glance. Using them consistently across the codebase reduces cognitive load and avoids the subtle bugs that the `strpos()`-comparison pattern is prone to (e.g. loose vs. strict comparison against `0`/`false`).

WordPress ships polyfills for these functions (`wp-includes/compat.php`), so they are safe to use even on the minimum supported PHP 7.4 — no bump of the minimum PHP version is required.

## How?
- `strpos( $x, $needle ) === 0` → `str_starts_with( $x, $needle )`
- `false === strpos( $x, $needle )` / `strpos(...) === false` → (`!`)`str_contains( $x, $needle )`
- `substr( $x, -5 ) === '[...]'` → `str_ends_with( $x, '[...]' )`

No behavioral changes.