### PR TITLE
Block Visibility: Show toggle option in the block inspector when responsive editing

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -38,7 +38,10 @@ import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSett
 import { useBorderPanelLabel } from '../../hooks/border';
 import { BlockStateBadges, BlockStatesControl } from '../../hooks/states';
 import ContentTab from '../inspector-controls-tabs/content-tab';
-import ViewportVisibilityInfo from '../block-visibility/viewport-visibility-info';
+import {
+	ViewportVisibilityInfo,
+	ViewportVisibilityInspectorControl,
+} from '../block-visibility';
 import { unlock } from '../../lock-unlock';
 import {
 	hasPseudoBlockStyleState,
@@ -466,7 +469,9 @@ const BlockInspectorSingleBlock = ( {
 					/>
 				</Spacer>
 			) }
-			<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
+			{ ! isEditingStyleState && (
+				<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
+			) }
 			<EditContents clientId={ renderedBlockClientId } />
 			{ ! isEditingStyleState && (
 				<BlockVariationTransforms
@@ -474,6 +479,14 @@ const BlockInspectorSingleBlock = ( {
 				/>
 			) }
 			<BlockInspectorPreTabsSlot />
+			{ isEditingStyleState && (
+				<ViewportVisibilityInspectorControl
+					blockEditingMode={ blockEditingMode }
+					blockName={ blockName }
+					clientId={ renderedBlockClientId }
+					selectedBlockStyleState={ selectedBlockStyleState }
+				/>
+			) }
 			{ isEditingStyleState && ! isSectionBlock && (
 				<StyleStateInspectorSlots
 					blockName={ blockName }

--- a/packages/block-editor/src/components/block-visibility/index.js
+++ b/packages/block-editor/src/components/block-visibility/index.js
@@ -3,4 +3,5 @@ export { default as useBlockVisibility } from './use-block-visibility';
 export { default as ViewportVisibilityToolbar } from './viewport-toolbar';
 export { default as BlockVisibilityViewportMenuItem } from './viewport-menu-item';
 export { default as ViewportVisibilityInfo } from './viewport-visibility-info';
+export { default as ViewportVisibilityInspectorControl } from './viewport-inspector-control';
 export { getBlockVisibilityLabel } from './utils';

--- a/packages/block-editor/src/components/block-visibility/test/utils.js
+++ b/packages/block-editor/src/components/block-visibility/test/utils.js
@@ -5,6 +5,7 @@ import {
 	getBlockVisibilityViewportEntries,
 	getViewportCheckboxState,
 	getHideEverywhereCheckboxState,
+	isBlockHiddenForViewport,
 } from '../utils';
 
 describe( 'block-visibility utils', () => {
@@ -288,6 +289,39 @@ describe( 'block-visibility utils', () => {
 				},
 			];
 			expect( getHideEverywhereCheckboxState( blocks ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isBlockHiddenForViewport', () => {
+		it( 'detects viewport-specific hidden state', () => {
+			expect(
+				isBlockHiddenForViewport(
+					{
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									viewport: { mobile: false },
+								},
+							},
+						},
+					},
+					'mobile'
+				)
+			).toBe( true );
+			expect(
+				isBlockHiddenForViewport(
+					{
+						attributes: {
+							metadata: {
+								blockVisibility: {
+									viewport: { tablet: false },
+								},
+							},
+						},
+					},
+					'mobile'
+				)
+			).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-visibility/utils.js
+++ b/packages/block-editor/src/components/block-visibility/utils.js
@@ -35,7 +35,7 @@ export function getBlockVisibilityViewportEntries( viewportSettings ) {
  * @param {string} viewport The viewport to check (e.g., 'mobile', 'tablet', 'desktop').
  * @return {boolean} Whether the block is hidden for the viewport.
  */
-function isBlockHiddenForViewport( block, viewport ) {
+export function isBlockHiddenForViewport( block, viewport ) {
 	if ( ! block ) {
 		return false;
 	}

--- a/packages/block-editor/src/components/block-visibility/viewport-inspector-control.js
+++ b/packages/block-editor/src/components/block-visibility/viewport-inspector-control.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { hasBlockSupport } from '@wordpress/blocks';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { cleanEmptyObject } from '../../hooks/utils';
+import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
+import { BLOCK_VISIBILITY_VIEWPORTS } from './constants';
+import { isBlockHiddenForViewport } from './utils';
+
+const VIEWPORT_BY_STYLE_STATE = {
+	'@tablet': BLOCK_VISIBILITY_VIEWPORTS.tablet.key,
+	'@mobile': BLOCK_VISIBILITY_VIEWPORTS.mobile.key,
+};
+
+export default function ViewportVisibilityInspectorControl( {
+	blockEditingMode,
+	blockName,
+	clientId,
+	selectedBlockStyleState,
+} ) {
+	const viewport =
+		VIEWPORT_BY_STYLE_STATE[ selectedBlockStyleState?.viewport ];
+	const viewportLabel = BLOCK_VISIBILITY_VIEWPORTS[ viewport ]?.label;
+	const attributes = useSelect(
+		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
+		[ clientId ]
+	);
+	const blockVisibility = attributes?.metadata?.blockVisibility;
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	if (
+		! clientId ||
+		! viewport ||
+		! viewportLabel ||
+		blockEditingMode !== 'default' ||
+		blockVisibility === false ||
+		! hasBlockSupport( blockName, 'visibility', true )
+	) {
+		return null;
+	}
+
+	const isHidden = isBlockHiddenForViewport( { attributes }, viewport );
+	const setViewportHidden = ( isHiddenOnViewport ) => {
+		const nextBlockVisibility = cleanEmptyObject( {
+			viewport: {
+				...blockVisibility?.viewport,
+				[ viewport ]: isHiddenOnViewport ? false : undefined,
+			},
+		} );
+
+		updateBlockAttributes( clientId, {
+			metadata: cleanEmptyObject( {
+				...attributes?.metadata,
+				blockVisibility: nextBlockVisibility,
+			} ),
+		} );
+	};
+	const label = sprintf(
+		/* translators: %s: viewport name, e.g. Tablet or Mobile. */
+		__( 'Hide on %s' ),
+		viewportLabel
+	);
+
+	return (
+		<ToolsPanel
+			label={ __( 'Visibility' ) }
+			resetAll={ () => setViewportHidden( false ) }
+			panelId={ clientId }
+			dropdownMenuProps={ dropdownMenuProps }
+		>
+			<ToolsPanelItem
+				label={ label }
+				hasValue={ () => isHidden }
+				onDeselect={ () => setViewportHidden( false ) }
+				isShownByDefault
+				panelId={ clientId }
+			>
+				<ToggleControl
+					label={ label }
+					checked={ isHidden }
+					onChange={ setViewportHidden }
+				/>
+			</ToolsPanelItem>
+		</ToolsPanel>
+	);
+}


### PR DESCRIPTION
## What?
Shows a control in the block inspector that allows a user to easily toggle block visibility when responsive editing.

## Why?
Viewport visibility allows hiding blocks on specific viewports, but until now it wasn't really connected at all to the new 'Responsive editing' option, which feels like a missing feature to me. The user has to open the viewport visibility modal which still displays options for every viewport, not the one selected.

## How?
Adds a simple toggle for block visibility in a ToolsPanel that's shown whenever Responsive editing is enabled, and the user has tablet or mobile viewport selected.

Whether to show anything when 'Desktop' is selected is an open question. I personally think it's ok not to bother with that in a first iteration. Alternatively, an idea I had is that on desktop the UI could show toggles for all breakpoints (since the desktop option is considered as 'Edit across all breakpoints').

## Testing Instructions
1. Insert a block
2. Enable 'Responsive editing' and select either mobile or tablet in the viewport dropdown
3. Open the block inspector. 
4. Observe there's a 'Hide on Tablet / Mobile' toggle.
5. Select it
6. Observe the block is hidden. 

## Screenshots or screencast <!-- if applicable -->
<img width="283" height="283" alt="Screenshot 2026-07-08 at 6 18 13 pm" src="https://github.com/user-attachments/assets/1c202b1d-e4b7-4b01-bbd6-1dceb9e9a23e" />

## Use of AI Tools
OpenCode / Codex