### PR TITLE
Block Editor: Fix style / nested attribute overwrite during multi-selection

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -38,6 +38,7 @@ import { useBlockProps } from './use-block-props';
 import { store as blockEditorStore } from '../../store';
 import { useLayout } from './layout';
 import { PrivateBlockContext } from './private-block-context';
+import { getAttributesDiff, applyAttributesDiff } from '../../utils/object';
 import { useBlockVisibility } from '../block-visibility/';
 import { unlock } from '../../lock-unlock';
 import { deviceTypeKey } from '../../store/private-keys';
@@ -267,20 +268,43 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 	// leaking new props to the public API (editor.BlockListBlock filter).
 	return {
 		setAttributes( nextAttributes ) {
-			const { getMultiSelectedBlockClientIds } =
+			const { getMultiSelectedBlockClientIds, getBlocksByClientId } =
 				registry.select( blockEditorStore );
 			const multiSelectedBlockClientIds =
 				getMultiSelectedBlockClientIds();
 			const { clientId, attributes } = ownProps;
-			const clientIds = multiSelectedBlockClientIds.length
-				? multiSelectedBlockClientIds
-				: [ clientId ];
 			const newAttributes =
 				typeof nextAttributes === 'function'
 					? nextAttributes( attributes )
 					: nextAttributes;
 
-			updateBlockAttributes( clientIds, newAttributes );
+			if ( multiSelectedBlockClientIds.length > 0 ) {
+				const diff = getAttributesDiff( attributes, newAttributes );
+				if ( diff !== undefined ) {
+					const blocks = getBlocksByClientId(
+						multiSelectedBlockClientIds
+					);
+					const updates = {};
+					multiSelectedBlockClientIds.forEach( ( id, index ) => {
+						const block = blocks[ index ];
+						if ( block ) {
+							updates[ id ] = applyAttributesDiff(
+								block.attributes,
+								diff
+							);
+						}
+					} );
+					updateBlockAttributes(
+						multiSelectedBlockClientIds,
+						updates,
+						{
+							uniqueByBlock: true,
+						}
+					);
+				}
+			} else {
+				updateBlockAttributes( clientId, newAttributes );
+			}
 		},
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;

--- a/packages/block-editor/src/utils/object.ts
+++ b/packages/block-editor/src/utils/object.ts
@@ -87,3 +87,120 @@ export function uniqByProperty< T extends AnyObject >(
 		return seen.has( value ) ? false : seen.add( value );
 	} );
 }
