### PR TITLE
CODEOWNERS: Exclude eslint suppressions.json from /tools ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 # Tooling
 /bin                                            @ntwb @nerrad @ajitbohra @manzoorwanijk
 /tools                                          @manzoorwanijk
+/tools/eslint/suppressions.json
 /packages/babel-plugin-import-jsx-pragma        @ntwb @nerrad @ajitbohra
 /packages/babel-plugin-makepot                  @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @ntwb @nerrad @ajitbohra


### PR DESCRIPTION
## What?

See https://github.com/WordPress/gutenberg/pull/80123#discussion_r3561218737

Excludes `tools/eslint/suppressions.json` from the `/tools` CODEOWNERS rule.

## Why?

I set myself as the code owner for `/tools` to keep an eye on changes there, but `tools/eslint/suppressions.json` changes very frequently, which results in my inbox being slammed with review-request emails for a file that doesn't need my review.

## How?

Adds a pattern for `tools/eslint/suppressions.json` with no owner after the `/tools` rule. In CODEOWNERS, the last matching pattern wins, so this un-assigns ownership for that file while keeping it for everything else under `/tools`. This is the same approach already used for `/packages/block-library/src/gallery`.

## Testing Instructions

1. Verify that changes to `tools/eslint/suppressions.json` no longer request a review from @manzoorwanijk.
2. Verify that changes to other files under `/tools` still request a review from @manzoorwanijk.

## Use of AI Tools

This PR was authored with the help of Claude Code and reviewed by a human.
