### PR TITLE
Editor: render mobile back button as proper <Button> and remove custom CSS

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -95,6 +95,7 @@ function Layout() {
 			( desktopToggle ?? mobileToggleRef.current )?.focus();
 		}
 		// Should not depend on the previous canvas mode value but the next.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ canvas ] );
 
 	return (
@@ -174,9 +175,6 @@ function Layout() {
 										{ showMobileSiteHub && (
 											<SiteHubMobile
 												ref={ mobileToggleRef }
-												isTransparent={
-													isResizableFrameOversized
-												}
 											/>
 										) }
 										{ areas.mobileContent ? (

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -177,61 +177,6 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 	}
 }
 
-.edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {
-	display: none;
-}
-
-.edit-site-layout__view-mode-toggle.components-button {
-	view-transition-name: toggle;
-	position: relative;
-	color: var(--wpds-color-foreground-interactive-neutral);
-	height: $header-height;
-	width: $header-height;
-	overflow: hidden;
-	padding: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: var(--wpds-color-background-surface-neutral-weak);
-	border-radius: 0;
-
-	&:hover,
-	&:active {
-		color: var(--wpds-color-foreground-interactive-neutral-active);
-	}
-
-	&:focus-visible,
-	&:focus {
-		box-shadow: 0 0 0 3px #1e1e1e, 0 0 0 6px var(--wp-admin-theme-color);
-		outline: 4px solid #0000;
-		outline-offset: 4px;
-	}
-
-	&::before {
-		content: "";
-		display: block;
-		position: absolute;
-		top: $grid-unit-10 + $border-width;
-		right: $grid-unit-10 + $border-width;
-		bottom: $grid-unit-10 + $border-width;
-		left: $grid-unit-20 + $border-width;
-		border-radius: $radius-medium;
-		box-shadow: none;
-
-		@media not (prefers-reduced-motion) {
-			transition: box-shadow 0.1s ease;
-		}
-	}
-
-	.edit-site-layout__view-mode-toggle-icon {
-		display: flex;
-		height: $header-height;
-		width: $header-height;
-		justify-content: center;
-		align-items: center;
-	}
-}
-
 .edit-site-layout__actions {
 	z-index: z-index(".edit-site-layout__actions");
 	position: fixed !important; // Need to override the default relative positioning

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -77,8 +77,9 @@ export const SiteHubMobile = memo(
 		return (
 			<div className="edit-site-site-hub">
 				<Button
-					__next40pxDefaultSize
+					size="compact"
 					ref={ ref }
+					className="edit-site-site-hub__back-button"
 					icon={ isRTL() ? chevronRight : chevronLeft }
 					{ ...backButtonProps }
 				/>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -1,17 +1,12 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { memo, forwardRef, useContext } from '@wordpress/element';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
@@ -23,7 +18,7 @@ import { SidebarNavigationContext } from '../sidebar';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 export const SiteHubMobile = memo(
-	forwardRef( ( { isTransparent }, ref ) => {
+	forwardRef( ( props, ref ) => {
 		const { path } = useLocation();
 		const history = useHistory();
 		const { navigate } = useContext( SidebarNavigationContext );
@@ -81,32 +76,12 @@ export const SiteHubMobile = memo(
 
 		return (
 			<div className="edit-site-site-hub">
-				<HStack justify="flex-start" spacing="0">
-					<div
-						className={ clsx(
-							'edit-site-site-hub__view-mode-toggle-container',
-							{
-								'has-transparent-background': isTransparent,
-							}
-						) }
-					>
-						<Button
-							__next40pxDefaultSize
-							ref={ ref }
-							className="edit-site-layout__view-mode-toggle"
-							style={ {
-								transform: 'scale(0.5)',
-								borderRadius: 4,
-							} }
-							{ ...backButtonProps }
-						>
-							<Icon
-								icon={ isRTL() ? chevronRight : chevronLeft }
-								size={ 48 }
-							/>
-						</Button>
-					</div>
-				</HStack>
+				<Button
+					__next40pxDefaultSize
+					ref={ ref }
+					icon={ isRTL() ? chevronRight : chevronLeft }
+					{ ...backButtonProps }
+				/>
 			</div>
 		);
 	} )

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,6 +3,13 @@
 .edit-site-site-hub {
 	display: flex;
 	align-items: center;
-	padding-left: $grid-unit-15;
+	padding-left: $grid-unit-20;
 	height: $header-height;
+}
+
+.edit-site-site-hub__back-button {
+	&:hover:not(:disabled, [aria-disabled="true"]),
+	&:active:not(:disabled, [aria-disabled="true"]) {
+		color: var(--wpds-color-foreground-interactive-neutral-active);
+	}
 }

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -3,18 +3,6 @@
 .edit-site-site-hub {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: $grid-unit-10;
-	margin-right: $grid-unit-15;
+	padding-left: $grid-unit-15;
 	height: $header-height;
-}
-
-.edit-site-site-hub__view-mode-toggle-container {
-	height: $header-height;
-	width: $header-height;
-	flex-shrink: 0;
-
-	&.has-transparent-background .edit-site-layout__view-mode-toggle-icon {
-		background: transparent;
-	}
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1144,11 +1144,6 @@
 			"count": 3
 		}
 	},
-	"packages/edit-site/src/components/site-hub/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/edit-widgets/src/components/layout/index.js": {
 		"react-hooks/refs": {
 			"count": 3


### PR DESCRIPTION

## What?

Similar to https://github.com/WordPress/gutenberg/pull/79862, this is a follow-up to:

- https://github.com/WordPress/gutenberg/pull/79197

As the W logo/site icon has been replaced by a back button, this PR replaces the back button on `SiteHubMobile` (rendered in mobile resolution) with a simple `<Button>`. This PR also removes all custom CSS and now-unused animation/transition-related CSS. Now the styles are mostly using `<Button>`'s own styles.

## Testing Instructions

1. Go to Appearance -> Editor
2. Click Templates
3. Resize to mobile resolution
4. Verify the back button still works

## Screenshots or screencast <!-- if applicable -->

<img width="549" height="187" alt="image" src="https://github.com/user-attachments/assets/eda3ba88-fa55-4d9e-9d60-c599a0edc05b" />

Note that this PR does not introduce any visual changes.

## Use of AI Tools

Used Opus 4.8 to help clean up the CSS, also reviewed by me.
