### PR TITLE
Typography: Revert font-weight 499 workaround back to 500

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698)).
 
+### Bug Fixes
+
+-   Revert the `$font-weight-medium` `499` workaround back to `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
+
 ## 10.2.0 (2026-07-01)
 
 ## 10.1.0 (2026-06-24)

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Enhancements
 
 -   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698)).
-
-### Bug Fixes
-
 -   Revert the `$font-weight-medium` `499` workaround back to `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ## 10.2.0 (2026-07-01)

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -37,7 +37,7 @@ $font-line-height-2x-large: 40px;
 
 // Weights
 $font-weight-regular: 400;
-$font-weight-medium: 499; // ensures fallback to 400 (instead of 600)
+$font-weight-medium: 500;
 
 // Families
 $font-family-headings: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/packages/base-styles/internal/_wpds-token-fallbacks.scss
+++ b/packages/base-styles/internal/_wpds-token-fallbacks.scss
@@ -185,7 +185,7 @@ $fallbacks: (
 	'--wpds-typography-font-size-sm': '12px',
 	'--wpds-typography-font-size-xl': '20px',
 	'--wpds-typography-font-size-xs': '11px',
-	'--wpds-typography-font-weight-medium': '499',
+	'--wpds-typography-font-weight-medium': '500',
 	'--wpds-typography-font-weight-regular': '400',
 	'--wpds-typography-line-height-2xl': '40px',
 	'--wpds-typography-line-height-lg': '28px',

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -19,7 +19,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
     -   `BorderControl` ([#79418](https://github.com/WordPress/gutenberg/pull/79418))
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `ToggleGroupControl` ([#79656](https://github.com/WordPress/gutenberg/pull/79656))
+-   Revert the medium font-weight `499` workaround back to `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ### Documentation
 
@@ -47,7 +48,6 @@
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).
 -   `BorderBoxControl`: Fix the unlink button positioning by restoring the linked control's right-hand margin, which was overridden by `BorderControl`'s base `margin: 0` after `View` stopped rendering styles through Emotion ([#79967](https://github.com/WordPress/gutenberg/pull/79967)).
--   Revert the medium font-weight `499` workaround back to `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,6 +47,7 @@
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).
 -   `BorderBoxControl`: Fix the unlink button positioning by restoring the linked control's right-hand margin, which was overridden by `BorderControl`'s base `margin: 0` after `View` stopped rendering styles through Emotion ([#79967](https://github.com/WordPress/gutenberg/pull/79967)).
+-   Revert the medium font-weight `499` workaround back to `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ### Internal
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -19,7 +19,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -135,7 +135,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   padding-left: 0;
   padding-right: 0;
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
-  font-weight: 499;
+  font-weight: 500;
 }
 
 @media not ( prefers-reduced-motion ) {
@@ -354,7 +354,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -595,7 +595,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -711,7 +711,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   padding-left: 0;
   padding-right: 0;
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
-  font-weight: 499;
+  font-weight: 500;
 }
 
 @media not ( prefers-reduced-motion ) {
@@ -924,7 +924,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -50,7 +50,7 @@ export default Object.assign( {}, CONTROL_PROPS, {
 	fontSizeXSmall: 'calc(0.75 * 13px)',
 	fontLineHeightBase: '1.4',
 	fontWeight: 'normal',
-	fontWeightMedium: '499', // ensures fallback to 400 (instead of 600)
+	fontWeightMedium: '500',
 	fontWeightHeading: '600',
 	gridBase: '4px',
 	elevationXSmall: `0 1px 1px rgba(0, 0, 0, 0.03), 0 1px 2px rgba(0, 0, 0, 0.02), 0 3px 3px rgba(0, 0, 0, 0.02), 0 4px 4px rgba(0, 0, 0, 0.01)`,

--- a/packages/editor/src/components/collaborators-overlay/collaborator-styles.ts
+++ b/packages/editor/src/components/collaborators-overlay/collaborator-styles.ts
@@ -41,7 +41,7 @@ export const FONT_SIZE_X_SMALL = '11px';
 export const FONT_SIZE_MEDIUM = '13px';
 
 // _font.scss — $font-weight-medium
-export const FONT_WEIGHT_MEDIUM = '499';
+export const FONT_WEIGHT_MEDIUM = '500';
 
 // _font.scss — $font-line-height-small
 export const FONT_LINE_HEIGHT_SMALL = '20px';

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -223,7 +223,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Revert the medium font-weight `499` workaround so the `font-weight.medium` token outputs `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
+
 ### Bug Fixes
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
--   Revert the medium font-weight `499` workaround so the `font-weight.medium` token outputs `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ### Documentation
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
+-   Revert the medium font-weight `499` workaround so the `font-weight.medium` token outputs `500` ([#79986](https://github.com/WordPress/gutenberg/pull/79986)).
 
 ### Documentation
 

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -348,7 +348,7 @@
 	/* Regular font weight for body text */
 	--wpds-typography-font-weight-regular: 400;
 	/* Medium font weight for emphasis and headings */
-	--wpds-typography-font-weight-medium: 499;
+	--wpds-typography-font-weight-medium: 500;
 }
 
 @media ( -webkit-min-device-pixel-ratio: 2 ), ( min-resolution: 192dpi ) {

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -183,7 +183,7 @@ export default {
 	'--wpds-typography-font-size-sm': '12px',
 	'--wpds-typography-font-size-xl': '20px',
 	'--wpds-typography-font-size-xs': '11px',
-	'--wpds-typography-font-weight-medium': '499',
+	'--wpds-typography-font-weight-medium': '500',
 	'--wpds-typography-font-weight-regular': '400',
 	'--wpds-typography-line-height-2xl': '40px',
 	'--wpds-typography-line-height-lg': '28px',

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -39,28 +39,6 @@ const config: Config = {
 		pluginCSS( {
 			filename: 'css/design-tokens.css',
 			variableName: ( token ) => makeCSSVar( token.id ),
-			transform( token ) {
-				// This addresses a specific browser issue where Chrome renders
-				// a font-weight of 500 as 600 instead of 400 when the target
-				// weight is not locally available, which is inconsistent with
-				// the spec-defined behavior. This workaround ensures that a 400
-				// weight is used if the 500 weight is not locally available,
-				// while still using the 500 weight if it _is_ available. This
-				// is applied at the plugin layer to ensure the original token
-				// value can be preserved at the intended 500 weight, where the
-				// bug only occurs in specific browser rendering.
-				//
-				// See: https://issues.chromium.org/issues/40552893
-				// See: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight#fallback_weights
-				if (
-					token.id.startsWith( 'wpds-typography.font-weight.' ) &&
-					token.$value === 500
-				) {
-					return '499';
-				}
-
-				return undefined;
-			},
 			baseSelector: ':root',
 			modeSelectors: [
 				{


### PR DESCRIPTION
Closes #79525

## What?

Follow up to #72473.

Revert the `font-weight: 499` workaround and unify all medium font weights back to `500`.

## Why?

#72473 changed the medium font weight from `500` to `499` to work around a Chrome/Windows behavior where a `500` weight falls back to `600` when the `500` weight is not locally available, instead of the spec-defined `400`. However, this has the side effect of rendering elements that are expected to have a bold weight, such as headings, in a regular weight.

For now, I think it would be better to accept that `500` weights render as `600` on Windows.

If a specific spot looks unnatural with `600`, let's consider changing that individual value from `500` back to `400`. Note this must be weighed carefully: it also makes the weight render thinner (`500` → `400`) on macOS.

## Testing Instructions

Please test various areas, such as the post editor and the site editor.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="1449" height="915" alt="image" src="https://github.com/user-attachments/assets/0dd549dc-6f62-499c-93d7-fa6ca2536192" /> | <img width="1458" height="918" alt="image" src="https://github.com/user-attachments/assets/ab6f4196-b208-4e00-91d4-b4b471efb6d5" /> |
| <img width="1455" height="913" alt="image" src="https://github.com/user-attachments/assets/9cc6cd42-98a1-4fcb-b022-12c71419f7e3" /> | <img width="1452" height="912" alt="image" src="https://github.com/user-attachments/assets/77e7b006-8197-4dc9-af4c-2d119180343c" /> |
| <img width="1017" height="816" alt="image" src="https://github.com/user-attachments/assets/e4244eb2-bf27-496d-b89e-77f4a7222120" /> | <img width="1058" height="794" alt="image" src="https://github.com/user-attachments/assets/986aa054-b741-4ce3-8221-2e68367a1ecf" />|

## Use of AI Tools

This PR was authored with the assistance of Claude Code. All changes were reviewed by the contributor.
