### PR TITLE
data-wp-input: Interactivity API two-way input binding directive

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/directive-input",
+	"title": "E2E Interactivity tests - directive input",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * HTML for testing the directive `data-wp-input`.
+ *
+ * @package gutenberg-test-interactive-blocks
+ */
+?>
+
+<div data-wp-interactive="directive-input">
+	<!-- Basic text input binding -->
+	<div>
+		<p data-wp-text="state.text" data-testid="text-output">hello</p>
+		<input
+			type="text"
+			data-testid="text-input"
+			data-wp-input="state.text"
+			value="hello"
+		/>
+	</div>
+
+	<!-- Checkbox (auto-detect) -->
+	<div>
+		<p data-wp-text="state.checkedVal" data-testid="checkbox-output">false</p>
+		<input
+			type="checkbox"
+			data-testid="checkbox-input"
+			data-wp-input="state.checkedVal"
+		/>
+	</div>
+
+	<!-- Number input (type preservation) -->
+	<div>
+		<p data-wp-text="state.num" data-testid="number-output">0</p>
+		<input
+			type="number"
+			data-testid="number-input"
+			data-wp-input="state.num"
+			value="0"
+		/>
+	</div>
+
+	<!-- Select element -->
+	<div>
+		<p data-wp-text="state.pet" data-testid="select-output">dog</p>
+		<select
+			data-testid="select-input"
+			data-wp-input="state.pet"
+		>
+			<option value="dog">Dog</option>
+			<option value="cat">Cat</option>
+		</select>
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -51,6 +51,18 @@
 		</select>
 	</div>
 
+	<!-- 4b. Single select (no default) -->
+	<div>
+		<p data-wp-text="state.selectNone" data-testid="select-none-output"></p>
+		<select
+			data-testid="select-none-input"
+			data-wp-input="state.selectNone"
+		>
+			<option value="x">X</option>
+			<option value="y">Y</option>
+		</select>
+	</div>
+
 	<!-- 5. Radio group -->
 	<div>
 		<p data-wp-text="state.petRadio" data-testid="radio-output">dog</p>
@@ -72,6 +84,29 @@
 				value="cat"
 			/>
 			Cat
+		</label>
+	</div>
+
+	<!-- 5b. Radio group (no default) -->
+	<div>
+		<p data-wp-text="state.radioNone" data-testid="radio-none-output"></p>
+		<label>
+			<input
+				type="radio"
+				data-testid="radio-none-x"
+				data-wp-input="state.radioNone"
+				value="x"
+			/>
+			X
+		</label>
+		<label>
+			<input
+				type="radio"
+				data-testid="radio-none-y"
+				data-wp-input="state.radioNone"
+				value="y"
+			/>
+			Y
 		</label>
 	</div>
 

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -109,15 +109,15 @@
 		</select>
 	</div>
 
-	<!-- 9. Checkbox group (explicit indices → array) -->
+	<!-- 9. Checkbox group (top-level properties) -->
 	<div>
-		<p data-wp-text="state.tags.0" data-testid="checkbox-group-output-a">a</p>
-		<p data-wp-text="state.tags.1" data-testid="checkbox-group-output-b"></p>
+		<p data-wp-text="state.tags0" data-testid="checkbox-group-output-a">a</p>
+		<p data-wp-text="state.tags1" data-testid="checkbox-group-output-b"></p>
 		<label>
 			<input
 				type="checkbox"
 				data-testid="checkbox-group-a"
-				data-wp-input="state.tags.0"
+				data-wp-input="state.tags0"
 				value="a"
 				checked
 			/>
@@ -127,7 +127,7 @@
 			<input
 				type="checkbox"
 				data-testid="checkbox-group-b"
-				data-wp-input="state.tags.1"
+				data-wp-input="state.tags1"
 				value="b"
 			/>
 			B

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -329,6 +329,25 @@
 		</button>
 	</div>
 
+	<!-- 15. File input -->
+	<div>
+		<p data-wp-text="state.fileCount" data-testid="file-count-output">0</p>
+		<input
+			type="file"
+			data-testid="file-input"
+			data-wp-input="state.fileData"
+		/>
+
+		<div data-wp-context='{ "ctxFileData": [] }'>
+			<p data-wp-text="context.ctxFileData" data-testid="ctx-file-count-output"></p>
+			<input
+				type="file"
+				data-testid="ctx-file-input"
+				data-wp-input="context.ctxFileData"
+			/>
+		</div>
+	</div>
+
 	<!-- 11. Element→signal seeding (state.seededVal NOT defined in view.js) -->
 	<div>
 		<p data-wp-text="state.seededVal" data-testid="seed-output"></p>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -331,7 +331,7 @@
 
 	<!-- 15. File input -->
 	<div>
-		<p data-wp-text="state.fileCount" data-testid="file-count-output">0</p>
+		<p data-wp-text="state.fileName" data-testid="file-name-output"></p>
 		<input
 			type="file"
 			data-testid="file-input"
@@ -339,7 +339,7 @@
 		/>
 
 		<div data-wp-context='{ "ctxFileData": [] }'>
-			<p data-wp-text="context.ctxFileData" data-testid="ctx-file-count-output"></p>
+			<p data-wp-text="context.ctxFileData.0.name" data-testid="ctx-file-name-output"></p>
 			<input
 				type="file"
 				data-testid="ctx-file-input"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -7,7 +7,7 @@
 ?>
 
 <div data-wp-interactive="directive-input">
-	<!-- Basic text input binding -->
+	<!-- 1. Basic text input binding -->
 	<div>
 		<p data-wp-text="state.text" data-testid="text-output">hello</p>
 		<input
@@ -18,7 +18,7 @@
 		/>
 	</div>
 
-	<!-- Checkbox (auto-detect) -->
+	<!-- 2. Checkbox (auto-detect) -->
 	<div>
 		<p data-wp-text="state.checkedVal" data-testid="checkbox-output">false</p>
 		<input
@@ -28,7 +28,7 @@
 		/>
 	</div>
 
-	<!-- Number input (type preservation) -->
+	<!-- 3. Number input (type preservation) -->
 	<div>
 		<p data-wp-text="state.num" data-testid="number-output">0</p>
 		<input
@@ -39,7 +39,7 @@
 		/>
 	</div>
 
-	<!-- Select element -->
+	<!-- 4. Single select -->
 	<div>
 		<p data-wp-text="state.pet" data-testid="select-output">dog</p>
 		<select
@@ -49,5 +49,133 @@
 			<option value="dog">Dog</option>
 			<option value="cat">Cat</option>
 		</select>
+	</div>
+
+	<!-- 5. Radio group -->
+	<div>
+		<p data-wp-text="state.petRadio" data-testid="radio-output">dog</p>
+		<label>
+			<input
+				type="radio"
+				data-testid="radio-dog"
+				data-wp-input="state.petRadio"
+				value="dog"
+				checked
+			/>
+			Dog
+		</label>
+		<label>
+			<input
+				type="radio"
+				data-testid="radio-cat"
+				data-wp-input="state.petRadio"
+				value="cat"
+			/>
+			Cat
+		</label>
+	</div>
+
+	<!-- 6. Range input -->
+	<div>
+		<p data-wp-text="state.rangeVal" data-testid="range-output">50</p>
+		<input
+			type="range"
+			data-testid="range-input"
+			data-wp-input="state.rangeVal"
+			value="50"
+		/>
+	</div>
+
+	<!-- 7. Textarea -->
+	<div>
+		<p data-wp-text="state.textareaVal" data-testid="textarea-output">default</p>
+		<textarea
+			data-testid="textarea-input"
+			data-wp-input="state.textareaVal"
+		>default</textarea>
+	</div>
+
+	<!-- 8. Multiple select -->
+	<div>
+		<p data-wp-text="state.multiPet" data-testid="multiselect-output">dog</p>
+		<select
+			multiple
+			data-testid="multiselect-input"
+			data-wp-input="state.multiPet"
+		>
+			<option value="dog" selected>Dog</option>
+			<option value="cat">Cat</option>
+			<option value="bird">Bird</option>
+		</select>
+	</div>
+
+	<!-- 9. Checkbox group (explicit indices → array) -->
+	<div>
+		<p data-wp-text="state.tags.0" data-testid="checkbox-group-output-a">a</p>
+		<p data-wp-text="state.tags.1" data-testid="checkbox-group-output-b"></p>
+		<label>
+			<input
+				type="checkbox"
+				data-testid="checkbox-group-a"
+				data-wp-input="state.tags.0"
+				value="a"
+				checked
+			/>
+			A
+		</label>
+		<label>
+			<input
+				type="checkbox"
+				data-testid="checkbox-group-b"
+				data-wp-input="state.tags.1"
+				value="b"
+			/>
+			B
+		</label>
+	</div>
+
+	<!-- 10. Toggle buttons (signal→element re-render verification) -->
+	<div>
+		<button
+			data-testid="toggle-text"
+			data-wp-on--click="actions.toggleText"
+		>
+			Toggle text
+		</button>
+		<button
+			data-testid="toggle-checked"
+			data-wp-on--click="actions.toggleChecked"
+		>
+			Toggle checked
+		</button>
+		<button
+			data-testid="toggle-num"
+			data-wp-on--click="actions.toggleNum"
+		>
+			Toggle num
+		</button>
+		<button
+			data-testid="toggle-pet"
+			data-wp-on--click="actions.togglePet"
+		>
+			Toggle pet
+		</button>
+		<button
+			data-testid="toggle-multipet"
+			data-wp-on--click="actions.toggleMultiPet"
+		>
+			Toggle multiPet
+		</button>
+	</div>
+
+	<!-- 11. Element→signal seeding (state.seededVal NOT defined in view.js) -->
+	<div>
+		<p data-wp-text="state.seededVal" data-testid="seed-output"></p>
+		<input
+			type="text"
+			data-testid="seed-input"
+			data-wp-input="state.seededVal"
+			value="seeded-from-html"
+		/>
 	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/render.php
@@ -16,6 +16,22 @@
 			data-wp-input="state.text"
 			value="hello"
 		/>
+
+		<div data-wp-context='{ "ctxText": "ctx-hello" }'>
+			<p data-wp-text="context.ctxText" data-testid="ctx-text-output">ctx-hello</p>
+			<input
+				type="text"
+				data-testid="ctx-text-input"
+				data-wp-input="context.ctxText"
+				value="ctx-hello"
+			/>
+			<button
+				data-testid="toggle-ctx-text"
+				data-wp-on--click="actions.toggleCtxText"
+			>
+				Toggle ctx text
+			</button>
+		</div>
 	</div>
 
 	<!-- 2. Checkbox (auto-detect) -->
@@ -26,6 +42,21 @@
 			data-testid="checkbox-input"
 			data-wp-input="state.checkedVal"
 		/>
+
+		<div data-wp-context='{ "ctxChecked": false }'>
+			<p data-wp-text="context.ctxChecked" data-testid="ctx-checkbox-output">false</p>
+			<input
+				type="checkbox"
+				data-testid="ctx-checkbox-input"
+				data-wp-input="context.ctxChecked"
+			/>
+			<button
+				data-testid="toggle-ctx-checked"
+				data-wp-on--click="actions.toggleCtxChecked"
+			>
+				Toggle ctx checked
+			</button>
+		</div>
 	</div>
 
 	<!-- 3. Number input (type preservation) -->
