### PR TITLE
Block Library: Parse Markdown when converting Classic blocks

### DIFF
--- a/packages/block-library/src/freeform/migration-notice.js
+++ b/packages/block-library/src/freeform/migration-notice.js
@@ -3,7 +3,8 @@
  */
 import { Warning } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { createBlock, rawHandler } from '@wordpress/blocks';
+import { createBlock, pasteHandler } from '@wordpress/blocks';
+import { removep } from '@wordpress/autop';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -23,7 +24,17 @@ export default function MigrationNotice( { content, onReplace } ) {
 			__next40pxDefaultSize
 			key="convert-to-blocks"
 			variant="primary"
-			onClick={ () => onReplace( rawHandler( { HTML: content } ) ) }
+			onClick={ () => {
+				const plainContent = removep( content );
+
+				onReplace(
+					pasteHandler( {
+						HTML: plainContent,
+						plainText: plainContent,
+						mode: 'BLOCKS',
+					} )
+				);
+			} }
 		>
 			{ __( 'Convert to blocks' ) }
 		</Button>,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #79871.

Updates the Classic block's **Convert to blocks** action so Markdown content is correctly converted into Gutenberg blocks instead of being preserved as literal Markdown inside a Paragraph block.

## Why?

Markdown content inserted outside the editor (for example using WP-CLI) is loaded into a Classic block when the post is opened in Gutenberg.

When the user clicks **Convert to blocks**, the current conversion flow treats the content as HTML and bypasses Gutenberg's Markdown conversion, resulting in content such as:

```text
## Heading
```

being converted into a Paragraph block containing the literal Markdown rather than a Heading block.

The issue is limited to the Classic block conversion flow.

## How?

This PR updates the Classic block migration action to reuse Gutenberg's existing Markdown conversion flow.

Before passing the content to `pasteHandler`, the automatic paragraph wrappers generated by the Classic editor are removed using the existing `removep` utility from `@wordpress/autop`. The resulting plain text is then passed to `pasteHandler` in `BLOCKS` mode, allowing Gutenberg's existing Markdown parser to generate the appropriate blocks.

This keeps the implementation minimal by reusing existing utilities instead of introducing any custom Markdown parsing logic.

## Testing Instructions

1. Start the development environment.
   ```bash
   npm run wp-env start
   npm run dev
   ```
2. Create a post containing Markdown using WP-CLI.
   ```bash
   npm run wp-env run cli -- wp post create \
     --post_title="Markdown Test" \
     --post_content="## Radiohead rocks" \
     --post_status="publish"
   ```
3. Open the newly created post in the block editor.
4. Verify the content is loaded inside a Classic block.
5. Select the Classic block.
6. Click **Convert to blocks**.
7. Verify the content is converted into a Heading block instead of a Paragraph block containing the literal Markdown.

### Additional testing

Verify list conversion. Create another post:
```bash
npm run wp-env run cli -- wp post create --post_title="Markdown List Test" --post_content="* Item 1
* Item 2
* Item 3"
```

Repeat the conversion steps above.

Verify the content is converted into a List block.

## Screenshots or screencast

 Before:  `## Radiohead rocks` becomes a Paragraph block 


https://github.com/user-attachments/assets/1a4e42e8-fc06-4f45-ac16-57008f3a94dd


 After:  `## Radiohead rocks` becomes a Heading block 

https://github.com/user-attachments/assets/9811406e-229a-4d4f-82d6-06feeab5c351

