### PR TITLE
Fix clipped focus ring on the document bar

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -89,8 +89,6 @@
 	align-items: center;
 	// To enable shrinking and truncating of child text, apply an explicit min-width.
 	min-width: 0;
-	// Clip the box while leaving room for focus rings.
-	clip-path: inset(-2px);
 	// At less than mobile the header’s `gap` is zero so margins are added to create a smaller
 	// gap around the center’s contents.
 	@media (max-width: #{$break-mobile - 1}) {
@@ -100,10 +98,6 @@
 		> :last-child {
 			margin-inline-end: $grid-unit;
 		}
-	}
-
-	.editor-revisions-header & {
-		clip-path: none;
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/79813

## What?

Removes the `clip-path` on the editor header center area, which was clipping the document bar's focus ring.

## Why?

The button focus ring was changed from a `box-shadow` to an `outline` in #78646, so the ring now extends further out from the element. The header center had `clip-path: inset(-2px)`, which only leaves 2px of room, so the wider outline ring gets clipped.

## How?

This could be fixed by bumping the value to `inset(-4px)`, but the `clip-path` itself looks unnecessary now. It was originally added to prevent an overlap (see https://github.com/WordPress/gutenberg/pull/62636#discussion_r2709192219), but that problem no longer seems to occur, so the `clip-path` is removed entirely rather than adjusted.


https://github.com/user-attachments/assets/db9f519c-235d-4910-afc9-12cd29013552



## Testing Instructions

1. Open the Post or Site Editor.
2. Tab to the document bar in the header
3. Confirm the focus ring is rendered fully on all sides and is not clipped at the top or bottom.

### Testing Instructions for Keyboard

Same as above — the document bar is reached and verified using the keyboard (Tab).

## Screenshots or screencast

### Before

<img width="1023" height="141" alt="image" src="https://github.com/user-attachments/assets/5fd8dd14-b800-4633-8b9b-c7579f30ff34" />

### After

<img width="1023" height="162" alt="image" src="https://github.com/user-attachments/assets/cb98cd44-dfab-467f-91b2-8ce542811169" />

## Use of AI Tools

This PR was authored with the assistance of AI tools (Claude Code) for investigation and drafting. All changes were reviewed by the author.
