### PR TITLE
BorderBoxControl: Fix unlink button positioning after View Emotion migration

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,6 +46,7 @@
 -   `SandBox`: Inject the resize script into the document `<head>` so an unclosed attribute quote in the sandboxed HTML can no longer swallow the script and leak its source as visible text in the preview. ([#79920](https://github.com/WordPress/gutenberg/pull/79920))
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).
+-   `BorderBoxControl`: Fix the unlink button positioning by restoring the linked control's right-hand margin, which was overridden by `BorderControl`'s base `margin: 0` after `View` stopped rendering styles through Emotion ([#79967](https://github.com/WordPress/gutenberg/pull/79967)).
 
 ### Internal
 

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -13,9 +13,13 @@ import type { Borders } from './types';
 
 export const borderBoxControl = css``;
 
+// '&&' outranks BorderControl's base 'margin: 0' to keep the 24px unlink
+// button gutter, which View no longer preserves via className (#79443).
 export const linkedBorderControl = () => css`
-	flex: 1;
-	${ rtl( { marginRight: '24px' } )() }
+	&& {
+		flex: 1;
+		${ rtl( { marginRight: '24px' } )() }
+	}
 `;
 
 export const wrapper = css`


### PR DESCRIPTION
## What?

Fixes the broken positioning of the `BorderBoxControl` link/unlink button, which was overlapping the border control instead of sitting in its right-hand gutter.


## Why?

https://github.com/WordPress/gutenberg/pull/79443 (migrate `View` away from Emotion) introduced a visual regression.

The unlink button is absolutely positioned (`right: 0`) inside a `24px` gutter created by the linked control's `margin-right: 24px` (`linkedBorderControl`). That class and `BorderControl`'s own base styles (`borderControl`, `margin: 0`) land on the same `fieldset` at equal specificity, so the cascade winner is decided by stylesheet insertion order.

Previously the Emotion styled `View` re-serialized the composed `className` so the passed class won. Now that `View` renders a plain element, `useContextSystem` inserts the passed `className` before the component's own base styles, so `borderControl`'s `margin: 0` wins, the gutter collapses, and the button overlaps the control.


## How?

Doubles the `linkedBorderControl` selector specificity via `&&` so its `margin-right` wins deterministically, regardless of insertion order.

## Testing Instructions

1. Add a Group block (or any block with border support).
2. In the sidebar, open Border.
3. Confirm the link/unlink button sits cleanly to the right of the slider
4. Toggle link/unlink and confirm the button stays correctly positioned.

## Screenshots
|Before|After|
|-|-|
| <img width="453" height="85" alt="Screenshot 2026-07-07 at 2 59 26 pm" src="https://github.com/user-attachments/assets/5dde2082-7ae4-42f2-9635-80b437804700" /> | <img width="460" height="93" alt="Screenshot 2026-07-07 at 1 30 46 pm" src="https://github.com/user-attachments/assets/0159f50d-76ed-41d3-8349-bf477fe3e3b1" /> |

## Use of AI Tools

Used claude to debug and pinpoint root cause of the visual regression this PR fixes as well as confirm that `cx()` use does prevent our ability to control the style load order here.