### PR TITLE
Button: hide Core focus ring when button as link is pressed

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698)).
 
+### Bug Fixes
+
+-   `outset-ring__focus`: Show no focus ring while the element is pressed — the outline is now scoped to `:not(:active)`, and the reset of the WordPress core `a:focus` ring covers the whole duration of focus, including the pressed state ([#80082](https://github.com/WordPress/gutenberg/pull/80082)).
+
 ## 10.2.0 (2026-07-01)
 
 ## 10.1.0 (2026-06-24)

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Enhancements
 
--   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698)).
-
-### Bug Fixes
-
--   `outset-ring__focus`: Show no focus ring while the element is pressed — the outline is now scoped to `:not(:active)`, and the reset of the WordPress core `a:focus` ring covers the whole duration of focus, including the pressed state ([#80082](https://github.com/WordPress/gutenberg/pull/80082)).
+-   Add `outset-ring__focus` mixin for outline-based focus rings using `--wpds-*` design tokens ([#78698](https://github.com/WordPress/gutenberg/pull/78698), [#80082](https://github.com/WordPress/gutenberg/pull/80082)).
 
 ## 10.2.0 (2026-07-01)
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -189,15 +189,8 @@
  */
 
 @mixin outset-ring__focus() {
-	&:not(:active) {
-		outline: wpds.var("--wpds-border-width-focus") solid wpds.var("--wpds-color-stroke-focus");
-		outline-offset: wpds.var("--wpds-border-width-focus");
-	}
-
-	// Defend against a conflicting focus ring from WordPress common.css on `a:focus`.
-	&:is(a) {
-		box-shadow: none;
-	}
+	outline: wpds.var("--wpds-border-width-focus") solid wpds.var("--wpds-color-stroke-focus");
+	outline-offset: wpds.var("--wpds-border-width-focus");
 }
 
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -189,8 +189,10 @@
  */
 
 @mixin outset-ring__focus() {
-	outline: wpds.var("--wpds-border-width-focus") solid wpds.var("--wpds-color-stroke-focus");
-	outline-offset: wpds.var("--wpds-border-width-focus");
+	&:not(:active) {
+		outline: wpds.var("--wpds-border-width-focus") solid wpds.var("--wpds-color-stroke-focus");
+		outline-offset: wpds.var("--wpds-border-width-focus");
+	}
 
 	// Defend against a conflicting focus ring from WordPress common.css on `a:focus`.
 	&:is(a) {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,6 +47,7 @@
 -   `SandBox`: Inject the resize script into the document `<head>` so an unclosed attribute quote in the sandboxed HTML can no longer swallow the script and leak its source as visible text in the preview. ([#79920](https://github.com/WordPress/gutenberg/pull/79920))
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).
+-   `Button`: Remove a flash of the WordPress core focus ring while a button rendered as a link is pressed ([#80082](https://github.com/WordPress/gutenberg/pull/80082)).
 -   `BorderBoxControl`: Fix the unlink button positioning by restoring the linked control's right-hand margin, which was overridden by `BorderControl`'s base `margin: 0` after `View` stopped rendering styles through Emotion ([#79967](https://github.com/WordPress/gutenberg/pull/79967)).
 
 ### Internal

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -12,7 +12,12 @@
  */
 
 .components-button {
-	&:focus {
+	// Defend against a conflicting focus ring from WordPress common.css on `a:focus`.
+	&:focus:is(a) {
+		box-shadow: none;
+	}
+
+	&:focus:not(:active) {
 		@include mixins.outset-ring__focus();
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -12,7 +12,7 @@
  */
 
 .components-button {
-	&:focus:not(:active) {
+	&:focus {
 		@include mixins.outset-ring__focus();
 	}
 


### PR DESCRIPTION
## What?

This PR hides the default focus ring, when a button that is rendered as link is pressed.

## Why?

In https://github.com/WordPress/gutenberg/pull/74106 we want to hide focus ring when a button is pressed.

However, the combination of recent PRs https://github.com/WordPress/gutenberg/pull/78646 + https://github.com/WordPress/gutenberg/pull/79837 excludes the case when a link button is pressed.

## How?

This PR fixes the behavior:

- ~~Include the mixin in button under `&:focus`, not `&focus:not(:active)`, and we add the `:not(:active)` in the mixin.~~ Move the `:is(a)` guard to the Button component itself, outside `:not(:active)` clause
- With this, the `:focus:is(a)` case is guarded from Core ring in all cases.

## Testing Instructions

1. Go to Site Editor
2. Click the `<` back button (`< Design`)
3. Observe you don't see a flash of Core focus ring (which has different color than DS's).

## Screenshots or screencast <!-- if applicable -->



|Focused|Pressed (Before)|Pressed (After)|
|-|-|-|
|<img width="280" height="75" alt="image" src="https://github.com/user-attachments/assets/8ddfb935-8cd2-4d0a-bde8-48ff0c72e3d7" />|<img width="280" height="75" alt="image" src="https://github.com/user-attachments/assets/1f621250-4c6d-4130-b0e4-a6bb589f3f36" />|<img width="280" height="75" alt="image" src="https://github.com/user-attachments/assets/6660d146-0062-4218-8be9-a016de622215" />

## Use of AI Tools

Used Opus 4.8 to help brainstorm solutions.