### PR TITLE
Theme: Remove experimental package messaging

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Documentation
 
+-   Remove the experimental messaging from the package README and update the package keywords to reflect its stable design system purpose ([#80049](https://github.com/WordPress/gutenberg/pull/80049)).
 -   Clarify what `@wordpress/theme` provides, when consumers need to load `design-tokens.css`, the `ThemeProvider` contract including root provider usage, and the legacy compatibility boundary ([#79961](https://github.com/WordPress/gutenberg/pull/79961)).
 -   Document build plugin behavior and add parity coverage for PostCSS, esbuild, and Vite ([#80088](https://github.com/WordPress/gutenberg/pull/80088)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Stable Release
+
+This package is now considered stable and production-ready. The API will follow semantic versioning from this point forward.
+
 ### Breaking Changes
 
 -   Remove the `--wpds-elevation-*` design tokens while the complete elevation model is still being defined ([#80099](https://github.com/WordPress/gutenberg/pull/80099)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,9 +1,5 @@
 # Theme
 
-<div class="callout callout-alert">
-This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 A theming package that's part of the WordPress Design System. It has two parts:
 
 -   **Design Tokens**: A comprehensive system of design tokens for colors, spacing, typography, and more.

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -7,7 +7,9 @@
 	"keywords": [
 		"wordpress",
 		"gutenberg",
-		"components"
+		"design-system",
+		"design-tokens",
+		"theme"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/theme/README.md",
 	"repository": {


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/issues/77462.

This PR addresses:

- D1: removes the experimental package warning from the `@wordpress/theme` README.
- P7: updates the package keywords to reflect the stable design system token/theme purpose.
- Adds the documented changelog marker that promotes the next package release to stable `1.0.0`.

## Why?
The package has been moving toward stabilization, so the README should no longer tell consumers that it is experimental. The npm metadata should also describe the package by its current public purpose rather than as a generic components package.

## How?
Removes the experimental callout from `packages/theme/README.md`, replaces the package keywords with `design-system`, `design-tokens`, and `theme`, and adds the package changelog entries.

The package version stays unchanged. Per `packages/README.md`, the release tooling promotes a pre-`1.0.0` package when it sees `### Stable Release` in the package changelog.

## Testing Instructions
1. Confirm `packages/theme/README.md` no longer includes the experimental warning at the top.
2. Confirm `packages/theme/package.json` includes the updated keywords.
3. Confirm `packages/theme/CHANGELOG.md` includes `### Stable Release` under `## Unreleased`.

Checks run:

- `npm run lint:pkg-json -- packages/theme/package.json`
- `git diff --check`
- `npm run lint:md:docs -- packages/theme/README.md` (fails on pre-existing package footer inline HTML: `MD033/no-inline-html`)
- `npm run lint:md:docs -- packages/theme/CHANGELOG.md` (fails on pre-existing whole-file changelog heading noise: `MD041` / `MD024`)

### Testing Instructions for Keyboard
Not applicable; this is a documentation and package metadata change.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Created with AI assistance using OpenAI Codex. I reviewed and verified the changes.

## ✍️ Dev Note

The `@wordpress/theme` package reaches stability ahead of the WordPress 7.1 release.

`@wordpress/theme` is the WordPress Design System theming package. It provides the semantic design tokens used to style admin UI consistently, the generated token assets exposed through `@wordpress/theme/design-tokens.css` and `@wordpress/theme/design-tokens.js`, and the `ThemeProvider` React component for applying configurable theme values such as colors, cursor behavior, and corner radius to a subtree or document.

These APIs are the foundation for consistent, accessible admin UI styling and future theming capabilities such as user color schemes. See the [Design System Theming merge proposal](https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/) for more context.