@@ -37,6 +68,22 @@
 			data-wp-input="state.num"
 			value="0"
 		/>
+
+		<div data-wp-context='{ "ctxNum": 0 }'>
+			<p data-wp-text="context.ctxNum" data-testid="ctx-number-output">0</p>
+			<input
+				type="number"
+				data-testid="ctx-number-input"
+				data-wp-input="context.ctxNum"
+				value="0"
+			/>
+			<button
+				data-testid="toggle-ctx-num"
+				data-wp-on--click="actions.toggleCtxNum"
+			>
+				Toggle ctx num
+			</button>
+		</div>
 	</div>
 
 	<!-- 4. Single select -->
@@ -49,6 +96,23 @@
 			<option value="dog">Dog</option>
 			<option value="cat">Cat</option>
 		</select>
+
+		<div data-wp-context='{ "ctxPet": "dog" }'>
+			<p data-wp-text="context.ctxPet" data-testid="ctx-select-output">dog</p>
+			<select
+				data-testid="ctx-select-input"
+				data-wp-input="context.ctxPet"
+			>
+				<option value="dog">Dog</option>
+				<option value="cat">Cat</option>
+			</select>
+			<button
+				data-testid="toggle-ctx-pet"
+				data-wp-on--click="actions.toggleCtxPet"
+			>
+				Toggle ctx pet
+			</button>
+		</div>
 	</div>
 
 	<!-- 4b. Single select (no default) -->
@@ -85,6 +149,29 @@
 			/>
 			Cat
 		</label>
+
+		<div data-wp-context='{ "ctxRadioPet": "dog" }'>
+			<p data-wp-text="context.ctxRadioPet" data-testid="ctx-radio-output">dog</p>
+			<label>
+				<input
+					type="radio"
+					data-testid="ctx-radio-dog"
+					data-wp-input="context.ctxRadioPet"
+					value="dog"
+					checked
+				/>
+				Dog
+			</label>
+			<label>
+				<input
+					type="radio"
+					data-testid="ctx-radio-cat"
+					data-wp-input="context.ctxRadioPet"
+					value="cat"
+				/>
+				Cat
+			</label>
+		</div>
 	</div>
 
 	<!-- 5b. Radio group (no default) -->
@@ -119,6 +206,16 @@
 			data-wp-input="state.rangeVal"
 			value="50"
 		/>
+
+		<div data-wp-context='{ "ctxRangeVal": 50 }'>
+			<p data-wp-text="context.ctxRangeVal" data-testid="ctx-range-output">50</p>
+			<input
+				type="range"
+				data-testid="ctx-range-input"
+				data-wp-input="context.ctxRangeVal"
+				value="50"
+			/>
+		</div>
 	</div>
 
 	<!-- 7. Textarea -->
@@ -128,6 +225,14 @@
 			data-testid="textarea-input"
 			data-wp-input="state.textareaVal"
 		>default</textarea>
+
+		<div data-wp-context='{ "ctxTextareaVal": "default" }'>
+			<p data-wp-text="context.ctxTextareaVal" data-testid="ctx-textarea-output">default</p>
+			<textarea
+				data-testid="ctx-textarea-input"
+				data-wp-input="context.ctxTextareaVal"
+			>default</textarea>
+		</div>
 	</div>
 
 	<!-- 8. Multiple select -->
@@ -142,7 +247,28 @@
 			<option value="cat">Cat</option>
 			<option value="bird">Bird</option>
 		</select>
+
+		<div data-wp-context='{ "ctxMultiPet": ["dog"] }'>
+			<p data-wp-text="context.ctxMultiPet" data-testid="ctx-multiselect-output">dog</p>
+			<select
+				multiple
+				data-testid="ctx-multiselect-input"
+				data-wp-input="context.ctxMultiPet"
+			>
+				<option value="dog" selected>Dog</option>
+				<option value="cat">Cat</option>
+				<option value="bird">Bird</option>
+			</select>
+			<button
+				data-testid="toggle-ctx-multipet"
+				data-wp-on--click="actions.toggleCtxMultiPet"
+			>
+				Toggle ctx multiPet
+			</button>
+		</div>
 	</div>
+
+
 
 	<!-- 9. Checkbox group (top-level properties) -->
 	<div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -1,13 +1,39 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext } from '@wordpress/interactivity';
+import { store } from '@wordpress/interactivity';
 
