### PR TITLE
Components: Components and UI Button color parity

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
--   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens.
+-   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
 
 ## 37.0.0 (2026-07-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
+-   `Button`: Align brand, pressed, and destructive variant colors with WPDS interactive tokens used by `@wordpress/ui` Button while preserving admin theme color support via token fallbacks.
 
 ## 37.0.0 (2026-07-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens.
+
 ## 37.0.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
--   `Button`: Migrate hardcoded Sass color, spacing, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
+-   `Button`: Migrate hardcoded Sass spacing, border, and typography values to WPDS design tokens ([#79993](https://github.com/WordPress/gutenberg/pull/79993)).
 -   `Button`: Align brand, pressed, and destructive variant colors with WPDS interactive tokens used by `@wordpress/ui` Button while preserving admin theme color support via token fallbacks.
 
 ## 37.0.0 (2026-07-14)

--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -118,6 +118,13 @@ IsDestructive.args = {
 	isDestructive: true,
 };
 
+export const WithIcon = Template.bind( {} );
+WithIcon.args = {
+	children: 'Code is poetry',
+	icon: 'wordpress',
+	variant: 'primary',
+};
+
 export const Icon = Template.bind( {} );
 Icon.args = {
 	label: 'Code is poetry',

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -17,6 +17,9 @@
 		box-shadow: none;
 	}
 
+	// Legacy default height (36px) has no exact WPDS size token match.
+	--wp-components-button-height: 36px;
+
 	&:focus:not(:active) {
 		@include mixins.outset-ring__focus();
 	}
@@ -24,24 +27,26 @@
 	display: inline-flex;
 	text-decoration: none;
 	font-family: inherit;
-	font-size: $default-font-size;
+	font-size: var(--wpds-typography-font-size-md);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 	margin: 0;
 	cursor: var(--wpds-cursor-control);
 	appearance: none;
 	background: none;
-	height: $button-size;
+	height: var(--wp-components-button-height);
 	align-items: center;
 	box-sizing: border-box;
-	padding: 4px 12px; // Allows 32px min-height.
-	border-radius: $radius-small;
+	padding:
+		var(--wpds-dimension-padding-xs)
+		var(--wpds-dimension-padding-md); // Allows 32px min-height.
+	border-radius: var(--wpds-border-radius-sm);
 	color: $components-color-foreground;
 	// Every variant reserves a 1px border (transparent by default) so the box
 	// size stays identical whether or not a variant paints a visible border.
 	border: $border-width solid transparent;
 
 	&.is-next-40px-default-size {
-		height: $button-size-next-default-40px;
+		height: var(--wpds-dimension-size-lg);
 	}
 
 	&[aria-expanded="true"],
@@ -168,7 +173,7 @@
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
 		p + & {
-			margin-left: -($grid-unit-15 * 0.5);
+			margin-left: calc(-1 * var(--wpds-dimension-padding-md) / 2);
 		}
 	}
 
@@ -237,7 +242,7 @@
 		height: auto;
 
 		&:focus:not(:active) {
-			border-radius: $radius-small;
+			border-radius: var(--wpds-border-radius-sm);
 			text-decoration: none;
 		}
 
@@ -278,19 +283,20 @@
 	}
 
 	&.is-compact {
-		height: $button-size-compact;
+		height: var(--wpds-dimension-size-md);
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			min-width: $button-size-compact;
+			min-width: var(--wpds-dimension-size-md);
 		}
 	}
 
 	&.is-small {
 		height: var(--wpds-dimension-size-sm);
+		// 22px has no exact WPDS line-height token match (sm is 20px, md is 24px).
 		line-height: 22px;
-		padding: 0 8px;
-		font-size: 11px;
+		padding: 0 var(--wpds-dimension-padding-sm);
+		font-size: var(--wpds-typography-font-size-xs);
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
@@ -299,32 +305,33 @@
 	}
 
 	&.has-icon {
-		padding: 6px; // Works for 24px icons. Smaller icons are vertically centered by flex alignments.
+		padding-block: var(--wpds-dimension-padding-xs);
+		padding-inline: 0;
 
 		// Icon buttons are square.
-		min-width: $button-size;
+		min-width: var(--wp-components-button-height);
 		justify-content: center;
 
 		&.is-next-40px-default-size {
-			min-width: $button-size-next-default-40px;
+			min-width: var(--wpds-dimension-size-lg);
 		}
 
 		.dashicon {
 			display: inline-flex;
 			justify-content: center;
 			align-items: center;
-			padding: 2px;
+			padding: var(--wpds-dimension-padding-xs);
 			box-sizing: content-box;
 		}
 
 		&.has-text {
 			justify-content: start;
-			padding-right: $grid-unit-15;
-			padding-left: $grid-unit-10;
-			gap: $grid-unit-05;
+			padding-right: var(--wpds-dimension-padding-md);
+			padding-left: var(--wpds-dimension-gap-sm);
+			gap: var(--wpds-dimension-gap-xs);
 			&.has-icon-right {
-				padding-right: $grid-unit-10;
-				padding-left: $grid-unit-15;
+				padding-right: var(--wpds-dimension-gap-sm);
+				padding-left: var(--wpds-dimension-padding-md);
 			}
 		}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,8 +1,5 @@
-@use "sass:color";
-@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/mixins";
 @use "@wordpress/base-styles/variables" as *;
-@use "../utils/theme-variables" as *;
 
 /**
  * For easier testing of potential regressions, you can use a Button variant matrix
@@ -40,7 +37,7 @@
 		var(--wpds-dimension-padding-xs)
 		var(--wpds-dimension-padding-md); // Allows 32px min-height.
 	border-radius: var(--wpds-border-radius-sm);
-	color: $components-color-foreground;
+	color: var(--wpds-color-foreground-content-neutral);
 	// Every variant reserves a 1px border (transparent by default) so the box
 	// size stays identical whether or not a variant paints a visible border.
 	border: $border-width solid transparent;
@@ -51,7 +48,7 @@
 
 	&[aria-expanded="true"],
 	&:hover:not(:disabled, [aria-disabled="true"]) {
-		color: $components-color-accent;
+		color: var(--wpds-color-foreground-interactive-brand);
 	}
 
 	/**
@@ -60,19 +57,15 @@
 
 	&.is-primary {
 		white-space: nowrap;
-		background: $components-color-accent;
-		color: $components-color-accent-inverted;
+		background: var(--wpds-color-background-interactive-brand-strong);
+		color: var(--wpds-color-foreground-interactive-brand-strong);
 		text-decoration: none;
 		text-shadow: none;
 
-		&:hover:not(:disabled) {
-			background: $components-color-accent-darker-10;
-			color: $components-color-accent-inverted;
-		}
-
+		&:hover:not(:disabled),
 		&:active:not(:disabled) {
-			background: $components-color-accent-darker-20;
-			color: $components-color-accent-inverted;
+			background: var(--wpds-color-background-interactive-brand-strong-active);
+			color: var(--wpds-color-foreground-interactive-brand-strong-active);
 		}
 
 		&:disabled,
@@ -80,23 +73,22 @@
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
-			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: rgba($white, 0.4);
-			background: $components-color-accent;
+			color: var(--wpds-color-foreground-interactive-brand-strong-disabled);
+			background: var(--wpds-color-background-interactive-brand-strong-disabled);
 		}
 
 		&.is-busy,
 		&.is-busy:disabled,
 		&.is-busy[aria-disabled="true"] {
-			color: $components-color-accent-inverted;
+			color: var(--wpds-color-foreground-interactive-brand-strong);
 			background-size: 100px 100%;
 			/* stylelint-disable -- Disable reason: This function call looks nicer when each argument is on its own line. */
 			background-image: linear-gradient(
 				-45deg,
-				$components-color-accent 33%,
-				$components-color-accent-darker-20 33%,
-				$components-color-accent-darker-20 70%,
-				$components-color-accent 70%
+				var(--wpds-color-background-interactive-brand-strong) 33%,
+				var(--wpds-color-background-interactive-brand-strong-active) 33%,
+				var(--wpds-color-background-interactive-brand-strong-active) 70%,
+				var(--wpds-color-background-interactive-brand-strong) 70%
 			);
 			/* stylelint-enable */
 		}
