### PR TITLE
Theme: Document and test build plugin transform boundaries

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Documentation
 
 -   Clarify what `@wordpress/theme` provides, when consumers need to load `design-tokens.css`, the `ThemeProvider` contract including root provider usage, and the legacy compatibility boundary ([#79961](https://github.com/WordPress/gutenberg/pull/79961)).
+-   Document build plugin behavior and add parity coverage for PostCSS, esbuild, and Vite ([#80088](https://github.com/WordPress/gutenberg/pull/80088)).
 -   Document design token accessibility responsibilities ([#79943](https://github.com/WordPress/gutenberg/pull/79943)).
 -   Document that `ThemeProvider` does not accept wrapper customization props ([#79763](https://github.com/WordPress/gutenberg/pull/79763)).
 -   Clarify the design token documentation entry points and keep the generated token guidance source internal ([#79829](https://github.com/WordPress/gutenberg/pull/79829)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -304,7 +304,17 @@ Three plugin variants are available, covering common build tool setups:
 | `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks` | esbuild | JS/TS |
 | `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks`       | Vite    | JS/TS |
 
-All three plugins skip files that don't contain `--wpds-` references, so there is zero overhead on unrelated modules.
+All three plugins skip transformation when the source does not contain a `--wpds-` reference.
+
+### Transform boundaries and errors
+
+The plugins transform bare `var(--wpds-*)` calls, including calls with whitespace such as `var( --wpds-color-foreground-content-neutral )`. Calls that already include a fallback are left unchanged, and non-`--wpds-*` custom properties are ignored.
+
+The PostCSS plugin transforms declaration values in any stylesheet processed by PostCSS, including plain CSS and CSS modules. It does not transform token references in CSS comments.
+
+The esbuild and Vite plugins transform JavaScript and TypeScript source files with `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.mts`, `.cjs`, and `.cts` extensions, except files in `node_modules`. They transform matching source text in template literals, quoted strings, and comments.
+
+If a transformed bare `var()` call references an unknown `--wpds-*` token, the plugin stops the build with an `Unknown design token` error. This also applies to matching references in JavaScript or TypeScript comments and strings; remove example references to unknown tokens or use a known token name.
 
 ### PostCSS
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -215,12 +215,6 @@ After the prebuild step, the package will be built into its final form via the r
 
 These rules validate design token usage in CSS:
 
-| Rule                                            | Reports                                                   |
-| ----------------------------------------------- | --------------------------------------------------------- |
-| `plugin-wpds/no-unknown-ds-tokens`              | References to unknown `--wpds-*` tokens                   |
-| `plugin-wpds/no-setting-wpds-custom-properties` | Definitions or overrides in the `--wpds-*` namespace      |
-| `plugin-wpds/no-token-fallback-values`          | Manual fallbacks that can drift from the generated values |
-
 Enable them in your Stylelint configuration:
 
 ```json
@@ -237,6 +231,18 @@ Enable them in your Stylelint configuration:
 	}
 }
 ```
+
+### `plugin-wpds/no-unknown-ds-tokens`
+
+Reports references to unknown `--wpds-*` tokens.
+
+### `plugin-wpds/no-setting-wpds-custom-properties`
+
+Reports definitions or overrides in the `--wpds-*` namespace.
+
+### `plugin-wpds/no-token-fallback-values`
+
+Reports manual fallbacks that can drift from the generated values.
 
 ## Build Plugins
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -213,9 +213,7 @@ After the prebuild step, the package will be built into its final form via the r
 
 ## Stylelint Plugins
 
-These rules validate design token usage in CSS:
-
-Enable them in your Stylelint configuration:
+These rules validate design token usage in CSS. Enable them in your Stylelint configuration:
 
 ```json
 {
@@ -256,9 +254,7 @@ The build plugins inject generated fallbacks into bare `var(--wpds-*)` reference
 | `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks` | esbuild | JS/TS |
 | `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks`       | Vite    | JS/TS |
 
-Existing fallbacks and non-`--wpds-*` properties are unchanged. An unknown token in a bare reference fails the build.
-
-PostCSS transforms declaration values in plain CSS and CSS modules, but not comments. The esbuild and Vite plugins transform `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.mts`, `.cjs`, and `.cts` files outside `node_modules`; their source-text transform includes strings, template literals, and comments.
+Existing fallbacks are unchanged. An unknown token in a bare reference fails the build.
 
 ### PostCSS
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -64,9 +64,7 @@ If your application renders React content into additional documents (an iframe, 
 
 ### Developer Tools
 
-For the best development experience, we recommend configuring the [Stylelint rules](#stylelint-plugins) provided by this package. The Stylelint rules catch typos, unknown tokens, and other discouraged patterns during development.
-
-If you reference `--wpds-*` tokens in CSS or JS/TS source, use the [build plugins](#build-plugins) to inject fallback values at build time so components render correctly even when the tokens stylesheet is not loaded. If you use `@wordpress/build`, these plugins are already enabled by default when `@wordpress/theme` is installed.
+Use the [Stylelint plugins](#stylelint-plugins) to validate token usage and the [build plugins](#build-plugins) to inject generated fallback values. `@wordpress/build` enables the build plugins automatically when `@wordpress/theme` is installed.
 
 ### Accessibility
 
@@ -215,7 +213,15 @@ After the prebuild step, the package will be built into its final form via the r
 
 ## Stylelint Plugins
 
-This package provides Stylelint plugins to help enforce consistent usage of design tokens. To use them, add the plugins to your Stylelint configuration:
+These rules validate design token usage in CSS:
+
+| Rule                                            | Reports                                                   |
+| ----------------------------------------------- | --------------------------------------------------------- |
+| `plugin-wpds/no-unknown-ds-tokens`              | References to unknown `--wpds-*` tokens                   |
+| `plugin-wpds/no-setting-wpds-custom-properties` | Definitions or overrides in the `--wpds-*` namespace      |
+| `plugin-wpds/no-token-fallback-values`          | Manual fallbacks that can drift from the generated values |
+
+Enable them in your Stylelint configuration:
 
 ```json
 {
@@ -232,71 +238,11 @@ This package provides Stylelint plugins to help enforce consistent usage of desi
 }
 ```
 
-### `plugin-wpds/no-unknown-ds-tokens`
-
-This rule reports an error when a CSS value references a `--wpds-*` custom property that is not a valid design token. This helps catch typos and ensures that only valid design tokens are used.
-
-```css
-/* ✗ Error: '--wpds-unknown-token' is not a valid Design System token */
-.example {
-	color: var( --wpds-unknown-token );
-}
-
-/* ✓ OK */
-.example {
-	color: var( --wpds-color-foreground-content-neutral );
-}
-```
-
-### `plugin-wpds/no-setting-wpds-custom-properties`
-
-This rule reports an error when a CSS declaration sets (defines) a custom property in the `--wpds-*` namespace. The design system tokens should only be consumed, not defined or overridden in consuming code.
-
-```css
-/* ✗ Error: Do not set CSS custom properties using the Design System tokens namespace */
-.example {
-	--wpds-my-token: red;
-}
-
-/* ✗ Error: Overriding existing tokens is also not allowed */
-.example {
-	--wpds-color-foreground-content-neutral: red;
-}
-
-/* ✓ OK */
-.example {
-	--my-custom-token: red;
-}
-```
-
-### `plugin-wpds/no-token-fallback-values`
-
-This rule reports an error when a `var()` call for a `--wpds-*` token includes a manual fallback value. In CSS processed by the [build plugins](#build-plugins), fallback values are injected automatically, so manual fallbacks in `var(--wpds-*)` references are redundant and can drift out of sync with the token definitions.
-
-```css
-/* ✗ Error: Do not add a fallback value for Design System token '--wpds-color-foreground-content-neutral' */
-.example {
-	color: var( --wpds-color-foreground-content-neutral, #1e1e1e );
-}
-
-/* ✓ OK */
-.example {
-	color: var( --wpds-color-foreground-content-neutral );
-}
-
-/* ✓ OK: Non-wpds custom properties are not checked */
-.example {
-	color: var( --my-custom-color, red );
-}
-```
-
 ## Build Plugins
 
-This package provides build plugins that inject fallback values into bare `var(--wpds-*)` references at build time. This ensures components render correctly even when a `ThemeProvider` or design tokens stylesheet is not present — for example, `var(--wpds-color-foreground-content-neutral)` becomes `var(--wpds-color-foreground-content-neutral, #1e1e1e)`.
+The build plugins inject generated fallbacks into bare `var(--wpds-*)` references so components still render when the design tokens stylesheet is unavailable. For example, `var(--wpds-color-foreground-content-neutral)` becomes `var(--wpds-color-foreground-content-neutral, #1e1e1e)`.
 
 `@wordpress/build` already applies these plugins automatically when `@wordpress/theme` is installed. You only need to configure them manually for custom build setups.
-
-Three plugin variants are available, covering common build tool setups:
 
 | Export                                                        | Tool    | Scope |
 | ------------------------------------------------------------- | ------- | ----- |
@@ -304,17 +250,9 @@ Three plugin variants are available, covering common build tool setups:
 | `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks` | esbuild | JS/TS |
 | `@wordpress/theme/vite-plugins/vite-ds-token-fallbacks`       | Vite    | JS/TS |
 
-All three plugins skip transformation when the source does not contain a `--wpds-` reference.
+Existing fallbacks and non-`--wpds-*` properties are unchanged. An unknown token in a bare reference fails the build.
 
-### Transform boundaries and errors
-
-The plugins transform bare `var(--wpds-*)` calls, including calls with whitespace such as `var( --wpds-color-foreground-content-neutral )`. Calls that already include a fallback are left unchanged, and non-`--wpds-*` custom properties are ignored.
-
-The PostCSS plugin transforms declaration values in any stylesheet processed by PostCSS, including plain CSS and CSS modules. It does not transform token references in CSS comments.
-
-The esbuild and Vite plugins transform JavaScript and TypeScript source files with `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.mts`, `.cjs`, and `.cts` extensions, except files in `node_modules`. They transform matching source text in template literals, quoted strings, and comments.
-
-If a transformed bare `var()` call references an unknown `--wpds-*` token, the plugin stops the build with an `Unknown design token` error. This also applies to matching references in JavaScript or TypeScript comments and strings; remove example references to unknown tokens or use a known token name.
+PostCSS transforms declaration values in plain CSS and CSS modules, but not comments. The esbuild and Vite plugins transform `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.mts`, `.cjs`, and `.cts` files outside `node_modules`; their source-text transform includes strings, template literals, and comments.
 
 ### PostCSS
 

--- a/packages/theme/src/test/__snapshots__/build-plugin-parity.test.ts.snap
+++ b/packages/theme/src/test/__snapshots__/build-plugin-parity.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`design token fallback build plugin parity keeps esbuild and Vite source-text transforms aligned 1`] = `
+"// Source text is transformed consistently: var(--wpds-border-radius-sm, 2px).
+export const templateStyles = \`color: var(--wpds-color-foreground-content-neutral, #1e1e1e);\`;
+export const doubleQuotedStyles =
+	"gap: var(--wpds-dimension-gap-sm, 8px); content: 'fixture';";
+export const singleQuotedStyles = 'radius: var(--wpds-border-radius-sm, 2px);';
+export const manualFallback = 'radius: var(--wpds-border-radius-sm, 99px);';
+"
+`;
+
+exports[`design token fallback build plugin parity transforms supported CSS in styles.css 1`] = `
+"/* Token references in CSS comments are not transformed: var(--wpds-border-radius-sm). */
+.fixture {
+	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	content: "var(--wpds-border-radius-sm, 2px)";
+}
+"
+`;
+
+exports[`design token fallback build plugin parity transforms supported CSS in styles.module.css 1`] = `
+".fixture {
+	gap: var(--wpds-dimension-gap-sm, 8px);
+}
+"
+`;

--- a/packages/theme/src/test/build-plugin-parity.test.ts
+++ b/packages/theme/src/test/build-plugin-parity.test.ts
@@ -1,0 +1,145 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import type {
+	OnLoadArgs,
+	OnLoadOptions,
+	OnLoadResult,
+	PluginBuild,
+} from 'esbuild';
+import postcss from 'postcss';
+
+import esbuildPlugin from '../esbuild-plugins/esbuild-ds-token-fallbacks.mjs';
+import postcssPlugin from '../postcss-plugins/postcss-ds-token-fallbacks.mjs';
+import vitePlugin from '../vite-plugins/vite-ds-token-fallbacks.mjs';
+
+const fixturesDirectory = join( __dirname, 'fixtures/build-plugins' );
+const validJsFixture = join( fixturesDirectory, 'source.ts' );
+const unknownJsFixture = join( fixturesDirectory, 'unknown-token.ts' );
+
+type EsbuildOnLoad = (
+	args: OnLoadArgs
+) =>
+	| OnLoadResult
+	| Promise< OnLoadResult | null | undefined >
+	| null
+	| undefined;
+
+type ViteTransform = (
+	code: string,
+	id: string
+) => { code: string; map: null } | null;
+
+function getEsbuildHook(): {
+	options: OnLoadOptions;
+	transform: EsbuildOnLoad;
+} {
+	let options: OnLoadOptions | undefined;
+	let transform: EsbuildOnLoad | undefined;
+
+	esbuildPlugin.setup( {
+		onLoad: ( onLoadOptions, callback ) => {
+			options = onLoadOptions;
+			transform = callback;
+		},
+	} as Pick< PluginBuild, 'onLoad' > as PluginBuild );
+
+	if ( ! options || ! transform ) {
+		throw new Error( 'Expected the esbuild plugin to register onLoad.' );
+	}
+
+	return { options, transform };
+}
+
+function getViteTransform(): ViteTransform {
+	const transform = vitePlugin().transform;
+
+	if ( typeof transform !== 'function' ) {
+		throw new Error( 'Expected the Vite plugin to register transform.' );
+	}
+
+	return transform as ViteTransform;
+}
+
+describe( 'design token fallback build plugin parity', () => {
+	it.each( [ 'styles.css', 'styles.module.css' ] )(
+		'transforms supported CSS in %s',
+		async ( fixture ) => {
+			const filename = join( fixturesDirectory, fixture );
+			const source = await readFile( filename, 'utf8' );
+			const result = await postcss( [ postcssPlugin ] ).process( source, {
+				from: filename,
+			} );
+
+			expect( result.css ).toMatchSnapshot();
+		}
+	);
+
+	it( 'keeps esbuild and Vite source-text transforms aligned', async () => {
+		const source = await readFile( validJsFixture, 'utf8' );
+		const esbuildResult = await getEsbuildHook().transform( {
+			path: validJsFixture,
+		} as OnLoadArgs );
+		const viteResult = getViteTransform()( source, validJsFixture );
+
+		expect( esbuildResult?.loader ).toBe( 'tsx' );
+		expect( esbuildResult?.contents ).toBe( viteResult?.code );
+		expect( viteResult?.code ).toMatchSnapshot();
+	} );
+
+	it.each( [ '.js', '.jsx', '.ts', '.tsx', '.mjs', '.mts', '.cjs', '.cts' ] )(
+		'transforms the documented JavaScript and TypeScript %s extension',
+		async ( extension ) => {
+			const source = await readFile( validJsFixture, 'utf8' );
+			const { options } = getEsbuildHook();
+
+			expect( options.filter.test( `fixture${ extension }` ) ).toBe(
+				true
+			);
+			expect(
+				getViteTransform()( source, `fixture${ extension }` )
+			).not.toBeNull();
+		}
+	);
+
+	it( 'skips unsupported JS plugin inputs', async () => {
+		const source = await readFile( validJsFixture, 'utf8' );
+		const { options, transform } = getEsbuildHook();
+
+		expect( options.filter.test( 'fixture.css' ) ).toBe( false );
+		expect( getViteTransform()( source, 'fixture.css' ) ).toBeNull();
+		await expect(
+			transform( {
+				path: '/project/node_modules/package/fixture.ts',
+			} as OnLoadArgs )
+		).resolves.toBeUndefined();
+		expect(
+			getViteTransform()(
+				source,
+				'/project/node_modules/package/fixture.ts'
+			)
+		).toBeNull();
+	} );
+
+	it( 'fails consistently for unknown tokens in transformed content', async () => {
+		const unknownCssFixture = join(
+			fixturesDirectory,
+			'unknown-token.css'
+		);
+		const cssSource = await readFile( unknownCssFixture, 'utf8' );
+		const jsSource = await readFile( unknownJsFixture, 'utf8' );
+
+		await expect(
+			postcss( [ postcssPlugin ] ).process( cssSource, {
+				from: unknownCssFixture,
+			} )
+		).rejects.toThrow( 'Unknown design token: --wpds-not-a-token' );
+		await expect(
+			getEsbuildHook().transform( {
+				path: unknownJsFixture,
+			} as OnLoadArgs )
+		).rejects.toThrow( 'Unknown design token: --wpds-not-a-token' );
+		expect( () =>
+			getViteTransform()( jsSource, unknownJsFixture )
+		).toThrow( 'Unknown design token: --wpds-not-a-token' );
+	} );
+} );

--- a/packages/theme/src/test/fixtures/build-plugins/source.ts
+++ b/packages/theme/src/test/fixtures/build-plugins/source.ts
@@ -1,0 +1,6 @@
+// Source text is transformed consistently: var(--wpds-border-radius-sm).
+export const templateStyles = `color: var(--wpds-color-foreground-content-neutral);`;
+export const doubleQuotedStyles =
+	"gap: var(--wpds-dimension-gap-sm); content: 'fixture';";
+export const singleQuotedStyles = 'radius: var(--wpds-border-radius-sm);';
+export const manualFallback = 'radius: var(--wpds-border-radius-sm, 99px);';

--- a/packages/theme/src/test/fixtures/build-plugins/styles.css
+++ b/packages/theme/src/test/fixtures/build-plugins/styles.css
@@ -1,0 +1,5 @@
+/* Token references in CSS comments are not transformed: var(--wpds-border-radius-sm). */
+.fixture {
+	color: var(--wpds-color-foreground-content-neutral);
+	content: "var(--wpds-border-radius-sm)";
+}

--- a/packages/theme/src/test/fixtures/build-plugins/styles.module.css
+++ b/packages/theme/src/test/fixtures/build-plugins/styles.module.css
@@ -1,0 +1,3 @@
+.fixture {
+	gap: var(--wpds-dimension-gap-sm);
+}

--- a/packages/theme/src/test/fixtures/build-plugins/unknown-token.css
+++ b/packages/theme/src/test/fixtures/build-plugins/unknown-token.css
@@ -1,0 +1,4 @@
+.fixture {
+	/* stylelint-disable-next-line plugin-wpds/no-unknown-ds-tokens -- This fixture verifies the plugin's error. */
+	color: var(--wpds-not-a-token);
+}

--- a/packages/theme/src/test/fixtures/build-plugins/unknown-token.ts
+++ b/packages/theme/src/test/fixtures/build-plugins/unknown-token.ts
@@ -1,0 +1,1 @@
+export const styles = 'color: var(--wpds-not-a-token);';


### PR DESCRIPTION
Follow-up to #77462 (T3 and T4).

## What?

Documents the essential tooling contracts for `@wordpress/theme` and adds shared build-plugin parity fixtures for PostCSS, esbuild, and Vite.

## Why?

Consumers need concise guidance on token linting, supported transform boundaries, and unknown-token failures. The build plugins also need regression coverage to prevent their behavior from drifting apart.

## How?

- Consolidates the Stylelint guidance into a rule summary and keeps only actionable configuration.
- Documents the build plugins' supported inputs and failure behavior.
- Adds shared fixtures and snapshots for PostCSS, esbuild, and Vite.

## Testing Instructions

1. Run `npm run test:unit -- packages/theme/src/test/build-plugin-parity.test.ts --runInBand`.
2. Run `./node_modules/.bin/tsgo --build packages/theme/tsconfig.json`.
3. Run `npm run build --workspace @wordpress/theme`.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex. The implementation, tests, documentation, and verification were reviewed in the local checkout.