### PR TITLE
Style Book: Pass site editor settings to StyleBookPreview on the styles route

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/styles.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles.js
@@ -16,7 +16,7 @@ import SidebarGlobalStyles from '../sidebar-global-styles';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { StyleBookPreview } = unlock( editorPrivateApis );
 
-function StylesPreviewArea() {
+function StylesPreviewArea( { siteData } ) {
 	const { path, query } = useLocation();
 	const history = useHistory();
 	const isStylebook = query.preview === 'stylebook';
@@ -36,6 +36,7 @@ function StylesPreviewArea() {
 			<StyleBookPreview
 				path={ section }
 				onPathChange={ onChangeSection }
+				settings={ siteData.editorSettings }
 			/>
 		);
 	}
@@ -49,7 +50,9 @@ export const stylesRoute = {
 	areas: {
 		content: <SidebarGlobalStyles />,
 		sidebar: <SidebarNavigationScreenGlobalStyles backPath="/" />,
-		preview: <StylesPreviewArea />,
+		preview: ( { siteData } ) => (
+			<StylesPreviewArea siteData={ siteData } />
+		),
 		mobileContent: <SidebarGlobalStyles />,
 	},
 	widths: {


### PR DESCRIPTION
## What?
Closes #73869.
Related #76843.

PR fixes a root cause for #73869 and avoids potential errors over missing editor settings.

## Why?
The `/styles` route rendered `StyleBookPreview` without a `settings` prop, so it fell back to `editorStore.getEditorSettings()`. Since the full `<Editor>` isn't mounted for the stylebook preview, that store still holds `EDITOR_SETTINGS_DEFAULTS`, missing `__experimentalDiscussionSettings` (and other server-bootstrapped settings).

The `/stylebook` route already passes `siteData.editorSettings`, so the two routes feed `StyleBookPreview` different settings, and consumers reading `__experimentalDiscussionSettings` could error on the styles route.

This thread's `siteData.editorSettings` (edit-site store, server-bootstrapped) into `StyleBookPreview` on the styles route too, so both routes supply consistent, complete settings.

## Testing Instructions
1. Navigate to `wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks&preview=stylebook`.
2. Open the DevTools and run  `wp.data.select( 'core/block-editor' ).getSettings().__experimentalDiscussionSettings`.
3. The setting should be defined.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
