### PR TITLE
Enable default gap processing on Gallery block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45216,6 +45216,7 @@
 				"@wordpress/dom": "file:../dom",
 				"@wordpress/element": "file:../element",
 				"@wordpress/escape-html": "file:../escape-html",
+				"@wordpress/global-styles-engine": "file:../global-styles-engine",
 				"@wordpress/hooks": "file:../hooks",
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -108,6 +108,7 @@
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
+		"@wordpress/global-styles-engine": "file:../global-styles-engine",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/block-library/src/gallery/README.md
+++ b/packages/block-library/src/gallery/README.md
@@ -47,7 +47,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):
   - `margin`: `true`
   - `padding`: `true`
-  - `blockGap`: `["horizontal","vertical"]`
+  - `blockGap`: `{"sides":["horizontal","vertical"],"__experimentalDefault":"var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )"}`
 - [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
   - [`text`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-text): `false`
   - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-background): `true`

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -142,8 +142,10 @@
 		"spacing": {
 			"margin": true,
 			"padding": true,
-			"blockGap": [ "horizontal", "vertical" ],
-			"__experimentalSkipSerialization": [ "blockGap" ],
+			"blockGap": {
+				"sides": [ "horizontal", "vertical" ],
+				"__experimentalDefault": "var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )"
+			},
 			"__experimentalDefaultControls": {
 				"blockGap": true,
 				"margin": false,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -66,7 +66,7 @@ import {
 import useImageSizes from './use-image-sizes';
 import useGetNewImages from './use-get-new-images';
 import useGetMedia from './use-get-media';
-import GapStyles from './gap-styles';
+import GalleryGapCustomProperties from './gap-styles';
 import useDynamicGallery from './use-dynamic-gallery';
 import { GallerySourcePanel, GalleryDynamicView } from './dynamic-gallery';
 import { getDynamicSource, ATTACHED_MEDIA } from './dynamic-source';
@@ -941,7 +941,10 @@ export default function GalleryEdit( props ) {
 						/>
 					</BlockControls>
 				) }
-				<GapStyles style={ attributes.style } clientId={ clientId } />
+				<GalleryGapCustomProperties
+					style={ attributes.style }
+					clientId={ clientId }
+				/>
 			</>
 			{ isDynamic ? (
 				<GalleryDynamicView

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -941,10 +941,7 @@ export default function GalleryEdit( props ) {
 						/>
 					</BlockControls>
 				) }
-				<GapStyles
-					blockGap={ attributes.style?.spacing?.blockGap }
-					clientId={ clientId }
-				/>
+				<GapStyles style={ attributes.style } clientId={ clientId } />
 			</>
 			{ isDynamic ? (
 				<GalleryDynamicView

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -10,27 +10,19 @@ export default function GapStyles( { blockGap, clientId } ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	const fallbackValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
-	let gapValue = fallbackValue;
 	let column = fallbackValue;
-	let row;
 
 	// Check for the possibility of split block gap values. See: https://github.com/WordPress/gutenberg/pull/37736
 	if ( !! blockGap ) {
-		row =
-			typeof blockGap === 'string'
-				? getGapCSSValue( blockGap )
-				: getGapCSSValue( blockGap?.top ) || fallbackValue;
 		column =
 			typeof blockGap === 'string'
 				? getGapCSSValue( blockGap )
 				: getGapCSSValue( blockGap?.left ) || fallbackValue;
-		gapValue = row === column ? row : `${ row } ${ column }`;
 	}
 
 	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
 	const gap = `#block-${ clientId } {
-		--wp--style--unstable-gallery-gap: ${ column === '0' ? '0px' : column };
-		gap: ${ gapValue }
+		--wp--style--unstable-gallery-gap: ${ column === '0' ? '0px' : column }
 	}`;
 
 	useStyleOverride( { css: gap } );

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -19,7 +19,7 @@ const { getResponsiveMediaQueries } = unlock( globalStylesEnginePrivateApis );
 // gap on the gallery.
 const FALLBACK_VALUE = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
 
-function getGapColumnValue( blockGap ) {
+function getGalleryGapCustomPropertyStyle( selector, blockGap ) {
 	let column = FALLBACK_VALUE;
 	if ( blockGap ) {
 		column =
@@ -29,19 +29,18 @@ function getGapColumnValue( blockGap ) {
 	}
 
 	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
-	return column === '0' ? '0px' : column;
-}
-
-function getGapStyle( selector, blockGap ) {
 	return `${ selector } {
-		--wp--style--unstable-gallery-gap: ${ getGapColumnValue( blockGap ) }
+		--wp--style--unstable-gallery-gap: ${ column === '0' ? '0px' : column }
 	}`;
 }
 
-export default function GapStyles( { style, clientId } ) {
+export default function GalleryGapCustomProperties( { style, clientId } ) {
 	const selector = `#block-${ clientId }`;
 	const [ viewportSettings ] = useSettings( 'viewport' );
-	let gap = getGapStyle( selector, style?.spacing?.blockGap );
+	let gap = getGalleryGapCustomPropertyStyle(
+		selector,
+		style?.spacing?.blockGap
+	);
 
 	Object.entries( getResponsiveMediaQueries( viewportSettings ) ).forEach(
 		( [ viewport, mediaQuery ] ) => {
@@ -50,7 +49,7 @@ export default function GapStyles( { style, clientId } ) {
 				return;
 			}
 
-			gap += `${ mediaQuery }{${ getGapStyle(
+			gap += `${ mediaQuery }{${ getGalleryGapCustomPropertyStyle(
 				selector,
 				viewportBlockGap
 			) }}`;

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -4,26 +4,58 @@
 import {
 	__experimentalGetGapCSSValue as getGapCSSValue,
 	useStyleOverride,
+	useSettings,
 } from '@wordpress/block-editor';
+import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
 
-export default function GapStyles( { blockGap, clientId } ) {
-	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
-	// gap on the gallery.
-	const fallbackValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
-	let column = fallbackValue;
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
 
-	// Check for the possibility of split block gap values. See: https://github.com/WordPress/gutenberg/pull/37736
-	if ( !! blockGap ) {
+const { getResponsiveMediaQueries } = unlock( globalStylesEnginePrivateApis );
+
+// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
+// gap on the gallery.
+const FALLBACK_VALUE = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
+
+function getGapColumnValue( blockGap ) {
+	let column = FALLBACK_VALUE;
+	if ( blockGap ) {
 		column =
 			typeof blockGap === 'string'
-				? getGapCSSValue( blockGap )
-				: getGapCSSValue( blockGap?.left ) || fallbackValue;
+				? getGapCSSValue( blockGap ) || FALLBACK_VALUE
+				: getGapCSSValue( blockGap?.left ) || FALLBACK_VALUE;
 	}
 
 	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
-	const gap = `#block-${ clientId } {
-		--wp--style--unstable-gallery-gap: ${ column === '0' ? '0px' : column }
+	return column === '0' ? '0px' : column;
+}
+
+function getGapStyle( selector, blockGap ) {
+	return `${ selector } {
+		--wp--style--unstable-gallery-gap: ${ getGapColumnValue( blockGap ) }
 	}`;
+}
+
+export default function GapStyles( { style, clientId } ) {
+	const selector = `#block-${ clientId }`;
+	const [ viewportSettings ] = useSettings( 'viewport' );
+	let gap = getGapStyle( selector, style?.spacing?.blockGap );
+
+	Object.entries( getResponsiveMediaQueries( viewportSettings ) ).forEach(
+		( [ viewport, mediaQuery ] ) => {
+			const viewportBlockGap = style?.[ viewport ]?.spacing?.blockGap;
+			if ( viewportBlockGap === undefined || viewportBlockGap === null ) {
+				return;
+			}
+
+			gap += `${ mediaQuery }{${ getGapStyle(
+				selector,
+				viewportBlockGap
+			) }}`;
+		}
+	);
 
 	useStyleOverride( { css: gap } );
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -385,13 +385,10 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-	$gap_value    = $gap ? $gap : $fallback_gap;
-	$gap_column   = $gap_value;
+	$gap_column   = ( null !== $gap && '' !== $gap ) ? $gap : $fallback_gap;
 
-	if ( is_array( $gap_value ) ) {
-		$gap_row    = $gap_value['top'] ?? $fallback_gap;
-		$gap_column = $gap_value['left'] ?? $fallback_gap;
-		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+	if ( is_array( $gap_column ) ) {
+		$gap_column = $gap_column['left'] ?? $fallback_gap;
 	}
 
 	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
@@ -399,13 +396,12 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 		$gap_column = '0px';
 	}
 
-	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
+	// Set the CSS variable to the column value for Gallery's flex width calculations.
 	$gallery_styles = array(
 		array(
 			'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
 			'declarations' => array(
 				'--wp--style--unstable-gallery-gap' => $gap_column,
-				'gap'                               => $gap_value,
 			),
 		),
 	);

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -383,7 +383,11 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	$style_attr = is_array( $attributes['style'] ?? null )
 		? $attributes['style']
 		: array();
-	if ( function_exists( 'gutenberg_resolve_style_state_aliases' ) ) {
+	if (
+		defined( 'IS_GUTENBERG_PLUGIN' ) &&
+		IS_GUTENBERG_PLUGIN &&
+		function_exists( 'gutenberg_resolve_style_state_aliases' )
+	) {
 		$style_attr = gutenberg_resolve_style_state_aliases( $style_attr, 'core/gallery' );
 	}
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -66,7 +66,12 @@ function block_core_gallery_get_column_gap_value( $gap, $fallback_gap ) {
 		$gap = $gap['left'] ?? $fallback_gap;
 	}
 
+	// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
 	$gap = is_string( $gap ) ? $gap : '';
+
+	// Skip if gap value contains unsupported characters.
+	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
+	// because we only want to match against the value, not the CSS attribute.
 	$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 
 	// Get spacing CSS variable from preset value if provided.
@@ -80,24 +85,6 @@ function block_core_gallery_get_column_gap_value( $gap, $fallback_gap ) {
 
 	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
 	return '0' === $gap_column ? '0px' : $gap_column;
-}
-
-/**
- * Returns configured viewport media queries.
- *
- * @since 7.1.0
- *
- * @param mixed $viewport_settings Viewport settings from theme.json.
- * @return array Responsive media queries.
- */
-function block_core_gallery_get_viewport_media_queries( $viewport_settings ) {
-	foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
-		if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
-			return $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
-		}
-	}
-
-	return array();
 }
 
 /**
@@ -422,7 +409,13 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 
 	$global_settings          = wp_get_global_settings();
 	$viewport_settings        = $global_settings['viewport'] ?? null;
-	$responsive_media_queries = block_core_gallery_get_viewport_media_queries( $viewport_settings );
+	$responsive_media_queries = array();
+	foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
+		if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
+			$responsive_media_queries = $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
+			break;
+		}
+	}
 
 	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
 		$viewport_style = $style_attr[ $breakpoint ] ?? null;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -53,6 +53,54 @@ function block_core_gallery_render_context( $context, $parsed_block ) {
 add_filter( 'render_block_context', 'block_core_gallery_render_context', 10, 2 );
 
 /**
+ * Returns the column gap value used for Gallery image width calculations.
+ *
+ * @since 7.1.0
+ *
+ * @param string|array|null $gap          Gallery block gap value.
+ * @param string            $fallback_gap Fallback gap value.
+ * @return string Gallery column gap value.
+ */
+function block_core_gallery_get_column_gap_value( $gap, $fallback_gap ) {
+	if ( is_array( $gap ) ) {
+		$gap = $gap['left'] ?? $fallback_gap;
+	}
+
+	$gap = is_string( $gap ) ? $gap : '';
+	$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+
+	// Get spacing CSS variable from preset value if provided.
+	if ( is_string( $gap ) && str_contains( $gap, 'var:preset|spacing|' ) ) {
+		$index_to_splice = strrpos( $gap, '|' ) + 1;
+		$slug            = _wp_to_kebab_case( substr( $gap, $index_to_splice ) );
+		$gap             = "var(--wp--preset--spacing--$slug)";
+	}
+
+	$gap_column = ( null !== $gap && '' !== $gap ) ? $gap : $fallback_gap;
+
+	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
+	return '0' === $gap_column ? '0px' : $gap_column;
+}
+
+/**
+ * Returns configured viewport media queries.
+ *
+ * @since 7.1.0
+ *
+ * @param mixed $viewport_settings Viewport settings from theme.json.
+ * @return array Responsive media queries.
+ */
+function block_core_gallery_get_viewport_media_queries( $viewport_settings ) {
+	foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
+		if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
+			return $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
+		}
+	}
+
+	return array();
+}
+
+/**
  * Resolves a Gallery block's `dynamicContent` to an ordered list of image
  * attachment IDs.
  *
@@ -345,36 +393,11 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// the current gap setting in order to maintain the number of flex columns
 	// so a css var is added to allow this.
 
-	$gap = $attributes['style']['spacing']['blockGap'] ?? null;
-	// Skip if gap value contains unsupported characters.
-	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
-	// because we only want to match against the value, not the CSS attribute.
-	if ( is_array( $gap ) ) {
-		foreach ( $gap as $key => $value ) {
-			// Make sure $value is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
-			$value = is_string( $value ) ? $value : '';
-			$value = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
-
-			// Get spacing CSS variable from preset value if provided.
-			if ( is_string( $value ) && str_contains( $value, 'var:preset|spacing|' ) ) {
-				$index_to_splice = strrpos( $value, '|' ) + 1;
-				$slug            = _wp_to_kebab_case( substr( $value, $index_to_splice ) );
-				$value           = "var(--wp--preset--spacing--$slug)";
-			}
-
-			$gap[ $key ] = $value;
-		}
-	} else {
-		// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
-		$gap = is_string( $gap ) ? $gap : '';
-		$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
-
-		// Get spacing CSS variable from preset value if provided.
-		if ( is_string( $gap ) && str_contains( $gap, 'var:preset|spacing|' ) ) {
-			$index_to_splice = strrpos( $gap, '|' ) + 1;
-			$slug            = _wp_to_kebab_case( substr( $gap, $index_to_splice ) );
-			$gap             = "var(--wp--preset--spacing--$slug)";
-		}
+	$style_attr = is_array( $attributes['style'] ?? null )
+		? $attributes['style']
+		: array();
+	if ( function_exists( 'gutenberg_resolve_style_state_aliases' ) ) {
+		$style_attr = gutenberg_resolve_style_state_aliases( $style_attr, 'core/gallery' );
 	}
 
 	$unique_gallery_classname = wp_unique_id( 'wp-block-gallery-' );
@@ -385,16 +408,7 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-	$gap_column   = ( null !== $gap && '' !== $gap ) ? $gap : $fallback_gap;
-
-	if ( is_array( $gap_column ) ) {
-		$gap_column = $gap_column['left'] ?? $fallback_gap;
-	}
-
-	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
-	if ( '0' === $gap_column ) {
-		$gap_column = '0px';
-	}
+	$gap_column   = block_core_gallery_get_column_gap_value( $style_attr['spacing']['blockGap'] ?? null, $fallback_gap );
 
 	// Set the CSS variable to the column value for Gallery's flex width calculations.
 	$gallery_styles = array(
@@ -405,6 +419,28 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 			),
 		),
 	);
+
+	$global_settings          = wp_get_global_settings();
+	$viewport_settings        = $global_settings['viewport'] ?? null;
+	$responsive_media_queries = block_core_gallery_get_viewport_media_queries( $viewport_settings );
+
+	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
+		$viewport_style = $style_attr[ $breakpoint ] ?? null;
+		if ( ! is_array( $viewport_style ) || ! isset( $viewport_style['spacing']['blockGap'] ) ) {
+			continue;
+		}
+
+		$gallery_styles[] = array(
+			'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
+			'declarations' => array(
+				'--wp--style--unstable-gallery-gap' => block_core_gallery_get_column_gap_value(
+					$viewport_style['spacing']['blockGap'],
+					$fallback_gap
+				),
+			),
+			'rules_group'  => $media_query,
+		);
+	}
 
 	wp_style_engine_get_stylesheet_from_css_rules(
 		$gallery_styles,

--- a/packages/block-library/tsconfig.json
+++ b/packages/block-library/tsconfig.json
@@ -21,6 +21,7 @@
 		{ "path": "../dom" },
 		{ "path": "../element" },
 		{ "path": "../escape-html" },
+		{ "path": "../global-styles-engine" },
 		{ "path": "../private-apis" },
 		{ "path": "../hooks" },
 		{ "path": "../html-entities" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #79968.

Gallery was skipping gap serialization and using a custom output, probably so it could use the value in the calculation of image widths for its layout, which is a custom flexbox grid-type thing. This means the viewport-specific styles that come for free with default serialization weren't being output.

This PR removes the custom gap output and the serialization skipping, so Gallery can have its viewport-specific block gaps output by default.

But in order to ensure the custom layout thing works as expected, the gallery block is now outputting its own media query with the viewport-specific value of gap applied to the `--wp--style--unstable-gallery-gap` custom property used to calculate the image widths.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Gallery block to a post and set different block gap values for its mobile/tablet viewports;
2. Save and check that the gap values are correct for all viewport sizes in editor and front end.
3. Check that a media query is also output for `--wp--style--unstable-gallery-gap`.

## Screenshots or screencast <!-- if applicable -->


<img width="885" height="784" alt="Screenshot 2026-07-08 at 2 59 18 pm" src="https://github.com/user-attachments/assets/28c5a069-4b91-4936-96e9-ff1aea91a82c" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
used codex/gpt 5.5