### PR TITLE
Added Missing Global Documentation

### DIFF
--- a/lib/compat/wordpress-7.1/meta-box-rtc-compat.php
+++ b/lib/compat/wordpress-7.1/meta-box-rtc-compat.php
@@ -17,6 +17,8 @@
  * Hooks into filter_block_editor_meta_boxes at a late priority so that it
  * runs after any developer filters that add the flag to third-party meta boxes.
  *
+ * @global WP_Screen $current_screen WordPress current screen object.
+ *
  * @param array $wp_meta_boxes Global meta box state.
  * @return array Unmodified meta box state.
  */


### PR DESCRIPTION
### What? Why?
Global documentation for `$current_screen` is missing in `meta-box-rtc-compat.php`.

### How?
Added missing global documentation in `meta-box-rtc-compat.php` file.

### Testing Instructions
1. Open `meta-box-rtc-compat.php` file.
2. Verify that the DocBlock for the `gutenberg_inject_rtc_compatible_meta_boxes()` function now includes the `@global WP_Screen $current_screen` documentation tag.

### Use of AI Tools
None