### PR TITLE
Block Bindings: Add server support for innerBlocks bindings

### DIFF
--- a/lib/experimental/block-bindings-inner-blocks.php
+++ b/lib/experimental/block-bindings-inner-blocks.php
@@ -75,11 +75,18 @@ function gutenberg_block_bindings_rebuild_inner_content( $inner_content, $block_
 		}
 	}
 
-	return array_merge(
+	$rebuilt_inner_content = array_merge(
 		array_slice( $inner_content, 0, $first_placeholder ),
 		array_fill( 0, $block_count, null ),
 		array_slice( $inner_content, $last_placeholder + 1 )
 	);
+
+	/*
+	 * WP_Block refreshes its existing inner content only when the replacement
+	 * array is non-empty. An empty static chunk renders nothing while ensuring
+	 * a nested bound block drops its already-constructed fallback children.
+	 */
+	return empty( $rebuilt_inner_content ) ? array( '' ) : $rebuilt_inner_content;
 }
 
 /**

--- a/lib/experimental/block-bindings-inner-blocks.php
+++ b/lib/experimental/block-bindings-inner-blocks.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Experimental structural block bindings.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Enables the Gutenberg-only editor implementation of structural bindings.
+ *
+ * @since 7.2.0
+ *
+ * @param array $settings Block editor settings.
+ * @return array Block editor settings.
+ */
+function gutenberg_block_bindings_inner_blocks_editor_setting( $settings ) {
+	$settings['blockBindingsInnerBlocks'] = true;
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_block_bindings_inner_blocks_editor_setting' );
+
+/**
+ * Gets a usable structural binding descriptor.
+ *
+ * The experiment accepts any registered source on a block with one ordinary
+ * InnerBlocks area. `core/html` has a separate multi-area editor component and
+ * is not such a host.
+ *
+ * @since 7.2.0
+ *
+ * @param array $parsed_block Parsed block.
+ * @return array|null Binding descriptor, or null.
+ */
+function gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) {
+	if ( 'core/html' === ( $parsed_block['blockName'] ?? null ) ) {
+		return null;
+	}
+
+	$binding = $parsed_block['attrs']['metadata']['bindings']['innerBlocks'] ?? null;
+	if ( ! is_array( $binding ) || ! isset( $binding['source'] ) || ! is_string( $binding['source'] ) || '' === $binding['source'] ) {
+		return null;
+	}
+
+	return $binding;
+}
+
+/**
+ * Replaces the existing InnerBlocks placeholders while retaining host markup.
+ *
+ * The parser records ordinary InnerBlocks locations as `null` entries in
+ * `innerContent`. An initially-empty static host has no such location, so this
+ * first experiment leaves it unchanged rather than inferring a location from
+ * arbitrary HTML.
+ *
+ * @since 7.2.0
+ *
+ * @param array $inner_content Existing static markup and block placeholders.
+ * @param int   $block_count   Number of replacement blocks.
+ * @return array|null Rebuilt inner content, or null if this host has no slot.
+ */
+function gutenberg_block_bindings_rebuild_inner_content( $inner_content, $block_count ) {
+	if ( ! is_array( $inner_content ) ) {
+		return null;
+	}
+
+	$first_placeholder = array_search( null, $inner_content, true );
+	if ( false === $first_placeholder ) {
+		return null;
+	}
+
+	$last_placeholder = $first_placeholder;
+	foreach ( $inner_content as $index => $content ) {
+		if ( null === $content ) {
+			$last_placeholder = $index;
+		}
+	}
+
+	return array_merge(
+		array_slice( $inner_content, 0, $first_placeholder ),
+		array_fill( 0, $block_count, null ),
+		array_slice( $inner_content, $last_placeholder + 1 )
+	);
+}
+
+/**
+ * Reads the full context inherited by a nested block instance.
+ *
+ * `WP_Block::$available_context` includes values provided by ancestors even
+ * when the bound host does not list them in `uses_context` itself.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_Block $block_instance Bound child block instance.
+ * @param WP_Block $parent_block   Parent block instance.
+ * @return array Context visible to the binding source.
+ */
+function gutenberg_block_bindings_get_inner_blocks_context( $block_instance, $parent_block ) {
+	static $read_available_context = null;
+
+	if ( null === $read_available_context ) {
+		$read_available_context = Closure::bind(
+			static function ( $block ) {
+				return $block->available_context;
+			},
+			null,
+			WP_Block::class
+		);
+	}
+
+	$context = $read_available_context( $block_instance );
+	return is_array( $context ) ? $context : $parent_block->context;
+}
+
+/**
+ * Finds the constructed child matching filtered parsed data.
+ *
+ * @since 7.2.0
+ *
+ * @param array    $source_block Unfiltered parsed block.
+ * @param WP_Block $parent_block Parent block instance.
+ * @return WP_Block|null Matching child instance.
+ */
+function gutenberg_block_bindings_get_inner_blocks_instance( $source_block, $parent_block ) {
+	foreach ( $parent_block->inner_blocks as $inner_block ) {
+		if ( $inner_block instanceof WP_Block && $inner_block->parsed_block === $source_block ) {
+			return $inner_block;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Resolves a serialized structural binding value.
+ *
+ * Strings replace fallback children; `null`, `undefined`, and all non-string
+ * values preserve the host's own serialized children. An empty string is a
+ * deliberate empty value.
+ *
+ * @since 7.2.0
+ *
+ * @param array    $parsed_block Parsed bound block.
+ * @param array    $context      Context inherited by the host.
+ * @return array Parsed block, substituted only when resolution is usable.
+ */
+function gutenberg_block_bindings_resolve_inner_blocks( $parsed_block, $context ) {
+	$binding = gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block );
+	if ( null === $binding ) {
+		return $parsed_block;
+	}
+
+	$source = get_block_bindings_source( $binding['source'] );
+	if ( null === $source ) {
+		return $parsed_block;
+	}
+
+	$source_args    = isset( $binding['args'] ) && is_array( $binding['args'] ) ? $binding['args'] : array();
+	$block_instance = new WP_Block( $parsed_block, $context );
+	foreach ( $source->uses_context ?? array() as $context_name ) {
+		if ( array_key_exists( $context_name, $context ) ) {
+			$block_instance->context[ $context_name ] = $context[ $context_name ];
+		}
+	}
+
+	$value = $source->get_value( $source_args, $block_instance, 'innerBlocks' );
+	if ( ! is_string( $value ) ) {
+		return $parsed_block;
+	}
+
+	$inner_blocks  = '' === $value ? array() : parse_blocks( $value );
+	$inner_content = gutenberg_block_bindings_rebuild_inner_content(
+		$parsed_block['innerContent'] ?? null,
+		count( $inner_blocks )
+	);
+	if ( null === $inner_content ) {
+		return $parsed_block;
+	}
+
+	$parsed_block['innerBlocks']  = $inner_blocks;
+	$parsed_block['innerContent'] = $inner_content;
+	$parsed_block['innerHTML']    = implode( '', array_filter( $inner_content, 'is_string' ) );
+
+	return $parsed_block;
+}
+
+/**
+ * Resolves a nested structural binding before the child renders.
+ *
+ * @since 7.2.0
+ *
+ * @param array         $parsed_block Filtered parsed block.
+ * @param array         $source_block Original parsed block.
+ * @param WP_Block|null $parent_block Parent block instance.
+ * @return array Filtered parsed block.
+ */
+function gutenberg_block_bindings_replace_inner_blocks( $parsed_block, $source_block, $parent_block ) {
+	if ( ! $parent_block instanceof WP_Block || null === gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		return $parsed_block;
+	}
+
+	$block_instance = gutenberg_block_bindings_get_inner_blocks_instance( $source_block, $parent_block );
+	if ( ! $block_instance instanceof WP_Block ) {
+		return $parsed_block;
+	}
+
+	return gutenberg_block_bindings_resolve_inner_blocks(
+		$parsed_block,
+		gutenberg_block_bindings_get_inner_blocks_context( $block_instance, $parent_block )
+	);
+}
+add_filter( 'render_block_data', 'gutenberg_block_bindings_replace_inner_blocks', 10, 3 );
+
+/**
+ * Renders a top-level bound block after reproducing `render_block()`'s tail.
+ *
+ * A plugin cannot place structural resolution inside `WP_Block`, so the
+ * top-level path runs the same data and context filters once before creating
+ * the final instance. This moves into Core if the experiment is adopted.
+ *
+ * @since 7.2.0
+ *
+ * @param string|null   $pre_render   Pre-rendered content.
+ * @param array         $parsed_block Parsed block.
+ * @param WP_Block|null $parent_block Parent block instance.
+ * @return string|null Rendered content, or the existing pre-render value.
+ */
+function gutenberg_block_bindings_render_top_level_bound_block( $pre_render, $parsed_block, $parent_block ) {
+	if ( null !== $pre_render || null !== $parent_block || null === gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		return $pre_render;
+	}
+
+	global $post;
+	$source_block = $parsed_block;
+	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block, null );
+	$context      = array();
+	if ( $post instanceof WP_Post ) {
+		$context['postId']   = $post->ID;
+		$context['postType'] = $post->post_type;
+	}
+	$context = apply_filters( 'render_block_context', $context, $parsed_block, null );
+	$context = is_array( $context ) ? $context : array();
+
+	return ( new WP_Block( gutenberg_block_bindings_resolve_inner_blocks( $parsed_block, $context ), $context ) )->render();
+}
+add_filter( 'pre_render_block', 'gutenberg_block_bindings_render_top_level_bound_block', PHP_INT_MAX, 3 );

--- a/lib/experimental/block-bindings-inner-blocks.php
+++ b/lib/experimental/block-bindings-inner-blocks.php
@@ -22,9 +22,9 @@ add_filter( 'block_editor_settings_all', 'gutenberg_block_bindings_inner_blocks_
 /**
  * Gets a usable structural binding descriptor.
  *
- * The experiment accepts any registered source on a block with one ordinary
- * InnerBlocks area. `core/html` has a separate multi-area editor component and
- * is not such a host.
+ * The experiment is private to pattern overrides on Core blocks with one
+ * ordinary InnerBlocks area. `core/html` has a separate multi-area editor
+ * component and is not such a host.
  *
  * @since 7.2.0
  *
@@ -32,12 +32,13 @@ add_filter( 'block_editor_settings_all', 'gutenberg_block_bindings_inner_blocks_
  * @return array|null Binding descriptor, or null.
  */
 function gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) {
-	if ( 'core/html' === ( $parsed_block['blockName'] ?? null ) ) {
+	$block_name = $parsed_block['blockName'] ?? null;
+	if ( ! is_string( $block_name ) || 0 !== strpos( $block_name, 'core/' ) || 'core/html' === $block_name ) {
 		return null;
 	}
 
 	$binding = $parsed_block['attrs']['metadata']['bindings']['innerBlocks'] ?? null;
-	if ( ! is_array( $binding ) || ! isset( $binding['source'] ) || ! is_string( $binding['source'] ) || '' === $binding['source'] ) {
+	if ( ! is_array( $binding ) || 'core/pattern-overrides' !== ( $binding['source'] ?? null ) ) {
 		return null;
 	}
 

--- a/lib/experimental/block-bindings-inner-blocks.php
+++ b/lib/experimental/block-bindings-inner-blocks.php
@@ -95,6 +95,10 @@ function gutenberg_block_bindings_rebuild_inner_content( $inner_content, $block_
  * @return array Context visible to the binding source.
  */
 function gutenberg_block_bindings_get_inner_blocks_context( $block_instance, $parent_block ) {
+	if ( ! property_exists( WP_Block::class, 'available_context' ) ) {
+		return is_array( $parent_block->context ) ? $parent_block->context : array();
+	}
+
 	static $read_available_context = null;
 
 	if ( null === $read_available_context ) {
@@ -108,7 +112,9 @@ function gutenberg_block_bindings_get_inner_blocks_context( $block_instance, $pa
 	}
 
 	$context = $read_available_context( $block_instance );
-	return is_array( $context ) ? $context : $parent_block->context;
+	return is_array( $context )
+		? $context
+		: ( is_array( $parent_block->context ) ? $parent_block->context : array() );
 }
 
 /**

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -25,6 +25,11 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Enables experimental blocks on a rolling basis as they are developed. (Warning: these blocks may have significant changes during development that cause validation errors and display issues.)', 'gutenberg' ),
 				),
 				array(
+					'id'          => 'gutenberg-pattern-overrides-inner-blocks',
+					'label'       => __( 'Inner block bindings for synced patterns', 'gutenberg' ),
+					'description' => __( 'Enables experimental Block Bindings for editable areas in synced patterns, allowing their nested blocks to be customized for each pattern instance.', 'gutenberg' ),
+				),
+				array(
 					'id'          => 'gutenberg-form-blocks',
 					'label'       => __( 'Form and input blocks', 'gutenberg' ),
 					'description' => __( 'Enables new blocks to allow building forms. You are likely to experience UX issues that are being addressed.', 'gutenberg' ),

--- a/lib/load.php
+++ b/lib/load.php
@@ -137,6 +137,7 @@ require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/site-editor.php';
 require __DIR__ . '/experimental/extensible-site-editor.php';
+require __DIR__ . '/experimental/block-bindings-inner-blocks.php';
 if ( gutenberg_is_experiment_enabled( 'gutenberg-dataform-inspector' ) ) {
 	require __DIR__ . '/experimental/dataform-inspector-preload.php';
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -137,7 +137,9 @@ require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/site-editor.php';
 require __DIR__ . '/experimental/extensible-site-editor.php';
-require __DIR__ . '/experimental/block-bindings-inner-blocks.php';
+if ( gutenberg_is_experiment_enabled( 'gutenberg-pattern-overrides-inner-blocks' ) ) {
+	require __DIR__ . '/experimental/block-bindings-inner-blocks.php';
+}
 if ( gutenberg_is_experiment_enabled( 'gutenberg-dataform-inspector' ) ) {
 	require __DIR__ . '/experimental/dataform-inspector-preload.php';
 }

--- a/phpunit/block-bindings-innerblocks-test.php
+++ b/phpunit/block-bindings-innerblocks-test.php
@@ -7,21 +7,13 @@
 
 class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
-	const SOURCE_NAME = 'test/inner-blocks';
+	const SOURCE_NAME = 'core/pattern-overrides';
 
 	private static $value          = null;
 	private static $source_context = array();
+	private $original_source;
 
 	public static function wpSetUpBeforeClass() {
-		register_block_type(
-			'test/inner-host',
-			array(
-				'render_callback' => static function ( $attributes, $content ) {
-					return '<div class="inner-host">' . $content . '</div>';
-				},
-			)
-		);
-		register_block_type( 'test/static-inner-host', array() );
 		register_block_type(
 			'test/context-provider',
 			array(
@@ -41,15 +33,15 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
-		unregister_block_type( 'test/inner-host' );
-		unregister_block_type( 'test/static-inner-host' );
 		unregister_block_type( 'test/context-provider' );
 	}
 
 	public function set_up() {
 		parent::set_up();
-		self::$value          = null;
-		self::$source_context = array();
+		self::$value           = null;
+		self::$source_context  = array();
+		$this->original_source = get_block_bindings_source( self::SOURCE_NAME );
+		unregister_block_bindings_source( self::SOURCE_NAME );
 
 		register_block_bindings_source(
 			self::SOURCE_NAME,
@@ -66,15 +58,27 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function tear_down() {
 		unregister_block_bindings_source( self::SOURCE_NAME );
+		$original_source = $this->original_source;
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => $original_source->label,
+				'uses_context'       => $original_source->uses_context,
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $original_source ) {
+					return $original_source->get_value( $source_args, $block_instance, $attribute_name );
+				},
+			)
+		);
 		parent::tear_down();
 	}
 
-	private function block_markup( $name, $children, $attributes = array() ) {
+	private function block_markup( $children, $attributes = array() ) {
 		$attributes['metadata']['bindings']['innerBlocks'] = array( 'source' => self::SOURCE_NAME );
 
-		return '<!-- wp:' . $name . ' ' . wp_json_encode( $attributes ) . ' -->' .
+		return '<!-- wp:group ' . wp_json_encode( $attributes ) . ' -->' .
+			'<div class="wp-block-group">' .
 			$children .
-			'<!-- /wp:' . $name . ' -->';
+			'</div><!-- /wp:group -->';
 	}
 
 	private function fallback_paragraph( $content = 'Fallback' ) {
@@ -85,9 +89,44 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		return '<!-- wp:paragraph --><p>' . $content . '</p><!-- /wp:paragraph -->';
 	}
 
+	public function test_binding_gate_accepts_pattern_overrides_on_a_core_host() {
+		$parsed = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+
+		$this->assertSame(
+			array( 'source' => self::SOURCE_NAME ),
+			gutenberg_block_bindings_get_inner_blocks_binding( $parsed[0] )
+		);
+	}
+
+	/**
+	 * @dataProvider data_unsupported_bindings
+	 */
+	public function test_binding_gate_rejects_unsupported_hosts_and_sources( $block_name, $source_name ) {
+		$parsed_block = array(
+			'blockName' => $block_name,
+			'attrs'     => array(
+				'metadata' => array(
+					'bindings' => array(
+						'innerBlocks' => array( 'source' => $source_name ),
+					),
+				),
+			),
+		);
+
+		$this->assertNull( gutenberg_block_bindings_get_inner_blocks_binding( $parsed_block ) );
+	}
+
+	public function data_unsupported_bindings() {
+		return array(
+			'custom source' => array( 'core/group', 'test/source' ),
+			'custom host'   => array( 'test/inner-host', self::SOURCE_NAME ),
+			'custom html'   => array( 'core/html', self::SOURCE_NAME ),
+		);
+	}
+
 	public function test_registered_source_replaces_fallback_children() {
 		self::$value = $this->sourced_paragraph();
-		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
 		$this->assertStringContainsString( 'Sourced', $result );
@@ -99,7 +138,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	 */
 	public function test_absent_or_invalid_values_preserve_fallback_children( $value ) {
 		self::$value = $value;
-		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
 		$this->assertStringContainsString( 'Fallback', $result );
@@ -115,16 +154,16 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function test_empty_string_intentionally_removes_fallback_children() {
 		self::$value = '';
-		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( 'class="inner-host"', $result );
+		$this->assertStringContainsString( 'class="wp-block-group"', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
-	public function test_empty_string_removes_fallback_children_from_a_nested_dynamic_host() {
+	public function test_empty_string_removes_fallback_children_from_a_nested_host() {
 		self::$value = '';
-		$bound       = $this->block_markup( 'test/inner-host', $this->fallback_paragraph() );
+		$bound       = $this->block_markup( $this->fallback_paragraph() );
 		$parsed      = parse_blocks(
 			'<!-- wp:test/context-provider -->' .
 			$bound .
@@ -132,27 +171,24 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		);
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( 'class="inner-host"', $result );
+		$this->assertStringContainsString( 'class="wp-block-group"', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
 	public function test_static_host_keeps_its_wrapper() {
 		self::$value = $this->sourced_paragraph();
-		$markup      = $this->block_markup(
-			'test/static-inner-host',
-			'<section class="static-wrapper">' . $this->fallback_paragraph() . '</section>'
-		);
+		$markup      = $this->block_markup( $this->fallback_paragraph() );
 		$parsed      = parse_blocks( $markup );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( '<section class="static-wrapper">', $result );
+		$this->assertStringContainsString( '<div class="wp-block-group">', $result );
 		$this->assertStringContainsString( 'Sourced', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
 	public function test_nested_source_receives_context_from_a_provider() {
 		self::$value = $this->sourced_paragraph();
-		$bound       = $this->block_markup( 'test/inner-host', $this->fallback_paragraph() );
+		$bound       = $this->block_markup( $this->fallback_paragraph() );
 		$parsed      = parse_blocks(
 			'<!-- wp:test/context-provider {"provided":"from-provider"} -->' .
 			$bound .
@@ -168,7 +204,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		self::$value = $this->sourced_paragraph();
 		$calls       = 0;
 		$filter      = static function ( $context, $parsed_block ) use ( &$calls ) {
-			if ( 'test/inner-host' !== ( $parsed_block['blockName'] ?? null ) ) {
+			if ( 'core/group' !== ( $parsed_block['blockName'] ?? null ) ) {
 				return $context;
 			}
 
@@ -179,7 +215,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		add_filter( 'render_block_context', $filter, 10, 3 );
 
 		try {
-			$parsed = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+			$parsed = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
 			render_block( $parsed[0] );
 		} finally {
 			remove_filter( 'render_block_context', $filter, 10 );
@@ -191,11 +227,11 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function test_nonempty_value_fails_closed_without_a_parsed_slot() {
 		self::$value = $this->sourced_paragraph();
-		$markup      = $this->block_markup( 'test/static-inner-host', '<section class="static-wrapper"></section>' );
+		$markup      = $this->block_markup( '' );
 		$parsed      = parse_blocks( $markup );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( '<section class="static-wrapper"></section>', $result );
+		$this->assertStringContainsString( 'class="wp-block-group"', $result );
 		$this->assertStringNotContainsString( 'Sourced', $result );
 	}
 }

--- a/phpunit/block-bindings-innerblocks-test.php
+++ b/phpunit/block-bindings-innerblocks-test.php
@@ -122,6 +122,20 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
+	public function test_empty_string_removes_fallback_children_from_a_nested_dynamic_host() {
+		self::$value = '';
+		$bound       = $this->block_markup( 'test/inner-host', $this->fallback_paragraph() );
+		$parsed      = parse_blocks(
+			'<!-- wp:test/context-provider -->' .
+			$bound .
+			'<!-- /wp:test/context-provider -->'
+		);
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( 'class="inner-host"', $result );
+		$this->assertStringNotContainsString( 'Fallback', $result );
+	}
+
 	public function test_static_host_keeps_its_wrapper() {
 		self::$value = $this->sourced_paragraph();
 		$markup      = $this->block_markup(

--- a/phpunit/block-bindings-innerblocks-test.php
+++ b/phpunit/block-bindings-innerblocks-test.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests for experimental structural block bindings.
+ *
+ * @package gutenberg
+ */
+
+class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
+
+	const SOURCE_NAME = 'test/inner-blocks';
+
+	private static $value          = null;
+	private static $source_context = array();
+
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'test/inner-host',
+			array(
+				'render_callback' => static function ( $attributes, $content ) {
+					return '<div class="inner-host">' . $content . '</div>';
+				},
+			)
+		);
+		register_block_type( 'test/static-inner-host', array() );
+		register_block_type(
+			'test/context-provider',
+			array(
+				'attributes'       => array(
+					'provided' => array(
+						'type' => 'string',
+					),
+				),
+				'provides_context' => array(
+					'test/provided' => 'provided',
+				),
+				'render_callback'  => static function ( $attributes, $content ) {
+					return '<div class="context-provider">' . $content . '</div>';
+				},
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/inner-host' );
+		unregister_block_type( 'test/static-inner-host' );
+		unregister_block_type( 'test/context-provider' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		self::$value          = null;
+		self::$source_context = array();
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => 'Inner blocks test source',
+				'uses_context'       => array( 'test/provided', 'test/filter' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					self::$source_context = $block_instance->context;
+					return 'innerBlocks' === $attribute_name ? self::$value : null;
+				},
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_block_bindings_source( self::SOURCE_NAME );
+		parent::tear_down();
+	}
+
+	private function block_markup( $name, $children, $attributes = array() ) {
+		$attributes['metadata']['bindings']['innerBlocks'] = array( 'source' => self::SOURCE_NAME );
+
+		return '<!-- wp:' . $name . ' ' . wp_json_encode( $attributes ) . ' -->' .
+			$children .
+			'<!-- /wp:' . $name . ' -->';
+	}
+
+	private function fallback_paragraph( $content = 'Fallback' ) {
+		return '<!-- wp:paragraph --><p>' . $content . '</p><!-- /wp:paragraph -->';
+	}
+
+	private function sourced_paragraph( $content = 'Sourced' ) {
+		return '<!-- wp:paragraph --><p>' . $content . '</p><!-- /wp:paragraph -->';
+	}
+
+	public function test_registered_source_replaces_fallback_children() {
+		self::$value = $this->sourced_paragraph();
+		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( 'Sourced', $result );
+		$this->assertStringNotContainsString( 'Fallback', $result );
+	}
+
+	/**
+	 * @dataProvider data_absent_values
+	 */
+	public function test_absent_or_invalid_values_preserve_fallback_children( $value ) {
+		self::$value = $value;
+		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( 'Fallback', $result );
+	}
+
+	public function data_absent_values() {
+		return array(
+			'null'        => array( null ),
+			'integer'     => array( 1 ),
+			'block array' => array( array() ),
+		);
+	}
+
+	public function test_empty_string_intentionally_removes_fallback_children() {
+		self::$value = '';
+		$parsed      = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( 'class="inner-host"', $result );
+		$this->assertStringNotContainsString( 'Fallback', $result );
+	}
+
+	public function test_static_host_keeps_its_wrapper() {
+		self::$value = $this->sourced_paragraph();
+		$markup      = $this->block_markup(
+			'test/static-inner-host',
+			'<section class="static-wrapper">' . $this->fallback_paragraph() . '</section>'
+		);
+		$parsed      = parse_blocks( $markup );
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( '<section class="static-wrapper">', $result );
+		$this->assertStringContainsString( 'Sourced', $result );
+		$this->assertStringNotContainsString( 'Fallback', $result );
+	}
+
+	public function test_nested_source_receives_context_from_a_provider() {
+		self::$value = $this->sourced_paragraph();
+		$bound       = $this->block_markup( 'test/inner-host', $this->fallback_paragraph() );
+		$parsed      = parse_blocks(
+			'<!-- wp:test/context-provider {"provided":"from-provider"} -->' .
+			$bound .
+			'<!-- /wp:test/context-provider -->'
+		);
+
+		render_block( $parsed[0] );
+
+		$this->assertSame( 'from-provider', self::$source_context['test/provided'] );
+	}
+
+	public function test_top_level_takeover_applies_context_filters_once() {
+		self::$value = $this->sourced_paragraph();
+		$calls       = 0;
+		$filter      = static function ( $context, $parsed_block ) use ( &$calls ) {
+			if ( 'test/inner-host' !== ( $parsed_block['blockName'] ?? null ) ) {
+				return $context;
+			}
+
+			++$calls;
+			$context['test/filter'] = 'from-filter';
+			return $context;
+		};
+		add_filter( 'render_block_context', $filter, 10, 3 );
+
+		try {
+			$parsed = parse_blocks( $this->block_markup( 'test/inner-host', $this->fallback_paragraph() ) );
+			render_block( $parsed[0] );
+		} finally {
+			remove_filter( 'render_block_context', $filter, 10 );
+		}
+
+		$this->assertSame( 1, $calls );
+		$this->assertSame( 'from-filter', self::$source_context['test/filter'] );
+	}
+
+	public function test_nonempty_value_fails_closed_without_a_parsed_slot() {
+		self::$value = $this->sourced_paragraph();
+		$markup      = $this->block_markup( 'test/static-inner-host', '<section class="static-wrapper"></section>' );
+		$parsed      = parse_blocks( $markup );
+		$result      = render_block( $parsed[0] );
+
+		$this->assertStringContainsString( '<section class="static-wrapper"></section>', $result );
+		$this->assertStringNotContainsString( 'Sourced', $result );
+	}
+}

--- a/phpunit/block-bindings-innerblocks-test.php
+++ b/phpunit/block-bindings-innerblocks-test.php
@@ -14,6 +14,19 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	private $original_source;
 
 	public static function wpSetUpBeforeClass() {
+		/*
+		 * Core-namespaced fixtures satisfy the private binding gate without
+		 * invoking unrelated block supports such as core/group's layout cache.
+		 */
+		register_block_type(
+			'core/test-inner-host',
+			array(
+				'render_callback' => static function ( $attributes, $content ) {
+					return '<div class="inner-host">' . $content . '</div>';
+				},
+			)
+		);
+		register_block_type( 'core/test-static-inner-host', array() );
 		register_block_type(
 			'test/context-provider',
 			array(
@@ -33,6 +46,8 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	}
 
 	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'core/test-inner-host' );
+		unregister_block_type( 'core/test-static-inner-host' );
 		unregister_block_type( 'test/context-provider' );
 	}
 
@@ -72,13 +87,12 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	private function block_markup( $children, $attributes = array() ) {
+	private function block_markup( $name, $children, $attributes = array() ) {
 		$attributes['metadata']['bindings']['innerBlocks'] = array( 'source' => self::SOURCE_NAME );
 
-		return '<!-- wp:group ' . wp_json_encode( $attributes ) . ' -->' .
-			'<div class="wp-block-group">' .
+		return '<!-- wp:' . $name . ' ' . wp_json_encode( $attributes ) . ' -->' .
 			$children .
-			'</div><!-- /wp:group -->';
+			'<!-- /wp:' . $name . ' -->';
 	}
 
 	private function fallback_paragraph( $content = 'Fallback' ) {
@@ -90,7 +104,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	}
 
 	public function test_binding_gate_accepts_pattern_overrides_on_a_core_host() {
-		$parsed = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+		$parsed = parse_blocks( $this->block_markup( 'group', $this->fallback_paragraph() ) );
 
 		$this->assertSame(
 			array( 'source' => self::SOURCE_NAME ),
@@ -126,7 +140,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function test_registered_source_replaces_fallback_children() {
 		self::$value = $this->sourced_paragraph();
-		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( 'test-inner-host', $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
 		$this->assertStringContainsString( 'Sourced', $result );
@@ -138,7 +152,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 	 */
 	public function test_absent_or_invalid_values_preserve_fallback_children( $value ) {
 		self::$value = $value;
-		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( 'test-inner-host', $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
 		$this->assertStringContainsString( 'Fallback', $result );
@@ -154,16 +168,16 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function test_empty_string_intentionally_removes_fallback_children() {
 		self::$value = '';
-		$parsed      = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+		$parsed      = parse_blocks( $this->block_markup( 'test-inner-host', $this->fallback_paragraph() ) );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( 'class="wp-block-group"', $result );
+		$this->assertStringContainsString( 'class="inner-host"', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
 	public function test_empty_string_removes_fallback_children_from_a_nested_host() {
 		self::$value = '';
-		$bound       = $this->block_markup( $this->fallback_paragraph() );
+		$bound       = $this->block_markup( 'test-inner-host', $this->fallback_paragraph() );
 		$parsed      = parse_blocks(
 			'<!-- wp:test/context-provider -->' .
 			$bound .
@@ -171,24 +185,27 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		);
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( 'class="wp-block-group"', $result );
+		$this->assertStringContainsString( 'class="inner-host"', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
 	public function test_static_host_keeps_its_wrapper() {
 		self::$value = $this->sourced_paragraph();
-		$markup      = $this->block_markup( $this->fallback_paragraph() );
+		$markup      = $this->block_markup(
+			'test-static-inner-host',
+			'<section class="static-wrapper">' . $this->fallback_paragraph() . '</section>'
+		);
 		$parsed      = parse_blocks( $markup );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( '<div class="wp-block-group">', $result );
+		$this->assertStringContainsString( '<section class="static-wrapper">', $result );
 		$this->assertStringContainsString( 'Sourced', $result );
 		$this->assertStringNotContainsString( 'Fallback', $result );
 	}
 
 	public function test_nested_source_receives_context_from_a_provider() {
 		self::$value = $this->sourced_paragraph();
-		$bound       = $this->block_markup( $this->fallback_paragraph() );
+		$bound       = $this->block_markup( 'test-inner-host', $this->fallback_paragraph() );
 		$parsed      = parse_blocks(
 			'<!-- wp:test/context-provider {"provided":"from-provider"} -->' .
 			$bound .
@@ -204,7 +221,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		self::$value = $this->sourced_paragraph();
 		$calls       = 0;
 		$filter      = static function ( $context, $parsed_block ) use ( &$calls ) {
-			if ( 'core/group' !== ( $parsed_block['blockName'] ?? null ) ) {
+			if ( 'core/test-inner-host' !== ( $parsed_block['blockName'] ?? null ) ) {
 				return $context;
 			}
 
@@ -215,7 +232,7 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 		add_filter( 'render_block_context', $filter, 10, 3 );
 
 		try {
-			$parsed = parse_blocks( $this->block_markup( $this->fallback_paragraph() ) );
+			$parsed = parse_blocks( $this->block_markup( 'test-inner-host', $this->fallback_paragraph() ) );
 			render_block( $parsed[0] );
 		} finally {
 			remove_filter( 'render_block_context', $filter, 10 );
@@ -227,11 +244,11 @@ class Tests_Block_Bindings_InnerBlocks extends WP_UnitTestCase {
 
 	public function test_nonempty_value_fails_closed_without_a_parsed_slot() {
 		self::$value = $this->sourced_paragraph();
-		$markup      = $this->block_markup( '' );
+		$markup      = $this->block_markup( 'test-static-inner-host', '<section class="static-wrapper"></section>' );
 		$parsed      = parse_blocks( $markup );
 		$result      = render_block( $parsed[0] );
 
-		$this->assertStringContainsString( 'class="wp-block-group"', $result );
+		$this->assertStringContainsString( '<section class="static-wrapper"></section>', $result );
 		$this->assertStringNotContainsString( 'Sourced', $result );
 	}
 }

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -86,14 +86,15 @@ tests_add_filter( 'wp_die_handler', 'fail_if_died' );
 
 $GLOBALS['wp_tests_options'] = array(
 	'gutenberg-experiments' => array(
-		'gutenberg-widget-experiments' => '1',
-		'gutenberg-full-site-editing'  => 1,
-		'gutenberg-form-blocks'        => 1,
-		'gutenberg-block-experiments'  => 1,
-		'gutenberg-media-processing'   => 1,
-		'gutenberg-guidelines'         => 1,
-		'gutenberg-content-types'      => 1,
-		'gutenberg-dashboard-widgets'  => 1,
+		'gutenberg-widget-experiments'             => '1',
+		'gutenberg-full-site-editing'              => 1,
+		'gutenberg-form-blocks'                    => 1,
+		'gutenberg-block-experiments'              => 1,
+		'gutenberg-pattern-overrides-inner-blocks' => 1,
+		'gutenberg-media-processing'               => 1,
+		'gutenberg-guidelines'                     => 1,
+		'gutenberg-content-types'                  => 1,
+		'gutenberg-dashboard-widgets'              => 1,
 	),
 );
 


### PR DESCRIPTION
I think this server flow presents better what it does rather than AI gen description.

## Complete server flow

  Saved block markup
          │
          ▼
  WordPress parses fallback children
          │
          ▼
  Is metadata.bindings.innerBlocks eligible?
          │
          ├── No ──► Render normal fallback children
          │
          ▼
  Is the block nested?
          │
          ├── Yes ─► render_block_data path
          │          Find child WP_Block and inherited context
          │
          └── No ──► pre_render_block takeover
                     Reproduce data/context filters
          │
          ▼
  Call the registered source
          │
          ├── null/non-string ─► Keep fallback
          ├── '' ──────────────► Render empty area
          └── markup string ───► Parse replacement blocks
          │
          ▼
  Rebuild innerBlocks + innerContent + innerHTML
          │
          ▼
  Render replacement children inside the original host wrapper


<details>
<summary>AI Description</summary>

## What?

Adds the Gutenberg-only server half of the experimental innerBlocks binding for WP 7.2 and registers it behind a user-enabled Gutenberg experiment.

A standard, otherwise-uncontrolled InnerBlocks host may resolve its children from a registered source. The shared value contract is deliberate: a serialized block-markup string replaces fallback children; `null`, `undefined`, and other non-string values fall back to the hosts own children; `''` is intentionally empty. The server does not apply a different source-value transformation than the editor.

Nested resolution uses `render_block_data`. The necessary top-level `pre_render_block` shim mirrors the `render_block()` tail because a plugin cannot extend `WP_Block`; that code would move into Core if the experiment is adopted.

## Experimental first slice and caveats

- This is Gutenberg-only and loaded only when the user enables the **Inner block bindings for synced patterns** experiment. The experiment injects the `blockBindingsInnerBlocks` editor setting for WP 7.2; Core remains inert and there is no Core sync in this stack.
- This is mechanism only. There is no authoring UI yet: a plugin or pre-authored block markup must supply the `metadata.bindings.innerBlocks` descriptor.
- It supports one ordinary, static, otherwise-uncontrolled InnerBlocks area. `core/html`, hosts with multiple or interleaved structural areas, and caller-controlled InnerBlocks areas are excluded.
- A nonempty source value for a static host that was initially empty fails closed, because parser output has no child placeholder to replace. Supporting that case, `core/html`, or multiple structural areas needs a separate HTML API design to identify and replace the right slot safely; this experiment must not infer it from arbitrary HTML or use regex.
- Sources own the serialized-markup contract. The experiment does not establish a separate source-specific sanitization policy or a server-only markup rewrite.
- Read-only sources and sources without a supported write-back path are not designed yet. This is not a noneditable-host feature.
- It establishes no generic structural-recursion policy. Future recursive sources need a concrete reproducer and a bounded design before support is added.
- Direct release keeps the current children, but manual detach/rebind flows and complex source/history/undo combinations are outside the supported contract for this first slice.

Stack: #79855 → this PR → #79940 → #79852.
</details>