@@ -111,8 +103,8 @@
 		&:disabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
-			color: $gray-600;
-			background: transparent;
+			color: var(--wpds-color-foreground-interactive-brand-disabled);
+			background: var(--wpds-color-background-interactive-brand-weak-disabled);
 			transform: none;
 		}
 	}
@@ -126,30 +118,31 @@
 			transition: border-color 0.1s linear;
 		}
 
-		border-color: $components-color-accent;
+		border-color: var(--wpds-color-stroke-interactive-brand);
 		white-space: nowrap;
-		color: $components-color-accent;
-		background: transparent;
+		color: var(--wpds-color-foreground-interactive-brand);
+		background: var(--wpds-color-background-interactive-brand-weak);
 
 		&:active:not(:disabled) {
 			// Hide the border while pressed, keeping its width to avoid a size shift.
 			border-color: transparent;
 		}
 
-		&:hover:not(:disabled, [aria-disabled="true"], .is-pressed) {
-			border-color: $components-color-accent-darker-20;
-			color: $components-color-accent-darker-20;
-			background: color-mix(in srgb, $components-color-accent 4%, transparent);
+		&:hover:not(:disabled, [aria-disabled="true"], .is-pressed),
+		&:active:not(:disabled, [aria-disabled="true"], .is-pressed) {
+			border-color: var(--wpds-color-stroke-interactive-brand-active);
+			color: var(--wpds-color-foreground-interactive-brand-active);
+			background: var(--wpds-color-background-interactive-brand-weak-active);
 		}
 
 		&:focus:not(:active) {
-			border-color: $components-color-accent;
+			border-color: var(--wpds-color-stroke-interactive-brand);
 		}
 
 		&:disabled:not(:focus),
 		&[aria-disabled="true"]:not(:focus),
 		&[aria-disabled="true"]:hover:not(:focus) {
-			border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
+			border-color: var(--wpds-color-stroke-interactive-brand-disabled);
 		}
 	}
 
