### PR TITLE
Notes: Add a "Resolved" divider above resolved notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -154,13 +154,15 @@ export function useNoteThreads( postId ) {
 			}
 		}
 
-		// Orphans: root threads without a linked block. They only need to come last.
+		// Orphans: root threads without a linked block. They stay with the
+		// active notes (above the "Resolved" separator) since they may still
+		// need attention even though their associated block is gone.
 		const orphans = rootThreads.filter(
 			( thread ) => ! thread.blockClientId
 		);
 
 		return {
-			notes: [ ...unresolved, ...resolved, ...orphans ],
+			notes: [ ...unresolved, ...orphans, ...resolved ],
 			unresolvedNotes: unresolved,
 		};
 	}, [ clientIds, threads, getBlockAttributes ] );

--- a/packages/editor/src/components/collab-sidebar/notes.js
+++ b/packages/editor/src/components/collab-sidebar/notes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { Fragment, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Stack } from '@wordpress/ui';
@@ -238,6 +238,18 @@ export function Notes( { notes, sidebarRef, isFloating = false, styles } ) {
 		}
 	};
 
+	// In the "All notes" view, find where the resolved notes begin so a
+	// "Resolved" divider can be rendered above them. Resolved notes (status
+	// 'approved' with a still-present block) always sort after the active
+	// ones, so the first match marks the boundary. The floating view only
+	// lists unresolved notes, so it needs no divider.
+	const firstResolvedIndex = isFloating
+		? -1
+		: threads.findIndex(
+				( thread ) =>
+					thread.status === 'approved' && !! thread.blockClientId
+		  );
+
 	return (
 		<Stack
 			className="editor-collab-sidebar-panel"
@@ -267,32 +279,43 @@ export function Notes( { notes, sidebarRef, isFloating = false, styles } ) {
 							sidebarRef={ sidebarRef }
 						/>
 					) }
-					{ threads.map( ( thread ) => (
-						<NoteThread
-							key={ thread.id }
-							note={ thread }
-							onAddReply={ onAddReply }
-							onDeleteNote={ handleDelete }
-							onEditNote={ onEditNote }
-							isSelected={ selectedNote === thread.id }
-							sidebarRef={ sidebarRef }
-							floating={
-								isFloating
-									? {
-											y: notePositions[ thread.id ],
-											registerThread,
-											unregisterThread,
-									  }
-									: undefined
-							}
-							onKeyDown={ ( event ) =>
-								navigate(
-									event,
-									thread,
-									selectedNote === thread.id
-								)
-							}
-						/>
+					{ threads.map( ( thread, index ) => (
+						<Fragment key={ thread.id }>
+							{ index === firstResolvedIndex && (
+								<Stack
+									direction="row"
+									align="center"
+									justify="center"
+									className="editor-collab-sidebar-panel__status-separator"
+								>
+									<p>{ __( 'Resolved' ) }</p>
+								</Stack>
+							) }
+							<NoteThread
+								note={ thread }
+								onAddReply={ onAddReply }
+								onDeleteNote={ handleDelete }
+								onEditNote={ onEditNote }
+								isSelected={ selectedNote === thread.id }
+								sidebarRef={ sidebarRef }
+								floating={
+									isFloating
+										? {
+												y: notePositions[ thread.id ],
+												registerThread,
+												unregisterThread,
+										  }
+										: undefined
+								}
+								onKeyDown={ ( event ) =>
+									navigate(
+										event,
+										thread,
+										selectedNote === thread.id
+									)
+								}
+							/>
+						</Fragment>
 					) ) }
 				</>
 			) }

--- a/packages/editor/src/components/collab-sidebar/notes.js
+++ b/packages/editor/src/components/collab-sidebar/notes.js
@@ -4,7 +4,7 @@
 import { Fragment, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Stack } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
@@ -286,9 +286,12 @@ export function Notes( { notes, sidebarRef, isFloating = false, styles } ) {
 									direction="row"
 									align="center"
 									justify="center"
+									gap="sm"
 									className="editor-collab-sidebar-panel__status-separator"
 								>
-									<p>{ __( 'Resolved' ) }</p>
+									<Text variant="heading-sm" render={ <p /> }>
+										{ __( 'Resolved' ) }
+									</Text>
 								</Stack>
 							) }
 							<NoteThread

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -140,10 +140,7 @@
 .editor-collab-sidebar-panel__status-separator p {
 	margin: 0;
 	padding: 0 $grid-unit-10;
-	color: $gray-700;
-	font-size: 11px;
-	font-weight: $font-weight-medium;
-	text-transform: uppercase;
+	font-weight: 600;
 }
 
 .editor-collab-sidebar-panel__more-reply-button {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -124,7 +124,8 @@
 	}
 }
 
