### PR TITLE
Media: Fix fatal error from narrowed create_item_from_url() visibility

### DIFF
--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -646,7 +646,7 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
 	 */
-	protected function create_item_from_url( WP_REST_Request $request ) {
+	protected function create_item_from_url( $request ) {
 		// Sideloading downloads and stores a file, so require the upload capability.
 		if ( ! current_user_can( 'upload_files' ) ) {
 			return new WP_Error(

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -646,7 +646,7 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
 	 */
-	private function create_item_from_url( WP_REST_Request $request ) {
+	protected function create_item_from_url( WP_REST_Request $request ) {
 		// Sideloading downloads and stores a file, so require the upload capability.
 		if ( ! current_user_can( 'upload_files' ) ) {
 			return new WP_Error(


### PR DESCRIPTION
## What?

Changes the `create_item_from_url()` override in `Gutenberg_REST_Attachments_Controller` from `private` to `protected`.

## Why?

WordPress core's parent `WP_REST_Attachments_Controller::create_item_from_url()` is declared `protected`. PHP does not allow an overriding method to narrow the inherited visibility, so the `private` override raised:

```
Fatal error: Access level to Gutenberg_REST_Attachments_Controller::create_item_from_url() must be protected (as in class WP_REST_Attachments_Controller) or weaker
```

The class loads on every REST attachment request, so this fatal breaks the PHP unit test suite on trunk and cascades REST 500s into the Playwright e2e suite, failing CI on trunk and every trunk-based PR.

This is a regression from #79409, which added the override with `private` visibility.

## How?

Match the parent's `protected` visibility. No behavior change; the method remains an internal override invoked by `create_item()`.

## Testing Instructions

1. On current trunk, run the PHP unit tests (`npm run test:unit:php`) and observe the fatal error.
2. With this change, the class loads cleanly and the suite runs; e2e REST requests no longer 500.

## Type of change

Bug fix (non-breaking change which fixes an issue)