### PR TITLE
Hide navigation commands that match the current screen context

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -45,23 +45,43 @@ const getViewSiteCommand = () =>
 
 export function useAdminNavigationCommands( menuCommands ) {
 	const commands = useMemo( () => {
-		return ( menuCommands ?? [] ).map( ( menuCommand ) => {
-			const label = sprintf(
-				/* translators: %s: menu label */
-				__( 'Go to: %s' ),
-				menuCommand.label
-			);
-			return {
-				name: menuCommand.name,
-				label,
-				searchLabel: label,
-				category: 'view',
-				callback: ( { close } ) => {
-					document.location = menuCommand.url;
-					close();
-				},
-			};
-		} );
+		return ( menuCommands ?? [] )
+			.filter( ( menuCommand ) => {
+				try {
+					const currentUrl = new URL( window.location.href );
+					const commandUrl = new URL(
+						menuCommand.url,
+						window.location.href
+					);
+
+					if (
+						currentUrl.pathname === commandUrl.pathname &&
+						currentUrl.search === commandUrl.search
+					) {
+						return false;
+					}
+				} catch {
+					// Ignore invalid URLs and let them render.
+				}
+				return true;
+			} )
+			.map( ( menuCommand ) => {
+				const label = sprintf(
+					/* translators: %s: menu label */
+					__( 'Go to: %s' ),
+					menuCommand.label
+				);
+				return {
+					name: menuCommand.name,
+					label,
+					searchLabel: label,
+					category: 'view',
+					callback: ( { close } ) => {
+						document.location = menuCommand.url;
+						close();
+					},
+				};
+			} );
 	}, [ menuCommands ] );
 	useCommands( commands );
 

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -91,6 +91,46 @@ function isInSiteEditor() {
 	);
 }
 
