### PR TITLE
Theme: Document token JSON as internal

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Documentation
 
+-   Document raw token JSON files as internal maintainer inputs ([#80048](https://github.com/WordPress/gutenberg/pull/80048)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -23,6 +23,15 @@ Design tokens are named values that describe the visual purpose of a value. Rath
 
 The **[Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md)** explains the naming pattern, how to choose a token, and the complete generated list of available design tokens.
 
+### Public Token Surfaces
+
+The public design token surfaces are:
+
+-   **CSS custom properties** in the `--wpds-*` namespace, delivered through `@wordpress/theme/design-tokens.css` and documented in the [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md).
+-   **Generated runtime token metadata** exposed through `@wordpress/theme/design-tokens.js`, for tooling that needs the list of valid public token names.
+
+The raw JSON files under `packages/theme/tokens/` are maintainer-facing source files. They intentionally include primitive tokens, internal generation data, semantic token definitions, and design-tool metadata in one place. They are not published, exported, or supported as a public API. Consumers should use the generated CSS custom properties and package exports instead of importing or depending on the token JSON structure.
+
 ### Using Design Tokens
 
 Design tokens are delivered as CSS custom properties (e.g. `var(--wpds-color-foreground-content-neutral)`). To use them, a stylesheet defining the token values must be loaded on the page.

--- a/packages/theme/tokens/README.md
+++ b/packages/theme/tokens/README.md
@@ -19,6 +19,8 @@ The design system follows the [Design Tokens Community Group (DTCG)](https://des
 
 Each JSON file contains both primitive and semantic token definitions in a hierarchical structure. These files are the source of truth for the design system and are processed during the build step to generate CSS custom properties and other output formats in `/src/prebuilt`.
 
+The JSON files in this directory are internal maintainer inputs, not package exports. They intentionally mix primitive tokens, semantic token definitions, generation metadata, and design-tool metadata, so their structure can change when the build pipeline or design tooling needs it. Consumers should treat the generated `--wpds-*` CSS custom properties and the package's generated runtime token metadata as the public token surfaces.
+
 ## Token Naming
 
 Semantic tokens follow a consistent naming pattern that encodes the token's purpose. See the [Design Tokens Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) for the naming pattern, the meaning of each segment (type, property, target, tone, emphasis, state), guidance on how to pick the right token, and the complete generated list of token names.


### PR DESCRIPTION
## What?
Follow-up to #77462 (P4).

Documents that the raw `packages/theme/tokens/*.json` files are maintainer-facing inputs, not a public token API.

## Why?
The raw token JSON mixes primitive tokens, semantic token definitions, generation metadata, and design-tool metadata. Consumers should not depend on that structure when the stable surfaces are the generated `--wpds-*` CSS custom properties and generated runtime token metadata.

## How?
- Adds a public token surfaces section to the package README.
- Clarifies in the token maintainer guide that raw JSON files are internal inputs and are not package exports.
- Adds the package changelog entry.

## Testing Instructions
1. Read `packages/theme/README.md` and confirm it points consumers to `@wordpress/theme/design-tokens.css`, `@wordpress/theme/design-tokens.js`, and the generated token reference.
2. Read `packages/theme/tokens/README.md` and confirm it frames `tokens/*.json` as maintainer-facing source files.
3. Confirm `packages/theme/CHANGELOG.md` includes the documentation entry for this PR.

### Testing Instructions for Keyboard
Not applicable; this is a documentation-only change.

## Screenshots or screencast
Not applicable; this is a documentation-only change.

## Use of AI Tools
This PR was created with assistance from OpenAI Codex.