### PR TITLE
UI: Restore Link focus styles

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+-   `Link`: Restore the focus ring removed when `LinkButton` was added. ([#80091](https://github.com/WordPress/gutenberg/pull/80091))
 -   `Tabs`: Re-measure overflow when the list or its content changes size so the scroll fade stays in sync as labels/badges load or a web font reflows the tabs. ([#79856](https://github.com/WordPress/gutenberg/pull/79856))
 -   `IconButton`: Keep the inline padding override valid when reused in button length calculations ([#79722](https://github.com/WordPress/gutenberg/pull/79722)).
 -   `IconButton`: Restore the default tooltip delay on hover ([#79505](https://github.com/WordPress/gutenberg/pull/79505)).

--- a/packages/ui/src/link-button/link-button.tsx
+++ b/packages/ui/src/link-button/link-button.tsx
@@ -3,7 +3,6 @@ import { forwardRef } from '@wordpress/element';
 import { Link } from '../link';
 import { type LinkButtonProps } from './types';
 import buttonStyles from '../button/style.module.css';
-import focusStyles from '../utils/css/focus.module.css';
 import styles from './style.module.css';
 
 /**
@@ -31,7 +30,6 @@ export const LinkButton = forwardRef< HTMLAnchorElement, LinkButtonProps >(
 				variant="unstyled"
 				className={ clsx(
 					styles[ 'link-button' ],
-					focusStyles[ 'outset-ring--focus-except-active' ],
 					variant !== 'unstyled' && buttonStyles.button,
 					buttonStyles[ `is-${ tone }` ],
 					buttonStyles[ `is-${ variant }` ],

--- a/packages/ui/src/link-button/test/link-button.test.tsx
+++ b/packages/ui/src/link-button/test/link-button.test.tsx
@@ -41,10 +41,7 @@ describe( 'LinkButton', () => {
 
 		const link = screen.getByRole( 'link', { name: 'Go to example' } );
 
-		expect( link ).toHaveClass( 'style-outset-ring-focus' );
-		expect( link ).not.toHaveClass(
-			'style-outset-ring-focus-except-active'
-		);
+		expect( link ).toHaveClass( 'style-outset-ring-focus-except-active' );
 	} );
 
 	describe( 'openInNewTab', () => {

--- a/packages/ui/src/link-button/test/link-button.test.tsx
+++ b/packages/ui/src/link-button/test/link-button.test.tsx
@@ -36,6 +36,17 @@ describe( 'LinkButton', () => {
 		).toHaveClass( customClass );
 	} );
 
+	it( 'inherits focus ring styles from Link', () => {
+		render( <LinkButton href="/example">Go to example</LinkButton> );
+
+		const link = screen.getByRole( 'link', { name: 'Go to example' } );
+
+		expect( link ).toHaveClass( 'style-outset-ring-focus' );
+		expect( link ).not.toHaveClass(
+			'style-outset-ring-focus-except-active'
+		);
+	} );
+
 	describe( 'openInNewTab', () => {
 		it( 'sets target="_blank" when true', () => {
 			render(

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -35,7 +35,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 			className: clsx(
 				defenseStyles.a,
 				resetStyles[ 'box-sizing' ],
-				focusStyles[ 'outset-ring--focus' ],
+				focusStyles[ 'outset-ring--focus-except-active' ],
 				variant !== 'unstyled' && styles.link,
 				variant !== 'unstyled' && styles[ `is-${ tone }` ],
 				variant === 'unstyled' && styles[ 'is-unstyled' ],

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { type LinkProps } from './types';
 import resetStyles from '../utils/css/resets.module.css';
+import focusStyles from '../utils/css/focus.module.css';
 import styles from './style.module.css';
 import defenseStyles from '../utils/css/global-css-defense.module.css';
 
@@ -34,6 +35,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 			className: clsx(
 				defenseStyles.a,
 				resetStyles[ 'box-sizing' ],
+				focusStyles[ 'outset-ring--focus' ],
 				variant !== 'unstyled' && styles.link,
 				variant !== 'unstyled' && styles[ `is-${ tone }` ],
 				variant === 'unstyled' && styles[ 'is-unstyled' ],

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -16,6 +16,14 @@ describe( 'Link', () => {
 		expect( ref.current ).toBeInstanceOf( HTMLAnchorElement );
 	} );
 
+	it( 'applies focus ring styles', () => {
+		render( <Link href="/">Home</Link> );
+
+		expect( screen.getByRole( 'link', { name: 'Home' } ) ).toHaveClass(
+			'style-outset-ring-focus'
+		);
+	} );
+
 	it( 'calls onClick when clicked (often used for analytics tracking)', async () => {
 		const user = userEvent.setup();
 		const onClick = jest.fn(

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -16,14 +16,6 @@ describe( 'Link', () => {
 		expect( ref.current ).toBeInstanceOf( HTMLAnchorElement );
 	} );
 
-	it( 'applies focus ring styles except while active', () => {
-		render( <Link href="/">Home</Link> );
-
-		expect( screen.getByRole( 'link', { name: 'Home' } ) ).toHaveClass(
-			'style-outset-ring-focus-except-active'
-		);
-	} );
-
 	it( 'calls onClick when clicked (often used for analytics tracking)', async () => {
 		const user = userEvent.setup();
 		const onClick = jest.fn(

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -16,11 +16,11 @@ describe( 'Link', () => {
 		expect( ref.current ).toBeInstanceOf( HTMLAnchorElement );
 	} );
 
-	it( 'applies focus ring styles', () => {
+	it( 'applies focus ring styles except while active', () => {
 		render( <Link href="/">Home</Link> );
 
 		expect( screen.getByRole( 'link', { name: 'Home' } ) ).toHaveClass(
-			'style-outset-ring-focus'
+			'style-outset-ring-focus-except-active'
 		);
 	} );
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/78944#discussion_r3557034539

## What?

Restores the focus ring on `Link` and lets `LinkButton` inherit the same focus behavior.

## Why?

The `LinkButton` addition moved focus styles off the base `Link`, leaving standalone links without the expected focus outline.

## How?

Applies `outset-ring--focus-except-active` to `Link`, removes the duplicate focus utility from `LinkButton`, and verifies that `LinkButton` inherits the utility. This keeps the focus ring visible except during the active state, matching `Button`.

## Testing Instructions

1. Run `npm run test:unit -- packages/ui/src/link/test/index.test.tsx packages/ui/src/link-button/test/link-button.test.tsx --runInBand`.
2. Run `npm run build`.

### Testing Instructions for Keyboard

1. Open the `Link` and `LinkButton` Storybook stories.
2. Use Tab to focus each component and confirm the focus outline is visible.
3. Press and hold Enter and confirm the outline is hidden only while the component is active.


### Screenshots

| - | Before | After |
|---|---|---|
| `Link`| <img width="292" height="168" alt="Screenshot 2026-07-10 at 10 31 51" src="https://github.com/user-attachments/assets/63fcedd5-8003-403b-87d6-853265259f26" /> | <img width="286" height="142" alt="Screenshot 2026-07-10 at 10 33 24" src="https://github.com/user-attachments/assets/04ab676b-62e1-4ff6-866e-c8fed6489812" /> |
| `LinkButton` |  <img width="322" height="184" alt="Screenshot 2026-07-10 at 10 31 57" src="https://github.com/user-attachments/assets/f52d4487-0214-4056-a2bd-2b960c1bbd63" /> |  <img width="310" height="206" alt="Screenshot 2026-07-10 at 10 34 17" src="https://github.com/user-attachments/assets/808ae4f7-d35c-4ce0-ab70-5ac50477dc19" /> |  





## Use of AI Tools

Codex was used to investigate the regression, implement the fix, and run verification.