### PR TITLE
Widget Dashboard: reserve paint space for tile focus rings

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 -   Widget grid: reserve top paint space for outward tile focus rings so scroll
     containers do not clip the widget chrome outline.
+-   CSS Modules: rename camelCase class selectors to kebab-case in
+    `@wordpress/widget-dashboard`.
 -   `WidgetHeader`: surface the widget type's `help` note as an infotip
     beside the title: a click-open popover with the note and its links.
 -   Widget inserter: render more accurate widget previews.

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Enhancements
 
+-   Widget grid: reserve top paint space for outward tile focus rings so scroll
+    containers do not clip the widget chrome outline.
 -   `WidgetHeader`: surface the widget type's `help` note as an infotip
     beside the title: a click-open popover with the note and its links.
 -   Widget inserter: render more accurate widget previews.

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -16,8 +16,11 @@
 
 -   Widget grid: reserve top paint space for outward tile focus rings so scroll
     containers do not clip the widget chrome outline.
--   CSS Modules: rename camelCase class selectors to kebab-case in
-    `@wordpress/widget-dashboard`.
+
+### Internal
+
+-   Rename CSS Module class selectors to kebab-case and drop the package
+    suppressions from `stylelint-suppressions.json`.
 -   `WidgetHeader`: surface the widget type's `help` note as an infotip
     beside the title: a click-open popover with the note and its links.
 -   Widget inserter: render more accurate widget previews.

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -15,12 +15,12 @@
 ### Enhancements
 
 -   Widget grid: reserve top paint space for outward tile focus rings so scroll
