### PR TITLE
Media Inserter: Add pagination to core media inserter categories

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1426,6 +1426,7 @@ _Type Definition_
 _Properties_
 
 -   _per_page_ `number`: How many items to fetch per page.
+-   _page_ `[number]`: Which page of results to fetch. Defaults to the first page.
 -   _search_ `string`: The search term to use for filtering the results.
 
 _Type Definition_
@@ -1441,6 +1442,16 @@ _Properties_
 -   _sourceId_ `[number|string]`: The id of the media item from external source.
 -   _alt_ `[string]`: The alt text of the media item.
 -   _caption_ `[string]`: The caption of the media item.
+
+_Type Definition_
+
+-   _InserterMediaResponse_ `Object`: Interface for paginated inserter media responses. A media category's `fetch` may return this instead of a plain array to opt into pagination, in which case the media tab renders paging controls for the category.
+
+_Properties_
+
+-   _mediaItems_ `InserterMediaItem[]`: The media items for the requested page.
+-   _totalItems_ `number`: The total number of items across all pages.
+-   _totalPages_ `number`: The total number of pages available.
 
 _Usage_
 
@@ -1511,7 +1522,7 @@ _Properties_
 -   _labels.name_ `string`: General name of the media category. It's used in the inserter media items list.
 -   _labels.search_items_ `[string]`: Label for searching items. Default is ‘Search Posts’ / ‘Search Pages’.
 -   _mediaType_ `('image'|'audio'|'video')`: The media type of the media category.
--   _fetch_ `(InserterMediaRequest) => Promise<InserterMediaItem[]>`: The function to fetch media items for the category.
+-   _fetch_ `(InserterMediaRequest) => Promise<InserterMediaItem[]|InserterMediaResponse>`: The function to fetch media items for the category. Returning an `InserterMediaResponse` instead of a plain array opts the category into pagination.
 -   _getReportUrl_ `[(InserterMediaItem) => string]`: If the media category supports reporting media items, this function should return the report url for the media item. It accepts the `InserterMediaItem` as an argument.
 -   _isExternalResource_ `[boolean]`: If the media category is an external resource, this should be set to true. This is used to avoid making a request to the external resource when checking whether the category has any media items to display in the media tab.
 -   _emptyMessage_ `[string]`: Optional message shown in place of the generic "No results found." when the source has no items and there is no active search. Providing it also keeps the source in the tab list while empty, so the message stays reachable.

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -21,10 +21,14 @@ import { unlock } from '../../../lock-unlock';
  * @param {InserterMediaRequest} query      The query args to use for the request.
  * @param {any}                  refreshKey Optional value that, when changed, forces
  *                                          a refetch (e.g. after attaching/detaching).
