### PR TITLE
Media Inserter: Guard attach, detach, and invalidate behind a ! isExternalResource check

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1513,7 +1513,7 @@ _Properties_
 -   _mediaType_ `('image'|'audio'|'video')`: The media type of the media category.
 -   _fetch_ `(InserterMediaRequest) => Promise<InserterMediaItem[]>`: The function to fetch media items for the category.
 -   _getReportUrl_ `[(InserterMediaItem) => string]`: If the media category supports reporting media items, this function should return the report url for the media item. It accepts the `InserterMediaItem` as an argument.
--   _isExternalResource_ `[boolean]`: If the media category is an external resource, this should be set to true. This is used to avoid making a request to the external resource when the user
+-   _isExternalResource_ `[boolean]`: If the media category is an external resource, this should be set to true. This is used to avoid making a request to the external resource when checking whether the category has any media items to display in the media tab.
 -   _emptyMessage_ `[string]`: Optional message shown in place of the generic "No results found." when the source has no items and there is no active search. Providing it also keeps the source in the tab list while empty, so the message stays reachable.
 
 ### removeBlock

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -83,6 +83,17 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	);
 	const { createErrorNotice, createSuccessNotice, createWarningNotice } =
 		useDispatch( noticesStore );
+
+	// Attach/detach are first-party-only capabilities for local sources (the
+	// Attachments source). Categories registered through the public
+	// `registerInserterMediaCategory` API are always flagged as external, so this
+	// guard stops a third-party source from opting into the internal attach/detach
+	// workflow just by setting these props. It is also semantically correct:
+	// external resources can never own a post's attachments.
+	const supportsAttachments = ! category.isExternalResource;
+	const attach = supportsAttachments ? category.attach : undefined;
+	const detach = supportsAttachments ? category.detach : undefined;
+
 	// Dim (rather than blank) the populated grid while a refetch is in flight,
 	// but only once it has run long enough to be worth signalling — quick
 	// attach/detach refetches resolve before this and show nothing.
@@ -91,14 +102,16 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	// Invalidate the cached results and force `useMediaResults` to refetch so
 	// the grid reflects images that were just attached or detached.
 	const refresh = useCallback( () => {
-		category.invalidate?.( query );
+		if ( supportsAttachments ) {
+			category.invalidate?.( query );
+		}
 		setRefreshKey( ( key ) => key + 1 );
-	}, [ category, query ] );
+	}, [ category, query, supportsAttachments ] );
 
 	const handleAttach = useCallback(
 		async ( selectedMedia ) => {
 			try {
-				const attachedCount = await category.attach( selectedMedia );
+				const attachedCount = await attach( selectedMedia );
 
 				if ( ! attachedCount ) {
 					// This source only attaches images (the picker's "Upload
@@ -143,6 +156,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 			}
 		},
 		[
+			attach,
 			category,
 			refresh,
 			createErrorNotice,
@@ -154,7 +168,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const handleDetach = useCallback(
 		async ( media ) => {
 			try {
-				await category.detach( media );
+				await detach( media );
 				refresh();
 				createSuccessNotice(
 					category.postTypeLabel
@@ -173,7 +187,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 				} );
 			}
 		},
-		[ category, refresh, createErrorNotice, createSuccessNotice ]
+		[ detach, category, refresh, createErrorNotice, createSuccessNotice ]
 	);
 
 	// Detaching is confirmed first: the dropdown sets the pending item, which
@@ -192,7 +206,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 			className={ clsx( baseCssClass, {
 				// The attach footer supplies the breathing room beneath the
 				// grid, so the list drops its own bottom padding (see styles).
-				'has-attach-footer': !! category.attach,
+				'has-attach-footer': !! attach,
 			} ) }
 		>
 			<SearchControl
@@ -231,15 +245,13 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					<MediaList
 						rootClientId={ rootClientId }
 						onClick={ onInsert }
-						onDetach={
-							category.detach ? setMediaPendingDetach : undefined
-						}
+						onDetach={ detach ? setMediaPendingDetach : undefined }
 						mediaList={ mediaList }
 						category={ category }
 					/>
 				</div>
 			) }
