### PR TITLE
Responsive editing: Hide block toolbar slots when editing a responsive style state

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -40,6 +40,7 @@ import EditSectionButton from './edit-section-button';
 import { unlock } from '../../lock-unlock';
 import { deviceTypeKey } from '../../store/private-keys';
 import BlockToolbarIcon from './block-toolbar-icon';
+import { hasViewportBlockStyleState } from '../../hooks/block-style-state';
 
 /**
  * Renders the block toolbar.
@@ -95,6 +96,8 @@ export function PrivateBlockToolbar( {
 			isZoomOut,
 			isSectionBlock,
 			isBlockHiddenAtViewport,
+			getSelectedBlockStyleState,
+			isResponsiveEditing,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -135,6 +138,11 @@ export function PrivateBlockToolbar( {
 			selectedBlockClientIds.every( ( id ) =>
 				isBlockHiddenAtViewport( id, _currentDeviceType )
 			);
+		const _isEditingResponsiveStyleState =
+			isResponsiveEditing() &&
+			hasViewportBlockStyleState(
+				getSelectedBlockStyleState( selectedBlockClientId )
+			);
 
 		return {
 			blockClientId: selectedBlockClientId,
@@ -158,7 +166,7 @@ export function PrivateBlockToolbar( {
 			isSectionContainer: _isSectionBlock,
 			hasContentOnlyLocking: _hasTemplateLock,
 			showShuffleButton: _isZoomOut,
-			showSlots: ! _isZoomOut,
+			showSlots: ! _isZoomOut && ! _isEditingResponsiveStyleState,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
 			showBlockVisibilityButton: ! _isZoomOut,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Proposes hiding block toolbar items when editing a responsive style state. 

## Why?
Users can find the toolbar items misleading. The Responsive editing option proclaims that edits / style edits apply only to the current viewport. However, this is true only of inspector controls. Toolbar controls currently don't work for responsive editing.

see: https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/#comment-3693

## Testing Instructions
1. Toggle on Responsive editing from the viewport dropdown
2. Select the tablet or mobile viewport from the same dropdown
3. Select a block
4. Observe there are limited toolbar controls
5. Disengage Responsive editing
6. Observe the toolbar controls are back

## Screenshots or screencast <!-- if applicable -->

<img width="1111" height="597" alt="Screenshot 2026-07-08 at 6 52 59 pm" src="https://github.com/user-attachments/assets/5b741673-4f77-42e0-b88a-07060020b24e" />

## Use of AI Tools

OpenCode / Codex