### PR TITLE
RTC: Improve stress test flakines

### DIFF
--- a/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-stress.spec.ts
@@ -427,25 +427,20 @@ test.describe( 'Collaboration - Stress Test', () => {
 		await collaborationUtils.waitForMutualDiscovery();
 
 		// ── Phase 4 — Two users type in the same paragraph ──────
-		// The two users edit distinct ends of the paragraph: Admin appends
-		// at the end, Editor prepends at the start.
+		// Place carets before either user types. The click + select steps
+		// concurrently seem flakey in Playwright, so place carets first and then
+		// start typing simultaneously.
+		await editor.canvas.getByText( 'shared editing target' ).click();
+		await page.keyboard.press( 'ControlOrMeta+a' );
+		await page.keyboard.press( 'ArrowRight' );
+
+		await editor2.canvas.getByText( 'shared editing target' ).click();
+		await page2.keyboard.press( 'ControlOrMeta+a' );
+		await page2.keyboard.press( 'ArrowLeft' );
+
 		await Promise.all( [
-			( async () => {
-				await editor.canvas
-					.getByText( 'shared editing target' )
-					.click();
-				await page.keyboard.press( 'ControlOrMeta+a' );
-				await page.keyboard.press( 'ArrowRight' );
-				await page.keyboard.insertText( '- Admin was here.' );
-			} )(),
-			( async () => {
-				await editor2.canvas
-					.getByText( 'shared editing target' )
-					.click();
-				await page2.keyboard.press( 'ControlOrMeta+a' );
-				await page2.keyboard.press( 'ArrowLeft' );
-				await page2.keyboard.insertText( 'Editor was here -' );
-			} )(),
+			page.keyboard.insertText( '- Admin was here.' ),
+			page2.keyboard.insertText( 'Editor was here -' ),
 		] );
 
 		// All three active users should see both additions.


### PR DESCRIPTION
## What?

After https://github.com/WordPress/gutenberg/pull/79757 merged yesterday, I noticed some intermittent flaky failures of the `collaboration-stress.spec.ts` test. #79757 changed the cursors to insert at the beginning and end of a paragraph instead of the exact same place ([discussed here](https://github.com/WordPress/gutenberg/pull/79757/changes#r3514570951)), but Playwright seems to struggle with placing a cursor while another user edits the same DOM element.

## Why?

Fix the stress test to pass. Locally, 10/10 runs succeeded with the changes in this PR (see Testing Instructions).

## How?

In testing, Playwright seemed to lose selection between the `getByText().click()` actions and `insertText()` when two users concurrent do the same actions. This likely wasn't an issue with HTTP polling, but with the new WebSocket tests running in Gutenberg updates are synced much more quickly. I also can't replicate manually, and I suspect this is a Playwright API limitation. Separating the two users' selection and insertion steps still tests the same behavior (ensuring dual editing within the same paragraph succeeds), but splitting the selection and insertion steps seems to fix the flakiness.

## Testing Instructions

The automated test can be verified locally with this command (10 times):

```bash
$ npm run test:e2e:rtc-websocket -- collaboration-stress.spec.ts -g "three users concurrently" --repeat-each=10

> gutenberg@23.5.0 test:e2e:rtc-websocket
> npm exec --workspace @wordpress/e2e-tests-playwright -- wp-scripts test-playwright --config playwright.rtc-websocket.config.ts collaboration-stress.spec.ts -g three users concurrently --repeat-each=10

[WebServer] gutenberg-rtc-test-ws-sync-server listening on 127.0.0.1:18991

Running 10 tests using 1 worker

  ✓   1 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.6s)
  ✓   2 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.4s)
  ✓   3 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.3s)
  ✓   4 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.3s)
  ✓   5 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.3s)
  ✓   6 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.3s)
  ✓   7 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.3s)
  ✓   8 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.4s)
  ✓   9 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.5s)
  ✓  10 [chromium] › specs/editor/collaboration/collaboration-stress.spec.ts:362:6 › Collaboration - Stress Test › three users concurrently edit a large post with diverse blocks (8.5s)

  10 passed (1.5m)
``` 

## Use of AI Tools

Claude for debugging.
