### PR TITLE
Admin UI: forward search/params/hash from Breadcrumbs items to their links

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Breadcrumbs: forward `search`, `params`, and `hash` to breadcrumb links so crumbs can preserve router state. ([#PR](https://github.com/WordPress/gutenberg/pull/PR))
+
 ## 2.5.0 (2026-07-01)
 
 ## 2.4.0 (2026-06-24)

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Breadcrumbs: forward `search`, `params`, and `hash` to breadcrumb links so crumbs can preserve router state. ([#PR](https://github.com/WordPress/gutenberg/pull/PR))
+-   Breadcrumbs: forward `search`, `params`, and `hash` to breadcrumb links so crumbs can preserve router state. ([#80013](https://github.com/WordPress/gutenberg/pull/80013))
 
 ## 2.5.0 (2026-07-01)
 

--- a/packages/admin-ui/README.md
+++ b/packages/admin-ui/README.md
@@ -45,12 +45,14 @@ Renders a breadcrumb navigation trail.
 
 All items except the last one must provide a `to` prop for navigation. In development mode, an error is thrown when a non-last item is missing `to`. The last item represents the current page and its `to` prop is optional. Only the last item (when it has no `to` prop) is rendered as an `h1`.
 
+Link items may also forward router `search` (query params), `params` (dynamic path params), and `hash` to the underlying `@wordpress/route` `Link`, so navigating to a parent crumb can preserve URL state such as active filters or sort order.
+
 _Usage_
 
 ```jsx
 <Breadcrumbs
 	items={ [
-		{ label: 'Home', to: '/' },
+		{ label: 'Home', to: '/', search: { filter: 'active' } },
 		{ label: 'Settings', to: '/settings' },
 		{ label: 'General' },
 	] }
@@ -60,7 +62,7 @@ _Usage_
 _Parameters_
 
 -   _props_ `BreadcrumbsProps`:
--   _props.items_ `BreadcrumbsProps[ 'items' ]`: The breadcrumb items to display.
+-   _props.items_ `BreadcrumbsProps[ 'items' ]`: The breadcrumb items to display. Each item accepts `label`, optional `to`, and optional `search`, `params`, and `hash` for link items.
 
 ### getAdminThemeColors
 

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -19,14 +19,21 @@ import styles from './style.module.css';
  * The last item represents the current page and its `to` prop is optional.
  * Only the last item (when it has no `to` prop) is rendered as an `h1`.
  *
+ * Link items may also forward router `search` (query params), `params`
+ * (dynamic path params), and `hash` to the underlying `@wordpress/route`
+ * `Link`, so navigating to a parent crumb can preserve URL state such as
+ * active filters or sort order.
+ *
  * @param props
- * @param props.items The breadcrumb items to display.
+ * @param props.items The breadcrumb items to display. Each item accepts
+ *                    `label`, optional `to`, and optional `search`, `params`,
+ *                    and `hash` for link items.
  *
  * @example
  * ```jsx
  * <Breadcrumbs
  *   items={ [
- *     { label: 'Home', to: '/' },
+ *     { label: 'Home', to: '/', search: { filter: 'active' } },
  *     { label: 'Settings', to: '/settings' },
  *     { label: 'General' },
  *   ] }
@@ -65,7 +72,14 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							render={
 								<Link
 									tone="neutral"
-									render={ <RouterLink to={ item.to } /> }
+									render={
+										<RouterLink
+											to={ item.to }
+											search={ item.search as never }
+											params={ item.params as never }
+											hash={ item.hash }
+										/>
+									}
 								/>
 							}
 						>
@@ -87,7 +101,14 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 							render={
 								<Link
 									tone="neutral"
-									render={ <RouterLink to={ lastItem.to } /> }
+									render={
+										<RouterLink
+											to={ lastItem.to }
+											search={ lastItem.search as never }
+											params={ lastItem.params as never }
+											hash={ lastItem.hash }
+										/>
+									}
 								/>
 							}
 						>

--- a/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
+++ b/packages/admin-ui/src/breadcrumbs/stories/index.story.tsx
@@ -43,3 +43,22 @@ export const ThreeLevels: Story = {
 		],
 	},
 };
+
+export const WithSearchParams: Story = {
+	args: {
+		items: [
+			{
+				label: 'Root breadcrumb',
+				to: '/settings',
+				search: { filter: 'active', sort: 'name' },
+			},
+			{
+				label: 'Level 1 breadcrumb',
+				to: '/settings/connectors',
+				search: { filter: 'active' },
+				params: { connectorId: 'example' },
+			},
+			{ label: 'Level 2 breadcrumb' },
+		],
+	},
+};

--- a/packages/admin-ui/src/breadcrumbs/test/index.test.tsx
+++ b/packages/admin-ui/src/breadcrumbs/test/index.test.tsx
@@ -9,9 +9,42 @@ import { render, screen } from '@testing-library/react';
 import { Breadcrumbs } from '..';
 
 jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, children }: { to: string; children: React.ReactNode } ) => (
-		<a href={ to }>{ children }</a>
-	),
+	Link: ( {
+		to,
+		children,
+		search,
+		params,
+		hash,
+	}: {
+		to: string;
+		children: React.ReactNode;
+		search?: Record< string, unknown >;
+		params?: Record< string, unknown >;
+		hash?: string;
+	} ) => {
+		const searchString =
+			search && Object.keys( search ).length
+				? '?' +
+				  new URLSearchParams(
+						Object.fromEntries(
+							Object.entries( search ).map(
+								( [ key, value ] ) => [ key, String( value ) ]
+							)
+						)
+				  ).toString()
+				: '';
+		const href = `${ to }${ searchString }${ hash ? `#${ hash }` : '' }`;
+
+		return (
+			<a
+				href={ href }
+				data-params={ params ? JSON.stringify( params ) : undefined }
+				data-hash={ hash }
+			>
+				{ children }
+			</a>
+		);
+	},
 } ) );
 
 describe( 'Breadcrumbs', () => {
@@ -164,6 +197,100 @@ describe( 'Breadcrumbs', () => {
 			expect(
 				screen.getByRole( 'navigation', { name: 'Breadcrumbs' } )
 			).toBeInTheDocument();
+		} );
+
+		it( 'should forward search from a preceding item to its link', () => {
+			render(
+				<Breadcrumbs
+					items={ [
+						{
+							label: 'Home',
+							to: '/',
+							search: { filter: 'active', page: 2 },
+						},
+						{ label: 'Current Page' },
+					] }
+				/>
+			);
+
+			const link = screen.getByRole( 'link', { name: 'Home' } );
+			expect( link ).toHaveAttribute( 'href', '/?filter=active&page=2' );
+		} );
+
+		it( 'should forward search from the last item when it has `to`', () => {
+			render(
+				<Breadcrumbs
+					items={ [
+						{ label: 'Home', to: '/' },
+						{
+							label: 'Settings',
+							to: '/settings',
+							search: { tab: 'general' },
+						},
+					] }
+				/>
+			);
+
+			const link = screen.getByRole( 'link', { name: 'Settings' } );
+			expect( link ).toHaveAttribute( 'href', '/settings?tab=general' );
+		} );
+
+		it( 'should forward params to breadcrumb links', () => {
+			render(
+				<Breadcrumbs
+					items={ [
+						{
+							label: 'Post',
+							to: '/posts/$postId',
+							params: { postId: '42' },
+						},
+						{ label: 'Edit' },
+					] }
+				/>
+			);
+
+			const link = screen.getByRole( 'link', { name: 'Post' } );
+			expect( link ).toHaveAttribute(
+				'data-params',
+				JSON.stringify( { postId: '42' } )
+			);
+		} );
+
+		it( 'should forward hash to breadcrumb links', () => {
+			render(
+				<Breadcrumbs
+					items={ [
+						{
+							label: 'Settings',
+							to: '/settings',
+							hash: 'advanced',
+						},
+						{ label: 'General' },
+					] }
+				/>
+			);
+
+			const link = screen.getByRole( 'link', { name: 'Settings' } );
+			expect( link ).toHaveAttribute( 'href', '/settings#advanced' );
+			expect( link ).toHaveAttribute( 'data-hash', 'advanced' );
+		} );
+
+		it( 'should render links without search, params, or hash unchanged', () => {
+			render(
+				<Breadcrumbs
+					items={ [
+						{ label: 'Home', to: '/' },
+						{ label: 'Settings', to: '/settings' },
+						{ label: 'General' },
+					] }
+				/>
+			);
+
+			const links = screen.getAllByRole( 'link' );
+			expect( links[ 0 ] ).toHaveAttribute( 'href', '/' );
+			expect( links[ 0 ] ).not.toHaveAttribute( 'data-params' );
+			expect( links[ 0 ] ).not.toHaveAttribute( 'data-hash' );
+			expect( links[ 1 ] ).toHaveAttribute( 'href', '/settings' );
 		} );
 	} );
 } );

