### PR TITLE
Icons: Unify collection-scoping route param on `collection` and validate description

### DIFF
--- a/lib/class-wp-rest-icons-controller-gutenberg.php
+++ b/lib/class-wp-rest-icons-controller-gutenberg.php
@@ -58,7 +58,7 @@ class WP_REST_Icons_Controller_Gutenberg extends WP_REST_Icons_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<namespace>[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?)',
+			'/' . $this->rest_base . '/(?P<collection>[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -74,15 +74,15 @@ class WP_REST_Icons_Controller_Gutenberg extends WP_REST_Icons_Controller {
 	/**
 	 * Retrieves the query params for the icons collection.
 	 *
-	 * Extends the base params with a `namespace` parameter that corresponds
+	 * Extends the base params with a `collection` parameter that corresponds
 	 * to an icon collection slug. The same parameter is also captured as a
 	 * URL segment by the collection-scoped route.
 	 *
 	 * @return array Collection parameters.
 	 */
 	public function get_collection_params() {
-		$query_params              = parent::get_collection_params();
-		$query_params['namespace'] = array(
+		$query_params               = parent::get_collection_params();
+		$query_params['collection'] = array(
 			'description' => __( 'Limit results to icons belonging to the given collection slug.', 'gutenberg' ),
 			'type'        => 'string',
 			'pattern'     => '^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$',
@@ -97,7 +97,7 @@ class WP_REST_Icons_Controller_Gutenberg extends WP_REST_Icons_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$collection = $request->get_param( 'namespace' );
+		$collection = $request->get_param( 'collection' );
 
 		if ( null !== $collection && ! WP_Icon_Collections_Registry::get_instance()->is_registered( $collection ) ) {
 			return new WP_Error(

--- a/lib/compat/wordpress-7.1/class-wp-icon-collections-registry.php
+++ b/lib/compat/wordpress-7.1/class-wp-icon-collections-registry.php
@@ -90,6 +90,15 @@ if ( ! class_exists( 'WP_Icon_Collections_Registry' ) ) {
 				return false;
 			}
 
+			if ( isset( $collection_properties['description'] ) && ! is_string( $collection_properties['description'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Icon collection description must be a string.', 'gutenberg' ),
+					'7.1.0'
+				);
+				return false;
+			}
+
 			$defaults = array(
 				'description' => '',
 			);

--- a/packages/block-library/src/icon/components/custom-inserter/index.js
+++ b/packages/block-library/src/icon/components/custom-inserter/index.js
@@ -46,7 +46,7 @@ export default function CustomInserterModal( { onClose, value, onChange } ) {
 				return { icons: null, hasResolvedIcons: false };
 			}
 			const query =
-				collectionSlug === '' ? {} : { namespace: collectionSlug };
+				collectionSlug === '' ? {} : { collection: collectionSlug };
 			const { getEntityRecords, hasFinishedResolution } =
 				select( coreDataStore );
 			return {


### PR DESCRIPTION
## What?

See: https://github.com/WordPress/gutenberg/pull/79681#discussion_r3559387732

Aligns the icons REST API with the WordPress core rename of the collection-scoping route param from `namespace` to `collection`, and adds the matching validation for the collection `description` field.

## Why?

The core PR https://github.com/WordPress/wordpress-develop/pull/11559 is renaming the route param from `namespace` to `collection`. Once that core PR is merged, the Gutenberg icon picker would still send/read `namespace`, which no longer exists — causing errors. Unifying on `collection` in Gutenberg too prevents that breakage.

The same core PR added, in a later review, a validation that the collection `description` must be a string. This PR mirrors that validation so the two implementations stay in sync.

## Testing Instructions

1. Insert an Icon block.
2. Open the icon picker.
3. Confirm the icon list is displayed as before.

### Testing Instructions for Keyboard

1. Insert an Icon block and open the icon picker using the keyboard.
2. Confirm the icon list is displayed as before.

## Use of AI Tools

This PR was authored with the assistance of Claude Code. All changes were reviewed by the author.
