### PR TITLE
Notes: An alternative sidebar dropdown control in the editor header

### DIFF
--- a/packages/editor/src/components/collab-sidebar/constants.js
+++ b/packages/editor/src/components/collab-sidebar/constants.js
@@ -1,3 +1,4 @@
 export const ALL_NOTES_SIDEBAR = 'edit-post/collab-history-sidebar';
 export const FLOATING_NOTES_SIDEBAR = 'edit-post/collab-sidebar';
+export const NOOP_NOTES_SIDEBAR = 'edit-post/notes-noop-sidebar';
 export const SIDEBARS = [ ALL_NOTES_SIDEBAR, FLOATING_NOTES_SIDEBAR ];

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -518,7 +518,7 @@ export function useEnableFloatingSidebar( enabled = false ) {
 			if (
 				getActiveComplementaryArea( 'core' ) === FLOATING_NOTES_SIDEBAR
 			) {
-				disableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
+				disableComplementaryArea( 'core' );
 			}
 		};
 	}, [ enabled, registry ] );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -4,11 +4,16 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItemsChoice,
+} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as interfaceStore } from '@wordpress/interface';
+import { PinnedItems, store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 
@@ -17,9 +22,10 @@ import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
  */
 import PluginSidebar from '../plugin-sidebar';
 import {
+	SIDEBARS,
 	ALL_NOTES_SIDEBAR,
 	FLOATING_NOTES_SIDEBAR,
-	SIDEBARS,
+	NOOP_NOTES_SIDEBAR,
 } from './constants';
 import { Notes } from './notes';
 import { store as editorStore } from '../../store';
@@ -32,6 +38,54 @@ import { getNoteIdsFromMetadata, pickPrimaryNote } from './utils';
 import { NOTE_FORMAT_NAME, noteFormat } from './format';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
+
+function NotesSidebarPinnedItems( { isLargeViewport } ) {
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const activeComplementaryArea = useSelect( ( select ) => {
+		return select( interfaceStore ).getActiveComplementaryArea( 'core' );
+	}, [] );
+
+	return (
+		<PinnedItems scope="core">
+			<DropdownMenu
+				icon={ commentIcon }
+				label={ __( 'Notes' ) }
+				menuProps={ {
+					'aria-label': __( 'Notes display options' ),
+				} }
+				toggleProps={ {
+					size: 'compact',
+				} }
+			>
+				{ () => (
+					<MenuGroup>
+						<MenuItemsChoice
+							choices={ [
+								{
+									value: FLOATING_NOTES_SIDEBAR,
+									label: __( 'Show notes' ),
+									disabled: ! isLargeViewport,
+								},
+								{
+									value: ALL_NOTES_SIDEBAR,
+									label: __( 'Show all notes' ),
+								},
+								{
+									value: NOOP_NOTES_SIDEBAR,
+									label: __( 'Hide notes' ),
+								},
+							] }
+							value={ activeComplementaryArea }
+							onSelect={ ( value ) => {
+								enableComplementaryArea( 'core', value );
+							} }
+						/>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+		</PinnedItems>
+	);
+}
 
 function NotesSidebar( { postId } ) {
 	useEffect( () => {
@@ -185,20 +239,26 @@ function NotesSidebar( { postId } ) {
 				}
 			/>
 			{ showAllNotesSidebar && (
-				<PluginSidebar
-					identifier={ ALL_NOTES_SIDEBAR }
-					name={ ALL_NOTES_SIDEBAR }
-					title={ __( 'All notes' ) }
-					header={
-						<h2 className="interface-complementary-area-header__title">
-							{ __( 'All notes' ) }
-						</h2>
-					}
-					icon={ commentIcon }
-					closeLabel={ __( 'Close Notes' ) }
-				>
-					<Notes notes={ notes } sidebarRef={ sidebarRef } />
-				</PluginSidebar>
+				<>
+					<NotesSidebarPinnedItems
+						isLargeViewport={ isLargeViewport }
+					/>
+					<PluginSidebar
+						isPinnable={ false }
+						identifier={ ALL_NOTES_SIDEBAR }
+						name={ ALL_NOTES_SIDEBAR }
+						title={ __( 'All notes' ) }
+						header={
+							<h2 className="interface-complementary-area-header__title">
+								{ __( 'All notes' ) }
+							</h2>
+						}
+						icon={ commentIcon }
+						closeLabel={ __( 'Close Notes' ) }
+					>
+						<Notes notes={ notes } sidebarRef={ sidebarRef } />
+					</PluginSidebar>
+				</>
 			) }
 			{ isLargeViewport && (
 				<PluginSidebar

--- a/test/e2e/specs/editor/collaboration/collaboration-notes.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-notes.spec.ts
@@ -1,7 +1,31 @@
 /**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+
+/**
  * Internal dependencies
  */
 import { test, expect } from './fixtures';
+
+/**
+ * Chooses a display option from the Notes dropdown in the top bar. The dropdown
+ * appears once the post has notes, which may take a moment after a note syncs.
+ *
+ * @param page The page to act on.
+ * @param view The dropdown choice, e.g. 'Show all notes'.
+ */
+async function chooseNotesView( page: Page, view: string ) {
+	const notesButton = page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Notes', exact: true } );
+	await expect( notesButton ).toBeVisible( { timeout: 10000 } );
+	await notesButton.click();
+	await page.getByRole( 'menuitemradio', { name: view } ).click();
+	// Selecting a choice leaves the dropdown open; close it so it doesn't
+	// overlap later interactions.
+	await page.keyboard.press( 'Escape' );
+}
 
 test.describe( 'Collaboration - Notes Sync', () => {
 	test.afterAll( async ( { requestUtils } ) => {
@@ -53,16 +77,7 @@ test.describe( 'Collaboration - Notes Sync', () => {
 		await collaborationUtils.waitForSyncCycle( page2 );
 
 		// Open the All Notes sidebar on User B's page.
-		const toggleButton = page2
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'All notes', exact: true } );
-
-		// The button may need a moment to appear after the note syncs.
-		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
-		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
-		if ( isExpanded === 'false' ) {
-			await toggleButton.click();
-		}
+		await chooseNotesView( page2, 'Show all notes' );
 
 		// User B should see the note from User A.
 		await expect(
@@ -126,14 +141,7 @@ test.describe( 'Collaboration - Notes Sync', () => {
 		await collaborationUtils.waitForSyncCycle( page );
 
 		// Open notes sidebar on User A's page.
-		const toggleButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'All notes', exact: true } );
-		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
-		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
-		if ( isExpanded === 'false' ) {
-			await toggleButton.click();
-		}
+		await chooseNotesView( page, 'Show all notes' );
 
 		// User A should see the note from User B.
 		await expect(
@@ -200,14 +208,7 @@ test.describe( 'Collaboration - Notes Sync', () => {
 		await collaborationUtils.waitForSyncCycle( page2 );
 
 		// Open notes sidebar on User B's page.
-		const toggleButton = page2
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'All notes', exact: true } );
-		await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
-		const isExpanded = await toggleButton.getAttribute( 'aria-expanded' );
-		if ( isExpanded === 'false' ) {
-			await toggleButton.click();
-		}
+		await chooseNotesView( page2, 'Show all notes' );
 
 		// User B should see the main note.
 		const thread = page2

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -39,11 +39,8 @@ test.describe( 'Block Notes', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Add note' );
 		await expect( form ).toBeFocused();
-		// Close the pinned notes sidebar.
-		await page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'All notes', exact: true } )
-			.click();
+		// Hide the notes sidebars via the Notes dropdown.
+		await blockNoteUtils.chooseNotesView( 'Hide notes' );
 		await editor.clickBlockOptionsMenuItem( 'Add note' );
 		await expect( form ).toBeFocused();
 	} );
@@ -156,7 +153,7 @@ test.describe( 'Block Notes', () => {
 			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment to resolve.',
 		} );
-		await blockNoteUtils.openBlockNoteSidebar();
+		await blockNoteUtils.chooseNotesView( 'Show all notes' );
 
 		const thread = page
 			.getByRole( 'region', { name: 'Editor settings' } )
@@ -206,7 +203,7 @@ test.describe( 'Block Notes', () => {
 				.filter( { hasText: 'Note marked as resolved.' } )
 		).toBeVisible();
 
-		await blockNoteUtils.openBlockNoteSidebar();
+		await blockNoteUtils.chooseNotesView( 'Show all notes' );
 		await page.locator( '.editor-collab-sidebar-panel__thread' ).click();
 		await expect( resolveButton ).toBeDisabled();
 		const commentForm = page.getByRole( 'textbox', { name: 'Reply to' } );
@@ -1476,6 +1473,116 @@ test.describe( 'Block Notes', () => {
 			await expect.poll( alphaOf ).toBeGreaterThan( 0.4 );
 		} );
 	} );
+
+	test.describe( 'Notes visibility toggle', () => {
+		test( 'shows the display options with the current state selected', async ( {
+			page,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Toggle menu block' },
+				comment: 'Toggle menu note',
+			} );
+
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Notes', exact: true } )
+				.click();
+
+			const menu = page.getByRole( 'menu', {
+				name: 'Notes display options',
+			} );
+			await expect( menu.getByRole( 'menuitemradio' ) ).toHaveText( [
+				'Show notes',
+				'Show all notes',
+				'Hide notes',
+			] );
+			// The floating notes are visible by default, so "Show notes" is
+			// the selected choice.
+			await expect(
+				menu.getByRole( 'menuitemradio', {
+					name: 'Show notes',
+					exact: true,
+				} )
+			).toHaveAttribute( 'aria-checked', 'true' );
+			await page.keyboard.press( 'Escape' );
+		} );
+
+		test( 'can hide and show notes', async ( { page, blockNoteUtils } ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Hide and show' },
+				comment: 'Now you see me',
+			} );
+
+			const thread = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Now you see me' } );
+			await expect( thread ).toBeVisible();
+
+			await blockNoteUtils.chooseNotesView( 'Hide notes' );
+			await expect( thread ).toBeHidden();
+
+			await blockNoteUtils.chooseNotesView( 'Show notes' );
+			await expect( thread ).toBeVisible();
+		} );
+
+		test( 'opens and closes the All notes sidebar from the dropdown', async ( {
+			page,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Sidebar block' },
+				comment: 'Sidebar note',
+			} );
+
+			await blockNoteUtils.chooseNotesView( 'Show all notes' );
+			const closeButton = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Close Notes' } );
+			await expect( closeButton ).toBeVisible();
+
+			// Hiding notes closes the All notes sidebar too.
+			await blockNoteUtils.chooseNotesView( 'Hide notes' );
+			await expect( closeButton ).toBeHidden();
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'treeitem', { name: 'Note: Sidebar note' } )
+			).toBeHidden();
+		} );
+
+		test( 'adding a note while hidden makes notes visible again', async ( {
+			editor,
+			page,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'First block' },
+				comment: 'Existing note',
+			} );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Second block' },
+			} );
+
+			await blockNoteUtils.chooseNotesView( 'Hide notes' );
+			const existingThread = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Existing note' } );
+			await expect( existingThread ).toBeHidden();
+
+			// Adding a note from the block options menu unhides notes.
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+			await expect( existingThread ).toBeVisible();
+		} );
+	} );
 } );
 
 class BlockNoteUtils {
@@ -1489,23 +1596,15 @@ class BlockNoteUtils {
 		this.#editor = editor;
 	}
 
-	async openBlockNoteSidebar() {
-		const toggleButton = this.#page
+	async chooseNotesView( view ) {
+		await this.#page
 			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'All notes', exact: true } );
-
-		const isClosed =
-			( await toggleButton.getAttribute( 'aria-expanded' ) ) === 'false';
-
-		if ( isClosed ) {
-			await toggleButton.click();
-			await this.#page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Close Notes' } )
-				.waitFor();
-		}
-
-		return toggleButton;
+			.getByRole( 'button', { name: 'Notes', exact: true } )
+			.click();
+		await this.#page.getByRole( 'menuitemradio', { name: view } ).click();
+		// Selecting a choice leaves the dropdown open; close it so it doesn't
+		// overlap later interactions.
+		await this.#page.keyboard.press( 'Escape' );
 	}
 
 	async addBlockWithNote( { type, attributes = {}, comment } ) {


### PR DESCRIPTION
## What?
Closes #79963.
Alternative to #76024.

PR adds a **Notes** dropdown to the editor header (a pinned item) with three display choices:

- **Show notes** — floating sidebar (large viewports)
- **Show all notes** — the All notes complementary sidebar
- **Hide notes** — hides both

#76024 tracks the hidden/visible state in local React component state. This branch drives visibility entirely through the interface store's active complementary area.

Benefits: single source of truth, less bookkeeping / smaller surface.

## How?
Uses a faux sidebar (`NOOP_NOTES_SIDEBAR`) to hide everything. It's a trade-off, but it keeps all visibility state in a single layer rather than splitting it between store and component state.

## Testing Instructions
1. Open a post with notes.
2. Switch between different view choices.
3. Confirm all views are rendered.
4. Resize the browser window to a small screen.
5. Confirm that the floating notes option is disabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/238d2845-c09e-476f-afab-b21e1b8dd648

## Use of AI Tools

Assisted by Claude.