+
+/**
+ * Recursively determines the differences between two objects.
+ * Keys present in `original` but not in `updated` (or explicitly set to undefined) are mapped to `undefined`.
+ * Returns only the changed properties.
+ *
+ * @param original The original object.
+ * @param updated  The updated object.
+ * @return A new object containing only the differences, or undefined if no differences.
+ */
+export function getAttributesDiff(
+	original: AnyObject | undefined | null,
+	updated: AnyObject | undefined | null
+): AnyObject | undefined {
+	if ( original === updated ) {
+		return undefined;
+	}
+	if ( ! original && ! updated ) {
+		return undefined;
+	}
+	if ( ! original ) {
+		return updated as AnyObject;
+	}
+	if ( ! updated ) {
+		// If updated is explicitly set to empty/nullish but original had keys,
+		// we should return an object mapping original keys to undefined to delete them.
+		const diff: AnyObject = {};
+		for ( const key in original ) {
+			diff[ key ] = undefined;
+		}
+		return diff;
+	}
+
+	const diff: AnyObject = {};
+	let hasDiff = false;
+
+	// Check for new and updated keys
+	for ( const key in updated ) {
+		const originalValue = original[ key ];
+		const updatedValue = updated[ key ];
+
+		if ( originalValue === updatedValue ) {
+			continue;
+		}
+
+		if (
+			typeof originalValue === 'object' &&
+			originalValue !== null &&
+			! Array.isArray( originalValue ) &&
+			typeof updatedValue === 'object' &&
+			updatedValue !== null &&
+			! Array.isArray( updatedValue )
+		) {
+			const nestedDiff = getAttributesDiff(
+				originalValue as AnyObject,
+				updatedValue as AnyObject
+			);
+			if ( nestedDiff !== undefined ) {
+				diff[ key ] = nestedDiff;
+				hasDiff = true;
+			}
+		} else {
+			diff[ key ] = updatedValue;
+			hasDiff = true;
+		}
+	}
+
+	// Check for deleted keys
+	for ( const key in original ) {
+		if ( ! ( key in updated ) ) {
+			diff[ key ] = undefined;
+			hasDiff = true;
+		}
+	}
+
+	return hasDiff ? diff : undefined;
+}
+
+/**
+ * Recursively applies a difference object to an original object.
+ * Keys mapped to `undefined` in the diff are deleted from the result.
+ *
+ * @param original The original object.
+ * @param diff     The difference object to apply.
+ * @return A new object with the differences applied.
+ */
+export function applyAttributesDiff(
+	original: AnyObject | undefined | null,
+	diff: AnyObject | undefined | null
+): AnyObject {
+	if ( ! diff ) {
+		return original ? { ...original } : {};
+	}
+
+	const result = original ? { ...original } : {};
+
+	for ( const key in diff ) {
+		const diffValue = diff[ key ];
+
+		if ( diffValue === undefined ) {
+			delete result[ key ];
+		} else if (
+			typeof diffValue === 'object' &&
+			diffValue !== null &&
+			! Array.isArray( diffValue )
+		) {
+			result[ key ] = applyAttributesDiff(
+				result[ key ] as AnyObject,
+				diffValue as AnyObject
+			);
+		} else {
+			result[ key ] = diffValue;
+		}
+	}
+
+	return result;
+}

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { setImmutably } from '../object';
+import {
+	setImmutably,
+	getAttributesDiff,
+	applyAttributesDiff,
+} from '../object';
 
 describe( 'setImmutably', () => {
 	describe( 'handling falsy values properly', () => {
@@ -176,6 +180,88 @@ describe( 'setImmutably', () => {
 			expect( result[ 0 ][ 0 ][ 0 ][ 1 ] ).not.toBe(
 				input[ 0 ][ 0 ][ 0 ][ 1 ]
 			);
+		} );
+	} );
+} );
+
+describe( 'getAttributesDiff', () => {
+	it( 'should return undefined if no differences', () => {
+		expect( getAttributesDiff( { a: 1 }, { a: 1 } ) ).toBeUndefined();
+	} );
+
+	it( 'should return diff for changed flat properties', () => {
+		expect( getAttributesDiff( { a: 1, b: 2 }, { a: 1, b: 3 } ) ).toEqual( {
+			b: 3,
+		} );
+	} );
+
+	it( 'should map deleted properties to undefined', () => {
+		expect( getAttributesDiff( { a: 1, b: 2 }, { a: 1 } ) ).toEqual( {
+			b: undefined,
+		} );
+	} );
+
+	it( 'should handle nested objects', () => {
+		const original = {
+			style: { color: { text: 'red' }, border: { radius: 5 } },
+		};
+		const updated = {
+			style: { color: { text: 'green' }, border: { radius: 5 } },
+		};
+		expect( getAttributesDiff( original, updated ) ).toEqual( {
+			style: { color: { text: 'green' } },
+		} );
+	} );
+
+	it( 'should return undefined for nested objects if no changes', () => {
+		const original = { style: { color: { text: 'red' } } };
+		const updated = { style: { color: { text: 'red' } } };
+		expect( getAttributesDiff( original, updated ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'applyAttributesDiff', () => {
+	it( 'should return original if no diff', () => {
+		expect( applyAttributesDiff( { a: 1 }, undefined ) ).toEqual( {
+			a: 1,
+		} );
+	} );
+
+	it( 'should merge flat properties', () => {
+		expect( applyAttributesDiff( { a: 1, b: 2 }, { b: 3, c: 4 } ) ).toEqual(
+			{
+				a: 1,
+				b: 3,
+				c: 4,
+			}
+		);
+	} );
+
+	it( 'should delete properties mapped to undefined', () => {
+		expect(
+			applyAttributesDiff( { a: 1, b: 2 }, { b: undefined } )
+		).toEqual( {
+			a: 1,
+		} );
+	} );
+
+	it( 'should merge nested properties', () => {
+		const original = {
+			style: { color: { text: 'red', background: 'blue' } },
+		};
+		const diff = { style: { color: { text: 'green' } } };
+		expect( applyAttributesDiff( original, diff ) ).toEqual( {
+			style: { color: { text: 'green', background: 'blue' } },
+		} );
+	} );
+
+	it( 'should delete nested properties mapped to undefined', () => {
+		const original = {
+			style: { color: { text: 'red', background: 'blue' } },
+		};
+		const diff = { style: { color: { background: undefined } } };
+		expect( applyAttributesDiff( original, diff ) ).toEqual( {
+			style: { color: { text: 'red' } },
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1335,6 +1335,86 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should preserve other style attributes on selected blocks when updating a specific style property', async ( {
+		page,
+		editor,
+		pageUtils,
+		multiBlockSelectionUtils,
+	} ) => {
+		// Insert 3 paragraph blocks with different custom background colors
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'First',
+				style: { color: { background: '#ff0000' } },
+			},
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Second',
+				style: { color: { background: '#00ff00' } },
+			},
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Third',
+				style: { color: { background: '#0000ff' } },
+			},
+		} );
+
+		// Select all 3 blocks
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
+			.toEqual( [ 1, 2, 3 ] );
+
+		// Open block settings sidebar
+		await editor.openDocumentSettingsSidebar();
+
+		const settings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settings
+			.locator( '.components-tools-panel' )
+			.filter( {
+				has: page.getByRole( 'heading', { name: 'Typography' } ),
+			} )
+			.getByRole( 'button', { name: 'Color', exact: true } )
+			.click();
+
+		// Wait for the color picker to appear and click white
+		await page.getByRole( 'option', { name: 'White' } ).click();
+
+		// Check that the blocks have the white text color but kept their original backgrounds
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					textColor: 'white',
+					style: { color: { background: '#ff0000' } },
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					textColor: 'white',
+					style: { color: { background: '#00ff00' } },
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					textColor: 'white',
+					style: { color: { background: '#0000ff' } },
+				},
+			},
+		] );
+	} );
+
 	test.describe( 'shift+click multi-selection', () => {
 		test( 'should multi-select block with text selection and a block without text selection', async ( {
 			page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #51609 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
This PR fixes a bug in the Block Editor where changing a design setting (such as text color) on multiple selected blocks completely overwrites their other distinct, non-conflicting style attributes (such as background colors, borders, and margins). This fix also applies globally to other nested object attributes, such as `metadata` and custom block configurations.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When editing multiple blocks, the settings sidebar renders controls populated by the active/primary block. Previously, when you changed a style, the intercepting `setAttributes` wrapper inside the `BlockListBlock` component would broadcast the primary block's entire updated `style` object to all other selected blocks.

Because the Redux store reducer only performs a shallow merge on top-level keys like `style`, it would overwrite the entire `style` object of the other blocks, erasing their defined unique custom styles (e.g. different custom background colors) and replace them with the primary block's values.

As mentioned by @t-hamano in the linked issue: "Changing one style may cause the related styles to be overwritten by all the styles in one block."

Additionally, this affects every other attribute change as well where nested values are thus overwritten irrespective of change diff.

For example:
*   **Active Block 1:** `{ style: { color: { background: '#ff0000' } } }` (Red background)
*   **Also In selection Block 2:** `{ style: { color: { background: '#00ff00' } } }` (Green background)

When updating the text color to white (`#ffffff`), the control sends the entire active block's style container i.e. :
`{ style: { color: { text: '#ffffff', background: '#ff0000' } } }`

Due to the shallow merge, this completely replaces Block 2's style object:
From: `{ style: { color: { background: '#00ff00' } } }`
To: `{ style: { color: { text: '#ffffff', background: '#ff0000' } } }` (Block 2's Green background `#00ff00` gets overwritten with Block 1's Red background `#ff0000`).


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added Diffing Utilities: Created two recursive helper functions - `getAttributesDiff` and `applyAttributesDiff` in `packages/block-editor/src/utils/object.ts` which determine the differences in attributes between two objects and apply only those specific diffs to the target object (supporting nested keys and handling deletion when values are explicitly set to undefined).

- Updated the Multi-Selection Interceptor: Refactored `packages/block-editor/src/components/block-list/block.js` so that when multiple blocks are selected:
  - It calculates the recursive diff of what actually changed between the active block's old and new attributes.
  - Then we loop through all selected blocks and apply only that specific diff (instead of everything) to their current attributes.
  - Finally updates all blocks in a single, performant transaction using `updateBlockAttributes( clientIds, updates, { uniqueByBlock: true } )`.

- Tests:
  - Added unit tests for both recursive helpers in `packages/block-editor/src/utils/test/object.js`.
  - Added an integration E2E test in `test/e2e/specs/editor/various/multi-block-selection.spec.js` asserting that custom block backgrounds are preserved when text colors are updated during multi-selection.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the post editor.
2. Insert 3 Paragraph blocks.
3. Give Block 1 a Red background, Block 2 a Blue background, and Block 3 a Green background (using custom color codes).
3. Select all 3 blocks (via dragging or Shift+clicking or via List view blocks selection).
4. In the block settings sidebar under Typography, change the Text Color to a different color (like White).
5. Verify that all 3 blocks get the White text color, but retain their original backgrounds (Red, Blue, Green).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/ad52d8d4-88d5-4a1c-aef2-6ce5609f4de3" controls></video> | <video src="https://github.com/user-attachments/assets/90757328-d0d8-42bc-bb40-6ee53a7202cf" controls></video> |


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.5 Flash (Low)
Used for: Identifying relevant code files, deciding on implementation for the fix. E2E, integration test was implemented via it. Final implementation and tests were reviewed and edited by me.
