### PR TITLE
Site Editor v2 experiment: hide admin bar in distraction-free mode

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -77,6 +77,16 @@ function gutenberg_site_editor_enable_admin_bar() {
 	bottom: 0;
 	height: calc(100vh - var(--wp-admin--admin-bar--height, 0)) !important;
 }
+
+@media (min-width: 782px) {
+	body:has(.editor-editor-interface.is-distraction-free) {
+		--wp-admin--admin-bar--height: 0px;
+	}
+
+	body:has(.editor-editor-interface.is-distraction-free) #wpadminbar {
+		display: none;
+	}
+}
 CSS;
 
 	wp_add_inline_style( 'admin-bar', $css );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR hides the admin bar In Site Editor v2 (Extensible Site Editor experiment), when we enter the distraction-free mode.

## Why?

Follows existing behavior in other editors, after:

- https://github.com/WordPress/gutenberg/pull/78397

Site Editor:

https://github.com/WordPress/gutenberg/blob/45a48edbd04daeccfd92f04caeaf42fa49733b95/packages/edit-site/src/style.scss#L57-L65

Post Editor: 

https://github.com/WordPress/gutenberg/blob/45a48edbd04daeccfd92f04caeaf42fa49733b95/packages/edit-post/src/style.scss#L13-L21

## Testing Instructions

1. Go to Settings -> Gutenberg
2. Enable the Extensible Site Editor experiment
3. Go to Appearance -> Editor
4. Click Templates, then click any template
5. Click the 3-dot top-left menu, then click Distraction-free mode
6. Verify the admin bar is now hidden.

## Use of AI Tools

I use Opus 4.8 to help adapt the existing CSS.