### PR TITLE
Panel: fix focus style for toggle button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,6 +47,7 @@
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).
 -   `BorderBoxControl`: Fix the unlink button positioning by restoring the linked control's right-hand margin, which was overridden by `BorderControl`'s base `margin: 0` after `View` stopped rendering styles through Emotion ([#79967](https://github.com/WordPress/gutenberg/pull/79967)).
+-   `Panel`: Fix the body toggle focus style ([#80064](https://github.com/WordPress/gutenberg/pull/80064)).
 
 ### Internal
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -87,13 +87,10 @@
 .components-panel__body-toggle.components-button {
 	position: relative;
 	padding: $grid-unit-20 $grid-unit-60 $grid-unit-20 $grid-unit-20;
-	outline: none;
 	width: 100%;
 	font-weight: $font-weight-medium;
 	text-align: left;
 	color: $gray-900;
-	border: none;
-	box-shadow: none;
 
 	@media not (prefers-reduced-motion) {
 		transition: 0.1s background ease-in-out;
@@ -102,7 +99,7 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+		outline-offset: calc(#{$border-width} - var(--wpds-border-width-focus));
 		border-radius: 0;
 	}
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -99,7 +99,7 @@
 	height: auto;
 
 	&:focus {
-		outline-offset: calc(#{$border-width} - var(--wpds-border-width-focus));
+		outline-offset: calc(var(--wpds-border-width-focus) * -1);
 		border-radius: 0;
 	}
 


### PR DESCRIPTION
Part of #79813

## What?

Fix the double focus rings on the toggle button of the panel component.

## Why?

We changed the button focus style in https://github.com/WordPress/gutenberg/pull/78646. As a result, style overrides are no longer applied correctly in this component, which is overwriting the button's focus style.

## How?

Redefine styles based on the outline property and remove unnecessary styles. Change the outline offset to the inside. This is because the PanelBody component is mainly used in the block inspector, so it prevents the focus ring from being cut off and restores the previous focus style.

## Testing Instructions
1. Open the block editor and select a block so the settings sidebar is visible.
2. Tab to a panel section header
3. Confirm the focus indicator renders as a native outline aligned to the toggle edge, with no layout shift.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="303" height="144" alt="image" src="https://github.com/user-attachments/assets/f9b325bc-9307-4d69-80ab-c4038194aafc" />| <img width="301" height="149" alt="image" src="https://github.com/user-attachments/assets/bc73a25f-5778-4dc3-a574-f5adf76a3097" /> |
| <img width="564" height="293" alt="image" src="https://github.com/user-attachments/assets/baa13d31-d903-4697-a369-177b76f8e76e" /> | <img width="503" height="287" alt="image" src="https://github.com/user-attachments/assets/09007a5e-2429-4b89-9303-e42992645c7b" /> |

## Use of AI Tools
This PR was authored with the assistance of Claude Code (Claude Opus 4.8). The maintainer reviewed and verified the change.
