### PR TITLE
Bump plugin version to 23.5.1

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 23.5.0
+ * Version: 23.5.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.0",
+	"version": "23.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg",
-			"version": "23.5.0",
+			"version": "23.5.1",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "23.5.0",
+	"version": "23.5.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## What?

Bumps the plugin version on `trunk` from `23.5.0` to `23.5.1` in `package.json`, `package-lock.json`, and `gutenberg.php`.

## Why?

During the [23.5.1 release run](https://github.com/WordPress/gutenberg/actions/runs/28931232711/job/85830624407), the **"Cherry-pick the version bump commit to trunk"** step failed. As a result, trunk ended up in an inconsistent state:

- `Update Changelog for 23.5.1` **did** land on trunk (`9c3db9b9a92`), so the changelog already advertises 23.5.1.
- The version bump (`Bump plugin version to 23.5.1`, `ab914b96fc6` on `release/23.5`) **did not** get cherry-picked, so the three version files still read `23.5.0`.

This PR replicates that missing bump on trunk, matching the diff that landed on the release branch. This is the recovery described in the release docs for that step failing.

## How?

Same edits the workflow would have applied — `23.5.0` → `23.5.1` in:
- `gutenberg.php` (`Version:` header)
- `package.json` (`version`)
- `package-lock.json` (both `version` fields)

## Testing Instructions

- Confirm `package.json`, `package-lock.json`, and `gutenberg.php` all report `23.5.1`.
- Confirm the release branch `release/23.5` is unaffected (already at `23.5.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)