-    containers do not clip the widget chrome outline.
+    containers do not clip the widget chrome outline ([#79990](https://github.com/WordPress/gutenberg/pull/79990)).
 
 ### Internal
 
 -   Rename CSS Module class selectors to kebab-case and drop the package
-    suppressions from `stylelint-suppressions.json`.
+    suppressions from `stylelint-suppressions.json` ([#79990](https://github.com/WordPress/gutenberg/pull/79990)).
 -   `WidgetHeader`: surface the widget type's `help` note as an infotip
     beside the title: a click-open popover with the note and its links.
 -   Widget inserter: render more accurate widget previews.

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -172,8 +172,6 @@ import { Page } from '@wordpress/admin-ui';
 
 `<Page>` is optional. The compound renders inside any container, so a bare `<header>` or custom chrome works just as well.
 
-When the widgets grid sits inside a scroll container, `<WidgetDashboard.Widgets />` reserves a small amount of top padding so outward tile focus rings stay visible. Hosts that already pad the scroll viewport (for example `<Page hasPadding>`) do not need extra spacing.
-
 ## Inserting widgets
 
 The "Add widget" button in `<WidgetDashboard.Actions />` opens a modal inserter. It lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a "Select" action with bulk support so users can insert one or several widgets in a single layout change.

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -172,6 +172,8 @@ import { Page } from '@wordpress/admin-ui';
 
 `<Page>` is optional. The compound renders inside any container, so a bare `<header>` or custom chrome works just as well.
 
+When the widgets grid sits inside a scroll container, `<WidgetDashboard.Widgets />` reserves a small amount of top padding so outward tile focus rings stay visible. Hosts that already pad the scroll viewport (for example `<Page hasPadding>`) do not need extra spacing.
+
 ## Inserting widgets
 
 The "Add widget" button in `<WidgetDashboard.Actions />` opens a modal inserter. It lists every entry in the `widgetTypes` prop as a grid of live previews (each preview renders the type's `example` attributes through its own render module), supports search, and exposes a "Select" action with bulk support so users can insert one or several widgets in a single layout change.

--- a/packages/widget-dashboard/src/components/actions/actions.module.css
+++ b/packages/widget-dashboard/src/components/actions/actions.module.css
@@ -1,12 +1,12 @@
-.editActionsEnter,
-.editActionsExit {
+.edit-actions-enter,
+.edit-actions-exit {
 	display: inline-flex;
 	align-items: center;
 	gap: var(--wp--preset--spacing--20);
 	transform-origin: right center;
 }
 
-.editActionsDivider {
+.edit-actions-divider {
 	flex-shrink: 0;
 	align-self: center;
 	width: 1px;
@@ -15,16 +15,16 @@
 }
 
 @media not ( prefers-reduced-motion ) {
-	.editActionsEnter,
-	.editActionsExit {
+	.edit-actions-enter,
+	.edit-actions-exit {
 		will-change: opacity, transform;
 	}
 
-	.editActionsEnter {
+	.edit-actions-enter {
 		animation: actions-slide-in var(--wpds-motion-duration-md) var(--wpds-motion-easing-expressive) forwards;
 	}
 
-	.editActionsExit {
+	.edit-actions-exit {
 		animation: actions-fold-out var(--wpds-motion-duration-sm) var(--wpds-motion-easing-balanced) forwards;
 	}
 

--- a/packages/widget-dashboard/src/components/actions/actions.tsx
+++ b/packages/widget-dashboard/src/components/actions/actions.tsx
@@ -105,8 +105,8 @@ export function Actions(): React.ReactNode {
 					gap="sm"
 					className={
 						isExitingEditActions
-							? styles.editActionsExit
-							: styles.editActionsEnter
+							? styles[ 'edit-actions-exit' ]
+							: styles[ 'edit-actions-enter' ]
 					}
 				>
 					<Button
@@ -120,7 +120,7 @@ export function Actions(): React.ReactNode {
 					</Button>
 
 					<div
-						className={ styles.editActionsDivider }
+						className={ styles[ 'edit-actions-divider' ] }
 						aria-hidden="true"
 					/>
 

--- a/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
+++ b/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
@@ -1,7 +1,7 @@
-/* Outline the whole tile when the body holds keyboard focus; an inner ring is easy to miss. */
+/* Outward tile focus ring; paint space reserved on `.grid`. */
 .widgetChrome:has(:focus-visible) {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
-	outline-offset: 2px;
+	outline-offset: var(--wp-widget-dashboard-tile-focus-offset, 2px);
 }
 
 .widgetChromeHeaderIcon {

--- a/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
+++ b/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
@@ -1,16 +1,16 @@
 /* Outward tile focus ring; paint space reserved on `.grid`. */
-.widgetChrome:has(:focus-visible) {
+.widget-chrome:has(:focus-visible) {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
 	outline-offset: var(--wp-widget-dashboard-tile-focus-offset, 2px);
 }
 
-.widgetChromeHeaderIcon {
+.widget-chrome-header-icon {
 	display: inline-flex;
 	color: var(--wpds-color-foreground-content-neutral);
 }
 
 /* Fill the tile so placeholder states center in the full height. */
-.widgetChromeContent {
+.widget-chrome-content {
 	flex: 1;
 	height: 100%;
 	min-width: 0;

--- a/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.tsx
+++ b/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.tsx
@@ -30,13 +30,13 @@ function UnavailableWidget( { widgetTypeName }: UnavailableWidgetProps ) {
 		<>
 			<Card.Header>
 				<span
-					className={ styles.widgetChromeHeaderIcon }
+					className={ styles[ 'widget-chrome-header-icon' ] }
 					aria-hidden="true"
 				>
 					<Icon icon={ plugins } />
 				</span>
 			</Card.Header>
-			<Card.Content className={ styles.widgetChromeContent }>
+			<Card.Content className={ styles[ 'widget-chrome-content' ] }>
 				<Stack
 					direction="column"
 					justify="center"
@@ -94,12 +94,15 @@ export const WidgetChrome = forwardRef< HTMLDivElement, WidgetChromeProps >(
 						<Card.Root
 							render={ <section /> }
 							ref={ ref }
-							className={ clsx( styles.widgetChrome, className ) }
+							className={ clsx(
+								styles[ 'widget-chrome' ],
+								className
+							) }
 							aria-busy="true"
 							aria-label={ __( 'Loading' ) }
 						>
 							<Card.Content
-								className={ styles.widgetChromeContent }
+								className={ styles[ 'widget-chrome-content' ] }
 							>
 								<LoadingOverlay />
 							</Card.Content>
@@ -113,7 +116,10 @@ export const WidgetChrome = forwardRef< HTMLDivElement, WidgetChromeProps >(
 					<Card.Root
 						render={ <section /> }
 						ref={ ref }
-						className={ clsx( styles.widgetChrome, className ) }
+						className={ clsx(
+							styles[ 'widget-chrome' ],
+							className
+						) }
 						aria-label={ __( 'Missing widget' ) }
 					>
 						<UnavailableWidget widgetTypeName={ widget.type } />
@@ -127,7 +133,7 @@ export const WidgetChrome = forwardRef< HTMLDivElement, WidgetChromeProps >(
 				<Card.Root
 					render={ <section /> }
 					ref={ ref }
-					className={ clsx( styles.widgetChrome, className ) }
+					className={ clsx( styles[ 'widget-chrome' ], className ) }
 					aria-labelledby={ widgetType.title ? titleId : undefined }
 				>
 					<WidgetFrame

--- a/packages/widget-dashboard/src/components/widget-frame/widget-frame.module.css
+++ b/packages/widget-dashboard/src/components/widget-frame/widget-frame.module.css
@@ -8,7 +8,7 @@
 }
 
 /* Bleeding body reaches the card borders. Card exposes no padding-less section. */
-.bleedContent {
+.bleed-content {
 	padding: 0;
 }
 

--- a/packages/widget-dashboard/src/components/widget-frame/widget-frame.tsx
+++ b/packages/widget-dashboard/src/components/widget-frame/widget-frame.tsx
@@ -122,7 +122,7 @@ export function WidgetFrame( {
 			<Card.Content
 				className={ clsx(
 					styles.content,
-					isBodyBleeding && styles.bleedContent
+					isBodyBleeding && styles[ 'bleed-content' ]
 				) }
 				{ ...( editMode ? { inert: 'true' } : {} ) }
 			>

--- a/packages/widget-dashboard/src/components/widget-header/widget-header-infotip.tsx
+++ b/packages/widget-dashboard/src/components/widget-header/widget-header-infotip.tsx
@@ -46,7 +46,7 @@ export function WidgetInfotip( {
 			</Popover.Trigger>
 
 			<Popover.Popup
-				className={ styles.popoverPopup }
+				className={ styles[ 'popover-popup' ] }
 				positioner={ <Popover.Positioner side="top" align="start" /> }
 			>
 				<Popover.Arrow />

--- a/packages/widget-dashboard/src/components/widget-header/widget-header.module.css
+++ b/packages/widget-dashboard/src/components/widget-header/widget-header.module.css
@@ -1,15 +1,10 @@
-/**
- * Tile header row: identity leads, toolbar trails, on one line.
- */
-.widgetHeader {
+/* Tile header row: identity leads, toolbar trails. */
+.widget-header {
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-gap-sm);
 }
 
-/**
- * Identity and toolbar share one box so they stay aligned.
- */
 .identity,
 .toolbar {
 	display: flex;
@@ -17,9 +12,6 @@
 	height: var(--wpds-dimension-size-lg);
 }
 
-/**
- * Shrink a long title instead of pushing the toolbar out.
- */
 .identity {
 	min-width: 0;
 }
@@ -29,13 +21,10 @@
 	color: var(--wpds-color-foreground-content-neutral);
 }
 
-.popoverPopup {
+.popover-popup {
 	max-width: 300px;
 }
 
-/**
- * Infotip trigger: a bare icon button beside the title.
- */
 .help {
 	display: inline-flex;
 	align-items: center;
@@ -46,9 +35,6 @@
 	cursor: var(--wpds-cursor-control);
 }
 
-/**
- * Divide adjacent links in the infotip.
- */
 .link + .link {
 	border-inline-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 	padding-inline-start: var(--wpds-dimension-gap-sm);
@@ -58,10 +44,7 @@
 	margin-inline-start: auto;
 }
 
-/**
- * Floats over the tile, click-through except the toolbar; re-declares the card
- * padding var (outside Card.Root).
- */
+/* Floats over the tile; re-declares card padding outside Card.Root. */
 .overlay {
 	position: absolute;
 	inset-block-start: 0;

--- a/packages/widget-dashboard/src/components/widget-header/widget-header.tsx
+++ b/packages/widget-dashboard/src/components/widget-header/widget-header.tsx
@@ -66,7 +66,10 @@ export function WidgetHeader( {
 }: WidgetHeaderProps ): React.ReactNode {
 	return (
 		<Card.Header
-			className={ clsx( styles.widgetHeader, overlay && styles.overlay ) }
+			className={ clsx(
+				styles[ 'widget-header' ],
+				overlay && styles.overlay
+			) }
 		>
 			{ showIdentity && widgetType?.title && (
 				<Stack

--- a/packages/widget-dashboard/src/components/widget-toolbar/widget-toolbar.module.css
+++ b/packages/widget-dashboard/src/components/widget-toolbar/widget-toolbar.module.css
@@ -1,4 +1,4 @@
-.widgetToolbar {
+.widget-toolbar {
 	padding: var(--wpds-dimension-padding-xs);
 	background: var(--wpds-color-background-surface-neutral-strong);
 }

--- a/packages/widget-dashboard/src/components/widget-toolbar/widget-toolbar.tsx
+++ b/packages/widget-dashboard/src/components/widget-toolbar/widget-toolbar.tsx
@@ -42,7 +42,7 @@ export function WidgetToolbar( {
 			align="center"
 			gap="xs"
 			className={ clsx(
-				styles.widgetToolbar,
+				styles[ 'widget-toolbar' ],
 				editMode && styles.elevated
 			) }
 		>

--- a/packages/widget-dashboard/src/components/widgets/widget-resize-handle.module.css
+++ b/packages/widget-dashboard/src/components/widgets/widget-resize-handle.module.css
@@ -26,13 +26,13 @@
  * Larger box = hit target; small `::after` = visual only (still uses
  * logical borders so RTL needs no mirroring).
  */
-.handleCorner {
+.handle-corner {
 	width: var(--wpds-dimension-size-sm);
 	height: var(--wpds-dimension-size-sm);
 	cursor: nwse-resize;
 }
 
-.handleCorner::after {
+.handle-corner::after {
 	content: "";
 	position: absolute;
 	bottom: var(--widget-resize-handle-visual-inset);
@@ -54,13 +54,13 @@
 	transform-origin: 100% 100%;
 }
 
-[dir="rtl"] .handleCorner::after {
+[dir="rtl"] .handle-corner::after {
 	transform-origin: 0% 100%;
 }
 
-.handleCorner.resizing::after,
-.handleCorner:hover::after,
-.handleCorner:focus-visible::after {
+.handle-corner.resizing::after,
+.handle-corner:hover::after,
+.handle-corner:focus-visible::after {
 	transform: scale(var(--widget-resize-handle-hover-scale));
 	border-block-end:
 		var(--wpds-border-width-sm) solid
@@ -70,7 +70,7 @@
 		var(--wpds-color-foreground-interactive-brand-active);
 }
 
-.handleHorizontal {
+.handle-horizontal {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -82,7 +82,7 @@
 }
 
 @media not ( prefers-reduced-motion ) {
-	.handleCorner::after {
+	.handle-corner::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
 			var(--wpds-motion-easing-balanced),
@@ -92,7 +92,7 @@
 			var(--wpds-motion-easing-balanced);
 	}
 
-	.handleHorizontal::after {
+	.handle-horizontal::after {
 		transition:
 			transform var(--wpds-motion-duration-xs)
 			var(--wpds-motion-easing-balanced),
@@ -101,7 +101,7 @@
 	}
 }
 
-.handleHorizontal::after {
+.handle-horizontal::after {
 	content: "";
 	width: var(--wpds-border-width-sm);
 	height: var(--wpds-dimension-size-3xs);
@@ -110,26 +110,26 @@
 	transform-origin: 50% 100%;
 }
 
-.handleHorizontal.resizing::after,
-.handleHorizontal:hover::after,
-.handleHorizontal:focus-visible::after {
+.handle-horizontal.resizing::after,
+.handle-horizontal:hover::after,
+.handle-horizontal:focus-visible::after {
 	transform: scale(var(--widget-resize-handle-hover-scale));
 	background-color: var(--wpds-color-foreground-interactive-brand-active);
 }
 
 @media (forced-colors: active) {
-	.handleCorner::after,
-	.handleCorner.resizing::after,
-	.handleCorner:hover::after,
-	.handleCorner:focus-visible::after {
+	.handle-corner::after,
+	.handle-corner.resizing::after,
+	.handle-corner:hover::after,
+	.handle-corner:focus-visible::after {
 		border-block-end-color: Highlight;
 		border-inline-end-color: Highlight;
 	}
 
-	.handleHorizontal::after,
-	.handleHorizontal.resizing::after,
-	.handleHorizontal:hover::after,
-	.handleHorizontal:focus-visible::after {
+	.handle-horizontal::after,
+	.handle-horizontal.resizing::after,
+	.handle-horizontal:hover::after,
+	.handle-horizontal:focus-visible::after {
 		background-color: Highlight;
 	}
 }

--- a/packages/widget-dashboard/src/components/widgets/widget-resize-handle.tsx
+++ b/packages/widget-dashboard/src/components/widgets/widget-resize-handle.tsx
@@ -36,7 +36,7 @@ export const WidgetResizeHandle = forwardRef<
 				ref={ ref }
 				className={ clsx(
 					styles.handle,
-					styles.handleHorizontal,
+					styles[ 'handle-horizontal' ],
 					isResizing && styles.resizing
 				) }
 				{ ...listeners }
@@ -50,7 +50,7 @@ export const WidgetResizeHandle = forwardRef<
 			ref={ ref }
 			className={ clsx(
 				styles.handle,
-				styles.handleCorner,
+				styles[ 'handle-corner' ],
 				isResizing && styles.resizing
 			) }
 			{ ...listeners }

--- a/packages/widget-dashboard/src/components/widgets/widgets.module.css
+++ b/packages/widget-dashboard/src/components/widgets/widgets.module.css
@@ -5,6 +5,10 @@
 	/* Placeholder and drag-preview radii: match `.tile` and `@wordpress/ui` Card (`--wpds-border-radius-lg`). */
 	--wp-grid-placeholder-radius: var(--wpds-border-radius-lg);
 	--wp-grid-drag-preview-radius: var(--wpds-border-radius-lg);
+	/* Reserve top paint space so scroll containers do not clip tile focus rings. */
+	--wp-widget-dashboard-tile-focus-offset: 2px;
+	--wp-widget-dashboard-focus-ring-reserve: calc(var(--wpds-border-width-focus) + var(--wp-widget-dashboard-tile-focus-offset));
+	padding-block-start: var(--wp-widget-dashboard-focus-ring-reserve);
 }
 
 .tile {
@@ -22,7 +26,7 @@
 
 .tileEditMode:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
-	outline-offset: 2px;
+	outline-offset: var(--wp-widget-dashboard-tile-focus-offset, 2px);
 }
 
 /*

--- a/packages/widget-dashboard/src/components/widgets/widgets.module.css
+++ b/packages/widget-dashboard/src/components/widgets/widgets.module.css
@@ -20,11 +20,11 @@
  * Edit-mode tiles stay at resting elevation (`xs`) on hover; only the
  * drag preview (`.drag-preview-frame` on `@wordpress/grid`) lifts to `md`.
  */
-.tileEditMode {
+.tile-edit-mode {
 	box-shadow: var(--wpds-elevation-xs);
 }
 
-.tileEditMode:focus-visible {
+.tile-edit-mode:focus-visible {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
 	outline-offset: var(--wp-widget-dashboard-tile-focus-offset, 2px);
 }
@@ -37,10 +37,10 @@
  * `.drag-preview-frame` (`md` while dragging); strip the cloned tile shadow so it
  * does not stack on the frame.
  */
-.dragPreview {
+.drag-preview {
 	height: 100%;
 }
 
-.dragPreview .tile {
+.drag-preview .tile {
 	box-shadow: none;
 }

--- a/packages/widget-dashboard/src/components/widgets/widgets.tsx
+++ b/packages/widget-dashboard/src/components/widgets/widgets.tsx
@@ -174,7 +174,7 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 					widget={ widget }
 					index={ index }
 					className={ clsx( styles.tile, {
-						[ styles.tileEditMode ]: editMode,
+						[ styles[ 'tile-edit-mode' ] ]: editMode,
 					} ) }
 					actionableArea={ actionableArea }
 					headerToolbar={ ! inSlot ? toolbar : undefined }
@@ -184,7 +184,7 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 
 		const renderDragPreview = useCallback(
 			( { children: clone }: DragPreviewRenderProps ) => (
-				<div className={ styles.dragPreview }>{ clone }</div>
+				<div className={ styles[ 'drag-preview' ] }>{ clone }</div>
 			),
 			[]
 		);

--- a/tools/stylelint/stylelint-suppressions.json
+++ b/tools/stylelint/stylelint-suppressions.json
@@ -59,46 +59,6 @@
 			"count": 1
 		}
 	},
-	"packages/widget-dashboard/src/components/actions/actions.module.css": {
-		"selector-class-pattern": {
-			"count": 7
-		}
-	},
-	"packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css": {
-		"selector-class-pattern": {
-			"count": 3
-		}
-	},
-	"packages/widget-dashboard/src/components/widget-frame/widget-frame.module.css": {
-		"selector-class-pattern": {
-			"count": 1
-		}
-	},
-	"packages/widget-dashboard/src/components/widget-header/widget-header.module.css": {
-		"selector-class-pattern": {
-			"count": 2
-		}
-	},
-	"packages/widget-dashboard/src/components/widget-toolbar/widget-toolbar.module.css": {
-		"selector-class-pattern": {
-			"count": 1
-		}
-	},
-	"packages/widget-dashboard/src/components/widgets/widget-resize-handle.module.css": {
-		"selector-class-pattern": {
-			"count": 21
-		}
-	},
-	"packages/widget-dashboard/src/components/widgets/widgets.module.css": {
-		"selector-class-pattern": {
-			"count": 4
-		}
-	},
-	"packages/widget-dashboard/src/components/layout-settings/layout-model-edit-field/style.module.css": {
-		"selector-class-pattern": {
-			"count": 3
-		}
-	},
 	"routes/template-list/add-new-template/style.scss": {
 		"selector-class-pattern": {
 			"count": 1


### PR DESCRIPTION
## Summary

- Reserve top padding on the widget grid so outward tile focus rings are not clipped by `overflow: auto` scroll containers.
- Tie the ring offset to a shared custom property on `.grid` and document the behavior for hosts in the package README.
- Rename CSS Module class selectors in `@wordpress/widget-dashboard` to kebab-case and remove the package entries from `stylelint-suppressions.json`.

Related context: [Automattic/jetpack#50262](https://github.com/Automattic/jetpack/pull/50262) applied a similar stage-level padding fix in Premium Analytics; this moves the concern upstream into the dashboard engine.

## Test plan

- [ ] Open the Gutenberg dashboard (`routes/dashboard`) and Tab through controls in a first-row widget; confirm the blue tile focus outline is fully visible at the top edge.
- [ ] Toggle customize mode and Tab between tiles; confirm edit-mode tile focus outlines remain visible.
- [ ] Run `npm run test:unit -- packages/widget-dashboard` (48 tests).
- [ ] Run `npx wp-scripts lint-style --suppress-location=tools/stylelint/stylelint-suppressions.json "packages/widget-dashboard/src/**/*.module.css"`.


Made with [Cursor](https://cursor.com)