@@ -159,16 +152,13 @@
 
 	&.is-tertiary {
 		white-space: nowrap;
-		color: $components-color-accent;
-		background: transparent;
+		color: var(--wpds-color-foreground-interactive-brand);
+		background: var(--wpds-color-background-interactive-brand-weak);
 
-		&:hover:not(:disabled, [aria-disabled="true"], .is-pressed) {
-			background: color-mix(in srgb, $components-color-accent 4%, transparent);
-			color: $components-color-accent-darker-20;
-		}
-
-		&:active:not(:disabled, [aria-disabled="true"]) {
-			background: color-mix(in srgb, $components-color-accent 8%, transparent);
+		&:hover:not(:disabled, [aria-disabled="true"], .is-pressed),
+		&:active:not(:disabled, [aria-disabled="true"], .is-pressed) {
+			background: var(--wpds-color-background-interactive-brand-weak-active);
+			color: var(--wpds-color-foreground-interactive-brand-active);
 		}
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
@@ -181,37 +171,92 @@
 	 * Destructive buttons.
 	 */
 	&.is-destructive {
-		--wp-components-color-accent: #{$alert-red};
-		--wp-components-color-accent-darker-10: #{color.adjust($alert-red, $lightness: -10%)};
-		--wp-components-color-accent-darker-20: #{color.adjust($alert-red, $lightness: -20%)};
-
 		// Only the default variant is styled differently from the non-destructive counterparts.
 		&:not(.is-primary):not(.is-secondary):not(.is-tertiary):not(.is-link) {
-			color: $alert-red;
+			color: var(--wpds-color-foreground-interactive-error);
 
 			&:hover:not(:disabled, [aria-disabled="true"]) {
-				color: color.adjust($alert-red, $lightness: -20%);
+				color: var(--wpds-color-foreground-interactive-error-active);
 			}
 
 			&:active:not(:disabled, [aria-disabled="true"]) {
-				background: $gray-400;
+				background: var(--wpds-color-stroke-surface-neutral);
 			}
 
 			&:disabled,
 			&[aria-disabled="true"] {
-				color: $gray-600;
+				color: var(--wpds-color-foreground-interactive-neutral-disabled);
 			}
 		}
 
-		&.is-tertiary,
-		&.is-secondary {
-			&:hover:not(:disabled, [aria-disabled="true"]) {
-				background: rgba($alert-red, 0.04);
+		&.is-primary {
+			background: var(--wpds-color-background-interactive-error-strong);
+			color: var(--wpds-color-foreground-interactive-error-strong);
+
+			&:hover:not(:disabled),
+			&:active:not(:disabled) {
+				background: var(--wpds-color-background-interactive-error-strong-active);
+				color: var(--wpds-color-foreground-interactive-error-strong-active);
 			}
 
-			&:active:not(:disabled, [aria-disabled="true"]) {
-				background: rgba($alert-red, 0.08);
+			&:disabled,
+			&:disabled:active:enabled,
+			&[aria-disabled="true"],
+			&[aria-disabled="true"]:enabled,
+			&[aria-disabled="true"]:active:enabled {
+				color: var(--wpds-color-foreground-interactive-error-strong-disabled);
+				background: var(--wpds-color-background-interactive-error-strong-disabled);
 			}
+
+			&.is-busy,
+			&.is-busy:disabled,
+			&.is-busy[aria-disabled="true"] {
+				color: var(--wpds-color-foreground-interactive-error-strong);
+				background-size: 100px 100%;
+				/* stylelint-disable -- Disable reason: This function call looks nicer when each argument is on its own line. */
+				background-image: linear-gradient(
+					-45deg,
+					var(--wpds-color-background-interactive-error-strong) 33%,
+					var(--wpds-color-background-interactive-error-strong-active) 33%,
+					var(--wpds-color-background-interactive-error-strong-active) 70%,
+					var(--wpds-color-background-interactive-error-strong) 70%
+				);
+				/* stylelint-enable */
+			}
+		}
+
+		&.is-secondary {
+			border-color: var(--wpds-color-stroke-interactive-error);
+			color: var(--wpds-color-foreground-interactive-error);
+			background: var(--wpds-color-background-interactive-error-weak);
+
+			&:hover:not(:disabled, [aria-disabled="true"], .is-pressed),
+			&:active:not(:disabled, [aria-disabled="true"], .is-pressed) {
+				border-color: var(--wpds-color-stroke-interactive-error-active);
+				color: var(--wpds-color-foreground-interactive-error-active);
+				background: var(--wpds-color-background-interactive-error-weak-active);
+			}
+
+			&:disabled:not(:focus),
+			&[aria-disabled="true"]:not(:focus),
+			&[aria-disabled="true"]:hover:not(:focus) {
+				border-color: var(--wpds-color-stroke-interactive-error-disabled);
+			}
+		}
+
+		&.is-tertiary {
+			color: var(--wpds-color-foreground-interactive-error);
+			background: var(--wpds-color-background-interactive-error-weak);
+
+			&:hover:not(:disabled, [aria-disabled="true"], .is-pressed),
+			&:active:not(:disabled, [aria-disabled="true"], .is-pressed) {
+				background: var(--wpds-color-background-interactive-error-weak-active);
+				color: var(--wpds-color-foreground-interactive-error-active);
+			}
+		}
+
+		&.is-link {
+			color: var(--wpds-color-foreground-interactive-error);
 		}
 	}
 
@@ -228,7 +273,7 @@
 		outline: none;
 		text-align: left;
 		font-weight: var(--wpds-typography-font-weight-default);
-		color: $components-color-accent;
+		color: var(--wpds-color-foreground-interactive-brand);
 		text-decoration: underline;
 		text-underline-offset: 0.2em;
 		text-decoration-thickness: from-font;
@@ -248,18 +293,18 @@
 
 		&:disabled,
 		&[aria-disabled="true"] {
-			color: $gray-600;
+			color: var(--wpds-color-foreground-interactive-neutral-disabled);
 		}
 	}
 
 	&:not(:disabled, [aria-disabled="true"]):active {
-		color: $components-color-foreground;
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 
 	&:disabled,
 	&[aria-disabled="true"] {
 		cursor: default;
-		color: $gray-600;
+		color: var(--wpds-color-foreground-interactive-neutral-disabled);
 	}
 
 	&.is-busy,
@@ -273,11 +318,10 @@
 		/* stylelint-disable -- Disable reason: This function call looks nicer when each argument is on its own line. */
 		background-image: linear-gradient(
 			-45deg,
-			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color.adjust($white, $lightness: -2%) 33%,
-			color.adjust($white, $lightness: -12%) 33%,
-			color.adjust($white, $lightness: -12%) 70%,
-			color.adjust($white, $lightness: -2%) 70%
+			var(--wpds-color-background-surface-neutral-strong) 33%,
+			var(--wpds-color-background-surface-neutral) 33%,
+			var(--wpds-color-background-surface-neutral) 70%,
+			var(--wpds-color-background-surface-neutral-strong) 70%
 		);
 		/* stylelint-enable */
 	}
@@ -349,19 +393,19 @@
 	&.is-pressed {
 		&,
 		&:hover {
-			color: $components-color-foreground-inverted;
+			color: var(--wpds-color-foreground-interactive-neutral-strong);
 			&:not(:disabled, [aria-disabled="true"]) {
-				background: $components-color-foreground;
+				background: var(--wpds-color-background-interactive-neutral-strong);
 			}
 		}
 
 		&:disabled,
 		&[aria-disabled="true"] {
-			color: $gray-600;
+			color: var(--wpds-color-foreground-interactive-neutral-strong-disabled);
 
 			&:not(.is-primary):not(.is-secondary):not(.is-tertiary) {
-				color: $components-color-foreground-inverted;
-				background: $gray-600;
+				color: var(--wpds-color-foreground-interactive-neutral-strong-disabled);
+				background: var(--wpds-color-background-interactive-neutral-strong-disabled);
 			}
 		}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -53,6 +53,7 @@
 
 	/**
 	 * Primary button style.
+	 * Maps to `@wordpress/ui` Button: brand / solid.
 	 */
 
 	&.is-primary {
@@ -111,6 +112,7 @@
 
 	/**
 	 * Secondary button style.
+	 * Maps to `@wordpress/ui` Button: brand / outline.
 	 */
 
 	&.is-secondary {
@@ -148,6 +150,7 @@
 
 	/**
 	 * Tertiary buttons.
+	 * Maps to `@wordpress/ui` Button: brand / minimal.
 	 */
 
 	&.is-tertiary {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -99,8 +99,8 @@
 	 * Secondary and tertiary buttons.
 	 */
 
-	&.is-secondary,
-	&.is-tertiary {
+	&.is-secondary:not(.is-destructive),
+	&.is-tertiary:not(.is-destructive) {
 		&:disabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
@@ -225,6 +225,17 @@
 					var(--wpds-color-background-interactive-error-strong) 70%
 				);
 				/* stylelint-enable */
+			}
+		}
+
+		&.is-secondary,
+		&.is-tertiary {
+			&:disabled,
+			&[aria-disabled="true"],
+			&[aria-disabled="true"]:hover {
+				color: var(--wpds-color-foreground-interactive-error-disabled);
+				background: var(--wpds-color-background-interactive-error-weak-disabled);
+				transform: none;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

WIP

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/76135

Follow-up to https://github.com/WordPress/gutenberg/pull/79993

Fixes https://github.com/WordPress/gutenberg/issues/80211

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test `npm run storybook:e2e:dev` to see button grid before and after.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
