### PR TITLE
Perf tests: wait for upload queue to settle between media-upload iterations

### DIFF
--- a/test/performance/specs/media-upload.spec.js
+++ b/test/performance/specs/media-upload.spec.js
@@ -42,6 +42,49 @@ async function createTempImage( sourceFile, ext ) {
 }
 
 /**
+ * Waits for the client-side upload queue to fully settle.
+ *
+ * With client-side media processing, the image `src` flips to the server URL
+ * as soon as the main file is uploaded, but thumbnail and original-image
+ * sideloads plus finalization are still in flight. Cleaning up (deleting
+ * media) while those requests are pending deletes the attachment out from
+ * under them, causing 404s and intermittently wedging the upload queue so
+ * the next upload never completes. See
+ * https://github.com/WordPress/gutenberg/issues/79923.
+ *
+ * @param {Object} page Playwright page.
+ */
+async function waitForUploadQueueEmpty( page ) {
+	await page.waitForFunction(
+		() => {
+			const store = window.wp.data.select( 'core/upload-media' );
+			return ! store || store.getItems().length === 0;
+		},
+		undefined,
+		{ timeout: 120_000 }
+	);
+}
+
+/**
+ * Deletes all media as a best effort, tolerating already-deleted items.
+ *
+ * When an upload errors client-side after the attachment was created, the
+ * upload queue deletes its own orphaned attachment in a fire-and-forget
+ * request. That request can race this cleanup, making one of the deletes
+ * 404. Leftovers, if any, are swept by the next iteration's cleanup.
+ *
+ * @param {Object} requestUtils Request utility.
+ */
+async function deleteAllMediaBestEffort( requestUtils ) {
+	try {
+		await requestUtils.deleteAllMedia();
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.warn( `Media cleanup failed, continuing: ${ error.message }` );
+	}
+}
+
+/**
  * Runs upload iterations for a single image variant within one editor lifecycle.
  *
  * Inserts an image block, uploads the file, measures elapsed time, then
@@ -99,13 +142,17 @@ async function runUploadIterations( {
 			bucket.push( elapsed );
 		}
 
+		// Let pending sideloads/finalization finish before cleanup so
+		// deleting media doesn't race in-flight requests.
+		await waitForUploadQueueEmpty( page );
+
 		// Reset state for next iteration. Use resetBlocks rather than
 		// selecting and pressing Backspace because after upload, DOM focus
 		// is inside the block and Backspace is consumed by an inner element.
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/block-editor' ).resetBlocks( [] );
 		} );
-		await requestUtils.deleteAllMedia();
+		await deleteAllMediaBestEffort( requestUtils );
 		await fs.rm( tmpDirectory, {
 			recursive: true,
 			force: true,
@@ -246,13 +293,17 @@ test.describe( 'Media Upload Performance', () => {
 					results.multipleImageUploadProcessing.push( elapsed );
 				}
 
+				// Let pending sideloads/finalization finish before cleanup
+				// so deleting media doesn't race in-flight requests.
+				await waitForUploadQueueEmpty( page );
+
 				// Reset state for next iteration.
 				await page.evaluate( () => {
 					window.wp.data
 						.dispatch( 'core/block-editor' )
 						.resetBlocks( [] );
 				} );
-				await requestUtils.deleteAllMedia();
+				await deleteAllMediaBestEffort( requestUtils );
 				await fs.rm( tmpDirectory, {
 					recursive: true,
 					force: true,


### PR DESCRIPTION
## What?

Fixes the flaky `Media Upload Performance > Single Image Upload > Large JPEG uploads` performance test.

Fixes https://github.com/WordPress/gutenberg/issues/79923

## Why?

The test treated the image `src` flipping from `blob:` to a server URL as "upload complete". With client-side media processing that is only the **main file**: thumbnail sideloads, the `original_image` sideload (the large JPEG is over the 2560px big-image threshold, so it uploads a scaled main file plus the original), and the finalize request are all still in flight at that point.

The per-iteration cleanup then ran `deleteAllMedia()` while those requests were pending, deleting the attachment out from under them. Consequences, all visible in the failing CI runs:

- Repeated `404 (Not Found)` console errors on every run (sideload/finalize `POST`s against the deleted attachment). These appear in passing runs too - the race fires every iteration; the stall is just its worst case.
- Cross-iteration queue contamination: every failing CI screenshot shows the upload snackbar at **"Uploading 1 of 2"** while the stalled image sits on its `blob:` URL. A single in-progress upload before any sideloads shows "1 of 1", so the second item is a leftover from the raced previous iteration. When the wedge happens, the next upload never completes and the test times out after 120s.
- The `Batch upload 5 images` failure in the same runs (`rest_cannot_delete`, 500) is the same race seen from the server side.

## How?

- After each measured upload, wait for the `core/upload-media` queue to fully settle before resetting blocks and deleting media (same pattern as `waitForUploadQueueEmpty` in the client-side media processing e2e spec). The wait happens outside the measured window, so reported timings are unaffected.
- Make the media cleanup tolerant of already-deleted attachments: when an upload errors client-side after the attachment exists, the queue deletes its own orphaned attachment in a fire-and-forget request that can race `deleteAllMedia()` (observed locally as `rest_post_invalid_id` thrown from the cleanup).

## Testing

Reproduced and verified locally against `wp-env` (client-side media processing active):

- **Before:** every run of the spec logged 404s from the cleanup race; an instrumented 50-iteration variant of the large-JPEG loop under 4x CPU throttling + added network latency (emulating CI runners) hit the race constantly and intermittently failed cleanup.
- **After:** 300+ iterations of the throttled 50-iteration variant plus repeated full runs of the spec: zero 404s, zero failures.

To run:

```
npm run test:performance -- media-upload
```
