### PR TITLE
Fix global gap styles for Gallery block

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -73,6 +73,7 @@
 					"wp_enqueue_block_support_styles",
 					"wp_get_typography_font_size_value",
 					"wp_style_engine_get_styles",
+					"wp_get_global_styles",
 					"wp_get_global_settings"
 				],
 				"suffixClasses": [

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -3,9 +3,12 @@
  */
 import {
 	__experimentalGetGapCSSValue as getGapCSSValue,
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 	useStyleOverride,
 	useSettings,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
 
 /**
@@ -14,6 +17,8 @@ import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-
 import { unlock } from '../lock-unlock';
 
 const { getResponsiveMediaQueries } = unlock( globalStylesEnginePrivateApis );
+const { globalStylesDataKey } = unlock( blockEditorPrivateApis );
+const GALLERY_BLOCK_NAME = 'core/gallery';
 
 // --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 // gap on the gallery.
@@ -34,17 +39,48 @@ function getGalleryGapCustomPropertyStyle( selector, blockGap ) {
 	}`;
 }
 
+function getBlockGapValue( style ) {
+	if ( ! Object.hasOwn( style?.spacing || {}, 'blockGap' ) ) {
+		return undefined;
+	}
+
+	return style.spacing.blockGap;
+}
+
 export default function GalleryGapCustomProperties( { style, clientId } ) {
 	const selector = `#block-${ clientId }`;
 	const [ viewportSettings ] = useSettings( 'viewport' );
-	let gap = getGalleryGapCustomPropertyStyle(
-		selector,
-		style?.spacing?.blockGap
+	const globalStyles = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()?.[ globalStylesDataKey ],
+		[]
 	);
+	const globalGalleryStyles =
+		globalStyles?.blocks?.[ GALLERY_BLOCK_NAME ] || {};
+	const styleBlockGap = getBlockGapValue( style );
+	const globalBlockGap =
+		globalGalleryStyles?.spacing?.blockGap ??
+		globalStyles?.spacing?.blockGap;
+	// Prefer the block's own gap value, then Gallery global styles, then root global styles.
+	const blockGap =
+		styleBlockGap === undefined ? globalBlockGap : styleBlockGap;
+	let gap = getGalleryGapCustomPropertyStyle( selector, blockGap );
 
 	Object.entries( getResponsiveMediaQueries( viewportSettings ) ).forEach(
 		( [ viewport, mediaQuery ] ) => {
-			const viewportBlockGap = style?.[ viewport ]?.spacing?.blockGap;
+			const styleViewportBlockGap = getBlockGapValue(
+				style?.[ viewport ]
+			);
+			// Viewport-specific block values win. Global viewport values only apply
+			// when the block has no base gap, so they do not override an instance value.
+			const globalViewportBlockGap =
+				styleBlockGap === undefined
+					? globalGalleryStyles?.[ viewport ]?.spacing?.blockGap
+					: undefined;
+			const viewportBlockGap =
+				styleViewportBlockGap === undefined
+					? globalViewportBlockGap
+					: styleViewportBlockGap;
 			if ( viewportBlockGap === undefined || viewportBlockGap === null ) {
 				return;
 			}

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -58,12 +58,12 @@ export default function GalleryGapCustomProperties( { style, clientId } ) {
 	const globalGalleryStyles =
 		globalStyles?.blocks?.[ GALLERY_BLOCK_NAME ] || {};
 	const styleBlockGap = getBlockGapValue( style );
-	const globalBlockGap =
-		globalGalleryStyles?.spacing?.blockGap ??
-		globalStyles?.spacing?.blockGap;
-	// Prefer the block's own gap value, then Gallery global styles, then root global styles.
+	const globalGalleryBlockGap =
+		globalGalleryStyles?.spacing?.blockGap ?? FALLBACK_VALUE;
+	// Prefer the block's own gap value, then Gallery global styles. Missing
+	// values fall back to the Gallery blockGap default.
 	const blockGap =
-		styleBlockGap === undefined ? globalBlockGap : styleBlockGap;
+		styleBlockGap === undefined ? globalGalleryBlockGap : styleBlockGap;
 	let gap = getGalleryGapCustomPropertyStyle( selector, blockGap );
 
 	Object.entries( getResponsiveMediaQueries( viewportSettings ) ).forEach(
@@ -71,8 +71,8 @@ export default function GalleryGapCustomProperties( { style, clientId } ) {
 			const styleViewportBlockGap = getBlockGapValue(
 				style?.[ viewport ]
 			);
-			// Viewport-specific block values win. Global viewport values only apply
-			// when the block has no base gap, so they do not override an instance value.
+			// Viewport-specific block values win. Gallery global viewport values
+			// only apply when the block has no base gap, so they do not override an instance value.
 			const globalViewportBlockGap =
 				styleBlockGap === undefined
 					? globalGalleryStyles?.[ viewport ]?.spacing?.blockGap

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -399,7 +399,16 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-	$gap_column   = block_core_gallery_get_column_gap_value( $style_attr['spacing']['blockGap'] ?? null, $fallback_gap );
+
+	$global_styles         = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
+	$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();
+	$global_block_gap      = $global_gallery_styles['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+	$has_block_gap         = is_array( $style_attr['spacing'] ?? null ) && array_key_exists( 'blockGap', $style_attr['spacing'] );
+	// Prefer the block's own gap value, then Gallery global styles, then root global styles.
+	$block_gap  = $has_block_gap
+		? $style_attr['spacing']['blockGap']
+		: $global_block_gap;
+	$gap_column = block_core_gallery_get_column_gap_value( $block_gap, $fallback_gap );
 
 	// Set the CSS variable to the column value for Gallery's flex width calculations.
 	$gallery_styles = array(
@@ -422,8 +431,24 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	}
 
 	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
-		$viewport_style = $style_attr[ $breakpoint ] ?? null;
-		if ( ! is_array( $viewport_style ) || ! isset( $viewport_style['spacing']['blockGap'] ) ) {
+		$viewport_style                = $style_attr[ $breakpoint ] ?? null;
+		$has_viewport_block_gap        = is_array( $viewport_style ) &&
+			is_array( $viewport_style['spacing'] ?? null ) &&
+			array_key_exists( 'blockGap', $viewport_style['spacing'] );
+		$has_global_viewport_block_gap = is_array( $global_gallery_styles[ $breakpoint ]['spacing'] ?? null ) &&
+			array_key_exists( 'blockGap', $global_gallery_styles[ $breakpoint ]['spacing'] );
+
+		// Viewport-specific block values win. Global viewport values only apply
+		// when the block has no base gap, so they do not override an instance value.
+		if ( $has_viewport_block_gap ) {
+			$viewport_gap = $viewport_style['spacing']['blockGap'];
+		} elseif ( ! $has_block_gap && $has_global_viewport_block_gap ) {
+			$viewport_gap = $global_gallery_styles[ $breakpoint ]['spacing']['blockGap'];
+		} else {
+			continue;
+		}
+
+		if ( null === $viewport_gap ) {
 			continue;
 		}
 
@@ -431,7 +456,7 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 			'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
 			'declarations' => array(
 				'--wp--style--unstable-gallery-gap' => block_core_gallery_get_column_gap_value(
-					$viewport_style['spacing']['blockGap'],
+					$viewport_gap,
 					$fallback_gap
 				),
 			),

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -307,6 +307,8 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
+	static $global_styles = null;
+
 	// In dynamic mode the gallery's images are resolved at render time instead of
 	// being authored as inner blocks, so `save.js` persists at most the
 	// gallery-level caption — a bare `<figcaption>`, or nothing when there is no
@@ -400,14 +402,18 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
 
-	$global_styles         = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
+	if ( null === $global_styles ) {
+		$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
+	}
+
 	$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();
-	$global_block_gap      = $global_gallery_styles['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+	$global_gallery_gap    = $global_gallery_styles['spacing']['blockGap'] ?? $fallback_gap;
 	$has_block_gap         = is_array( $style_attr['spacing'] ?? null ) && array_key_exists( 'blockGap', $style_attr['spacing'] );
-	// Prefer the block's own gap value, then Gallery global styles, then root global styles.
+	// Prefer the block's own gap value, then Gallery global styles. Missing
+	// values fall back to the Gallery blockGap default.
 	$block_gap  = $has_block_gap
 		? $style_attr['spacing']['blockGap']
-		: $global_block_gap;
+		: $global_gallery_gap;
 	$gap_column = block_core_gallery_get_column_gap_value( $block_gap, $fallback_gap );
 
 	// Set the CSS variable to the column value for Gallery's flex width calculations.
@@ -438,8 +444,8 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 		$has_global_viewport_block_gap = is_array( $global_gallery_styles[ $breakpoint ]['spacing'] ?? null ) &&
 			array_key_exists( 'blockGap', $global_gallery_styles[ $breakpoint ]['spacing'] );
 
-		// Viewport-specific block values win. Global viewport values only apply
-		// when the block has no base gap, so they do not override an instance value.
+		// Viewport-specific block values win. Gallery global viewport values
+		// only apply when the block has no base gap, so they do not override an instance value.
 		if ( $has_viewport_block_gap ) {
 			$viewport_gap = $viewport_style['spacing']['blockGap'];
 		} elseif ( ! $has_block_gap && $has_global_viewport_block_gap ) {

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1012,7 +1012,11 @@ function getResponsiveStyleNodes(
 	const {
 		styles,
 		selector,
+		fallbackGapValue,
 		featureSelectors,
+		hasLayoutSupport,
+		layoutHasBlockGapSupport,
+		layoutSelector,
 		name,
 		elementName,
 		isStyleVariation,
@@ -1039,10 +1043,14 @@ function getResponsiveStyleNodes(
 						featureSelectors && typeof featureSelectors !== 'string'
 							? featureSelectors
 							: undefined,
+					fallbackGapValue,
+					hasLayoutSupport,
 					name,
 					elementName,
 					isStyleVariation,
 					variationName,
+					layoutSelector,
+					layoutHasBlockGapSupport,
 				},
 			];
 		}

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -1040,6 +1040,47 @@ describe( 'global styles renderer', () => {
 			);
 		} );
 
+		it( 'handles responsive block gap styles', () => {
+			const tree = {
+				styles: {
+					blocks: {
+						'core/group': {
+							'@mobile': {
+								spacing: {
+									blockGap: '24px',
+								},
+							},
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const blockSelectors = {
+				'core/group': {
+					selector: '.wp-block-group',
+					hasLayoutSupport: true,
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				true,
+				false,
+				false,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toContain( '@media (width <= 480px)' );
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-flow) > * { margin-block-start: 24px; margin-block-end: 0; }'
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-flex) { gap: 24px; }'
+			);
+		} );
+
 		it( 'handles legacy responsive block styles', () => {
 			const tree = {
 				styles: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #56554.
Fixes #60505.

Follow-up from [#79984](https://github.com/WordPress/gutenberg/pull/79984#issuecomment-4920842386).

#79984 missed that if the Gallery gap is set in global styles but not in the block instance, we still need to update the custom property used to compute image width for the pseudo-grid layout. 

This PR fixes that by fetching any values from global styles so they can be added to that custom property.

It also adds a bit of logic that was missing from `global-styles-engine/src/core/render.tsx` to output viewport-specific global gap values in the editor (this was an issue for all blocks that support gap, not just Gallery)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Set some global gap styles for default and mobile viewports on the Gallery block.
2. Add a Gallery to a post. Check that the global styles display correctly in the editor, and that the image width computation is correct (an easy way to check this visually is to set a really big gap value and see if the Gallery still has the correct number of columns)
3. Save and check that all displays correctly in the front end too.


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
used codex/gpt 5.5