### PR TITLE
Cover: Create the initial paragraph when the block gains a background

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -226,8 +226,27 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
-	// Create the initial inner paragraph when the block gains a background
-	// and has no content yet.
+	// Mirrors the placeholder render condition, for reading the state
+	// before an action runs.
+	const isShowingPlaceholder = () => {
+		const { getBlocks, getBlockAttributes } =
+			registry.select( blockEditorStore );
+		const currentAttributes = getBlockAttributes( clientId );
+		return (
+			getBlocks( clientId ).length === 0 &&
+			! currentAttributes.useFeaturedImage &&
+			! currentAttributes.url &&
+			! currentAttributes.overlayColor &&
+			! currentAttributes.customOverlayColor &&
+			! currentAttributes.gradient &&
+			! currentAttributes.customGradient
+		);
+	};
+
+	// Create the initial inner paragraph when the block exits its
+	// placeholder. The template was only ever applied at that transition:
+	// afterwards, removing the paragraph is a content choice that further
+	// background changes should not override.
 	const scaffoldInnerBlocks = () => {
 		const {
 			getBlocks,
@@ -271,6 +290,7 @@ function CoverEdit( {
 	};
 
 	const onSelectMedia = async ( newMedia ) => {
+		const wasShowingPlaceholder = isShowingPlaceholder();
 		const mediaAttributes = attributesFromMedia( newMedia );
 		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
 			IMAGE_BACKGROUND_TYPE
@@ -345,7 +365,9 @@ function CoverEdit( {
 				isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
 			} );
 
-			scaffoldInnerBlocks();
+			if ( wasShowingPlaceholder ) {
+				scaffoldInnerBlocks();
+			}
 		} );
 	};
 
@@ -378,6 +400,7 @@ function CoverEdit( {
 	};
 
 	const onSetOverlayColor = async ( newOverlayColor ) => {
+		const wasShowingPlaceholder = isShowingPlaceholder();
 		const averageBackgroundColor = await getMediaColor( url );
 
 		// Read latest dimRatio after await to avoid stale closure.
@@ -400,7 +423,9 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			scaffoldInnerBlocks();
+			if ( wasShowingPlaceholder ) {
+				scaffoldInnerBlocks();
+			}
 		} );
 	};
 
@@ -626,6 +651,7 @@ function CoverEdit( {
 		!! openMediaEditorModal;
 
 	const toggleUseFeaturedImage = async () => {
+		const wasShowingPlaceholder = isShowingPlaceholder();
 		const newUseFeaturedImage = ! useFeaturedImage;
 
 		const averageBackgroundColor = newUseFeaturedImage
@@ -671,7 +697,9 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			scaffoldInnerBlocks();
+			if ( wasShowingPlaceholder ) {
+				scaffoldInnerBlocks();
+			}
 		} );
 	};
 

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -226,49 +226,15 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
-	// Mirrors the placeholder render condition, for reading the state
-	// before an action runs.
-	const isShowingPlaceholder = () => {
-		const { getBlocks, getBlockAttributes } =
-			registry.select( blockEditorStore );
-		const currentAttributes = getBlockAttributes( clientId );
-		return (
-			getBlocks( clientId ).length === 0 &&
-			! currentAttributes.useFeaturedImage &&
-			! currentAttributes.url &&
-			! currentAttributes.overlayColor &&
-			! currentAttributes.customOverlayColor &&
-			! currentAttributes.gradient &&
-			! currentAttributes.customGradient
-		);
-	};
-
-	// Create the initial inner paragraph when the block exits its
-	// placeholder. The template was only ever applied at that transition:
-	// afterwards, removing the paragraph is a content choice that further
-	// background changes should not override.
+	// Create the initial inner paragraph when the block gains a background
+	// and has no content yet.
 	const scaffoldInnerBlocks = () => {
 		const {
 			getBlocks,
-			getBlockAttributes,
 			isBlockSelected,
 			getSelectedBlocksInitialCaretPosition,
 		} = registry.select( blockEditorStore );
 		if ( getBlocks( clientId ).length > 0 ) {
-			return;
-		}
-		// The calling actions can also remove the background, returning the
-		// block to its placeholder, which should remain empty.
-		const currentAttributes = getBlockAttributes( clientId );
-		const hasBackground = !! (
-			currentAttributes.url ||
-			currentAttributes.useFeaturedImage ||
-			currentAttributes.overlayColor ||
-			currentAttributes.customOverlayColor ||
-			currentAttributes.gradient ||
-			currentAttributes.customGradient
-		);
-		if ( ! hasBackground ) {
 			return;
 		}
 		// Check for fontSize support before we pass a fontSize attribute to
@@ -290,7 +256,6 @@ function CoverEdit( {
 	};
 
 	const onSelectMedia = async ( newMedia ) => {
-		const wasShowingPlaceholder = isShowingPlaceholder();
 		const mediaAttributes = attributesFromMedia( newMedia );
 		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
 			IMAGE_BACKGROUND_TYPE
@@ -365,9 +330,7 @@ function CoverEdit( {
 				isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
 			} );
 
-			if ( wasShowingPlaceholder ) {
-				scaffoldInnerBlocks();
-			}
+			scaffoldInnerBlocks();
 		} );
 	};
 
