### PR TITLE
Visual revisions: Label autosaves in the revisions timeline

### DIFF
--- a/packages/editor/src/components/post-revisions-timeline/index.js
+++ b/packages/editor/src/components/post-revisions-timeline/index.js
@@ -6,9 +6,9 @@ import { store as coreStore } from '@wordpress/core-data';
 import { DataViewsPicker, filterSortAndPaginate } from '@wordpress/dataviews';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { authorField } from '@wordpress/fields';
-import { Text } from '@wordpress/ui';
+import { Badge, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -40,16 +40,28 @@ function getDisplayDate( value ) {
 		: humanTimeDiff( date );
 }
 
+function isAutosaveRevision( item ) {
+	// Autosaves use the `{parent_id}-autosave-v1` slug, like Core's `wp_is_post_autosave()`.
+	return item.slug?.endsWith( '-autosave-v1' ) ?? false;
+}
+
+function RevisionBadges( { item } ) {
+	if ( ! isAutosaveRevision( item ) ) {
+		return null;
+	}
+
+	return <Badge intent="none">{ __( 'Autosave' ) }</Badge>;
+}
+
 export default function PostRevisionsTimeline() {
 	const { setCurrentRevisionId } = unlock( useDispatch( editorStore ) );
 	const [ view, setView ] = useState( baseView );
 
-	const { revisions, revisionKey, currentRevisionId, currentRevision } =
-		useSelect( ( select ) => {
+	const { revisions, revisionKey, currentRevisionId } = useSelect(
+		( select ) => {
 			const { getCurrentPostType } = select( editorStore );
 			const {
 				getCurrentRevisionId: _getCurrentRevisionId,
-				getCurrentRevision,
 				getRevisionPage,
 				getPageRevisions,
 			} = unlock( select( editorStore ) );
@@ -65,13 +77,10 @@ export default function PostRevisionsTimeline() {
 				revisions: getPageRevisions( getRevisionPage() ),
 				revisionKey: _revisionKey,
 				currentRevisionId: _currentRevisionId,
-				currentRevision: _currentRevisionId
-					? getCurrentRevision()
-					: undefined,
 			};
-		}, [] );
-
-	const postContent = currentRevision?.content?.raw;
+		},
+		[]
+	);
 
 	const isLoading = ! revisions;
 
@@ -83,14 +92,30 @@ export default function PostRevisionsTimeline() {
 				// Return the humanized label the row renders so the picker
 				// option's accessible name announces e.g. "5 minutes ago"
 				// instead of the raw ISO timestamp.
-				getValue: ( { item } ) => getDisplayDate( item.date ),
+				getValue: ( { item } ) => {
+					const displayDate = getDisplayDate( item.date );
+
+					if ( ! isAutosaveRevision( item ) ) {
+						return displayDate;
+					}
+
+					return sprintf(
+						/* translators: 1: revision date, 2: revision type. */
+						__( '%1$s, %2$s' ),
+						displayDate,
+						__( 'Autosave' )
+					);
+				},
 				render: ( { item } ) => (
-					<Text
-						variant="heading-sm"
-						render={ <time dateTime={ item.date } /> }
-					>
-						{ getDisplayDate( item.date ) }
-					</Text>
+					<Stack direction="row" align="center" gap="sm">
+						<Text
+							variant="heading-sm"
+							render={ <time dateTime={ item.date } /> }
+						>
+							{ getDisplayDate( item.date ) }
+						</Text>
+						<RevisionBadges item={ item } />
+					</Stack>
 				),
 				enableSorting: false,
 				enableHiding: false,
@@ -107,14 +132,16 @@ export default function PostRevisionsTimeline() {
 						return null;
 					}
 					return (
-						<PostContentInformationUI postContent={ postContent } />
+						<PostContentInformationUI
+							postContent={ item.content?.raw }
+						/>
 					);
 				},
 				enableSorting: false,
 				enableHiding: false,
 			},
 		],
