### PR TITLE
wp-build: Allow @wordpress/theme 1.x peer versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48433,7 +48433,7 @@
 				"@wordpress/boot": ">=0.3.0 <1.0.0",
 				"@wordpress/private-apis": "^1.0.0",
 				"@wordpress/route": ">=0.2.0 <1.0.0",
-				"@wordpress/theme": ">=0.8.0 <1.0.0"
+				"@wordpress/theme": ">=0.8.0 <2.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@wordpress/boot": {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -12,6 +12,10 @@
     [#79701](https://github.com/WordPress/gutenberg/pull/79701),
     [#79830](https://github.com/WordPress/gutenberg/pull/79830)).
 
+### Bug Fixes
+
+-   Widen the optional `@wordpress/theme` peer dependency range to allow 1.x releases and preserve automatic design token fallback plugin loading ([#80089](https://github.com/WordPress/gutenberg/pull/80089)).
+
 ## 0.18.0 (2026-07-01)
 
 ## 0.17.0 (2026-06-24)

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/boot": ">=0.3.0 <1.0.0",
 		"@wordpress/private-apis": "^1.0.0",
 		"@wordpress/route": ">=0.2.0 <1.0.0",
-		"@wordpress/theme": ">=0.8.0 <1.0.0"
+		"@wordpress/theme": ">=0.8.0 <2.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@wordpress/boot": {


### PR DESCRIPTION
See #77462.

## What?

Allows `@wordpress/build` to use stable `@wordpress/theme` 1.x releases.

## Why?

The optional peer range currently stops below 1.0.0, which would prevent the design-token fallback plugins from auto-loading once `@wordpress/theme` is stabilized (will happen in the next round of releases, see https://github.com/WordPress/gutenberg/pull/80049)

## How?

Widens the `@wordpress/theme` peer range from `>=0.8.0 <1.0.0` to `>=0.8.0 <2.0.0`. The 0.8.0 floor remains because that release introduced the fallback plugin exports.

## Testing Instructions

1. Run `npm run lint:pkg-json -- packages/wp-build/package.json`.
2. Run `npm run lint:lockfile`.
3. Run `./node_modules/.bin/tsgo --build packages/wp-build/tsconfig.json`.
4. Build a package containing `var(--wpds-color-foreground-content-neutral)` in JavaScript and SCSS with `packages/wp-build/lib/build.mjs`.
5. Confirm both outputs contain `var(--wpds-color-foreground-content-neutral, #1e1e1e)`.

### Testing Instructions for Keyboard

Not applicable; this change does not affect the UI.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement and verify this change.