### PR TITLE
theme: Clarify package docs

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Documentation
 
+-   Clarify what `@wordpress/theme` provides, when consumers need to load `design-tokens.css`, the `ThemeProvider` contract including root provider usage, and the legacy compatibility boundary ([#79961](https://github.com/WordPress/gutenberg/pull/79961)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).
@@ -54,16 +55,14 @@
 ### Enhancements
 
 -   `ThemeProvider`: forward the `cornerRadius` preset to the document element when `isRoot` is set, matching `color` and `cursor`. [#79153](https://github.com/WordPress/gutenberg/pull/79153).
+-   Tweak `--wpds-color-foreground-interactive-brand-active` and `--wpds-color-foreground-interactive-error-active` to differentiate them from the non-`active` counterparts ([#79151](https://github.com/WordPress/gutenberg/pull/79151)).
 
 ### Documentation
 
 -   Rename the `bg` and `fg` design token groups to `background` and `foreground`. All `--wpds-color-bg-*` custom properties are now `--wpds-color-background-*`, and all `--wpds-color-fg-*` custom properties are now `--wpds-color-foreground-*` ([#79098](https://github.com/WordPress/gutenberg/pull/79098)).
 -   Rename the `--wpds-color-stroke-focus-brand` design token to `--wpds-color-stroke-focus` ([#79125](https://github.com/WordPress/gutenberg/pull/79125)).
 -   Added [Design Tokens Maintainer's Guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/tokens/README.md) and trimmed maintainer-facing content from package README ([#79157](https://github.com/WordPress/gutenberg/pull/79157)).
-
-### Enhancements
-
--   Tweak `--wpds-color-foreground-interactive-brand-active` and `--wpds-color-foreground-interactive-error-active` to differentiate them from the non-`active` counterparts ([#79151](https://github.com/WordPress/gutenberg/pull/79151)).
+-   Document the static-stylesheet + `<ThemeProvider>` delivery model, the `isRoot` prop, and the canonical pattern for using `<ThemeProvider>` across documents (iframes and other portals) ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 
 ### Bug Fixes
 
@@ -73,10 +72,6 @@
 
 -   Add unit tests for `ThemeProvider` and `useThemeProviderStyles` ([#79126](https://github.com/WordPress/gutenberg/pull/79126)).
 -   Run the stylelint plugin tests through the stylelint Node API instead of spawning the CLI via `child_process` ([#79199](https://github.com/WordPress/gutenberg/pull/79199)).
-
-### Documentation
-
--   Document the static-stylesheet + `<ThemeProvider>` delivery model, the `isRoot` prop, and the canonical pattern for using `<ThemeProvider>` across documents (iframes and other portals) ([#78664](https://github.com/WordPress/gutenberg/pull/78664)).
 
 ### Code Quality
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -9,6 +9,8 @@ A theming package that's part of the WordPress Design System. It has two parts:
 -   **Design Tokens**: A comprehensive system of design tokens for colors, spacing, typography, and more.
 -   **Theme System**: A flexible theming provider for consistent theming across applications.
 
+This package is not a WordPress block theme, site theme, or `theme.json` API. It provides the WordPress Design System's design tokens and React theming primitives for JavaScript packages and applications.
+
 ## Documentation
 
 This README is the entry point for package consumers. It covers how to load design tokens, use `ThemeProvider`, and configure the package's development tooling.
@@ -38,11 +40,13 @@ The design system splits token delivery into two complementary layers:
 
 #### Within WordPress
 
-Stylesheets are managed on your behalf in a WordPress context, so you don't need to worry about loading them yourself. The design tokens stylesheet is enqueued automatically on every admin page and inside the block editor's content iframe.
+Stylesheets are managed on your behalf in standard WordPress admin and editor screens. WordPress registers the design tokens stylesheet as the `wp-theme` style handle and loads it where WordPress admin and editor packages already depend on the shared base styles. This includes the admin page and the block editor's content iframe.
+
+If your plugin renders a separate app shell, iframe, popup window, or package bundle outside those WordPress-managed style dependencies, enqueue the `wp-theme` stylesheet in that document instead of bundling `@wordpress/theme/design-tokens.css` into your plugin. See the [wp_enqueue_style documentation](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters) for how to specify stylesheet dependencies.
 
 #### Outside WordPress
 
-Outside of WordPress, you will need to install and load the design tokens stylesheet to support the full range of theming capabilities:
+Outside of WordPress, install and load the design tokens stylesheet to support the full range of theming capabilities:
 
 ```sh
 npm install @wordpress/theme
@@ -147,7 +151,11 @@ Setting `isRoot` additionally hoists those overrides to the containing document'
 </ThemeProvider>
 ```
 
-Use `isRoot` on the top-level provider for an application or page. It's also the recommended pattern for the topmost provider rendered into a separate document (iframe, popup window). The static design-tokens stylesheet still provides the default values; `isRoot` is only needed when you want a `<ThemeProvider>`'s overrides to reach the whole document.
+Use `isRoot` on the top-level provider for an application or page. It's also the recommended pattern for the topmost provider rendered into a separate document (iframe, popup window).
+
+Render at most one root provider per document. Multiple `isRoot` providers that share the same document are unsupported because each one would try to define the document-level token values. Nested and sibling providers can still be used normally when `isRoot` is omitted, and separate documents can each have their own root provider.
+
+The static design-tokens stylesheet still provides the default values; `isRoot` is only needed when you want a `<ThemeProvider>`'s overrides to reach the whole document.
 
 ### Across documents (iframes and other portals)
 
@@ -157,7 +165,7 @@ When you render React content into a different document (typically an iframe), t
 
     Inside WordPress, this is enqueued automatically for both the admin page and the block editor's content iframe.
 
-    For custom iframes, the consumer is responsible for loading it — either by importing `@wordpress/theme/design-tokens.css` from a stylesheet that the iframe already loads, or by injecting the CSS string directly.
+    For custom iframes, the consumer is responsible for loading it in the iframe document. Within WordPress, enqueue the `wp-theme` stylesheet for that document. Outside WordPress, import `@wordpress/theme/design-tokens.css` from a stylesheet that the iframe already loads, or inject the CSS string directly.
 
 2.  **Dynamically injected component styles are routed to the iframe document.** Some `@wordpress/components` styles are injected into the document at runtime rather than shipped as static CSS — for example Emotion-based styles, and styles from CSS modules built with `@wordpress/build`. `StyleProvider` tells that machinery which document's `<head>` to inject into. Wrap the iframe subtree in `<StyleProvider document={ iframeDocument }>`.
 
@@ -181,6 +189,12 @@ function IframeContent( { iframeDocument, children } ) {
 ```
 
 The static stylesheet inside the iframe provides every default; `<ThemeProvider isRoot>` adds (or omits) overrides on top, exactly like in the main document.
+
+### Legacy compatibility
+
+The public token surface is the semantic `--wpds-*` custom properties documented in the [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
+
+`@wordpress/theme` may also maintain legacy compatibility aliases for existing WordPress admin and `@wordpress/components` internals. Those aliases are transitional implementation details, including the `--wp-components-*` namespace, and are not a supported API for consumers. New code should use semantic `--wpds-*` design tokens instead.
 
 ### Building
 

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -42,7 +42,7 @@ export interface ThemeProviderSettings {
 		 * (e.g. buttons, checkboxes, and toggles).
 		 *
 		 * By default, it inherits from the parent `ThemeProvider`,
-		 * and falls back to the prebuilt default (`default`).
+		 * and falls back to the prebuilt default (`pointer`).
 		 */
 		control?: 'default' | 'pointer';
 	};
@@ -79,6 +79,9 @@ export interface ThemeProviderProps extends ThemeProviderSettings {
 	 * This is useful, for example, to make sure that the `html` element can
 	 * consume the right background color, or that overlays rendered inside a
 	 * portal can inherit the correct color scheme.
+	 *
+	 * Render at most one root provider per document. Multiple root providers
+	 * that share the same document are unsupported.
 	 *
 	 * @default false
 	 */

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -16,6 +16,7 @@ The design system follows the [Design Tokens Community Group (DTCG)](https://des
 | `border.json`     | Border radius and width values                                                                                                   |
 | `elevation.json`  | Shadow definitions for creating depth and layering                                                                               |
 | `motion.json`     | Animation durations and easing curves                                                                                            |
+| `cursor.json`     | Cursor values for interactive controls                                                                                           |
 
 Each JSON file contains both primitive and semantic token definitions in a hierarchical structure. These files are the source of truth for the design system and are processed during the build step to generate CSS custom properties and other output formats in `/src/prebuilt`.
 


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/issues/77462.

Clarifies `@wordpress/theme` documentation for D3-D8:

- positions the package as WordPress Design System tokens/theming, not a block theme, site theme, or `theme.json` API
- clarifies when WordPress loads or enqueues `design-tokens.css` and when non-WordPress consumers should import it directly
- expands the `ThemeProvider` contract around inheritance, `isRoot`, and wrapper customization
- clarifies that legacy CSS aliases are compatibility details, not a consumer API
- adds `cursor.json` to the token source guide
- consolidates duplicate changelog headings in the `0.16.0` section

## Why?
These docs are part of the stabilization checklist for `@wordpress/theme`. The package needs clearer consumer-facing boundaries before it can be treated as stable.

## How?
Updates the package README, exported `ThemeProvider` JSDoc, token maintainer guide, and package changelog. The changes are documentation-only.

## Testing Instructions
1. Read `packages/theme/README.md` and confirm the package positioning, runtime CSS loading guidance, `ThemeProvider` contract, and legacy compatibility note are clear.
2. Read `packages/theme/tokens/README.md` and confirm `cursor.json` is listed in the source file table.
3. Read `packages/theme/CHANGELOG.md` and confirm the `0.16.0` section no longer has duplicate `Enhancements` or `Documentation` headings.

### Testing Instructions for Keyboard
Not applicable. This PR only changes documentation.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Used Codex to inspect the issue checklist, update documentation, run focused verification, and draft this PR description. The changes were reviewed before opening the PR.

## Verification
- `npm run format -- packages/theme/README.md packages/theme/tokens/README.md packages/theme/CHANGELOG.md packages/theme/src/types.ts`
- `npm run lint:js -- packages/theme/src/types.ts`
- `npm run lint:md:docs -- packages/theme/tokens/README.md`
- `git diff --check`

`npm run lint:md:docs -- packages/theme/README.md packages/theme/tokens/README.md` still reports existing inline HTML in `packages/theme/README.md`.
