### PR TITLE
Preserve inline image and Image block links when replacing media

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -356,17 +356,14 @@ export function ImageEdit( {
 			}
 		}
 
-		// Check if the image is linked to it's media.
-		let href;
 		switch ( linkDestination ) {
 			case LINK_DESTINATION_MEDIA:
-				href = media.url;
+				mediaAttributes.href = media.url;
 				break;
 			case LINK_DESTINATION_ATTACHMENT:
-				href = media.link;
+				mediaAttributes.href = media.link;
 				break;
 		}
-		mediaAttributes.href = href;
 
 		setAttributes( {
 			blob: undefined,

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -165,20 +165,27 @@ function Edit( {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ getCurrentImageId( activeObjectAttributes ) }
 				onSelect={ ( { id, url, alt, width: imgWidth } ) => {
-					onChange(
-						insertObject( value, {
-							type: name,
-							attributes: {
-								className: `wp-image-${ id }`,
-								style: `width: ${ Math.min(
-									imgWidth,
-									150
-								) }px;`,
-								url,
-								alt,
-							},
-						} )
-					);
+					const existingFormats = isObjectActive
+						? value.formats[ value.start ] ?? []
+						: [];
+
+					let newValue = insertObject( value, {
+						type: name,
+						attributes: {
+							className: `wp-image-${ id }`,
+							style: `width: ${ Math.min( imgWidth, 150 ) }px;`,
+							url,
+							alt,
+						},
+					} );
+
+					if ( existingFormats.length ) {
+						const newFormats = newValue.formats.slice();
+						newFormats[ value.start ] = existingFormats;
+						newValue = { ...newValue, formats: newFormats };
+					}
+
+					onChange( newValue );
 					onFocus();
 				} }
 				render={ ( { open } ) => (


### PR DESCRIPTION
## What?
Closes #41800

Fixes two related bugs where replacing an image causes any link applied to that image to be silently removed:
1. The **Inline Image** rich-text format (used in Paragraph, Table, etc. via More → Inline Image).
2. The core **Image** block, when using the toolbar "Replace" action with a `custom` or `none` link destination.

## Why?
As reported in #41800, linking an inline image (or a block Image with a custom link) and then replacing the image via the "Replace"/"Inline Image" action causes the link to disappear, with no way to recover it short of re-adding it manually. This is unexpected, replacing the underlying image shouldn't discard a link the user deliberately set, and nothing about "replace" suggests it will touch the link.

## Testing Instructions
1. **Inline Image:**
   - Create a new Post, add a Paragraph block, and type some text.
   - Insert an image via More → Inline Image.
   - Click the image, select "Link", and add a URL.
   - Click the image again → More → Inline Image → select a different image.
   - Confirm the link is still present on the new image (click it and check the link popover, or view the saved HTML).
2. **Image block:**
   - Insert an Image block and select an image.
   - Use the toolbar link icon to set a custom URL (link destination "Custom URL").
   - Click "Replace" in the toolbar and select a different image.
   - Confirm the custom link is still present on the new image.
   - Repeat with link destination set to "Media File" and "Attachment Page" and confirm the href still correctly updates to point at the newly selected image in those cases (regression check for existing behavior).
   - Repeat with no link set ("None") and confirm no link is added after replacing.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/34ddcbc5-900d-4c78-8ff9-99d0296ca622
