### PR TITLE
Block Supports: Add opt-in semantic CSS class generation for style properties

### DIFF
--- a/lib/block-supports/style-classes.php
+++ b/lib/block-supports/style-classes.php
@@ -1,0 +1,605 @@
+<?php
+/**
+ * Block support to add semantic CSS classes to blocks when style properties are applied.
+ *
+ * @since 23.4.0
+ * @package gutenberg
+ */
+
+/**
+ * Callback function for the render_block filter to compute and inject style classes.
+ *
+ * @since 23.4.0
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
+ * @return string Filtered block content with style classes injected.
+ */
+function gutenberg_render_style_classes( $block_content, $block ) {
+	/**
+	 * Filters the list of style properties enabled for CSS class generation.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param string[] $enabled Array of enabled style property slugs.
+	 */
+	$enabled = (array) apply_filters( 'wp_enabled_style_properties', array() );
+
+	if ( empty( $enabled ) || '' === $block_content ) {
+		return $block_content;
+	}
+
+	$block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+	if ( $block_name ) {
+		$slug = str_replace( '/', '-', $block_name );
+
+		/**
+		 * Filters the list of style properties enabled for CSS class generation for a specific block type.
+		 *
+		 * The dynamic portion of the hook name, `$block_name`, refers to the block type name.
+		 *
+		 * @since 23.4.0
+		 *
+		 * @param string[] $enabled Array of enabled style property slugs.
+		 * @param array    $block   The full block, including name and attributes.
+		 */
+		$enabled = (array) apply_filters( "wp_enabled_style_properties_{$block_name}", $enabled, $block );
+
+		/**
+		 * Filters the list of style properties enabled for CSS class generation for a specific block type slug.
+		 *
+		 * The dynamic portion of the hook name, `$slug`, refers to the kebab case block type name.
+		 *
+		 * @since 23.4.0
+		 *
+		 * @param string[] $enabled Array of enabled style property slugs.
+		 * @param array    $block   The full block, including name and attributes.
+		 */
+		$enabled = (array) apply_filters( "wp_enabled_style_properties_{$slug}", $enabled, $block );
+	}
+
+	if ( empty( $enabled ) ) {
+		return $block_content;
+	}
+
+	$ctx = array(
+		'style'  => isset( $block['attrs']['style'] ) ? $block['attrs']['style'] : array(),
+		'attrs'  => isset( $block['attrs'] ) ? $block['attrs'] : array(),
+		'layout' => isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : array(),
+		'block'  => $block,
+	);
+
+	$classes = array();
+
+	foreach ( $enabled as $property ) {
+		$handler = gutenberg_get_style_classes_handler( $property );
+		if ( null !== $handler ) {
+			$new_classes = call_user_func( $handler, $ctx );
+			if ( ! empty( $new_classes ) ) {
+				$classes = array_merge( $classes, $new_classes );
+			}
+		}
+	}
+
+	/**
+	 * Filters the final list of semantic style classes before they are injected into the block.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param string[] $classes Array of semantic style classes.
+	 * @param array    $block   The full block, including name and attributes.
+	 */
+	$classes = (array) apply_filters( 'wp_block_style_classes', array_unique( array_filter( $classes ) ), $block );
+
+	if ( empty( $classes ) ) {
+		return $block_content;
+	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+	if ( $processor->next_tag() ) {
+		foreach ( $classes as $class_name ) {
+			$processor->add_class( $class_name );
+		}
+		return $processor->get_updated_html();
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_render_style_classes', 10, 2 );
+
+/**
+ * Returns the map of property key to callback functions.
+ *
+ * @since 23.4.0
+ *
+ * @return array Array of style property handlers.
+ */
+function gutenberg_get_style_classes_handlers() {
+
+	$defaults = array(
+		'padding'          => function ( $ctx ) {
+			return gutenberg_spacing_style_classes( 'padding', _wp_array_get( $ctx, array( 'style', 'spacing', 'padding' ) ) );
+		},
+		'margin'           => function ( $ctx ) {
+			return gutenberg_spacing_style_classes( 'margin', _wp_array_get( $ctx, array( 'style', 'spacing', 'margin' ) ) );
+		},
+		'block-gap'        => function ( $ctx ) {
+			return gutenberg_block_gap_style_classes( _wp_array_get( $ctx, array( 'style', 'spacing', 'blockGap' ) ) );
+		},
+		'border-radius'    => function ( $ctx ) {
+			return gutenberg_border_radius_style_classes( _wp_array_get( $ctx, array( 'style', 'border', 'radius' ) ) );
+		},
+		'border-width'     => function ( $ctx ) {
+			$border = _wp_array_get( $ctx, array( 'style', 'border' ) );
+			return gutenberg_border_side_style_classes( 'border-width', is_array( $border ) ? $border : array(), 'width' );
+		},
+		'border-style'     => function ( $ctx ) {
+			$border = _wp_array_get( $ctx, array( 'style', 'border' ) );
+			return gutenberg_border_side_style_classes( 'border-style', is_array( $border ) ? $border : array(), 'style', true );
+		},
+		'border-color'     => function ( $ctx ) {
+			$border = _wp_array_get( $ctx, array( 'style', 'border' ) );
+			return gutenberg_border_side_style_classes( 'border-color', is_array( $border ) ? $border : array(), 'color' );
+		},
+		'font-size'        => function ( $ctx ) {
+			$val = _wp_array_get( $ctx, array( 'style', 'typography', 'fontSize' ) );
+			if ( null === $val ) {
+				$val = _wp_array_get( $ctx, array( 'attrs', 'fontSize' ) );
+			}
+			return gutenberg_typo_style_classes( 'font-size', $val );
+		},
+		'font-weight'      => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'font-weight', _wp_array_get( $ctx, array( 'style', 'typography', 'fontWeight' ) ), true );
+		},
+		'font-style'       => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'font-style', _wp_array_get( $ctx, array( 'style', 'typography', 'fontStyle' ) ), true );
+		},
+		'font-family'      => function ( $ctx ) {
+			$val = _wp_array_get( $ctx, array( 'style', 'typography', 'fontFamily' ) );
+			if ( null === $val ) {
+				$val = _wp_array_get( $ctx, array( 'attrs', 'fontFamily' ) );
+			}
+			return gutenberg_typo_style_classes( 'font-family', $val );
+		},
+		'line-height'      => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'line-height', _wp_array_get( $ctx, array( 'style', 'typography', 'lineHeight' ) ) );
+		},
+		'letter-spacing'   => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'letter-spacing', _wp_array_get( $ctx, array( 'style', 'typography', 'letterSpacing' ) ) );
+		},
+		'text-decoration'  => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'text-decoration', _wp_array_get( $ctx, array( 'style', 'typography', 'textDecoration' ) ), true );
+		},
+		'text-transform'   => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'text-transform', _wp_array_get( $ctx, array( 'style', 'typography', 'textTransform' ) ), true );
+		},
+		'writing-mode'     => function ( $ctx ) {
+			return gutenberg_typo_style_classes( 'writing-mode', _wp_array_get( $ctx, array( 'style', 'typography', 'writingMode' ) ), true );
+		},
+		'min-height'       => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'min-height', _wp_array_get( $ctx, array( 'style', 'dimensions', 'minHeight' ) ) );
+		},
+		'aspect-ratio'     => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'aspect-ratio', _wp_array_get( $ctx, array( 'style', 'dimensions', 'aspectRatio' ) ), true );
+		},
+		'shadow'           => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'shadow', _wp_array_get( $ctx, array( 'style', 'shadow' ) ) );
+		},
+		'color-gradient'   => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'gradient', _wp_array_get( $ctx, array( 'style', 'color', 'gradient' ) ) );
+		},
+		'color-duotone'    => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'duotone', _wp_array_get( $ctx, array( 'style', 'color', 'duotone' ) ) );
+		},
+		'color-background' => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'background', _wp_array_get( $ctx, array( 'style', 'color', 'background' ) ) );
+		},
+		'color-text'       => function ( $ctx ) {
+			return gutenberg_single_style_classes( 'color', _wp_array_get( $ctx, array( 'style', 'color', 'text' ) ) );
+		},
+	);
+
+	/**
+	 * Filters the map of style property handlers.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param array $defaults Array mapping property keys to callable handlers.
+	 */
+	$handlers = (array) apply_filters( 'wp_style_property_handlers', $defaults );
+
+	return $handlers;
+}
+
+/**
+ * Returns the callable for a single property key.
+ *
+ * @since 23.4.0
+ *
+ * @param string $property Property key.
+ * @return callable|null Handler function, or null if not found.
+ */
+function gutenberg_get_style_classes_handler( $property ) {
+	$handlers = gutenberg_get_style_classes_handlers();
+	return isset( $handlers[ $property ] ) ? $handlers[ $property ] : null;
+}
+
+/**
+ * Parses a raw Gutenberg style value and categorizes it.
+ *
+ * @since 23.4.0
+ *
+ * @param mixed $raw Raw value from block attributes.
+ * @return array Parsed value details.
+ */
+function gutenberg_parse_style_classes_value( $raw ) {
+	if ( null === $raw || '' === $raw ) {
+		return array(
+			'type' => 'empty',
+			'slug' => null,
+			'safe' => '',
+		);
+	}
+
+	$str = is_scalar( $raw ) ? (string) $raw : '';
+
+	if ( '' === $str ) {
+		return array(
+			'type' => 'empty',
+			'slug' => null,
+			'safe' => '',
+		);
+	}
+
+	if ( preg_match( '/^var:preset\|[^|]+\|(.+)$/D', $str, $matches ) ) {
+		return array(
+			'type' => 'preset',
+			'slug' => $matches[1],
+			'safe' => gutenberg_to_style_class( $matches[1] ),
+		);
+	}
+
+	if ( preg_match( '/^var\(--wp--preset--[a-z0-9-]+--([a-z0-9-]+)\)$/iD', $str, $matches ) ) {
+		return array(
+			'type' => 'preset',
+			'slug' => $matches[1],
+			'safe' => gutenberg_to_style_class( $matches[1] ),
+		);
+	}
+
+	if ( preg_match( '/^[a-z][a-z0-9-]*$/iD', $str ) ) {
+		return array(
+			'type' => 'slug',
+			'slug' => $str,
+			'safe' => gutenberg_to_style_class( $str ),
+		);
+	}
+
+	return array(
+		'type' => 'custom',
+		'slug' => null,
+		'safe' => gutenberg_to_style_class( $str ),
+	);
+}
+
+/**
+ * Converts an arbitrary string to a valid CSS class token.
+ *
+ * @since 23.4.0
+ *
+ * @param string $value Raw string.
+ * @return string CSS class safe string.
+ */
+function gutenberg_to_style_class( $value ) {
+	$class_name = strtolower( $value );
+	$class_name = preg_replace( '/[^a-z0-9]+/', '-', $class_name );
+	return trim( $class_name, '-' );
+}
+
+/**
+ * Generates classes for a single scalar value property.
+ *
+ * @since 23.4.0
+ *
+ * @param string  $property    CSS property name.
+ * @param mixed   $value       Raw value from block attrs.
+ * @param boolean $embed_value Whether to embed the raw value in the class.
+ * @return array List of generated classes.
+ */
+function gutenberg_single_style_classes( $property, $value, $embed_value = false ) {
+	if ( null === $value || '' === $value ) {
+		return array();
+	}
+
+	$classes = array( 'has-' . $property );
+	$parsed  = gutenberg_parse_style_classes_value( $value );
+
+	if ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] ) {
+		$classes[] = 'has-' . $parsed['safe'] . '-' . $property;
+	} elseif ( $embed_value && '' !== $parsed['safe'] ) {
+		$classes[] = 'has-' . $parsed['safe'] . '-' . $property;
+	} else {
+		$classes[] = 'has-custom-' . $property;
+	}
+
+	return $classes;
+}
+
+/**
+ * Generates classes for spacing properties (padding, margin).
+ *
+ * @since 23.4.0
+ *
+ * @param string $property 'padding' or 'margin'.
+ * @param mixed  $value    Property value.
+ * @return array List of generated classes.
+ */
+function gutenberg_spacing_style_classes( $property, $value ) {
+	if ( null === $value || '' === $value ) {
+		return array();
+	}
+
+	$classes = array( 'has-' . $property );
+
+	if ( is_string( $value ) ) {
+		$parsed    = gutenberg_parse_style_classes_value( $value );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-' . $property
+			: 'has-custom-' . $property;
+		return $classes;
+	}
+
+	if ( ! is_array( $value ) ) {
+		return $classes;
+	}
+
+	$side_keys = array( 'top', 'right', 'bottom', 'left' );
+	$sides     = array();
+
+	foreach ( $side_keys as $side ) {
+		if ( isset( $value[ $side ] ) && '' !== $value[ $side ] ) {
+			$sides[ $side ] = (string) $value[ $side ];
+		}
+	}
+
+	if ( empty( $sides ) ) {
+		return $classes;
+	}
+
+	$side_values = array_values( $sides );
+	$all_equal   = count( array_unique( $side_values ) ) === 1 && count( $sides ) === count( $side_keys );
+
+	if ( $all_equal ) {
+		$parsed    = gutenberg_parse_style_classes_value( $side_values[0] );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-' . $property
+			: 'has-custom-' . $property;
+	} else {
+		$classes[] = 'has-mixed-' . $property;
+		foreach ( $sides as $side => $raw ) {
+			$parsed    = gutenberg_parse_style_classes_value( $raw );
+			$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+				? 'has-' . $parsed['safe'] . '-' . $side . '-' . $property
+				: 'has-custom-' . $side . '-' . $property;
+		}
+	}
+
+	return $classes;
+}
+
+/**
+ * Generates classes for block gap.
+ *
+ * @since 23.4.0
+ *
+ * @param mixed $value Property value.
+ * @return array List of generated classes.
+ */
+function gutenberg_block_gap_style_classes( $value ) {
+	if ( null === $value || '' === $value ) {
+		return array();
+	}
+
+	if ( is_string( $value ) ) {
+		return gutenberg_single_style_classes( 'block-gap', $value );
+	}
+
+	if ( ! is_array( $value ) ) {
+		return array();
+	}
+
+	$classes = array( 'has-block-gap' );
+	$axes    = array( 'horizontal', 'vertical' );
+
+	foreach ( $axes as $axis ) {
+		if ( empty( $value[ $axis ] ) ) {
+			continue;
+		}
+		$parsed    = gutenberg_parse_style_classes_value( $value[ $axis ] );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-' . $axis . '-block-gap'
+			: 'has-custom-' . $axis . '-block-gap';
+	}
+
+	if ( isset( $value['horizontal'], $value['vertical'] ) && $value['horizontal'] === $value['vertical'] ) {
+		$parsed    = gutenberg_parse_style_classes_value( $value['horizontal'] );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-block-gap'
+			: 'has-custom-block-gap';
+	}
+
+	return array_unique( $classes );
+}
+
+/**
+ * Generates classes for border radius.
+ *
+ * @since 23.4.0
+ *
+ * @param mixed $value Property value.
+ * @return array List of generated classes.
+ */
+function gutenberg_border_radius_style_classes( $value ) {
+	if ( null === $value || '' === $value ) {
+		return array();
+	}
+
+	$classes = array( 'has-border-radius' );
+
+	if ( is_string( $value ) ) {
+		$parsed    = gutenberg_parse_style_classes_value( $value );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-border-radius'
+			: 'has-custom-border-radius';
+		return $classes;
+	}
+
+	if ( ! is_array( $value ) ) {
+		return $classes;
+	}
+
+	$corner_map = array(
+		'topLeft'     => 'top-left',
+		'topRight'    => 'top-right',
+		'bottomRight' => 'bottom-right',
+		'bottomLeft'  => 'bottom-left',
+	);
+
+	$corners = array();
+	foreach ( $corner_map as $key => $label ) {
+		if ( isset( $value[ $key ] ) && '' !== $value[ $key ] ) {
+			$corners[ $label ] = (string) $value[ $key ];
+		}
+	}
+
+	if ( empty( $corners ) ) {
+		return $classes;
+	}
+
+	$corner_values = array_values( $corners );
+	$all_equal     = count( array_unique( $corner_values ) ) === 1 && count( $corners ) === count( $corner_map );
+
+	if ( $all_equal ) {
+		$parsed    = gutenberg_parse_style_classes_value( $corner_values[0] );
+		$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+			? 'has-' . $parsed['safe'] . '-border-radius'
+			: 'has-custom-border-radius';
+	} else {
+		$classes[] = 'has-mixed-border-radius';
+		foreach ( $corners as $corner => $raw ) {
+			$parsed    = gutenberg_parse_style_classes_value( $raw );
+			$classes[] = ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] )
+				? 'has-' . $parsed['safe'] . '-' . $corner . '-border-radius'
+				: 'has-custom-' . $corner . '-border-radius';
+		}
+	}
+
+	return $classes;
+}
+
+/**
+ * Generates classes for per side border properties: width, style, color.
+ *
+ * @since 23.4.0
+ *
+ * @param string  $property    CSS property.
+ * @param array   $border      Border object.
+ * @param string  $key         Specific key to extract.
+ * @param boolean $embed_value Whether to embed the raw value.
+ * @return array List of generated classes.
+ */
+function gutenberg_border_side_style_classes( $property, $border, $key, $embed_value = false ) {
+	if ( empty( $border ) ) {
+		return array();
+	}
+
+	$uniform  = isset( $border[ $key ] ) ? $border[ $key ] : null;
+	$side_map = array( 'top', 'right', 'bottom', 'left' );
+	$sides    = array();
+
+	foreach ( $side_map as $side ) {
+		if ( isset( $border[ $side ][ $key ] ) && '' !== $border[ $side ][ $key ] ) {
+			$sides[ $side ] = (string) $border[ $side ][ $key ];
+		}
+	}
+
+	if ( null === $uniform && empty( $sides ) ) {
+		return array();
+	}
+
+	$classes = array( 'has-' . $property );
+
+	$get_class = function ( $raw, $side = '' ) use ( $property, $embed_value ) {
+		$parsed = gutenberg_parse_style_classes_value( $raw );
+		$suffix = $side ? '-' . $side . '-' . $property : '-' . $property;
+
+		if ( 'preset' === $parsed['type'] || 'slug' === $parsed['type'] ) {
+			return 'has-' . $parsed['safe'] . $suffix;
+		}
+		if ( $embed_value && '' !== $parsed['safe'] ) {
+			return 'has-' . $parsed['safe'] . $suffix;
+		}
+		return 'has-custom' . $suffix;
+	};
+
+	if ( null !== $uniform ) {
+		$classes[] = call_user_func( $get_class, (string) $uniform );
+		return $classes;
+	}
+
+	$side_values = array_values( $sides );
+	$all_equal   = count( array_unique( $side_values ) ) === 1 && count( $sides ) === count( $side_map );
+
+	if ( $all_equal ) {
+		$classes[] = call_user_func( $get_class, $side_values[0] );
+	} else {
+		$classes[] = 'has-mixed-' . $property;
+		foreach ( $sides as $side => $raw ) {
+			$classes[] = call_user_func( $get_class, $raw, $side );
+		}
+	}
+
+	return $classes;
+}
+
+/**
+ * Generates classes for typography properties.
+ *
+ * @since 23.4.0
+ *
+ * @param string  $property    CSS property.
+ * @param mixed   $value       Property value.
+ * @param boolean $embed_value Whether to embed the raw value.
+ * @return array List of generated classes.
+ */
+function gutenberg_typo_style_classes( $property, $value, $embed_value = false ) {
+	if ( null === $value || '' === $value ) {
+		return array();
+	}
+
+	return gutenberg_single_style_classes( $property, $value, $embed_value );
+}
+
+/**
+ * Pass enabled style properties to the React editor settings.
+ *
+ * @since 23.4.0
+ *
+ * @param array $settings Default editor settings.
+ * @return array Filtered editor settings.
+ */
+function gutenberg_style_classes_editor_settings( $settings ) {
+	/**
+	 * Filters the list of style properties enabled for CSS class generation.
+	 *
+	 * @since 23.4.0
+	 *
+	 * @param string[] $enabled Array of enabled style property slugs.
+	 */
+	$enabled = (array) apply_filters( 'wp_enabled_style_properties', array() );
+
+	$settings['__experimentalStyleClassesEnabled'] = $enabled;
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_style_classes_editor_settings' );

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -181,6 +181,12 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 						'context'     => array( 'mobile' ),
 					),
 
