### PR TITLE
Block editor: Display tooltip for inherited global styles with breadcrumb path

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Inspector controls that inherit a value from Global Styles now expose a tooltip on the control label describing the breadcrumb path to the Global Styles source the value is inherited from (e.g. `Styles > Blocks > Group > Variations > Subtitle`). The tooltip is only shown in the block inspector, not in the Global Styles screens.
+
 ### Internal
 
 -   Extract a shared `getBlockBindingsContext` helper for assembling the context handed to block-bindings sources; only entries present in the surrounding block context are copied ([#79855](https://github.com/WordPress/gutenberg/pull/79855)).

--- a/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
@@ -21,15 +21,16 @@ import { InheritanceToolsPanelItem } from '../global-styles/inheritance';
 
 /**
  * @typedef {Object} AspectRatioToolProps
- * @property {string}                       [panelId]          ID of the panel this tool is associated with.
- * @property {string}                       [value]            Current aspect ratio value.
- * @property {AspectRatioToolPropsOnChange} [onChange]         Callback to update the aspect ratio value.
- * @property {SelectControlProps[]}         [options]          Aspect ratio options.
- * @property {string}                       [defaultValue]     Default aspect ratio value.
- * @property {boolean}                      [isShownByDefault] Whether the tool is shown by default.
- * @property {string}                       [className]        Additional CSS class on the wrapping panel item.
- * @property {boolean}                      [isInherited]      Whether the control is displaying an inherited Global Styles value.
- * @property {boolean}                      [hasLocalOverride] Whether a local value is overriding an inherited Global Styles value.
+ * @property {string}                       [panelId]                ID of the panel this tool is associated with.
+ * @property {string}                       [value]                  Current aspect ratio value.
+ * @property {AspectRatioToolPropsOnChange} [onChange]               Callback to update the aspect ratio value.
+ * @property {SelectControlProps[]}         [options]                Aspect ratio options.
+ * @property {string}                       [defaultValue]           Default aspect ratio value.
+ * @property {boolean}                      [isShownByDefault]       Whether the tool is shown by default.
+ * @property {string}                       [className]              Additional CSS class on the wrapping panel item.
+ * @property {boolean}                      [isInherited]            Whether the control is displaying an inherited Global Styles value.
+ * @property {boolean}                      [hasLocalOverride]       Whether a local value is overriding an inherited Global Styles value.
+ * @property {string}                       [inheritanceTooltipText] Tooltip text describing the inherited Global Styles source.
  */
 
 export default function AspectRatioTool( {
@@ -43,6 +44,7 @@ export default function AspectRatioTool( {
 	className,
 	isInherited,
 	hasLocalOverride,
+	inheritanceTooltipText,
 } ) {
 	// Match the CSS default so if the value is used directly in CSS it will look correct in the control.
 	const displayValue = value ?? 'auto';
@@ -86,6 +88,7 @@ export default function AspectRatioTool( {
 			className={ className }
 			isInherited={ isInherited }
 			hasLocalOverride={ hasLocalOverride }
+			inheritanceTooltipText={ inheritanceTooltipText }
 			hasValue={
 				hasValue ? hasValue : () => displayValue !== defaultValue
 			}

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -18,7 +18,11 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -160,6 +164,7 @@ export default function BackgroundImagePanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -333,6 +338,18 @@ export default function BackgroundImagePanel( {
 		showInheritanceLabelIndicators
 			? getInheritanceProps( isInherited, hasLocalOverride, classNames )
 			: { className: classNames };
+	// The background image is stored as an object, so its source lives on the
+	// leaf sub-paths. Resolve the breadcrumb from the image leaves only (not
+	// size/position) so the tooltip reflects the inherited image itself.
+	const backgroundImageTooltipText = getCommonInheritanceTooltipText(
+		inheritedSources,
+		[
+			'background.backgroundImage.url',
+			'background.backgroundImage.id',
+			'background.backgroundImage.title',
+			'background.backgroundImage.source',
+		]
+	);
 
 	// The inherited value arrives already resolved (refs + theme-file pointers)
 	// with non-cascading root values dropped, so a presence check drives the
@@ -362,6 +379,7 @@ export default function BackgroundImagePanel( {
 					showLocalOverrideActionsInLabel={ false }
 					hasValue={ () => hasBackgroundImageValue( value ) }
 					label={ __( 'Image' ) }
+					inheritanceTooltipText={ backgroundImageTooltipText }
 					onDeselect={ resetBackground }
 					isShownByDefault={ defaultControls.backgroundImage }
 					panelId={ panelId }
@@ -390,6 +408,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userBackgroundColor === undefined &&
 						backgroundColor !== undefined
@@ -399,6 +418,7 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'background',
 							label: __( 'Color' ),
+							sourcePaths: [ 'color.background' ],
 							inheritedValue: backgroundColor,
 							// Resolve the slug from the same source as the
 							// displayed value (user value first, then the
@@ -440,6 +460,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						currentGradient === undefined &&
 						inheritedGradient !== undefined
@@ -449,6 +470,10 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'gradient',
 							label: __( 'Gradient' ),
+							sourcePaths: [
+								'background.gradient',
+								'color.gradient',
+							],
 							inheritedValue: inheritedGradient,
 							setValue: setGradient,
 							userValue: currentGradient,
@@ -477,6 +502,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userLegacyColorGradient === undefined &&
 						legacyColorGradient !== undefined
@@ -486,6 +512,7 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'gradient',
 							label: __( 'Gradient' ),
+							sourcePaths: [ 'color.gradient' ],
 							inheritedValue: legacyColorGradient,
 							setValue: setLegacyColorGradient,
 							userValue: userLegacyColorGradient,

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -21,7 +21,12 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -99,6 +104,7 @@ export default function BorderPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	name,
@@ -115,6 +121,35 @@ export default function BorderPanel( {
 		showInheritanceLabelIndicators
 			? getInheritanceProps( isInherited, hasLocalOverride, className )
 			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
+	const borderTooltipText = commonTooltipText( [
+		'border.color',
+		'border.style',
+		'border.width',
+		'border.top.color',
+		'border.top.style',
+		'border.top.width',
+		'border.right.color',
+		'border.right.style',
+		'border.right.width',
+		'border.bottom.color',
+		'border.bottom.style',
+		'border.bottom.width',
+		'border.left.color',
+		'border.left.style',
+		'border.left.width',
+	] );
+	const borderRadiusTooltipText = commonTooltipText( [
+		'border.radius',
+		'border.radius.topLeft',
+		'border.radius.topRight',
+		'border.radius.bottomLeft',
+		'border.radius.bottomRight',
+	] );
+	const shadowTooltipText = tooltipText( 'shadow' );
 	const encodeColorValue = ( colorValue ) => {
 		const allColors = colors.flatMap(
 			( { colors: originColors } ) => originColors
@@ -391,6 +426,7 @@ export default function BorderPanel( {
 					) }
 					hasValue={ () => isDefinedBorder( value?.border ) }
 					label={ __( 'Border' ) }
+					inheritanceTooltipText={ borderTooltipText }
 					onDeselect={ () => resetBorder() }
 					isShownByDefault={ showBorderByDefault }
 					panelId={ panelId }
@@ -430,6 +466,7 @@ export default function BorderPanel( {
 					) }
 					hasValue={ hasBorderRadius }
 					label={ __( 'Radius' ) }
+					inheritanceTooltipText={ borderRadiusTooltipText }
 					hasInlineEndToggle
 					onDeselect={ () => setBorderRadius( undefined ) }
 					isShownByDefault={ defaultControls.radius }
@@ -451,6 +488,7 @@ export default function BorderPanel( {
 						hasShadow() && inheritedShadow !== undefined
 					) }
 					label={ __( 'Shadow' ) }
+					inheritanceTooltipText={ shadowTooltipText }
 					hasValue={ hasShadow }
 					onDeselect={ resetShadow }
 					isShownByDefault={ defaultControls.shadow }

--- a/packages/block-editor/src/components/global-styles/build-inherited-value.js
+++ b/packages/block-editor/src/components/global-styles/build-inherited-value.js
@@ -52,20 +52,61 @@ const TREE_STRUCTURAL_KEYS = new Set( [ 'blocks', 'variations', 'css' ] );
 // Empty inheritance data returned before Global Styles payloads settle.
 const EMPTY_INHERITANCE = Object.freeze( { value: {}, sources: {} } );
 
-// Source descriptors per inheritance layer. `layer` identifies which layer
-// supplied a leaf and drives inherited-value detection.
-const SOURCE_DESCRIPTORS = {
-	root: { layer: 'root' },
-	block: { layer: 'block' },
-	blockVariation: { layer: 'blockVariation' },
+// Breadcrumb part identifiers for each Global Styles inheritance layer.
+const SOURCE_BREADCRUMB_PARTS = {
+	styles: 'styles',
+	elements: 'elements',
+	blocks: 'blocks',
+	blockName: 'blockName',
+	variations: 'variations',
+	variationName: 'variationName',
 };
 
-function createSourceDescriptor( type ) {
+// Source descriptors per inheritance layer. `layer` identifies which layer
+// supplied a leaf and drives inherited-value detection; `breadcrumb` describes
+// the Global Styles path surfaced in the inspector label tooltip.
+const SOURCE_DESCRIPTORS = {
+	root: {
+		breadcrumb: [ SOURCE_BREADCRUMB_PARTS.styles ],
+		layer: 'root',
+	},
+	block: {
+		breadcrumb: [
+			SOURCE_BREADCRUMB_PARTS.styles,
+			SOURCE_BREADCRUMB_PARTS.blocks,
+			SOURCE_BREADCRUMB_PARTS.blockName,
+		],
+		layer: 'block',
+	},
+	blockVariation: {
+		breadcrumb: [
+			SOURCE_BREADCRUMB_PARTS.styles,
+			SOURCE_BREADCRUMB_PARTS.blocks,
+			SOURCE_BREADCRUMB_PARTS.blockName,
+			SOURCE_BREADCRUMB_PARTS.variations,
+			SOURCE_BREADCRUMB_PARTS.variationName,
+		],
+		layer: 'blockVariation',
+	},
+};
+
+function createSourceDescriptor(
+	type,
+	{ blockName, variation, blockStyles } = {}
+) {
 	const descriptor = SOURCE_DESCRIPTORS[ type ];
 	if ( ! descriptor ) {
 		return null;
 	}
-	return { ...descriptor };
+	return {
+		...descriptor,
+		breadcrumb: [ ...descriptor.breadcrumb ],
+		blockName: blockName ?? null,
+		variation: variation ?? null,
+		variationTitle:
+			blockStyles?.find( ( style ) => style.name === variation )?.label ??
+			null,
+	};
 }
 
 function createContribution( styles, source ) {
@@ -81,8 +122,14 @@ function getPathKey( path ) {
 
 // Clone the descriptor so source-map entries can diverge as paths differ.
 function getSourceForPath( source, path ) {
+	const breadcrumb = [ ...source.breadcrumb ];
+	const [ maybeElementsKey, maybeElement ] = path;
+	if ( maybeElementsKey === 'elements' && maybeElement ) {
+		breadcrumb.push( SOURCE_BREADCRUMB_PARTS.elements, maybeElement );
+	}
 	return {
 		...source,
+		breadcrumb,
 		path: [ ...path ],
 	};
 }
@@ -339,6 +386,7 @@ function resolveThemeFileBackgroundImage( value, globalStyles, links ) {
  * @param {string}  args.blockName       Block name (e.g. `core/heading`).
  * @param {?string} [args.ownVariation]  Active block style variation slug, or null.
  * @param {Object}  [args.globalStyles]  The `settings[ globalStylesDataKey ]` payload.
+ * @param {Array}   [args.blockStyles]   Registered styles for the block type (for variation titles).
  * @param {?Object} [args.selectedState] Selected block style state, or null for the default state.
  * @param {?Object} [args._links]        Theme-file links (`settings[ globalStylesLinksDataKey ]`), used to resolve theme-file pointers.
  * @return {{ value: Object, sources: Object }} Merged panel-scoped payload and source map.
@@ -347,6 +395,7 @@ function computeResolvedStyles( {
 	blockName,
 	ownVariation = null,
 	globalStyles,
+	blockStyles = [],
 	selectedState = null,
 	_links = null,
 } = {} ) {
@@ -382,13 +431,17 @@ function computeResolvedStyles( {
 		block
 			? createContribution(
 					pickLayerRootContribution( block ),
-					createSourceDescriptor( 'block' )
+					createSourceDescriptor( 'block', { blockName } )
 			  )
 			: null,
 		variation
 			? createContribution(
 					pickLayerRootContribution( variation ),
-					createSourceDescriptor( 'blockVariation' )
+					createSourceDescriptor( 'blockVariation', {
+						blockName,
+						variation: ownVariation,
+						blockStyles,
+					} )
 			  )
 			: null,
 	];
@@ -411,7 +464,7 @@ function computeResolvedStyles( {
 						pickLayerRootContribution(
 							getStateSlice( block, selectedState )
 						),
-						createSourceDescriptor( 'block' )
+						createSourceDescriptor( 'block', { blockName } )
 				  )
 				: null,
 			variation
@@ -419,7 +472,11 @@ function computeResolvedStyles( {
 						pickLayerRootContribution(
 							getStateSlice( variation, selectedState )
 						),
-						createSourceDescriptor( 'blockVariation' )
+						createSourceDescriptor( 'blockVariation', {
+							blockName,
+							variation: ownVariation,
+							blockStyles,
+						} )
 				  )
 				: null
 		);
@@ -454,7 +511,7 @@ function computeResolvedStyles( {
 }
 
 // Shared memo for `resolveStyles`, keyed by Global Styles object identity and
-// a `(blockName, ownVariation, selectedState)` composite.
+// a `(blockName, ownVariation, blockStyles, selectedState)` composite.
 const memo = new WeakMap();
 
 /**
@@ -475,6 +532,9 @@ export function resolveStyles( args ) {
 		inner = new Map();
 		memo.set( globalStyles, inner );
 	}
+	const blockStylesKey = ( args.blockStyles || [] )
+		.map( ( { name, label } ) => `${ name }:${ label }` )
+		.join( ',' );
 	const selectedStateKey = args.selectedState
 		? `${ args.selectedState.viewport ?? '' }:${
 				args.selectedState.pseudo ?? ''
@@ -484,6 +544,8 @@ export function resolveStyles( args ) {
 		( args.blockName || '' ) +
 		'\u0001' +
 		( args.ownVariation || '' ) +
+		'\u0001' +
+		blockStylesKey +
 		'\u0001' +
 		selectedStateKey;
 	if ( inner.has( key ) ) {

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -28,6 +28,7 @@ import ColorGradientControl from '../colors-gradients/control';
 import { unlock } from '../../lock-unlock';
 import {
 	getInheritanceProps,
+	getCommonInheritanceTooltipText,
 	InheritanceResetButton,
 	InheritanceToolsPanelItem,
 } from './inheritance';
@@ -208,6 +209,7 @@ export default function ColorGradientDropdownItem( {
 	isPlaceholder = false,
 	hasInheritedValue = false,
 	showInheritanceLabelIndicators = true,
+	inheritedSources = {},
 } ) {
 	const colorGradientDropdownButtonRef = useRef( undefined );
 	const itemClassName = clsx( 'block-editor-color-gradient-item', className );
@@ -219,12 +221,18 @@ export default function ColorGradientDropdownItem( {
 	const inheritanceProps = showInheritanceLabelIndicators
 		? getInheritanceProps( isPlaceholder, hasLocalOverride, itemClassName )
 		: { className: itemClassName };
+	const tabSourcePaths = tabs.flatMap( ( tab ) => tab.sourcePaths ?? [] );
+	const inheritanceTooltipText = getCommonInheritanceTooltipText(
+		inheritedSources,
+		tabSourcePaths
+	);
 	return (
 		<InheritanceToolsPanelItem
 			{ ...inheritanceProps }
 			showLocalOverrideActionsInLabel={ false }
 			hasValue={ hasValue }
 			label={ label }
+			inheritanceTooltipText={ inheritanceTooltipText }
 			onDeselect={ resetValue }
 			isShownByDefault={ isShownByDefault }
 			panelId={ panelId }

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -142,6 +142,7 @@ export default function ColorPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources = {},
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -301,6 +302,10 @@ export default function ColorPanel( {
 		showLinkPanel && {
 			key: 'link',
 			label: __( 'Link' ),
+			sourcePaths: [
+				'elements.link.color.text',
+				'elements.link.:hover.color.text',
+			],
 			hasValue: hasLink,
 			resetValue: resetLink,
 			isShownByDefault: defaultControls.link,
@@ -319,6 +324,7 @@ export default function ColorPanel( {
 				{
 					key: 'link',
 					label: __( 'Default' ),
+					sourcePaths: [ 'elements.link.color.text' ],
 					inheritedValue: linkColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.link?.color?.text,
@@ -332,6 +338,7 @@ export default function ColorPanel( {
 				{
 					key: 'hover',
 					label: __( 'Hover' ),
+					sourcePaths: [ 'elements.link.:hover.color.text' ],
 					inheritedValue: hoverLinkColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.link?.[ ':hover' ]?.color
@@ -453,6 +460,11 @@ export default function ColorPanel( {
 		items.push( {
 			key: name,
 			label: elementLabel,
+			sourcePaths: [
+				`elements.${ name }.color.text`,
+				`elements.${ name }.color.background`,
+				`elements.${ name }.color.gradient`,
+			],
 			hasValue: hasElement,
 			resetValue: resetElement,
 			isShownByDefault: defaultControls[ name ],
@@ -471,6 +483,7 @@ export default function ColorPanel( {
 				hasSolidColors && {
 					key: 'text',
 					label: __( 'Text' ),
+					sourcePaths: [ `elements.${ name }.color.text` ],
 					inheritedValue: elementTextColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.[ name ]?.color?.text,
@@ -484,6 +497,7 @@ export default function ColorPanel( {
 					supportsBackground && {
 						key: 'background',
 						label: __( 'Background' ),
+						sourcePaths: [ `elements.${ name }.color.background` ],
 						inheritedValue: elementBackgroundColor,
 						inheritedSlug: extractPresetSlug(
 							inheritedValue?.elements?.[ name ]?.color
@@ -498,6 +512,7 @@ export default function ColorPanel( {
 					supportsBackground && {
 						key: 'gradient',
 						label: __( 'Gradient' ),
+						sourcePaths: [ `elements.${ name }.color.gradient` ],
 						inheritedValue: elementGradient,
 						setValue: setElementGradient,
 						userValue: elementGradientUserColor,
@@ -517,7 +532,7 @@ export default function ColorPanel( {
 			label={ label }
 		>
 			{ items.map( ( item ) => {
-				const { key, ...restItem } = item;
+				const { key, sourcePaths, ...restItem } = item;
 				return (
 					<ColorGradientDropdownItem
 						key={ key }
@@ -525,6 +540,7 @@ export default function ColorPanel( {
 						showInheritanceLabelIndicators={
 							showInheritanceLabelIndicators
 						}
+						inheritedSources={ inheritedSources }
 						colorGradientControlSettings={ {
 							colors,
 							disableCustomColors: ! areCustomSolidsEnabled,

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,7 +33,12 @@ import {
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -322,6 +327,7 @@ export default function DimensionsPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -355,6 +361,10 @@ export default function DimensionsPanel( {
 		showInheritanceLabelIndicators
 			? getInheritanceProps( isInherited, hasLocalOverride, className )
 			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
 
 	const showSpacingPresetsControl = hasSpacingPresets( settings );
 	const units = useCustomUnits( {
@@ -490,6 +500,12 @@ export default function DimensionsPanel( {
 		hasValue( value?.spacing?.padding ) &&
 		Object.keys( value?.spacing?.padding ).length;
 	const resetPaddingValue = () => setPaddingValues( undefined );
+	const paddingTooltipText = commonTooltipText( [
+		'spacing.padding.top',
+		'spacing.padding.right',
+		'spacing.padding.bottom',
+		'spacing.padding.left',
+	] );
 	const onMouseOverPadding = () => onVisualize( 'padding' );
 
 	// Margin
@@ -526,6 +542,12 @@ export default function DimensionsPanel( {
 		hasValue( value?.spacing?.margin ) &&
 		Object.keys( value?.spacing?.margin ).length;
 	const resetMarginValue = () => setMarginValues( undefined );
+	const marginTooltipText = commonTooltipText( [
+		'spacing.margin.top',
+		'spacing.margin.right',
+		'spacing.margin.bottom',
+		'spacing.margin.left',
+	] );
 	const onMouseOverMargin = () => onVisualize( 'margin' );
 
 	// Block Gap
@@ -573,6 +595,11 @@ export default function DimensionsPanel( {
 	};
 	const resetGapValue = () => setGapValue( undefined );
 	const hasGapValue = () => hasValue( value?.spacing?.blockGap );
+	const gapTooltipText = commonTooltipText( [
+		'spacing.blockGap',
+		'spacing.blockGap.top',
+		'spacing.blockGap.left',
+	] );
 
 	// Min Height
 	const showMinHeightControl = hasMinHeight( settings );
@@ -740,6 +767,9 @@ export default function DimensionsPanel( {
 						DEFAULT_CONTROLS.contentSize
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText(
+						'layout.contentSize'
+					) }
 				>
 					<UnitControl
 						label={ __( 'Content width' ) }
@@ -776,6 +806,7 @@ export default function DimensionsPanel( {
 						defaultControls.wideSize ?? DEFAULT_CONTROLS.wideSize
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText( 'layout.wideSize' ) }
 				>
 					<UnitControl
 						label={ __( 'Wide width' ) }
@@ -816,6 +847,7 @@ export default function DimensionsPanel( {
 						}
 					) }
 					panelId={ panelId }
+					inheritanceTooltipText={ paddingTooltipText }
 				>
 					{ ! showSpacingPresetsControl && (
 						<BoxControl
@@ -867,6 +899,7 @@ export default function DimensionsPanel( {
 						}
 					) }
 					panelId={ panelId }
+					inheritanceTooltipText={ marginTooltipText }
 				>
 					{ ! showSpacingPresetsControl && (
 						<BoxControl
@@ -930,6 +963,7 @@ export default function DimensionsPanel( {
 						}
 					) }
 					panelId={ panelId }
+					inheritanceTooltipText={ gapTooltipText }
 				>
 					{ ! showSpacingPresetsControl &&
 						( isAxialGap ? (
@@ -999,6 +1033,9 @@ export default function DimensionsPanel( {
 						defaultControls.minHeight ?? DEFAULT_CONTROLS.minHeight
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText(
+						'dimensions.minHeight'
+					) }
 				>
 					<DimensionControl
 						label={ __( 'Minimum height' ) }
@@ -1034,6 +1071,9 @@ export default function DimensionsPanel( {
 						defaultControls.minWidth ?? DEFAULT_CONTROLS.minWidth
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText(
+						'dimensions.minWidth'
+					) }
 				>
 					<DimensionControl
 						label={ __( 'Minimum width' ) }
@@ -1067,6 +1107,9 @@ export default function DimensionsPanel( {
 						defaultControls.height ?? DEFAULT_CONTROLS.height
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText(
+						'dimensions.height'
+					) }
 				>
 					<DimensionControl
 						label={ __( 'Height' ) }
@@ -1094,6 +1137,7 @@ export default function DimensionsPanel( {
 						defaultControls.width ?? DEFAULT_CONTROLS.width
 					}
 					panelId={ panelId }
+					inheritanceTooltipText={ tooltipText( 'dimensions.width' ) }
 				>
 					<DimensionControl
 						label={ __( 'Width' ) }
@@ -1116,6 +1160,9 @@ export default function DimensionsPanel( {
 						isAspectRatioPlaceholder,
 						hasAspectRatioValue() &&
 							inheritedAspectRatioValue !== undefined
+					) }
+					inheritanceTooltipText={ tooltipText(
+						'dimensions.aspectRatio'
 					) }
 					isShownByDefault={
 						defaultControls.aspectRatio ??

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -32,6 +32,7 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import {
 	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
 	InheritanceToolsPanelItem,
 	InheritanceResetButton,
 } from './inheritance';
@@ -183,6 +184,7 @@ export default function FiltersPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -194,6 +196,8 @@ export default function FiltersPanel( {
 		showInheritanceLabelIndicators
 			? getInheritanceProps( isInherited, hasLocalOverride, className )
 			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
 
 	// Duotone
 	const hasDuotoneEnabled = useHasDuotoneControl( settings );
@@ -267,6 +271,7 @@ export default function FiltersPanel( {
 							inheritedDuotone !== undefined
 					) }
 					label={ __( 'Duotone' ) }
+					inheritanceTooltipText={ tooltipText( 'filter.duotone' ) }
 					hasValue={ hasDuotone }
 					onDeselect={ resetDuotone }
 					isShownByDefault={ defaultControls.duotone }

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -11,8 +11,159 @@ import {
 	Icon as WCIcon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { Tooltip } from '@wordpress/ui';
+import {
+	createPortal,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
 import { reset as resetIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+const GENERIC_INHERITANCE_TOOLTIP_TEXT = __( 'Default inherited from:' );
+const INHERITANCE_TOOLTIP_LINE_SEPARATOR = '\n';
+
+// Label nodes the portal may adorn with the inherited-value tooltip. Shared by
+// the initial query and the `MutationObserver` re-query so the two never drift.
+// Kept in lockstep with the label targets the inheritance SCSS treats: most
+// controls expose `.components-base-control__label`, but bare
+// `UnitControl`/`NumberControl` controls (Line height, Letter spacing, Columns,
+// unit-based dimensions) expose `.components-input-control__label`; the color,
+// background image, and duotone controls use their own label classes.
+const LABEL_TARGET_SELECTOR =
+	'.components-base-control__label, .components-input-control__label, .block-editor-panel-color-gradient-settings__color-name, .block-editor-global-styles-background-panel__inspector-media-replace-title, .block-editor-panel-duotone-settings__label';
+
+// Class of the stable wrapper this component owns and re-parents between
+// labels; the portal renders into it.
+const PORTAL_CONTAINER_CLASS = 'global-styles-inheritance-portal';
+
+// Classes owned by the nodes this component portals into the label. Mutations
+// that only touch these must not retrigger the observer's re-query, otherwise
+// the injection feeds back into the observer.
+const PORTAL_OWNED_CLASSES = [
+	PORTAL_CONTAINER_CLASS,
+	'global-styles-inheritance-tooltip-anchor',
+];
+
+function isPortalOwnedNode( node ) {
+	return (
+		node?.nodeType === window.Node.ELEMENT_NODE &&
+		PORTAL_OWNED_CLASSES.some( ( className ) =>
+			node.classList.contains( className )
+		)
+	);
+}
+
+const BREADCRUMB_LABELS = {
+	styles: __( 'Styles' ),
+	elements: __( 'Elements' ),
+	blocks: __( 'Blocks' ),
+	variations: __( 'Variations' ),
+};
+
+function getBlockTitle( blockName ) {
+	return getBlockType( blockName )?.title ?? blockName;
+}
+
+function getVariationTitle( variation, blockStyles, variationTitle ) {
+	return (
+		variationTitle ??
+		blockStyles?.find( ( style ) => style.name === variation )?.label ??
+		variation
+	);
+}
+
+function getTranslatedBreadcrumb( source, blockStyles ) {
+	const breadcrumb = source?.breadcrumb;
+	const parts = breadcrumb
+		.map( ( part ) => {
+			if ( part === 'blockName' ) {
+				return getBlockTitle( source.blockName );
+			}
+			if ( part === 'variationName' ) {
+				return getVariationTitle(
+					source.variation,
+					blockStyles,
+					source.variationTitle
+				);
+			}
+			return BREADCRUMB_LABELS[ part ] ?? part;
+		} )
+		.filter( Boolean );
+	return parts.join( ' > ' );
+}
+
+/**
+ * Formats a source entry into user-facing tooltip text.
+ *
+ * @param {?Object} source      Source metadata.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+function getInheritanceTooltipText( source, blockStyles ) {
+	const breadcrumb = source?.breadcrumb;
+	if ( ! Array.isArray( breadcrumb ) || breadcrumb.length === 0 ) {
+		return undefined;
+	}
+	return [
+		__( 'Default inherited from:' ),
+		getTranslatedBreadcrumb( source, blockStyles ),
+	].join( INHERITANCE_TOOLTIP_LINE_SEPARATOR );
+}
+
+function InheritanceTooltipContent( { text } ) {
+	return text
+		.split( INHERITANCE_TOOLTIP_LINE_SEPARATOR )
+		.map( ( line, index ) => (
+			<span
+				key={ `${ line }-${ index }` }
+				className="global-styles-inheritance-tooltip-content__line"
+			>
+				{ line }
+			</span>
+		) );
+}
+
+/**
+ * Formats a source entry from a source map path.
+ *
+ * @param {?Object} sources     Source metadata keyed by dot path.
+ * @param {string}  path        Dot path.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+export function getInheritanceTooltipTextByPath( sources, path, blockStyles ) {
+	return getInheritanceTooltipText( sources?.[ path ], blockStyles );
+}
+
+/**
+ * Formats a tooltip for a compound control. A shared source is used only when
+ * all contributing paths resolve to the same breadcrumb; mixed sources receive
+ * a conservative summary.
+ *
+ * @param {?Object} sources     Source metadata keyed by dot path.
+ * @param {Array}   paths       Dot paths to inspect.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+export function getCommonInheritanceTooltipText( sources, paths, blockStyles ) {
+	const sourceEntries = paths
+		.map( ( path ) => sources?.[ path ] )
+		.filter( Boolean );
+	if ( sourceEntries.length === 0 ) {
+		return undefined;
+	}
+	const firstBreadcrumb = sourceEntries[ 0 ].breadcrumb?.join( ' > ' );
+	const hasCommonBreadcrumb = sourceEntries.every(
+		( source ) => source.breadcrumb?.join( ' > ' ) === firstBreadcrumb
+	);
+	if ( hasCommonBreadcrumb ) {
+		return getInheritanceTooltipText( sourceEntries[ 0 ], blockStyles );
+	}
+	return __( 'Default inherited from multiple Styles sources' );
+}
 
 /**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
@@ -118,13 +269,183 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
 }
 
 /**
+ * Helper that portals the inherited-value tooltip into the panel item's
+ * visible label so the tooltip anchors on the label text rather than
+ * affecting the panel item's control layout.
+ *
+ * Mounts a hidden sentinel `<span>` whose `parentElement` is the
+ * `ToolsPanelItem` content wrapper. From the sentinel we run a
+ * `querySelector` for the supported label selectors and adopt the first
+ * match.
+ *
+ * Rather than portaling directly into the label — which is owned by the
+ * inner control's React tree and may be swapped out on re-render (e.g. when
+ * setting a new background image), causing `removeChild` errors during
+ * reconciliation — we create our own stable `<span>` and imperatively
+ * re-parent it into the current label. React only ever manages the inside
+ * of that span, so it never conflicts with the label owner's DOM updates.
+ * The span uses `display: contents` so it adds no box of its own.
+ *
+ * A `MutationObserver` re-attaches the container when the inner control
+ * replaces its own label node on re-render; the observer skips this
+ * component's own portaled nodes to avoid a feedback loop.
+ *
+ * @param {Object} props
+ * @param {string} props.inheritanceTooltipText Tooltip text for inherited
+ *                                              controls.
+ * @param {string} props.label                  Pristine label text used as the
+ *                                              tooltip anchor. Sourced from the
+ *                                              `label` prop rather than the
+ *                                              mutated DOM so it never compounds.
+ *
+ * @return {Element} The sentinel span plus portaled tooltip.
+ */
+function PortaledInheritanceControls( { inheritanceTooltipText, label } ) {
+	const sentinelRef = useRef( null );
+	const portalNodeRef = useRef( null );
+	const [ portalNode, setPortalNode ] = useState( null );
+
+	useLayoutEffect( () => {
+		const sentinel = sentinelRef.current;
+		if ( ! sentinel ) {
+			return;
+		}
+		// `parentElement` is the `ToolsPanelItem` content wrapper. Scope
+		// the lookup so we don't match label elements outside this
+		// panel item.
+		const scope = sentinel.parentElement;
+		if ( ! scope ) {
+			return;
+		}
+
+		// Our own container. `display: contents` keeps it layout-neutral so
+		// the anchor behaves as a direct child of the label.
+		if ( ! portalNodeRef.current ) {
+			const node = sentinel.ownerDocument.createElement( 'span' );
+			node.className = PORTAL_CONTAINER_CLASS;
+			node.style.display = 'contents';
+			portalNodeRef.current = node;
+		}
+		const portal = portalNodeRef.current;
+
+		// Forward clicks on the tooltip anchor overlay to the control it
+		// labels. The anchor is portaled, so React routes its synthetic
+		// events through the portal's React parent tree rather than the
+		// DOM-ancestor control; for toggle-based controls (color, background
+		// image) the overlay would otherwise swallow the click and the toggle
+		// would never open. A native listener re-dispatches the click on the
+		// nearest ancestor button. Plain-label controls have no ancestor
+		// button, so this is a no-op for them.
+		const forwardAnchorClick = ( event ) => {
+			if (
+				! event.target.closest(
+					'.global-styles-inheritance-tooltip-anchor'
+				)
+			) {
+				return;
+			}
+			const button = portal.closest( 'button' );
+			button?.click();
+		};
+		portal.addEventListener( 'click', forwardAnchorClick );
+
+		// Adopt the current label (re-parenting our stable container so React
+		// never has to unmount the portal across label swaps).
+		const syncTarget = () => {
+			// Idempotent guard: if our container is already attached to a
+			// valid label, leave it in place. Re-parenting the node while
+			// the inner control is mid-interaction — e.g. opening/closing the
+			// background image dropdown or switching the image — races with
+			// that control's own click/focus handling and makes the dropdown
+			// fail to open or close reliably. Only move when the label node
+			// has actually been detached or replaced.
+			if (
+				portal.isConnected &&
+				portal.parentElement?.matches( LABEL_TARGET_SELECTOR )
+			) {
+				return;
+			}
+			const target = scope.querySelector( LABEL_TARGET_SELECTOR );
+			if ( ! target ) {
+				portal.remove();
+				setPortalNode( null );
+				return;
+			}
+			target.appendChild( portal );
+			setPortalNode( portal );
+		};
+		syncTarget();
+
+		// Watch for label DOM replacement when the inner control
+		// re-renders (e.g. on value change). Only observe direct
+		// child changes within this panel item — cheap and bounded.
+		const observer = new window.MutationObserver( ( mutations ) => {
+			// Skip mutations caused solely by this component's own
+			// portaled nodes to avoid an observer feedback loop.
+			const hasRelevantMutation = mutations.some( ( mutation ) =>
+				[ ...mutation.addedNodes, ...mutation.removedNodes ].some(
+					( node ) => ! isPortalOwnedNode( node )
+				)
+			);
+			if ( ! hasRelevantMutation ) {
+				return;
+			}
+			syncTarget();
+		} );
+		observer.observe( scope, { childList: true, subtree: true } );
+		return () => {
+			observer.disconnect();
+			portal.removeEventListener( 'click', forwardAnchorClick );
+			portal.remove();
+			portalNodeRef.current = null;
+		};
+	}, [] );
+
+	return (
+		<>
+			<span
+				ref={ sentinelRef }
+				aria-hidden="true"
+				style={ { display: 'none' } }
+			/>
+			{ portalNode &&
+				createPortal(
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							render={
+								<span className="global-styles-inheritance-tooltip-anchor">
+									<span className="global-styles-inheritance-tooltip-anchor__text">
+										{ label }
+									</span>
+								</span>
+							}
+						/>
+						<Tooltip.Popup>
+							<InheritanceTooltipContent
+								text={
+									inheritanceTooltipText ??
+									GENERIC_INHERITANCE_TOOLTIP_TEXT
+								}
+							/>
+						</Tooltip.Popup>
+					</Tooltip.Root>,
+					portalNode
+				) }
+		</>
+	);
+}
+
+/**
  * A `ToolsPanelItem` that reflects whether its control's value is inherited
  * from Global Styles or locally overridden. The two states are mutually
  * exclusive.
  *
  * - Inherited: the control label receives the inherited-from-Global-Styles
  *   treatment (dotted underline) via the `is-inherited-from-global-styles`
- *   class applied through `getInheritanceProps`. No dot is shown.
+ *   class applied through `getInheritanceProps`. When an
+ *   `inheritanceTooltipText` is supplied, a breadcrumb tooltip pointing at the
+ *   originating Global Styles source is portaled onto the label. No dot is
+ *   shown.
  * - Local override: a reset dot is rendered as a plain sibling of the control
  *   at the item's inline-end — never nested in the label — exposing the same
  *   one-click reset the `ToolsPanel` options menu performs via `onDeselect`.
@@ -135,20 +456,21 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
  *
  * @param {Object}                    props
  * @param {?string}                   props.className                         Item className.
- * @param {boolean}                   props.isInherited                       Value is inherited at rest. Accepted so the `getInheritanceProps` spread does not leak onto the underlying `ToolsPanelItem`; the inherited treatment is applied via `className`.
+ * @param {boolean}                   props.isInherited                       Value is inherited at rest. Gates the breadcrumb tooltip and (via `getInheritanceProps`) the label treatment applied through `className`.
  * @param {boolean}                   props.hasLocalOverride                  Local override is set.
  * @param {import('react').ReactNode} props.label                             Control label.
  * @param {?Function}                 props.onDeselect                        Reset handler.
  * @param {boolean}                   [props.showLocalOverrideActionsInLabel] Render the reset dot here (default true).
  * @param {boolean}                   [props.hasInlineEndToggle]              The control renders a 24x24 toggle (linked/unlink, units switch) at its inline-end; offset the reset dot to sit just to its inline-start (default false).
+ * @param {?string}                   [props.inheritanceTooltipText]          Breadcrumb tooltip text describing the Global Styles source the value is inherited from. Only rendered in the block inspector, where sources are provided.
  * @param {import('react').ReactNode} props.children                          The control.
  *
  * @return {Element} The panel item.
  */
 export function InheritanceToolsPanelItem( {
 	className,
-	// Destructured (and unused) so the `getInheritanceProps` spread does not
-	// leak `isInherited` onto the underlying `ToolsPanelItem`. The inherited
+	// `isInherited` gates the breadcrumb tooltip below. It is intentionally
+	// not forwarded onto the underlying `ToolsPanelItem`; the inherited label
 	// treatment is applied purely via `className`
 	// (`is-inherited-from-global-styles`).
 	isInherited,
@@ -157,11 +479,16 @@ export function InheritanceToolsPanelItem( {
 	onDeselect,
 	showLocalOverrideActionsInLabel = true,
 	hasInlineEndToggle = false,
+	inheritanceTooltipText,
 	children,
 	...rest
 } ) {
 	const showResetAffordance =
 		hasLocalOverride && showLocalOverrideActionsInLabel;
+	// The breadcrumb tooltip is inspector-only: Global Styles screens render
+	// these panels without an inheritance provider, so `inheritanceTooltipText`
+	// is undefined there and no tooltip is portaled onto the label.
+	const showInheritedTooltip = isInherited && !! inheritanceTooltipText;
 
 	return (
 		<ToolsPanelItem
@@ -171,6 +498,12 @@ export function InheritanceToolsPanelItem( {
 			{ ...rest }
 		>
 			{ children }
+			{ showInheritedTooltip && (
+				<PortaledInheritanceControls
+					label={ label }
+					inheritanceTooltipText={ inheritanceTooltipText }
+				/>
+			) }
 			{ showResetAffordance && (
 				<div
 					className={ clsx( 'global-styles-inheritance-affordance', {

--- a/packages/block-editor/src/components/global-styles/inheritance/style.scss
+++ b/packages/block-editor/src/components/global-styles/inheritance/style.scss
@@ -7,6 +7,17 @@
 // inherited values: a blue reset dot is rendered as a sibling at the item's
 // inline-end. The states are mutually exclusive.
 .is-inherited-from-global-styles {
+	// The tooltip anchor overlays the visible label text (`position:
+	// absolute; inset: 0`), so every label target must establish a
+	// positioning context. Kept in lockstep with `LABEL_TARGET_SELECTOR`.
+	.components-base-control__label,
+	.components-input-control__label,
+	.block-editor-panel-color-gradient-settings__color-name,
+	.block-editor-global-styles-background-panel__inspector-media-replace-title,
+	.block-editor-panel-duotone-settings__label {
+		position: relative;
+	}
+
 	// `.components-base-control__label` covers most controls (ToggleGroup,
 	// selects, the visible `<span>` label some controls render). Controls
 	// built on a bare `UnitControl`/`NumberControl` (Line height, Letter
@@ -28,6 +39,24 @@
 	.block-editor-panel-duotone-settings__label {
 		border-bottom: 1px dotted currentColor;
 	}
+}
+
+// The tooltip target overlays the visible label text only. This keeps the
+// inherited-value tooltip scoped to labels without wrapping the full control or
+// intercepting nested control tooltips. The anchor is portaled into the label
+// DOM node so the trigger sits inline with the label text.
+.global-styles-inheritance-tooltip-anchor {
+	display: inline-block;
+	position: absolute;
+	inset: 0;
+}
+
+.global-styles-inheritance-tooltip-anchor__text {
+	visibility: hidden;
+}
+
+.global-styles-inheritance-tooltip-content__line {
+	display: block;
 }
 
 // Local-override reset dot — a sibling of the control positioned at the item's

--- a/packages/block-editor/src/components/global-styles/inheritance/test/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/test/index.js
@@ -143,43 +143,26 @@ describe( 'getInheritanceProps', () => {
 } );
 
 describe( 'InheritanceToolsPanelItem inherited state', () => {
-	function renderInheritedItem( label, labelClassName ) {
+	function renderInheritedItem() {
 		return render(
 			<ToolsPanel label="Panel" panelId="panel">
 				<InheritanceToolsPanelItem
 					{ ...getInheritanceProps( true, false ) }
-					label={ label }
+					label="Line height"
 					panelId="panel"
 					isShownByDefault
 					hasValue={ () => false }
 				>
-					<div className={ labelClassName }>{ label }</div>
+					<div className="components-base-control__label">
+						Line height
+					</div>
 				</InheritanceToolsPanelItem>
 			</ToolsPanel>
 		);
 	}
 
-	// The SCSS treatment keys off the label class, and controls on a bare
-	// `UnitControl`/`NumberControl` expose `input-control__label` rather than
-	// the usual `base-control__label`, so guard both.
-	test.each( [
-		[ 'base-control', 'components-base-control__label' ],
-		[ 'input-control', 'components-input-control__label' ],
-	] )(
-		'nests the %s label inside the inherited-from-global-styles item',
-		( _name, labelClassName ) => {
-			renderInheritedItem( 'Line height', labelClassName );
-			const label = screen.getByText( 'Line height' );
-			expect( label ).toHaveClass( labelClassName );
-			expect(
-				// eslint-disable-next-line testing-library/no-node-access
-				label.closest( '.is-inherited-from-global-styles' )
-			).not.toBeNull();
-		}
-	);
-
 	test( 'does not render a reset dot in the inherited state', () => {
-		renderInheritedItem( 'Line height', 'components-base-control__label' );
+		renderInheritedItem();
 		expect(
 			screen.queryByRole( 'button', {
 				name: 'Reset to inherited value',
@@ -207,22 +190,13 @@ describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
 		);
 	}
 
-	test( 'renders the reset dot as a sibling of the control, not inside the label', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		expect( resetButton ).toBeVisible();
-
-		// The reset dot is a plain sibling; it must never be nested inside
-		// the label (which would create an interactive-in-label a11y issue).
+	test( 'renders a reset dot in the local-override state', () => {
+		renderItem( { hasLocalOverride: true, onDeselect: () => {} } );
 		expect(
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.components-base-control__label' )
-		).toBeNull();
+			screen.getByRole( 'button', {
+				name: 'Reset to inherited value',
+			} )
+		).toBeVisible();
 	} );
 
 	test( 'does not render the item reset dot when showLocalOverrideActionsInLabel is false', () => {
@@ -247,35 +221,5 @@ describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
 			screen.getByRole( 'button', { name: 'Reset to inherited value' } )
 		);
 		expect( onDeselect ).toHaveBeenCalled();
-	} );
-
-	test( 'does not offset the reset dot by default', () => {
-		renderItem( { hasLocalOverride: true, onDeselect: () => {} } );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).not.toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
-	} );
-
-	test( 'offsets the reset dot when the control has an inline-end toggle', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			hasInlineEndToggle: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -17,26 +17,36 @@ import { resolveStyles } from './build-inherited-value';
 import { getVariationNameFromClass } from '../../hooks/block-style-variation';
 
 /**
- * Internal hook that reads the Global Styles payload and returns the wrapped
- * `{ styles }` shape the builder and ref-resolver helpers expect, along with
- * the theme-file `_links` map used to resolve theme-file pointers (e.g.
- * background images).
+ * Internal hook that reads the Global Styles payload and the block's
+ * registered styles, and returns the wrapped `{ styles }` shape the builder
+ * and ref-resolver helpers expect, along with the theme-file `_links` map used
+ * to resolve theme-file pointers (e.g. background images) and the block's
+ * registered styles (used for variation titles in breadcrumb tooltips).
  *
- * @return {{ globalStyles: ?Object, links: ?Object }} Wrapped Global Styles payload and links map.
+ * @param {?string} blockName Selected block name (e.g. `core/heading`).
+ * @return {{ globalStyles: ?Object, links: ?Object, blockStyles: Array }} Wrapped Global Styles payload, links map, and block styles.
  */
-function useRawGlobalStyles() {
-	const { rawGlobalStylesData, links } = useSelect( ( select ) => {
-		const settings = select( blockEditorStore ).getSettings();
-		return {
-			rawGlobalStylesData: settings[ globalStylesDataKey ] ?? null,
-			links: settings[ globalStylesLinksDataKey ] ?? null,
-		};
-	}, [] );
+function useRawGlobalStyles( blockName ) {
+	const { rawGlobalStylesData, links, blockStyles } = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			const blockStylesSelector = select( blocksStore ).getBlockStyles;
+			return {
+				rawGlobalStylesData: settings[ globalStylesDataKey ] ?? null,
+				links: settings[ globalStylesLinksDataKey ] ?? null,
+				blockStyles:
+					blockName && blockStylesSelector
+						? blockStylesSelector( blockName )
+						: [],
+			};
+		},
+		[ blockName ]
+	);
 	const globalStyles = useMemo(
 		() => ( rawGlobalStylesData ? { styles: rawGlobalStylesData } : null ),
 		[ rawGlobalStylesData ]
 	);
-	return { globalStyles, links };
+	return { globalStyles, links, blockStyles };
 }
 
 /**
@@ -93,7 +103,8 @@ export function useResolvedStyles(
 	selectedState = null
 ) {
 	const ownVariation = useOwnVariation( blockName, className );
-	const { globalStyles, links } = useRawGlobalStyles();
+	const { globalStyles, links, blockStyles } =
+		useRawGlobalStyles( blockName );
 
 	return useMemo( () => {
 		if ( ! blockName ) {
@@ -103,8 +114,16 @@ export function useResolvedStyles(
 			blockName,
 			ownVariation,
 			globalStyles,
+			blockStyles,
 			selectedState,
 			_links: links,
 		} );
-	}, [ blockName, ownVariation, globalStyles, selectedState, links ] );
+	}, [
+		blockName,
+		ownVariation,
+		globalStyles,
+		blockStyles,
+		selectedState,
+		links,
+	] );
 }

--- a/packages/block-editor/src/components/global-styles/test/build-inherited-value.js
+++ b/packages/block-editor/src/components/global-styles/test/build-inherited-value.js
@@ -12,6 +12,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { resolveStyles, privateHelpers } from '../build-inherited-value';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceTooltipTextByPath,
+} from '../inheritance';
 import { useResolvedStyles } from '../inherited-value-context';
 
 import { globalStylesDataKey } from '../../../store/private-keys';
@@ -468,6 +472,67 @@ describe( 'resolveStyles – merged output', () => {
 		} );
 	} );
 
+	describe( 'tooltip formatting', () => {
+		test( 'formats a source breadcrumb', () => {
+			expect(
+				getInheritanceTooltipTextByPath(
+					{
+						typography: {
+							breadcrumb: [
+								'styles',
+								'blocks',
+								'blockName',
+								'variations',
+								'variationName',
+							],
+							blockName: 'core/group',
+							variation: 'subtitle',
+							variationTitle: 'Subtitle',
+						},
+					},
+					'typography'
+				)
+			).toBe(
+				'Default inherited from:\nStyles > Blocks > Group > Variations > Subtitle'
+			);
+		} );
+
+		test( 'uses common source for compound controls when breadcrumbs match', () => {
+			expect(
+				getCommonInheritanceTooltipText(
+					{
+						'border.color': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+						'border.width': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+					},
+					[ 'border.color', 'border.width' ]
+				)
+			).toBe( 'Default inherited from:\nStyles > Blocks > Group' );
+		} );
+
+		test( 'uses conservative text for mixed-source compound controls', () => {
+			expect(
+				getCommonInheritanceTooltipText(
+					{
+						'border.color': {
+							breadcrumb: [ 'styles' ],
+						},
+						'border.width': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+					},
+					[ 'border.color', 'border.width' ]
+				)
+			).toBe( 'Default inherited from multiple Styles sources' );
+		} );
+	} );
+
 	describe( 'source provenance', () => {
 		const gs = {
 			styles: {
@@ -502,15 +567,27 @@ describe( 'resolveStyles – merged output', () => {
 			const { value, sources } = resolveStyles( {
 				blockName: 'core/heading',
 				ownVariation: 'plain',
+				blockStyles: [ { name: 'plain', label: 'Plain' } ],
 				globalStyles: gs,
 			} );
 			expect( value.typography.fontSize ).toBe( '20px' );
 			expect( value.typography.lineHeight ).toBe( '1.5' );
 			expect( sources[ 'typography.fontSize' ] ).toMatchObject( {
+				breadcrumb: [
+					'styles',
+					'blocks',
+					'blockName',
+					'variations',
+					'variationName',
+				],
 				layer: 'blockVariation',
+				blockName: 'core/heading',
+				variation: 'plain',
+				variationTitle: 'Plain',
 				path: [ 'typography', 'fontSize' ],
 			} );
 			expect( sources[ 'typography.lineHeight' ] ).toMatchObject( {
+				breadcrumb: [ 'styles' ],
 				layer: 'root',
 			} );
 		} );
@@ -521,6 +598,7 @@ describe( 'resolveStyles – merged output', () => {
 				globalStyles: gs,
 			} );
 			expect( sources[ 'elements.link.color.text' ] ).toMatchObject( {
+				breadcrumb: [ 'styles', 'elements', 'link' ],
 				layer: 'root',
 				path: [ 'elements', 'link', 'color', 'text' ],
 			} );
@@ -541,7 +619,9 @@ describe( 'resolveStyles – memoization', () => {
 		} );
 		expect( a ).toBe( b );
 		expect( a.value.typography.fontSize ).toBe( '16px' );
-		expect( a.sources[ 'typography.fontSize' ].layer ).toBe( 'root' );
+		expect( a.sources[ 'typography.fontSize' ].breadcrumb ).toEqual( [
+			'styles',
+		] );
 	} );
 
 	test( 'different composite key → different result', () => {
@@ -648,8 +728,8 @@ describe( 'useResolvedStyles hook', () => {
 		// `elements` passthrough, not folded up to the top level.
 		expect( parsed.value.elements.h2.typography.fontSize ).toBe( '24px' );
 		expect(
-			parsed.sources[ 'elements.h2.typography.fontSize' ].layer
-		).toBe( 'root' );
+			parsed.sources[ 'elements.h2.typography.fontSize' ].breadcrumb
+		).toEqual( [ 'styles', 'elements', 'h2' ] );
 	} );
 } );
 

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -685,6 +685,12 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 						},
 					},
 				},
+				inheritedSources: {
+					'spacing.padding.top': { layer: 'block' },
+					'spacing.padding.right': { layer: 'block' },
+					'spacing.padding.bottom': { layer: 'block' },
+					'spacing.padding.left': { layer: 'block' },
+				},
 				settings: settingsWithSpacingPresets,
 			} );
 

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -38,7 +38,12 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -221,6 +226,7 @@ export default function TypographyPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources = {},
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -234,6 +240,10 @@ export default function TypographyPanel( {
 		showInheritanceLabelIndicators
 			? getInheritanceProps( isInherited, hasLocalOverride, className )
 			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
 
 	// Text color. Writes to `color.text` (unchanged storage path). The
 	// control is rendered here instead of the Color panel because text
@@ -795,6 +805,7 @@ export default function TypographyPanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userTextColor === undefined && textColor !== undefined
 					}
@@ -803,6 +814,7 @@ export default function TypographyPanel( {
 						{
 							key: 'text',
 							label: __( 'Color' ),
+							sourcePaths: [ 'color.text' ],
 							inheritedValue: textColor,
 							inheritedSlug:
 								extractPresetSlug(
@@ -834,6 +846,9 @@ export default function TypographyPanel( {
 						hasFontFamily() && inheritedFontFamily !== undefined
 					) }
 					label={ __( 'Font' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.fontFamily'
+					) }
 					hasValue={ hasFontFamily }
 					onDeselect={ resetFontFamily }
 					isShownByDefault={ defaultControls.fontFamily }
@@ -853,6 +868,9 @@ export default function TypographyPanel( {
 						hasFontSize() && rawInheritedFontSize !== undefined
 					) }
 					label={ __( 'Size' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.fontSize'
+					) }
 					hasValue={ hasFontSize }
 					hasInlineEndToggle
 					onDeselect={ resetFontSize }
@@ -879,6 +897,10 @@ export default function TypographyPanel( {
 								inheritedFontWeight !== undefined )
 					) }
 					label={ appearanceControlLabel }
+					inheritanceTooltipText={ commonTooltipText( [
+						'typography.fontStyle',
+						'typography.fontWeight',
+					] ) }
 					hasValue={ hasFontAppearance }
 					onDeselect={ resetFontAppearance }
 					isShownByDefault={ defaultControls.fontAppearance }
@@ -904,6 +926,9 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Line height' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.lineHeight'
+					) }
 					hasValue={ hasLineHeight }
 					onDeselect={ resetLineHeight }
 					isShownByDefault={ defaultControls.lineHeight }
@@ -936,6 +961,9 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Letter spacing' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.letterSpacing'
+					) }
 					hasValue={ hasLetterSpacing }
 					onDeselect={ resetLetterSpacing }
 					isShownByDefault={ defaultControls.letterSpacing }
@@ -969,6 +997,9 @@ export default function TypographyPanel( {
 						hasTextIndent() && inheritedTextIndent !== undefined
 					) }
 					label={ __( 'Line indent' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.textIndent'
+					) }
 					hasValue={ hasTextIndent }
 					onDeselect={ resetTextIndent }
 					isShownByDefault={ defaultControls.textIndent }
@@ -1010,6 +1041,9 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Columns' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.textColumns'
+					) }
 					hasValue={ hasTextColumns }
 					onDeselect={ resetTextColumns }
 					isShownByDefault={ defaultControls.textColumns }
@@ -1040,6 +1074,9 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Decoration' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.textDecoration'
+					) }
 					hasValue={ hasTextDecoration }
 					onDeselect={ resetTextDecoration }
 					isShownByDefault={ defaultControls.textDecoration }
@@ -1061,6 +1098,9 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Orientation' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.writingMode'
+					) }
 					hasValue={ hasWritingMode }
 					onDeselect={ resetWritingMode }
 					isShownByDefault={ defaultControls.writingMode }
@@ -1081,6 +1121,9 @@ export default function TypographyPanel( {
 							inheritedTextTransform !== undefined
 					) }
 					label={ __( 'Letter case' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.textTransform'
+					) }
 					hasValue={ hasTextTransform }
 					onDeselect={ resetTextTransform }
 					isShownByDefault={ defaultControls.textTransform }
@@ -1102,6 +1145,9 @@ export default function TypographyPanel( {
 						hasTextAlign() && inheritedTextAlign !== undefined
 					) }
 					label={ __( 'Text alignment' ) }
+					inheritanceTooltipText={ tooltipText(
+						'typography.textAlign'
+					) }
 					hasValue={ hasTextAlign }
 					onDeselect={ resetTextAlign }
 					isShownByDefault={ defaultControls.textAlign }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -193,11 +193,8 @@ export function BackgroundImagePanel( {
 		[ clientId ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,
@@ -393,6 +390,7 @@ export function BackgroundImagePanel( {
 			}
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -170,11 +170,8 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
@@ -219,6 +216,7 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 			onChange={ onChange }
 			defaultControls={ defaultControls }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -95,11 +95,8 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 	const value = isStateSelected
@@ -152,6 +149,7 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 					isStateSelected ? undefined : setVisualizedProperty
 				}
 				inheritedValue={ inheritedValue }
+				inheritedSources={ inheritedSources }
 			/>
 			{ ! isStateSelected &&
 				!! settings?.spacing?.padding &&

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -114,7 +114,8 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 				: undefined,
 		[ clientId ]
 	);
-	const { value: inheritedValue } = useResolvedStyles( name, className );
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className );
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
@@ -166,6 +167,7 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 					} }
 					settings={ settings }
 					inheritedValue={ inheritedValue }
+					inheritedSources={ inheritedSources }
 				/>
 			</InspectorControls>
 			<BlockControls group="block" __experimentalShareWithChildBlocks>

--- a/packages/block-editor/src/hooks/elements.js
+++ b/packages/block-editor/src/hooks/elements.js
@@ -75,11 +75,8 @@ export function ElementsEdit( {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
@@ -146,6 +143,7 @@ export function ElementsEdit( {
 			label={ label }
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -182,11 +182,8 @@ export function TypographyPanel( {
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
@@ -270,6 +267,7 @@ export function TypographyPanel( {
 			defaultControls={ defaultControls }
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/77894.

This adds a tooltip to inspector control labels that inherit a value from Global Styles. The tooltip shows a breadcrumb path to where the value comes from, for example Styles > Blocks > Group > Variations > Subtitle. Designs are in https://github.com/WordPress/gutenberg/issues/77595.


## Why?

\#77894 makes inspector controls reflect values inherited from Global Styles, but there's no way to tell where an inherited value actually comes from. The breadcrumb tooltip closes that gap so the source is clear without leaving the inspector.


## How?

The inherited value builder already resolves each value against the merged Global Styles layers. This carries a breadcrumb for each source path through that result, then hands it to the control's label as tooltip text.

A control renders its own label, and we don't want to change any component's public API to wrap it, so the tooltip is rendered through a portal into the label node. That's the same portal approach proposed and then set aside in #77894. A mutation observer re-attaches the portal when a control re-renders its own label.

Compound controls (border, or a grouped colour item) collapse to a single shared breadcrumb when every contributing value resolves to the same source, and fall back to a conservative summary when they don't.

It's scoped to the block inspector. The Global Styles screens render these panels without the inherited-value provider, so there's no source to describe and no tooltip shows.


## Testing Instructions

You need a block theme whose theme.json sets styles for a few blocks, so there are values to inherit. test/emptytheme can be extended with block styles for this.

1. Open a post or the site editor.
2. Insert a block that inherits some of those styles, e.g. a Paragraph, Image, or Group.
3. Open the block inspector and expand the relevant panels (Typography, Color, Border, Dimensions, Background, Filters).
4. Hover a control label that is inheriting a value. Confirm the tooltip shows the breadcrumb path to the Global Styles source.
5. Set a local value on that control. Confirm the inherited label treatment clears and the reset affordance still works.
6. Open the same panels in the Styles screen (Global Styles). Confirm no breadcrumb tooltip appears there.