### PR TITLE
Theme: Document root provider contract

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Documentation
 
+-   Document that only one `ThemeProvider` root provider is supported per document ([#80055](https://github.com/WordPress/gutenberg/pull/80055)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -149,6 +149,8 @@ Setting `isRoot` additionally hoists those overrides to the containing document'
 
 Use `isRoot` on the top-level provider for an application or page. It's also the recommended pattern for the topmost provider rendered into a separate document (iframe, popup window). The static design-tokens stylesheet still provides the default values; `isRoot` is only needed when you want a `<ThemeProvider>`'s overrides to reach the whole document.
 
+Render at most one root provider per document. Multiple `isRoot` providers that share the same document are unsupported because each one would try to define the document-level token values. Nested and sibling providers can still be used normally when `isRoot` is omitted, and separate documents can each have their own root provider.
+
 ### Across documents (iframes and other portals)
 
 When you render React content into a different document (typically an iframe), two things must be true for design tokens to work correctly in that document:

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -80,6 +80,9 @@ export interface ThemeProviderProps extends ThemeProviderSettings {
 	 * consume the right background color, or that overlays rendered inside a
 	 * portal can inherit the correct color scheme.
 	 *
+	 * Render at most one root provider per document. Multiple root providers
+	 * that share the same document are unsupported.
+	 *
 	 * @default false
 	 */
 	isRoot?: boolean;


### PR DESCRIPTION
## What?
Follow-up to #77462.

Documents that `@wordpress/theme` supports at most one `ThemeProvider isRoot` per document.

## Why?
The runtime already warns and tests this unsupported case, but the stable docs did not make the contract explicit for consumers.

## How?
Adds the single-root-provider-per-document guidance to:

- `packages/theme/README.md`
- `ThemeProviderProps.isRoot` JSDoc
- `packages/theme/CHANGELOG.md`

## Testing Instructions
1. Read `packages/theme/README.md` and confirm the `isRoot` section states that only one root provider should be rendered per document.
2. Read `packages/theme/src/types.ts` and confirm the `isRoot` prop JSDoc states the same contract.
3. Run `npm run test:unit -- packages/theme/src/test/theme-provider.test.tsx`.

### Testing Instructions for Keyboard
Not applicable; this PR only updates documentation and JSDoc.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Used OpenAI Codex to draft the docs update and run focused verification.