### PR TITLE
Feat: Skip Performance CI tests for docs and workflows files

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,6 +5,9 @@ on:
         paths-ignore:
             - 'docs/**'
             - '.github/workflows/*.yml'
+            - 'storybook/**'
+            - 'test/storybook-playwright/**'
+            - 'packages/*/src/**/stories/**'
     release:
         types: [published]
     push:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,6 +2,9 @@ name: Performance Tests
 
 on:
     pull_request:
+        paths-ignore:
+            - 'docs/**'
+            - '.github/workflows/*.yml'
     release:
         types: [published]
     push:


### PR DESCRIPTION

## What?
Part of: https://github.com/WordPress/gutenberg/issues/44679

Skip the Performance Tests workflow for PRs that only change docs, workflow YAML files, or Storybook-related files.

## Why?
These changes do not affect editor performance, so running the performance workflow for them adds unnecessary CI time.

## How?
Adds `pull_request.paths-ignore` rules in performance.yml for docs, workflow files, and Storybook-only paths.

## Testing Instructions 

This PR includes a YAML-related file change, and the performance tests did not run. Therefore, I believe this is a reasonable way to validate that the PR works as expected.
