### PR TITLE
Docs: Generalize the `npx` guidance in AGENTS.md to cover `wp-scripts`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
 -   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
--   Never run `npx prettier`. WordPress uses its own fork of prettier, `wp-prettier`. Use npm scripts (e.g. `npm run format`) commands to format code instead.
+-   Never invoke WordPress's forked or local CLIs through npx (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` resolves to an unrelated, seized package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
 -   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
--   Never invoke WordPress's forked or local CLIs through npx (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` resolves to an unrelated, seized package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
+-   Never invoke WordPress's forked or local CLIs through `npx` (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` can resolve to an unrelated third-party package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
 
 ## PR instructions
 


### PR DESCRIPTION
## What

Broadens the existing "Never run `npx prettier`" line in `AGENTS.md` into a general rule against invoking WordPress's forked or local CLIs through `npx`, and calls out `wp-scripts` specifically.

## Why

We already tell people not to run `npx prettier`, because WordPress ships its own `wp-prettier` fork. 

`wp-scripts` has the same trap. Running a bare `npx wp-scripts` from the wrong directory and npx goes looking for a package *actually named* `wp-scripts` on the public registry. There is one. It's an unrelated, npm-seized stub, not our tool. Nothing malicious gets installed, but the lookup alone is enough to set off supply-chain scanners.

The local binaries are already exposed through npm scripts, so there's no reason to reach for `npx` at all inside the repo.

## Change

Replaces the single prettier-specific bullet with a generalized one that names both `prettier` and `wp-scripts` and points at `npm run format` / `npm run lint:js` / `npm run lint:css`.