### PR TITLE
GIF block variation: Remove icons from "Display as" toolbar buttons and only show when block can be inserted

### DIFF
--- a/packages/block-library/src/image/animated-gif-convert-control.js
+++ b/packages/block-library/src/image/animated-gif-convert-control.js
@@ -9,7 +9,6 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { video as videoIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -53,16 +52,18 @@ export default function AnimatedGifConvertControl( { attributes, clientId } ) {
 			if ( ! urlPath?.toLowerCase().endsWith( '.gif' ) ) {
 				return null;
 			}
-			// A gallery only accepts `core/image` children, so swapping the
-			// image for a video block there would be rejected. Hide the
-			// control inside a gallery; the converted video is still
+			// Only offer the conversion when a Video block can actually be
+			// inserted in place of this block (e.g. it isn't disabled and the
+			// parent allows it). This also covers galleries, whose children
+			// are restricted to `core/image`; the converted video is still
 			// sideloaded and stored for use elsewhere.
-			const { getBlockRootClientId, getBlockName } =
+			const { getBlockRootClientId, canInsertBlockType } =
 				select( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
 			if (
-				rootClientId &&
-				getBlockName( rootClientId ) === 'core/gallery'
+				! canInsertBlockType(
+					'core/video',
+					getBlockRootClientId( clientId )
+				)
 			) {
 				return null;
 			}
@@ -126,7 +127,7 @@ export default function AnimatedGifConvertControl( { attributes, clientId } ) {
 	return (
 		<BlockControls group="other">
 			<ToolbarGroup>
-				<ToolbarButton icon={ videoIcon } onClick={ convertToVideo }>
+				<ToolbarButton onClick={ convertToVideo }>
 					{ __( 'Display as video' ) }
 				</ToolbarButton>
 			</ToolbarGroup>

--- a/packages/block-library/src/image/animated-gif-convert-control.js
+++ b/packages/block-library/src/image/animated-gif-convert-control.js
@@ -52,11 +52,6 @@ export default function AnimatedGifConvertControl( { attributes, clientId } ) {
 			if ( ! urlPath?.toLowerCase().endsWith( '.gif' ) ) {
 				return null;
 			}
-			// Only offer the conversion when a Video block can actually be
-			// inserted in place of this block (e.g. it isn't disabled and the
-			// parent allows it). This also covers galleries, whose children
-			// are restricted to `core/image`; the converted video is still
-			// sideloaded and stored for use elsewhere.
 			const { getBlockRootClientId, canInsertBlockType } =
 				select( blockEditorStore );
 			if (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -854,21 +854,27 @@ export default function Image( {
 
 	const showBlockControls = showUrlInput || allowCrop || showCoverControls;
 
-	const mediaReplaceFlow = isSingleSelected && ! lockUrlControls && (
-		// For contentOnly mode, put this button in its own area so it has borders around it.
-		<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
-			<MediaReplaceFlow
-				mediaId={ id }
-				mediaURL={ url }
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				onSelect={ onSelectImage }
-				onSelectURL={ onSelectURL }
-				onError={ onUploadError }
-				name={ ! url ? __( 'Add image' ) : __( 'Replace' ) }
-				onReset={ () => onSelectImage( undefined ) }
-				variant="toolbar"
+	const mediaControls = isSingleSelected && ! lockUrlControls && (
+		<>
+			{ /* For contentOnly mode, put this button in its own area so it has borders around it. */ }
+			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					onSelect={ onSelectImage }
+					onSelectURL={ onSelectURL }
+					onError={ onUploadError }
+					name={ ! url ? __( 'Add image' ) : __( 'Replace' ) }
+					onReset={ () => onSelectImage( undefined ) }
+					variant="toolbar"
+				/>
+			</BlockControls>
+			<AnimatedGifConvertControl
+				attributes={ attributes }
+				clientId={ clientId }
 			/>
-		</BlockControls>
+		</>
 	);
 
 	const hasDataFormBlockFields =
@@ -1355,7 +1361,7 @@ export default function Image( {
 	if ( ! url && ! temporaryURL ) {
 		return (
 			<>
-				{ mediaReplaceFlow }
+				{ mediaControls }
 				{ controls }
 			</>
 		);
@@ -1390,13 +1396,7 @@ export default function Image( {
 
 	return (
 		<>
-			{ isSingleSelected && ! lockUrlControls && (
-				<AnimatedGifConvertControl
-					attributes={ attributes }
-					clientId={ clientId }
-				/>
-			) }
-			{ mediaReplaceFlow }
+			{ mediaControls }
 			{ controls }
 			{ featuredImageControl }
 			{ img }

--- a/packages/block-library/src/image/test/animated-gif-convert-control.js
+++ b/packages/block-library/src/image/test/animated-gif-convert-control.js
@@ -60,17 +60,16 @@ jest.mock( '@wordpress/blocks', () => ( {
  * whether the attachment record was requested.
  *
  * @param {Object}   options                 Options.
- * @param {string}   [options.rootBlockName] Block name of the block's root (e.g. 'core/gallery').
+ * @param {boolean}  [options.canInsert]     Whether a `core/video` block can be inserted in the parent.
  * @param {Function} options.getEntityRecord Spy used for getEntityRecord.
  * @return {Function} A select() implementation.
  */
-function makeSelect( { rootBlockName = undefined, getEntityRecord } ) {
+function makeSelect( { canInsert = true, getEntityRecord } ) {
 	return ( storeName ) => {
 		if ( storeName === 'core/block-editor' ) {
 			return {
-				getBlockRootClientId: () =>
-					rootBlockName ? 'root-client-id' : undefined,
-				getBlockName: () => rootBlockName,
+				getBlockRootClientId: () => undefined,
+				canInsertBlockType: () => canInsert,
 			};
 		}
 		// core-data store.
@@ -180,14 +179,14 @@ describe( 'AnimatedGifConvertControl', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'hides the control inside a gallery without fetching', () => {
+	it( 'hides the control when a video block cannot be inserted in the parent (e.g. a gallery) without fetching', () => {
 		const { container } = renderControl( {
 			attributes: {
 				id: 7,
 				url: 'https://example.com/wp-content/uploads/cat.gif',
 			},
 			select: makeSelect( {
-				rootBlockName: 'core/gallery',
+				canInsert: false,
 				getEntityRecord,
 			} ),
 		} );

--- a/packages/block-library/src/video/gif-restore-control.js
+++ b/packages/block-library/src/video/gif-restore-control.js
@@ -57,9 +57,6 @@ export default function GifRestoreControl( { attributes, clientId } ) {
 
 			return {
 				gif: record?.mime_type?.startsWith( 'image/' ) ? record : null,
-				// Only offer the restore when an Image block can actually be
-				// inserted in place of this block (e.g. it isn't disabled and
-				// the parent allows it).
 				canRestoreToImage: canInsertBlockType(
 					'core/image',
 					getBlockRootClientId( clientId )

--- a/packages/block-library/src/video/gif-restore-control.js
+++ b/packages/block-library/src/video/gif-restore-control.js
@@ -9,7 +9,6 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { image as imageIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -44,26 +43,33 @@ export default function GifRestoreControl( { attributes, clientId } ) {
 	// The original GIF is the underlying image attachment. Only offer the
 	// restore when the media resolves to an image (an editor-converted GIF),
 	// not when a regular video has simply been set to loop/autoplay/mute.
-	const gif = useSelect(
+	const { gif, canRestoreToImage } = useSelect(
 		( select ) => {
-			if ( ! id ) {
-				return null;
-			}
-			const record = select( coreStore ).getEntityRecord(
-				'postType',
-				'attachment',
-				id,
-				{ context: 'view' }
-			);
-			if ( ! record?.mime_type?.startsWith( 'image/' ) ) {
-				return null;
-			}
-			return record;
+			const { getEntityRecord } = select( coreStore );
+			const { canInsertBlockType, getBlockRootClientId } =
+				select( blockEditorStore );
+
+			const record = id
+				? getEntityRecord( 'postType', 'attachment', id, {
+						context: 'view',
+				  } )
+				: null;
+
+			return {
+				gif: record?.mime_type?.startsWith( 'image/' ) ? record : null,
+				// Only offer the restore when an Image block can actually be
+				// inserted in place of this block (e.g. it isn't disabled and
+				// the parent allows it).
+				canRestoreToImage: canInsertBlockType(
+					'core/image',
+					getBlockRootClientId( clientId )
+				),
+			};
 		},
-		[ id ]
+		[ id, clientId ]
 	);
 
-	if ( ! gif?.source_url ) {
+	if ( ! gif?.source_url || ! canRestoreToImage ) {
 		return null;
 	}
 
@@ -83,7 +89,7 @@ export default function GifRestoreControl( { attributes, clientId } ) {
 	return (
 		<BlockControls group="other">
 			<ToolbarGroup>
-				<ToolbarButton icon={ imageIcon } onClick={ restoreToImage }>
+				<ToolbarButton onClick={ restoreToImage }>
 					{ __( 'Display as GIF' ) }
 				</ToolbarButton>
 			</ToolbarGroup>


### PR DESCRIPTION

## What?

Part of:

* #79787 

This PR just fixes two issues:

* Removes icons from the "Display as GIF" and "Display as video" buttons
* Ensures the buttons only show when the "to" block is available to be inserted (removing the hard-coded Gallery block check)

Note: this is intentionally a minimally scoped PR to fix these bugs — the broader question of whether or not this button should be here is best discussed in #79787 or in separate PRs. My goal with this PR is simply to polish what's already there 🙂

## Why?

* Usually toolbar buttons use one of an icon _or_ text and not both. Since this button sits next to a text button, I went with removing the icon for now
* For the insertion check: users (or blocks) can define allowed blocks and so if we're exposing transform buttons we must ensure the target is available before showing the button

## How?

* Remove the icons
* Add `canInsertBlockType` checks

## Testing Instructions

Note: you might need to test this in a local checkout as I'm not sure this works in Playground.

* Upload an animated GIF that doesn't have transparency to the Image block
* Once complete, it should have transformed to a GIF block variation of the Video block
* Note that the "Display as GIF" button will appear in the block toolbar
* Clicking it will switch it to an Image block, where there's then a "Display as video" button
* That button should get you back to the video block state

Next up:

* Open the block editors preferences panel and toggle which blocks are active. I.e. hide the Image block and the "Display as GIF" button on the video block state should be hidden. Hide the Video block, and the "Display as video" button should be hidden in the Image block state

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1744" height="1264" alt="image" src="https://github.com/user-attachments/assets/4e6b0903-9cf4-40d2-bfe8-614ba80e0c70" />

### After

| Video block state: | Image block state: |
| --- | --- |
| <img width="1426" height="1216" alt="image" src="https://github.com/user-attachments/assets/31e72ba4-d7ef-4418-8af2-a2bbea5b000b" /> | <img width="1424" height="1000" alt="image" src="https://github.com/user-attachments/assets/7fd531fd-0ff0-4f17-bfad-bf81c154837b" /> |

For reference this is the modal where you can hide particular blocks in the editor:

<img width="1610" height="1334" alt="image" src="https://github.com/user-attachments/assets/a52796db-1c35-46d1-b698-e2d7b04ff3d6" />

## Use of AI Tools

Claude Code
