### PR TITLE
Revisions: Ensure assertive announcements when exiting or restoring revisions 

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-header.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
 import { __, _x, isRTL } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { drawerLeft, drawerRight, seen } from '@wordpress/icons';
 
 /**
@@ -95,7 +96,10 @@ function RevisionsHeader( { showDiff, onToggleDiff } ) {
 						__next40pxDefaultSize
 						variant="secondary"
 						size="compact"
-						onClick={ () => setCurrentRevisionId( null ) }
+						onClick={ () => {
+							setCurrentRevisionId( null );
+							speak( __( 'Revisions exited.' ), 'assertive' );
+						} }
 					>
 						{ __( 'Exit' ) }
 					</Button>

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -11,6 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -747,18 +748,20 @@ export const restoreRevision =
 		// Save the post to persist the restored revision.
 		await dispatch.savePost();
 
-		// Show success notice.
-		registry.dispatch( noticesStore ).createSuccessNotice(
-			sprintf(
-				/* translators: %s: Date and time of the revision. */
-				__( 'Restored to revision from %s.' ),
-				dateI18n( getDateSettings().formats.datetime, revision.date )
-			),
-			{
-				type: 'snackbar',
-				id: 'editor-revision-restored',
-			}
+		const message = sprintf(
+			/* translators: %s: Date and time of the revision. */
+			__( 'Restored to revision from %s.' ),
+			dateI18n( getDateSettings().formats.datetime, revision.date )
 		);
+
+		speak( message, 'assertive' );
+
+		// Show success notice.
+		registry.dispatch( noticesStore ).createSuccessNotice( message, {
+			type: 'snackbar',
+			id: 'editor-revision-restored',
+			speak: false,
+		} );
 	};
 
 /**


### PR DESCRIPTION

## What?

Part of https://github.com/WordPress/gutenberg/issues/77530

Ensures that exiting the Revisions mode and restoring a revision trigger reliable, assertive screen reader announcements.

## Why?

Previously, exiting or restoring revisions inconsistently announced confirmations. Restoring triggered a standard `polite` snackbar notification, which was frequently interrupted and dropped by screen readers due to focus shifting back to the main editor context. Furthermore, clicking "Exit" provided no explicit screen reader confirmation. Utilizing an assertive live region ensures users get immediate feedback that their action succeeded, regardless of underlying focus changes.

## How?

*   Imported `speak` from `@wordpress/a11y`.
*   Added `speak( __( 'Revisions exited.' ), 'assertive' );` to the `onClick` handler of the Revisions "Exit" button.
*   Added `speak( message, 'assertive' );` in the `restoreRevision` action prior to creating the snackbar success notice.
*   Disabled the default polite spoken message on the resulting success notice (`speak: false`) to prevent redundant double announcements.


## Testing Instructions

1. Enable a screen reader.
2. Open a post containing revisions in the block editor.
3. Open the visual revision editor from the Document settings sidebar.
4. Click the "Exit" button in the revisions header. Verify the screen reader announces "Revisions exited."
5. Re-open the visual revisions editor.
6. Drag the slider to select an older revision.
7. Click the "Restore" button. Verify the screen reader assertively announces "Restored to revision from [Date]." without a duplicate announcement overlapping it.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/9a4a3e49-f2d7-46d0-8700-b9a040302fcd


