### PR TITLE
Style Book: Migrate to Tabs from @wordpress/ui

### DIFF
--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -6,11 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	Disabled,
-	Composite,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Disabled, Composite } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import {
 	BlockList,
@@ -36,6 +32,7 @@ import {
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { uploadMedia } from '@wordpress/media-utils';
 import { store as coreStore } from '@wordpress/core-data';
+import { Tabs } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -57,7 +54,6 @@ import { useStyle, useGlobalStyles } from '../global-styles';
 import { store as editorStore } from '../../store';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
-const { Tabs } = unlock( componentsPrivateApis );
 
 function isObjectEmpty( object ) {
 	return ! object || Object.keys( object ).length === 0;
@@ -311,15 +307,18 @@ function StyleBook(
 			} }
 		>
 			{ showTabs ? (
-				<Tabs>
+				<Tabs.Root
+					className="editor-style-book__tabs"
+					defaultValue={ tabs[ 0 ]?.slug }
+				>
 					<div className="editor-style-book__tablist-container">
-						<Tabs.TabList>
+						<Tabs.List>
 							{ tabs.map( ( tab ) => (
-								<Tabs.Tab tabId={ tab.slug } key={ tab.slug }>
+								<Tabs.Tab value={ tab.slug } key={ tab.slug }>
 									{ tab.title }
 								</Tabs.Tab>
 							) ) }
-						</Tabs.TabList>
+						</Tabs.List>
 					</div>
 					{ tabs.map( ( tab ) => {
 						const categoryDefinition = tab.slug
@@ -334,10 +333,10 @@ function StyleBook(
 							  )
 							: { examples };
 						return (
-							<Tabs.TabPanel
+							<Tabs.Panel
 								key={ tab.slug }
-								tabId={ tab.slug }
-								focusable={ false }
+								value={ tab.slug }
+								tabIndex={ -1 }
 								className="editor-style-book__tabpanel"
 							>
 								<StyleBookBody
@@ -349,10 +348,10 @@ function StyleBook(
 									title={ tab.title }
 									goTo={ goTo }
 								/>
-							</Tabs.TabPanel>
+							</Tabs.Panel>
 						);
 					} ) }
-				</Tabs>
+				</Tabs.Root>
 			) : (
 				<StyleBookBody
 					examples={ { examples: examplesForSinglePageUse } }

--- a/packages/editor/src/components/style-book/style.scss
+++ b/packages/editor/src/components/style-book/style.scss
@@ -8,10 +8,6 @@
 	&.is-button {
 		border-radius: $radius-large;
 	}
-
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
 }
 
 .editor-style-book__iframe {
@@ -26,6 +22,15 @@
 		outline: calc(2 * var(--wp-admin-border-width-focus)) solid var(--wp-admin-theme-color);
 		outline-offset: calc(-2 * var(--wp-admin-border-width-focus));
 	}
+}
+
+.editor-style-book__tabs {
+	// `Tabs.Root` renders a wrapping element, so it establishes the flex column
+	// that keeps the tab list at the top and lets the tab panel fill the height.
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
 }
 
 .editor-style-book__tablist-container {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1322,11 +1322,6 @@
 			"count": 2
 		}
 	},
-	"packages/editor/src/components/style-book/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/sync-connection-error-modal/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What?
Noticed why working on #80035.

PR refactors the Style Book to use the recommended `Tabs` from `@wordpress/ui` instead of the deprecated `Tabs` private API from `@wordpress/components`.

Note: `Tabs.Root` renders a wrapping element (the old root didn't), so the flex column moved to a new `.editor-style-book__tabs` class and `.editor-style-book` was simplified accordingl

## Testing Instructions
1. Open the Site Editor → Styles → Style Book.
2. Confirm the tabs (Overview, Text, Colors) render, switch correctly, and the first tab is selected on load.
3. Confirm the Style Book fills the full available height with no layout regression.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="1490" height="758" alt="CleanShot 2026-07-09 at 11 31 32" src="https://github.com/user-attachments/assets/1c92c658-f646-4132-bcf3-3001605325c1" />


## Use of AI Tools

Assisted by Claude.