+					'__experimentalStyleClassesEnabled' => array(
+						'description' => __( 'List of style properties explicitly enabled for semantic CSS class generation.', 'gutenberg' ),
+						'type'        => 'array',
+						'context'     => array( 'edit', 'view' ),
+					),
+
 					'alignWide'                        => array(
 						'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 						'type'        => 'boolean',

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -133,19 +133,19 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 						'context'     => array( 'default' ),
 					),
 
-					'styles'                           => array(
+					'styles'                            => array(
 						'description' => __( 'Editor styles', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
 
-					'supportsTemplateMode'             => array(
+					'supportsTemplateMode'              => array(
 						'description' => __( 'Indicates whether the current theme supports block-based templates.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'supportsLayout'                   => array(
+					'supportsLayout'                    => array(
 						'description' => __( 'Enable/disable layouts support in container blocks.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
@@ -157,25 +157,25 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 						'context'     => array( 'default' ),
 					),
 
-					'__experimentalFeatures'           => array(
+					'__experimentalFeatures'            => array(
 						'description' => __( 'Settings consolidated from core, theme, and user origins.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'default', 'mobile' ),
 					),
 
-					'__experimentalStyles'             => array(
+					'__experimentalStyles'              => array(
 						'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'mobile' ),
 					),
 
-					'__experimentalEnableQuoteBlockV2' => array(
+					'__experimentalEnableQuoteBlockV2'  => array(
 						'description' => __( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'mobile' ),
 					),
 
-					'__experimentalEnableListBlockV2'  => array(
+					'__experimentalEnableListBlockV2'   => array(
 						'description' => __( 'Whether the V2 of the list block that uses inner blocks should be enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'mobile' ),
@@ -187,142 +187,142 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 						'context'     => array( 'edit', 'view' ),
 					),
 
-					'alignWide'                        => array(
+					'alignWide'                         => array(
 						'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'allowedBlockTypes'                => array(
+					'allowedBlockTypes'                 => array(
 						'description' => __( 'List of allowed block types.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'allowedMimeTypes'                 => array(
+					'allowedMimeTypes'                  => array(
 						'description' => __( 'List of allowed mime types and file extensions.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'default' ),
 					),
 
-					'blockCategories'                  => array(
+					'blockCategories'                   => array(
 						'description' => __( 'Returns all the categories for block types that will be shown in the block editor.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
 
-					'blockInspectorTabs'               => array(
+					'blockInspectorTabs'                => array(
 						'description' => __( 'Block inspector tab display overrides.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'default' ),
 					),
 
-					'disableCustomColors'              => array(
+					'disableCustomColors'               => array(
 						'description' => __( 'Disables custom colors.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'disableCustomFontSizes'           => array(
+					'disableCustomFontSizes'            => array(
 						'description' => __( 'Disables custom font size.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'disableCustomGradients'           => array(
+					'disableCustomGradients'            => array(
 						'description' => __( 'Disables custom font size.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'disableLayoutStyles'              => array(
+					'disableLayoutStyles'               => array(
 						'description' => __( 'Disables output of layout styles.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'enableCustomLineHeight'           => array(
+					'enableCustomLineHeight'            => array(
 						'description' => __( 'Enables custom line height.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'enableCustomSpacing'              => array(
+					'enableCustomSpacing'               => array(
 						'description' => __( 'Enables custom spacing.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'enableCustomUnits'                => array(
+					'enableCustomUnits'                 => array(
 						'description' => __( 'Enables custom units.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'isRTL'                            => array(
+					'isRTL'                             => array(
 						'description' => __( 'Determines whether the current locale is right-to-left (RTL).', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'imageDefaultSize'                 => array(
+					'imageDefaultSize'                  => array(
 						'description' => __( 'Default size for images.', 'gutenberg' ),
 						'type'        => 'string',
 						'context'     => array( 'default' ),
 					),
 
-					'imageDimensions'                  => array(
+					'imageDimensions'                   => array(
 						'description' => __( 'Available image dimensions.', 'gutenberg' ),
 						'type'        => 'object',
 						'context'     => array( 'default' ),
 					),
 
-					'imageEditing'                     => array(
+					'imageEditing'                      => array(
 						'description' => __( 'Determines whether the image editing feature is enabled.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),
 					),
 
-					'imageSizes'                       => array(
+					'imageSizes'                        => array(
 						'description' => __( 'Available image sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
 
-					'maxUploadFileSize'                => array(
+					'maxUploadFileSize'                 => array(
 						'description' => __( 'Maximum upload size in bytes allowed for the site.', 'gutenberg' ),
 						'type'        => 'number',
 						'context'     => array( 'default' ),
 					),
 
-					'colors'                           => array(
+					'colors'                            => array(
 						'description' => __( 'Active theme color palette.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
 
-					'fontSizes'                        => array(
+					'fontSizes'                         => array(
 						'description' => __( 'Active theme font sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
 
-					'gradients'                        => array(
+					'gradients'                         => array(
 						'description' => __( 'Active theme gradients.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
-					'spacingSizes'                     => array(
+					'spacingSizes'                      => array(
 						'description' => __( 'Active theme spacing sizes.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
-					'spacingScale'                     => array(
+					'spacingScale'                      => array(
 						'description' => __( 'Active theme spacing scale.', 'gutenberg' ),
 						'type'        => 'array',
 						'context'     => array( 'default' ),
 					),
-					'disableCustomSpacingSizes'        => array(
+					'disableCustomSpacingSizes'         => array(
 						'description' => __( 'Disables custom spacing sizes.', 'gutenberg' ),
 						'type'        => 'boolean',
 						'context'     => array( 'default' ),

--- a/lib/load.php
+++ b/lib/load.php
@@ -211,6 +211,7 @@ require __DIR__ . '/block-supports/anchor.php';
 require __DIR__ . '/block-supports/block-visibility.php';
 require __DIR__ . '/block-supports/custom-css.php';
 require __DIR__ . '/block-supports/states.php';
+require __DIR__ . '/block-supports/style-classes.php';
 
 // Client-side media processing.
 require_once __DIR__ . '/media/load.php';

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -39,6 +39,7 @@ import listView from './list-view';
 import './block-renaming';
 import './grid-visualizer';
 import AutoRegisterControls from './auto-inspector-controls';
+import './style-classes';
 
 createBlockEditFilter(
 	[

--- a/packages/block-editor/src/hooks/style-classes.js
+++ b/packages/block-editor/src/hooks/style-classes.js
@@ -1,0 +1,456 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter, applyFilters } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+
+/**
+ * Converts an arbitrary string to a valid CSS class token.
+ *
+ * @param {string} value Raw string.
+ * @return {string} CSS class safe string.
+ */
+const toStyleClass = ( value ) => {
+	if ( typeof value !== 'string' ) {
+		return '';
+	}
+	return value
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-|-$/g, '' );
+};
+
+/**
+ * Parses a raw Gutenberg style value and categorizes it.
+ *
+ * @param {*} raw Raw value from block attributes.
+ * @return {Object} Parsed value details containing type and safe string.
+ */
+const parseValue = ( raw ) => {
+	if ( ! raw ) {
+		return { type: 'empty', safe: '' };
+	}
+	const str = String( raw );
+	if ( ! str ) {
+		return { type: 'empty', safe: '' };
+	}
+
+	const presetMatch = str.match( /^var:preset\|[^|]+\|(.+)$/i );
+	if ( presetMatch ) {
+		return { type: 'preset', safe: toStyleClass( presetMatch[ 1 ] ) };
+	}
+
+	const cssVarMatch = str.match(
+		/^var\(--wp--preset--[a-z0-9-]+--([a-z0-9-]+)\)$/i
+	);
+	if ( cssVarMatch ) {
+		return { type: 'preset', safe: toStyleClass( cssVarMatch[ 1 ] ) };
+	}
+
+	if ( /^[a-z][a-z0-9-]*$/i.test( str ) ) {
+		return { type: 'slug', safe: toStyleClass( str ) };
+	}
+
+	return { type: 'custom', safe: toStyleClass( str ) };
+};
+
+/**
+ * Generates classes for a single scalar value property.
+ *
+ * @param {string}  property   CSS property name.
+ * @param {*}       value      Raw value from block attrs.
+ * @param {boolean} embedValue Whether to embed the raw value in the class.
+ * @return {string[]} List of generated classes.
+ */
+const getSingleClasses = ( property, value, embedValue = false ) => {
+	if ( ! value ) {
+		return [];
+	}
+	const classes = [ `has-${ property }` ];
+	const parsed = parseValue( value );
+
+	if (
+		parsed.type === 'preset' ||
+		parsed.type === 'slug' ||
+		( embedValue && parsed.safe )
+	) {
+		classes.push( `has-${ parsed.safe }-${ property }` );
+	} else {
+		classes.push( `has-custom-${ property }` );
+	}
+	return classes;
+};
+
+/**
+ * Generates classes for spacing properties (padding, margin).
+ *
+ * @param {string} property 'padding' or 'margin'.
+ * @param {*}      value    Property value.
+ * @return {string[]} List of generated classes.
+ */
+const getSpacingClasses = ( property, value ) => {
+	if ( ! value ) {
+		return [];
+	}
+	if ( typeof value === 'string' ) {
+		return getSingleClasses( property, value );
+	}
+
+	const sides = [ 'top', 'right', 'bottom', 'left' ];
+	const activeSides = sides.filter( ( side ) => value[ side ] );
+
+	if ( activeSides.length === 0 ) {
+		return [];
+	}
+
+	const sideValues = activeSides.map( ( side ) => value[ side ] );
+	const allEqual =
+		activeSides.length === 4 && new Set( sideValues ).size === 1;
+
+	const classes = [ `has-${ property }` ];
+
+	if ( allEqual ) {
+		const parsed = parseValue( sideValues[ 0 ] );
+		classes.push(
+			parsed.type === 'preset' || parsed.type === 'slug'
+				? `has-${ parsed.safe }-${ property }`
+				: `has-custom-${ property }`
+		);
+	} else {
+		classes.push( `has-mixed-${ property }` );
+		activeSides.forEach( ( side ) => {
+			const parsed = parseValue( value[ side ] );
+			classes.push(
+				parsed.type === 'preset' || parsed.type === 'slug'
+					? `has-${ parsed.safe }-${ side }-${ property }`
+					: `has-custom-${ side }-${ property }`
+			);
+		} );
+	}
+
+	return classes;
+};
+
+/**
+ * Generates classes for border radius.
+ *
+ * @param {*} value Property value.
+ * @return {string[]} List of generated classes.
+ */
+const getBorderRadiusClasses = ( value ) => {
+	if ( ! value ) {
+		return [];
+	}
+	if ( typeof value === 'string' ) {
+		return getSingleClasses( 'border-radius', value );
+	}
+
+	const corners = [ 'topLeft', 'topRight', 'bottomRight', 'bottomLeft' ];
+	const activeCorners = corners.filter( ( corner ) => value[ corner ] );
+
+	if ( activeCorners.length === 0 ) {
+		return [];
+	}
+
+	const cornerValues = activeCorners.map( ( corner ) => value[ corner ] );
+	const allEqual =
+		activeCorners.length === 4 && new Set( cornerValues ).size === 1;
+
+	const classes = [ 'has-border-radius' ];
+
+	if ( allEqual ) {
+		const parsed = parseValue( cornerValues[ 0 ] );
+		classes.push(
+			parsed.type === 'preset' || parsed.type === 'slug'
+				? `has-${ parsed.safe }-border-radius`
+				: 'has-custom-border-radius'
+		);
+	} else {
+		classes.push( 'has-mixed-border-radius' );
+		const cornerMap = {
+			topLeft: 'top-left',
+			topRight: 'top-right',
+			bottomRight: 'bottom-right',
+			bottomLeft: 'bottom-left',
+		};
+		activeCorners.forEach( ( corner ) => {
+			const parsed = parseValue( value[ corner ] );
+			const kebabCorner = cornerMap[ corner ];
+			classes.push(
+				parsed.type === 'preset' || parsed.type === 'slug'
+					? `has-${ parsed.safe }-${ kebabCorner }-border-radius`
+					: `has-custom-${ kebabCorner }-border-radius`
+			);
+		} );
+	}
+	return classes;
+};
+
+/**
+ * Generates classes for per-side border properties: width, style, color.
+ *
+ * @param {string}  property   CSS property.
+ * @param {Object}  borderObj  Border object.
+ * @param {string}  key        Specific key to extract.
+ * @param {boolean} embedValue Whether to embed the raw value.
+ * @return {string[]} List of generated classes.
+ */
+const getBorderSideClasses = (
+	property,
+	borderObj,
+	key,
+	embedValue = false
+) => {
+	if ( ! borderObj ) {
+		return [];
+	}
+	const uniform = borderObj[ key ];
+	const sides = [ 'top', 'right', 'bottom', 'left' ];
+	const activeSides = sides.filter(
+		( side ) => borderObj[ side ] && borderObj[ side ][ key ]
+	);
+
+	if ( ! uniform && activeSides.length === 0 ) {
+		return [];
+	}
+
+	const classes = [ `has-${ property }` ];
+
+	const getClass = ( raw, side = '' ) => {
+		const parsed = parseValue( raw );
+		const suffix = side ? `-${ side }-${ property }` : `-${ property }`;
+		if (
+			parsed.type === 'preset' ||
+			parsed.type === 'slug' ||
+			( embedValue && parsed.safe )
+		) {
+			return `has-${ parsed.safe }${ suffix }`;
+		}
+		return `has-custom${ suffix }`;
+	};
+
+	if ( uniform ) {
+		classes.push( getClass( uniform ) );
+		return classes;
+	}
+
+	const sideValues = activeSides.map( ( side ) => borderObj[ side ][ key ] );
+	const allEqual =
+		activeSides.length === 4 && new Set( sideValues ).size === 1;
+
+	if ( allEqual ) {
+		classes.push( getClass( sideValues[ 0 ] ) );
+	} else {
+		classes.push( `has-mixed-${ property }` );
+		activeSides.forEach( ( side ) => {
+			classes.push( getClass( borderObj[ side ][ key ], side ) );
+		} );
+	}
+	return classes;
+};
+
+/**
+ * Map of property keys to their respective class generation functions.
+ */
+const processors = {
+	padding: ( ctx ) =>
+		getSpacingClasses( 'padding', ctx?.style?.spacing?.padding ),
+	margin: ( ctx ) =>
+		getSpacingClasses( 'margin', ctx?.style?.spacing?.margin ),
+	'block-gap': ( ctx ) => {
+		const gap = ctx?.style?.spacing?.blockGap;
+		if ( ! gap ) {
+			return [];
+		}
+		if ( typeof gap === 'string' ) {
+			return getSingleClasses( 'block-gap', gap );
+		}
+		const classes = [ 'has-block-gap' ];
+		[ 'horizontal', 'vertical' ].forEach( ( axis ) => {
+			if ( gap[ axis ] ) {
+				const parsed = parseValue( gap[ axis ] );
+				classes.push(
+					parsed.type === 'preset' || parsed.type === 'slug'
+						? `has-${ parsed.safe }-${ axis }-block-gap`
+						: `has-custom-${ axis }-block-gap`
+				);
+			}
+		} );
+		return classes;
+	},
+	'border-radius': ( ctx ) =>
+		getBorderRadiusClasses( ctx?.style?.border?.radius ),
+	'border-width': ( ctx ) =>
+		getBorderSideClasses( 'border-width', ctx?.style?.border, 'width' ),
+	'border-style': ( ctx ) =>
+		getBorderSideClasses(
+			'border-style',
+			ctx?.style?.border,
+			'style',
+			true
+		),
+	'border-color': ( ctx ) =>
+		getBorderSideClasses( 'border-color', ctx?.style?.border, 'color' ),
+	'font-size': ( ctx ) =>
+		getSingleClasses(
+			'font-size',
+			ctx?.style?.typography?.fontSize || ctx?.attrs?.fontSize
+		),
+	'font-weight': ( ctx ) =>
+		getSingleClasses(
+			'font-weight',
+			ctx?.style?.typography?.fontWeight,
+			true
+		),
+	'font-style': ( ctx ) =>
+		getSingleClasses(
+			'font-style',
+			ctx?.style?.typography?.fontStyle,
+			true
+		),
+	'font-family': ( ctx ) =>
+		getSingleClasses(
+			'font-family',
+			ctx?.style?.typography?.fontFamily || ctx?.attrs?.fontFamily
+		),
+	shadow: ( ctx ) => getSingleClasses( 'shadow', ctx?.style?.shadow ),
+	'aspect-ratio': ( ctx ) =>
+		getSingleClasses(
+			'aspect-ratio',
+			ctx?.style?.dimensions?.aspectRatio,
+			true
+		),
+	'min-height': ( ctx ) =>
+		getSingleClasses( 'min-height', ctx?.style?.dimensions?.minHeight ),
+	'color-background': ( ctx ) =>
+		getSingleClasses( 'background', ctx?.style?.color?.background ),
+	'color-text': ( ctx ) =>
+		getSingleClasses( 'color', ctx?.style?.color?.text ),
+};
+
+/**
+ * Higher Order Component that injects semantic style classes into the block wrapper in the editor.
+ */
+export const withStyleClasses = createHigherOrderComponent(
+	( BlockListBlock ) => {
+		const StyleClassesWrapper = ( props ) => {
+			const enabledProperties = useSelect( ( select ) => {
+				const settings = select( blockEditorStore ).getSettings();
+				return settings.__experimentalStyleClassesEnabled || [];
+			}, [] );
+
+			if ( ! enabledProperties.length ) {
+				return <BlockListBlock { ...props } />;
+			}
+
+			const { attributes, name: blockName } = props;
+
+			/**
+			 * Filters the list of style properties enabled for CSS class generation.
+			 *
+			 * @param {string[]} enabledProperties Array of enabled style property slugs.
+			 * @param {Object}   props             Block wrapper props.
+			 */
+			let activeProps = applyFilters(
+				'editor.enabledStyleProperties',
+				enabledProperties,
+				props
+			);
+
+			if ( blockName ) {
+				const slug = blockName.replace( /\//g, '-' );
+
+				/**
+				 * Filters the list of style properties enabled for CSS class generation for a specific block type.
+				 *
+				 * @param {string[]} activeProps Array of enabled style property slugs.
+				 * @param {Object}   props       Block wrapper props.
+				 */
+				activeProps = applyFilters(
+					`editor.enabledStyleProperties.${ blockName }`,
+					activeProps,
+					props
+				);
+
+				/**
+				 * Filters the list of style properties enabled for CSS class generation for a specific block slug.
+				 *
+				 * @param {string[]} activeProps Array of enabled style property slugs.
+				 * @param {Object}   props       Block wrapper props.
+				 */
+				activeProps = applyFilters(
+					`editor.enabledStyleProperties.${ slug }`,
+					activeProps,
+					props
+				);
+			}
+
+			if ( ! activeProps.length ) {
+				return <BlockListBlock { ...props } />;
+			}
+
+			const ctx = {
+				style: attributes?.style || {},
+				attrs: attributes || {},
+			};
+			let injectedClasses = [];
+
+			activeProps.forEach( ( prop ) => {
+				if ( processors[ prop ] ) {
+					injectedClasses.push( ...processors[ prop ]( ctx ) );
+				}
+			} );
+
+			/**
+			 * Filters the final list of semantic style classes before they are injected into the block.
+			 *
+			 * @param {string[]} injectedClasses Array of semantic style classes.
+			 * @param {Object}   props           Block wrapper props.
+			 */
+			injectedClasses = applyFilters(
+				'editor.blockStyleClasses',
+				injectedClasses,
+				props
+			);
+
+			if ( injectedClasses.length > 0 ) {
+				const existingClassName = props.wrapperProps?.className || '';
+				const mergedClasses = Array.from(
+					new Set( [
+						...existingClassName.split( ' ' ),
+						...injectedClasses,
+					] )
+				)
+					.filter( Boolean )
+					.join( ' ' );
+
+				return (
+					<BlockListBlock
+						{ ...props }
+						wrapperProps={ {
+							...props.wrapperProps,
+							className: mergedClasses,
+						} }
+					/>
+				);
+			}
+
+			return <BlockListBlock { ...props } />;
+		};
+
+		return StyleClassesWrapper;
+	},
+	'withStyleClasses'
+);
+
+addFilter(
+	'editor.BlockListBlock',
+	'core/block-supports/style-classes',
+	withStyleClasses
+);

--- a/packages/block-editor/src/hooks/test/style-classes.js
+++ b/packages/block-editor/src/hooks/test/style-classes.js
@@ -1,0 +1,404 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { withStyleClasses } from '../style-classes';
+
+jest.mock( '../../store', () => ( {
+	store: { name: 'core/block-editor' },
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	combineReducers: jest.fn( ( reducers ) => reducers ),
+	registerStore: jest.fn(),
+	createRegistrySelector: jest.fn(),
+	useDispatch: jest.fn(),
+	useRegistry: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/hooks', () => ( {
+	applyFilters: jest.fn(),
+	addFilter: jest.fn(),
+} ) );
+
+describe( 'withStyleClasses', () => {
+	const MockBlockListBlock = ( props ) => {
+		return (
+			<div
+				data-testid="mock-block"
+				className={ props.wrapperProps?.className }
+			/>
+		);
+	};
+
+	const EnhancedBlock = withStyleClasses( MockBlockListBlock );
+
+	beforeEach( () => {
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( () => ( {
+				getSettings: () => ( {
+					__experimentalStyleClassesEnabled: [
+						'padding',
+						'margin',
+						'block-gap',
+						'border-radius',
+						'border-width',
+						'border-style',
+						'border-color',
+						'font-size',
+						'font-weight',
+						'shadow',
+						'aspect-ratio',
+						'min-height',
+						'color-background',
+						'color-text',
+						'font-family',
+					],
+				} ),
+			} ) );
+		} );
+
+		applyFilters.mockImplementation( ( hookName, val ) => val );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'bails out gracefully if no styles are present', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {},
+			wrapperProps: { className: 'original-class' },
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'original-class' );
+		expect( block ).toHaveClass( 'original-class', { exact: true } );
+	} );
+
+	it( 'generates accurate spacing classes for uniform and mixed sides', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					spacing: {
+						padding: 'var:preset|spacing|80',
+						margin: {
+							top: '20px',
+							bottom: 'var:preset|spacing|40',
+						},
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'has-padding', 'has-80-padding' );
+		expect( block ).toHaveClass(
+			'has-margin',
+			'has-mixed-margin',
+			'has-custom-top-margin',
+			'has-40-bottom-margin'
+		);
+	} );
+
+	it( 'generates axial classes for block-gap', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					spacing: {
+						blockGap: {
+							horizontal: 'var:preset|spacing|20',
+							vertical: '50px',
+						},
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-block-gap',
+			'has-20-horizontal-block-gap',
+			'has-custom-vertical-block-gap'
+		);
+	} );
+
+	it( 'collapses border radius to uniform class when all corners are identical', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					border: {
+						radius: {
+							topLeft: '100px',
+							topRight: '100px',
+							bottomLeft: '100px',
+							bottomRight: '100px',
+						},
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-border-radius',
+			'has-custom-border-radius'
+		);
+		expect( block ).not.toHaveClass( 'has-mixed-border-radius' );
+	} );
+
+	it( 'embeds raw values for border style but uses custom for width', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					border: {
+						style: 'dashed',
+						width: '2px',
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-border-style',
+			'has-dashed-border-style'
+		);
+		expect( block ).toHaveClass(
+			'has-border-width',
+			'has-custom-border-width'
+		);
+	} );
+
+	it( 'generates mixed side classes for border width', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					border: {
+						top: { width: '2px' },
+						bottom: { width: 'var:preset|spacing|40' },
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-border-width',
+			'has-mixed-border-width',
+			'has-custom-top-border-width',
+			'has-40-bottom-border-width'
+		);
+	} );
+
+	it( 'reads typography from both top-level attributes and the style object', () => {
+		const props = {
+			name: 'core/paragraph',
+			attributes: {
+				fontSize: 'large',
+				style: { typography: { fontWeight: 'bold' } },
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'has-font-size', 'has-large-font-size' );
+		expect( block ).toHaveClass(
+			'has-font-weight',
+			'has-bold-font-weight'
+		);
+	} );
+
+	it( 'maps aspect ratio and min-height correctly', () => {
+		const props = {
+			name: 'core/cover',
+			attributes: {
+				style: {
+					dimensions: {
+						aspectRatio: '16/9',
+						minHeight: '50vh',
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-aspect-ratio',
+			'has-16-9-aspect-ratio'
+		);
+		expect( block ).toHaveClass(
+			'has-min-height',
+			'has-custom-min-height'
+		);
+	} );
+
+	it( 'maps custom colors correctly', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					color: {
+						background: '#ff0000',
+						text: 'var:preset|color|primary',
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-background',
+			'has-custom-background'
+		);
+		expect( block ).toHaveClass( 'has-color', 'has-primary-color' );
+	} );
+
+	it( 'extracts CSS variables and deduplicates overlapping class names', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: { shadow: 'var(--wp--preset--shadow--natural)' },
+			},
+			wrapperProps: { className: 'has-shadow' },
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'has-natural-shadow' );
+		expect( block ).toHaveClass( 'has-shadow has-natural-shadow', {
+			exact: true,
+		} );
+	} );
+
+	it( 'honors JS block-specific exclusion filters', () => {
+		// Mock applyFilters to strip 'margin' from core/image blocks
+		applyFilters.mockImplementation( ( hookName, val ) => {
+			if ( hookName === 'editor.enabledStyleProperties.core/image' ) {
+				return val.filter( ( p ) => p !== 'margin' );
+			}
+			return val;
+		} );
+
+		const props = {
+			name: 'core/image',
+			attributes: {
+				style: {
+					spacing: { padding: '20px', margin: '20px' },
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'has-padding' );
+		expect( block ).not.toHaveClass( 'has-margin' );
+	} );
+
+	it( 'honors JS final class injection filters', () => {
+		applyFilters.mockImplementation( ( hookName, val, blockProps ) => {
+			if (
+				hookName === 'editor.blockStyleClasses' &&
+				blockProps.name === 'core/group'
+			) {
+				return [ ...val, 'my-js-injected-class' ];
+			}
+			return val;
+		} );
+
+		const props = {
+			name: 'core/group',
+			attributes: { style: { shadow: 'var:preset|shadow|natural' } },
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-natural-shadow',
+			'my-js-injected-class'
+		);
+	} );
+
+	it( 'handles completely missing attributes gracefully', () => {
+		const props = { name: 'core/group' };
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+		expect( block ).toHaveClass( '', { exact: true } );
+	} );
+
+	it( 'ignores empty string sides in complex arrays', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: {
+					spacing: {
+						margin: { top: '20px', bottom: '', left: null },
+					},
+				},
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-margin',
+			'has-mixed-margin',
+			'has-custom-top-margin'
+		);
+		expect( block ).not.toHaveClass( 'has-custom-bottom-margin' );
+	} );
+
+	it( 'falls back to custom if preset string is malformed', () => {
+		const props = {
+			name: 'core/group',
+			attributes: {
+				style: { spacing: { padding: 'var:preset|spacing' } },
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass( 'has-padding', 'has-custom-padding' );
+	} );
+
+	it( 'sanitizes weird text into valid CSS kebab-case classes', () => {
+		const props = {
+			name: 'core/heading',
+			attributes: {
+				style: { typography: { fontWeight: 'Super Heavy!' } },
+			},
+		};
+		render( <EnhancedBlock { ...props } /> );
+		const block = screen.getByTestId( 'mock-block' );
+
+		expect( block ).toHaveClass(
+			'has-font-weight',
+			'has-super-heavy-font-weight'
+		);
+	} );
+} );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -55,6 +55,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__experimentalDiscussionSettings',
 	'__experimentalFeatures',
 	'__experimentalGlobalStylesBaseStyles',
+	'__experimentalStyleClassesEnabled',
 	'allImageSizes',
 	'alignWide',
 	'blockInspectorTabs',

--- a/phpunit/block-supports/style-classes-test.php
+++ b/phpunit/block-supports/style-classes-test.php
@@ -1,0 +1,478 @@
+<?php
+/**
+ * Test the style classes block support.
+ *
+ * @since 23.4.0
+ *
+ * @package gutenberg
+ */
+
+class WP_Block_Supports_Style_Classes_Test extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'wp_enabled_style_properties', array( $this, 'enable_all_properties' ) );
+	}
+
+	public function tear_down() {
+		remove_filter( 'wp_enabled_style_properties', array( $this, 'enable_all_properties' ) );
+		parent::tear_down();
+	}
+
+	/**
+	 * Callback to enable standard style properties.
+	 *
+	 * @return array
+	 */
+	public function enable_all_properties() {
+		return array(
+			'padding',
+			'margin',
+			'block-gap',
+			'border-radius',
+			'border-width',
+			'border-style',
+			'border-color',
+			'font-size',
+			'font-weight',
+			'shadow',
+			'aspect-ratio',
+			'min-height',
+			'color-background',
+			'color-text',
+			'font-family',
+		);
+	}
+
+	/**
+	 * Tests that the block support bails out early if no styles are present.
+	 */
+	public function test_bails_if_no_styles_present() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertSame( $content, $result, 'Should not modify content if no styles are present.' );
+	}
+
+	/**
+	 * Tests that spacing generates uniform and mixed classes.
+	 */
+	public function test_spacing_uniform_and_mixed() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'spacing' => array(
+						'padding' => 'var:preset|spacing|80',
+						'margin'  => array(
+							'top'    => '20px',
+							'bottom' => 'var:preset|spacing|40',
+							'left'   => '0',
+							'right'  => '0',
+						),
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-padding', $result );
+		$this->assertStringContainsString( 'has-80-padding', $result );
+		$this->assertStringContainsString( 'has-margin', $result );
+		$this->assertStringContainsString( 'has-mixed-margin', $result );
+		$this->assertStringContainsString( 'has-custom-top-margin', $result );
+		$this->assertStringContainsString( 'has-40-bottom-margin', $result );
+	}
+
+	/**
+	 * Tests that block gap generates axial and uniform classes.
+	 */
+	public function test_block_gap_axial_and_uniform() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'spacing' => array(
+						'blockGap' => array(
+							'horizontal' => 'var:preset|spacing|20',
+							'vertical'   => '50px',
+						),
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-block-gap', $result );
+		$this->assertStringContainsString( 'has-20-horizontal-block-gap', $result );
+		$this->assertStringContainsString( 'has-custom-vertical-block-gap', $result );
+	}
+
+	/**
+	 * Tests that border radius collapses identical corners into a uniform class.
+	 */
+	public function test_border_radius_all_identical_corners() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'border' => array(
+						'radius' => array(
+							'topLeft'     => '100px',
+							'topRight'    => '100px',
+							'bottomLeft'  => '100px',
+							'bottomRight' => '100px',
+						),
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-border-radius', $result );
+		$this->assertStringContainsString( 'has-custom-border-radius', $result );
+		$this->assertStringNotContainsString( 'has-mixed-border-radius', $result );
+	}
+
+	/**
+	 * Tests that border style embeds the raw value while border width uses a custom class.
+	 */
+	public function test_border_style_embeds_raw_value() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'border' => array(
+						'style' => 'dashed',
+						'width' => '2px',
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-border-style', $result );
+		$this->assertStringContainsString( 'has-dashed-border-style', $result );
+		$this->assertStringContainsString( 'has-border-width', $result );
+		$this->assertStringContainsString( 'has-custom-border-width', $result );
+	}
+
+	/**
+	 * Tests that border width generates classes for mixed sides.
+	 */
+	public function test_border_width_mixed_sides() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'border' => array(
+						'top'    => array( 'width' => '2px' ),
+						'bottom' => array( 'width' => 'var:preset|spacing|40' ),
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-border-width', $result );
+		$this->assertStringContainsString( 'has-mixed-border-width', $result );
+		$this->assertStringContainsString( 'has-custom-top-border-width', $result );
+		$this->assertStringContainsString( 'has-40-bottom-border-width', $result );
+	}
+
+	/**
+	 * Tests that typography properties read both top-level attributes and the style object.
+	 */
+	public function test_typography_reads_top_level_and_style_object() {
+		$block   = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'fontSize' => 'large',
+				'style'    => array(
+					'typography' => array(
+						'fontWeight' => 'bold',
+					),
+				),
+			),
+		);
+		$content = '<p class="wp-block-paragraph"></p>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-font-size', $result );
+		$this->assertStringContainsString( 'has-large-font-size', $result );
+		$this->assertStringContainsString( 'has-font-weight', $result );
+		$this->assertStringContainsString( 'has-bold-font-weight', $result );
+	}
+
+	/**
+	 * Tests that dimension properties map correctly to aspect ratio and min height classes.
+	 */
+	public function test_aspect_ratio_and_min_height() {
+		$block   = array(
+			'blockName' => 'core/cover',
+			'attrs'     => array(
+				'style' => array(
+					'dimensions' => array(
+						'aspectRatio' => '16/9',
+						'minHeight'   => '50vh',
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-cover"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-aspect-ratio', $result );
+		$this->assertStringContainsString( 'has-16-9-aspect-ratio', $result );
+		$this->assertStringContainsString( 'has-min-height', $result );
+		$this->assertStringContainsString( 'has-custom-min-height', $result );
+	}
+
+	/**
+	 * Tests that color properties map correctly to background and text color classes.
+	 */
+	public function test_color_properties() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'color' => array(
+						'background' => '#ff0000',
+						'text'       => 'var:preset|color|primary',
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-background', $result );
+		$this->assertStringContainsString( 'has-custom-background', $result );
+		$this->assertStringContainsString( 'has-color', $result );
+		$this->assertStringContainsString( 'has-primary-color', $result );
+	}
+
+	/**
+	 * Tests that the parser correctly extracts CSS variables.
+	 */
+	public function test_parser_extracts_css_variables() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'shadow' => 'var(--wp--preset--shadow--natural)',
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-shadow', $result );
+		$this->assertStringContainsString( 'has-natural-shadow', $result );
+	}
+
+	/**
+	 * Tests that the per-block override filter correctly opts-out specific properties.
+	 */
+	public function test_per_block_override_filter() {
+		$filter = function ( $enabled ) {
+			return array_diff( $enabled, array( 'margin' ) );
+		};
+		add_filter( 'wp_enabled_style_properties_core-image', $filter );
+
+		$block   = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'style' => array(
+					'spacing' => array(
+						'padding' => '20px',
+						'margin'  => '20px',
+					),
+				),
+			),
+		);
+		$content = '<figure class="wp-block-image"></figure>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		remove_filter( 'wp_enabled_style_properties_core-image', $filter );
+
+		$this->assertStringContainsString( 'has-padding', $result );
+		$this->assertStringNotContainsString( 'has-margin', $result );
+	}
+
+	/**
+	 * Tests that the final class modification filter can inject custom classes.
+	 */
+	public function test_final_class_modification_filter() {
+		$filter = function ( $classes, $block ) {
+			if ( 'core/group' === $block['blockName'] ) {
+				$classes[] = 'my-injected-class';
+			}
+			return $classes;
+		};
+		add_filter( 'wp_block_style_classes', $filter, 10, 2 );
+
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'shadow' => 'var:preset|shadow|natural',
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		remove_filter( 'wp_block_style_classes', $filter );
+
+		$this->assertStringContainsString( 'has-natural-shadow', $result );
+		$this->assertStringContainsString( 'my-injected-class', $result );
+	}
+
+	/**
+	 * Tests that a custom property handler filter can register new logic.
+	 */
+	public function test_custom_property_handler_filter() {
+		add_filter(
+			'wp_enabled_style_properties',
+			function ( $enabled ) {
+				$enabled[] = 'my-custom-prop';
+				return $enabled;
+			}
+		);
+
+		$filter = function ( $handlers ) {
+			$handlers['my-custom-prop'] = function ( $ctx ) {
+				$val = isset( $ctx['attrs']['myCustomAttr'] ) ? $ctx['attrs']['myCustomAttr'] : null;
+				return $val ? array( 'has-my-custom-prop', 'has-' . $val . '-custom' ) : array();
+			};
+			return $handlers;
+		};
+		add_filter( 'wp_style_property_handlers', $filter );
+
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'myCustomAttr' => 'magic',
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		remove_filter( 'wp_style_property_handlers', $filter );
+
+		$this->assertStringContainsString( 'has-my-custom-prop', $result );
+		$this->assertStringContainsString( 'has-magic-custom', $result );
+	}
+
+	/**
+	 * Tests that the engine gracefully handles missing block properties without throwing warnings.
+	 */
+	public function test_gracefully_handles_missing_block_properties() {
+		$block   = array();
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertSame( $content, $result, 'Should return content unaltered without throwing warnings.' );
+	}
+
+	/**
+	 * Tests that empty strings in multi-sided arrays are ignored.
+	 */
+	public function test_ignores_empty_strings_in_sides() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'spacing' => array(
+						'margin' => array(
+							'top'    => '20px',
+							'bottom' => '',
+							'left'   => null,
+						),
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-margin', $result );
+		$this->assertStringContainsString( 'has-mixed-margin', $result );
+		$this->assertStringContainsString( 'has-custom-top-margin', $result );
+		$this->assertStringNotContainsString( 'bottom', $result );
+		$this->assertStringNotContainsString( 'left', $result );
+	}
+
+	/**
+	 * Tests that malformed preset strings fall back to custom classes safely.
+	 */
+	public function test_handles_malformed_preset_strings() {
+		$block   = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'spacing' => array(
+						'padding' => 'var:preset|spacing',
+					),
+				),
+			),
+		);
+		$content = '<div class="wp-block-group"></div>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-padding', $result );
+		$this->assertStringContainsString( 'has-custom-padding', $result );
+	}
+
+	/**
+	 * Tests that weirdly capitalized or spaced custom values are sanitized to valid kebab-case classes.
+	 */
+	public function test_sanitizes_weird_slugs_and_values() {
+		$block   = array(
+			'blockName' => 'core/heading',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'fontWeight' => 'Super Heavy!',
+					),
+				),
+			),
+		);
+		$content = '<h2 class="wp-block-heading">Heading</h2>';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertStringContainsString( 'has-font-weight', $result );
+		$this->assertStringContainsString( 'has-super-heavy-font-weight', $result );
+	}
+
+	/**
+	 * Tests that the processor bails if the content has no HTML tags.
+	 */
+	public function test_bails_if_no_html_tags_in_content() {
+		$block   = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'fontSize' => 'var:preset|font-size|large',
+					),
+				),
+			),
+		);
+		$content = 'Just some raw text without a div or p tag.';
+		$result  = gutenberg_render_style_classes( $content, $block );
+
+		$this->assertSame( $content, $result, 'Should return raw text unaltered since there is no HTML tag to attach classes to.' );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71693

This PR introduces a opt-in architecture that translates Gutenberg block style attributes (like padding, margin, typography, and borders) into semantic, standardized CSS classes (e.g., `has-padding`, `has-large-font-size`) on both the server (PHP) and client (React).

## Why?
Currently, Gutenberg hardcodes user styling choices via inline styles (`style="padding: 100px;"`) or scoped style blocks. This creates a nightmare for theme developers trying to enforce responsive design or global brand consistency (e.g., updating a primary brand color across hundreds of old posts). 

By translating these stubborn inline styles into predictable CSS classes, we give control back to theme authors, allowing them to target and override editor styles easily via CSS.

## How?

- Implemented a opt-in architecture via the `wp_enabled_style_properties` filter, defaulting to off so it doesn't break backwards compatibility for existing themes.
- Built a PHP engine that evaluates block attributes, safely navigates deeply nested properties, and injects sanitized kebab-case classes into the markup via `WP_HTML_Tag_Processor`.
- Created a React Component that perfectly mirrors the PHP logic, injecting the exact same classes into the editor canvas to maintain true WYSIWYG parity.
- Registered the `__experimentalStyleClassesEnabled` key in the `WP_REST_Block_Editor_Settings_Controller` schema and added it to the `BLOCK_EDITOR_SETTINGS` JS allowlist to securely pass the active filters from the PHP server to the React client.
- Added dynamic extension hooks, such as `wp_enabled_style_properties_{$block_name} `and `wp_enabled_style_properties_{$slug}`, allowing developers to target or exclude specific blocks.
- Engineered 19 PHPUnit tests and 16 Jest tests to guarantee complete cross-environment logic parity.

## Testing Instructions
1. Open a post/page in the block editor. Add a Group block and apply various styles (padding, margin, border-radius, background color, font size).
2. Inspect the DOM in the editor and on the frontend. Notice that no semantic classes are generated (verifying the strict default-off behavior).
3. Open your active theme's `functions.php` and add the global opt-in filter:
   ```php
   add_filter( 'wp_enabled_style_properties', function() {
       return array( 'padding', 'margin', 'border-radius', 'shadow', 'color-background', 'font-size' );
   } );```
4. Refresh the editor. Inspect the Group block in the editor canvas and verify that semantic classes (e.g., has-padding, has-border-radius, has-custom-background) are now accurately applied to the wrapper.
5. Save the post and check the frontend to verify the exact same class string is generated by the PHP engine.

## Screenshots or screencast <!-- if applicable -->

### Goal
If a developer wants to add custom badges, specific borders, or design adjustments to a block based on user layout choices (like specific padding alignments or mixed border-radii), they can simply write clean class selectors. The video shows this in action across both the editor and the frontend once the opt-in filter is active.

### Setup
Theme Opt-In (functions.php):

```PHP
add_filter( 'wp_enabled_style_properties', function() {
    return array( 'padding', 'margin', 'border-radius', 'color-background' );
} );

```
Custom Theme Styles (style.css):

```CSS
.wp-block-group.has-80-padding.has-custom-border-radius {
    position: relative;
    border: 2px solid #ff0000;
}

.wp-block-group.has-80-padding.has-custom-border-radius::after {
    content: "Perfectly Padded!";
    position: absolute;
    top: -15px;
    right: -15px;
    background: #ff0000;
    color: #fff;
    padding: 4px 8px;
    border-radius: inherit;
    font-size: 12px;
    font-weight: bold;
}

.wp-block-group.has-mixed-border-radius.has-custom-top-margin {
    border: 5px dashed red;
    transform: rotate(2deg);
}
```


https://github.com/user-attachments/assets/2f40e920-8afa-4b20-b308-3dfc6b67b029

When the block receives 80px padding and unlinked corner values, the engine injects `has-80-padding` and `has-mixed-border-radius` alongside side specific classes, allowing the theme's custom CSS to match those precise state combinations and apply the custom red borders, badges, and rotational effects instantly.

## Use of AI Tools
I utilized AI to assist with scaffolding the PHP and JavaScript parsers, and drafting the PHPUnit/Jest test suites. I directed the architecture, reviewed all generated code against Gutenberg coding standards, executed fault-injection tests.
