### PR TITLE
Project automation: Stop flagging returning contributors as first-timers when they use hidden email addresses

### DIFF
--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   First-time contributor label: detect previous contributions with the commit search API so contributors whose commits are authored under a GitHub noreply email are no longer mislabeled as first-time contributors ([#79987](https://github.com/WordPress/gutenberg/pull/79987)).
+
 ## 2.50.0 (2026-07-01)
 
 ## 2.49.0 (2026-06-24)

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   First-time contributor label: detect previous contributions with the commit search API so contributors whose commits are authored under a GitHub noreply email are no longer mislabeled as first-time contributors ([#79987](https://github.com/WordPress/gutenberg/pull/79987)).
+-   First-time contributor label: detect prior contributions made under a GitHub noreply email so those contributors are no longer mislabeled as first-time contributors ([#79987](https://github.com/WordPress/gutenberg/pull/79987)).
 
 ## 2.50.0 (2026-07-01)
 

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -38,18 +38,18 @@ async function firstTimeContributorLabel( payload, octokit ) {
 	// account, so it can miss commits made under a GitHub noreply address. When
 	// it finds nothing, confirm with a commit search, which matches by account.
 	// Search has a tighter rate limit, so it only runs in this rare fallback.
-	let previousCommits = commits.length;
-	if ( previousCommits === 0 ) {
+	let hasPreviousCommits = commits.length > 0;
+	if ( ! hasPreviousCommits ) {
 		const {
 			data: { total_count: searchCount },
 		} = await octokit.rest.search.commits( {
 			q: `repo:${ owner }/${ repo } author:${ author }`,
 			per_page: 1,
 		} );
-		previousCommits = searchCount;
+		hasPreviousCommits = searchCount > 0;
 	}
 
-	if ( previousCommits > 0 ) {
+	if ( hasPreviousCommits ) {
 		debug(
 			`first-time-contributor-label: Not the first commit for author. Aborting`
 		);

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -28,16 +28,26 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		`first-time-contributor: Searching for commits in ${ owner }/${ repo } by @${ author }`
 	);
 
-	// Use commit search instead of listing commits by author. The commits list
-	// only matches an account's verified emails, so it misses commits made
-	// under a GitHub noreply address and wrongly flags those contributors as
-	// new. Search matches by account, so it finds them whatever email they used.
-	const {
-		data: { total_count: previousCommits },
-	} = await octokit.rest.search.commits( {
-		q: `repo:${ owner }/${ repo } author:${ author }`,
-		per_page: 1,
+	const { data: commits } = await octokit.rest.repos.listCommits( {
+		owner,
+		repo,
+		author,
 	} );
+
+	// The commits list matches an author only by the emails verified on their
+	// account, so it can miss commits made under a GitHub noreply address. When
+	// it finds nothing, confirm with a commit search, which matches by account.
+	// Search has a tighter rate limit, so it only runs in this rare fallback.
+	let previousCommits = commits.length;
+	if ( previousCommits === 0 ) {
+		const {
+			data: { total_count: searchCount },
+		} = await octokit.rest.search.commits( {
+			q: `repo:${ owner }/${ repo } author:${ author }`,
+			per_page: 1,
+		} );
+		previousCommits = searchCount;
+	}
 
 	if ( previousCommits > 0 ) {
 		debug(

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -28,13 +28,18 @@ async function firstTimeContributorLabel( payload, octokit ) {
 		`first-time-contributor: Searching for commits in ${ owner }/${ repo } by @${ author }`
 	);
 
-	const { data: commits } = await octokit.rest.repos.listCommits( {
-		owner,
-		repo,
-		author,
+	// Use commit search instead of listing commits by author. The commits list
+	// only matches an account's verified emails, so it misses commits made
+	// under a GitHub noreply address and wrongly flags those contributors as
+	// new. Search matches by account, so it finds them whatever email they used.
+	const {
+		data: { total_count: previousCommits },
+	} = await octokit.rest.search.commits( {
+		q: `repo:${ owner }/${ repo } author:${ author }`,
+		per_page: 1,
 	} );
 
-	if ( commits.length > 0 ) {
+	if ( previousCommits > 0 ) {
 		debug(
 			`first-time-contributor-label: Not the first commit for author. Aborting`
 		);

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -33,6 +33,9 @@ describe( 'firstTimeContributorLabel', () => {
 
 		const octokit = {
 			rest: {
+				repos: {
+					listCommits: jest.fn(),
+				},
 				search: {
 					commits: jest.fn(),
 				},
@@ -41,12 +44,54 @@ describe( 'firstTimeContributorLabel', () => {
 
 		await firstTimeContributorLabel( payloadForBot, octokit );
 
+		expect( octokit.rest.repos.listCommits ).not.toHaveBeenCalled();
 		expect( octokit.rest.search.commits ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does nothing if the user has at least one commit', async () => {
+	it( 'does nothing if the commits list finds a previous commit', async () => {
 		const octokit = {
 			rest: {
+				repos: {
+					listCommits: jest.fn( () =>
+						Promise.resolve( {
+							data: [
+								{
+									sha: '4c535288a6a2b75ff23ee96c75f7d9877e919241',
+								},
+							],
+						} )
+					),
+				},
+				search: {
+					commits: jest.fn(),
+				},
+				issues: {
+					addLabels: jest.fn(),
+					createComment: jest.fn(),
+				},
+			},
+		};
+
+		await firstTimeContributorLabel( payload, octokit );
+
+		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			author: 'ghost',
+		} );
+		expect( octokit.rest.search.commits ).not.toHaveBeenCalled();
+		expect( octokit.rest.issues.addLabels ).not.toHaveBeenCalled();
+		expect( octokit.rest.issues.createComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing if the search fallback finds a previous commit', async () => {
+		const octokit = {
+			rest: {
+				repos: {
+					listCommits: jest.fn( () =>
+						Promise.resolve( { data: [] } )
+					),
+				},
 				search: {
 					commits: jest.fn( () =>
 						Promise.resolve( {
@@ -78,9 +123,14 @@ describe( 'firstTimeContributorLabel', () => {
 		expect( octokit.rest.issues.createComment ).not.toHaveBeenCalled();
 	} );
 
-	it( 'adds the First Time Contributor label if the user has no commits', async () => {
+	it( 'adds the First Time Contributor label if neither finds a commit', async () => {
 		const octokit = {
 			rest: {
+				repos: {
+					listCommits: jest.fn( () =>
+						Promise.resolve( { data: [] } )
+					),
+				},
 				search: {
 					commits: jest.fn( () =>
 						Promise.resolve( {
@@ -105,10 +155,6 @@ describe( 'firstTimeContributorLabel', () => {
 
 		await firstTimeContributorLabel( payload, octokit );
 
-		expect( octokit.rest.search.commits ).toHaveBeenCalledWith( {
-			q: 'repo:WordPress/gutenberg author:ghost',
-			per_page: 1,
-		} );
 		expect( octokit.rest.issues.addLabels ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -33,28 +33,31 @@ describe( 'firstTimeContributorLabel', () => {
 
 		const octokit = {
 			rest: {
-				repos: {
-					listCommits: jest.fn(),
+				search: {
+					commits: jest.fn(),
 				},
 			},
 		};
 
 		await firstTimeContributorLabel( payloadForBot, octokit );
 
-		expect( octokit.rest.repos.listCommits ).not.toHaveBeenCalled();
+		expect( octokit.rest.search.commits ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does nothing if the user has at least one commit', async () => {
 		const octokit = {
 			rest: {
-				repos: {
-					listCommits: jest.fn( () =>
+				search: {
+					commits: jest.fn( () =>
 						Promise.resolve( {
-							data: [
-								{
-									sha: '4c535288a6a2b75ff23ee96c75f7d9877e919241',
-								},
-							],
+							data: {
+								total_count: 1,
+								items: [
+									{
+										sha: '4c535288a6a2b75ff23ee96c75f7d9877e919241',
+									},
+								],
+							},
 						} )
 					),
 				},
@@ -67,10 +70,9 @@ describe( 'firstTimeContributorLabel', () => {
 
 		await firstTimeContributorLabel( payload, octokit );
 
-		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
-			owner: 'WordPress',
-			repo: 'gutenberg',
-			author: 'ghost',
+		expect( octokit.rest.search.commits ).toHaveBeenCalledWith( {
+			q: 'repo:WordPress/gutenberg author:ghost',
+			per_page: 1,
 		} );
 		expect( octokit.rest.issues.addLabels ).not.toHaveBeenCalled();
 		expect( octokit.rest.issues.createComment ).not.toHaveBeenCalled();
@@ -79,10 +81,13 @@ describe( 'firstTimeContributorLabel', () => {
 	it( 'adds the First Time Contributor label if the user has no commits', async () => {
 		const octokit = {
 			rest: {
-				repos: {
-					listCommits: jest.fn( () =>
+				search: {
+					commits: jest.fn( () =>
 						Promise.resolve( {
-							data: [],
+							data: {
+								total_count: 0,
+								items: [],
+							},
 						} )
 					),
 				},
@@ -100,10 +105,9 @@ describe( 'firstTimeContributorLabel', () => {
 
 		await firstTimeContributorLabel( payload, octokit );
 
-		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
-			owner: 'WordPress',
-			repo: 'gutenberg',
-			author: 'ghost',
+		expect( octokit.rest.search.commits ).toHaveBeenCalledWith( {
+			q: 'repo:WordPress/gutenberg author:ghost',
+			per_page: 1,
 		} );
 		expect( octokit.rest.issues.addLabels ).toHaveBeenCalledWith( {
 			owner: 'WordPress',


### PR DESCRIPTION
## What

Fixes the "First-time Contributor" label being added to returning contributors who commit under a GitHub noreply email, like this very same PR.

## Why

When a contributor keeps their email address private, as I do, their squash-merged commits are authored under a GitHub noreply address. The old check matched by verified email, so these contributors were treated as new on every pull request and had to remove the label and its welcome comment by hand each time.

## How

Using a different endpoint and checking prior commits matched by the contributor's account instead of the email addresses verified on it, so commits authored under a noreply email are still counted.

## Testing Instructions

The workflow runs from trunk on `pull_request_target`, so the new code cannot run against this pull request. Test the query the check now relies on instead, using a contributor whose commits are authored under a GitHub noreply email (for example, `priethor` 🙂):

1. Confirm the new check finds their commits: `gh api "/search/commits?q=repo:WordPress/gutenberg+author:priethor" --jq '.total_count'` shows a count above 0, so they would not be labeled.
2. Confirm the old check missed them: `gh api "/repos/WordPress/gutenberg/commits?author=priethor" --jq 'length'` returns 0, which is why they were mislabeled.
3. Run step 1 with a username that has never contributed to the repository and confirm the count is 0, so genuine first-time contributors are still labeled.
---
I used Claude to help diagnose the root cause and implement the fix under my guidance and review.