### PR TITLE
Checkbox: Add form primitive to @wordpress/ui

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+-   Add `Checkbox` form primitive ([#80039](https://github.com/WordPress/gutenberg/pull/80039)).
 -   Add `Skeleton` component ([#79671](https://github.com/WordPress/gutenberg/pull/79671)).
 
 ### Enhancements

--- a/packages/ui/src/form/primitives/checkbox/checkbox.tsx
+++ b/packages/ui/src/form/primitives/checkbox/checkbox.tsx
@@ -1,0 +1,39 @@
+import { Checkbox as _Checkbox } from '@base-ui/react/checkbox';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { check, reset } from '@wordpress/icons';
+import { Icon } from '../../../icon';
+import resetStyles from '../../../utils/css/resets.module.css';
+import focusStyles from '../../../utils/css/focus.module.css';
+import styles from './style.module.css';
+import type { CheckboxProps } from './types';
+
+export const Checkbox = forwardRef< HTMLSpanElement, CheckboxProps >(
+	function Checkbox( { className, indeterminate, ...restProps }, ref ) {
+		return (
+			<_Checkbox.Root
+				ref={ ref }
+				className={ clsx(
+					resetStyles[ 'box-sizing' ],
+					focusStyles[ 'outset-ring--focus' ],
+					styles.root,
+					className
+				) }
+				indeterminate={ indeterminate }
+				{ ...restProps }
+			>
+				<_Checkbox.Indicator
+					className={ styles[ 'indicator-icon' ] }
+					render={ ( props, state ) => (
+						<Icon
+							{ ...props }
+							icon={ state.indeterminate ? reset : check }
+							viewBox="4 4 16 16"
+							size={ 16 }
+						/>
+					) }
+				/>
+			</_Checkbox.Root>
+		);
+	}
+);

--- a/packages/ui/src/form/primitives/checkbox/index.ts
+++ b/packages/ui/src/form/primitives/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './checkbox';

--- a/packages/ui/src/form/primitives/checkbox/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/checkbox/stories/index.story.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Checkbox } from '../';
+
+const meta: Meta< typeof Checkbox > = {
+	title: 'Design System/Components/Form/Primitives/Checkbox',
+	component: Checkbox,
+	parameters: {
+		componentStatus: {
+			status: 'use-with-caution',
+			whereUsed: 'global',
+			notes: 'Not yet recommended for use alongside components from `@wordpress/components`, pending review of style consistency with `@wordpress/components` and component set completeness. See [WordPress/gutenberg#76135](https://github.com/WordPress/gutenberg/issues/76135).',
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof Checkbox >;
+
+export const Default: Story = {
+	args: {},
+};
+
+export const Checked: Story = {
+	args: {
+		defaultChecked: true,
+	},
+};
+
+export const Indeterminate: Story = {
+	args: {
+		indeterminate: true,
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		disabled: true,
+	},
+};
+
+export const DisabledChecked: Story = {
+	args: {
+		disabled: true,
+		defaultChecked: true,
+	},
+};

--- a/packages/ui/src/form/primitives/checkbox/style.module.css
+++ b/packages/ui/src/form/primitives/checkbox/style.module.css
@@ -37,6 +37,7 @@
 				color: var(--wpds-color-foreground-interactive-neutral-disabled);
 
 				@media (forced-colors: active) {
+					color: GrayText;
 					border-color: GrayText;
 				}
 			}

--- a/packages/ui/src/form/primitives/checkbox/style.module.css
+++ b/packages/ui/src/form/primitives/checkbox/style.module.css
@@ -15,6 +15,10 @@
 			padding: 0;
 			background-color: var(--wpds-color-background-interactive-neutral-weak);
 
+			&:not([data-disabled]) {
+				cursor: var(--wpds-cursor-control);
+			}
+
 			[data-highlighted] &,
 			&:hover {
 				border-color: var(--wpds-color-stroke-interactive-neutral-active);
@@ -27,8 +31,7 @@
 				color: var(--wpds-color-foreground-interactive-brand-strong);
 			}
 
-			&[disabled],
-			&[aria-disabled="true"] {
+			&[data-disabled] {
 				background-color: var(--wpds-color-background-interactive-neutral-weak-disabled);
 				border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
 				color: var(--wpds-color-foreground-interactive-neutral-disabled);

--- a/packages/ui/src/form/primitives/checkbox/style.module.css
+++ b/packages/ui/src/form/primitives/checkbox/style.module.css
@@ -11,7 +11,9 @@
 			width: var(--wp-ui-checkbox-input-size);
 			height: var(--wp-ui-checkbox-input-size);
 			border-radius: var(--wpds-border-radius-sm);
-			border: 1px solid var(--wpds-color-stroke-interactive-neutral);
+			border:
+				var(--wpds-border-width-xs) solid
+				var(--wpds-color-stroke-interactive-neutral);
 			padding: 0;
 			background-color: var(--wpds-color-background-interactive-neutral-weak);
 
@@ -44,9 +46,9 @@
 		}
 
 		.indicator-icon {
-			/* Ignore the 1px border width and take up the full 16px */
+			/* Ignore the border width and take up the full 16px */
 			position: absolute;
-			inset: -1px;
+			inset: calc(0px - var(--wpds-border-width-xs));
 		}
 	}
 }

--- a/packages/ui/src/form/primitives/checkbox/style.module.css
+++ b/packages/ui/src/form/primitives/checkbox/style.module.css
@@ -1,0 +1,51 @@
+@layer wp-ui {
+	@layer utilities, components, compositions, overrides;
+
+	@layer components {
+		.root {
+			--wp-ui-checkbox-input-size: 16px;
+
+			position: relative;
+			display: inline-block;
+			flex-shrink: 0;
+			margin-inline-start:
+				calc(var(--wp-ui-checkbox-input-size) +
+				var(--wp-ui-checkbox-input-indent-adjustment, 0));
+			width: var(--wp-ui-checkbox-input-size);
+			height: var(--wp-ui-checkbox-input-size);
+			border-radius: var(--wpds-border-radius-sm);
+			border: 1px solid var(--wpds-color-stroke-interactive-neutral);
+			padding: 0;
+			background-color: var(--wpds-color-background-interactive-neutral-weak);
+
+			[data-highlighted] &,
+			&:hover {
+				border-color: var(--wpds-color-stroke-interactive-neutral-active);
+			}
+
+			&[aria-checked="true"],
+			&[aria-checked="mixed"] {
+				border-color: transparent;
+				background-color: var(--wpds-color-background-interactive-brand-strong);
+				color: var(--wpds-color-foreground-interactive-brand-strong);
+			}
+
+			&[disabled],
+			&[aria-disabled="true"] {
+				background-color: var(--wpds-color-background-interactive-neutral-weak-disabled);
+				border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
+				color: var(--wpds-color-foreground-interactive-neutral-disabled);
+
+				@media (forced-colors: active) {
+					border-color: GrayText;
+				}
+			}
+		}
+
+		.indicator-icon {
+			/* Ignore the 1px border width and take up the full 16px */
+			position: absolute;
+			inset: -1px;
+		}
+	}
+}

--- a/packages/ui/src/form/primitives/checkbox/style.module.css
+++ b/packages/ui/src/form/primitives/checkbox/style.module.css
@@ -8,9 +8,6 @@
 			position: relative;
 			display: inline-block;
 			flex-shrink: 0;
-			margin-inline-start:
-				calc(var(--wp-ui-checkbox-input-size) +
-				var(--wp-ui-checkbox-input-indent-adjustment, 0));
 			width: var(--wp-ui-checkbox-input-size);
 			height: var(--wp-ui-checkbox-input-size);
 			border-radius: var(--wpds-border-radius-sm);

--- a/packages/ui/src/form/primitives/checkbox/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/checkbox/test/index.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from '@wordpress/element';
+import { Checkbox } from '../index';
+
+describe( 'Checkbox', () => {
+	it( 'forwards ref', () => {
+		const ref = createRef< HTMLSpanElement >();
+
+		render( <Checkbox ref={ ref } /> );
+
+		expect( ref.current ).toBeInstanceOf( HTMLSpanElement );
+	} );
+
+	it( 'renders checked when defaultChecked is true', () => {
+		render( <Checkbox defaultChecked /> );
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+	} );
+
+	it( 'renders indeterminate state', () => {
+		render( <Checkbox indeterminate defaultChecked /> );
+
+		expect( screen.getByRole( 'checkbox' ) ).toBePartiallyChecked();
+	} );
+} );

--- a/packages/ui/src/form/primitives/checkbox/types.ts
+++ b/packages/ui/src/form/primitives/checkbox/types.ts
@@ -1,0 +1,4 @@
+import type { Checkbox as _Checkbox } from '@base-ui/react/checkbox';
+import type { ComponentProps } from '../../../utils/types';
+
+export type CheckboxProps = ComponentProps< typeof _Checkbox.Root >;

--- a/packages/ui/src/form/primitives/index.ts
+++ b/packages/ui/src/form/primitives/index.ts
@@ -1,4 +1,5 @@
 export * as Autocomplete from './autocomplete';
+export { Checkbox } from './checkbox';
 export * as Combobox from './combobox';
 export * as Field from './field';
 export * as Fieldset from './fieldset';


### PR DESCRIPTION
## What?

Adds a `Checkbox` form primitive to `@wordpress/ui`.

## Why?

The design system needs a styled checkbox primitive. This will build up to a higher-level `CheckboxControl`, which will also be able to compose with a `CheckboxGroup` (coming to the package later).

## Testing Instructions

See stories for **Design System/Components/Form/Primitives/Checkbox**.

### Testing Instructions for Keyboard

1. Tab to a checkbox and confirm it receives a visible focus ring.
3. Press Space to toggle checked state.
4. Tab to the disabled stories and confirm they are not interactive.

## Screenshots

<img width="676" height="373" alt="Storybook docs for checkbox" src="https://github.com/user-attachments/assets/f9c95712-d613-4c6b-b024-d11b1b4164f0" />
<img width="280" height="896" alt="checkbox states" src="https://github.com/user-attachments/assets/603bdac3-5e3c-4432-bdd5-a5459af930dd" />
