### PR TITLE
useInnerBlockTemplateSync: remove microtask

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -14,6 +14,7 @@ import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { flushPendingNestedSettingsUpdate } from './use-nested-settings-update';
 
 /**
  * This hook makes sure that a block's inner blocks stay in sync with the given
@@ -48,8 +49,6 @@ export default function useInnerBlockTemplateSync(
 	const existingTemplateRef = useRef( null );
 
 	useLayoutEffect( () => {
-		let isCancelled = false;
-
 		const {
 			getBlocks,
 			getSelectedBlocksInitialCaretPosition,
@@ -58,61 +57,56 @@ export default function useInnerBlockTemplateSync(
 		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
 			registry.dispatch( blockEditorStore );
 
-		// There's an implicit dependency between useInnerBlockTemplateSync and useNestedSettingsUpdate
-		// The former needs to happen after the latter and since the latter is using microtasks to batch updates (performance optimization),
-		// we need to schedule this one in a microtask as well.
-		// Example: If you remove queueMicrotask here, ctrl + click to insert quote block won't close the inserter.
-		window.queueMicrotask( () => {
-			if ( isCancelled ) {
-				return;
-			}
+		// There's an implicit dependency between useInnerBlockTemplateSync and
+		// useNestedSettingsUpdate: the block's own nested settings must be in
+		// the store before the template is applied. useNestedSettingsUpdate
+		// batches its updates into a microtask, so apply this block's pending
+		// settings update now, ahead of the batched flush.
+		// Example: without this flush, ctrl + click to insert quote block
+		// wouldn't close the inserter.
+		flushPendingNestedSettingsUpdate( registry, clientId );
 
-			// Only synchronize innerBlocks with template if innerBlocks are empty
-			// or a locking "all" or "contentOnly" exists directly on the block.
-			const currentInnerBlocks = getBlocks( clientId );
-			const shouldApplyTemplate =
-				currentInnerBlocks.length === 0 ||
-				templateLock === 'all' ||
-				templateLock === 'contentOnly';
+		// Only synchronize innerBlocks with template if innerBlocks are empty
+		// or a locking "all" or "contentOnly" exists directly on the block.
+		const currentInnerBlocks = getBlocks( clientId );
+		const shouldApplyTemplate =
+			currentInnerBlocks.length === 0 ||
+			templateLock === 'all' ||
+			templateLock === 'contentOnly';
 
-			const hasTemplateChanged = ! fastDeepEqual(
-				template,
-				existingTemplateRef.current
+		const hasTemplateChanged = ! fastDeepEqual(
+			template,
+			existingTemplateRef.current
+		);
+
+		if ( ! shouldApplyTemplate || ! hasTemplateChanged ) {
+			return;
+		}
+
+		existingTemplateRef.current = template;
+		const nextBlocks = synchronizeBlocksWithTemplate(
+			currentInnerBlocks,
+			template
+		);
+
+		if ( ! fastDeepEqual( nextBlocks, currentInnerBlocks ) ) {
+			__unstableMarkNextChangeAsNotPersistent( {
+				history: 'ignore',
+			} );
+			replaceInnerBlocks(
+				clientId,
+				nextBlocks,
+				currentInnerBlocks.length === 0 &&
+					templateInsertUpdatesSelection &&
+					nextBlocks.length !== 0 &&
+					isBlockSelected( clientId ),
+				// This ensures the "initialPosition" doesn't change when applying the template
+				// If we're supposed to focus the block, we'll focus the first inner block
+				// otherwise, we won't apply any auto-focus.
+				// This ensures for instance that the focus stays in the inserter when inserting the "buttons" block.
+				getSelectedBlocksInitialCaretPosition()
 			);
-
-			if ( ! shouldApplyTemplate || ! hasTemplateChanged ) {
-				return;
-			}
-
-			existingTemplateRef.current = template;
-			const nextBlocks = synchronizeBlocksWithTemplate(
-				currentInnerBlocks,
-				template
-			);
-
-			if ( ! fastDeepEqual( nextBlocks, currentInnerBlocks ) ) {
-				__unstableMarkNextChangeAsNotPersistent( {
-					history: 'ignore',
-				} );
-				replaceInnerBlocks(
-					clientId,
-					nextBlocks,
-					currentInnerBlocks.length === 0 &&
-						templateInsertUpdatesSelection &&
-						nextBlocks.length !== 0 &&
-						isBlockSelected( clientId ),
-					// This ensures the "initialPosition" doesn't change when applying the template
-					// If we're supposed to focus the block, we'll focus the first inner block
-					// otherwise, we won't apply any auto-focus.
-					// This ensures for instance that the focus stays in the inserter when inserting the "buttons" block.
-					getSelectedBlocksInitialCaretPosition()
-				);
-			}
-		} );
-
-		return () => {
-			isCancelled = true;
-		};
+		}
 	}, [
 		template,
 		templateLock,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -16,6 +16,27 @@ import { getLayoutType } from '../../layouts';
 
 const pendingSettingsUpdates = new WeakMap();
 
+/**
+ * Immediately applies the pending block list settings update for the given
+ * block, if there is one, instead of waiting for the batched microtask flush.
+ * The flushed entry is removed from the pending batch; updates for other
+ * blocks stay queued for the regularly scheduled flush.
+ *
+ * @param {Object} registry Data registry.
+ * @param {string} clientId The block whose pending settings should be applied.
+ */
+export function flushPendingNestedSettingsUpdate( registry, clientId ) {
+	const pendingUpdates = pendingSettingsUpdates.get( registry );
+	const settings = pendingUpdates?.[ clientId ];
+	if ( settings === undefined ) {
+		return;
+	}
+	delete pendingUpdates[ clientId ];
+	registry
+		.dispatch( blockEditorStore )
+		.updateBlockListSettings( clientId, settings );
+}
+
 // Creates a memoizing caching function that remembers the last value and keeps returning it
 // as long as the new values are shallowly equal. Helps keep dependencies stable.
 function createShallowMemo() {

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -19,7 +19,7 @@ import {
 	formatOutdentRTL,
 } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useLayoutEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -47,7 +47,7 @@ function useMigrateOnLoad( attributes, clientId ) {
 	const { updateBlockAttributes, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		// As soon as the block is loaded, migrate it to the new version.
 
 		if ( ! attributes.values ) {
@@ -67,6 +67,19 @@ function useMigrateOnLoad( attributes, clientId ) {
 			replaceInnerBlocks( clientId, newInnerBlocks );
 		} );
 	}, [ attributes.values ] );
+}
+
+/**
+ * Rendered before the inner blocks children so that the migration effect runs
+ * before the inner block template sync, which then skips inserting the template.
+ *
+ * @param {Object} props            Component props.
+ * @param {Object} props.attributes Block attributes.
+ * @param {string} props.clientId   Block client ID.
+ */
+function MigrateOnLoad( { attributes, clientId } ) {
+	useMigrateOnLoad( attributes, clientId );
+	return null;
 }
 
 function useOutdentList( clientId ) {
@@ -133,7 +146,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		templateInsertUpdatesSelection: true,
 		__experimentalCaptureToolbars: true,
 	} );
