### PR TITLE
Editor: Conditionally apply wp-site-blocks class in visual editor based on theme type

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -112,6 +112,7 @@ function VisualEditor( {
 		isPreview,
 		styles,
 		hasCanvasWidth,
+		isBlockTheme,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -163,6 +164,7 @@ function VisualEditor( {
 			isPreview: editorSettings.isPreviewMode,
 			styles: editorSettings.styles,
 			hasCanvasWidth: getCanvasWidth() !== undefined,
+			isBlockTheme: editorSettings.__unstableIsBlockBasedTheme,
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -472,7 +474,7 @@ function VisualEditor( {
 							className={ clsx(
 								'is-' + deviceType.toLowerCase() + '-preview',
 								renderingMode !== 'post-only' ||
-									isDesignPostType
+									( isDesignPostType && isBlockTheme )
 									? 'wp-site-blocks'
 									: `${ blockListLayoutClass } wp-block-post-content`, // Ensure root level blocks receive default/flow blockGap styling rules.
 								{


### PR DESCRIPTION


#### **Description:**

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #79838

<!-- In a few words, what is the PR actually doing? -->
This PR updates the visual editor's root `BlockList` component to only apply the `wp-site-blocks` class name when editing design post types (like patterns/template parts) if the active theme is a block-based theme.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When editing a non-synced pattern (`wp_block` post type) under a classic theme, the root container incorrectly gets the `wp-site-blocks` class applied because it's a design post type. Since classic themes do not use or support block templates, applying this class causes global/layout styling rules (specifically `:root :where(.wp-site-blocks) > *`) to target the editor block list and override the classic theme's custom editor margins, breaking the layout.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Retrieved the `isBlockTheme` flag (`editorSettings.__unstableIsBlockBasedTheme`) inside the `useSelect` hook in `packages/editor/src/components/visual-editor/index.js`.
- Updated the wrapper class name condition to require `isBlockTheme` to be true when deciding whether to apply `wp-site-blocks` class to design post types:
  ```js
  renderingMode !== 'post-only' || ( isDesignPostType && isBlockTheme )
  ```

## Testing Instructions
<!-- Please include step by step instructions on some how to test this PR. -->
1. Activate a classic theme, such as Twenty Twenty-One.
2. Create a new post, add some text and a heading, and convert the content to a non-synced pattern.
3. Go to **Appearance > Patterns** (or Manage Patterns) and click to edit the pattern.
4. Inspect the DOM element of the block list wrapper.
5. Confirm that the root block container has the class `wp-block-post-content` (not `wp-site-blocks`) and that headings/paragraphs margins are correctly set by the theme.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A (This change does not modify UI components or keyboard interaction patterns).

## Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
This pull request was authored with the assistance of Antigravity, a coding assistant.
```