### PR TITLE
File Block: Changed the context for fetching the media

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -77,14 +77,14 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const { media } = useSelect(
 		( select ) => ( {
-			media:
-				id === undefined
-					? undefined
-					: select( coreStore ).getEntityRecord(
-							'postType',
-							'attachment',
-							id
-					  ),
+			media: !! id
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						id,
+						{ context: 'view' }
+				  )
+				: undefined,
 		} ),
 		[ id ]
 	);

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -86,7 +86,9 @@ const transforms = {
 					return false;
 				}
 				const { getEntityRecord } = select( coreStore );
-				const media = getEntityRecord( 'postType', 'attachment', id );
+				const media = getEntityRecord( 'postType', 'attachment', id, {
+					context: 'view',
+				} );
 				return !! media && media.mime_type.includes( 'audio' );
 			},
 			transform: ( attributes ) => {
@@ -106,7 +108,9 @@ const transforms = {
 					return false;
 				}
 				const { getEntityRecord } = select( coreStore );
-				const media = getEntityRecord( 'postType', 'attachment', id );
+				const media = getEntityRecord( 'postType', 'attachment', id, {
+					context: 'view',
+				} );
 				return !! media && media.mime_type.includes( 'video' );
 			},
 			transform: ( attributes ) => {
@@ -126,7 +130,9 @@ const transforms = {
 					return false;
 				}
 				const { getEntityRecord } = select( coreStore );
-				const media = getEntityRecord( 'postType', 'attachment', id );
+				const media = getEntityRecord( 'postType', 'attachment', id, {
+					context: 'view',
+				} );
 				return !! media && media.mime_type.includes( 'image' );
 			},
 			transform: ( attributes ) => {


### PR DESCRIPTION
## What?
PR changes the attachment fetch context to `view` for the File block, preventing 403 errors for users with low capabilities when selecting files uploaded by other users.

## Testing Instructions
1. Uploaded a PDF or any file as an admin user.
2. Switch to the author and create a post.
3. Insert a file block.
4. Select the file uploaded by the admin.
5. Confirm that there are now 403 errors in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1140" height="56" alt="CleanShot 2026-07-10 at 10 48 13" src="https://github.com/user-attachments/assets/134b82a4-5a83-45ad-a870-5d05725d25e3" />


## Use of AI Tools

None.