### PR TITLE
Editor: restore the behavior of only showing back button focus ring on :focus-visible

### DIFF
--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -2,6 +2,10 @@
 	color: var(--wpds-color-foreground-interactive-neutral);
 	flex-shrink: 0;
 
+	&:focus:not(:focus-visible) {
+		outline: none;
+	}
+
 	&:hover:not(:disabled,[aria-disabled="true"]),
 	&:focus-visible,
 	&:focus,


### PR DESCRIPTION
## What?

In #48472 we only show the focus ring for editor sidebar back button on `:focus-visible` only.  Then #80029 removes that behavior by mistake (sorry!). This PR reintroduces the behavior, but not by reverting as-is and instead proposing a simpler CSS. So in the end we still get a cleaner CSS in the file 😄 

## Testing Instructions

1. Go to Site Editor.
2. Click Pages (via mouse).
3. Verify the chevron back button (`< Pages`) doesn't get focused (you don't see focus ring).

## Use of AI Tools

Used Opus 4.8 to brainstorm solutions.
