### PR TITLE
Components: update Button to use more wpds tokens

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -103,6 +103,7 @@
 
 -   Add a private, presentational `ContentEditableControl`: a labeled `contentEditable` form field. The rich-text behavior is injected by the consumer (e.g. the DataViews `richtext` control), keeping the component free of any `@wordpress/rich-text` dependency ([#78471](https://github.com/WordPress/gutenberg/pull/78471)).
 -   `Autocomplete`: subscribe the keyboard listener through the rich text selection owner, so it also handles events targeting a focused editing host ([#79105](https://github.com/WordPress/gutenberg/pull/79105)).
+-   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@ariakit/react` to `0.4.32` ([#79860](https://github.com/WordPress/gutenberg/pull/79860)).
 -   `Flex`: Migrate styles from Emotion to SCSS Modules ([#79450](https://github.com/WordPress/gutenberg/pull/79450)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -39,6 +39,7 @@
 -   `ToggleGroupControl`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#80381](https://github.com/WordPress/gutenberg/pull/80381)).
 -   `Disabled`: Migrate styles from Emotion to an SCSS Module ([#80643](https://github.com/WordPress/gutenberg/pull/80643)).
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
+-   `Button`: Migrate hardcoded Sass spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
 
 ## 37.0.0 (2026-07-14)
 
@@ -103,7 +104,6 @@
 
 -   Add a private, presentational `ContentEditableControl`: a labeled `contentEditable` form field. The rich-text behavior is injected by the consumer (e.g. the DataViews `richtext` control), keeping the component free of any `@wordpress/rich-text` dependency ([#78471](https://github.com/WordPress/gutenberg/pull/78471)).
 -   `Autocomplete`: subscribe the keyboard listener through the rich text selection owner, so it also handles events targeting a focused editing host ([#79105](https://github.com/WordPress/gutenberg/pull/79105)).
--   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@ariakit/react` to `0.4.32` ([#79860](https://github.com/WordPress/gutenberg/pull/79860)).
 -   `Flex`: Migrate styles from Emotion to SCSS Modules ([#79450](https://github.com/WordPress/gutenberg/pull/79450)).

--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -118,6 +118,13 @@ IsDestructive.args = {
 	isDestructive: true,
 };
 
+export const WithIcon = Template.bind( {} );
+WithIcon.args = {
+	children: 'Code is poetry',
+	icon: 'wordpress',
+	variant: 'primary',
+};
+
 export const Icon = Template.bind( {} );
 Icon.args = {
 	label: 'Code is poetry',

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -320,7 +320,8 @@
 			display: inline-flex;
 			justify-content: center;
 			align-items: center;
-			padding: var(--wpds-dimension-padding-xs);
+			// 2px allows Dashicons (20px glyphs) to visually fill a 24px icon slot.
+			padding: 2px;
 			box-sizing: content-box;
 		}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -293,10 +293,8 @@
 
 	&.is-small {
 		height: var(--wpds-dimension-size-sm);
-		// 22px has no exact WPDS line-height token match (sm is 20px, md is 24px).
-		line-height: 22px;
+		line-height: var(--wpds-typography-line-height-sm);
 		padding: 0 var(--wpds-dimension-padding-sm);
-		font-size: var(--wpds-typography-font-size-xs);
 
 		&.has-icon:not(.has-text) {
 			padding: 0;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -292,9 +292,13 @@
 	}
 
 	&.is-small {
-		height: var(--wpds-dimension-size-sm);
 		line-height: var(--wpds-typography-line-height-sm);
-		padding: 0 var(--wpds-dimension-padding-sm);
+
+		// Link buttons keep `padding: 0` / `height: auto` from `.is-link`.
+		&:not(.is-link) {
+			height: var(--wpds-dimension-size-sm);
+			padding: 0 var(--wpds-dimension-padding-sm);
+		}
 
 		&.has-icon:not(.has-text) {
 			padding: 0;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -100,10 +100,6 @@
 			);
 			/* stylelint-enable */
 		}
-
-		@media (forced-colors: active) {
-			outline: 1px solid ButtonBorder;
-		}
 	}
 
 	/**
@@ -118,10 +114,6 @@
 			color: $gray-600;
 			background: transparent;
 			transform: none;
-		}
-
-		@media (forced-colors: active) {
-			outline: 1px solid ButtonBorder;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -305,7 +305,8 @@
 	}
 
 	&.has-icon {
-		padding-block: var(--wpds-dimension-padding-xs);
+		// Legacy 6px has no exact WPDS padding token match (xs is 4px, sm is 8px).
+		padding-block: 6px;
 		padding-inline: 0;
 
 		// Icon buttons are square.

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -17,6 +17,9 @@
 		box-shadow: none;
 	}
 
+	// Legacy default height (36px) has no exact WPDS size token match.
+	--wp-components-button-height: 36px;
+
 	&:focus:not(:active) {
 		@include mixins.outset-ring__focus();
 	}
@@ -24,24 +27,26 @@
 	display: inline-flex;
 	text-decoration: none;
 	font-family: inherit;
-	font-size: $default-font-size;
+	font-size: var(--wpds-typography-font-size-md);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 	margin: 0;
 	cursor: var(--wpds-cursor-control);
 	appearance: none;
 	background: none;
-	height: $button-size;
+	height: var(--wp-components-button-height);
 	align-items: center;
 	box-sizing: border-box;
-	padding: 4px 12px; // Allows 32px min-height.
-	border-radius: $radius-small;
+	padding:
+		var(--wpds-dimension-padding-xs)
+		var(--wpds-dimension-padding-md); // Allows 32px min-height.
+	border-radius: var(--wpds-border-radius-sm);
 	color: $components-color-foreground;
 	// Every variant reserves a 1px border (transparent by default) so the box
 	// size stays identical whether or not a variant paints a visible border.
 	border: $border-width solid transparent;
 
 	&.is-next-40px-default-size {
-		height: $button-size-next-default-40px;
+		height: var(--wpds-dimension-size-lg);
 	}
 
 	&[aria-expanded="true"],
@@ -95,6 +100,10 @@
 			);
 			/* stylelint-enable */
 		}
+
+		@media (forced-colors: active) {
+			outline: 1px solid ButtonBorder;
+		}
 	}
 
 	/**
@@ -109,6 +118,10 @@
 			color: $gray-600;
 			background: transparent;
 			transform: none;
+		}
+
+		@media (forced-colors: active) {
+			outline: 1px solid ButtonBorder;
 		}
 	}
 
@@ -168,7 +181,7 @@
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
 		p + & {
-			margin-left: -($grid-unit-15 * 0.5);
+			margin-left: calc(-1 * var(--wpds-dimension-padding-md) / 2);
 		}
 	}
 
@@ -237,7 +250,7 @@
 		height: auto;
 
 		&:focus:not(:active) {
-			border-radius: $radius-small;
+			border-radius: var(--wpds-border-radius-sm);
 			text-decoration: none;
 		}
 
@@ -278,19 +291,20 @@
 	}
 
 	&.is-compact {
-		height: $button-size-compact;
+		height: var(--wpds-dimension-size-md);
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			min-width: $button-size-compact;
+			min-width: var(--wpds-dimension-size-md);
 		}
 	}
 
 	&.is-small {
 		height: var(--wpds-dimension-size-sm);
+		// 22px has no exact WPDS line-height token match (sm is 20px, md is 24px).
 		line-height: 22px;
-		padding: 0 8px;
-		font-size: 11px;
+		padding: 0 var(--wpds-dimension-padding-sm);
+		font-size: var(--wpds-typography-font-size-xs);
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
@@ -299,32 +313,33 @@
 	}
 
 	&.has-icon {
-		padding: 6px; // Works for 24px icons. Smaller icons are vertically centered by flex alignments.
+		padding-block: var(--wpds-dimension-padding-xs);
+		padding-inline: 0;
 
 		// Icon buttons are square.
-		min-width: $button-size;
+		min-width: var(--wp-components-button-height);
 		justify-content: center;
 
 		&.is-next-40px-default-size {
-			min-width: $button-size-next-default-40px;
+			min-width: var(--wpds-dimension-size-lg);
 		}
 
 		.dashicon {
 			display: inline-flex;
 			justify-content: center;
 			align-items: center;
-			padding: 2px;
+			padding: var(--wpds-dimension-padding-xs);
 			box-sizing: content-box;
 		}
 
 		&.has-text {
 			justify-content: start;
-			padding-right: $grid-unit-15;
-			padding-left: $grid-unit-10;
-			gap: $grid-unit-05;
+			padding-right: var(--wpds-dimension-padding-md);
+			padding-left: var(--wpds-dimension-gap-sm);
+			gap: var(--wpds-dimension-gap-xs);
 			&.has-icon-right {
-				padding-right: $grid-unit-10;
-				padding-left: $grid-unit-15;
+				padding-right: var(--wpds-dimension-gap-sm);
+				padding-left: var(--wpds-dimension-padding-md);
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/76135

- Migrate `@wordpress/components` Button baseline styles to WPDS tokens (typography, spacing, sizing, radius, and focus), while preserving existing component behaviour and legacy 36px default height.
- Adds "With Icon" Storybook example for easier testing of that case specifically.
- Updates "small" buttons to use same font size as UI Button (11px → 13px). 

Doesn't migrate colour-related variables yet to keep testing easier/more focused. I have another follow-up which migrates colors: https://github.com/WordPress/gutenberg/pull/79994

Earlier PRs on Button tokenisation:
- https://github.com/WordPress/gutenberg/pull/78646
- https://github.com/WordPress/gutenberg/pull/79278


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Aligns Theming systems between `@wordpress/components` and `@wordpress/ui`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Run storybook: `npm run storybook:dev` and open `http://localhost:50240/?path=/docs/components-button--docs`

Verify Button variants in Storybook (`default`, `primary`, `secondary`, `tertiary`, `link`, `small`, `compact`, icon-only) all look and behave the same:
- Resting
- Hover
- Focus
- Focus hover
- Active
- Keyboard navigation


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

There should not be any visual difference between before/after:

### Before
<img width="183" height="117" alt="Screenshot 2026-07-08 at 12 46 27" src="https://github.com/user-attachments/assets/148fcfc8-2dc7-467b-aef0-07a10980fba7" />
<img width="182" height="119" alt="Screenshot 2026-07-08 at 12 46 32" src="https://github.com/user-attachments/assets/1962e0fe-cb85-496a-a36c-f550447304d4" />
<img width="794" height="508" alt="Screenshot 2026-07-14 at 18 21 14" src="https://github.com/user-attachments/assets/339e41ce-fa4d-4f40-a574-5bf56a91f310" />


### After
<img width="172" height="120" alt="Screenshot 2026-07-08 at 12 47 30" src="https://github.com/user-attachments/assets/e4585b3a-d2c7-48c1-9fc9-811198ec7b35" />
<img width="192" height="119" alt="Screenshot 2026-07-08 at 12 47 35" src="https://github.com/user-attachments/assets/f62fd9ca-80d6-418b-8f12-43465039aa17" />
<img width="822" height="512" alt="Screenshot 2026-07-14 at 18 20 56" src="https://github.com/user-attachments/assets/275def68-6df7-467e-8a44-af8ec1434604" />


### Icon one specifically:

#### Before 
<img width="254" height="172" alt="Screenshot 2026-07-08 at 13 08 31" src="https://github.com/user-attachments/assets/d74f7814-a56c-4771-b42f-a655dc894dc9" />

#### After 
<img width="192" height="116" alt="image" src="https://github.com/user-attachments/assets/305e6f85-b21a-475d-bf41-3f7319b7c50d" />



## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
