### PR TITLE
Editor: use the DS focus color for all sidebar elements

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   `ListView`: Use the DS focus color token for the row focus ring so it adapts to themed surfaces such as the site editor navigation sidebar, and remove the duplicate focus ring on the row's Options (three-dot) button, which already draws the standard `Button` focus ring. ([#80087](https://github.com/WordPress/gutenberg/pull/80087)).
 -   `DimensionControl`: Include component styles in the block editor stylesheet so the fieldset reset is applied in Storybook and other contexts without WordPress core styles ([#79916](https://github.com/WordPress/gutenberg/pull/79916)).
 -   `InnerContent`: Render the selected inner block synchronously so its rich text selection stays current while typing; otherwise a stale selection offset could place a typed character at the wrong position in editable static inner blocks ([#79726](https://github.com/WordPress/gutenberg/pull/79726)).
 -   `useTypingObserver`: Capture the window reference at mount and reuse it during cleanup so the ref cleanup no longer reads `node.ownerDocument.defaultView` (which is `null` once the iframe-hosted editor has been detached from its window) and throws, which was also leaking the `removeEventListener` calls that follow it ([#78772](https://github.com/WordPress/gutenberg/pull/78772)).

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -95,7 +95,7 @@
 			box-shadow:
 				inset 0 0 0 1px $white,
 				0 0 0 var(--wp-admin-border-width-focus)
-				var(--wp-admin-theme-color);
+				var(--wpds-color-stroke-focus);
 		}
 	}
 	&.is-selected.is-synced .block-editor-list-view-block-contents:focus {
@@ -272,7 +272,7 @@
 			border-radius: inherit;
 			box-shadow:
 				inset 0 0 0 var(--wp-admin-border-width-focus)
-				var(--wp-admin-theme-color);
+				var(--wpds-color-stroke-focus);
 			z-index: 2;
 			pointer-events: none;
 		}
@@ -283,11 +283,10 @@
 		right: 0;
 	}
 
-	&.is-nesting .block-editor-list-view__menu,
-	.block-editor-list-view-block__menu:focus {
+	&.is-nesting .block-editor-list-view__menu {
 		box-shadow:
 			inset 0 0 0 var(--wp-admin-border-width-focus)
-			var(--wp-admin-theme-color);
+			var(--wpds-color-stroke-focus);
 		z-index: 1;
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -26,6 +26,9 @@
 
 	// Make sure the focus style is drawn on top of the current item background.
 	&:focus-visible {
+		// TODO: remove once the <Item> component has migrated to the WPDS focus color token.
+		--wp-components-color-accent: var(--wpds-color-stroke-focus);
+
 		transform: translateZ(0);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow-up to:

- https://github.com/WordPress/gutenberg/pull/80029#discussion_r3549372574
- https://github.com/WordPress/gutenberg/pull/80029#discussion_r3549451707

This PR fixes the focus ring color for all editor sidebar elements to use DS focus color for consistency. Here, we fix:

- The focus color for sidebar item (`<Item>` component). We override the color token here as discussed in the linked PR above.
- The focus color for block-editor list view. We fix the color token directly. Also removed doubled ring on the three-dot menu.

## Testing Instructions

1. Open Site Editor
2. Navigate to the sidebar menu items by keyboard. Verify you always see the same focus color ring. See the following screenshots for example.

## Screenshots or screencast <!-- if applicable -->

### Sidebar submenu items

|Before|After|
|-|-|
|<img width="296" height="600" alt="image" src="https://github.com/user-attachments/assets/9deb3220-b9c7-4cd5-9607-74c5a3e1ac30" />|<img width="296" height="600" alt="image" src="https://github.com/user-attachments/assets/0d93760a-1896-411d-ab07-9eeb5b620771" />|


### Navigation list view

|Before|After|
|-|-|
|<img width="296" height="446" alt="image" src="https://github.com/user-attachments/assets/53bfda4b-2967-4fbc-bf44-45223e83b6e8" />|<img width="298" height="446" alt="image" src="https://github.com/user-attachments/assets/1ce8b7da-3cb3-48ab-acdd-5d8d96e09bdd" />|

### Editor list view (UNCHANGED)

<img width="350" height="232" alt="image" src="https://github.com/user-attachments/assets/d7a8d19c-8cba-401b-9f9e-0b7030f8ce7c" />


## Use of AI Tools

Used Opus 4.8 to brainstorm the solution.