### PR TITLE
Code Quality: Use null coalescing operator instead of isset() ternaries

### DIFF
--- a/lib/experimental/dashboard-widgets/dashboard-layout.php
+++ b/lib/experimental/dashboard-widgets/dashboard-layout.php
@@ -67,9 +67,7 @@ function gutenberg_inject_dashboard_default_layout( $value, $user_id, $meta_key 
 		$base = array();
 	}
 
-	$committed = isset( $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] )
-		? $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ]
-		: array();
+	$committed = $base[ GUTENBERG_DASHBOARD_LAYOUT_SCOPE ][ GUTENBERG_DASHBOARD_LAYOUT_KEY ] ?? array();
 
 	if ( ! empty( $committed ) ) {
 		return $value;

--- a/lib/experimental/knowledge/class-gutenberg-guideline-scopes-rest-controller.php
+++ b/lib/experimental/knowledge/class-gutenberg-guideline-scopes-rest-controller.php
@@ -100,10 +100,10 @@ class Gutenberg_Guideline_Scopes_REST_Controller extends WP_REST_Controller {
 			$data['slug'] = $item['slug'];
 		}
 		if ( rest_is_field_included( 'title', $fields ) ) {
-			$data['title'] = isset( $item['title'] ) ? $item['title'] : '';
+			$data['title'] = $item['title'] ?? '';
 		}
 		if ( rest_is_field_included( 'description', $fields ) ) {
-			$data['description'] = isset( $item['description'] ) ? $item['description'] : '';
+			$data['description'] = $item['description'] ?? '';
 		}
 		if ( rest_is_field_included( 'order', $fields ) ) {
 			$data['order'] = isset( $item['order'] ) ? (int) $item['order'] : 0;

--- a/lib/experimental/knowledge/class-gutenberg-guideline-scopes-rest-controller.php
+++ b/lib/experimental/knowledge/class-gutenberg-guideline-scopes-rest-controller.php
@@ -106,7 +106,7 @@ class Gutenberg_Guideline_Scopes_REST_Controller extends WP_REST_Controller {
 			$data['description'] = $item['description'] ?? '';
 		}
 		if ( rest_is_field_included( 'order', $fields ) ) {
-			$data['order'] = isset( $item['order'] ) ? (int) $item['order'] : 0;
+			$data['order'] = (int) ( $item['order'] ?? 0 );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';


### PR DESCRIPTION
## What?
Replace `isset( $x ) ? $x : $default` ternaries with the `??` operator for consistency.

