### PR TITLE
Move styles into specific waveform styles dropdown area

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -637,7 +637,7 @@ Embed a simple playlist.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding)
--	**Attributes:** caption, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type
+-	**Attributes:** caption, order, showArtists, showImages, showNumbers, showTrackLength, showTracklist, type, waveformStyle
 
 ## Playlist track
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -70,6 +70,7 @@ function StyleInspectorSlots( {
 				label={ __( 'Background' ) }
 				className="background-block-support-panel__inner-wrapper"
 			/>
+			<InspectorControls.Slot group="styles" />
 			<InspectorControls.Slot group="layout" label={ __( 'Layout' ) } />
 			<InspectorControls.Slot
 				group="dimensions"
@@ -82,7 +83,6 @@ function StyleInspectorSlots( {
 				className="elements-block-support-panel__inner-wrapper"
 			/>
 			{ showPositionControls && <PositionControls /> }
-			<InspectorControls.Slot group="styles" />
 			{ showBindingsControls && (
 				<InspectorControls.Slot group="bindings" />
 			) }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -140,6 +140,7 @@ const StylesTab = ( {
 						label={ __( 'Background' ) }
 						className="background-block-support-panel__inner-wrapper"
 					/>
+					<InspectorControls.Slot group="styles" />
 					<InspectorControls.Slot group="filter" />
 					<InspectorControls.Slot
 						group="layout"
@@ -159,7 +160,6 @@ const StylesTab = ( {
 						className="elements-block-support-panel__inner-wrapper"
 					/>
 					<PositionControls />
-					<InspectorControls.Slot group="styles" />
 				</>
 			) }
 		</>

--- a/packages/block-library/src/playlist/README.md
+++ b/packages/block-library/src/playlist/README.md
@@ -29,6 +29,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `showArtists` | `boolean` | `true` | — |
 | `showNumbers` | `boolean` | `true` | — |
 | `showTrackLength` | `boolean` | `true` | — |
+| `waveformStyle` | `string` | `"bars"` | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `bars`, `mirror`, `line`, `blocks`, `dots`, `seekbar` |
 | `caption` | `string` | — | — |
 
 ## Supports
@@ -54,25 +55,12 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `showArtists` → attribute `showArtists`
 - `showImages` → attribute `showImages`
 
-## Block Styles
-
-_Defined via the [`styles`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/) property in block.json._
-
-| Style Name | Label | Default |
-|------------|-------|---------|
-| `bars` | Bars | Yes |
-| `mirror` | Mirror | No |
-| `line` | Line | No |
-| `blocks` | Blocks | No |
-| `dots` | Dots | No |
-| `seekbar` | Seekbar | No |
-
 ## Block Markup
 
 This is a [**hybrid block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). It saves static markup that the server may enhance during rendering.
 
 ```html
-<!-- wp:playlist {"type":"audio","order":"asc","showTracklist":true,"showImages":true,"showArtists":true,"showNumbers":true,"showTrackLength":true} -->
+<!-- wp:playlist {"type":"audio","order":"asc","showTracklist":true,"showImages":true,"showArtists":true,"showNumbers":true,"showTrackLength":true,"waveformStyle":"bars"} -->
 <!-- Content... -->
 <!-- /wp:playlist -->
 ```

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -38,6 +38,11 @@
 			"type": "boolean",
 			"default": true
 		},
+		"waveformStyle": {
+			"type": "string",
+			"enum": [ "bars", "mirror", "line", "blocks", "dots", "seekbar" ],
+			"default": "bars"
+		},
 		"caption": {
 			"type": "string"
 		}
@@ -73,14 +78,6 @@
 			"padding": true
 		}
 	},
-	"styles": [
-		{ "name": "bars", "label": "Bars", "isDefault": true },
-		{ "name": "mirror", "label": "Mirror" },
-		{ "name": "line", "label": "Line" },
-		{ "name": "blocks", "label": "Blocks" },
-		{ "name": "dots", "label": "Dots" },
-		{ "name": "seekbar", "label": "Seekbar" }
-	],
 	"editorStyle": "wp-block-playlist-editor",
 	"style": "wp-block-playlist"
 }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -41,6 +41,15 @@ import { PlaylistContext } from './context';
 import { getTrackAttributes } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const DEFAULT_WAVEFORM_STYLE = 'bars';
+const WAVEFORM_STYLE_OPTIONS = [
+	{ label: __( 'Bars' ), value: 'bars' },
+	{ label: __( 'Mirror' ), value: 'mirror' },
+	{ label: __( 'Line' ), value: 'line' },
+	{ label: __( 'Blocks' ), value: 'blocks' },
+	{ label: __( 'Dots' ), value: 'dots' },
+	{ label: __( 'Seekbar' ), value: 'seekbar' },
+];
 
 const PlaylistEdit = ( {
 	attributes,
@@ -56,12 +65,11 @@ const PlaylistEdit = ( {
 		showImages,
 		showArtists,
 		showTrackLength,
+		waveformStyle = DEFAULT_WAVEFORM_STYLE,
 	} = attributes;
 
-	// Extract the waveform style from the block style variation class.
-	const waveformStyle =
-		attributes.className?.match( /is-style-([\w-]+)/ )?.[ 1 ] || 'bars';
 	const blockProps = useBlockProps();
+	const waveformPanelId = `${ clientId }-waveform`;
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -188,6 +196,18 @@ const PlaylistEdit = ( {
 			setAttributes( { [ attribute ]: newValue } );
 		};
 	}
+
+	const onChangeWaveformStyle = useCallback(
+		( newWaveformStyle ) => {
+			setAttributes( {
+				waveformStyle:
+					newWaveformStyle === DEFAULT_WAVEFORM_STYLE
+						? undefined
+						: newWaveformStyle,
+			} );
+		},
+		[ setAttributes ]
+	);
 
 	const hasSelectedChild = useSelect(
 		( select ) =>
@@ -354,6 +374,37 @@ const PlaylistEdit = ( {
 								{ label: __( 'Ascending' ), value: 'asc' },
 							] }
 							onChange={ ( value ) => onChangeOrder( value ) }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
+			<InspectorControls group="styles">
+				<ToolsPanel
+					label={ __( 'Waveform' ) }
+					resetAll={ () => {
+						setAttributes( {
+							waveformStyle: undefined,
+						} );
+					} }
+					panelId={ waveformPanelId }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						label={ __( 'Shape' ) }
+						isShownByDefault
+						hasValue={ () =>
+							waveformStyle !== DEFAULT_WAVEFORM_STYLE
+						}
+						onDeselect={ () =>
+							onChangeWaveformStyle( DEFAULT_WAVEFORM_STYLE )
+						}
+						panelId={ waveformPanelId }
+					>
+						<SelectControl
+							label={ __( 'Shape' ) }
+							value={ waveformStyle }
+							options={ WAVEFORM_STYLE_OPTIONS }
+							onChange={ onChangeWaveformStyle }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -117,11 +117,8 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	$processor = new WP_HTML_Tag_Processor( $content );
 	$processor->next_tag( 'figure' );
 	$processor->set_attribute( 'data-wp-interactive', 'core/playlist' );
-	// Extract the waveform style from the block style variation class.
-	$waveform_style = 'bars';
-	if ( ! empty( $attributes['className'] ) && preg_match( '/is-style-([\w-]+)/', $attributes['className'], $matches ) ) {
-		$waveform_style = $matches[1];
-	}
+
+	$waveform_style = $attributes['waveformStyle'] ?? 'bars';
 
 	$processor->set_attribute(
 		'data-wp-context',

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -156,10 +156,10 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_waveform_style_extracted_from_single_word_style_class() {
+	public function test_waveform_style_uses_attribute() {
 		$markup = $this->build_playlist_markup(
 			array(
-				'className' => 'is-style-mirror',
+				'waveformStyle' => 'dots',
 			),
 			array(
 				array(
@@ -175,20 +175,16 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$p->next_tag( 'figure' );
 
 		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
-		$this->assertSame( 'mirror', $context['waveformStyle'] );
+		$this->assertSame( 'dots', $context['waveformStyle'] );
 	}
 
 	/**
-	 * A hyphenated block style slug (e.g. one registered by a theme) must be
-	 * extracted in full. The `\w+` pattern stops at the first hyphen and would
-	 * yield 'thin' instead of 'thin-line'.
-	 *
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_waveform_style_extracted_from_hyphenated_style_class() {
+	public function test_waveform_style_defaults_to_bars_for_invalid_attribute() {
 		$markup = $this->build_playlist_markup(
 			array(
-				'className' => 'is-style-thin-line',
+				'waveformStyle' => 'thin-line',
 			),
 			array(
 				array(
@@ -204,7 +200,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$p->next_tag( 'figure' );
 
 		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
-		$this->assertSame( 'thin-line', $context['waveformStyle'] );
+		$this->assertSame( 'bars', $context['waveformStyle'] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Moves waveform style selection from general block styles pane into dedicated Waveform panel

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For long-term, I think waveform selection needs to be a dropdown so we can reserve the Styles pane for traditional combination of styles, not restricted to one waveform setting.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add Waveform panel
- Add waveform styles to block json
- Output waveform style options as dropdown

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a playlist block
- Go to Block Inspector -> Styles
- Choose different Waveform styles from the dropdown

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1263" height="537" alt="playlist block with waveform style options" src="https://github.com/user-attachments/assets/91269856-c61f-4fb3-b649-8c50f7f9f8e5" />

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