-	useMigrateOnLoad( attributes, clientId );
 
 	const controls = (
 		<BlockControls group="block">
@@ -166,7 +178,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				reversed={ reversed }
 				start={ start }
 				{ ...innerBlocksProps }
-			/>
+			>
+				<MigrateOnLoad
+					attributes={ attributes }
+					clientId={ clientId }
+				/>
+				{ innerBlocksProps.children }
+			</TagName>
 			{ controls }
 			{ ordered && (
 				<OrderedListSettings

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { useDispatch, useRegistry } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useLayoutEffect } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 import { verse } from '@wordpress/icons';
 
@@ -40,7 +40,7 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 	const registry = useRegistry();
 	const { updateBlockAttributes, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
-	useEffect( () => {
+	useLayoutEffect( () => {
 		// As soon as the block is loaded, migrate it to the new version.
 
 		if ( ! attributes.value ) {
@@ -64,6 +64,19 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 	}, [ attributes.value ] );
 };
 
+/**
+ * Rendered before the inner blocks children so that the migration effect runs
+ * before the inner block template sync, which then skips inserting the template.
+ *
+ * @param {Object} props            Component props.
+ * @param {Object} props.attributes Block attributes.
+ * @param {string} props.clientId   Block client ID.
+ */
+function MigrateOnLoad( { attributes, clientId } ) {
+	useMigrateOnLoad( attributes, clientId );
+	return null;
+}
+
 export default function QuoteEdit( {
 	attributes,
 	setAttributes,
@@ -73,8 +86,6 @@ export default function QuoteEdit( {
 	isSelected,
 } ) {
 	const { textAlign, allowedBlocks } = attributes;
-
-	useMigrateOnLoad( attributes, clientId );
 
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
@@ -100,6 +111,10 @@ export default function QuoteEdit( {
 				/>
 			</BlockControls>
 			<BlockQuotation { ...innerBlocksProps }>
+				<MigrateOnLoad
+					attributes={ attributes }
+					clientId={ clientId }
+				/>
 				{ innerBlocksProps.children }
 				<Caption
 					attributeKey="citation"


### PR DESCRIPTION
This is a spinoff from #79021 that extract a valuable part of the PR: do the template sync more straightforwardly, without and extra mysterious `queueMicrotask`. The reason why the microtask was there is that `useNestedSettingsUpdate` also defers store updates to a microtask, because of batching. In our new implementation we do a selective synchronous flush of just the one relevant update that we need.

Doing the template sync a bit earlier causes a reordering conflict with `useMigrateOnLoad` in the List and Quote block. I'm solving this by moving the migration to an `InnerBlocks` child. Then the effects will run in the original order: migration first, template sync second.