-		[ revisionKey, currentRevisionId, postContent ]
+		[ revisionKey, currentRevisionId ]
 	);
 
 	const { data: shownRevisions, paginationInfo } = useMemo(

--- a/packages/editor/src/components/post-revisions-timeline/test/index.js
+++ b/packages/editor/src/components/post-revisions-timeline/test/index.js
@@ -1,0 +1,180 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import PostRevisionsTimeline from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/fields', () => ( {
+	authorField: {
+		id: 'author',
+		label: 'Author',
+		getValue: ( { item } ) => item?._embedded?.author?.[ 0 ]?.name,
+		render: ( { item } ) => {
+			const { createElement } = require( '@wordpress/element' );
+			const authorName = item?._embedded?.author?.[ 0 ]?.name;
+
+			return createElement(
+				'span',
+				null,
+				createElement(
+					'span',
+					{ 'aria-hidden': 'true' },
+					'Author icon'
+				),
+				createElement( 'span', null, authorName )
+			);
+		},
+	},
+} ) );
+
+jest.mock( '@wordpress/dataviews', () => {
+	const DataViewsPicker = ( { data, fields, getItemId, selection } ) => {
+		const titleField = fields.find( ( field ) => field.id === 'date' );
+
+		return (
+			<div>
+				{ data.map( ( item ) => (
+					<div
+						key={ getItemId( item ) }
+						role="option"
+						aria-label={ titleField.getValue( { item } ) }
+						aria-selected={ selection.includes(
+							getItemId( item )
+						) }
+					>
+						{ fields.map( ( field ) => {
+							const normalizedField = {
+								id: field.id,
+								label: field.label,
+								render: field.render,
+							};
+
+							return normalizedField.render ? (
+								<div key={ normalizedField.id }>
+									<normalizedField.render
+										item={ item }
+										field={ normalizedField }
+									/>
+								</div>
+							) : null;
+						} ) }
+					</div>
+				) ) }
+			</div>
+		);
+	};
+	DataViewsPicker.Layout = () => null;
+	DataViewsPicker.Footer = () => null;
+
+	return {
+		DataViewsPicker,
+		filterSortAndPaginate: ( data ) => ( {
+			data,
+			paginationInfo: { totalItems: data.length },
+		} ),
+	};
+} );
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( object ) => {
+		return {
+			...object,
+			registerPrivateActions: jest.fn(),
+			registerPrivateSelectors: jest.fn(),
+		};
+	},
+} ) );
+
+jest.mock( '../../post-content-information', () => ( {
+	PostContentInformationUI: () => null,
+} ) );
+
+describe( 'PostRevisionsTimeline', () => {
+	let getCurrentRevision;
+
+	beforeEach( () => {
+		const revisions = [
+			{
+				id: 3,
+				date: '2026-07-07T12:00:00',
+				author: 1,
+				slug: '10-autosave-v1',
+				content: { raw: 'Autosaved content' },
+				_embedded: { author: [ { id: 1, name: 'Alice' } ] },
+			},
+			{
+				id: 2,
+				date: '2026-07-07T11:00:00',
+				author: 2,
+				slug: '10-revision-v1',
+				content: { raw: 'Current revision content' },
+				_embedded: { author: [ { id: 2, name: 'Bob' } ] },
+			},
+			{
+				id: 1,
+				date: '2026-07-07T10:00:00',
+				author: 1,
+				slug: '10-revision-v1',
+				content: { raw: 'Older revision content' },
+				_embedded: { author: [ { id: 1, name: 'Alice' } ] },
+			},
+		];
+		const users = {
+			1: { name: 'Alice' },
+			2: { name: 'Bob' },
+		};
+
+		getCurrentRevision = jest.fn( () => revisions[ 0 ] );
+
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getCurrentPostType: () => 'post',
+				getCurrentRevisionId: () => 3,
+				getCurrentRevision,
+				getRevisionPage: () => 1,
+				getPageRevisions: () => revisions,
+				getCurrentPostLastRevisionId: () => 2,
+				getEntityConfig: () => ( { revisionKey: 'id' } ),
+				getEntityRecord: ( _kind, _name, id ) => users[ id ],
+			} ) )
+		);
+		useDispatch.mockReturnValue( { setCurrentRevisionId: jest.fn() } );
+	} );
+
+	it( 'keeps the author field intact and labels autosaves', () => {
+		render( <PostRevisionsTimeline /> );
+
+		expect( screen.getAllByText( 'Author icon' ) ).toHaveLength( 3 );
+		expect( screen.getAllByText( 'Alice' ) ).toHaveLength( 2 );
+		expect( screen.getByText( 'Bob' ) ).toBeVisible();
+		expect( screen.getByText( 'Autosave' ) ).toBeVisible();
+		expect( screen.getAllByRole( 'option' )[ 0 ] ).toHaveAccessibleName(
+			/Autosave/
+		);
+		expect( screen.getAllByRole( 'option' )[ 1 ] ).not.toHaveAccessibleName(
+			/Autosave/
+		);
+		expect( screen.queryByText( 'Current' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Revision by Alice' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Current Revision by Bob' )
+		).not.toBeInTheDocument();
+		expect( getCurrentRevision ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -393,6 +393,7 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 				'date',
 				'modified',
 				'author',
+				'slug',
 				'meta',
 				'title.raw',
 				'excerpt.raw',


### PR DESCRIPTION
## What

Part of #79120.

Adds an `Autosave` badge to autosave entries in the new revisions timeline. The label appears next to the revision date and is also included in the row’s accessible name, so screen reader users get the same context.

## Why

Autosaves and regular revisions looked the same in the timeline, which made the list harder to scan and easier to misread. This is a feature that already exists in the classic revisions screen.

## How

Detects autosaves on the client from the revision `slug`, which follows the `{parent}-autosave-v1` naming that Core relies on, as pointed out in [this comment](https://github.com/WordPress/gutenberg/pull/79950#issuecomment-4907236962). 

## Testing Instructions

1. Open a post with revisions and a recent autosave.
2. Open the revisions screen from the editor sidebar.
3. Confirm the autosave row shows an `Autosave` label.
4. Confirm regular revision rows do not show that label.
5. Select different rows in the timeline and confirm the list does not reload.

## Screenshots
| Before | After |
| - | - |
| <img width="280" height="451" alt="image" src="https://github.com/user-attachments/assets/a62bb3f5-7676-420d-a439-b983b4c6389b" /> | <img width="282" height="481" alt="image" src="https://github.com/user-attachments/assets/b01e3fb0-75c0-408d-a3a2-8028490074b0" /> | 
