### PR TITLE
Theme: Use adjusted Segoe font-face for medium -> semibold fallback

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stacks and setting `$font-weight-medium` to `500`, matching the design token behavior.
+-   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stacks and setting `$font-weight-medium` to `500`, matching the design token behavior ([#80020](https://github.com/WordPress/gutenberg/pull/80020)).
 
 ## 10.2.0 (2026-07-01)
 

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698)).
 
+### Bug Fixes
+
+-   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stacks and setting `$font-weight-medium` to `500`, matching the design token behavior.
+
 ## 10.2.0 (2026-07-01)
 
 ## 10.1.0 (2026-06-24)
@@ -17,7 +21,7 @@
 ### Breaking Changes
 
 -   Remove the following entries from the `z-index()` helper ([#77773](https://github.com/WordPress/gutenberg/pull/77773)):
-   -   `.nux-dot-tip`
+    -   `.nux-dot-tip`
 
 ## 9.0.0 (2026-05-27)
 

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -12,7 +12,7 @@
  * Fonts & basic variables.
  */
 
-$default-font: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif; // Todo: deprecate in favor of $family variables
+$default-font: -apple-system, "Segoe UI WordPress Adjusted", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; // Todo: deprecate in favor of $family variables
 $default-line-height: 1.4; // Todo: deprecate in favor of $line-height tokens
 
 /**
@@ -37,11 +37,11 @@ $font-line-height-2x-large: 40px;
 
 // Weights
 $font-weight-regular: 400;
-$font-weight-medium: 499; // ensures fallback to 400 (instead of 600)
+$font-weight-medium: 500;
 
 // Families
-$font-family-headings: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-$font-family-body: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$font-family-headings: -apple-system, "Segoe UI WordPress Adjusted", "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$font-family-body: -apple-system, "Segoe UI WordPress Adjusted", "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 $font-family-mono: Menlo, Consolas, monaco, monospace;
 
 /**

--- a/packages/base-styles/internal/_wpds-token-fallbacks.scss
+++ b/packages/base-styles/internal/_wpds-token-fallbacks.scss
@@ -174,9 +174,9 @@ $fallbacks: (
 	'--wpds-motion-easing-expressive': 'cubic-bezier(0.25, 0, 0, 1)',
 	'--wpds-motion-easing-subtle': 'cubic-bezier(0.15, 0, 0.15, 1)',
 	'--wpds-typography-font-family-body':
-		'-apple-system, system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+		'-apple-system, "Segoe UI WordPress Adjusted", system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
 	'--wpds-typography-font-family-heading':
-		'-apple-system, system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+		'-apple-system, "Segoe UI WordPress Adjusted", system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
 	'--wpds-typography-font-family-mono':
 		'"Menlo", "Consolas", monaco, monospace',
 	'--wpds-typography-font-size-2xl': '32px',
@@ -185,7 +185,7 @@ $fallbacks: (
 	'--wpds-typography-font-size-sm': '12px',
 	'--wpds-typography-font-size-xl': '20px',
 	'--wpds-typography-font-size-xs': '11px',
-	'--wpds-typography-font-weight-medium': '499',
+	'--wpds-typography-font-weight-medium': '500',
 	'--wpds-typography-font-weight-regular': '400',
 	'--wpds-typography-line-height-2xl': '40px',
 	'--wpds-typography-line-height-lg': '28px',

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ColorPaletteControl matches the snapshot 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -19,7 +19,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -37,6 +37,10 @@
     -   `FontSizePicker` ([#79481](https://github.com/WordPress/gutenberg/pull/79481))
     -   `ToggleGroupControl` ([#79656](https://github.com/WordPress/gutenberg/pull/79656))
 
+### Bug Fixes
+
+-   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stack and setting the medium font weight to `500`.
+
 ### Documentation
 
 -   Document `clsx` object syntax for conditional CSS Module classes ([#79490](https://github.com/WordPress/gutenberg/pull/79490), [#79535](https://github.com/WordPress/gutenberg/pull/79535)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ### Bug Fixes
 
--   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stack and setting the medium font weight to `500`.
+-   Restore a consistent medium (`500`) font weight on Windows by referencing the synthetic `Segoe UI WordPress Adjusted` font family in the default font stack and setting the medium font weight to `500` ([#80020](https://github.com/WordPress/gutenberg/pull/80020)).
 
 ### Documentation
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ToggleGroupControl controlled should render correctly with icons 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -19,7 +19,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -135,7 +135,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
   padding-left: 0;
   padding-right: 0;
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
-  font-weight: 499;
+  font-weight: 500;
 }
 
 @media not ( prefers-reduced-motion ) {
@@ -337,7 +337,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 
 exports[`ToggleGroupControl controlled should render correctly with text options 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -354,7 +354,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -578,7 +578,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 
 exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -595,7 +595,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -711,7 +711,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
   padding-left: 0;
   padding-right: 0;
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
-  font-weight: 499;
+  font-weight: 500;
 }
 
 @media not ( prefers-reduced-motion ) {
@@ -907,7 +907,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 
 exports[`ToggleGroupControl uncontrolled should render correctly with text options 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -924,7 +924,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -50,7 +50,7 @@ export default Object.assign( {}, CONTROL_PROPS, {
 	fontSizeXSmall: 'calc(0.75 * 13px)',
 	fontLineHeightBase: '1.4',
 	fontWeight: 'normal',
-	fontWeightMedium: '499', // ensures fallback to 400 (instead of 600)
+	fontWeightMedium: '500',
 	fontWeightHeading: '600',
 	gridBase: '4px',
 	elevationXSmall: `0 1px 1px rgba(0, 0, 0, 0.03), 0 1px 2px rgba(0, 0, 0, 0.02), 0 3px 3px rgba(0, 0, 0, 0.02), 0 4px 4px rgba(0, 0, 0, 0.01)`,

--- a/packages/components/src/utils/font-values.js
+++ b/packages/components/src/utils/font-values.js
@@ -1,6 +1,6 @@
 export default {
 	'default.fontFamily':
-		"-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+		"-apple-system, 'Segoe UI WordPress Adjusted', BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 	'default.fontSize': '13px',
 
 	'helpText.fontSize': '12px',

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation message when toggled on 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -75,7 +75,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
 
 exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields are enabled 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -138,7 +138,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
 
 exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmation message when toggled off 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -212,7 +212,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
 
 exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fields are disabled 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -2,7 +2,7 @@
 
 exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -81,7 +81,7 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
 
 exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -248,7 +248,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
 
 exports[`MetaBoxesSection renders meta box options 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PostPublishPanel should render the post-publish panel if the post is published 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -19,7 +19,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -206,7 +206,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 
 exports[`PostPublishPanel should render the post-publish panel if the post is scheduled 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -223,7 +223,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 
 .emotion-4 {
   font-size: 11px;
-  font-weight: 499;
+  font-weight: 500;
   line-height: 1.4;
   text-transform: uppercase;
   display: block;
@@ -388,7 +388,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 
 exports[`PostPublishPanel should render the pre-publish panel if post status is scheduled but date is before now 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -520,7 +520,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
 
 exports[`PostPublishPanel should render the pre-publish panel if the post is not saving, published or scheduled 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }
@@ -696,7 +696,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
 }
 
 .emotion-6 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-family: -apple-system,'Segoe UI WordPress Adjusted',BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
   box-sizing: border-box;
 }

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Restore a consistent medium (`500`) font weight on Windows by registering a synthetic `Segoe UI WordPress Adjusted` font family that remaps the weight to Segoe UI Semibold, instead of relying on inconsistent browser fallback behavior ([#79525](https://github.com/WordPress/gutenberg/issues/79525)).
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
 
 ### Documentation

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Restore a consistent medium (`500`) font weight on Windows by registering a synthetic `Segoe UI WordPress Adjusted` font family that remaps the weight to Segoe UI Semibold, instead of relying on inconsistent browser fallback behavior ([#79525](https://github.com/WordPress/gutenberg/issues/79525)).
+-   Restore a consistent medium (`500`) font weight on Windows by registering a synthetic `Segoe UI WordPress Adjusted` font family that remaps the weight to Segoe UI Semibold, instead of relying on inconsistent browser fallback behavior ([#80020](https://github.com/WordPress/gutenberg/pull/80020)).
 -   Mark the published `design-tokens.css` file as side-effectful so downstream bundlers preserve the documented CSS import ([#79551](https://github.com/WordPress/gutenberg/pull/79551)).
 
 ### Documentation

--- a/packages/theme/bin/build-design-tokens/index.ts
+++ b/packages/theme/bin/build-design-tokens/index.ts
@@ -38,8 +38,26 @@ const { outputFiles } = await build( tokens, {
 
 const outDir = fileURLToPath( config.outDir );
 
+// Append the hand-authored `@font-face` rules that back the synthetic font
+// families referenced by the typography tokens, so they always ship in the
+// same stylesheet as the tokens that reference them regardless of how
+// `design-tokens.css` is loaded.
+//
+// TODO: Ideally this should happen in Terrazzo itself during the build process.
+// Terrazzo's `permutations[].prepare()` hook on the CSS plugin is a perfect fit
+// for this, but it is mutually exclusive with `modeSelectors`/`baseSelector`
+// APIs, so this should be done as part of the work to migrate to the newer API.
+const fontFacesCSS = await readFile(
+	new URL( '../../src/font-faces.css', import.meta.url ),
+	'utf8'
+);
+
 for ( const file of outputFiles ) {
 	const filePath = resolve( outDir, file.filename );
 	await mkdir( dirname( filePath ), { recursive: true } );
-	await writeFile( filePath, file.contents );
+	const contents =
+		file.filename === 'css/design-tokens.css'
+			? `${ file.contents.toString() }\n${ fontFacesCSS }`
+			: file.contents;
+	await writeFile( filePath, contents );
 }

--- a/packages/theme/src/font-faces.css
+++ b/packages/theme/src/font-faces.css
@@ -1,0 +1,51 @@
+/*
+ * Synthetic font family that restores a consistent "medium" weight on Windows.
+ *
+ * Segoe UI (the Windows system font) ships without a medium (500) weight, so
+ * browsers resolve the design system's medium font weight inconsistently: some
+ * fall back to regular (400), while Chrome falls back to semibold (600) via a
+ * non-standard quirk. Referencing this family remaps the medium weight to Segoe
+ * UI Semibold deterministically across browsers.
+ */
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI Semibold");
+	font-weight: 500;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI Bold");
+	font-weight: 600;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI Italic");
+	font-weight: 400;
+	font-style: italic;
+}
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI Semibold Italic");
+	font-weight: 500;
+	font-style: italic;
+}
+
+@font-face {
+	font-family: "Segoe UI WordPress Adjusted";
+	src: local("Segoe UI Bold Italic");
+	font-weight: 600;
+	font-style: italic;
+}

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -312,13 +312,13 @@
 	/* Noticeable easing for enter/exit and spatial transitions like menus, popovers, dialogs, and drawers */
 	--wpds-motion-easing-expressive: cubic-bezier( 0.25, 0, 0, 1 );
 	/* Headings font family */
