### PR TITLE
Theme: Document root corner radius forwarding

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Documentation
 
+-   Document the `ThemeProvider` root corner-radius forwarding rationale ([#80054](https://github.com/WordPress/gutenberg/pull/80054)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -149,6 +149,8 @@ Setting `isRoot` additionally hoists those overrides to the containing document'
 
 Use `isRoot` on the top-level provider for an application or page. It's also the recommended pattern for the topmost provider rendered into a separate document (iframe, popup window). The static design-tokens stylesheet still provides the default values; `isRoot` is only needed when you want a `<ThemeProvider>`'s overrides to reach the whole document.
 
+For root providers, dynamic `color` and `cursor` overrides are mirrored to `:root` at runtime. The `cornerRadius` preset is finite, so it is forwarded by the generated token stylesheet instead, using `:has()` selectors that match the root provider's `data-wpds-corner-radius` attribute. Keeping that preset in CSS avoids duplicating generated token values in JavaScript while still making the document root match the provider's roundedness.
+
 ### Across documents (iframes and other portals)
 
 When you render React content into a different document (typically an iframe), two things must be true for design tokens to work correctly in that document:


### PR DESCRIPTION
## What?
See #77462.

Documents why root `ThemeProvider` corner-radius forwarding stays in generated CSS with `:has()` selectors.

## Why?
Point I2 asks to document the `:has()` root corner-radius implementation now that browser support is not a stabilization blocker.

## How?
Adds a short note to the `isRoot` docs explaining that dynamic `color` and `cursor` overrides are mirrored at runtime, while the finite `cornerRadius` preset is forwarded by the generated token stylesheet to avoid duplicating generated token values in JavaScript.

## Testing Instructions
1. Review `packages/theme/README.md`.
2. Confirm the `isRoot` section explains why root `cornerRadius` forwarding differs from dynamic `color` and `cursor` forwarding.

### Testing Instructions for Keyboard
Not applicable; this is a documentation-only change.

## Screenshots or screencast
Not applicable; this is a documentation-only change.

## Use of AI Tools
Used OpenAI Codex to inspect the issue context, edit documentation, and run verification.