+// Helper to determine if a target command path matches the current site editor view.
+function isSameSiteEditorPath( targetPath, targetParams = {} ) {
+	if ( ! isInSiteEditor() ) {
+		return false;
+	}
+
+	const searchParams = new URLSearchParams( window.location.search );
+	const currentPath =
+		searchParams.get( 'path' ) || searchParams.get( 'p' ) || '/';
+
+	const queryStr = new URLSearchParams( targetParams ).toString();
+	const fullTargetPath = targetPath + ( queryStr ? '?' + queryStr : '' );
+	const mappedTargetPath = mapRoute( fullTargetPath );
+
+	if ( currentPath !== targetPath && currentPath !== mappedTargetPath ) {
+		return false;
+	}
+
+	if ( currentPath === mappedTargetPath && mappedTargetPath !== targetPath ) {
+		return true;
+	}
+
+	for ( const [ key, value ] of Object.entries( targetParams ) ) {
+		if ( searchParams.get( key ) !== value ) {
+			return false;
+		}
+	}
+
+	if (
+		targetPath === '/pattern' &&
+		Object.keys( targetParams ).length === 0
+	) {
+		if ( searchParams.has( 'postType' ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 const getNavigationCommandLoaderPerPostType = ( postType ) =>
 	function useNavigationCommandLoader( { search } ) {
 		const history = useHistory();
@@ -144,58 +184,68 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 		);
 
 		const commands = useMemo( () => {
-			return ( records ?? [] ).map( ( record ) => {
-				const command = {
-					name: postType + '-' + record.id,
-					searchLabel: record.title?.rendered + ' ' + record.id,
-					label: record.title?.rendered
-						? decodeEntities( record.title?.rendered )
-						: __( '(no title)' ),
-					icon: icons[ postType ],
-					category: 'edit',
-				};
+			return ( records ?? [] )
+				.filter(
+					( record ) =>
+						! isSameSiteEditorPath(
+							`/${ postType }/${ record.id }`
+						)
+				)
+				.map( ( record ) => {
+					const command = {
+						name: postType + '-' + record.id,
+						searchLabel: record.title?.rendered + ' ' + record.id,
+						label: record.title?.rendered
+							? decodeEntities( record.title?.rendered )
+							: __( '(no title)' ),
+						icon: icons[ postType ],
+						category: 'edit',
+					};
 
-				if (
-					! canCreateTemplate ||
-					postType === 'post' ||
-					( postType === 'page' && ! isBlockBasedTheme )
-				) {
+					if (
+						! canCreateTemplate ||
+						postType === 'post' ||
+						( postType === 'page' && ! isBlockBasedTheme )
+					) {
+						return {
+							...command,
+							callback: ( { close } ) => {
+								const args = {
+									post: record.id,
+									action: 'edit',
+								};
+								const targetUrl = addQueryArgs(
+									'post.php',
+									args
+								);
+								document.location = targetUrl;
+								close();
+							},
+						};
+					}
+
+					const isSiteEditor = isInSiteEditor();
+
 					return {
 						...command,
 						callback: ( { close } ) => {
-							const args = {
-								post: record.id,
-								action: 'edit',
-							};
-							const targetUrl = addQueryArgs( 'post.php', args );
-							document.location = targetUrl;
+							if ( isSiteEditor ) {
+								history.navigate(
+									`/${ postType }/${ record.id }?canvas=edit`
+								);
+							} else {
+								document.location = addQueryArgs(
+									getSiteEditorPage(),
+									{
+										p: `/${ postType }/${ record.id }`,
+										canvas: 'edit',
+									}
+								);
+							}
 							close();
 						},
 					};
-				}
-
-				const isSiteEditor = isInSiteEditor();
-
-				return {
-					...command,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate(
-								`/${ postType }/${ record.id }?canvas=edit`
-							);
-						} else {
-							document.location = addQueryArgs(
-								getSiteEditorPage(),
-								{
-									p: `/${ postType }/${ record.id }`,
-									canvas: 'edit',
-								}
-							);
-						}
-						close();
-					},
-				};
-			} );
+				} );
 		}, [ canCreateTemplate, records, isBlockBasedTheme, history ] );
 
 		return {
@@ -253,38 +303,50 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 			);
 			const result = [];
 			result.push(
-				...orderedRecords.map( ( record ) => {
-					return {
-						name: templateType + '-' + record.id,
-						searchLabel: record.title?.rendered + ' ' + record.id,
-						label: record.title?.rendered
-							? record.title?.rendered
-							: __( '(no title)' ),
-						icon: icons[ templateType ],
-						category: 'edit',
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate(
-									`/${ templateType }/${ record.id }?canvas=edit`
-								);
-							} else {
-								document.location = addQueryArgs(
-									getSiteEditorPage(),
-									{
-										p: `/${ templateType }/${ record.id }`,
-										canvas: 'edit',
-									}
-								);
-							}
-							close();
-						},
-					};
-				} )
+				...orderedRecords
+					.filter(
+						( record ) =>
+							! isSameSiteEditorPath(
+								`/${ templateType }/${ record.id }`
+							)
+					)
+					.map( ( record ) => {
+						return {
+							name: templateType + '-' + record.id,
+							searchLabel:
+								record.title?.rendered + ' ' + record.id,
+							label: record.title?.rendered
+								? record.title?.rendered
+								: __( '(no title)' ),
+							icon: icons[ templateType ],
+							category: 'edit',
+							callback: ( { close } ) => {
+								if ( isSiteEditor ) {
+									history.navigate(
+										`/${ templateType }/${ record.id }?canvas=edit`
+									);
+								} else {
+									document.location = addQueryArgs(
+										getSiteEditorPage(),
+										{
+											p: `/${ templateType }/${ record.id }`,
+											canvas: 'edit',
+										}
+									);
+								}
+								close();
+							},
+						};
+					} )
 			);
 
 			if (
 				orderedRecords?.length > 0 &&
-				templateType === 'wp_template_part'
+				templateType === 'wp_template_part' &&
+				! isSameSiteEditorPath( '/pattern', {
+					postType: 'wp_template_part',
+					categoryId: 'all-parts',
+				} )
 			) {
 				result.push( {
 					name: 'core/edit-site/open-template-parts',
@@ -344,69 +406,75 @@ const getSiteEditorBasicNavigationCommands = () =>
 			const result = [];
 
 			if ( canCreateTemplate && isBlockBasedTheme ) {
-				// Go to Styles command
-				result.push( {
-					name: 'core/edit-site/open-styles',
-					label: __( 'Go to: Styles' ),
-					icon: styles,
-					category: 'view',
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/styles' );
-						} else {
-							document.location = addQueryArgs(
-								getSiteEditorPage(),
-								{
-									p: '/styles',
-								}
-							);
-						}
-						close();
-					},
-				} );
+				if ( ! isSameSiteEditorPath( '/styles' ) ) {
+					// Go to Styles command
+					result.push( {
+						name: 'core/edit-site/open-styles',
+						label: __( 'Go to: Styles' ),
+						icon: styles,
+						category: 'view',
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/styles' );
+							} else {
+								document.location = addQueryArgs(
+									getSiteEditorPage(),
+									{
+										p: '/styles',
+									}
+								);
+							}
+							close();
+						},
+					} );
+				}
 
