### PR TITLE
Fix flaky 'Activate theme' e2e test

### DIFF
--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -35,14 +35,14 @@ test.describe( 'Activate theme', () => {
 		admin,
 		page,
 	} ) => {
-		// Wait for the loading to complete.
-		await expect( page.locator( '.edit-site-canvas-loader' ) ).toHaveCount(
-			0
-		);
-		// Disable welcome guide to prevent onboarding modal from appearing.
+		// Wait for the Site Editor to load before interacting with the page.
+		await expect(
+			page.getByRole( 'button', { name: 'Activate Emptytheme' } )
+		).toBeVisible();
 		await editor.setPreferences( 'core/edit-site', {
 			welcomeGuide: false,
 		} );
+
 		await editor.canvas.locator( 'body' ).click();
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )


### PR DESCRIPTION
## What?
Closes #77712.

PR tries to fix flaky `Activate theme` e2e tests by changing the locator we want to wait for. Sometimes the `editor.setPreferences` runs before everything is loaded.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/activate-theme.spec.js --repeat-each 20
```

## Screenshots or screencast <!-- if applicable -->

<img width="1356" height="331" alt="CleanShot 2026-07-10 at 12 07 20" src="https://github.com/user-attachments/assets/9c0ad8d3-bf63-472d-8a46-8ca87f673493" />


## Use of AI Tools

None.