### PR TITLE
Editor: Fix regression and restore the back button focus ring

### DIFF
--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -2,18 +2,6 @@
 	color: var(--wpds-color-foreground-interactive-neutral);
 	flex-shrink: 0;
 
-	// Focus (resets default button focus and use focus-visible).
-	&:focus:not(:disabled) {
-		box-shadow: none;
-		outline: none;
-	}
-	&:focus-visible:not(:disabled) {
-		box-shadow:
-			0 0 0 var(--wp-admin-border-width-focus)
-			var(--wp-admin-theme-color);
-		outline: 3px solid transparent;
-	}
-
 	&:hover:not(:disabled,[aria-disabled="true"]),
 	&:focus-visible,
 	&:focus,

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/mixins";
 @use "@wordpress/base-styles/variables" as *;
 
 .edit-site-sidebar-navigation-item.components-item {
@@ -26,6 +27,13 @@
 	// Make sure the focus style is drawn on top of the current item background.
 	&:focus-visible {
 		transform: translateZ(0);
+		// TODO: remove once the <Item> component has migrated to the
+		// design-system focus ring (`outset-ring__focus`), as <Button> did in #78646.
+		//
+		// This override is necessary now so the focus ring matches with
+		// the editor back button.
+		box-shadow: none;
+		@include mixins.outset-ring__focus();
 	}
 
 	.edit-site-sidebar-navigation-item__drilldown-indicator {

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -27,13 +27,6 @@
 	// Make sure the focus style is drawn on top of the current item background.
 	&:focus-visible {
 		transform: translateZ(0);
-		// TODO: remove once the <Item> component has migrated to the
-		// design-system focus ring (`outset-ring__focus`), as <Button> did in #78646.
-		//
-		// This override is necessary now so the focus ring matches with
-		// the editor back button.
-		box-shadow: none;
-		@include mixins.outset-ring__focus();
 	}
 
 	.edit-site-sidebar-navigation-item__drilldown-indicator {


### PR DESCRIPTION
## What?

Fixes a "regression" introduced by #79837.

The sidebar back button in the Site Editor (`.edit-site-sidebar-button`) is overriding the default focus styles. It now conflicts with the linked PR because that added this rule:

```css
&:is(a) {
      box-shadow: none;
}
```

The correct fix here is to just follow what WP DS provides for the focus ring styles, so this PR removes the overrides.

~~However, it means that the focus ring color for the sidebar menu items (like Navigation, Pages, Templates) will be different from the back button. In this PR, we "fix" it by overriding it locally. The proper fix is to update the `<Item>` component so that it uses WP DS styles, as done in https://github.com/WordPress/gutenberg/pull/78646. I left a `// TODO` comment on that.~~

## Testing Instructions

1. Go to Site Editor (Appearance -> Editor)
2. Use the tab key to try to focus to the `<` back button in `< Design`
3. Verify you can see the focus state again.
4. ~~Verify the focus state for all sidebar items are consistent with the `<`.~~

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="300" height="165" alt="image" src="https://github.com/user-attachments/assets/afd6e7ec-8f22-408d-ac9f-00fb8d61597e" />|<img width="300" height="166" alt="image" src="https://github.com/user-attachments/assets/b9a237e4-54f4-4b07-b1f6-dd5f56196770" />|


## Use of AI Tools

Used Opus 4.8 to investigate the issue.