### PR TITLE
Theme: Use public design token stylesheet imports

### DIFF
--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -1,6 +1,7 @@
-@use "@wordpress/theme/src/prebuilt/css/design-tokens.css" as *;
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
+
+@import "@wordpress/theme/design-tokens.css";
 
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -1,8 +1,6 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-@import "@wordpress/theme/design-tokens.css";
-
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke
 	// the overscroll bounce on the non-scrolling container, for a bad experience.

--- a/storybook/package-styles/design-tokens.lazy.scss
+++ b/storybook/package-styles/design-tokens.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/theme/src/prebuilt/css/design-tokens.css";
+@import "@wordpress/theme/design-tokens.css";


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/issues/77462 (P5).

## What?
Removes remaining repo-internal usage of the private prebuilt design token stylesheet path where possible.

## Why?
P5 asks the repo to reinforce the stable `@wordpress/theme` API boundary by preferring public subpath imports where possible. For Boot, the correct boundary is to avoid a direct stylesheet import entirely because generated Boot pages already enqueue the registered `wp-theme` style handle through Boot's asset dependencies.

## How?
- Removes Boot's direct import of `@wordpress/theme/src/prebuilt/css/design-tokens.css`.
- Updates Storybook's lazy design-token stylesheet to import the public `@wordpress/theme/design-tokens.css` subpath.

## Testing Instructions
1. Run `npm run lint:css -- packages/boot/src/style.scss storybook/package-styles/design-tokens.lazy.scss`.
2. Run `./node_modules/.bin/sass --load-path=node_modules storybook/package-styles/design-tokens.lazy.scss /private/tmp/codex-design-tokens.css`.
3. Run `npm run build -- packages/boot/src/index.tsx --output-path=/private/tmp/codex-boot-build --webpack-no-externals`.
4. Confirm `build/modules/boot/index.min.asset.php` still lists `wp-theme` in Boot's dependencies.

### Testing Instructions for Keyboard
Not applicable; this is an internal stylesheet import change with no UI behavior change.

## Screenshots or screencast
Not applicable; no visual change expected.

## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex.