### PR TITLE
release: Gate npm publish on package contents

### DIFF
--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -932,6 +932,32 @@ async function publishVersionedPackagesToNpm(
 }
 
 /**
+ * Validates package contents before publishing packages to npm.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.commandFn                  Command runner.
+ */
+async function runPackageContentsValidation(
+	{ gitWorkingDirectoryPath },
+	deps = {}
+) {
+	const { commandFn = command } = deps;
+	log( '>> Building packages for package contents validation.' );
+	await commandFn( 'npm run build', {
+		cwd: gitWorkingDirectoryPath,
+		stdio: 'inherit',
+	} );
+
+	log( '>> Validating package contents with npm pack dry-run checks.' );
+	await commandFn( 'npm run lint:package-contents', {
+		cwd: gitWorkingDirectoryPath,
+		stdio: 'inherit',
+	} );
+}
+
+/**
  * Publishes all changed packages to npm.
  *
  * @param {WPPackagesConfig} config Command config.
@@ -954,6 +980,7 @@ async function publishPackagesToNpm(
 		commandFn = command,
 		git = SimpleGit( gitWorkingDirectoryPath ),
 		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
+		runPackageContentsValidationFn = runPackageContentsValidation,
 	} = deps;
 	log( '>> Installing npm packages.' );
 	await commandFn( 'npm ci', {
@@ -1002,6 +1029,11 @@ async function publishPackagesToNpm(
 			}
 		);
 	}
+
+	await runPackageContentsValidationFn(
+		{ gitWorkingDirectoryPath },
+		{ commandFn }
+	);
 
 	await publishVersionedPackagesToNpmFn( {
 		distTag,
@@ -1255,5 +1287,6 @@ module.exports = {
 	publishNpmNext,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
+	runPackageContentsValidation,
 	verifyRemotePackageTags,
 };

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -13,6 +13,7 @@ import {
 	pushNpmReleaseGitMetadata,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
+	runPackageContentsValidation,
 	verifyRemotePackageTags,
 } from '../packages';
 
@@ -697,6 +698,33 @@ describe( 'publishVersionedPackagesToNpm', () => {
 	} );
 } );
 
+describe( 'runPackageContentsValidation', () => {
+	it( 'builds packages before running the package contents lint command', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+
+		await runPackageContentsValidation(
+			{ gitWorkingDirectoryPath: '/repo' },
+			{ commandFn }
+		);
+
+		expect( commandFn ).toHaveBeenCalledWith( 'npm run build', {
+			cwd: '/repo',
+			stdio: 'inherit',
+		} );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npm run lint:package-contents',
+			{
+				cwd: '/repo',
+				stdio: 'inherit',
+			}
+		);
+		expect( commandFn.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			commandFn.mock.invocationCallOrder[ 1 ]
+		);
+		expect( console ).toHaveLogged();
+	} );
+} );
+
 describe( 'publishPackagesToNpm', () => {
 	const getConfig = ( releaseType ) => ( {
 		distTag: releaseType === 'next' ? 'next' : 'latest',
@@ -743,6 +771,7 @@ describe( 'publishPackagesToNpm', () => {
 					.mockResolvedValueOnce( 'after-sha' ),
 			};
 			const publishVersionedPackagesToNpmFn = jest.fn();
+			const runPackageContentsValidationFn = jest.fn();
 			const config = {
 				...getConfig( releaseType ),
 				distTag,
@@ -753,6 +782,7 @@ describe( 'publishPackagesToNpm', () => {
 				commandFn,
 				git,
 				publishVersionedPackagesToNpmFn,
+				runPackageContentsValidationFn,
 			} );
 
 			expect( commandFn ).toHaveBeenCalledWith( 'npm ci', {
@@ -774,6 +804,15 @@ describe( 'publishPackagesToNpm', () => {
 					command.includes( '--build-metadata' )
 				)
 			).toBe( false );
+			expect( runPackageContentsValidationFn ).toHaveBeenCalledWith(
+				{ gitWorkingDirectoryPath: '/repo' },
+				{ commandFn }
+			);
+			expect(
+				runPackageContentsValidationFn.mock.invocationCallOrder[ 0 ]
+			).toBeLessThan(
+				publishVersionedPackagesToNpmFn.mock.invocationCallOrder[ 0 ]
+			);
 			expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
 				distTag,
 				gitWorkingDirectoryPath: '/repo',


### PR DESCRIPTION
## What?
Follow up to #77462, P6. Builds on the package-contents validation from #79552.

Runs the package contents validator during the npm package release flow before publishing to npm.

## Why?
`lint:package-contents` catches accidental package contents and broken package targets. P6 asks for this validation to become a release gate, so publishing fails before npm upload when package contents drift.

## How?
- Adds `runPackageContentsValidation`, which runs `npm run build` and then `npm run lint:package-contents` in the release working directory.
- Calls it after Lerna versions packages and before the npm publish step.
- Covers the helper and publish ordering in release command unit tests.

## Testing Instructions
1. Run `npm run lint:js -- tools/release/commands/packages.js tools/release/commands/test/packages.js`.
2. Run `npm run test:unit -- tools/release/commands/test/packages.js`.
3. Run `npm run build`.
4. Run `npm run lint:package-contents`.
5. Run `git diff --check origin/trunk..HEAD`.

### Testing Instructions for Keyboard
Not applicable; this changes release/package tooling only.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
This PR was created with assistance from OpenAI Codex.