### PR TITLE
design-system-mcp: Use fixed version for alpha MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45340,7 +45340,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
-				"@modelcontextprotocol/server": "^2.0.0-alpha.2",
+				"@modelcontextprotocol/server": "2.0.0-alpha.2",
 				"zod": "^4.3.6"
 			},
 			"bin": {

--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix error caused by changes in upstream package APIs prerelease version ([#80061](https://github.com/WordPress/gutenberg/pull/80061)).
+
 ## 0.7.0 (2026-07-01)
 
 ## 0.6.0 (2026-06-24)

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -42,7 +42,7 @@
 	},
 	"dependencies": {
 		"@cfworker/json-schema": "^4.1.1",
-		"@modelcontextprotocol/server": "^2.0.0-alpha.2",
+		"@modelcontextprotocol/server": "2.0.0-alpha.2",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -40,6 +40,13 @@ export default {
 	],
 	semverGroups: [
 		{
+			label: 'Prerelease dependencies (e.g. alpha or beta) should be pinned to exact versions to avoid auto-upgrades that can include breaking changes. Remove entries once the dependency reaches a stable release.',
+			dependencies: [ '@modelcontextprotocol/server' ],
+			packages: [ '**' ],
+			dependencyTypes: [ 'prod', 'dev' ],
+			range: '',
+		},
+		{
 			label: 'All dependencies must use caret ranges.',
 			packages: [ '**' ],
 			dependencyTypes: [ 'prod', 'dev' ],


### PR DESCRIPTION
## What?

Fixes an issue where the design system MCP server will error on load on fresh installs.

## Why?

So that the MCP server is accessible to be used.

## How?

Updates dependency on `@modelcontextprotocol/server` from caret range to fixed version.

The issue is that more recent prerelease versions of the package have breaking API changes. Specifically, `beta.1` changed how `StdioServerTransport` is imported, producing errors on install:

```
file:////gutenberg/packages/design-system-mcp/bin/design-system-mcp.mjs:3
import { StdioServerTransport } from '@modelcontextprotocol/server';
         ^^^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module '@modelcontextprotocol/server' does not provide an export named 'StdioServerTransport'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:213:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:320:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

The actual changes themselves don't matter for this pull request and should be addressed separately. The problem to be addressed here is to prevent consumers from installing that newer version and instead using the version we know works, by specifying a fixed version and avoiding the `^` version range.

## Testing Instructions

1. Update dependencies to latest satisfied version: `npm update --workspace @wordpress/design-system-mcp`
2. Install latest: `npm install`
3. Verify running the bin/ script produces no errors: `node packages/design-system-mcp/bin/design-system-mcp.mjs`

## Use of AI Tools

AI was used by a colleague for troubleshooting the error, but no AI was used on my part in implementing this solution.