-				result.push( {
-					name: 'core/edit-site/open-navigation',
-					label: __( 'Go to: Navigation' ),
-					icon: navigation,
-					category: 'view',
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/navigation' );
-						} else {
-							document.location = addQueryArgs(
-								getSiteEditorPage(),
-								{
-									p: '/navigation',
-								}
-							);
-						}
-						close();
-					},
-				} );
+				if ( ! isSameSiteEditorPath( '/navigation' ) ) {
+					result.push( {
+						name: 'core/edit-site/open-navigation',
+						label: __( 'Go to: Navigation' ),
+						icon: navigation,
+						category: 'view',
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/navigation' );
+							} else {
+								document.location = addQueryArgs(
+									getSiteEditorPage(),
+									{
+										p: '/navigation',
+									}
+								);
+							}
+							close();
+						},
+					} );
+				}
 
-				result.push( {
-					name: 'core/edit-site/open-templates',
-					label: __( 'Go to: Templates' ),
-					icon: layout,
-					category: 'view',
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( mapRoute( '/template' ) );
-						} else {
-							document.location = addQueryArgs(
-								getSiteEditorPage(),
-								{
-									p: mapRoute( '/template' ),
-								}
-							);
-						}
-						close();
-					},
-				} );
+				if ( ! isSameSiteEditorPath( '/template' ) ) {
+					result.push( {
+						name: 'core/edit-site/open-templates',
+						label: __( 'Go to: Templates' ),
+						icon: layout,
+						category: 'view',
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( mapRoute( '/template' ) );
+							} else {
+								document.location = addQueryArgs(
+									getSiteEditorPage(),
+									{
+										p: mapRoute( '/template' ),
+									}
+								);
+							}
+							close();
+						},
+					} );
+				}
 			}
 
-			if ( canCreatePatterns ) {
+			if ( canCreatePatterns && ! isSameSiteEditorPath( '/pattern' ) ) {
 				result.push( {
 					name: 'core/edit-site/open-patterns',
 					label: __( 'Go to: Patterns' ),
@@ -472,7 +540,11 @@ const getGlobalStylesOpenCssCommands = () =>
 		}, [] );
 
 		const commands = useMemo( () => {
-			if ( ! canEditCSS || ! isBlockBasedTheme ) {
+			if (
+				! canEditCSS ||
+				! isBlockBasedTheme ||
+				isSameSiteEditorPath( '/styles', { section: '/css' } )
+			) {
 				return [];
 			}
 


### PR DESCRIPTION
## What?
Closes #71925

This PR hides redundant "Go to [location]" commands from the Command Palette if the user is already currently viewing that specific screen or context.

## Why?
Previously, the Command Palette statically registered all global navigation commands regardless of the user's current location. If a user was already on the Navigation screen, the palette would still suggest "Go to Navigation." This created unnecessary visual clutter and reduced the contextual usefulness of the palette by suggesting actions that had no effect.

## How?

- Updated `admin-navigation-commands.js` to parse generic menu URLs and filter out any commands where the target pathname and query string exactly match the browser's current `window.location`.
- Added a new `isSameSiteEditorPath()` helper in `site-editor-navigation-commands.js` to determine the active Site Editor view.

## Testing Instructions

1. Go to admin/editor area in your site.
2. Navigate to areas like Navigation, Template, Pages, Template parts, Dashboard, etc.
3. Open the Command Palette (Cmd + K / Ctrl + K).
4. Search for same areas again.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/99355703-714c-4b9c-9161-01e5920cff47