### PR TITLE
Button: Fix suppressed ESLint errors

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -63,21 +63,22 @@ const LINK_SETTINGS = [
 	},
 ];
 
-function useEnter( props ) {
+function useEnter( clientId ) {
 	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
-	const { getBlock, getBlockRootClientId, getBlockIndex } =
-		useSelect( blockEditorStore );
-	const propsRef = useRef( props );
-	useEffect( () => {
-		propsRef.current = props;
-	}, [ props ] );
+	const {
+		getBlock,
+		getBlockAttributes,
+		getBlockRootClientId,
+		getBlockIndex,
+	} = useSelect( blockEditorStore );
+
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented || event.keyCode !== ENTER ) {
 				return;
 			}
-			const { content, clientId } = propsRef.current;
-			if ( content.length ) {
+			const { text } = getBlockAttributes( clientId ) ?? {};
+			if ( text?.length ) {
 				return;
 			}
 			event.preventDefault();
@@ -268,7 +269,7 @@ function ButtonEdit( props ) {
 		[ url, opensInNewTab, nofollow ]
 	);
 
-	const useEnterRef = useEnter( { content: text, clientId } );
+	const useEnterRef = useEnter( clientId );
 	const mergedRef = useMergeRefs( [ useEnterRef, richTextRef ] );
 
 	const [ fluidTypographySettings, layout, dimensionSizes ] = useSettings(

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,12 +7,7 @@ import {
 	useMemo,
 	createInterpolateElement,
 } from '@wordpress/element';
-import {
-	TextControl,
-	ToolbarButton,
-	Popover,
-	ExternalLink,
-} from '@wordpress/components';
+import { TextControl, ToolbarButton, Popover } from '@wordpress/components';
 import {
 	BlockControls,
 	InspectorControls,
@@ -45,6 +40,11 @@ import {
 	privateApis as composePrivateApis,
 } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { Link } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
@@ -68,7 +68,9 @@ function useEnter( props ) {
 	const { getBlock, getBlockRootClientId, getBlockIndex } =
 		useSelect( blockEditorStore );
 	const propsRef = useRef( props );
-	propsRef.current = props;
+	useEffect( () => {
+		propsRef.current = props;
+	}, [ props ] );
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented || event.keyCode !== ENTER ) {
@@ -456,7 +458,10 @@ function ButtonEdit( props ) {
 							),
 							{
 								a: (
-									<ExternalLink href="https://developer.mozilla.org/docs/Web/HTML/Attributes/rel" />
+									<Link
+										openInNewTab
+										href="https://developer.mozilla.org/docs/Web/HTML/Attributes/rel"
+									/>
 								),
 							}
 						) }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -313,14 +313,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-library/src/button/edit.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		},
-		"react-hooks/refs": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/columns/edit.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
PR refactors button block to use the new recommended `Link` component and removes the latest props pattern in favor of getting fresh attributes as needed.

## Testing Instructions
1. Open a post.
2. Add a button block and text for it.
3. Then press <kbd>Enter</kbd> twice.
4. This should create a new default block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="269" height="292" alt="CleanShot 2026-07-07 at 17 16 57" src="https://github.com/user-attachments/assets/9acecd76-ea24-493a-ace2-67fed6f3402b" />

## Use of AI Tools

None.