-const { state } = store( 'directive-input', {
+const { state, actions } = store( 'directive-input', {
 	state: {
 		text: 'hello',
 		checkedVal: false,
 		num: 0,
 		pet: 'dog',
+		petRadio: 'dog',
+		rangeVal: 50,
+		textareaVal: 'default',
+		multiPet: [ 'dog' ],
+		tags: [ 'a', '' ],
+	},
+	actions: {
+		toggleText() {
+			state.text = state.text === 'hello' ? 'world' : 'hello';
+		},
+		toggleChecked() {
+			state.checkedVal = ! state.checkedVal;
+		},
+		toggleNum() {
+			state.num = 99;
+		},
+		togglePet() {
+			const next = { dog: 'cat', cat: 'bird', bird: 'dog' };
+			state.pet = next[ state.pet ] || 'dog';
+		},
+		toggleMultiPet() {
+			state.multiPet =
+				state.multiPet[ 0 ] === 'dog'
+					? [ 'cat', 'bird' ]
+					: [ 'dog' ];
+		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -13,7 +13,8 @@ const { state, actions } = store( 'directive-input', {
 		rangeVal: 50,
 		textareaVal: 'default',
 		multiPet: [ 'dog' ],
-		tags: [ 'a', '' ],
+		tags0: 'a',
+		tags1: '',
 	},
 	actions: {
 		toggleText() {

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -15,6 +15,8 @@ const { state, actions } = store( 'directive-input', {
 		multiPet: [ 'dog' ],
 		tags0: 'a',
 		tags1: '',
+		selectNone: '',
+		radioNone: '',
 	},
 	actions: {
 		toggleText() {

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -17,6 +17,10 @@ const { state, actions } = store( 'directive-input', {
 		tags1: '',
 		selectNone: '',
 		radioNone: '',
+		fileData: [],
+		get fileCount() {
+			return state.fileData.length;
+		},
 	},
 	actions: {
 		toggleText() {

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -18,8 +18,8 @@ const { state, actions } = store( 'directive-input', {
 		selectNone: '',
 		radioNone: '',
 		fileData: [],
-		get fileCount() {
-			return state.fileData.length;
+		get fileName() {
+			return state.fileData[ 0 ]?.name || '';
 		},
 	},
 	actions: {

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -3,7 +3,7 @@
  */
 import { store, getContext } from '@wordpress/interactivity';
 
-const { state, actions } = store( 'directive-input', {
+const { state } = store( 'directive-input', {
 	state: {
 		text: 'hello',
 		checkedVal: false,
@@ -38,9 +38,7 @@ const { state, actions } = store( 'directive-input', {
 		},
 		toggleMultiPet() {
 			state.multiPet =
-				state.multiPet[ 0 ] === 'dog'
-					? [ 'cat', 'bird' ]
-					: [ 'dog' ];
+				state.multiPet[ 0 ] === 'dog' ? [ 'cat', 'bird' ] : [ 'dog' ];
 		},
 
 		// ---- context-based actions ----
@@ -65,9 +63,7 @@ const { state, actions } = store( 'directive-input', {
 		toggleCtxMultiPet() {
 			const ctx = getContext();
 			ctx.ctxMultiPet =
-				ctx.ctxMultiPet[ 0 ] === 'dog'
-					? [ 'cat', 'bird' ]
-					: [ 'dog' ];
+				ctx.ctxMultiPet[ 0 ] === 'dog' ? [ 'cat', 'bird' ] : [ 'dog' ];
 		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+const { state } = store( 'directive-input', {
+	state: {
+		text: 'hello',
+		checkedVal: false,
+		num: 0,
+		pet: 'dog',
+	},
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-input/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store } from '@wordpress/interactivity';
+import { store, getContext } from '@wordpress/interactivity';
 
 const { state, actions } = store( 'directive-input', {
 	state: {
@@ -35,6 +35,33 @@ const { state, actions } = store( 'directive-input', {
 		toggleMultiPet() {
 			state.multiPet =
 				state.multiPet[ 0 ] === 'dog'
+					? [ 'cat', 'bird' ]
+					: [ 'dog' ];
+		},
+
+		// ---- context-based actions ----
+		toggleCtxText() {
+			const ctx = getContext();
+			ctx.ctxText =
+				ctx.ctxText === 'ctx-hello' ? 'ctx-world' : 'ctx-hello';
+		},
+		toggleCtxChecked() {
+			const ctx = getContext();
+			ctx.ctxChecked = ! ctx.ctxChecked;
+		},
+		toggleCtxNum() {
+			const ctx = getContext();
+			ctx.ctxNum = ctx.ctxNum === 0 ? 99 : 0;
+		},
+		toggleCtxPet() {
+			const ctx = getContext();
+			const next = { dog: 'cat', cat: 'bird', bird: 'dog' };
+			ctx.ctxPet = next[ ctx.ctxPet ] || 'dog';
+		},
+		toggleCtxMultiPet() {
+			const ctx = getContext();
+			ctx.ctxMultiPet =
+				ctx.ctxMultiPet[ 0 ] === 'dog'
 					? [ 'cat', 'bird' ]
 					: [ 'dog' ];
 		},

--- a/packages/interactivity/src/directives/index.ts
+++ b/packages/interactivity/src/directives/index.ts
@@ -11,6 +11,7 @@ import './context';
 import './each';
 import './ignore';
 import './init';
+import './input';
 import './on';
 import './router-region';
 import './run';

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -81,17 +81,15 @@ const detectDescriptor = (
 				// Datastar parity: default value "on" → boolean;
 				// custom values reflect the checked value or empty string.
 				if ( input.value !== 'on' ) {
-					return signalType === 'boolean'
-						? input.checked
-						: input.checked
-						? input.value
-						: '';
+					if ( signalType === 'boolean' ) {
+						return input.checked;
+					}
+					return input.checked ? input.value : '';
 				}
-				return signalType === 'string'
-					? input.checked
-						? input.value
-						: ''
-					: input.checked;
+				if ( signalType === 'string' ) {
+					return input.checked ? input.value : '';
+				}
+				return input.checked;
 			},
 		};
 	}
@@ -328,9 +326,14 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 				current = peek( syncParent, syncLeaf );
 			}
 		}
-		if ( current != null && current !== PENDING_GETTER ) {
+		if (
+			current !== null &&
+			current !== undefined &&
+			current !== PENDING_GETTER
+		) {
 			syncElementProp( el, desc, current, props );
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ signalValue ] );
 
 	// ---- wire up event handlers ----

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -27,13 +27,6 @@ import { store, setByPath } from '../store';
 import { PENDING_GETTER, peek } from '../proxies/state';
 
 /* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-/* setByPath is imported from ../store */
-
-
-/* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -91,8 +84,8 @@ const detectDescriptor = (
 					return signalType === 'boolean'
 						? input.checked
 						: input.checked
-							? input.value
-							: '';
+						? input.value
+						: '';
 				}
 				return signalType === 'string'
 					? input.checked
@@ -214,6 +207,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		return;
 	}
 
+	const path = entry.value;
 	const props = element.props as Record< string, unknown >;
 
 	// ---- file inputs – handled via useInit + FileReader ----
@@ -238,15 +232,15 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 										typeof reader.result === 'string'
 											? reader.result
 											: '';
-								const match = result.match( dataURIRegex );
-								if ( globalThis.SCRIPT_DEBUG ) {
-									if ( ! match?.groups ) {
-										warn(
-											'data-wp-input: Invalid data URI for file input.'
-										);
+									const match = result.match( dataURIRegex );
+									if ( globalThis.SCRIPT_DEBUG ) {
+										if ( ! match?.groups ) {
+											warn(
+												'data-wp-input: Invalid data URI for file input.'
+											);
+										}
 									}
-								}
-								resolve( {
+									resolve( {
 										name: f.name,
 										contents: match?.groups?.contents ?? '',
 										mime: match?.groups?.mime ?? '',
@@ -258,7 +252,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 				).then( ( signalFiles ) => {
 					setByPath(
 						store( entryForFile.namespace ),
-						entryForFile.value,
+						path,
 						signalFiles
 					);
 				} );
@@ -289,11 +283,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		props[ desc.prop ] = props.value;
 	}
 
-	// ---- initial DOM sync (pre-paint): seed & sync ----
-	// NOTE: no dependencies → runs after every render.  This is necessary
-	// for <select multiple> where Preact diff does not update selected
-	// options; for all other element types the sync is a no-op when the
-	// props already match the DOM.
+	// ---- initial DOM sync: seed & element sync ----
 	useLayoutEffect( () => {
 		const el = ( element.ref as { current?: InputBindingElement } ).current;
 		if ( ! el ) {
@@ -306,7 +296,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 			el.type === 'radio' &&
 			! el.name
 		) {
-			el.name = entry.value;
+			el.name = path;
 		}
 
 		// Element→signal seeding (ifMissing: adopt DOM value when signal is
@@ -314,20 +304,22 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		if ( signalValue === undefined ) {
 			const elValue = desc.toSignal( el, 'undefined' );
 			if ( elValue !== undefined ) {
-				setByPath( store( entry.namespace ), entry.value, elValue );
+				setByPath( store( entry.namespace ), path, elValue );
 			}
 		}
 
 		// Signal→element sync (re-read current value via peek — avoids
 		// evaluate/scope issues inside effects).
-		const syncParts = entry.value.split( '.' );
+		const syncParts = path.split( '.' );
 		const syncLeaf = syncParts.pop();
-		let current: unknown = undefined;
+		let current: unknown;
 		if ( syncLeaf && syncParts.length ) {
 			const syncRoot = store( entry.namespace );
 			const syncParent = syncParts.reduce(
 				( prev: any, key: string ): any => {
-					if ( ! prev ) return undefined;
+					if ( ! prev ) {
+						return undefined;
+					}
 					return peek( prev, key );
 				},
 				syncRoot
@@ -339,7 +331,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		if ( current != null && current !== PENDING_GETTER ) {
 			syncElementProp( el, desc, current, props );
 		}
-	} );
+	}, [ signalValue ] );
 
 	// ---- wire up event handlers ----
 	for ( const eventName of desc.events ) {
@@ -363,7 +355,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 				return;
 			}
 
-			setByPath( store( entry.namespace ), entry.value, raw );
+			setByPath( store( entry.namespace ), path, raw );
 		};
 	}
 } );

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -322,6 +322,30 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 	const path = entry.value;
 	const props = element.props as Record< string, unknown >;
 
+	// Create write/read roots at render time (scope is active).
+	// NOTE: these are created early so file input and all other code paths
+	// can share the same write mechanism.  They do not depend on signalValue.
+
+	const stateRoot = store( entry.namespace );
+
+	const contextRoot = path.startsWith( 'context.' )
+		? getContext( entry.namespace )
+		: undefined;
+
+	const writeSignal = createSignalWriter(
+		entry.namespace,
+		path,
+		stateRoot,
+		contextRoot
+	);
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const readSignal = createSignalReader(
+		entry.namespace,
+		path,
+		stateRoot,
+		contextRoot
+	);
+
 	// ---- file inputs – handled via useInit + FileReader ----
 	if ( ( props.type as string | undefined ) === 'file' ) {
 		useInit( () => {
@@ -376,24 +400,6 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 	if ( signalValue === PENDING_GETTER ) {
 		return;
 	}
-
-	// Capture write/read roots at render time (scope is active).
-	const stateRoot = store( entry.namespace );
-	const contextRoot = path.startsWith( 'context.' )
-		? getContext( entry.namespace )
-		: undefined;
-	const writeSignal = createSignalWriter(
-		entry.namespace,
-		path,
-		stateRoot,
-		contextRoot
-	);
-	const readSignal = createSignalReader(
-		entry.namespace,
-		path,
-		stateRoot,
-		contextRoot
-	);
 
 	const elementType =
 		typeof element.type === 'string' ? element.type.toLowerCase() : null;

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -1,0 +1,304 @@
+/**
+ * data-wp-input — Two-way input binding directive.
+ *
+ * Collapses `data-wp-bind--value` + `data-wp-on--input` into one attribute.
+ * Reads the signal value from the store and writes it back on input events.
+ *
+ * Auto-detects element type for correct binding:
+ *   - checkbox → binds `checked` property, fires on `change`
+ *   - radio    → binds `checked` based on value match
+ *   - range/number → preserves numeric type via unary `+`
+ *   - file     → reads files as base64-encoded data URIs
+ *   - select   → single value on `change`; `multiple` → array of values
+ *   - text, textarea → binds `value`, fires on `input`
+ *
+ * Examples:
+ * ```html
+ * <input data-wp-input="state.name" />
+ * <input type="checkbox" data-wp-input="state.isActive" />
+ * <input type="number" data-wp-input="state.count" />
+ * <textarea data-wp-input="state.description"></textarea>
+ * <select data-wp-input="state.country">...</select>
+ * ```
+ */
+import { directive, isDefaultDirectiveSuffix } from '../hooks';
+import { useInit } from '../utils';
+import { store } from '../store';
+import { PENDING_GETTER } from '../proxies/state';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Parses a directive value like "state.foo.bar" and sets the leaf
+ * property on the store's state via the proxy, which triggers signal
+ * updates.
+ *
+ * @param ns    The store namespace.
+ * @param path  Dot-separated path starting with "state" (e.g. "state.text").
+ * @param value The value to assign.
+ */
+const setStateValue = ( ns: string, path: string, value: unknown ): void => {
+	const parts = path.split( '.' ).slice( 1 ); // Remove "state"
+	if ( parts.length === 0 ) {
+		return;
+	}
+	const { state } = store( ns );
+	let obj: any = state;
+	for ( let i = 0; i < parts.length - 1; i++ ) {
+		obj = obj[ parts[ i ] ];
+	}
+	obj[ parts[ parts.length - 1 ] ] = value;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface BindDescriptor {
+	prop: string;
+	events: string[];
+	fromSignal?: (
+		signalValue: unknown,
+		props: Record< string, unknown >
+	) => unknown;
+	/**
+	 * Converts the element's current value to the appropriate type
+	 * for the signal.  Receives the signal's typeof as `signalType`.
+	 * Return `undefined` to signal "no change" (used by radio uncheck).
+	 */
+	toSignal: (
+		el: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+		signalType: string
+	) => unknown;
+}
+
+type SignalFile = {
+	name: string;
+	contents: string;
+	mime: string;
+};
+
+type InputBindingElement =
+	| HTMLInputElement
+	| HTMLSelectElement
+	| HTMLTextAreaElement;
+
+const dataURIRegex = /^data:(?<mime>[^;]+);base64,(?<contents>.*)$/;
+
+/* ------------------------------------------------------------------ */
+/*  Descriptor detection                                               */
+/* ------------------------------------------------------------------ */
+
+const detectDescriptor = (
+	elementType: string | null,
+	props: Record< string, unknown >
+): BindDescriptor => {
+	const type = props.type as string | undefined;
+
+	if ( type === 'checkbox' ) {
+		return {
+			prop: 'checked',
+			events: [ 'change' ],
+			fromSignal: ( signalValue ) => Boolean( signalValue ),
+			toSignal: ( el, signalType ) => {
+				const input = el as HTMLInputElement;
+				if ( signalType === 'boolean' ) {
+					return input.checked;
+				}
+				return input.checked ? input.value : '';
+			},
+		};
+	}
+
+	if ( type === 'radio' ) {
+		return {
+			prop: 'checked',
+			events: [ 'change' ],
+			fromSignal: ( signalValue, currentProps ) => {
+				const inputValue = currentProps.value;
+				return signalValue === inputValue;
+			},
+			toSignal: ( el, signalType ) => {
+				const input = el as HTMLInputElement;
+				if ( ! input.checked ) {
+					return undefined;
+				}
+				return signalType === 'number' ? +input.value : input.value;
+			},
+		};
+	}
+
+	if ( type === 'range' || type === 'number' ) {
+		return {
+			prop: 'value',
+			events: [ 'input' ],
+			toSignal: ( el ) => +( el as HTMLInputElement ).value,
+		};
+	}
+
+	if ( elementType === 'select' ) {
+		return {
+			prop: 'value',
+			events: [ 'change' ],
+			toSignal: ( el ) => {
+				const select = el as HTMLSelectElement;
+				if ( select.multiple ) {
+					return Array.from(
+						select.selectedOptions,
+						( option ) => option.value
+					);
+				}
+				return select.value;
+			},
+		};
+	}
+
+	// text, email, password, search, url, tel, textarea, select …
+	return {
+		prop: 'value',
+		events: [ 'input' ],
+		toSignal: ( el, signalType ) =>
+			signalType === 'number'
+				? +( el as HTMLInputElement ).value
+				: ( el as HTMLInputElement ).value,
+	};
+};
+
+const syncElementProp = (
+	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+	desc: BindDescriptor,
+	value: unknown,
+	props: Record< string, unknown >
+) => {
+	const propValue = desc.fromSignal ? desc.fromSignal( value, props ) : value;
+
+	if ( element instanceof HTMLSelectElement && element.multiple ) {
+		const selectedValues = new Set(
+			Array.isArray( propValue ) ? propValue.map( String ) : []
+		);
+		Array.from( element.options ).forEach( ( option ) => {
+			option.selected = selectedValues.has( option.value );
+		} );
+		return;
+	}
+
+	( element as any )[ desc.prop ] =
+		propValue === null || propValue === undefined ? '' : propValue;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Directive                                                          */
+/* ------------------------------------------------------------------ */
+
+directive( 'input', ( { directives, element, evaluate } ) => {
+	const entries = directives.input;
+	const entry = entries.find( isDefaultDirectiveSuffix );
+	if ( ! entry || typeof entry.value !== 'string' ) {
+		return;
+	}
+
+	const props = element.props as Record< string, unknown >;
+
+	// ---- file inputs – handled via useInit + FileReader ----
+	if ( ( props.type as string | undefined ) === 'file' ) {
+		const entryForFile = entry;
+		useInit( () => {
+			const el = ( element.ref as { current?: HTMLInputElement } )
+				.current;
+			if ( ! el ) {
+				return;
+			}
+
+			const syncFiles = () => {
+				const files = [ ...( el.files || [] ) ];
+				Promise.all(
+					files.map(
+						( f ) =>
+							new Promise< SignalFile >( ( resolve ) => {
+								const reader = new FileReader();
+								reader.onload = () => {
+									const result =
+										typeof reader.result === 'string'
+											? reader.result
+											: '';
+									const match = result.match( dataURIRegex );
+									resolve( {
+										name: f.name,
+										contents: match?.groups?.contents ?? '',
+										mime: match?.groups?.mime ?? '',
+									} );
+								};
+								reader.readAsDataURL( f );
+							} )
+					)
+				).then( ( signalFiles ) => {
+					setStateValue(
+						entryForFile.namespace,
+						entryForFile.value,
+						signalFiles
+					);
+				} );
+			};
+
+			el.addEventListener( 'change', syncFiles );
+			return () => el.removeEventListener( 'change', syncFiles );
+		} );
+		return;
+	}
+
+	// ---- read signal, detect type ----
+	const signalValue = evaluate( entry );
+	if ( signalValue === PENDING_GETTER ) {
+		return;
+	}
+	const elementType =
+		typeof element.type === 'string' ? element.type.toLowerCase() : null;
+	const desc = detectDescriptor( elementType, props );
+	const signalType = typeof signalValue;
+
+	// ---- set initial element prop (VDOM will diff) ----
+	if ( signalValue !== undefined && signalValue !== null ) {
+		props[ desc.prop ] = desc.fromSignal
+			? desc.fromSignal( signalValue, props )
+			: signalValue;
+	} else if ( props.value !== undefined && desc.prop === 'value' ) {
+		props[ desc.prop ] = props.value;
+	}
+
+	useInit( () => {
+		const el = ( element.ref as { current?: InputBindingElement }).current;
+		if ( ! el ) {
+			return;
+		}
+
+		syncElementProp( el, desc, signalValue, props );
+	} );
+
+	// ---- wire up event handlers ----
+	for ( const eventName of desc.events ) {
+		const propName = `on${ eventName }` as string;
+		const existing = props[ propName ] as
+			| ( ( e: Event ) => void )
+			| undefined;
+
+		props[ propName ] = ( event: Event ) => {
+			if ( existing ) {
+				existing( event );
+			}
+
+			const target = event.target as
+				| HTMLInputElement
+				| HTMLSelectElement
+				| HTMLTextAreaElement;
+			const raw = desc.toSignal( target, signalType );
+
+			if ( raw === undefined ) {
+				return;
+			}
+
+			setStateValue( entry.namespace, entry.value, raw );
+		};
+	}
+} );

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -22,35 +22,16 @@
  * ```
  */
 import { directive, isDefaultDirectiveSuffix } from '../hooks';
-import { useInit } from '../utils';
-import { store } from '../store';
+import { useInit, useLayoutEffect } from '../utils';
+import { store, setByPath } from '../store';
 import { PENDING_GETTER } from '../proxies/state';
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-/**
- * Parses a directive value like "state.foo.bar" and sets the leaf
- * property on the store's state via the proxy, which triggers signal
- * updates.
- *
- * @param ns    The store namespace.
- * @param path  Dot-separated path starting with "state" (e.g. "state.text").
- * @param value The value to assign.
- */
-const setStateValue = ( ns: string, path: string, value: unknown ): void => {
-	const parts = path.split( '.' ).slice( 1 ); // Remove "state"
-	if ( parts.length === 0 ) {
-		return;
-	}
-	const { state } = store( ns );
-	let obj: any = state;
-	for ( let i = 0; i < parts.length - 1; i++ ) {
-		obj = obj[ parts[ i ] ];
-	}
-	obj[ parts[ parts.length - 1 ] ] = value;
-};
+/* setByPath is imported from ../store */
+
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -104,10 +85,20 @@ const detectDescriptor = (
 			fromSignal: ( signalValue ) => Boolean( signalValue ),
 			toSignal: ( el, signalType ) => {
 				const input = el as HTMLInputElement;
-				if ( signalType === 'boolean' ) {
-					return input.checked;
+				// Datastar parity: default value "on" → boolean;
+				// custom values reflect the checked value or empty string.
+				if ( input.value !== 'on' ) {
+					return signalType === 'boolean'
+						? input.checked
+						: input.checked
+							? input.value
+							: '';
 				}
-				return input.checked ? input.value : '';
+				return signalType === 'string'
+					? input.checked
+						? input.value
+						: ''
+					: input.checked;
 			},
 		};
 	}
@@ -234,8 +225,8 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 							} )
 					)
 				).then( ( signalFiles ) => {
-					setStateValue(
-						entryForFile.namespace,
+					setByPath(
+						store( entryForFile.namespace ),
 						entryForFile.value,
 						signalFiles
 					);
@@ -267,14 +258,38 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		props[ desc.prop ] = props.value;
 	}
 
-	useInit( () => {
-		const el = ( element.ref as { current?: InputBindingElement }).current;
+	// ---- initial DOM sync (pre-paint): seed & sync ----
+	useLayoutEffect( () => {
+		const el = ( element.ref as { current?: InputBindingElement } ).current;
 		if ( ! el ) {
 			return;
 		}
 
-		syncElementProp( el, desc, signalValue, props );
-	} );
+		// Radio auto-name (Datastar parity: native grouping when name absent).
+		if (
+			el instanceof HTMLInputElement &&
+			el.type === 'radio' &&
+			! el.name
+		) {
+			el.name = entry.value;
+		}
+
+		// Element→signal seeding (ifMissing: adopt DOM value when signal is
+		// undefined — Datastar's `boundPath` + `mergePaths({ ifMissing })`).
+		if ( signalValue === undefined ) {
+			const elValue = desc.toSignal( el, 'undefined' );
+			if ( elValue !== undefined ) {
+				setByPath( store( entry.namespace ), entry.value, elValue );
+			}
+		}
+
+		// Signal→element sync (re-read via evaluate in effect context;
+		// signal reads inside effects do not subscribe the component).
+		const current = evaluate( entry );
+		if ( current != null && current !== PENDING_GETTER ) {
+			syncElementProp( el, desc, current, props );
+		}
+	}, [] );
 
 	// ---- wire up event handlers ----
 	for ( const eventName of desc.events ) {
@@ -298,7 +313,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 				return;
 			}
 
-			setStateValue( entry.namespace, entry.value, raw );
+			setByPath( store( entry.namespace ), entry.value, raw );
 		};
 	}
 } );

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -22,7 +22,7 @@
  * ```
  */
 import { directive, isDefaultDirectiveSuffix } from '../hooks';
-import { useInit, useLayoutEffect } from '../utils';
+import { useInit, useLayoutEffect, useWatch, warn } from '../utils';
 import { store, setByPath } from '../store';
 import { PENDING_GETTER } from '../proxies/state';
 
@@ -146,7 +146,31 @@ const detectDescriptor = (
 		};
 	}
 
-	// text, email, password, search, url, tel, textarea, select …
+	// Custom elements (web components with a dash in the tag name).
+	if ( elementType && elementType.includes( '-' ) ) {
+		return {
+			prop: 'value',
+			events: [ 'input', 'change' ],
+			toSignal: ( el, signalType ) =>
+				signalType === 'number'
+					? +( el as HTMLInputElement ).value
+					: ( el as any ).value,
+		};
+	}
+
+	// Textarea — explicit branch for readability.
+	if ( elementType === 'textarea' ) {
+		return {
+			prop: 'value',
+			events: [ 'input' ],
+			toSignal: ( el, signalType ) =>
+				signalType === 'number'
+					? +( el as HTMLTextAreaElement ).value
+					: ( el as HTMLTextAreaElement ).value,
+		};
+	}
+
+	// text, email, password, search, url, tel, …
 	return {
 		prop: 'value',
 		events: [ 'input' ],
@@ -214,8 +238,13 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 										typeof reader.result === 'string'
 											? reader.result
 											: '';
-									const match = result.match( dataURIRegex );
-									resolve( {
+									const match = result.match( dataURIRegex );								if ( globalThis.SCRIPT_DEBUG ) {
+									if ( ! match?.groups ) {
+										warn(
+											'data-wp-input: Invalid data URI for file input.'
+										);
+									}
+								}									resolve( {
 										name: f.name,
 										contents: match?.groups?.contents ?? '',
 										mime: match?.groups?.mime ?? '',
@@ -290,6 +319,22 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 			syncElementProp( el, desc, current, props );
 		}
 	}, [] );
+
+	// ---- multi-select: keep element in sync with signal (Preact diff
+	// does not handle <select multiple>) ----
+	if ( elementType === 'select' && props.multiple ) {
+		useWatch( () => {
+			const el = ( element.ref as { current?: HTMLSelectElement } )
+				.current;
+			if ( ! el ) {
+				return;
+			}
+			const current = evaluate( entry );
+			if ( Array.isArray( current ) ) {
+				syncElementProp( el, desc, current, props );
+			}
+		} );
+	}
 
 	// ---- wire up event handlers ----
 	for ( const eventName of desc.events ) {

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -23,8 +23,9 @@
  */
 import { directive, isDefaultDirectiveSuffix } from '../hooks';
 import { useInit, useLayoutEffect, warn } from '../utils';
-import { store, setByPath } from '../store';
+import { store } from '../store';
 import { PENDING_GETTER, peek } from '../proxies/state';
+import { getContext } from '../scopes';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -198,6 +199,119 @@ const syncElementProp = (
 /*  Directive                                                          */
 /* ------------------------------------------------------------------ */
 
+/* ------------------------------------------------------------------ */
+/*  writeSignal / readSignal helpers                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Writes a value to the signal at the given path (e.g. `'state.text'` or
+ * `'context.item.name'`).  Captures the store/context root at render time
+ * so it works correctly both during render and in event handlers.
+ *
+ * The helper navigates through the proxy normally (no peek), so each
+ * intermediate key returns a proxified nested object, and the final leaf
+ * assignment goes through the proxy's set/defineProperty traps → reactive.
+ * @param ns
+ * @param path
+ * @param stateRoot
+ * @param contextRoot
+ */
+const createSignalWriter = (
+	ns: string,
+	path: string,
+	stateRoot: Record< string, unknown >,
+	contextRoot: object | undefined
+) => {
+	const parts = path.split( '.' );
+	const leaf = parts.pop()!;
+	const rootKey = parts[ 0 ];
+
+	if ( rootKey === 'state' ) {
+		return ( value: unknown ) => {
+			let obj: any = stateRoot;
+			for ( const key of parts ) {
+				obj = obj[ key ];
+			}
+			obj[ leaf ] = value;
+		};
+	}
+
+	if ( rootKey === 'context' ) {
+		if ( ! contextRoot ) {
+			return () => undefined;
+		}
+		// For context paths the root IS the context; drop the 'context'
+		// segment.
+		const ctxParts = parts.slice( 1 );
+		return ( value: unknown ) => {
+			let obj: any = contextRoot;
+			for ( const key of ctxParts ) {
+				obj = obj[ key ];
+			}
+			obj[ leaf ] = value;
+		};
+	}
+
+	return () => undefined;
+};
+
+/**
+ * Reads the current value at the given path using `peek` (non-subscribing).
+ * Used inside the layout effect for signal→element sync.
+ * @param ns
+ * @param path
+ * @param stateRoot
+ * @param contextRoot
+ */
+const createSignalReader = (
+	ns: string,
+	path: string,
+	stateRoot: Record< string, unknown >,
+	contextRoot: object | undefined
+) => {
+	const parts = path.split( '.' );
+	const leaf = parts.pop()!;
+	const rootKey = parts[ 0 ];
+
+	if ( rootKey === 'state' ) {
+		return () => {
+			let obj: any = stateRoot;
+			for ( const key of parts ) {
+				if ( obj === null || obj === undefined ) {
+					return undefined;
+				}
+				obj = peek( obj, key );
+			}
+			if ( obj === null || obj === undefined ) {
+				return undefined;
+			}
+			return peek( obj, leaf );
+		};
+	}
+
+	if ( rootKey === 'context' ) {
+		if ( ! contextRoot ) {
+			return () => undefined;
+		}
+		const ctxParts = parts.slice( 1 );
+		return () => {
+			let obj: any = contextRoot;
+			for ( const key of ctxParts ) {
+				if ( obj === null || obj === undefined ) {
+					return undefined;
+				}
+				obj = peek( obj, key );
+			}
+			if ( obj === null || obj === undefined ) {
+				return undefined;
+			}
+			return peek( obj, leaf );
+		};
+	}
+
+	return () => undefined;
+};
+
 directive( 'input', ( { directives, element, evaluate } ) => {
 	const entries = directives.input;
 	const entry = entries.find( isDefaultDirectiveSuffix );
@@ -210,7 +324,6 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 
 	// ---- file inputs – handled via useInit + FileReader ----
 	if ( ( props.type as string | undefined ) === 'file' ) {
-		const entryForFile = entry;
 		useInit( () => {
 			const el = ( element.ref as { current?: HTMLInputElement } )
 				.current;
@@ -248,11 +361,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 							} )
 					)
 				).then( ( signalFiles ) => {
-					setByPath(
-						store( entryForFile.namespace ),
-						path,
-						signalFiles
-					);
+					writeSignal( signalFiles );
 				} );
 			};
 
@@ -267,6 +376,25 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 	if ( signalValue === PENDING_GETTER ) {
 		return;
 	}
+
+	// Capture write/read roots at render time (scope is active).
+	const stateRoot = store( entry.namespace );
+	const contextRoot = path.startsWith( 'context.' )
+		? getContext( entry.namespace )
+		: undefined;
+	const writeSignal = createSignalWriter(
+		entry.namespace,
+		path,
+		stateRoot,
+		contextRoot
+	);
+	const readSignal = createSignalReader(
+		entry.namespace,
+		path,
+		stateRoot,
+		contextRoot
+	);
+
 	const elementType =
 		typeof element.type === 'string' ? element.type.toLowerCase() : null;
 	const desc = detectDescriptor( elementType, props );
@@ -302,30 +430,13 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 		if ( signalValue === undefined ) {
 			const elValue = desc.toSignal( el, 'undefined' );
 			if ( elValue !== undefined ) {
-				setByPath( store( entry.namespace ), path, elValue );
+				writeSignal( elValue );
 			}
 		}
 
 		// Signal→element sync (re-read current value via peek — avoids
 		// evaluate/scope issues inside effects).
-		const syncParts = path.split( '.' );
-		const syncLeaf = syncParts.pop();
-		let current: unknown;
-		if ( syncLeaf && syncParts.length ) {
-			const syncRoot = store( entry.namespace );
-			const syncParent = syncParts.reduce(
-				( prev: any, key: string ): any => {
-					if ( ! prev ) {
-						return undefined;
-					}
-					return peek( prev, key );
-				},
-				syncRoot
-			);
-			if ( syncParent ) {
-				current = peek( syncParent, syncLeaf );
-			}
-		}
+		const current = readSignal();
 		if (
 			current !== null &&
 			current !== undefined &&
@@ -358,7 +469,7 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 				return;
 			}
 
-			setByPath( store( entry.namespace ), path, raw );
+			writeSignal( raw );
 		};
 	}
 } );

--- a/packages/interactivity/src/directives/input.ts
+++ b/packages/interactivity/src/directives/input.ts
@@ -22,9 +22,9 @@
  * ```
  */
 import { directive, isDefaultDirectiveSuffix } from '../hooks';
-import { useInit, useLayoutEffect, useWatch, warn } from '../utils';
+import { useInit, useLayoutEffect, warn } from '../utils';
 import { store, setByPath } from '../store';
-import { PENDING_GETTER } from '../proxies/state';
+import { PENDING_GETTER, peek } from '../proxies/state';
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -238,13 +238,15 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 										typeof reader.result === 'string'
 											? reader.result
 											: '';
-									const match = result.match( dataURIRegex );								if ( globalThis.SCRIPT_DEBUG ) {
+								const match = result.match( dataURIRegex );
+								if ( globalThis.SCRIPT_DEBUG ) {
 									if ( ! match?.groups ) {
 										warn(
 											'data-wp-input: Invalid data URI for file input.'
 										);
 									}
-								}									resolve( {
+								}
+								resolve( {
 										name: f.name,
 										contents: match?.groups?.contents ?? '',
 										mime: match?.groups?.mime ?? '',
@@ -288,6 +290,10 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 	}
 
 	// ---- initial DOM sync (pre-paint): seed & sync ----
+	// NOTE: no dependencies → runs after every render.  This is necessary
+	// for <select multiple> where Preact diff does not update selected
+	// options; for all other element types the sync is a no-op when the
+	// props already match the DOM.
 	useLayoutEffect( () => {
 		const el = ( element.ref as { current?: InputBindingElement } ).current;
 		if ( ! el ) {
@@ -312,29 +318,28 @@ directive( 'input', ( { directives, element, evaluate } ) => {
 			}
 		}
 
-		// Signal→element sync (re-read via evaluate in effect context;
-		// signal reads inside effects do not subscribe the component).
-		const current = evaluate( entry );
+		// Signal→element sync (re-read current value via peek — avoids
+		// evaluate/scope issues inside effects).
+		const syncParts = entry.value.split( '.' );
+		const syncLeaf = syncParts.pop();
+		let current: unknown = undefined;
+		if ( syncLeaf && syncParts.length ) {
+			const syncRoot = store( entry.namespace );
+			const syncParent = syncParts.reduce(
+				( prev: any, key: string ): any => {
+					if ( ! prev ) return undefined;
+					return peek( prev, key );
+				},
+				syncRoot
+			);
+			if ( syncParent ) {
+				current = peek( syncParent, syncLeaf );
+			}
+		}
 		if ( current != null && current !== PENDING_GETTER ) {
 			syncElementProp( el, desc, current, props );
 		}
-	}, [] );
-
-	// ---- multi-select: keep element in sync with signal (Preact diff
-	// does not handle <select multiple>) ----
-	if ( elementType === 'select' && props.multiple ) {
-		useWatch( () => {
-			const el = ( element.ref as { current?: HTMLSelectElement } )
-				.current;
-			if ( ! el ) {
-				return;
-			}
-			const current = evaluate( entry );
-			if ( Array.isArray( current ) ) {
-				syncElementProp( el, desc, current, props );
-			}
-		} );
-	}
+	} );
 
 	// ---- wire up event handlers ----
 	for ( const eventName of desc.events ) {

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -275,37 +275,6 @@ export const parseServerData = ( dom = document ) => {
 	return {};
 };
 
-/**
- * Sets a value in the store at a specific dot-separated path (e.g.
- * "state.user.name").  Navigates from the given root object using
- * {@link peek} (non-subscribing) so the caller is not subscribed to
- * intermediate properties.
- *
- * @param root  The root object (e.g. `store( ns )`).
- * @param path  Dot-separated path to the property (e.g. `"state.text"`).
- * @param value The value to set.
- */
-export const setByPath = (
-	root: Record< string, unknown >,
-	path: string,
-	value: unknown
-): void => {
-	const parts = path.split( '.' );
-	const leaf = parts.pop();
-	if ( ! leaf || ! parts.length ) {
-		return;
-	}
-	const parent = parts.reduce( ( prev: any, key: string ): any => {
-		if ( ! prev ) {
-			return undefined;
-		}
-		return peek( prev, key );
-	}, root );
-	if ( parent ) {
-		parent[ leaf ] = value;
-	}
-};
-
 export const populateServerData = ( data?: {
 	state?: Record< string, unknown >;
 	config?: Record< string, unknown >;
@@ -343,15 +312,17 @@ export const populateServerData = ( data?: {
 						st
 					);
 
-					// The derived state prop is considered a pending getter
-					// only if its value is a plain object, which is how
-					// closures are serialized from PHP.
+					// Get the descriptor of the derived state prop.
 					const desc = Object.getOwnPropertyDescriptor(
 						parent,
 						prop
 					);
+
+					// The derived state prop is considered a pending getter
+					// only if its value is a plain object, which is how
+					// closures are serialized from PHP.
 					if ( isPlainObject( desc?.value ) ) {
-						setByPath( st, path, PENDING_GETTER );
+						parent[ prop ] = PENDING_GETTER;
 					}
 				} );
 			}

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -295,15 +295,12 @@ export const setByPath = (
 	if ( ! leaf || ! parts.length ) {
 		return;
 	}
-	const parent = parts.reduce(
-		( prev: any, key: string ): any => {
-			if ( ! prev ) {
-				return undefined;
-			}
-			return peek( prev, key );
-		},
-		root
-	);
+	const parent = parts.reduce( ( prev: any, key: string ): any => {
+		if ( ! prev ) {
+			return undefined;
+		}
+		return peek( prev, key );
+	}, root );
 	if ( parent ) {
 		parent[ leaf ] = value;
 	}

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -275,6 +275,40 @@ export const parseServerData = ( dom = document ) => {
 	return {};
 };
 
+/**
+ * Sets a value in the store at a specific dot-separated path (e.g.
+ * "state.user.name").  Navigates from the given root object using
+ * {@link peek} (non-subscribing) so the caller is not subscribed to
+ * intermediate properties.
+ *
+ * @param root  The root object (e.g. `store( ns )`).
+ * @param path  Dot-separated path to the property (e.g. `"state.text"`).
+ * @param value The value to set.
+ */
+export const setByPath = (
+	root: Record< string, unknown >,
+	path: string,
+	value: unknown
+): void => {
+	const parts = path.split( '.' );
+	const leaf = parts.pop();
+	if ( ! leaf || ! parts.length ) {
+		return;
+	}
+	const parent = parts.reduce(
+		( prev: any, key: string ): any => {
+			if ( ! prev ) {
+				return undefined;
+			}
+			return peek( prev, key );
+		},
+		root
+	);
+	if ( parent ) {
+		parent[ leaf ] = value;
+	}
+};
+
 export const populateServerData = ( data?: {
 	state?: Record< string, unknown >;
 	config?: Record< string, unknown >;
@@ -312,17 +346,15 @@ export const populateServerData = ( data?: {
 						st
 					);
 
-					// Get the descriptor of the derived state prop.
+					// The derived state prop is considered a pending getter
+					// only if its value is a plain object, which is how
+					// closures are serialized from PHP.
 					const desc = Object.getOwnPropertyDescriptor(
 						parent,
 						prop
 					);
-
-					// The derived state prop is considered a pending getter
-					// only if its value is a plain object, which is how
-					// closures are serialized from PHP.
 					if ( isPlainObject( desc?.value ) ) {
-						parent[ prop ] = PENDING_GETTER;
+						setByPath( st, path, PENDING_GETTER );
 					}
 				} );
 			}

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -379,6 +379,33 @@ test.describe( 'data-wp-input', () => {
 	} );
 
 	/* ------------------------------------------------------------------ */
+	/*  15. File input                                                     */
+	/* ------------------------------------------------------------------ */
+	test.skip( 'should handle file input', async ( { page } ) => {
+		const countOutput = page.getByTestId( 'file-count-output' );
+		const fileInput = page.getByTestId( 'file-input' );
+
+		await expect( countOutput ).toHaveText( '0' );
+
+		await fileInput.setInputFiles( {
+			name: 'test.txt',
+			mimeType: 'text/plain',
+			buffer: Buffer.from( 'hello world' ),
+		} );
+
+		// The file input runs FileReader asynchronously; wait for it.
+		await page.waitForFunction(
+			() => {
+				const el = document.querySelector(
+					'[data-testid="file-count-output"]'
+				);
+				return el && el.textContent === '1';
+			},
+			{ timeout: 15000 }
+		);
+	} );
+
+	/* ------------------------------------------------------------------ */
 	/*  11. Element→signal seeding (state undefined → adopt DOM value)     */
 	/* ------------------------------------------------------------------ */
 	test( 'should retain HTML value and respond to input for undefined state', async ( {

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'data-wp-input', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		await utils.addPostWithBlock( 'test/directive-input' );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'test/directive-input' ) );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should bind text input value to state', async ( { page } ) => {
+		const output = page.getByTestId( 'text-output' );
+		const input = page.getByTestId( 'text-input' );
+
+		await expect( output ).toHaveText( 'hello' );
+		await input.fill( 'world' );
+		await expect( output ).toHaveText( 'world' );
+	} );
+
+	test( 'should bind checkbox checked to state', async ( { page } ) => {
+		const output = page.getByTestId( 'checkbox-output' );
+		const input = page.getByTestId( 'checkbox-input' );
+
+		await expect( output ).toHaveText( 'false' );
+		await input.check();
+		await expect( output ).toHaveText( 'true' );
+		await input.uncheck();
+		await expect( output ).toHaveText( 'false' );
+	} );
+
+	test( 'should preserve number type for number inputs', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'number-output' );
+		const input = page.getByTestId( 'number-input' );
+
+		await expect( output ).toHaveText( '0' );
+		await input.fill( '42' );
+		await expect( output ).toHaveText( '42' );
+	} );
+
+	test( 'should bind select element value to state', async ( { page } ) => {
+		const output = page.getByTestId( 'select-output' );
+		const input = page.getByTestId( 'select-input' );
+
+		await expect( output ).toHaveText( 'dog' );
+		await input.selectOption( 'cat' );
+		await expect( output ).toHaveText( 'cat' );
+	} );
+} );

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -153,7 +153,7 @@ test.describe( 'data-wp-input', () => {
 	/* ------------------------------------------------------------------ */
 	/*  9. Checkbox group (explicit indices → array)                       */
 	/* ------------------------------------------------------------------ */
-	test( 'should bind checkbox group with explicit indices to array', async ( {
+	test( 'should bind checkbox group with top-level properties', async ( {
 		page,
 	} ) => {
 		const outputA = page.getByTestId( 'checkbox-group-output-a' );
@@ -161,18 +161,18 @@ test.describe( 'data-wp-input', () => {
 		const checkboxA = page.getByTestId( 'checkbox-group-a' );
 		const checkboxB = page.getByTestId( 'checkbox-group-b' );
 
-		// Initial: A checked (state.tags.0 = 'a'), B unchecked (state.tags.1 = '').
+		// Initial: A checked (state.tags0 = 'a'), B unchecked (state.tags1 = '').
 		await expect( outputA ).toHaveText( 'a' );
 		await expect( outputB ).toHaveText( '' );
 		expect( await checkboxA.isChecked() ).toBe( true );
 		expect( await checkboxB.isChecked() ).toBe( false );
 
-		// Check B → tags.1 = 'b'.
+		// Check B → tags1 = 'b'.
 		await checkboxB.check();
 		await expect( outputB ).toHaveText( 'b' );
 		expect( await checkboxB.isChecked() ).toBe( true );
 
-		// Uncheck B → tags.1 = ''.
+		// Uncheck B → tags1 = ''.
 		await checkboxB.uncheck();
 		await expect( outputB ).toHaveText( '' );
 		expect( await checkboxB.isChecked() ).toBe( false );
@@ -252,7 +252,7 @@ test.describe( 'data-wp-input', () => {
 	/* ------------------------------------------------------------------ */
 	/*  11. Element→signal seeding (state undefined → adopt DOM value)     */
 	/* ------------------------------------------------------------------ */
-	test.skip( 'should seed signal from element value when state is undefined (needs debug)', async ( {
+	test.skip( 'should update text input value when signal changes via action', async ( {
 		page,
 	} ) => {
 		const output = page.getByTestId( 'seed-output' );

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -71,6 +71,20 @@ test.describe( 'data-wp-input', () => {
 	} );
 
 	/* ------------------------------------------------------------------ */
+	/*  4b. Single select (no default)                                     */
+	/* ------------------------------------------------------------------ */
+	test( 'should work for single select with no pre-selected option', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'select-none-output' );
+		const input = page.getByTestId( 'select-none-input' );
+
+		await expect( output ).toHaveText( '' );
+		await input.selectOption( 'x' );
+		await expect( output ).toHaveText( 'x' );
+	} );
+
+	/* ------------------------------------------------------------------ */
 	/*  5. Radio group                                                     */
 	/* ------------------------------------------------------------------ */
 	test( 'should bind radio button value to state', async ( { page } ) => {
@@ -86,6 +100,26 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'cat' );
 		expect( await radioDog.isChecked() ).toBe( false );
 		expect( await radioCat.isChecked() ).toBe( true );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  5b. Radio group (no default)                                       */
+	/* ------------------------------------------------------------------ */
+	test( 'should work for radio with no pre-selected option', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'radio-none-output' );
+		const radioX = page.getByTestId( 'radio-none-x' );
+		const radioY = page.getByTestId( 'radio-none-y' );
+
+		await expect( output ).toHaveText( '' );
+		expect( await radioX.isChecked() ).toBe( false );
+		expect( await radioY.isChecked() ).toBe( false );
+
+		await radioY.check();
+		await expect( output ).toHaveText( 'y' );
+		expect( await radioX.isChecked() ).toBe( false );
+		expect( await radioY.isChecked() ).toBe( true );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -185,13 +219,19 @@ test.describe( 'data-wp-input', () => {
 		page,
 	} ) => {
 		const output = page.getByTestId( 'text-output' );
+		const input = page.getByTestId( 'text-input' );
 		const toggleBtn = page.getByTestId( 'toggle-text' );
 
 		await expect( output ).toHaveText( 'hello' );
+		await expect( input ).toHaveValue( 'hello' );
+
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'world' );
+		await expect( input ).toHaveValue( 'world' );
+
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'hello' );
+		await expect( input ).toHaveValue( 'hello' );
 	} );
 
 	test( 'should update checkbox when signal changes via action', async ( {
@@ -252,13 +292,12 @@ test.describe( 'data-wp-input', () => {
 	/* ------------------------------------------------------------------ */
 	/*  11. Element→signal seeding (state undefined → adopt DOM value)     */
 	/* ------------------------------------------------------------------ */
-	test.skip( 'should update text input value when signal changes via action', async ( {
+	test( 'should retain HTML value and respond to input for undefined state', async ( {
 		page,
 	} ) => {
-		const output = page.getByTestId( 'seed-output' );
 		const input = page.getByTestId( 'seed-input' );
 
-		// Input should retain its HTML value after hydration.
+		// Input should retain its HTML value after hydration (no clearing).
 		await expect( input ).toHaveValue( 'seeded-from-html' );
 
 		// Typing should still update input value.

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -18,6 +18,9 @@ test.describe( 'data-wp-input', () => {
 		await utils.deleteAllPosts();
 	} );
 
+	/* ------------------------------------------------------------------ */
+	/*  1. Text input                                                      */
+	/* ------------------------------------------------------------------ */
 	test( 'should bind text input value to state', async ( { page } ) => {
 		const output = page.getByTestId( 'text-output' );
 		const input = page.getByTestId( 'text-input' );
@@ -27,6 +30,9 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'world' );
 	} );
 
+	/* ------------------------------------------------------------------ */
+	/*  2. Checkbox (boolean)                                              */
+	/* ------------------------------------------------------------------ */
 	test( 'should bind checkbox checked to state', async ( { page } ) => {
 		const output = page.getByTestId( 'checkbox-output' );
 		const input = page.getByTestId( 'checkbox-input' );
@@ -38,6 +44,9 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'false' );
 	} );
 
+	/* ------------------------------------------------------------------ */
+	/*  3. Number (type preservation)                                      */
+	/* ------------------------------------------------------------------ */
 	test( 'should preserve number type for number inputs', async ( {
 		page,
 	} ) => {
@@ -49,6 +58,9 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( '42' );
 	} );
 
+	/* ------------------------------------------------------------------ */
+	/*  4. Single select                                                   */
+	/* ------------------------------------------------------------------ */
 	test( 'should bind select element value to state', async ( { page } ) => {
 		const output = page.getByTestId( 'select-output' );
 		const input = page.getByTestId( 'select-input' );
@@ -56,5 +68,201 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'dog' );
 		await input.selectOption( 'cat' );
 		await expect( output ).toHaveText( 'cat' );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  5. Radio group                                                     */
+	/* ------------------------------------------------------------------ */
+	test( 'should bind radio button value to state', async ( { page } ) => {
+		const output = page.getByTestId( 'radio-output' );
+		const radioDog = page.getByTestId( 'radio-dog' );
+		const radioCat = page.getByTestId( 'radio-cat' );
+
+		await expect( output ).toHaveText( 'dog' );
+		expect( await radioDog.isChecked() ).toBe( true );
+		expect( await radioCat.isChecked() ).toBe( false );
+
+		await radioCat.check();
+		await expect( output ).toHaveText( 'cat' );
+		expect( await radioDog.isChecked() ).toBe( false );
+		expect( await radioCat.isChecked() ).toBe( true );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  6. Range (type preservation)                                       */
+	/* ------------------------------------------------------------------ */
+	test( 'should preserve number type for range inputs', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'range-output' );
+		const input = page.getByTestId( 'range-input' );
+
+		await expect( output ).toHaveText( '50' );
+		await input.fill( '75' );
+		await expect( output ).toHaveText( '75' );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  7. Textarea                                                        */
+	/* ------------------------------------------------------------------ */
+	test( 'should bind textarea value to state', async ( { page } ) => {
+		const output = page.getByTestId( 'textarea-output' );
+		const input = page.getByTestId( 'textarea-input' );
+
+		await expect( output ).toHaveText( 'default' );
+		await input.fill( 'updated' );
+		await expect( output ).toHaveText( 'updated' );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  8. Multiple select                                                 */
+	/* ------------------------------------------------------------------ */
+	test( 'should update multi-select when signal changes via toggle', async ( {
+		page,
+	} ) => {
+		const input = page.getByTestId( 'multiselect-input' );
+		const toggleBtn = page.getByTestId( 'toggle-multipet' );
+
+		// Initial: 'dog' selected (from store).
+		expect(
+			await input.evaluate(
+				( el: HTMLSelectElement ) =>
+					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			)
+		).toEqual( [ 'dog' ] );
+
+		// Toggle → state.multiPet becomes ['cat', 'bird'].
+		await toggleBtn.click();
+		expect(
+			await input.evaluate(
+				( el: HTMLSelectElement ) =>
+					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			)
+		).toEqual( [ 'cat', 'bird' ] );
+
+		// Toggle back → state.multiPet becomes ['dog'].
+		await toggleBtn.click();
+		expect(
+			await input.evaluate(
+				( el: HTMLSelectElement ) =>
+					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			)
+		).toEqual( [ 'dog' ] );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  9. Checkbox group (explicit indices → array)                       */
+	/* ------------------------------------------------------------------ */
+	test( 'should bind checkbox group with explicit indices to array', async ( {
+		page,
+	} ) => {
+		const outputA = page.getByTestId( 'checkbox-group-output-a' );
+		const outputB = page.getByTestId( 'checkbox-group-output-b' );
+		const checkboxA = page.getByTestId( 'checkbox-group-a' );
+		const checkboxB = page.getByTestId( 'checkbox-group-b' );
+
+		// Initial: A checked (state.tags.0 = 'a'), B unchecked (state.tags.1 = '').
+		await expect( outputA ).toHaveText( 'a' );
+		await expect( outputB ).toHaveText( '' );
+		expect( await checkboxA.isChecked() ).toBe( true );
+		expect( await checkboxB.isChecked() ).toBe( false );
+
+		// Check B → tags.1 = 'b'.
+		await checkboxB.check();
+		await expect( outputB ).toHaveText( 'b' );
+		expect( await checkboxB.isChecked() ).toBe( true );
+
+		// Uncheck B → tags.1 = ''.
+		await checkboxB.uncheck();
+		await expect( outputB ).toHaveText( '' );
+		expect( await checkboxB.isChecked() ).toBe( false );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  10. Update input elements when signal changes via toggle actions                              */
+	/* ------------------------------------------------------------------ */
+	test( 'should update text input value when signal changes via action', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'text-output' );
+		const toggleBtn = page.getByTestId( 'toggle-text' );
+
+		await expect( output ).toHaveText( 'hello' );
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'world' );
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'hello' );
+	} );
+
+	test( 'should update checkbox when signal changes via action', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'checkbox-output' );
+		const input = page.getByTestId( 'checkbox-input' );
+		const toggleBtn = page.getByTestId( 'toggle-checked' );
+
+		await expect( output ).toHaveText( 'false' );
+		expect( await input.isChecked() ).toBe( false );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'true' );
+		expect( await input.isChecked() ).toBe( true );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'false' );
+		expect( await input.isChecked() ).toBe( false );
+	} );
+
+	test( 'should update number input when signal changes via action', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'number-output' );
+		const input = page.getByTestId( 'number-input' );
+		const toggleBtn = page.getByTestId( 'toggle-num' );
+
+		await expect( output ).toHaveText( '0' );
+		await expect( input ).toHaveValue( '0' );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( '99' );
+		await expect( input ).toHaveValue( '99' );
+	} );
+
+	test( 'should update select when signal changes via action', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'select-output' );
+		const input = page.getByTestId( 'select-input' );
+		const toggleBtn = page.getByTestId( 'toggle-pet' );
+
+		await expect( output ).toHaveText( 'dog' );
+		await expect( input ).toHaveValue( 'dog' );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'cat' );
+		await expect( input ).toHaveValue( 'cat' );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'bird' );
+
+		await toggleBtn.click();
+		await expect( output ).toHaveText( 'dog' );
+	} );
+
+	/* ------------------------------------------------------------------ */
+	/*  11. Element→signal seeding (state undefined → adopt DOM value)     */
+	/* ------------------------------------------------------------------ */
+	test.skip( 'should seed signal from element value when state is undefined (needs debug)', async ( {
+		page,
+	} ) => {
+		const output = page.getByTestId( 'seed-output' );
+		const input = page.getByTestId( 'seed-input' );
+
+		// Input should retain its HTML value after hydration.
+		await expect( input ).toHaveValue( 'seeded-from-html' );
+
+		// Typing should still update input value.
+		await input.fill( 'updated' );
+		await expect( input ).toHaveValue( 'updated' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -119,13 +119,13 @@ test.describe( 'data-wp-input', () => {
 		const radioCat = page.getByTestId( 'radio-cat' );
 
 		await expect( output ).toHaveText( 'dog' );
-		expect( await radioDog.isChecked() ).toBe( true );
-		expect( await radioCat.isChecked() ).toBe( false );
+		await expect( radioDog ).toBeChecked();
+		await expect( radioCat ).not.toBeChecked();
 
 		await radioCat.check();
 		await expect( output ).toHaveText( 'cat' );
-		expect( await radioDog.isChecked() ).toBe( false );
-		expect( await radioCat.isChecked() ).toBe( true );
+		await expect( radioDog ).not.toBeChecked();
+		await expect( radioCat ).toBeChecked();
 
 		const ctxOutput = page.getByTestId( 'ctx-radio-output' );
 		const ctxRadioCat = page.getByTestId( 'ctx-radio-cat' );
@@ -145,13 +145,13 @@ test.describe( 'data-wp-input', () => {
 		const radioY = page.getByTestId( 'radio-none-y' );
 
 		await expect( output ).toHaveText( '' );
-		expect( await radioX.isChecked() ).toBe( false );
-		expect( await radioY.isChecked() ).toBe( false );
+		await expect( radioX ).not.toBeChecked();
+		await expect( radioY ).not.toBeChecked();
 
 		await radioY.check();
 		await expect( output ).toHaveText( 'y' );
-		expect( await radioX.isChecked() ).toBe( false );
-		expect( await radioY.isChecked() ).toBe( true );
+		await expect( radioX ).not.toBeChecked();
+		await expect( radioY ).toBeChecked();
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -203,27 +203,24 @@ test.describe( 'data-wp-input', () => {
 
 		// Initial: 'dog' selected (from store).
 		expect(
-			await input.evaluate(
-				( el: HTMLSelectElement ) =>
-					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			await input.evaluate( ( el: HTMLSelectElement ) =>
+				Array.from( el.selectedOptions ).map( ( o ) => o.value )
 			)
 		).toEqual( [ 'dog' ] );
 
 		// Toggle → state.multiPet becomes ['cat', 'bird'].
 		await toggleBtn.click();
 		expect(
-			await input.evaluate(
-				( el: HTMLSelectElement ) =>
-					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			await input.evaluate( ( el: HTMLSelectElement ) =>
+				Array.from( el.selectedOptions ).map( ( o ) => o.value )
 			)
 		).toEqual( [ 'cat', 'bird' ] );
 
 		// Toggle back → state.multiPet becomes ['dog'].
 		await toggleBtn.click();
 		expect(
-			await input.evaluate(
-				( el: HTMLSelectElement ) =>
-					Array.from( el.selectedOptions ).map( ( o ) => o.value )
+			await input.evaluate( ( el: HTMLSelectElement ) =>
+				Array.from( el.selectedOptions ).map( ( o ) => o.value )
 			)
 		).toEqual( [ 'dog' ] );
 	} );
@@ -242,18 +239,18 @@ test.describe( 'data-wp-input', () => {
 		// Initial: A checked (state.tags0 = 'a'), B unchecked (state.tags1 = '').
 		await expect( outputA ).toHaveText( 'a' );
 		await expect( outputB ).toHaveText( '' );
-		expect( await checkboxA.isChecked() ).toBe( true );
-		expect( await checkboxB.isChecked() ).toBe( false );
+		await expect( checkboxA ).toBeChecked();
+		await expect( checkboxB ).not.toBeChecked();
 
 		// Check B → tags1 = 'b'.
 		await checkboxB.check();
 		await expect( outputB ).toHaveText( 'b' );
-		expect( await checkboxB.isChecked() ).toBe( true );
+		await expect( checkboxB ).toBeChecked();
 
 		// Uncheck B → tags1 = ''.
 		await checkboxB.uncheck();
 		await expect( outputB ).toHaveText( '' );
-		expect( await checkboxB.isChecked() ).toBe( false );
+		await expect( checkboxB ).not.toBeChecked();
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -300,15 +297,15 @@ test.describe( 'data-wp-input', () => {
 		const toggleBtn = page.getByTestId( 'toggle-checked' );
 
 		await expect( output ).toHaveText( 'false' );
-		expect( await input.isChecked() ).toBe( false );
+		await expect( input ).not.toBeChecked();
 
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'true' );
-		expect( await input.isChecked() ).toBe( true );
+		await expect( input ).toBeChecked();
 
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'false' );
-		expect( await input.isChecked() ).toBe( false );
+		await expect( input ).not.toBeChecked();
 
 		const ctxOutput = page.getByTestId( 'ctx-checkbox-output' );
 		const ctxInput = page.getByTestId( 'ctx-checkbox-input' );
@@ -316,10 +313,10 @@ test.describe( 'data-wp-input', () => {
 		await expect( ctxOutput ).toHaveText( 'false' );
 		await ctxToggleBtn.click();
 		await expect( ctxOutput ).toHaveText( 'true' );
-		expect( await ctxInput.isChecked() ).toBe( true );
+		await expect( ctxInput ).toBeChecked();
 		await ctxToggleBtn.click();
 		await expect( ctxOutput ).toHaveText( 'false' );
-		expect( await ctxInput.isChecked() ).toBe( false );
+		await expect( ctxInput ).not.toBeChecked();
 	} );
 
 	test( 'should update number input when signal changes via action', async ( {
@@ -401,6 +398,7 @@ test.describe( 'data-wp-input', () => {
 				);
 				return el && el.textContent === 'test.txt';
 			},
+			undefined,
 			{ timeout: 15000 }
 		);
 
@@ -423,6 +421,7 @@ test.describe( 'data-wp-input', () => {
 				);
 				return el && el.textContent === 'test.txt';
 			},
+			undefined,
 			{ timeout: 15000 }
 		);
 	} );
@@ -442,5 +441,4 @@ test.describe( 'data-wp-input', () => {
 		await input.fill( 'updated' );
 		await expect( input ).toHaveValue( 'updated' );
 	} );
-
 } );

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -382,12 +382,12 @@ test.describe( 'data-wp-input', () => {
 	/*  15. File input                                                     */
 	/* ------------------------------------------------------------------ */
 	test( 'should handle file input', async ( { page } ) => {
-		const countOutput = page.getByTestId( 'file-count-output' );
-		const fileInput = page.getByTestId( 'file-input' );
+		const stateOutput = page.getByTestId( 'file-name-output' );
+		const stateInput = page.getByTestId( 'file-input' );
 
-		await expect( countOutput ).toHaveText( '0' );
+		await expect( stateOutput ).toHaveText( '' );
 
-		await fileInput.setInputFiles( {
+		await stateInput.setInputFiles( {
 			name: 'test.txt',
 			mimeType: 'text/plain',
 			buffer: Buffer.from( 'hello world' ),
@@ -397,9 +397,31 @@ test.describe( 'data-wp-input', () => {
 		await page.waitForFunction(
 			() => {
 				const el = document.querySelector(
-					'[data-testid="file-count-output"]'
+					'[data-testid="file-name-output"]'
 				);
-				return el && el.textContent === '1';
+				return el && el.textContent === 'test.txt';
+			},
+			{ timeout: 15000 }
+		);
+
+		// --- Context variant ---
+		const ctxOutput = page.getByTestId( 'ctx-file-name-output' );
+		const ctxInput = page.getByTestId( 'ctx-file-input' );
+
+		await expect( ctxOutput ).toHaveText( '' );
+
+		await ctxInput.setInputFiles( {
+			name: 'test.txt',
+			mimeType: 'text/plain',
+			buffer: Buffer.from( 'hello world' ),
+		} );
+
+		await page.waitForFunction(
+			() => {
+				const el = document.querySelector(
+					'[data-testid="ctx-file-name-output"]'
+				);
+				return el && el.textContent === 'test.txt';
 			},
 			{ timeout: 15000 }
 		);

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -381,7 +381,7 @@ test.describe( 'data-wp-input', () => {
 	/* ------------------------------------------------------------------ */
 	/*  15. File input                                                     */
 	/* ------------------------------------------------------------------ */
-	test.skip( 'should handle file input', async ( { page } ) => {
+	test( 'should handle file input', async ( { page } ) => {
 		const countOutput = page.getByTestId( 'file-count-output' );
 		const fileInput = page.getByTestId( 'file-input' );
 

--- a/test/e2e/specs/interactivity/directive-input.spec.ts
+++ b/test/e2e/specs/interactivity/directive-input.spec.ts
@@ -28,6 +28,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'hello' );
 		await input.fill( 'world' );
 		await expect( output ).toHaveText( 'world' );
+
+		const ctxOutput = page.getByTestId( 'ctx-text-output' );
+		const ctxInput = page.getByTestId( 'ctx-text-input' );
+		await expect( ctxOutput ).toHaveText( 'ctx-hello' );
+		await ctxInput.fill( 'ctx-world' );
+		await expect( ctxOutput ).toHaveText( 'ctx-world' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -42,6 +48,14 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'true' );
 		await input.uncheck();
 		await expect( output ).toHaveText( 'false' );
+
+		const ctxOutput = page.getByTestId( 'ctx-checkbox-output' );
+		const ctxInput = page.getByTestId( 'ctx-checkbox-input' );
+		await expect( ctxOutput ).toHaveText( 'false' );
+		await ctxInput.check();
+		await expect( ctxOutput ).toHaveText( 'true' );
+		await ctxInput.uncheck();
+		await expect( ctxOutput ).toHaveText( 'false' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -56,6 +70,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( '0' );
 		await input.fill( '42' );
 		await expect( output ).toHaveText( '42' );
+
+		const ctxOutput = page.getByTestId( 'ctx-number-output' );
+		const ctxInput = page.getByTestId( 'ctx-number-input' );
+		await expect( ctxOutput ).toHaveText( '0' );
+		await ctxInput.fill( '77' );
+		await expect( ctxOutput ).toHaveText( '77' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -68,6 +88,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'dog' );
 		await input.selectOption( 'cat' );
 		await expect( output ).toHaveText( 'cat' );
+
+		const ctxOutput = page.getByTestId( 'ctx-select-output' );
+		const ctxInput = page.getByTestId( 'ctx-select-input' );
+		await expect( ctxOutput ).toHaveText( 'dog' );
+		await ctxInput.selectOption( 'cat' );
+		await expect( ctxOutput ).toHaveText( 'cat' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -100,6 +126,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'cat' );
 		expect( await radioDog.isChecked() ).toBe( false );
 		expect( await radioCat.isChecked() ).toBe( true );
+
+		const ctxOutput = page.getByTestId( 'ctx-radio-output' );
+		const ctxRadioCat = page.getByTestId( 'ctx-radio-cat' );
+		await expect( ctxOutput ).toHaveText( 'dog' );
+		await ctxRadioCat.check();
+		await expect( ctxOutput ).toHaveText( 'cat' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -134,6 +166,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( '50' );
 		await input.fill( '75' );
 		await expect( output ).toHaveText( '75' );
+
+		const ctxOutput = page.getByTestId( 'ctx-range-output' );
+		const ctxInput = page.getByTestId( 'ctx-range-input' );
+		await expect( ctxOutput ).toHaveText( '50' );
+		await ctxInput.fill( '25' );
+		await expect( ctxOutput ).toHaveText( '25' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -146,6 +184,12 @@ test.describe( 'data-wp-input', () => {
 		await expect( output ).toHaveText( 'default' );
 		await input.fill( 'updated' );
 		await expect( output ).toHaveText( 'updated' );
+
+		const ctxOutput = page.getByTestId( 'ctx-textarea-output' );
+		const ctxInput = page.getByTestId( 'ctx-textarea-input' );
+		await expect( ctxOutput ).toHaveText( 'default' );
+		await ctxInput.fill( 'modified' );
+		await expect( ctxOutput ).toHaveText( 'modified' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -232,6 +276,20 @@ test.describe( 'data-wp-input', () => {
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'hello' );
 		await expect( input ).toHaveValue( 'hello' );
+
+		const ctxOutput = page.getByTestId( 'ctx-text-output' );
+		const ctxInput = page.getByTestId( 'ctx-text-input' );
+		const ctxToggleBtn = page.getByTestId( 'toggle-ctx-text' );
+		await expect( ctxOutput ).toHaveText( 'ctx-hello' );
+		await expect( ctxInput ).toHaveValue( 'ctx-hello' );
+
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'ctx-world' );
+		await expect( ctxInput ).toHaveValue( 'ctx-world' );
+
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'ctx-hello' );
+		await expect( ctxInput ).toHaveValue( 'ctx-hello' );
 	} );
 
 	test( 'should update checkbox when signal changes via action', async ( {
@@ -251,6 +309,17 @@ test.describe( 'data-wp-input', () => {
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'false' );
 		expect( await input.isChecked() ).toBe( false );
+
+		const ctxOutput = page.getByTestId( 'ctx-checkbox-output' );
+		const ctxInput = page.getByTestId( 'ctx-checkbox-input' );
+		const ctxToggleBtn = page.getByTestId( 'toggle-ctx-checked' );
+		await expect( ctxOutput ).toHaveText( 'false' );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'true' );
+		expect( await ctxInput.isChecked() ).toBe( true );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'false' );
+		expect( await ctxInput.isChecked() ).toBe( false );
 	} );
 
 	test( 'should update number input when signal changes via action', async ( {
@@ -266,6 +335,14 @@ test.describe( 'data-wp-input', () => {
 		await toggleBtn.click();
 		await expect( output ).toHaveText( '99' );
 		await expect( input ).toHaveValue( '99' );
+
+		const ctxOutput = page.getByTestId( 'ctx-number-output' );
+		const ctxInput = page.getByTestId( 'ctx-number-input' );
+		const ctxToggleBtn = page.getByTestId( 'toggle-ctx-num' );
+		await expect( ctxOutput ).toHaveText( '0' );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( '99' );
+		await expect( ctxInput ).toHaveValue( '99' );
 	} );
 
 	test( 'should update select when signal changes via action', async ( {
@@ -287,6 +364,18 @@ test.describe( 'data-wp-input', () => {
 
 		await toggleBtn.click();
 		await expect( output ).toHaveText( 'dog' );
+
+		const ctxOutput = page.getByTestId( 'ctx-select-output' );
+		const ctxInput = page.getByTestId( 'ctx-select-input' );
+		const ctxToggleBtn = page.getByTestId( 'toggle-ctx-pet' );
+		await expect( ctxOutput ).toHaveText( 'dog' );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'cat' );
+		await expect( ctxInput ).toHaveValue( 'cat' );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'bird' );
+		await ctxToggleBtn.click();
+		await expect( ctxOutput ).toHaveText( 'dog' );
 	} );
 
 	/* ------------------------------------------------------------------ */
@@ -304,4 +393,5 @@ test.describe( 'data-wp-input', () => {
 		await input.fill( 'updated' );
 		await expect( input ).toHaveValue( 'updated' );
 	} );
+
 } );


### PR DESCRIPTION
Closes: #80023

Note: this PR stacks on top of #79975, which refactors the directives mechanism to be cleaner and more extensible. Should probably review that first, though I can rebase this on trunk if needed.

## Description

Inspired by datastar's [bind attribute](https://data-star.dev/reference/attributes#data-bind), this PR implements a new `data-wp-input` directive for the Interactivity API that provides two-way binding between input elements and signals. This collapses `data-wp-bind--value` + `data-wp-on--input` into a single attribute.

### Features
- Two-way binding: signal→element and element→signal
- Auto-detects element type: checkbox, radio, range/number, file, select (single+multiple), text/textarea, custom elements
- Supports both state and context paths
- Element→signal seeding when signal is undefined
- Multi-select live updates via layout effect
- 17 e2e tests covering all element types with state + context variants

### How it works
The directive navigates through the store/context proxy normally (no `peek` for writes), so each intermediate key returns a proxified object, and the final leaf assignment goes through the proxy's set/defineProperty traps, so it is fully reactive at any depth.

## Use of AI Tools
AI assistance: Yes
Tool(s): VSCode Copilot Chat
Model(s): Deepseek V4 Flash, GLM 5.2
Used for: Pair programmer. I guided and reviewed it all