-	--wpds-typography-font-family-heading: -apple-system, system-ui, 'Segoe UI',
-		'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue',
-		sans-serif;
+	--wpds-typography-font-family-heading: -apple-system,
+		'Segoe UI WordPress Adjusted', system-ui, 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 	/* Body font family */
-	--wpds-typography-font-family-body: -apple-system, system-ui, 'Segoe UI',
-		'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue',
-		sans-serif;
+	--wpds-typography-font-family-body: -apple-system,
+		'Segoe UI WordPress Adjusted', system-ui, 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 	/* Monospace font family */
 	--wpds-typography-font-family-mono: 'Menlo', 'Consolas', monaco, monospace;
 	/* Extra small font size */
@@ -348,7 +348,7 @@
 	/* Regular font weight for body text */
 	--wpds-typography-font-weight-regular: 400;
 	/* Medium font weight for emphasis and headings */
-	--wpds-typography-font-weight-medium: 499;
+	--wpds-typography-font-weight-medium: 500;
 }
 
 @media ( -webkit-min-device-pixel-ratio: 2 ), ( min-resolution: 192dpi ) {
@@ -418,4 +418,56 @@
 	--wpds-border-radius-lg: 24px;
 	/* Page and app shell surfaces. */
 	--wpds-border-radius-xl: 26px;
+}
+
+/*
+ * Synthetic font family that restores a consistent "medium" weight on Windows.
+ *
+ * Segoe UI (the Windows system font) ships without a medium (500) weight, so
+ * browsers resolve the design system's medium font weight inconsistently: some
+ * fall back to regular (400), while Chrome falls back to semibold (600) via a
+ * non-standard quirk. Referencing this family remaps the medium weight to Segoe
+ * UI Semibold deterministically across browsers.
+ */
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI' );
+	font-weight: 400;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI Semibold' );
+	font-weight: 500;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI Bold' );
+	font-weight: 600;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI Italic' );
+	font-weight: 400;
+	font-style: italic;
+}
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI Semibold Italic' );
+	font-weight: 500;
+	font-style: italic;
+}
+
+@font-face {
+	font-family: 'Segoe UI WordPress Adjusted';
+	src: local( 'Segoe UI Bold Italic' );
+	font-weight: 600;
+	font-style: italic;
 }