--- a/packages/admin-ui/src/breadcrumbs/types.ts
+++ b/packages/admin-ui/src/breadcrumbs/types.ts
@@ -10,6 +10,18 @@ export interface BreadcrumbItem {
 	 * All preceding items should provide a `to` prop.
 	 */
 	to?: string;
+
+	/**
+	 * Router search (query) params to forward to the link, so navigating to this
+	 * crumb preserves URL state. Only applies to items rendered as links.
+	 */
+	search?: Record< string, unknown >;
+
+	/** Router path params to forward to the link (for dynamic `to` paths). */
+	params?: Record< string, unknown >;
+
+	/** URL hash fragment to forward to the link. */
+	hash?: string;
 }
 
 export interface BreadcrumbsProps extends React.HTMLAttributes< HTMLElement > {
@@ -18,6 +30,8 @@ export interface BreadcrumbsProps extends React.HTMLAttributes< HTMLElement > {
 	 * The last item is considered the current item and has an optional `to` prop.
 	 * All preceding items must have a `to` prop — in development mode,
 	 * an error is thrown when this requirement is not met.
+	 * Each item accepts `label`, optional `to`, and optional `search`,
+	 * `params`, and `hash` for link items.
 	 */
 	items: BreadcrumbItem[];
 	/**


### PR DESCRIPTION
## Summary

- Extend `BreadcrumbItem` with optional `search`, `params`, and `hash` fields so breadcrumb links can preserve router URL state (query params, dynamic path params, and hash fragments) when navigating up the trail.
- Forward the new fields to the underlying `@wordpress/route` `Link` in both link render paths (preceding items and last item with `to`).
- Add unit tests, a Storybook story, and README/JSDoc coverage for the new API.

## Backwards compatibility

All new fields are optional. Existing `{ label, to }` usage is unchanged.

## Test plan

- [x] `npm run test:unit -- packages/admin-ui/src/breadcrumbs`
- [x] `npm run lint:js -- packages/admin-ui/src/breadcrumbs`
- [x] `npx tsgo --build packages/admin-ui/tsconfig.json`
- [ ] Optional: open Storybook and verify the `WithSearchParams` Breadcrumbs story under `Admin UI/Breadcrumbs`.


Made with [Cursor](https://cursor.com)