- * @return {InserterMediaItem[]} The media results.
+ * @return {{ mediaList: InserterMediaItem[], isLoading: boolean, totalItems: number|undefined, totalPages: number|undefined }} The media results and paging totals.
  */
 export function useMediaResults( category, query = {}, refreshKey ) {
 	const [ mediaList, setMediaList ] = useState();
+	// A source can return totals for server-side pagination (as
+	// `{ mediaList, totalItems, totalPages }`) or a plain array (no pager). When
+	// no totals are provided, these stay `undefined` and the panel hides the pager.
+	const [ totals, setTotals ] = useState( {} );
 	const [ isLoading, setIsLoading ] = useState( false );
 	// We need to keep track of the last request made because
 	// multiple request can be fired without knowing the order
@@ -36,6 +40,7 @@ export function useMediaResults( category, query = {}, refreshKey ) {
 	const lastRequestRef = useRef();
 	const lastQueryKeyRef = useRef();
 	const lastFetchRef = useRef();
+	const lastSourceRef = useRef();
 	useEffect( () => {
 		( async () => {
 			const key = JSON.stringify( {
@@ -56,11 +61,35 @@ export function useMediaResults( category, query = {}, refreshKey ) {
 			) {
 				setMediaList( [] );
 			}
+			// Reset paging totals only when the source (category or its `fetch`)
+			// changes, so switching to an array-returning source doesn't leave a
+			// stale pager showing. A mere page change keeps the previous totals,
+			// which is what holds the footer mounted while the next page loads.
+			if (
+				lastSourceRef.current !== category.name ||
+				lastFetchRef.current !== category.fetch
+			) {
+				setTotals( {} );
+			}
 			lastQueryKeyRef.current = key;
 			lastFetchRef.current = category.fetch;
-			const _media = await category.fetch?.( query );
+			lastSourceRef.current = category.name;
+			const _result = await category.fetch?.( query );
+			// A source may return either a plain array or an object carrying
+			// pagination totals. Normalize both to a media list plus optional
+			// totals so results and totals update together.
+			const _media = Array.isArray( _result )
+				? _result
+				: _result?.mediaList;
+			const _totals = Array.isArray( _result )
+				? {}
+				: {
+						totalItems: _result?.totalItems,
+						totalPages: _result?.totalPages,
+				  };
 			if ( request === lastRequestRef.current ) {
 				setMediaList( _media );
+				setTotals( _totals );
 				setIsLoading( false );
 			}
 		} )();
@@ -70,7 +99,12 @@ export function useMediaResults( category, query = {}, refreshKey ) {
 		...Object.values( query ),
 		refreshKey,
 	] );
-	return { mediaList, isLoading };
+	return {
+		mediaList,
+		isLoading,
+		totalItems: totals.totalItems,
+		totalPages: totals.totalPages,
+	};
 }
 
 /**
@@ -144,9 +178,14 @@ export function useMediaCategories( rootClientId ) {
 						}
 						let results = [];
 						try {
-							results = await category.fetch( {
+							const result = await category.fetch( {
 								per_page: 1,
 							} );
+							// `fetch` may return a plain array or a
+							// `{ mediaList, ... }` object (paginated sources).
+							results = Array.isArray( result )
+								? result
+								: result?.mediaList ?? [];
 						} catch {
 							// If the request fails, we shallow the error and just don't show
 							// the category, in order to not break the media tab.

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -12,6 +12,27 @@ import { unlock } from '../../../lock-unlock';
 
 /** @typedef {import('../../../store/actions').InserterMediaRequest} InserterMediaRequest */
 /** @typedef {import('../../../store/actions').InserterMediaItem} InserterMediaItem */
+/** @typedef {import('../../../store/actions').InserterMediaResponse} InserterMediaResponse */
+
+/**
+ * Normalizes the result of a media category's `fetch`, which may be either a
+ * plain array of media items or an `InserterMediaResponse` carrying pagination
+ * totals. Sources that don't report totals leave them `undefined`, which is how
+ * the panel knows to hide the pager.
+ *
+ * @param {InserterMediaItem[]|InserterMediaResponse|undefined} result The raw `fetch` result.
+ * @return {{ mediaItems: InserterMediaItem[], totalItems: number|undefined, totalPages: number|undefined }} The normalized result.
+ */
+function normalizeFetchResult( result ) {
+	if ( Array.isArray( result ) ) {
+		return { mediaItems: result };
+	}
+	return {
+		mediaItems: result?.mediaItems ?? [],
+		totalItems: result?.totalItems,
+		totalPages: result?.totalPages,
+	};
+}
 
 /**
  * Fetches media items based on the provided category.
@@ -25,9 +46,6 @@ import { unlock } from '../../../lock-unlock';
  */
 export function useMediaResults( category, query = {}, refreshKey ) {
 	const [ mediaList, setMediaList ] = useState();
-	// A source can return totals for server-side pagination (as
-	// `{ mediaList, totalItems, totalPages }`) or a plain array (no pager). When
-	// no totals are provided, these stay `undefined` and the panel hides the pager.
 	const [ totals, setTotals ] = useState( {} );
 	const [ isLoading, setIsLoading ] = useState( false );
 	// We need to keep track of the last request made because
@@ -74,22 +92,13 @@ export function useMediaResults( category, query = {}, refreshKey ) {
 			lastQueryKeyRef.current = key;
 			lastFetchRef.current = category.fetch;
 			lastSourceRef.current = category.name;
-			const _result = await category.fetch?.( query );
-			// A source may return either a plain array or an object carrying
-			// pagination totals. Normalize both to a media list plus optional
-			// totals so results and totals update together.
-			const _media = Array.isArray( _result )
-				? _result
-				: _result?.mediaList;
-			const _totals = Array.isArray( _result )
-				? {}
-				: {
-						totalItems: _result?.totalItems,
-						totalPages: _result?.totalPages,
-				  };
+			const { mediaItems, totalItems, totalPages } = normalizeFetchResult(
+				await category.fetch?.( query )
+			);
 			if ( request === lastRequestRef.current ) {
-				setMediaList( _media );
-				setTotals( _totals );
+				// Set together so the grid and the pager never disagree.
+				setMediaList( mediaItems );
+				setTotals( { totalItems, totalPages } );
 				setIsLoading( false );
 			}
 		} )();
@@ -178,14 +187,10 @@ export function useMediaCategories( rootClientId ) {
 						}
 						let results = [];
 						try {
-							const result = await category.fetch( {
-								per_page: 1,
-							} );
-							// `fetch` may return a plain array or a
-							// `{ mediaList, ... }` object (paginated sources).
-							results = Array.isArray( result )
-								? result
-								: result?.mediaList ?? [];
+							const { mediaItems } = normalizeFetchResult(
+								await category.fetch( { per_page: 1 } )
+							);
+							results = mediaItems;
 						} catch {
 							// If the request fails, we shallow the error and just don't show
 							// the category, in order to not break the media tab.

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -19,6 +19,7 @@ import { useDebouncedInput, usePrevious } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { getScrollContainer } from '@wordpress/dom';
 import { store as noticesStore } from '@wordpress/notices';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -316,9 +317,12 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 			{ hasFooter && (
 				// A single footer wrapper owns the top and horizontal breathing
 				// room, so the pager and attach button don't span the full width
-				// and sit clear of the grid above. They stack as siblings with a
-				// natural gap between them (see styles).
-				<div className={ `${ baseCssClass }-footer` }>
+				// and sit clear of the grid above (see styles).
+				<Stack
+					direction="column"
+					gap="sm"
+					className={ `${ baseCssClass }-footer` }
+				>
 					{ showPagination && (
 						// Reuse the Patterns tab pager (presentational only); only
 						// rendered for multi-page sources (see `showPagination`).
@@ -334,7 +338,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 						// adjacent column.
 						<AttachImagesButton onSelect={ handleAttach } />
 					) }
-				</div>
+				</Stack>
 			) }
 			{ mediaPendingDetach && (
 				// A plain `Modal` (not `ConfirmDialog`) so we can pass

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -8,9 +8,16 @@ import clsx from 'clsx';
  */
 import { Button, Modal, Spinner, SearchControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
-import { useDebouncedInput } from '@wordpress/compose';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { useDebouncedInput, usePrevious } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
+import { getScrollContainer } from '@wordpress/dom';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -21,8 +28,9 @@ import MediaUpload from '../../media-upload';
 import MediaUploadCheck from '../../media-upload/check';
 import { useMediaResults, useDelayedLoading } from './hooks';
 import InserterNoResults from '../no-results';
+import BlockPatternsPaging from '../../block-patterns-paging';
 
-const INITIAL_MEDIA_ITEMS_PER_PAGE = 10;
+const MEDIA_ITEMS_PER_PAGE = 20;
 
 // The attach flow is image-only, so the picker is constrained to images.
 const ATTACH_ALLOWED_TYPES = [ 'image' ];
@@ -68,22 +76,42 @@ function AttachImagesButton( { onSelect } ) {
 
 export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput();
+	const [ page, setPage ] = useState( 1 );
+	// The desktop panel persists across category switches (it's driven by the
+	// selected category, not remounted), so reset paging whenever the source
+	// category or the search term changes. Adjusting state during render (rather
+	// than in an effect) keeps the query on page 1 for the very next fetch,
+	// avoiding a wasted request for the previous page. Mirrors `usePatternsPaging`.
+	const previousCategory = usePrevious( category.name );
+	const previousSearch = usePrevious( debouncedSearch );
+	if (
+		( previousCategory !== category.name ||
+			previousSearch !== debouncedSearch ) &&
+		page !== 1
+	) {
+		setPage( 1 );
+	}
 	const query = useMemo(
 		() => ( {
-			per_page: !! debouncedSearch ? 20 : INITIAL_MEDIA_ITEMS_PER_PAGE,
+			per_page: MEDIA_ITEMS_PER_PAGE,
+			page,
 			search: debouncedSearch,
 		} ),
-		[ debouncedSearch ]
+		[ page, debouncedSearch ]
 	);
 	const [ refreshKey, setRefreshKey ] = useState( 0 );
-	const { mediaList, isLoading } = useMediaResults(
+	const { mediaList, isLoading, totalItems, totalPages } = useMediaResults(
 		category,
 		query,
 		refreshKey
 	);
-	const { createErrorNotice, createSuccessNotice, createWarningNotice } =
-		useDispatch( noticesStore );
-
+	const numPages = totalPages || 1;
+	// If the current set shrinks below the active page (e.g. detaching images
+	// empties the last page), clamp back into range so the grid isn't left blank
+	// on a page that no longer exists.
+	if ( typeof totalPages === 'number' && page > numPages ) {
+		setPage( numPages );
+	}
 	// Private to core's media categories, these capabilities act on WordPress
 	// attachments:
 	// - `attach`/`detach`/`invalidate` manage the images attached to this post.
@@ -96,6 +124,25 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const attach = supportsAttachments ? category.attach : undefined;
 	const detach = supportsAttachments ? category.detach : undefined;
 	const subscribe = supportsAttachments ? category.subscribe : undefined;
+
+	// Only show the pager for multi-page sources. Gating on the page count (not
+	// `mediaList.length`) keeps the footer mounted while paging, since the count
+	// persists across the fetch. It also skips the shared component's stray
+	// single-page item count, which reads oddly here.
+	const showPagination = numPages > 1;
+	// The footer holds the pager and/or the attach button; it exists when either
+	// is present so it can own their shared top/horizontal breathing room.
+	const hasFooter = showPagination || !! attach;
+	const scrollContainerRef = useRef();
+	const changePage = useCallback( ( nextPage ) => {
+		const scrollContainer = getScrollContainer(
+			scrollContainerRef.current
+		);
+		scrollContainer?.scrollTo( 0, 0 );
+		setPage( nextPage );
+	}, [] );
+	const { createErrorNotice, createSuccessNotice, createWarningNotice } =
+		useDispatch( noticesStore );
 
 	// Dim (rather than blank) the populated grid while a refetch is in flight,
 	// but only once it has run long enough to be worth signalling — quick
@@ -217,10 +264,11 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const searchLabel = category.labels.search_items || __( 'Search' );
 	return (
 		<div
+			ref={ scrollContainerRef }
 			className={ clsx( baseCssClass, {
-				// The attach footer supplies the breathing room beneath the
-				// grid, so the list drops its own bottom padding (see styles).
-				'has-attach-footer': !! attach,
+				// The footer supplies the breathing room beneath the grid, so the
+				// list drops its own bottom padding (see styles).
+				'has-footer': hasFooter,
 			} ) }
 		>
 			<SearchControl
@@ -265,10 +313,28 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					/>
 				</div>
 			) }
-			{ attach && (
-				// Pinned to the bottom of the panel as a fixed footer so it lines
-				// up with the "Open Media Library" button in the adjacent column.
-				<AttachImagesButton onSelect={ handleAttach } />
+			{ hasFooter && (
+				// A single footer wrapper owns the top and horizontal breathing
+				// room, so the pager and attach button don't span the full width
+				// and sit clear of the grid above. They stack as siblings with a
+				// natural gap between them (see styles).
+				<div className={ `${ baseCssClass }-footer` }>
+					{ showPagination && (
+						// Reuse the Patterns tab pager (presentational only); only
+						// rendered for multi-page sources (see `showPagination`).
+						<BlockPatternsPaging
+							currentPage={ page }
+							numPages={ numPages }
+							changePage={ changePage }
+							totalItems={ totalItems }
+						/>
+					) }
+					{ attach && (
+						// Lines up with the "Open Media Library" button in the
+						// adjacent column.
+						<AttachImagesButton onSelect={ handleAttach } />
+					) }
+				</div>
 			) }
 			{ mediaPendingDetach && (
 				// A plain `Modal` (not `ConfirmDialog`) so we can pass

--- a/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
@@ -92,7 +92,7 @@ describe( 'useMediaResults', () => {
 		const category = {
 			name: 'images',
 			fetch: jest.fn( async () => ( {
-				mediaList: [ { id: 1 } ],
+				mediaItems: [ { id: 1 } ],
 				totalItems: 42,
 				totalPages: 3,
 			} ) ),

--- a/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
@@ -78,6 +78,34 @@ describe( 'useMediaResults', () => {
 		expect( result.current.mediaList ).toEqual( [ { id: 1 } ] );
 	} );
 
+	it( 'leaves paging totals undefined for an array-returning source', async () => {
+		const category = createCategory( 'images', [ { id: 1 } ] );
+		const { result } = renderHook( () =>
+			useMediaResults( category, { search: '' }, 0 )
+		);
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.totalItems ).toBeUndefined();
+		expect( result.current.totalPages ).toBeUndefined();
+	} );
+
+	it( 'surfaces paging totals from a source that returns them', async () => {
+		const category = {
+			name: 'images',
+			fetch: jest.fn( async () => ( {
+				mediaList: [ { id: 1 } ],
+				totalItems: 42,
+				totalPages: 3,
+			} ) ),
+		};
+		const { result } = renderHook( () =>
+			useMediaResults( category, { search: '' }, 0 )
+		);
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.mediaList ).toEqual( [ { id: 1 } ] );
+		expect( result.current.totalItems ).toBe( 42 );
+		expect( result.current.totalPages ).toBe( 3 );
+	} );
+
 	it( 'clears the previous results when the query changes', async () => {
 		const category = createCategory( 'images', [ { id: 1 } ] );
 		const { result, rerender } = renderHook(

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -518,24 +518,14 @@ $block-inserter-tabs-height: 44px;
 		flex-grow: 1;
 	}
 
-	// Groups the pager and the attach button beneath the grid. Owning their
-	// shared spacing here keeps them from spanning the full width and gives the
-	// breathing room above (matching what the attach button had on its own).
 	.block-editor-inserter__media-panel-footer {
-		display: flex;
-		flex-direction: column;
-		// `flex-shrink: 0` keeps the footer at its natural height as a flex child
-		// rather than collapsing to make room for the scrolling grid above.
+		// Keeps the footer at its natural height rather than collapsing to make
+		// room for the scrolling grid above.
 		flex-shrink: 0;
-		// Natural vertical spacing between the pager and the attach button.
-		gap: $grid-unit-10;
-		// Breathing room above and below, mirroring the attach button's former
-		// top/bottom margins.
 		padding-top: $grid-unit-20;
 		padding-bottom: $grid-unit-20;
 		@include break-medium() {
-			// Align with the search field and grid gutters instead of running
-			// edge to edge.
+			// Align with the search field and grid gutters.
 			padding-left: $grid-unit-30;
 			padding-right: $grid-unit-30;
 		}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -518,22 +518,35 @@ $block-inserter-tabs-height: 44px;
 		flex-grow: 1;
 	}
 
+	// Groups the pager and the attach button beneath the grid. Owning their
+	// shared spacing here keeps them from spanning the full width and gives the
+	// breathing room above (matching what the attach button had on its own).
+	.block-editor-inserter__media-panel-footer {
+		display: flex;
+		flex-direction: column;
+		// `flex-shrink: 0` keeps the footer at its natural height as a flex child
+		// rather than collapsing to make room for the scrolling grid above.
+		flex-shrink: 0;
+		// Natural vertical spacing between the pager and the attach button.
+		gap: $grid-unit-10;
+		// Breathing room above and below, mirroring the attach button's former
+		// top/bottom margins.
+		padding-top: $grid-unit-20;
+		padding-bottom: $grid-unit-20;
+		@include break-medium() {
+			// Align with the search field and grid gutters instead of running
+			// edge to edge.
+			padding-left: $grid-unit-30;
+			padding-right: $grid-unit-30;
+		}
+	}
+
 	.block-editor-inserter__media-panel-attach {
 		// Match the padding (and so the height) of the "Open Media Library"
 		// footer button in the adjacent column, so the two line up.
 		&.components-button {
 			justify-content: center;
 			padding: $grid-unit-20;
-		}
-		// Balanced breathing room above and below the footer button.
-		// `flex-shrink: 0` keeps it full height as a flex child rather than
-		// collapsing to its content.
-		flex-shrink: 0;
-		margin-top: $grid-unit-20;
-		margin-bottom: $grid-unit-20;
-		@include break-medium() {
-			margin-left: $grid-unit-30;
-			margin-right: $grid-unit-30;
 		}
 	}
 
@@ -561,10 +574,10 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 
-	// When the attach footer is present it supplies the breathing room beneath
-	// the grid, so drop the list's own bottom padding — otherwise scrolling to
-	// the end leaves a doubled gap before the footer.
-	&.has-attach-footer .block-editor-inserter__media-list {
+	// When the footer is present it supplies the breathing room beneath the grid,
+	// so drop the list's own bottom padding — otherwise scrolling to the end
+	// leaves a doubled gap before the footer.
+	&.has-footer .block-editor-inserter__media-list {
 		padding-bottom: 0;
 	}
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1935,6 +1935,7 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  *
  * @typedef {Object} InserterMediaRequest
  * @property {number} per_page How many items to fetch per page.
+ * @property {number} [page]   Which page of results to fetch. Defaults to the first page.
  * @property {string} search   The search term to use for filtering the results.
  */
 
@@ -1954,6 +1955,17 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  */
 
 /**
+ * Interface for paginated inserter media responses. A media category's `fetch`
+ * may return this instead of a plain array to opt into pagination, in which case
+ * the media tab renders paging controls for the category.
+ *
+ * @typedef {Object} InserterMediaResponse
+ * @property {InserterMediaItem[]} mediaItems The media items for the requested page.
+ * @property {number}              totalItems The total number of items across all pages.
+ * @property {number}              totalPages The total number of pages available.
+ */
+
+/**
  * Registers a new inserter media category. Once registered, the media category is
  * available in the inserter's media tab.
  *
@@ -1966,6 +1978,7 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  * _Properties_
  *
  * - _per_page_ `number`: How many items to fetch per page.
+ * - _page_ `[number]`: Which page of results to fetch. Defaults to the first page.
  * - _search_ `string`: The search term to use for filtering the results.
  *
  * _Type Definition_
@@ -1984,7 +1997,19 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  * - _alt_ `[string]`: The alt text of the media item.
  * - _caption_ `[string]`: The caption of the media item.
  *
- * @param    {InserterMediaCategory}                                  category                       The inserter media category to register.
+ * _Type Definition_
+ *
+ * - _InserterMediaResponse_ `Object`: Interface for paginated inserter media responses. A media
+ * category's `fetch` may return this instead of a plain array to opt into pagination, in which
+ * case the media tab renders paging controls for the category.
+ *
+ * _Properties_
+ *
+ * - _mediaItems_ `InserterMediaItem[]`: The media items for the requested page.
+ * - _totalItems_ `number`: The total number of items across all pages.
+ * - _totalPages_ `number`: The total number of pages available.
+ *
+ * @param    {InserterMediaCategory}                                                        category                       The inserter media category to register.
  *
  * @example
  * ```js
@@ -2041,18 +2066,20 @@ export function __unstableSetTemporarilyEditingAsBlocks( clientId ) {
  * ```
  *
  * @typedef {Object} InserterMediaCategory Interface for inserter media category.
- * @property {string}                                                 name                           The name of the media category, that should be unique among all media categories.
- * @property {Object}                                                 labels                         Labels for the media category.
- * @property {string}                                                 labels.name                    General name of the media category. It's used in the inserter media items list.
- * @property {string}                                                 [labels.search_items='Search'] Label for searching items. Default is ‘Search Posts’ / ‘Search Pages’.
- * @property {('image'|'audio'|'video')}                              mediaType                      The media type of the media category.
- * @property {(InserterMediaRequest) => Promise<InserterMediaItem[]>} fetch                          The function to fetch media items for the category.
- * @property {(InserterMediaItem) => string}                          [getReportUrl]                 If the media category supports reporting media items, this function should return
- *                                                                                                   the report url for the media item. It accepts the `InserterMediaItem` as an argument.
- * @property {boolean}                                                [isExternalResource]           If the media category is an external resource, this should be set to true.
- *                                                                                                   This is used to avoid making a request to the external resource when checking
- *                                                                                                   whether the category has any media items to display in the media tab.
- * @property {string}                                                 [emptyMessage]                 Optional message shown in place of the generic "No results found." when the source has no items and there is no active search. Providing it also keeps the source in the tab list while empty, so the message stays reachable.
+ * @property {string}                                                                       name                           The name of the media category, that should be unique among all media categories.
+ * @property {Object}                                                                       labels                         Labels for the media category.
+ * @property {string}                                                                       labels.name                    General name of the media category. It's used in the inserter media items list.
+ * @property {string}                                                                       [labels.search_items='Search'] Label for searching items. Default is ‘Search Posts’ / ‘Search Pages’.
+ * @property {('image'|'audio'|'video')}                                                    mediaType                      The media type of the media category.
+ * @property {(InserterMediaRequest) => Promise<InserterMediaItem[]|InserterMediaResponse>} fetch                          The function to fetch media items for the category. Returning an
+ *                                                                                                                         `InserterMediaResponse` instead of a plain array opts the category into
+ *                                                                                                                         pagination.
+ * @property {(InserterMediaItem) => string}                                                [getReportUrl]                 If the media category supports reporting media items, this function should return
+ *                                                                                                                         the report url for the media item. It accepts the `InserterMediaItem` as an argument.
+ * @property {boolean}                                                                      [isExternalResource]           If the media category is an external resource, this should be set to true.
+ *                                                                                                                         This is used to avoid making a request to the external resource when checking
+ *                                                                                                                         whether the category has any media items to display in the media tab.
+ * @property {string}                                                                       [emptyMessage]                 Optional message shown in place of the generic "No results found." when the source has no items and there is no active search. Providing it also keeps the source in the tab list while empty, so the message stays reachable.
  */
 export const registerInserterMediaCategory =
 	( category ) =>
@@ -2081,7 +2108,7 @@ export const registerInserterMediaCategory =
 		}
 		if ( ! category.fetch || typeof category.fetch !== 'function' ) {
 			console.error(
-				'Category should have a `fetch` function defined with the following signature `(InserterMediaRequest) => Promise<InserterMediaItem[]>`.'
+				'Category should have a `fetch` function defined with the following signature `(InserterMediaRequest) => Promise<InserterMediaItem[]|InserterMediaResponse>`.'
 			);
 			return;
 		}

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1379,7 +1379,7 @@ describe( 'actions', () => {
 					fetch: 'c',
 				} )( {} );
 				expect( console ).toHaveErroredWith(
-					'Category should have a `fetch` function defined with the following signature `(InserterMediaRequest) => Promise<InserterMediaItem[]>`.'
+					'Category should have a `fetch` function defined with the following signature `(InserterMediaRequest) => Promise<InserterMediaItem[]|InserterMediaResponse>`.'
 				);
 			} );
 			it( 'has unique name', () => {

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -133,7 +133,7 @@ const coreMediaFetch = async ( query = {} ) => {
 	// Use the same final query for the records fetch and the totals selectors so
 	// their cached query key matches and the totals resolve to this exact request.
 	const finalQuery = getCoreMediaQuery( query );
-	const mediaItems = await resolveSelect( coreStore ).getEntityRecords(
+	const records = await resolveSelect( coreStore ).getEntityRecords(
 		'postType',
 		'attachment',
 		finalQuery
@@ -152,12 +152,12 @@ const coreMediaFetch = async ( query = {} ) => {
 		finalQuery
 	);
 	return {
-		mediaList: mediaItems.map( ( mediaItem ) => ( {
-			...mediaItem,
-			alt: mediaItem.alt_text,
-			url: mediaItem.source_url,
-			previewUrl: mediaItem.media_details?.sizes?.medium?.source_url,
-			caption: mediaItem.caption?.raw,
+		mediaItems: records.map( ( record ) => ( {
+			...record,
+			alt: record.alt_text,
+			url: record.source_url,
+			previewUrl: record.media_details?.sizes?.medium?.source_url,
+			caption: record.caption?.raw,
 		} ) ),
 		totalItems,
 		totalPages,
@@ -390,7 +390,7 @@ const inserterMediaCategories = [
 			// This external source returns a plain array, so it renders without a
 			// pager (the shared panel treats a non-object result as a single
 			// page). To paginate it later, return the same
-			// `{ mediaList, totalItems, totalPages }` shape the core sources use,
+			// `{ mediaItems, totalItems, totalPages }` shape the core sources use,
 			// mapping `jsonResponse.result_count` -> `totalItems` and
 			// `jsonResponse.page_count` -> `totalPages` (Openverse already accepts
 			// a `page` query arg, which passes straight through above).

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -130,18 +130,38 @@ const getCoreMediaQuery = ( query = {} ) => ( {
 } );
 
 const coreMediaFetch = async ( query = {} ) => {
+	// Use the same final query for the records fetch and the totals selectors so
+	// their cached query key matches and the totals resolve to this exact request.
+	const finalQuery = getCoreMediaQuery( query );
 	const mediaItems = await resolveSelect( coreStore ).getEntityRecords(
 		'postType',
 		'attachment',
-		getCoreMediaQuery( query )
+		finalQuery
 	);
-	return mediaItems.map( ( mediaItem ) => ( {
-		...mediaItem,
-		alt: mediaItem.alt_text,
-		url: mediaItem.source_url,
-		previewUrl: mediaItem.media_details?.sizes?.medium?.source_url,
-		caption: mediaItem.caption?.raw,
-	} ) );
+	// Totals are read synchronously after resolution — the `getEntityRecords`
+	// resolver captures them from the `X-WP-Total` / `X-WP-TotalPages` response
+	// headers, and `resolveSelect().getEntityRecords()` only returns the records.
+	const totalItems = select( coreStore ).getEntityRecordsTotalItems(
+		'postType',
+		'attachment',
+		finalQuery
+	);
+	const totalPages = select( coreStore ).getEntityRecordsTotalPages(
+		'postType',
+		'attachment',
+		finalQuery
+	);
+	return {
+		mediaList: mediaItems.map( ( mediaItem ) => ( {
+			...mediaItem,
+			alt: mediaItem.alt_text,
+			url: mediaItem.source_url,
+			previewUrl: mediaItem.media_details?.sizes?.medium?.source_url,
+			caption: mediaItem.caption?.raw,
+		} ) ),
+		totalItems,
+		totalPages,
+	};
 };
 
 const getAttachedImagesQuery = ( postId, query = {} ) => ( {
@@ -367,6 +387,13 @@ const inserterMediaCategories = [
 			} );
 			const jsonResponse = await response.json();
 			const results = jsonResponse.results;
+			// This external source returns a plain array, so it renders without a
+			// pager (the shared panel treats a non-object result as a single
+			// page). To paginate it later, return the same
+			// `{ mediaList, totalItems, totalPages }` shape the core sources use,
+			// mapping `jsonResponse.result_count` -> `totalItems` and
+			// `jsonResponse.page_count` -> `totalPages` (Openverse already accepts
+			// a `page` query arg, which passes straight through above).
 			return results.map( ( result ) => ( {
 				...result,
 				// This is a temp solution for better titles, until Openverse API

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -91,7 +91,7 @@ describe( 'getInserterMediaCategories', () => {
 			expectedQuery
 		);
 		expect( results ).toEqual( {
-			mediaList: [
+			mediaItems: [
 				expect.objectContaining( {
 					id: 10,
 					url: 'https://example.com/image.jpg',

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -55,6 +55,12 @@ describe( 'getInserterMediaCategories', () => {
 			},
 		] );
 		resolveSelect.mockReturnValue( { getEntityRecords } );
+		const getEntityRecordsTotalItems = jest.fn().mockReturnValue( 1 );
+		const getEntityRecordsTotalPages = jest.fn().mockReturnValue( 1 );
+		select.mockReturnValue( {
+			getEntityRecordsTotalItems,
+			getEntityRecordsTotalPages,
+		} );
 
 		const [ attachedImagesCategory ] = getInserterMediaCategories(
 			42,
@@ -62,25 +68,41 @@ describe( 'getInserterMediaCategories', () => {
 		);
 		const results = await attachedImagesCategory.fetch( { per_page: 20 } );
 
+		const expectedQuery = {
+			per_page: 20,
+			media_type: 'image',
+			parent: 42,
+			orderBy: 'date',
+		};
 		expect( getEntityRecords ).toHaveBeenCalledWith(
 			'postType',
 			'attachment',
-			{
-				per_page: 20,
-				media_type: 'image',
-				parent: 42,
-				orderBy: 'date',
-			}
+			expectedQuery
 		);
-		expect( results ).toEqual( [
-			expect.objectContaining( {
-				id: 10,
-				url: 'https://example.com/image.jpg',
-				previewUrl: 'https://example.com/image-medium.jpg',
-				alt: 'Alt text',
-				caption: 'Caption',
-			} ),
-		] );
+		// Totals are read with the same final query so their cache key matches.
+		expect( getEntityRecordsTotalItems ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			expectedQuery
+		);
+		expect( getEntityRecordsTotalPages ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			expectedQuery
+		);
+		expect( results ).toEqual( {
+			mediaList: [
+				expect.objectContaining( {
+					id: 10,
+					url: 'https://example.com/image.jpg',
+					previewUrl: 'https://example.com/image-medium.jpg',
+					alt: 'Alt text',
+					caption: 'Caption',
+				} ),
+			],
+			totalItems: 1,
+			totalPages: 1,
+		} );
 	} );
 
 	it( 'attaches and detaches attachment records', async () => {


### PR DESCRIPTION
## What?

Part of:

* https://github.com/WordPress/gutenberg/issues/76955
* https://github.com/WordPress/gutenberg/issues/77117

Re-use the patterns pagination controls from the Pattern inserter in the Media inserter

## Why?

Currently the Media inserter only allows folks to navigate a very small number of recent images (10 or 20). While there are ideas for overhauling the Media Inserter in future WP releases (discussed in https://github.com/WordPress/gutenberg/issues/79729), this PR proposes a simpler approach for WP 7.1 — simply re-use the existing pagination controls we already have, and wire them up to the core media categories.

This should enable users to browse more deeply into the media categories without introducing too many changes.

## How?

* Pass along the total items and total pages from the query
* Use these to determine whether to render the existing `BlockPatternsPaging` component to handle pagination
* Update the inserter categories API so that the `fetch` method can return an object instead of an array to opt-in to pagination. In this case the response format is an object with `mediaItems`, `totalItems`, and `totalPages` properties.

While this _is_ an API change, my goal here is to make an API change that we believe categories will want to support in the future as well, irrespective of how the design looks.

## Testing Instructions

* In a site with enough media to cause pagination (i.e. you should have > 20 images in your library), create a post or page
* Attach or upload a bunch of images to the page. If it's < 20 images, the Attached images category in the media inserter should not show pagination
* If > 20 images are attached it should show pagination
* Other core media categories should also show pagination when required (e.g. Images)
* Note: Openverse is not covered by this PR but could be looked at separately in follow-ups, though it is not a priority for WP 7.1. For now, we're concerned with the behaviour for core media categories

## Screenshots or screencast <!-- if applicable -->

### Attached images category (button + pagination)

<img width="1696" height="853" alt="image" src="https://github.com/user-attachments/assets/7249cdf9-5492-4588-a98e-0695f83fdc63" />

### Images category (pagination, no "attach button")

<img width="1695" height="854" alt="image" src="https://github.com/user-attachments/assets/63824be7-b56a-4abb-9d1a-24ceac990765" />

### Attached images category without pagination (i.e. when fewer than the threshold)

When there aren't enough images to cause pagination, the pagination controls shouldn't render:

<img width="1694" height="999" alt="image" src="https://github.com/user-attachments/assets/0a4fe328-3ce2-4af3-a994-fe3c86c62a74" />

### Quick video

https://github.com/user-attachments/assets/a3832af4-9bec-49a2-801b-a60865f5caeb

## Use of AI Tools

Claude Code