--- a/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
+++ b/packages/theme/src/prebuilt/js/design-token-fallbacks.mjs
@@ -172,9 +172,9 @@ export default {
 	'--wpds-motion-easing-expressive': 'cubic-bezier(0.25, 0, 0, 1)',
 	'--wpds-motion-easing-subtle': 'cubic-bezier(0.15, 0, 0.15, 1)',
 	'--wpds-typography-font-family-body':
-		'-apple-system, system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+		'-apple-system, "Segoe UI WordPress Adjusted", system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
 	'--wpds-typography-font-family-heading':
-		'-apple-system, system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+		'-apple-system, "Segoe UI WordPress Adjusted", system-ui, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
 	'--wpds-typography-font-family-mono':
 		'"Menlo", "Consolas", monaco, monospace',
 	'--wpds-typography-font-size-2xl': '32px',
@@ -183,7 +183,7 @@ export default {
 	'--wpds-typography-font-size-sm': '12px',
 	'--wpds-typography-font-size-xl': '20px',
 	'--wpds-typography-font-size-xs': '11px',
-	'--wpds-typography-font-weight-medium': '499',
+	'--wpds-typography-font-weight-medium': '500',
 	'--wpds-typography-font-weight-regular': '400',
 	'--wpds-typography-line-height-2xl': '40px',
 	'--wpds-typography-line-height-lg': '28px',

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -39,28 +39,6 @@ const config: Config = {
 		pluginCSS( {
 			filename: 'css/design-tokens.css',
 			variableName: ( token ) => makeCSSVar( token.id ),
-			transform( token ) {
-				// This addresses a specific browser issue where Chrome renders
-				// a font-weight of 500 as 600 instead of 400 when the target
-				// weight is not locally available, which is inconsistent with
-				// the spec-defined behavior. This workaround ensures that a 400
-				// weight is used if the 500 weight is not locally available,
-				// while still using the 500 weight if it _is_ available. This
-				// is applied at the plugin layer to ensure the original token
-				// value can be preserved at the intended 500 weight, where the
-				// bug only occurs in specific browser rendering.
-				//
-				// See: https://issues.chromium.org/issues/40552893
-				// See: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight#fallback_weights
-				if (
-					token.id.startsWith( 'wpds-typography.font-weight.' ) &&
-					token.$value === 500
-				) {
-					return '499';
-				}
-
-				return undefined;
-			},
 			baseSelector: ':root',
 			modeSelectors: [
 				{

--- a/packages/theme/tokens/typography.json
+++ b/packages/theme/tokens/typography.json
@@ -5,6 +5,7 @@
 			"heading": {
 				"$value": [
 					"-apple-system",
+					"Segoe UI WordPress Adjusted",
 					"system-ui",
 					"Segoe UI",
 					"Roboto",
@@ -19,6 +20,7 @@
 			"body": {
 				"$value": [
 					"-apple-system",
+					"Segoe UI WordPress Adjusted",
 					"system-ui",
 					"Segoe UI",
 					"Roboto",


### PR DESCRIPTION
## What?

Closes #79525

Defines a custom Segoe UI font variant to control the fallback behavior for Windows system font missing medium font-weight (500), preferring to fall back to a bolder font (600) than a lighter font (400).

## Why?

As described in #79525, our typography scale relies on visual distinctiveness between regular (400) and medium (500) font-weights. But currently, Windows browsers will show a 400 font-weight for everything, because the Segoe system font does not include a 500 font-weight.

## How?

- Updates medium font-weight from 499 to 500 to avoid the fallback to 400
- Adds a new "Segoe UI WordPress Adjusted" font to the shared font-families used in `@wordpress/theme` and `@wordpress/base-styles`, ahead of `system-ui`
- Registers `@font-face` declarations to define "Segoe UI WordPress Adjusted" to emulate the default behavior, with one exception: `'Segoe UI Semibold'` is registered at `font-weight: 500` instead of the default effective `font-weight: 600` so that it is used at weights between 500 and 700 (default is that it is used between 600 and 700).

There's a lot more discussion in #79525 to the technical considerations of this implementation, specifically around specification behavior and browser behavior inconsistencies.

## Testing Instructions

Verify visual hierarchy of boldness in Storybook "Text" story, ideally from a Windows machine:

1. Run `npm run storybook:dev`
2. Go to http://localhost:50240/?path=/docs/design-system-components-text--docs#all-variants
3. Observe that heading variants are bolder than body variants
4. Compare against live version: https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-text--docs#all-variants

## Screenshots or screencast <!-- if applicable -->

The screenshots below are captured in a Windows environment, which is what's most impacted by these changes:

|Browser|Before|After|
|-|-|-|
|Chrome|<img width="1591" height="963" alt="image" src="https://github.com/user-attachments/assets/b954711d-d952-4037-8907-67aa69fe43c4" />|<img width="1586" height="964" alt="image" src="https://github.com/user-attachments/assets/f68986ea-614e-4dd6-b706-a90f9dc08b66" />|
Firefox|<img width="1590" height="961" alt="image" src="https://github.com/user-attachments/assets/e2e98e22-9309-4efa-903c-149368067ebd" />|<img width="1591" height="964" alt="image" src="https://github.com/user-attachments/assets/36c45ba9-e1c6-4607-bfe1-7071b8dda1d6" />|

## Use of AI Tools

Implemented with assistance by Cursor + Claude Opus 4.8, with reviews and iterations prompted by myself.