### PR TITLE
Build: Upgrade to TypeScript 7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@playwright/test": "^1.61.1",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+				"@typescript/native": "npm:typescript@^7.0.2",
 				"@wordpress/env": "file:./packages/env",
 				"@wordpress/eslint-tools": "file:./tools/eslint",
 				"@wordpress/release-tools": "file:./tools/release",
@@ -40,7 +40,7 @@
 				"patch-package": "^8.0.0",
 				"rimraf": "^5.0.10",
 				"syncpack": "^15.3.1",
-				"typescript": "^6.0.2",
+				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"wait-on": "^8.0.1"
 			},
 			"engines": {
@@ -5367,6 +5367,20 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@mawesome/dependency-audit/node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@mawesome/dependency-audit/node_modules/validate-npm-package-name": {
@@ -13465,31 +13479,76 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@typescript/native-preview": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg==",
+		"node_modules/@typescript/native": {
+			"name": "typescript",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
 			"license": "Apache-2.0",
 			"bin": {
-				"tsgo": "bin/tsgo.js"
+				"tsc": "bin/tsc"
 			},
 			"engines": {
 				"node": ">=16.20.0"
 			},
 			"optionalDependencies": {
-				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260423.1",
-				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260423.1"
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		},
-		"node_modules/@typescript/native-preview-darwin-arm64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA==",
+		"node_modules/@typescript/old": {
+			"name": "typescript",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
 			"cpu": [
 				"arm64"
 			],
@@ -13502,10 +13561,10 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-darwin-x64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA==",
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
 			"cpu": [
 				"x64"
 			],
@@ -13518,10 +13577,42 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-linux-arm": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ==",
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
 			"cpu": [
 				"arm"
 			],
@@ -13534,10 +13625,10 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-linux-arm64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA==",
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -13550,10 +13641,90 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-linux-x64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw==",
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
 			"cpu": [
 				"x64"
 			],
@@ -13566,10 +13737,90 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-win32-arm64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ==",
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -13582,10 +13833,10 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-win32-x64": {
-			"version": "7.0.0-dev.20260423.1",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260423.1.tgz",
-			"integrity": "sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ==",
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
 			"cpu": [
 				"x64"
 			],
@@ -40883,17 +41134,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"name": "@typescript/typescript6",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+			"integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+			"dependencies": {
+				"@typescript/old": "npm:typescript@^6"
 			},
-			"engines": {
-				"node": ">=14.17"
+			"bin": {
+				"tsc6": "bin/tsc6"
 			}
 		},
 		"node_modules/typescript-eslint": {
@@ -49050,7 +49301,7 @@
 				"@babel/parser": "^7.28.6",
 				"@babel/traverse": "^7.25.7",
 				"@emotion/babel-plugin": "^11.13.5",
-				"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+				"@typescript/native": "npm:typescript@^7.0.2",
 				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 				"@wordpress/build": "file:../../packages/wp-build",
 				"@wordpress/react-19": "file:../react-19",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@playwright/test": "^1.61.1",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
-		"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+		"@typescript/native": "npm:typescript@^7.0.2",
 		"@wordpress/env": "file:./packages/env",
 		"@wordpress/eslint-tools": "file:./tools/eslint",
 		"@wordpress/release-tools": "file:./tools/release",
@@ -83,7 +83,7 @@
 		"patch-package": "^8.0.0",
 		"rimraf": "^5.0.10",
 		"syncpack": "^15.3.1",
-		"typescript": "^6.0.2",
+		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
@@ -92,7 +92,7 @@
 	"scripts": {
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
-		"clean:package-types": "tsgo --build --clean && rimraf --glob \"./packages/*/build-types\"",
+		"clean:package-types": "tsc --build --clean && rimraf --glob \"./packages/*/build-types\"",
 		"clean:packages": "rimraf --glob \"./packages/*/{build,build-module,build-wp,build-style}\" \"./build\"",
 		"dev": "npm run --workspace @wordpress/build-scripts dev --",
 		"distclean": "git clean --force -d -X",

--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -135,7 +135,7 @@ async function build() {
 		if ( ! skipTypes ) {
 			console.log( '\n📘 Building TypeScript types...\n' );
 			const tsStartTime = Date.now();
-			await exec( 'tsgo', [ '--build' ] ).catch( () => {
+			await exec( 'tsc', [ '--build' ] ).catch( () => {
 				console.error(
 					'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
 				);

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -174,7 +174,7 @@ async function dev() {
 		if ( ! skipTypes ) {
 			console.log( '\n📘 Building TypeScript types...\n' );
 			const tsStartTime = Date.now();
-			await exec( 'tsgo', [ '--build' ] ).catch( () => {
+			await exec( 'tsc', [ '--build' ] ).catch( () => {
 				console.error(
 					'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
 				);
@@ -213,7 +213,7 @@ async function dev() {
 		// Start TypeScript watch (unless types are skipped).
 		const tscWatch = skipTypes
 			? null
-			: execAsync( 'tsgo', [
+			: execAsync( 'tsc', [
 					'--build',
 					'--watch',
 					'--preserveWatchOutput',

--- a/tools/build-scripts/package.json
+++ b/tools/build-scripts/package.json
@@ -24,7 +24,7 @@
 		"@babel/parser": "^7.28.6",
 		"@babel/traverse": "^7.25.7",
 		"@emotion/babel-plugin": "^11.13.5",
-		"@typescript/native-preview": "^7.0.0-dev.20260423.1",
+		"@typescript/native": "npm:typescript@^7.0.2",
 		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 		"@wordpress/build": "file:../../packages/wp-build",
 		"@wordpress/react-19": "file:../react-19",

--- a/tools/build-scripts/packages/check-build-type-declaration-files.cjs
+++ b/tools/build-scripts/packages/check-build-type-declaration-files.cjs
@@ -70,7 +70,7 @@ async function getDecFile( packagePath ) {
 async function typecheckDeclarations( file ) {
 	return new Promise( ( resolve, reject ) => {
 		exec(
-			`npx tsgo --ignoreConfig --target esnext --moduleResolution bundler --noEmit --skipLibCheck "${ file }"`,
+			`npx tsc --ignoreConfig --target esnext --moduleResolution bundler --noEmit --skipLibCheck "${ file }"`,
 			( error, stdout, stderr ) => {
 				if ( error ) {
 					reject( { file, error, stderr, stdout } );


### PR DESCRIPTION
## What?

Upgrades the repository to TypeScript 7.0, following the migration guidance in the [TypeScript 7.0 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0).

## Why?

We currently build package types with the `@typescript/native-preview` package (the `tsgo` preview of the native compiler). With TypeScript 7.0 the native compiler now ships as the stable `typescript` npm package, and the preview package is being phased out — nightly builds move to `typescript@next`, so the preview pin will stop receiving updates.

## How?

Following the dual-package layout recommended in the announcement for projects that still need the TypeScript 6 JS API (TypeScript 7.0 ships no stable programmatic API until 7.1, and typescript-eslint still embeds the TS 6 compiler):

- `@typescript/native-preview` is replaced with `@typescript/native`, an alias of `npm:typescript@^7.0.2`. This provides the native `tsc` binary that replaces `tsgo`, in both the root and `tools/build-scripts` manifests.
- The `typescript` devDependency is re-pointed to `npm:@typescript/typescript6@^6.0.2`, the compatibility package that re-exports the TypeScript 6.0 API for tools embedding the compiler (typescript-eslint). It ships its executable as `tsc6`, so the binary names don't clash.
- All `tsgo` invocations (`clean:package-types`, `tools/build-scripts/build.mjs`, `tools/build-scripts/dev.mjs`, `check-build-type-declaration-files.cjs`) now call `tsc`.

No `tsconfig` changes were needed: the base config already matches the new TypeScript 7 defaults (`strict`, `moduleResolution: bundler`, explicit `rootDir`, `types: []`), and none of the removed compiler options (`baseUrl`, `downlevelIteration`, `moduleResolution: node`, `target: es5`, …) are in use.

## Testing Instructions

1. `npm install`
2. `npx tsc --version` should report `7.0.2` and `node -e "console.log(require('typescript').version)"` should report the TypeScript 6 compat package version.
3. `npm run clean:package-types && npm run build` — completes with no type errors.
4. `npm run lint:js`, `npm run lint:deps`, `npm run lint:lockfile`, and `npm run lint:tsconfig` all pass.

### Testing Instructions for Keyboard

N/A — build tooling change only, no UI changes.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Anthropic); the changes and PR description were AI-generated under human direction and review.
