### PR TITLE
Fix flaky "can use appender in site editor sidebar list view" e2e test

### DIFF
--- a/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
+++ b/test/e2e/specs/site-editor/navigation-sidebar-list-view.spec.js
@@ -168,11 +168,15 @@ class LinkControl {
 
 		await this.page.keyboard.type( searchTerm, { delay: 50 } );
 
-		await expect(
-			this.page.getByRole( 'listbox', { name: 'Search results' } )
-		).toBeVisible();
+		const searchResults = this.page.getByRole( 'listbox', {
+			name: 'Search results',
+		} );
+		await expect( searchResults ).toBeVisible();
 
-		await this.page.keyboard.press( 'ArrowDown' );
-		await this.page.keyboard.press( 'Enter' );
+		// Click the matching result directly rather than pressing ArrowDown +
+		// Enter. The search is debounced, so the top result can still be a
+		// stale suggestion when the list first appears, and Enter would
+		// select it.
+		await searchResults.getByRole( 'option', { name: searchTerm } ).click();
 	}
 }


### PR DESCRIPTION
## What

Fixes #79632.

The appender test selected the first search result with ArrowDown + Enter the
moment the results list appeared. That search is debounced, so the first result
was sometimes a leftover suggestion and the test added the wrong page. Now it
waits for the matching result and clicks it.

## Testing Instructions

1. In the Site Editor, open a navigation menu's List View in the sidebar.
2. Use the "Add page" appender to search for an existing page and pick it.
3. Check that the page shows up in the List View.

---
Fix implemented by Claude, reviewed and tested by me.