### PR TITLE
Blocks package: Stabilize `cloneSanitizedBlock` and `sanitizeBlockAttributes`

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -5,7 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	cloneBlock,
 	createBlock,
-	__experimentalCloneSanitizedBlock,
+	cloneSanitizedBlock,
 	findTransform,
 	getBlockTransforms,
 	pasteHandler,
@@ -268,7 +268,7 @@ export default function useOnBlockDrop(
 				}
 
 				const groupInnerBlocks = blocks.map( ( block ) =>
-					__experimentalCloneSanitizedBlock( block )
+					cloneSanitizedBlock( block )
 				);
 
 				const areAllImages = blocks.every( ( block ) => {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -4,7 +4,7 @@
  */
 import {
 	cloneBlock,
-	__experimentalCloneSanitizedBlock,
+	cloneSanitizedBlock,
 	createBlock,
 	doBlocksMatchTemplate,
 	getBlockType,
@@ -1755,7 +1755,7 @@ export const duplicateBlocks =
 			clientIdsArray[ clientIdsArray.length - 1 ]
 		);
 		const clonedBlocks = blocks.map( ( block ) =>
-			__experimentalCloneSanitizedBlock( block )
+			cloneSanitizedBlock( block )
 		);
 		dispatch.insertBlocks(
 			clonedBlocks,

--- a/packages/block-library/src/details/transforms.js
+++ b/packages/block-library/src/details/transforms.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createBlock,
-	__experimentalCloneSanitizedBlock,
-} from '@wordpress/blocks';
+import { createBlock, cloneSanitizedBlock } from '@wordpress/blocks';
 
 export default {
 	from: [
@@ -21,9 +18,7 @@ export default {
 				return createBlock(
 					'core/details',
 					{},
-					blocks.map( ( block ) =>
-						__experimentalCloneSanitizedBlock( block )
-					)
+					blocks.map( ( block ) => cloneSanitizedBlock( block ) )
 				);
 			},
 		},

--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createBlock,
-	__experimentalCloneSanitizedBlock,
-} from '@wordpress/blocks';
+import { createBlock, cloneSanitizedBlock } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -33,7 +30,7 @@ const transforms = {
 				// are removed both from their original location and within the
 				// new group block.
 				const groupInnerBlocks = blocks.map( ( block ) =>
-					__experimentalCloneSanitizedBlock( block )
+					cloneSanitizedBlock( block )
 				);
 
 				return createBlock(

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -4,7 +4,7 @@
 import { RichText } from '@wordpress/block-editor';
 import {
 	createBlock,
-	__experimentalCloneSanitizedBlock,
+	cloneSanitizedBlock,
 	switchToBlockType,
 } from '@wordpress/blocks';
 
@@ -96,9 +96,7 @@ const transforms = {
 				createBlock(
 					'core/quote',
 					{},
-					blocks.map( ( block ) =>
-						__experimentalCloneSanitizedBlock( block )
-					)
+					blocks.map( ( block ) => cloneSanitizedBlock( block ) )
 				),
 		},
 	],

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -36,6 +36,20 @@ _Returns_
 
 -   `Block`: A cloned block.
 
+### cloneSanitizedBlock
+
+Given a block object, returns a copy of the block object while sanitizing its attributes, optionally merging new attributes and/or replacing its inner blocks.
+
+_Parameters_
+
+-   _block_ `Block`: Block instance.
+-   _mergeAttributes_ `Record< string, unknown >`: Block attributes.
+-   _newInnerBlocks_ `Block[]`: Nested blocks.
+
+_Returns_
+
+-   `Block`: A cloned block.
+
 ### createBlock
 
 Returns a block object given its type and attributes.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -691,6 +691,19 @@ _Parameters_
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
 -   _variation_ `BlockVariation | BlockVariation[]`: Object describing a block variation.
 
+### sanitizeBlockAttributes
+
+Ensure attributes contains only values defined by block type, and merge default values for missing attributes.
+
+_Parameters_
+
+-   _name_ `string`: The block's name.
+-   _attributes_ `Record< string, unknown >`: The block's attributes.
+
+_Returns_
+
+-   `Record< string, unknown >`: The sanitized attributes.
+
 ### serialize
 
 Takes a block or set of blocks and returns the serialized post content.

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
+import deprecated from '@wordpress/deprecated';
 import warning from '@wordpress/warning';
 
 /**
@@ -146,7 +147,7 @@ export function createBlocksFromInnerBlocksTemplate(
  *
  * @return A cloned block.
  */
-export function __experimentalCloneSanitizedBlock(
+export function cloneSanitizedBlock(
 	block: Block,
 	mergeAttributes: Record< string, unknown > = {},
 	newInnerBlocks?: Block[]
@@ -175,9 +176,22 @@ export function __experimentalCloneSanitizedBlock(
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>
-				__experimentalCloneSanitizedBlock( innerBlock )
+				cloneSanitizedBlock( innerBlock )
 			),
 	};
+}
+
+export function __experimentalCloneSanitizedBlock(
+	block: Block,
+	mergeAttributes: Record< string, unknown > = {},
+	newInnerBlocks?: Block[]
+): Block {
+	deprecated( '__experimentalCloneSanitizedBlock', {
+		since: '7.1',
+		alternative: 'cloneSanitizedBlock',
+	} );
+
+	return cloneSanitizedBlock( block, mergeAttributes, newInnerBlocks );
 }
 
 /**

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -21,7 +21,7 @@ import {
 import {
 	isBlockRegistered,
 	normalizeBlockType,
-	__experimentalSanitizeBlockAttributes,
+	sanitizeBlockAttributes,
 } from './utils';
 import type { Block, BlockType, BlockTransform } from '../types';
 
@@ -70,10 +70,7 @@ export function createBlock(
 		} );
 	}
 
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		name,
-		attributes
-	);
+	const sanitizedAttributes = sanitizeBlockAttributes( name, attributes );
 
 	const clientId = uuid();
 
@@ -164,7 +161,7 @@ export function cloneSanitizedBlock(
 
 	const clientId = uuid();
 
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes( name, {
+	const sanitizedAttributes = sanitizeBlockAttributes( name, {
 		...block.attributes,
 		...mergeAttributes,
 	} );

--- a/packages/blocks/src/api/index.ts
+++ b/packages/blocks/src/api/index.ts
@@ -154,6 +154,7 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
+	sanitizeBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
 	__experimentalGetBlockAttributesNamesByRole,

--- a/packages/blocks/src/api/index.ts
+++ b/packages/blocks/src/api/index.ts
@@ -14,6 +14,7 @@ export {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
+	cloneSanitizedBlock,
 	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -10,6 +10,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
+	cloneSanitizedBlock,
 	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
@@ -462,8 +463,8 @@ describe( 'block factory', () => {
 		} );
 	} );
 
-	describe( '__experimentalCloneSanitizedBlock', () => {
-		it( 'should sanitize attributes not defined in the block type', () => {
+	describe( 'cloneSanitizedBlock', () => {
+		beforeEach( () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
@@ -472,7 +473,21 @@ describe( 'block factory', () => {
 					},
 				},
 			} );
+		} );
 
+		it( 'sanitizes attributes not defined in the block type', () => {
+			const block = createBlock( 'core/test-block', {
+				notDefined: 'not-defined',
+			} );
+
+			const clonedBlock = cloneSanitizedBlock( block, {
+				notDefined2: 'not-defined-2',
+			} );
+
+			expect( clonedBlock.attributes ).toEqual( {} );
+		} );
+
+		it( 'keeps the experimental function as a deprecated alias', () => {
 			const block = createBlock( 'core/test-block', {
 				notDefined: 'not-defined',
 			} );
@@ -482,6 +497,9 @@ describe( 'block factory', () => {
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {} );
+			expect( console ).toHaveWarnedWith(
+				'__experimentalCloneSanitizedBlock is deprecated since version 7.1. Please use cloneSanitizedBlock instead.'
+			);
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -14,6 +14,7 @@ import {
 	getAccessibleBlockLabel,
 	getBlockLabel,
 	isBlockRegistered,
+	sanitizeBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
 	isContentBlock,
@@ -254,13 +255,10 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				defined: 'defined-attribute',
-				notDefined: 'not-defined-attribute',
-			}
-		);
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {
+			defined: 'defined-attribute',
+			notDefined: 'not-defined-attribute',
+		} );
 
 		expect( attributes ).toEqual( {
 			defined: 'defined-attribute',
@@ -269,10 +267,7 @@ describe( 'sanitizeBlockAttributes', () => {
 
 	it( 'throws error if the block is not registered', () => {
 		expect( () => {
-			__experimentalSanitizeBlockAttributes(
-				'core/not-registered-test-block',
-				{}
-			);
+			sanitizeBlockAttributes( 'core/not-registered-test-block', {} );
 		} ).toThrowErrorMatchingInlineSnapshot(
 			`"Block type 'core/not-registered-test-block' is not registered."`
 		);
@@ -293,10 +288,7 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{}
-		);
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {} );
 
 		expect( attributes ).toEqual( {
 			hasDefaultValue: 'default-value',
@@ -321,18 +313,42 @@ describe( 'sanitizeBlockAttributes', () => {
 			title: 'Test block',
 		} );
 
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				nodeContent: [ 'test-1', 'test-2' ],
-			}
-		);
+		const attributes = sanitizeBlockAttributes( 'core/test-block', {
+			nodeContent: [ 'test-1', 'test-2' ],
+		} );
 
 		expect( attributes ).toEqual( {
 			nodeContent: [ 'test-1', 'test-2' ],
 			childrenContent: [],
 			withDefault: [ 'test' ],
 		} );
+	} );
+
+	it( 'keeps the experimental function as a deprecated alias', () => {
+		registerBlockType( 'core/test-block', {
+			apiVersion: 3,
+			attributes: {
+				defined: {
+					type: 'string',
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{
+				defined: 'defined-attribute',
+				notDefined: 'not-defined-attribute',
+			}
+		);
+
+		expect( attributes ).toEqual( {
+			defined: 'defined-attribute',
+		} );
+		expect( console ).toHaveWarnedWith(
+			'__experimentalSanitizeBlockAttributes is deprecated since version 7.1. Please use sanitizeBlockAttributes instead.'
+		);
 	} );
 } );
 

--- a/packages/blocks/src/api/utils.ts
+++ b/packages/blocks/src/api/utils.ts
@@ -338,7 +338,7 @@ export function isBlockRegistered( name: string ): boolean {
  * @param attributes The block's attributes.
  * @return The sanitized attributes.
  */
-export function __experimentalSanitizeBlockAttributes(
+export function sanitizeBlockAttributes(
 	name: string,
 	attributes: Record< string, unknown >
 ): Record< string, unknown > {
@@ -392,6 +392,18 @@ export function __experimentalSanitizeBlockAttributes(
 		},
 		{}
 	);
+}
+
+export function __experimentalSanitizeBlockAttributes(
+	name: string,
+	attributes: Record< string, unknown >
+): Record< string, unknown > {
+	deprecated( '__experimentalSanitizeBlockAttributes', {
+		since: '7.1',
+		alternative: 'sanitizeBlockAttributes',
+	} );
+
+	return sanitizeBlockAttributes( name, attributes );
 }
 
 /**

--- a/packages/server-side-render/src/hook.ts
+++ b/packages/server-side-render/src/hook.ts
@@ -6,7 +6,7 @@ import { useEffect, useState, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
-import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
+import { sanitizeBlockAttributes } from '@wordpress/blocks';
 
 export function rendererPath(
 	block: string,
@@ -133,8 +133,7 @@ export function useServerSideRender(
 	} = args;
 
 	let sanitizedAttributes: Record< string, unknown > | null =
-		attributes &&
-		__experimentalSanitizeBlockAttributes( block, attributes );
+		attributes && sanitizeBlockAttributes( block, attributes );
 
 	if ( skipBlockSupportAttributes && sanitizedAttributes ) {
 		sanitizedAttributes =

--- a/packages/widgets/src/blocks/widget-group/index.js
+++ b/packages/widgets/src/blocks/widget-group/index.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	createBlock,
-	__experimentalCloneSanitizedBlock,
-} from '@wordpress/blocks';
+import { createBlock, cloneSanitizedBlock } from '@wordpress/blocks';
 import { group as icon } from '@wordpress/icons';
 
 /**
@@ -43,7 +40,7 @@ export const settings = {
 				__experimentalConvert( blocks ) {
 					// Put the selected blocks inside the new Widget Group's innerBlocks.
 					let innerBlocks = blocks.map( ( block ) =>
-						__experimentalCloneSanitizedBlock( block )
+						cloneSanitizedBlock( block )
 					);
 
 					// If the first block is a heading then assume this is intended


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In #79887 it was observed that there are `__experimentalCloneSanitizedBlock` and `__experimentalSanitizeBlockAttributes` functions used in a number of places.

This PR stabilizes them, removing the `__experimental` prefix, since `__experimental` is no longer an ongoing practice in the project.

Keeps a deprecated exports of `__experimentalCloneSanitizedBlock` and `__experimentalSanitizeBlockAttributes` that remain functional, but log a deprecation message.