-			{ category.attach && (
+			{ attach && (
 				// Pinned to the bottom of the panel as a fixed footer so it lines
 				// up with the "Open Media Library" button in the adjacent column.
 				<AttachImagesButton onSelect={ handleAttach } />

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -84,12 +84,13 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const { createErrorNotice, createSuccessNotice, createWarningNotice } =
 		useDispatch( noticesStore );
 
-	// Attach/detach are first-party-only capabilities for local sources (the
-	// Attachments source). Categories registered through the public
-	// `registerInserterMediaCategory` API are always flagged as external, so this
-	// guard stops a third-party source from opting into the internal attach/detach
-	// workflow just by setting these props. It is also semantically correct:
-	// external resources can never own a post's attachments.
+	// The attach/detach workflow belongs to WordPress's built-in Attachments
+	// source, which manages images attached to the current post. Any category
+	// registered by an extender through the public `registerInserterMediaCategory`
+	// API is always flagged as an external resource, so this guard stops such a
+	// category from opting into that workflow just by setting these props. The
+	// guard also reflects the underlying semantics: an external resource can
+	// never own a post's attachments.
 	const supportsAttachments = ! category.isExternalResource;
 	const attach = supportsAttachments ? category.attach : undefined;
 	const detach = supportsAttachments ? category.detach : undefined;

--- a/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { MediaCategoryPanel } from '../media-panel';
+
+// Keep the panel's data + async surface out of the test: return a small,
+// non-empty result set so the grid (and the detach affordance) render.
+jest.mock( '../hooks', () => ( {
+	useMediaResults: () => ( {
+		mediaList: [
+			{ id: 1, title: 'Example', url: 'https://example.com/1' },
+		],
+		isLoading: false,
+	} ),
+	useDelayedLoading: () => false,
+} ) );
+
+// Replace `MediaList` with a marker that only reports whether it was wired for
+// detach, so the gate can be asserted without the full preview/dropdown tree.
+jest.mock( '../media-list', () => ( {
+	__esModule: true,
+	default: ( { onDetach } ) => (
+		<div
+			data-testid="media-list"
+			data-has-detach={ String( !! onDetach ) }
+		/>
+	),
+} ) );
+
+// The attach button renders through MediaUpload's render prop behind a
+// capability check; stub both so the real Button (and its label) render.
+jest.mock( '../../../media-upload', () => ( {
+	__esModule: true,
+	default: ( { render: renderProp } ) => renderProp( { open: () => {} } ),
+} ) );
+jest.mock( '../../../media-upload/check', () => ( {
+	__esModule: true,
+	default: ( { children } ) => children,
+} ) );
+
+const baseCategory = {
+	name: 'attached-images',
+	labels: { name: 'Attached images', search_items: 'Search attachments' },
+	mediaType: 'image',
+	fetch: jest.fn(),
+	attach: jest.fn(),
+	detach: jest.fn(),
+	invalidate: jest.fn(),
+};
+
+function renderPanel( category ) {
+	return render(
+		<MediaCategoryPanel
+			rootClientId=""
+			onInsert={ jest.fn() }
+			category={ category }
+		/>
+	);
+}
+
+describe( 'MediaCategoryPanel attach/detach gating', () => {
+	it( 'exposes attach/detach for a first-party local source', () => {
+		renderPanel( baseCategory );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Attach images' } )
+		).toBeInTheDocument();
+		expect( screen.getByTestId( 'media-list' ) ).toHaveAttribute(
+			'data-has-detach',
+			'true'
+		);
+	} );
+
+	it( 'ignores attach/detach when the source is an external resource', () => {
+		// Every category registered through the public
+		// `registerInserterMediaCategory` API is forced to `isExternalResource:
+		// true`, so a third-party source cannot opt into the internal workflow
+		// even if it sets `attach`/`detach`.
+		renderPanel( { ...baseCategory, isExternalResource: true } );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Attach images' } )
+		).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'media-list' ) ).toHaveAttribute(
+			'data-has-detach',
+			'false'
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
@@ -64,7 +64,7 @@ function renderPanel( category ) {
 }
 
 describe( 'MediaCategoryPanel attach/detach gating', () => {
-	it( 'exposes attach/detach for a first-party local source', () => {
+	it( 'exposes attach/detach for the built-in Attachments source', () => {
 		renderPanel( baseCategory );
 
 		expect(
@@ -77,9 +77,9 @@ describe( 'MediaCategoryPanel attach/detach gating', () => {
 	} );
 
 	it( 'ignores attach/detach when the source is an external resource', () => {
-		// Every category registered through the public
+		// Every category registered by an extender through the public
 		// `registerInserterMediaCategory` API is forced to `isExternalResource:
-		// true`, so a third-party source cannot opt into the internal workflow
+		// true`, so an extender-registered source cannot opt into the workflow
 		// even if it sets `attach`/`detach`.
 		renderPanel( { ...baseCategory, isExternalResource: true } );
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2050,7 +2050,8 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  * @property {(InserterMediaItem) => string}                          [getReportUrl]                 If the media category supports reporting media items, this function should return
  *                                                                                                   the report url for the media item. It accepts the `InserterMediaItem` as an argument.
  * @property {boolean}                                                [isExternalResource]           If the media category is an external resource, this should be set to true.
- *                                                                                                   This is used to avoid making a request to the external resource when the user
+ *                                                                                                   This is used to avoid making a request to the external resource when checking
+ *                                                                                                   whether the category has any media items to display in the media tab.
  * @property {string}                                                 [emptyMessage]                 Optional message shown in place of the generic "No results found." when the source has no items and there is no active search. Providing it also keeps the source in the tab list while empty, so the message stays reachable.
  */
 export const registerInserterMediaCategory =


### PR DESCRIPTION
## What?

Follow-up to:

* https://github.com/WordPress/gutenberg/pull/79336#discussion_r3540383812

Within the media inserter's panel, treat the `attach`, `detach`, and `invalidate` methods as internal/private by guarding their usage behind a `category.isExternalResource` check.

Kudos @ntsekouras for flagging!

## Why?

While these newly added methods are intended to be private they're technically exposed so that 3rd party custom categories could collide with these methods. This PR proposes adding some hardening to this to guarantee that these methods really are treated as private/internal to core media categories.

## How?

When 3rd parties register custom media categories, they do so via the `registerInserterMediaCategory` action, which explicitly sets `isExternalResource: true`. We can therefore use a check against that prop to ensure that the logic that uses `attach`, `detach`, and `invalidate` only does so when dealing with core media categories (which are attachment-based). This also effectively guards `postTypeLabel`, too, as its usage is gated by the attach/detach behaviour.

## Testing Instructions

Basically just check that there's no regressions / follow the testing instructions in #79336. Briefly:

* Open a post or page
* Open the Media inserter and in the Attached images category try attaching an image
* Try detaching the image via its hover button in the Attached images category
* Ensure the "Images" category works as on trunk
* Ensure the Openverse category works as on trunk

## Screenshots or screencast <!-- if applicable -->

For visual reference, this is the inserter we're talking about here:

<img width="1391" height="806" alt="image" src="https://github.com/user-attachments/assets/d9428c3b-5cec-429e-ae17-aac231c7b319" />

## Use of AI Tools

Claude Code