### PR TITLE
Generalize playlist block wording

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -157,7 +157,7 @@ const PlaylistTrackEdit = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextControl
-						label={ __( 'Creator' ) }
+						label={ __( 'Artist' ) }
 						value={ artist ? stripHTML( artist ) : '' }
 						onChange={ ( artistValue ) => {
 							setAttributes( { artist: artistValue } );
@@ -281,7 +281,7 @@ const PlaylistTrackEdit = ( {
 								tagName="span"
 								className="wp-block-playlist-track__artist"
 								value={ artist }
-								placeholder={ __( 'Add creator' ) }
+								placeholder={ __( 'Add artist' ) }
 								onChange={ ( value ) =>
 									setAttributes( { artist: value } )
 								}

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -33,11 +33,11 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
  * Internal dependencies
  */
 import { PlaylistContext } from '../playlist/context';
-import { getAlbumCoverAttributes } from '../playlist/utils';
+import { getTrackAttributes, getTrackImageAttributes } from '../playlist/utils';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
-const ALBUM_COVER_ALLOWED_MEDIA_TYPES = [ 'image' ];
+const TRACK_IMAGE_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const PlaylistTrackEdit = ( {
 	attributes,
@@ -104,30 +104,16 @@ const PlaylistTrackEdit = ( {
 
 		setAttributes( {
 			blob: undefined,
-			id: media.id,
-			src: media.url,
-			artist:
-				media.artist ||
-				media?.meta?.artist ||
-				media?.media_details?.artist ||
-				__( 'Unknown artist' ),
-			album:
-				media.album ||
-				media?.meta?.album ||
-				media?.media_details?.album ||
-				__( 'Unknown album' ),
-			...getAlbumCoverAttributes( media?.image ),
-			length: media?.fileLength || media?.media_details?.length_formatted,
-			title: media.title,
+			...getTrackAttributes( media ),
 		} );
 		setTemporaryURL();
 	}
 
-	function onSelectAlbumCoverImage( coverImage ) {
-		setAttributes( getAlbumCoverAttributes( coverImage ) );
+	function onSelectTrackImage( trackImage ) {
+		setAttributes( getTrackImageAttributes( trackImage ) );
 	}
 
-	function onRemoveAlbumCoverImage() {
+	function onRemoveTrackImage() {
 		setAttributes( { image: undefined, imageAlt: undefined } );
 
 		// Move focus back to the Media Upload button.
@@ -171,7 +157,7 @@ const PlaylistTrackEdit = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextControl
-						label={ __( 'Artist' ) }
+						label={ __( 'Creator' ) }
 						value={ artist ? stripHTML( artist ) : '' }
 						onChange={ ( artistValue ) => {
 							setAttributes( { artist: artistValue } );
@@ -194,22 +180,22 @@ const PlaylistTrackEdit = ( {
 					<MediaUploadCheck>
 						<BaseControl>
 							<BaseControl.VisualLabel>
-								{ __( 'Album cover image' ) }
+								{ __( 'Track image' ) }
 							</BaseControl.VisualLabel>
 							<div className="editor-video-poster-control">
 								{ !! image && (
 									<img
 										src={ image }
 										alt={ __(
-											'Preview of the album cover image'
+											'Preview of the track image'
 										) }
 									/>
 								) }
 								<MediaUpload
 									title={ __( 'Select image' ) }
-									onSelect={ onSelectAlbumCoverImage }
+									onSelect={ onSelectTrackImage }
 									allowedTypes={
-										ALBUM_COVER_ALLOWED_MEDIA_TYPES
+										TRACK_IMAGE_ALLOWED_MEDIA_TYPES
 									}
 									render={ ( { open } ) => (
 										<Button
@@ -227,7 +213,7 @@ const PlaylistTrackEdit = ( {
 								{ !! image && (
 									<Button
 										__next40pxDefaultSize
-										onClick={ onRemoveAlbumCoverImage }
+										onClick={ onRemoveTrackImage }
 										variant="tertiary"
 									>
 										{ __( 'Remove' ) }
@@ -295,7 +281,7 @@ const PlaylistTrackEdit = ( {
 								tagName="span"
 								className="wp-block-playlist-track__artist"
 								value={ artist }
-								placeholder={ __( 'Add artist' ) }
+								placeholder={ __( 'Add creator' ) }
 								onChange={ ( value ) =>
 									setAttributes( { artist: value } )
 								}
@@ -308,8 +294,8 @@ const PlaylistTrackEdit = ( {
 						{ length && (
 							<span className="screen-reader-text">
 								{
-									/* translators: %s: Visually hidden label for the track length (screen reader text). */
-									__( 'Length:' )
+									/* translators: Visually hidden label for the track duration (screen reader text). */
+									__( 'Duration:' )
 								}
 							</span>
 						) }

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -51,7 +51,7 @@ function render_block_core_playlist_track( $attributes, $content = '', $block = 
 
 	if ( $length ) {
 		$html .= '<span class="wp-block-playlist-track__length">';
-		$html .= '<span class="screen-reader-text">' . esc_html__( 'Length:' ) . ' </span>';
+		$html .= '<span class="screen-reader-text">' . esc_html__( 'Duration:' ) . ' </span>';
 		$html .= esc_html( $length );
 		$html .= '</span>';
 	}

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -63,7 +63,7 @@ const defaultAttributes = {
 	album: 'Great Album',
 	artist: 'The Artist',
 	image: 'https://example.com/cover.jpg',
-	imageAlt: 'A bright abstract album cover',
+	imageAlt: 'A bright abstract track image',
 	length: '3:45',
 	title: 'Song One',
 };
@@ -98,7 +98,7 @@ describe( 'PlaylistTrackEdit', () => {
 		} );
 	} );
 
-	it( 'allows the album cover alternative text to be edited', () => {
+	it( 'allows the track image alternative text to be edited', () => {
 		const { setAttributes } = renderEdit();
 
 		expect(
@@ -122,7 +122,7 @@ describe( 'PlaylistTrackEdit', () => {
 		} );
 	} );
 
-	it( 'does not show the alternative text control without an album cover image', () => {
+	it( 'does not show the alternative text control without a track image', () => {
 		renderEdit( {
 			attributes: {
 				image: undefined,

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -273,7 +273,7 @@ const PlaylistEdit = ( {
 					{ showTracklist && (
 						<>
 							<ToolsPanelItem
-								label={ __( 'Show creator name in tracklist' ) }
+								label={ __( 'Show artist name in tracklist' ) }
 								isShownByDefault
 								hasValue={ () => showArtists !== true }
 								onDeselect={ () =>
@@ -282,7 +282,7 @@ const PlaylistEdit = ( {
 							>
 								<ToggleControl
 									label={ __(
-										'Show creator name in tracklist'
+										'Show artist name in tracklist'
 									) }
 									onChange={ toggleAttribute(
 										'showArtists'

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -257,7 +257,7 @@ const PlaylistEdit = ( {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						label={ __( 'Show Tracklist' ) }
+						label={ __( 'Show tracklist' ) }
 						isShownByDefault
 						hasValue={ () => showTracklist !== true }
 						onDeselect={ () =>
@@ -265,7 +265,7 @@ const PlaylistEdit = ( {
 						}
 					>
 						<ToggleControl
-							label={ __( 'Show Tracklist' ) }
+							label={ __( 'Show tracklist' ) }
 							onChange={ toggleAttribute( 'showTracklist' ) }
 							checked={ showTracklist }
 						/>
@@ -273,7 +273,7 @@ const PlaylistEdit = ( {
 					{ showTracklist && (
 						<>
 							<ToolsPanelItem
-								label={ __( 'Show artist name in Tracklist' ) }
+								label={ __( 'Show creator name in tracklist' ) }
 								isShownByDefault
 								hasValue={ () => showArtists !== true }
 								onDeselect={ () =>
@@ -282,7 +282,7 @@ const PlaylistEdit = ( {
 							>
 								<ToggleControl
 									label={ __(
-										'Show artist name in Tracklist'
+										'Show creator name in tracklist'
 									) }
 									onChange={ toggleAttribute(
 										'showArtists'
@@ -291,7 +291,9 @@ const PlaylistEdit = ( {
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
-								label={ __( 'Show number in Tracklist' ) }
+								label={ __(
+									'Show track numbers in tracklist'
+								) }
 								isShownByDefault
 								hasValue={ () => showNumbers !== true }
 								onDeselect={ () =>
@@ -299,7 +301,9 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									label={ __( 'Show number in Tracklist' ) }
+									label={ __(
+										'Show track numbers in tracklist'
+									) }
 									onChange={ toggleAttribute(
 										'showNumbers'
 									) }
@@ -307,7 +311,9 @@ const PlaylistEdit = ( {
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
-								label={ __( 'Show track length in Tracklist' ) }
+								label={ __(
+									'Show track duration in tracklist'
+								) }
 								isShownByDefault
 								hasValue={ () => showTrackLength !== true }
 								onDeselect={ () =>
@@ -316,7 +322,7 @@ const PlaylistEdit = ( {
 							>
 								<ToggleControl
 									label={ __(
-										'Show track length in Tracklist'
+										'Show track duration in tracklist'
 									) }
 									onChange={ toggleAttribute(
 										'showTrackLength'

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -47,8 +47,8 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 
 				if ( $title && $artist && $album ) {
 					$aria_label = sprintf(
-						/* translators: %1$s: track title, %2$s: creator name, %3$s: album name. */
-						_x( '%1$s by %2$s from the album %3$s', 'track title, creator name, album name' ),
+						/* translators: %1$s: track title, %2$s: artist name, %3$s: album name. */
+						_x( '%1$s by %2$s from the album %3$s', 'track title, artist name, album name' ),
 						$title,
 						$artist,
 						$album

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -47,8 +47,8 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 
 				if ( $title && $artist && $album ) {
 					$aria_label = sprintf(
-						/* translators: %1$s: track title, %2$s artist name, %3$s: album name. */
-						_x( '%1$s by %2$s from the album %3$s', 'track title, artist name, album name' ),
+						/* translators: %1$s: track title, %2$s: creator name, %3$s: album name. */
+						_x( '%1$s by %2$s from the album %3$s', 'track title, creator name, album name' ),
 						$title,
 						$artist,
 						$album

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -70,7 +70,7 @@ describe( 'Playlist block edit utilities', () => {
 			expect( result.artist ).toBe( 'Media Details Artist' );
 		} );
 
-		it( 'should use "Unknown creator" when no creator is available', () => {
+		it( 'should use "Unknown artist" when no artist is available', () => {
 			const media = {
 				url: 'https://example.com/song.mp3',
 				title: 'My Song',
@@ -78,7 +78,7 @@ describe( 'Playlist block edit utilities', () => {
 
 			const result = getTrackAttributes( media );
 
-			expect( result.artist ).toBe( 'Unknown creator' );
+			expect( result.artist ).toBe( 'Unknown artist' );
 		} );
 
 		it( 'should use "Unknown album" when no album is available', () => {

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -15,7 +15,7 @@ describe( 'Playlist block edit utilities', () => {
 				fileLength: '3:45',
 				image: {
 					src: 'https://example.com/cover.jpg',
-					alt: 'A bright abstract album cover',
+					alt: 'A bright abstract track image',
 				},
 			};
 
@@ -29,7 +29,7 @@ describe( 'Playlist block edit utilities', () => {
 				album: 'Great Album',
 				length: '3:45',
 				image: 'https://example.com/cover.jpg',
-				imageAlt: 'A bright abstract album cover',
+				imageAlt: 'A bright abstract track image',
 			} );
 		} );
 
@@ -70,7 +70,7 @@ describe( 'Playlist block edit utilities', () => {
 			expect( result.artist ).toBe( 'Media Details Artist' );
 		} );
 
-		it( 'should use "Unknown artist" when no artist is available', () => {
+		it( 'should use "Unknown creator" when no creator is available', () => {
 			const media = {
 				url: 'https://example.com/song.mp3',
 				title: 'My Song',
@@ -78,7 +78,7 @@ describe( 'Playlist block edit utilities', () => {
 
 			const result = getTrackAttributes( media );
 
-			expect( result.artist ).toBe( 'Unknown artist' );
+			expect( result.artist ).toBe( 'Unknown creator' );
 		} );
 
 		it( 'should use "Unknown album" when no album is available', () => {

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -4,12 +4,12 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Transform media library image data into album cover attributes.
+ * Transform media library image data into track image attributes.
  *
  * @param {Object} image - Image object from the media library.
- * @return {Object} Album cover attributes for the playlist-track block.
+ * @return {Object} Track image attributes for the playlist-track block.
  */
-export function getAlbumCoverAttributes( image ) {
+export function getTrackImageAttributes( image ) {
 	const imageSrc = image?.src ?? image?.url;
 
 	// Prevent using the default media attachment icon as the track image.
@@ -42,13 +42,13 @@ export function getTrackAttributes( media ) {
 			media.artist ||
 			media?.meta?.artist ||
 			media?.media_details?.artist ||
-			__( 'Unknown artist' ),
+			__( 'Unknown creator' ),
 		album:
 			media.album ||
 			media?.meta?.album ||
 			media?.media_details?.album ||
 			__( 'Unknown album' ),
 		length: media?.fileLength || media?.media_details?.length_formatted,
-		...getAlbumCoverAttributes( media?.image ),
+		...getTrackImageAttributes( media?.image ),
 	};
 }

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -42,7 +42,7 @@ export function getTrackAttributes( media ) {
 			media.artist ||
 			media?.meta?.artist ||
 			media?.media_details?.artist ||
-			__( 'Unknown creator' ),
+			__( 'Unknown artist' ),
 		album:
 			media.album ||
 			media?.meta?.album ||

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -258,7 +258,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	 * @covers ::render_block_core_playlist
 	 * @covers ::render_block_core_playlist_track
 	 */
-	public function test_tracklist_renders_album_art_when_show_images_is_enabled() {
+	public function test_tracklist_renders_track_image_when_show_images_is_enabled() {
 		$markup = $this->build_playlist_markup(
 			array( 'showImages' => true ),
 			array(
@@ -267,7 +267,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 					'title'    => 'Song One',
 					'src'      => 'http://example.com/song1.mp3',
 					'image'    => 'http://example.com/image1.jpg',
-					'imageAlt' => 'A bright abstract album cover',
+					'imageAlt' => 'A bright abstract track image',
 				),
 			)
 		);
@@ -276,14 +276,14 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'class="wp-block-playlist-track__image"', $output );
 		$this->assertStringContainsString( 'src="http://example.com/image1.jpg"', $output );
-		$this->assertStringContainsString( 'alt="A bright abstract album cover"', $output );
+		$this->assertStringContainsString( 'alt="A bright abstract track image"', $output );
 	}
 
 	/**
 	 * @covers ::render_block_core_playlist
 	 * @covers ::render_block_core_playlist_track
 	 */
-	public function test_tracklist_does_not_render_album_art_when_show_images_is_disabled() {
+	public function test_tracklist_does_not_render_track_image_when_show_images_is_disabled() {
 		$markup = $this->build_playlist_markup(
 			array( 'showImages' => false ),
 			array(
@@ -317,16 +317,16 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_aria_label_with_title_artist_and_album() {
+	public function test_aria_label_with_title_creator_and_album() {
 		$markup = $this->build_playlist_markup(
 			array(),
 			array(
 				array(
 					'id'     => 1,
-					'title'  => 'Song One',
-					'artist' => 'Artist One',
+					'title'  => 'Track One',
+					'artist' => 'Creator One',
 					'album'  => 'Album One',
-					'src'    => 'http://example.com/song1.mp3',
+					'src'    => 'http://example.com/track1.mp3',
 				),
 			)
 		);
@@ -338,7 +338,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$track    = $playlist['tracks']['track-0'];
 
 		$this->assertSame(
-			'Song One by Artist One from the album Album One',
+			'Track One by Creator One from the album Album One',
 			$track['ariaLabel']
 		);
 	}

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -317,14 +317,14 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	/**
 	 * @covers ::render_block_core_playlist
 	 */
-	public function test_aria_label_with_title_creator_and_album() {
+	public function test_aria_label_with_title_artist_and_album() {
 		$markup = $this->build_playlist_markup(
 			array(),
 			array(
 				array(
 					'id'     => 1,
 					'title'  => 'Track One',
-					'artist' => 'Creator One',
+					'artist' => 'Artist One',
 					'album'  => 'Album One',
 					'src'    => 'http://example.com/track1.mp3',
 				),
@@ -338,7 +338,7 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 		$track    = $playlist['tracks']['track-0'];
 
 		$this->assertSame(
-			'Track One by Creator One from the album Album One',
+			'Track One by Artist One from the album Album One',
 			$track['ariaLabel']
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Generalizes playlist block wording while keeping track/tracklist terminology.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The playlist won't be only used by musicians

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Renames visible Artist language to Creator
- Changes album cover UI language to Track image
- Lowercases tracklist in settings labels
- Updates playlist track metadata/docs keywords to be broader than music-only
- Updates related tests and generated block docs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
