### PR TITLE
Gallery Block: visually differentiate child Image blocks and prompt for a second image when only one remains

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -959,6 +959,7 @@ export default function GalleryEdit( props ) {
 					{ ...props }
 					isContentLocked={ isContentLocked }
 					images={ images }
+					hasSingleImagePlaceholder={ images.length === 1 }
 					blockProps={ innerBlocksProps }
 					insertBlocksAfter={ insertBlocksAfter }
 					multiGallerySelection={ multiGallerySelection }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -44,6 +44,51 @@
 		margin-top: -9px;
 		margin-left: -9px;
 	}
+
+	&.has-single-image-placeholder {
+		> .wp-block-image,
+		> .wp-block-gallery__single-image-placeholder {
+			width: calc(50% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) / 2));
+		}
+
+		> .wp-block-gallery__single-image-placeholder {
+			position: relative;
+			min-height: 120px;
+			aspect-ratio: 1;
+			border: 1px dashed $gray-300;
+			border-radius: $radius-small;
+			background: linear-gradient(180deg, rgba($gray-100, 0.8), rgba($gray-100, 0.35));
+			pointer-events: none;
+
+			&::before,
+			&::after {
+				content: "";
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				background: $gray-700;
+				transform: translate(-50%, -50%);
+				opacity: 0.7;
+			}
+
+			&::before {
+				width: 20px;
+				height: 2px;
+			}
+
+			&::after {
+				width: 2px;
+				height: 20px;
+			}
+		}
+
+		&.columns-1 {
+			> .wp-block-image,
+			> .wp-block-gallery__single-image-placeholder {
+				width: 100%;
+			}
+		}
+	}
 }
 
 /**

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -23,6 +23,7 @@ export default function Gallery( props ) {
 		__unstableLayoutClassNames: layoutClassNames,
 		isContentLocked,
 		multiGallerySelection,
+		hasSingleImagePlaceholder,
 	} = props;
 
 	const { align, columns, imageCrop } = attributes;
@@ -39,10 +40,17 @@ export default function Gallery( props ) {
 					[ `columns-${ columns }` ]: columns !== undefined,
 					[ `columns-default` ]: columns === undefined,
 					'is-cropped': imageCrop,
+					'has-single-image-placeholder': hasSingleImagePlaceholder,
 				}
 			) }
 		>
 			{ blockProps.children }
+			{ hasSingleImagePlaceholder && (
+				<div
+					className="wp-block-gallery__single-image-placeholder"
+					aria-hidden="true"
+				/>
+			) }
 			<Caption
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -155,6 +155,18 @@ export function ImageEdit( {
 	} = useSelect( blockEditorStore );
 	const blockEditingMode = useBlockEditingMode();
 
+	const isInGallery = useSelect(
+		( select ) => {
+			const { getBlockRootClientId: getRoot, getBlockName: getName } =
+				select( blockEditorStore );
+			const rootClientId = getRoot( clientId );
+			return (
+				!! rootClientId && getName( rootClientId ) === 'core/gallery'
+			);
+		},
+		[ clientId ]
+	);
+
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
@@ -251,10 +263,10 @@ export function ImageEdit( {
 		// skipped there; the converted video is still sideloaded and
 		// stored for use elsewhere.
 		const rootClientId = getBlockRootClientId( clientId );
-		const isInGallery =
+		const isGifDropRootGallery =
 			!! rootClientId && getBlockName( rootClientId ) === 'core/gallery';
 		if (
-			! isInGallery &&
+			! isGifDropRootGallery &&
 			media.media_details?.animated_video &&
 			media.url
 		) {
@@ -437,6 +449,7 @@ export function ImageEdit( {
 			!! borderProps.className ||
 			( borderProps.style &&
 				Object.keys( borderProps.style ).length > 0 ),
+		'is-in-gallery': isInGallery,
 	} );
 
 	const blockProps = useBlockProps( {
@@ -540,6 +553,7 @@ export function ImageEdit( {
 					blockEditingMode={ blockEditingMode }
 					parentLayoutType={ layoutType }
 					maxContentWidth={ maxContentWidth }
+					isInGallery={ isInGallery }
 				/>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -175,3 +175,15 @@ figure.wp-block-image:not(.wp-block) {
 	width: 250px;
 }
 
+.wp-block-image.is-in-gallery.is-selected,
+.wp-block-image.is-in-gallery.is-hovered {
+	outline: $border-width dashed $gray-600;
+	outline-offset: 2px;
+}
+
+.wp-block-image__gallery-dimensions-notice {
+	color: $gray-700;
+	font-size: 12px;
+	font-style: italic;
+	margin: 0;
+}

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -285,6 +285,7 @@ export default function Image( {
 	blockEditingMode,
 	parentLayoutType,
 	maxContentWidth,
+	isInGallery,
 } ) {
 	const {
 		url = '',
@@ -1058,6 +1059,19 @@ export default function Image( {
 				} }
 			>
 				{ dimensionsControl }
+				{ ! showDimensionsControls && isInGallery && (
+					<ToolsPanelItem
+						label={ __( 'Dimensions' ) }
+						hasValue={ () => false }
+						isShownByDefault
+					>
+						<p className="wp-block-image__gallery-dimensions-notice">
+							{ __(
+								'This image is part of a Gallery, so its dimensions follow the Gallery’s Resolution and Aspect ratio settings.'
+							) }
+						</p>
+					</ToolsPanelItem>
+				) }
 				{ ! hasSelectedStyleState && url && scale && (
 					<ToolsPanelItem
 						label={ __( 'Focal point' ) }


### PR DESCRIPTION
## What?
Closes #48375

Two related editor-only changes so a Gallery's child Image blocks are never mistaken for a standalone Image block:

1. When an Image block is selected inside a Gallery, the Dimensions panel now shows an explanatory note instead of silently disappearing, and the block gets a distinct selected/hover outline.
2. When a Gallery contains only a single image, an inline "Add another image" placeholder tile is shown next to it in the editor, since a Gallery with one image is functionally indistinguishable from an Image block and will auto-convert back to one if the last image is removed.

## Why?
As described in the issue, a Gallery's child Image block and a standalone Image block are visually identical in the editor, same title, same toolbar, but the Gallery child silently loses its Dimensions controls (Gallery sets `allowResize: false` in block context, which the Image block reads with no fallback UI). This left users searching for settings that were never going to appear, with no indication they were even inside a Gallery.

Separately, a Gallery with a single image reads as an Image block, which is confusing given galleries are meant to hold multiple images. A visual nudge in the editor (not saved to content) makes that expectation clear.

## Testing Instructions
1. Insert a Gallery block and add 2+ images.
2. Hover of the images inside the Gallery, confirm you see the dashed outline (in addition to the normal selection border) and that the Dimensions panel in the sidebar shows the explanatory note instead of being empty.
3. Insert a standalone Image block (not in a Gallery), confirm it looks and behaves as before (normal selection border, full Dimensions controls).
4. Remove images from the Gallery until only one remains, confirm the "Add another image" placeholder tile appears next to it.
5. Click the placeholder tile, confirm the media library opens in "add to gallery" mode, and selecting an image adds it to the Gallery.
6. Add a second image via the normal toolbar "Add" button instead confirm the placeholder tile disappears once there are 2+ images.
7. Save/preview the post, confirm the frontend output is unchanged (no placeholder tile, no extra classes/outline in the saved HTML).

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/dc3b7aa7-5e33-4446-9f10-06faf312dd03

