### PR TITLE
Theme: Cover display contents wrapper focus behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48251,6 +48251,7 @@
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
+				"@testing-library/user-event": "^14.6.1",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^20.19.39",
 				"esbuild": "^0.27.2",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -34,6 +34,10 @@
 -   Improve the `plugin-wpds/no-token-fallback-values` Stylelint rule message to point developers to the `@wordpress/theme` README for fallback setup guidance ([#79768](https://github.com/WordPress/gutenberg/pull/79768)).
 -   Widen React peer dependency ranges to `^18 || ^19` to support both React 18 and React 19 environments ([#80024](https://github.com/WordPress/gutenberg/pull/80024)).
 
+### Internal
+
+-   Add regression test coverage for the `ThemeProvider` wrapper's `display: contents` focus behavior ([#80056](https://github.com/WordPress/gutenberg/pull/80056)).
+
 ## 0.17.0 (2026-06-30)
 
 ### Breaking Changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -88,6 +88,7 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^20.19.39",
 		"esbuild": "^0.27.2",

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -36,11 +36,57 @@ function getScopingProvider( element: Element ) {
 	return element.closest< HTMLElement >( '.theme-provider-root' )!;
 }
 
+function injectThemeProviderStyles() {
+	const style = document.createElement( 'style' );
+	style.textContent = readFileSync(
+		join( import.meta.dirname, '../style.module.css' ),
+		'utf8'
+	).replaceAll( '.root', '.theme-provider-root' );
+	document.head.appendChild( style );
+	return style;
+}
+
 describe( 'ThemeProvider', () => {
 	it( 'renders its children', () => {
 		render( <ThemeProvider>content</ThemeProvider> );
 
 		expect( screen.getByText( 'content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps its scoping wrapper styled as display contents and unfocusable', () => {
+		const style = injectThemeProviderStyles();
+
+		try {
+			render(
+				<>
+					<button>Before</button>
+					<ThemeProvider>
+						<button>Inside</button>
+					</ThemeProvider>
+					<button>After</button>
+				</>
+			);
+
+			const before = screen.getByRole( 'button', { name: 'Before' } );
+			const inside = screen.getByRole( 'button', { name: 'Inside' } );
+			const after = screen.getByRole( 'button', { name: 'After' } );
+			const provider = getScopingProvider( inside );
+
+			expect( getComputedStyle( provider ).display ).toBe( 'contents' );
+			expect( provider ).not.toHaveAttribute( 'tabindex' );
+
+			provider.focus();
+			expect( provider ).not.toHaveFocus();
+
+			before.focus();
+			expect( before ).toHaveFocus();
+			inside.focus();
+			expect( inside ).toHaveFocus();
+			after.focus();
+			expect( after ).toHaveFocus();
+		} finally {
+			style.remove();
+		}
 	} );
 
 	it( 'defines the color tokens from the seeds within its subtree', () => {

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -6,6 +6,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '../theme-provider';
 
 // Give the wrapper a stable class so tests can locate it and read its
@@ -36,14 +37,21 @@ function getScopingProvider( element: Element ) {
 	return element.closest< HTMLElement >( '.theme-provider-root' )!;
 }
 
-function injectThemeProviderStyles() {
+async function withInjectedThemeProviderStyles(
+	callback: () => void | Promise< void >
+) {
 	const style = document.createElement( 'style' );
 	style.textContent = readFileSync(
 		join( import.meta.dirname, '../style.module.css' ),
 		'utf8'
 	).replaceAll( '.root', '.theme-provider-root' );
 	document.head.appendChild( style );
-	return style;
+
+	try {
+		await callback();
+	} finally {
+		style.remove();
+	}
 }
 
 describe( 'ThemeProvider', () => {
@@ -53,10 +61,10 @@ describe( 'ThemeProvider', () => {
 		expect( screen.getByText( 'content' ) ).toBeInTheDocument();
 	} );
 
-	it( 'keeps its scoping wrapper styled as display contents and unfocusable', () => {
-		const style = injectThemeProviderStyles();
+	it( 'keeps its scoping wrapper styled as display contents and unfocusable', async () => {
+		const user = userEvent.setup();
 
-		try {
+		await withInjectedThemeProviderStyles( async () => {
 			render(
 				<>
 					<button>Before</button>
@@ -78,15 +86,17 @@ describe( 'ThemeProvider', () => {
 			provider.focus();
 			expect( provider ).not.toHaveFocus();
 
-			before.focus();
+			await user.tab();
 			expect( before ).toHaveFocus();
-			inside.focus();
+			await user.tab();
 			expect( inside ).toHaveFocus();
-			after.focus();
+			await user.tab();
 			expect( after ).toHaveFocus();
-		} finally {
-			style.remove();
-		}
+			await user.tab( { shift: true } );
+			expect( inside ).toHaveFocus();
+			await user.tab( { shift: true } );
+			expect( before ).toHaveFocus();
+		} );
 	} );
 
 	it( 'defines the color tokens from the seeds within its subtree', () => {


### PR DESCRIPTION
## What?
Follow up to #77462.

Adds regression coverage for I4 by testing `ThemeProvider` in isolation:

- Verifies the scoping wrapper resolves to `display: contents`.
- Verifies the wrapper is not focusable.
- Verifies vanilla focusable children before, inside, and after the provider receive focus through realistic tabbing.

## Why?
`ThemeProvider` needs a DOM wrapper for token scoping, but that wrapper should stay transparent to focus behavior.

## How?
Adds focused unit coverage in `@wordpress/theme` using plain React children. The test imports the repo-standard `@testing-library/user-event` helper, so `@wordpress/theme` now declares that existing test dependency.

## Testing Instructions
1. Run `npm run test:unit -- packages/theme/src/test/theme-provider.test.tsx`.
2. Run `npm run lint:js -- packages/theme/src/test/theme-provider.test.tsx`.
3. Run `npm run lint:pkg-json -- packages/theme/package.json`.
4. Run `npx tsgo --build packages/theme/tsconfig.json`.

### Testing Instructions for Keyboard
Covered by the new `ThemeProvider` unit test, which verifies the wrapper is unfocusable and child controls receive focus via `userEvent.tab()`.

## Screenshots or screencast
Not applicable. Test-only change.

## Use of AI Tools
This PR was created with help from OpenAI Codex.