-.editor-collab-sidebar-panel__more-reply-separator {
+.editor-collab-sidebar-panel__more-reply-separator,
+.editor-collab-sidebar-panel__status-separator {
 	&::before,
 	&::after {
 		content: "";
@@ -134,6 +135,15 @@
 		background-color: $gray-300;
 		flex: 1;
 	}
+}
+
+.editor-collab-sidebar-panel__status-separator p {
+	margin: 0;
+	padding: 0 $grid-unit-10;
+	color: $gray-700;
+	font-size: 11px;
+	font-weight: $font-weight-medium;
+	text-transform: uppercase;
 }
 
 .editor-collab-sidebar-panel__more-reply-button {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -129,18 +129,10 @@
 	&::before,
 	&::after {
 		content: "";
-		display: block;
-		width: 100%;
+		flex: 1;
 		height: 1px;
 		background-color: $gray-300;
-		flex: 1;
 	}
-}
-
-.editor-collab-sidebar-panel__status-separator p {
-	margin: 0;
-	padding: 0 $grid-unit-10;
-	font-weight: 600;
 }
 
 .editor-collab-sidebar-panel__more-reply-button {

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -271,6 +271,77 @@ test.describe( 'Block Notes', () => {
 		await expect( separator ).toHaveText( 'Resolved' );
 	} );
 
+	test( 'keeps a note whose block was deleted above the "Resolved" divider', async ( {
+		editor,
+		page,
+		blockNoteUtils,
+	} ) => {
+		// First block: its note is orphaned when the block is deleted.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Orphan me.' },
+			comment: 'Note losing its block.',
+		} );
+		// Second block: this note will be resolved.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Keep me.' },
+			comment: 'Note to resolve.',
+		} );
+
+		await blockNoteUtils.openBlockNoteSidebar();
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Resolve the second note.
+		const resolvedThread = sidebar.getByRole( 'treeitem', {
+			name: 'Note: Note to resolve.',
+		} );
+		await resolvedThread.click();
+		await page.getByRole( 'button', { name: 'Resolve' } ).click();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Note marked as resolved.' } )
+		).toBeVisible();
+
+		// Delete the first block via the store, orphaning its note. Clicking
+		// the block in the canvas is unreliable here because the selected
+		// note's block toolbar popover overlaps it.
+		const orphanBlock = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Orphan me.' } );
+		const orphanClientId = await orphanBlock.getAttribute( 'data-block' );
+		await page.evaluate(
+			( clientId ) =>
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.removeBlock( clientId ),
+			orphanClientId
+		);
+
+		// The orphaned note persists and is flagged as detached, rather than
+		// being auto-deleted or moved into the resolved section.
+		const orphanThread = sidebar.getByRole( 'treeitem', {
+			name: 'Original block deleted. Note: Note losing its block.',
+		} );
+		await expect( orphanThread ).toBeVisible();
+
+		const separator = sidebar.locator(
+			'.editor-collab-sidebar-panel__status-separator'
+		);
+		await expect( separator ).toBeVisible();
+
+		// The orphaned note stays with the active notes above the divider;
+		// the resolved note sits below it.
+		const orphanBox = await orphanThread.boundingBox();
+		const separatorBox = await separator.boundingBox();
+		const resolvedBox = await resolvedThread.boundingBox();
+		expect( orphanBox.y ).toBeLessThan( separatorBox.y );
+		expect( separatorBox.y ).toBeLessThan( resolvedBox.y );
+	} );
+
 	test( 'selecting a block or note marks it as an active', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -224,6 +224,53 @@ test.describe( 'Block Notes', () => {
 		).toBeVisible();
 	} );
 
