### PR TITLE
RTC: Only apply CRDT updates synchronously when collaborating

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -323,7 +323,7 @@ export const prePersistPostType = async (
 	if ( persistedRecord ) {
 		const objectType = `postType/${ name }`;
 		const objectId = persistedRecord.id;
-		const serializedDoc = getSyncManager()?.createPersistedCRDTDoc(
+		const serializedDoc = await getSyncManager()?.createPersistedCRDTDoc(
 			objectType,
 			objectId
 		);

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -13,7 +13,11 @@ import {
 	CRDT_STATE_MAP_SAVED_AT_KEY as SAVED_AT_KEY,
 	LOCAL_SYNC_MANAGER_ORIGIN,
 } from './config';
-import { logPerformanceTiming, passThru } from './performance';
+import {
+	logPerformanceTiming,
+	passThru,
+	yieldToEventLoop,
+} from './performance';
 import { getProviderCreators } from './providers';
 import type {
 	CollectionHandlers,
@@ -501,13 +505,13 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * Get the awareness instance for the given object type and object ID, if supported.
 	 *
 	 * @template {Awareness} State
-	 * @param {ObjectType} objectType Object type.
-	 * @param {ObjectID}   objectId   Object ID.
+	 * @param {ObjectType}    objectType Object type.
+	 * @param {ObjectID|null} objectId   Object ID.
 	 * @return {State | undefined} The awareness instance, or undefined if not supported.
 	 */
 	function getAwareness< State extends Awareness >(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID | null
 	): State | undefined {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -677,6 +681,27 @@ export function createSyncManager( debug = false ): SyncManager {
 		}
 	}
 
+	// Deferred variant of `updateCRDTDoc`; keeps work off the typing hot path.
+	const deferUpdateCRDTDoc = yieldToEventLoop( updateCRDTDoc );
+
+	// Apply local changes to the CRDT doc — synchronously when a remote peer is
+	// present so the change lands before a remote update can race it (#78756),
+	// otherwise deferred off the typing hot path (#79964).
+	function updateOrDefer(
+		objectType: ObjectType,
+		objectId: ObjectID | null,
+		changes: Partial< ObjectData >,
+		origin: string,
+		options: SyncManagerUpdateOptions = {}
+	): void {
+		// `getStates()` counts the local client, so > 1 means a remote peer.
+		const hasRemotePeers =
+			( getAwareness( objectType, objectId )?.getStates().size ?? 0 ) > 1;
+
+		const update = hasRemotePeers ? updateCRDTDoc : deferUpdateCRDTDoc;
+		update( objectType, objectId, changes, origin, options );
+	}
+
 	/**
 	 * Update the entity record in the local store with changes from the CRDT
 	 * document.
@@ -723,16 +748,21 @@ export function createSyncManager( debug = false ): SyncManager {
 	 * @param {ObjectType} objectType Object type.
 	 * @param {ObjectID}   objectId   Object ID.
 	 */
-	function createPersistedCRDTDoc(
+	async function createPersistedCRDTDoc(
 		objectType: ObjectType,
 		objectId: ObjectID
-	): string | null {
+	): Promise< string | null > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
 
 		if ( ! entityState?.ydoc ) {
 			return null;
 		}
+
+		// Local updates may be deferred via yieldToEventLoop when editing alone.
+		// Await a promise that resolves on the next tick of the event loop so
+		// pending updates are flushed before we serialize the document.
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 		return serializeCrdtDoc( entityState.ydoc );
 	}
@@ -755,6 +785,6 @@ export function createSyncManager( debug = false ): SyncManager {
 		},
 		unload: debugWrap( unloadEntity ),
 		unloadAll: debugWrap( unloadAll ),
-		update: debugWrap( updateCRDTDoc ),
+		update: debugWrap( updateOrDefer ),
 	};
 }

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -641,7 +641,7 @@ describe( 'SyncManager', () => {
 			expect( stateMap.get( SAVED_BY_KEY ) ).toBeUndefined();
 		} );
 
-		it( 'applies local CRDT updates synchronously before processing remote record updates', async () => {
+		it( 'applies local CRDT updates synchronously before processing remote record updates when collaborating', async () => {
 			let capturedDoc: Y.Doc | null = null;
 			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
 				capturedDoc = ydoc;
@@ -691,6 +691,15 @@ describe( 'SyncManager', () => {
 
 			handlers.editRecord.mockClear();
 
+			// Simulate a remote peer so local updates are applied synchronously.
+			// (They are only deferred off the hot path when editing alone.)
+			const awareness = manager.getAwareness(
+				'post',
+				'123'
+			) as Awareness;
+			awareness.setLocalState( {} );
+			awareness.states.set( awareness.clientID + 1, {} );
+
 			manager.update(
 				'post',
 				'123',
@@ -715,6 +724,37 @@ describe( 'SyncManager', () => {
 			expect( handlers.editRecord ).toHaveBeenCalledWith( {
 				remoteField: 'Remote value',
 			} );
+		} );
+
+		it( 'defers local CRDT updates off the hot path when editing alone', async () => {
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			jest.clearAllMocks();
+
+			manager.update(
+				'post',
+				'123',
+				{ title: 'Updated Title' },
+				LOCAL_EDITOR_ORIGIN
+			);
+
+			// With no remote peers present, the update is deferred so nothing
+			// is applied synchronously on the typing hot path.
+			expect(
+				mockSyncConfig.applyChangesToCRDTDoc
+			).not.toHaveBeenCalled();
+
+			// It is applied on the next tick of the event loop.
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+			expect( mockSyncConfig.applyChangesToCRDTDoc ).toHaveBeenCalled();
 		} );
 
 		it( 'does not update when entity is not loaded', async () => {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -168,10 +168,10 @@ export interface SyncManager {
 	createPersistedCRDTDoc: (
 		objectType: ObjectType,
 		objectId: ObjectID
-	) => string | null;
+	) => Promise< string | null >;
 	getAwareness: < State extends Awareness >(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID | null
 	) => State | undefined;
 	load: (
 		syncConfig: SyncConfig,


### PR DESCRIPTION
## What?
Closes #79964.

PR tries to fix the ~75% typing latency regression from #78756 by only doing the extra per-keystroke work when there's actually someone else in the document.

## Why?

Typing latency went from ~15ms to ~25ms. Typing is one of the editor's most important metrics, and we shouldn't slow it down for all users to support a feature only some of them use. See #79964.

## How?

The synchronous commit only matters when a remote update can arrive and race the local keystroke — i.e. when another peer is present. So `SyncManager.update` now checks awareness for remote peers:

- **Editing alone** (no remote peers): defer the CRDT commit off the typing hot path, as it was before #78756. There's no remote update to race, so this is safe.
- **Collaborating** (a remote peer is present): commit synchronously, keeping #78756's fix for jumbled/dropped characters exactly as-is.

`createPersistedCRDTDoc` becomes async again, so a save flushes any deferred update before serializing (restores the pre-#78756 behavior).

## Testing Instructions
Just trying out CI checks. Will update later.

## Use of AI Tools

Heavily assisted by Claude. Did a sanity check on my logic.
