### PR TITLE
Element: Make the package importable in React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50384,10 +50384,10 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@types/react": "^18.3.27 || ^19.0.0",
-				"@types/react-dom": "^18.3.1 || ^19.0.0",
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15241,7 +15241,8 @@
 		"node_modules/@types/prop-types": {
 			"version": "15.7.4",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+			"dev": true
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -15257,6 +15258,7 @@
 			"version": "18.3.27",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -15267,6 +15269,7 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
@@ -50365,22 +50368,34 @@
 			"version": "8.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/escape-html": "file:../escape-html",
 				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
+				"is-plain-object": "^5.0.0"
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27 || ^19.0.0",
+				"@types/react-dom": "^18.3.1 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"packages/env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50375,9 +50375,7 @@
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
-				"@testing-library/react": "^16.3.2",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
+				"@testing-library/react": "^16.3.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## 8.3.0 (2026-07-14)
 
+### Breaking Changes
+
+-   Move `react` and `react-dom` from `dependencies` to `peerDependencies`. Consumers must now provide `react` and `react-dom` themselves. `@types/react` and `@types/react-dom` become optional peer dependencies ([#80053](https://github.com/WordPress/gutenberg/pull/80053)).
+
 ## 8.2.0 (2026-07-01)
 
 ## 8.1.0 (2026-06-24)

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -56,10 +56,10 @@
 		"react-dom": "^18.3.1"
 	},
 	"peerDependencies": {
-		"@types/react": "^18.3.27 || ^19.0.0",
-		"@types/react-dom": "^18.3.1 || ^19.0.0",
-		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0"
+		"@types/react": "^18 || ^19",
+		"@types/react-dom": "^18 || ^19",
+		"react": "^18 || ^19",
+		"react-dom": "^18 || ^19"
 	},
 	"peerDependenciesMeta": {
 		"@types/react": {

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -51,9 +51,7 @@
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/react": "^16.3.2",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"@testing-library/react": "^16.3.2"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -44,18 +44,30 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@types/react": "^18.3.27",
-		"@types/react-dom": "^18.3.1",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/escape-html": "file:../escape-html",
 		"change-case": "^4.1.2",
-		"is-plain-object": "^5.0.0",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"is-plain-object": "^5.0.0"
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.3.27 || ^19.0.0",
+		"@types/react-dom": "^18.3.1 || ^19.0.0",
+		"react": "^18.0.0 || ^19.0.0",
+		"react-dom": "^18.0.0 || ^19.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		},
+		"@types/react-dom": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/element/src/react-platform.ts
+++ b/packages/element/src/react-platform.ts
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-import {
+import * as ReactDOM from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+
+const {
 	createPortal,
-	findDOMNode,
 	flushSync,
 	/* eslint-disable react/no-deprecated */
+	findDOMNode,
 	render,
 	hydrate,
 	unmountComponentAtNode,
 	/* eslint-enable react/no-deprecated */
-} from 'react-dom';
-import { createRoot, hydrateRoot } from 'react-dom/client';
+} = ReactDOM;
 
 /**
  * Creates a portal into which a component can be rendered.


### PR DESCRIPTION
## What?

Follow up to #80024

Makes `@wordpress/element` importable under React 19 and widens the React peer ranges of the design-system packages like `ui` and `theme` to accept React 18 or 19.

The idea is to do a smaller working iteration rather than having to wait for a fully React 19 compliant build, which may take long and doesn't seem to be landing anywhere near WP 7.1 according to #71336

Two changes in `@wordpress/element`:

1. `src/react-platform.ts` no longer uses named imports for APIs that React 19 removed from `react-dom` (`findDOMNode`, `render`, `hydrate`, `unmountComponentAtNode`).
2. `react`, `react-dom` and their types move from `dependencies` to  `peerDependencies` (`^18.0.0 || ^19.0.0`), matching every sibling package.
3. Plus the range widening (`^18.0.0` -> `^18.0.0 || ^19.0.0`) in the five design-system packages.

## Why?

As a consumer running the design-system packages `ui` and `theme` in a React 19 app, the use case tracked in #76941. I find two problems:

Problem 1: `@wordpress/element` crashes at load time under React 19.  React 19 deleted these four exports from react-dom, so the module fails before any code runs:

Problem 2: Declaring React as a hard dependency creates a second React. For some reason I don't understand, `element` is the only package in this family declaring react/react-dom as dependencies.

## How?

Removing API from `react-dom` instead of named-importing them:

1. React 18: zero behavior change, deprecated exports keep working as before
2. React 19: names resolve as undefined. There is no scenario where this will cause regression because React 19 cannot use them by definition.

## Testing Instructions

1. Create a React 18 project consuming @wordpress/element: no change: `createRoot`, `createPortal`, `flushSync` work, and the deprecated `render/findDOMNode` still function as before.

2. Create a React 19 project: `import { createRoot } from '@wordpress/element'` now loads and works 

3. 🐞 Previously: `SyntaxError` at import. 