@@ -400,7 +363,6 @@ function CoverEdit( {
 	};
 
 	const onSetOverlayColor = async ( newOverlayColor ) => {
-		const wasShowingPlaceholder = isShowingPlaceholder();
 		const averageBackgroundColor = await getMediaColor( url );
 
 		// Read latest dimRatio after await to avoid stale closure.
@@ -423,7 +385,9 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			if ( wasShowingPlaceholder ) {
+			// Skip when the color is cleared: that returns the block to its
+			// placeholder, which only renders while there is no content.
+			if ( newOverlayColor ) {
 				scaffoldInnerBlocks();
 			}
 		} );
@@ -651,7 +615,6 @@ function CoverEdit( {
 		!! openMediaEditorModal;
 
 	const toggleUseFeaturedImage = async () => {
-		const wasShowingPlaceholder = isShowingPlaceholder();
 		const newUseFeaturedImage = ! useFeaturedImage;
 
 		const averageBackgroundColor = newUseFeaturedImage
@@ -697,7 +660,10 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			if ( wasShowingPlaceholder ) {
+			// Skip when the featured image is disabled: that can return the
+			// block to its placeholder, which only renders while there is no
+			// content.
+			if ( newUseFeaturedImage ) {
 				scaffoldInnerBlocks();
 			}
 		} );

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -242,7 +242,6 @@ function CoverEdit( {
 		if ( getBlocks( clientId ).length > 0 ) {
 			return;
 		}
-		__unstableMarkNextChangeAsNotPersistent( { history: 'ignore' } );
 		replaceInnerBlocks(
 			clientId,
 			createBlocksFromInnerBlocksTemplate(
@@ -320,18 +319,20 @@ function CoverEdit( {
 			}
 		}
 
-		setAttributes( {
-			...mediaAttributes,
-			focalPoint: undefined,
-			useFeaturedImage: undefined,
-			dimRatio: newDimRatio,
-			isDark: newIsDark,
-			isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
-		} );
+		registry.batch( () => {
+			setAttributes( {
+				...mediaAttributes,
+				focalPoint: undefined,
+				useFeaturedImage: undefined,
+				dimRatio: newDimRatio,
+				isDark: newIsDark,
+				isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
+			} );
 
-		if ( mediaAttributes?.url ) {
-			scaffoldInnerBlocks();
-		}
+			if ( mediaAttributes?.url ) {
+				scaffoldInnerBlocks();
+			}
+		} );
 	};
 
 	const onClearMedia = () => {
@@ -379,14 +380,16 @@ function CoverEdit( {
 		// Make undo revert the next setAttributes and the previous setOverlayColor.
 		__unstableMarkNextChangeAsNotPersistent();
 
-		setAttributes( {
-			isUserOverlayColor: true,
-			isDark: newIsDark,
-		} );
+		registry.batch( () => {
+			setAttributes( {
+				isUserOverlayColor: true,
+				isDark: newIsDark,
+			} );
 
-		if ( newOverlayColor ) {
-			scaffoldInnerBlocks();
-		}
+			if ( newOverlayColor ) {
+				scaffoldInnerBlocks();
+			}
+		} );
 	};
 
 	const onUpdateDimRatio = async ( newDimRatio ) => {
@@ -644,20 +647,22 @@ function CoverEdit( {
 			averageBackgroundColor
 		);
 
-		setAttributes( {
-			id: undefined,
-			url: undefined,
-			useFeaturedImage: newUseFeaturedImage,
-			dimRatio: newDimRatio,
-			backgroundType: useFeaturedImage
-				? IMAGE_BACKGROUND_TYPE
-				: undefined,
-			isDark: newIsDark,
-		} );
+		registry.batch( () => {
+			setAttributes( {
+				id: undefined,
+				url: undefined,
+				useFeaturedImage: newUseFeaturedImage,
+				dimRatio: newDimRatio,
+				backgroundType: useFeaturedImage
+					? IMAGE_BACKGROUND_TYPE
+					: undefined,
+				isDark: newIsDark,
+			} );
 
-		if ( newUseFeaturedImage ) {
-			scaffoldInnerBlocks();
-		}
+			if ( newUseFeaturedImage ) {
+				scaffoldInnerBlocks();
+			}
+		} );
 	};
 
 	const blockControls = (

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -20,7 +20,6 @@ import {
 	withColors,
 	ColorPalette,
 	useBlockProps,
-	useSettings,
 	useInnerBlocksProps,
 	__experimentalUseGradient,
 	store as blockEditorStore,
@@ -227,21 +226,38 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
-	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
-	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
-	const hasFontSizes = fontSizes?.length > 0;
-
 	// Create the initial inner paragraph when the block gains a background
 	// and has no content yet.
 	const scaffoldInnerBlocks = () => {
 		const {
 			getBlocks,
+			getBlockAttributes,
 			isBlockSelected,
 			getSelectedBlocksInitialCaretPosition,
 		} = registry.select( blockEditorStore );
 		if ( getBlocks( clientId ).length > 0 ) {
 			return;
 		}
+		// The calling actions can also remove the background, returning the
+		// block to its placeholder, which should remain empty.
+		const currentAttributes = getBlockAttributes( clientId );
+		const hasBackground = !! (
+			currentAttributes.url ||
+			currentAttributes.useFeaturedImage ||
+			currentAttributes.overlayColor ||
+			currentAttributes.customOverlayColor ||
+			currentAttributes.gradient ||
+			currentAttributes.customGradient
+		);
+		if ( ! hasBackground ) {
+			return;
+		}
+		// Check for fontSize support before we pass a fontSize attribute to
+		// the innerBlocks.
+		const [ fontSizes ] = unlock(
+			registry.select( blockEditorStore )
+		).getBlockSettings( clientId, 'typography.fontSizes' );
+		const hasFontSizes = fontSizes?.length > 0;
 		replaceInnerBlocks(
 			clientId,
 			createBlocksFromInnerBlocksTemplate(
@@ -329,9 +345,7 @@ function CoverEdit( {
 				isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
 			} );
 
-			if ( mediaAttributes?.url ) {
-				scaffoldInnerBlocks();
-			}
+			scaffoldInnerBlocks();
 		} );
 	};
 
@@ -386,9 +400,7 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			if ( newOverlayColor ) {
-				scaffoldInnerBlocks();
-			}
+			scaffoldInnerBlocks();
 		} );
 	};
 
@@ -659,9 +671,7 @@ function CoverEdit( {
 				isDark: newIsDark,
 			} );
 
-			if ( newUseFeaturedImage ) {
-				scaffoldInnerBlocks();
-			}
+			scaffoldInnerBlocks();
 		} );
 	};
 

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -28,7 +28,8 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
 import { isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -134,8 +135,9 @@ function CoverEdit( {
 		[]
 	);
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
+	const { __unstableMarkNextChangeAsNotPersistent, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 
 	// Ref to access latest values after async operations (e.g. getMediaColor),
 	// avoiding stale values that could overwrite concurrent remote changes.
@@ -225,6 +227,34 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
+	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
+	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
+	const hasFontSizes = fontSizes?.length > 0;
+
+	// Create the initial inner paragraph when the block gains a background
+	// and has no content yet.
+	const scaffoldInnerBlocks = () => {
+		const {
+			getBlocks,
+			isBlockSelected,
+			getSelectedBlocksInitialCaretPosition,
+		} = registry.select( blockEditorStore );
+		if ( getBlocks( clientId ).length > 0 ) {
+			return;
+		}
+		__unstableMarkNextChangeAsNotPersistent( { history: 'ignore' } );
+		replaceInnerBlocks(
+			clientId,
+			createBlocksFromInnerBlocksTemplate(
+				getInnerBlocksTemplate( {
+					fontSize: hasFontSizes ? 'large' : undefined,
+				} )
+			),
+			isBlockSelected( clientId ),
+			getSelectedBlocksInitialCaretPosition()
+		);
+	};
+
 	const onSelectMedia = async ( newMedia ) => {
 		const mediaAttributes = attributesFromMedia( newMedia );
 		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
@@ -298,6 +328,10 @@ function CoverEdit( {
 			isDark: newIsDark,
 			isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
 		} );
+
+		if ( mediaAttributes?.url ) {
+			scaffoldInnerBlocks();
+		}
 	};
 
 	const onClearMedia = () => {
@@ -349,6 +383,10 @@ function CoverEdit( {
 			isUserOverlayColor: true,
 			isDark: newIsDark,
 		} );
+
+		if ( newOverlayColor ) {
+			scaffoldInnerBlocks();
+		}
 	};
 
 	const onUpdateDimRatio = async ( newDimRatio ) => {
@@ -477,22 +515,11 @@ function CoverEdit( {
 	const ref = useRef();
 	const blockProps = useBlockProps( { ref } );
 
-	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
-	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
-	const hasFontSizes = fontSizes?.length > 0;
-	const innerBlocksTemplate = getInnerBlocksTemplate( {
-		fontSize: hasFontSizes ? 'large' : undefined,
-	} );
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
 		},
 		{
-			// Avoid template sync when the `templateLock` value is `all` or `contentOnly`.
-			// See: https://github.com/WordPress/gutenberg/pull/45632
-			template: ! hasInnerBlocks ? innerBlocksTemplate : undefined,
-			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
 			dropZoneElement: ref.current,
@@ -627,6 +654,10 @@ function CoverEdit( {
 				: undefined,
 			isDark: newIsDark,
 		} );
+
+		if ( newUseFeaturedImage ) {
+			scaffoldInnerBlocks();
+		}
 	};
 
 	const blockControls = (


### PR DESCRIPTION
## What?

Creates the Cover block's initial inner paragraph in the actions that give the block a background (selecting media, choosing an overlay color, enabling the featured image), instead of declaring it as an inner blocks template.

## Why?

1. **The template only ever applied on placeholder exit.** Cover's placeholder branch returns early without rendering the inner blocks container, so the template hook never ran until a background was chosen. Creating the paragraph in those actions encodes the actual behavior directly.
2. **Collaboration correctness.** Template insertion runs independently on every peer after mount; a user action runs only on the acting client, so peers receive the background and the paragraph together (see #79021 for the general problem).
3. **Removes the #45632 guard.** The conditional `template` prop existed to avoid re-synchronizing locked content; with no template there is nothing to guard.

## How?

A `scaffoldInnerBlocks()` helper inserts the paragraph (with the existing `fontSize` handling from #34993) when the inner blocks are empty, called from `onSelectMedia`, `onSetOverlayColor`, and `toggleUseFeaturedImage`. The block transforms already create the paragraph explicitly.

One behavior change: a saved empty Cover that already has a background no longer gains a paragraph when the post is opened; it shows the block appender instead.

## Testing Instructions

1. Insert a Cover block; the media/color placeholder appears as before.
2. Pick an overlay color or upload media; the title paragraph appears focused, type into it.
3. Transform an image into a Cover; the caption paragraph is present.
4. Undo after picking a color; the paragraph and background revert together.

### Testing Instructions for Keyboard

Insert a Cover, Tab to a color swatch in the placeholder, press Enter, and type the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