+	test( 'shows a "Resolved" separator above resolved notes', async ( {
+		page,
+		blockNoteUtils,
+	} ) => {
+		// First block: this note stays unresolved.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Block one' },
+			comment: 'Unresolved note.',
+		} );
+		// Second block: this note will be resolved.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Block two' },
+			comment: 'Note to resolve.',
+		} );
+
+		await blockNoteUtils.openBlockNoteSidebar();
+
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		const separator = sidebar.locator(
+			'.editor-collab-sidebar-panel__status-separator'
+		);
+
+		// No resolved notes yet, so the separator is absent.
+		await expect( separator ).toBeHidden();
+
+		// Resolve the second note.
+		const thread = sidebar.getByRole( 'treeitem', {
+			name: 'Note: Note to resolve.',
+		} );
+		await thread.click();
+		await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+		await page.getByRole( 'button', { name: 'Resolve' } ).click();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Note marked as resolved.' } )
+		).toBeVisible();
+
+		// The separator now labels the resolved section.
+		await expect( separator ).toBeVisible();
+		await expect( separator ).toHaveText( 'Resolved' );
+	} );
+
 	test( 'selecting a block or note marks it as an active', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -224,25 +224,31 @@ test.describe( 'Block Notes', () => {
 		).toBeVisible();
 	} );
 
