### PR TITLE
Switch from App ID to App user ID in git metadata.

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -126,8 +126,8 @@ jobs:
 
             - name: Configure Git user email
               env:
-                  APP_ID: ${{ vars.APP_ID }}
-              run: git config user.email "${APP_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+                  APP_USER_ID: ${{ vars.APP_USER_ID }}
+              run: git config user.email "${APP_USER_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
             - name: Create and switch to release branch
               if: |
@@ -384,8 +384,8 @@ jobs:
 
             - name: Configure Git user email
               env:
-                  APP_ID: ${{ vars.APP_ID }}
-              run: git config user.email "${APP_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+                  APP_USER_ID: ${{ vars.APP_USER_ID }}
+              run: git config user.email "${APP_USER_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
             - name: Revert version bump commit on release branch
               if: |


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This switches out the app ID for the app user ID when configuring the application's user in Git.

Follow up to #79912, #80005.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Apps have a user ID in addition to an app ID. The former is what must be specified for the user metadata in a commit.

## Use of AI Tools

None.