### PR TITLE
Theme: Fix token story swatch accessibility

### DIFF
--- a/packages/theme/src/stories/index.story.tsx
+++ b/packages/theme/src/stories/index.story.tsx
@@ -47,6 +47,7 @@ const ColorTokenTable = ( { tokens }: { tokens: string[] } ) => {
 					} }
 				>
 					<span
+						aria-hidden="true"
 						style={ {
 							backgroundColor: `var(${ name })`,
 							border: '1px solid var(--wpds-color-stroke-surface-neutral)',
@@ -54,7 +55,6 @@ const ColorTokenTable = ( { tokens }: { tokens: string[] } ) => {
 							aspectRatio: '2/1',
 							display: 'block',
 						} }
-						aria-label={ name }
 					></span>
 					<code>{ name }</code>
 				</li>


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/issues/77462, point X5.

## What?

Removes the unsupported accessible name from the decorative color swatch in the `@wordpress/theme` token Storybook story.

## Why?

The token name is already visible next to each swatch, so the swatch does not need its own `aria-label`. Keeping `aria-label` on a plain non-interactive `span` creates an accessibility lint nit without adding useful screen reader context.

## How?

Marks the swatch as decorative with `aria-hidden="true"` and relies on the adjacent visible `<code>` token name as the accessible text for each list item.

## Testing Instructions

1. Run `npm run lint:js -- packages/theme/src/stories/index.story.tsx`.
2. Run `npx tsgo --build packages/theme/tsconfig.json`.
3. Run `git diff --check`.

### Testing Instructions for Keyboard

No keyboard-specific testing is needed. This only changes the accessibility tree for non-interactive Storybook swatches.

## Screenshots or screencast

N/A. The visual output is unchanged.

## Use of AI Tools

This PR was created with assistance from OpenAI Codex.