-	test( 'shows a "Resolved" separator above resolved notes', async ( {
+	test( 'shows a "Resolved" divider between active and resolved notes', async ( {
+		editor,
 		page,
 		blockNoteUtils,
 	} ) => {
-		// First block: this note stays unresolved.
+		// First block: this note stays active and unresolved.
 		await blockNoteUtils.addBlockWithNote( {
 			type: 'core/paragraph',
-			attributes: { content: 'Block one' },
-			comment: 'Unresolved note.',
+			attributes: { content: 'Stays active.' },
+			comment: 'Active note.',
 		} );
 		// Second block: this note will be resolved.
 		await blockNoteUtils.addBlockWithNote( {
 			type: 'core/paragraph',
-			attributes: { content: 'Block two' },
+			attributes: { content: 'Resolve me.' },
 			comment: 'Note to resolve.',
+		} );
+		// Third block: its note is orphaned when the block is deleted.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'Orphan me.' },
+			comment: 'Note losing its block.',
 		} );
 
 		await blockNoteUtils.openBlockNoteSidebar();
-
 		const sidebar = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
@@ -250,55 +256,18 @@ test.describe( 'Block Notes', () => {
 			'.editor-collab-sidebar-panel__status-separator'
 		);
 
-		// No resolved notes yet, so the separator is absent.
+		// No resolved notes yet, so the divider is absent.
 		await expect( separator ).toBeHidden();
-
-		// Resolve the second note.
-		const thread = sidebar.getByRole( 'treeitem', {
-			name: 'Note: Note to resolve.',
-		} );
-		await thread.click();
-		await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
-		await page.getByRole( 'button', { name: 'Resolve' } ).click();
-		await expect(
-			page
-				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Note marked as resolved.' } )
-		).toBeVisible();
-
-		// The separator now labels the resolved section.
-		await expect( separator ).toBeVisible();
-		await expect( separator ).toHaveText( 'Resolved' );
-	} );
-
-	test( 'keeps a note whose block was deleted above the "Resolved" divider', async ( {
-		editor,
-		page,
-		blockNoteUtils,
-	} ) => {
-		// First block: its note is orphaned when the block is deleted.
-		await blockNoteUtils.addBlockWithNote( {
-			type: 'core/paragraph',
-			attributes: { content: 'Orphan me.' },
-			comment: 'Note losing its block.',
-		} );
-		// Second block: this note will be resolved.
-		await blockNoteUtils.addBlockWithNote( {
-			type: 'core/paragraph',
-			attributes: { content: 'Keep me.' },
-			comment: 'Note to resolve.',
-		} );
-
-		await blockNoteUtils.openBlockNoteSidebar();
-		const sidebar = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
 
 		// Resolve the second note.
 		const resolvedThread = sidebar.getByRole( 'treeitem', {
 			name: 'Note: Note to resolve.',
 		} );
 		await resolvedThread.click();
+		await expect( resolvedThread ).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
 		await page.getByRole( 'button', { name: 'Resolve' } ).click();
 		await expect(
 			page
@@ -306,7 +275,11 @@ test.describe( 'Block Notes', () => {
 				.filter( { hasText: 'Note marked as resolved.' } )
 		).toBeVisible();
 
-		// Delete the first block via the store, orphaning its note. Clicking
+		// The divider now labels the resolved section.
+		await expect( separator ).toBeVisible();
+		await expect( separator ).toHaveText( 'Resolved' );
+
+		// Delete the second block via the store, orphaning its note. Clicking
 		// the block in the canvas is unreliable here because the selected
 		// note's block toolbar popover overlaps it.
 		const orphanBlock = editor.canvas
@@ -323,23 +296,22 @@ test.describe( 'Block Notes', () => {
 
 		// The orphaned note persists and is flagged as detached, rather than
 		// being auto-deleted or moved into the resolved section.
-		const orphanThread = sidebar.getByRole( 'treeitem', {
-			name: 'Original block deleted. Note: Note losing its block.',
-		} );
-		await expect( orphanThread ).toBeVisible();
+		await expect(
+			sidebar.getByRole( 'treeitem', {
+				name: 'Original block deleted. Note: Note losing its block.',
+			} )
+		).toBeVisible();
 
-		const separator = sidebar.locator(
-			'.editor-collab-sidebar-panel__status-separator'
-		);
-		await expect( separator ).toBeVisible();
-
-		// The orphaned note stays with the active notes above the divider;
-		// the resolved note sits below it.
-		const orphanBox = await orphanThread.boundingBox();
-		const separatorBox = await separator.boundingBox();
-		const resolvedBox = await resolvedThread.boundingBox();
-		expect( orphanBox.y ).toBeLessThan( separatorBox.y );
-		expect( separatorBox.y ).toBeLessThan( resolvedBox.y );
+		// Rows render in DOM order: unresolved notes first, then orphaned ones,
+		// both above the divider, with the resolved note below it.
+		await expect(
+			sidebar.locator( '.editor-collab-sidebar-panel > *' )
+		).toContainText( [
+			'Active note.',
+			'Note losing its block.',
+			'Resolved',
+			'Note to resolve.',
+		] );
 	} );
 
 	test( 'selecting a block or note marks it as an active', async ( {


### PR DESCRIPTION
## What?

Adds a centered **Resolved** divider above the resolved notes in the "All notes" sidebar, so a note's status is easy to scan at a glance.

Fixes #72752.

This reimplements @Mamaduka's proof of concept from #72990 on the refactored collab-sidebar structure (the original PR's `comments.js` no longer exists), and follows the design @jasmussen [marked up on the issue](https://github.com/WordPress/gutenberg/issues/72752#issuecomment-3460182402).

## Why?

When the notes panel is open it shows unresolved, orphaned, and resolved notes in one continuous list with no visual break. There's no clear signal for where the "still needs attention" notes end and the "done" notes begin.

## How?

- `notes.js`: in the "All notes" view, find the first resolved note (status `approved` with a still-present block) and render a `Resolved` divider directly above it. The floating view lists unresolved notes only, so it gets no divider.
- `hooks.js`: orphaned notes (whose associated block was deleted) now sort with the active notes **above** the divider rather than at the very bottom, since they may still need attention. This matches the feedback on #72990 to keep orphaned notes grouped with the unresolved ones.
- `style.scss`: the new `__status-separator` reuses the existing `__more-reply-separator` line treatment, with a small muted, uppercase label.

Scope is intentionally minimal, the consensus subset that both @jasmussen and @desrosj signed off on. It leaves the broader questions (a separate "Detached" section for orphaned notes, or badges) for a follow-up.

## Testing Instructions

[![Test this PR in WordPress Playground](https://img.shields.io/badge/Test%20in%20WordPress%20Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=80019)

1. Create a post and add notes to a few different blocks.
2. Open the **All notes** sidebar (top bar).
3. Resolve one of the notes.
4. Confirm a centered **Resolved** divider appears above the resolved note, separating it from the still-active notes.
5. Reopen the note and confirm the divider disappears when nothing is resolved.

### Testing Instructions for Keyboard

Same as above; the divider is decorative and does not change tree navigation.

## Screenshots or screencast

<img width="1690" height="1384" alt="image" src="https://github.com/user-attachments/assets/aca7e186-2f8f-4c54-90ae-b0dea66447ce" />


Original block deleted for one note (see tagging)
<img width="375" height="" alt="image" src="https://github.com/user-attachments/assets/666691a8-11c4-46e1-b083-05393d5bb969" />