### PR TITLE
Writing flow: fix selection end mapping at block boundaries

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Writing flow: Only pull a forward selection ending at the next element's offset 0 back into the previous block for triple clicks, and clamp the dispatched selection end offset to the rich text content length so an overshooting selection no longer collapses to its start ([#80126](https://github.com/WordPress/gutenberg/pull/80126)).
 -   `ListView`: Use the DS focus color token for the row focus ring so it adapts to themed surfaces such as the site editor navigation sidebar, and remove the duplicate focus ring on the row's Options (three-dot) button, which already draws the standard `Button` focus ring. ([#80087](https://github.com/WordPress/gutenberg/pull/80087)).
 -   `DimensionControl`: Include component styles in the block editor stylesheet so the fieldset reset is applied in Storybook and other contexts without WordPress core styles ([#79916](https://github.com/WordPress/gutenberg/pull/79916)).
 -   `InnerContent`: Render the selected inner block synchronously so its rich text selection stays current while typing; otherwise a stale selection offset could place a typed character at the wrong position in editable static inner blocks ([#79726](https://github.com/WordPress/gutenberg/pull/79726)).

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -269,7 +269,16 @@ export default function useSelectionObserver() {
 									attributeKey:
 										richTextElement.dataset
 											.wpBlockAttributeKey,
-									offset: richTextData.end,
+									// Clamp the end offset to the element. A
+									// forward selection can overshoot past the
+									// rich text (e.g. a triple click extends
+									// into the next block at offset 0), leaving
+									// `end` undefined; that means the selection
+									// reaches through the end of this element's
+									// content.
+									offset:
+										richTextData.end ??
+										richTextData.text.length,
 								},
 							} );
 						} else {

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -39,11 +39,13 @@ function extractSelectionStartNode( selection ) {
  * a text node, the selection offset is the index of a child node. The selection
  * reaches up to but excluding that child node.
  *
- * @param {Selection} selection The selection.
+ * @param {Selection} selection     The selection.
+ * @param {boolean}   isTripleClick Whether the selection comes from a triple
+ *                                  click.
  *
  * @return {Element} The selection start node.
  */
-function extractSelectionEndNode( selection ) {
+function extractSelectionEndNode( selection, isTripleClick ) {
 	const { focusNode, focusOffset } = selection;
 
 	if ( focusNode.nodeType === focusNode.TEXT_NODE ) {
@@ -54,11 +56,18 @@ function extractSelectionEndNode( selection ) {
 		return focusNode;
 	}
 
-	// When the selection is forward (the selection ends with the focus node),
-	// the selection may extend into the next element with an offset of 0. This
-	// may trigger multi selection even though the selection does not visually
-	// end in the next block.
-	if ( focusOffset === 0 && isSelectionForward( selection ) ) {
+	// A triple click selects the paragraph, but the browser extends the
+	// forward selection into the next element at an offset of 0. This may
+	// trigger multi selection even though the selection does not visually end
+	// in the next block. Keyboard selections that legitimately extend to the
+	// same boundary (e.g. Shift+ArrowDown into a focusable block, where the
+	// browser reports the boundary at the element instead of its first text
+	// position) must not be corrected, so only do this for triple clicks.
+	if (
+		focusOffset === 0 &&
+		isSelectionForward( selection ) &&
+		isTripleClick
+	) {
 		return focusNode.previousSibling ?? focusNode.parentElement;
 	}
 
@@ -114,6 +123,16 @@ export default function useSelectionObserver() {
 			const { ownerDocument } = node;
 			const { defaultView } = ownerDocument;
 
+			let isTripleClick = false;
+
+			function onMouseDown( event ) {
+				isTripleClick = event.detail === 3;
+			}
+
+			function onKeyDown() {
+				isTripleClick = false;
+			}
+
 			function onSelectionChange( event ) {
 				const selection = defaultView.getSelection();
 
@@ -122,7 +141,10 @@ export default function useSelectionObserver() {
 				}
 
 				const startNode = extractSelectionStartNode( selection );
-				const endNode = extractSelectionEndNode( selection );
+				const endNode = extractSelectionEndNode(
+					selection,
+					isTripleClick
+				);
 
 				if (
 					! node.contains( startNode ) ||
@@ -323,12 +345,16 @@ export default function useSelectionObserver() {
 				onSelectionChange
 			);
 			defaultView.addEventListener( 'mouseup', onSelectionChange );
+			node.addEventListener( 'mousedown', onMouseDown );
+			node.addEventListener( 'keydown', onKeyDown );
 			return () => {
 				ownerDocument.removeEventListener(
 					'selectionchange',
 					onSelectionChange
 				);
 				defaultView.removeEventListener( 'mouseup', onSelectionChange );
+				node.removeEventListener( 'mousedown', onMouseDown );
+				node.removeEventListener( 'keydown', onKeyDown );
 			};
 		},
 		[ multiSelect, selectBlock, selectionChange, getBlockParents ]

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -876,6 +876,67 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should select the whole paragraph on triple click from the block edge', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second' },
+		} );
+
+		// Deselect the block so the rich text element is not focused and the
+		// selection observer, not the rich text, dispatches the selection.
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		const box = await paragraph.boundingBox();
+
+		// Triple click just left of the paragraph text (on the canvas
+		// padding), so the paragraph selection is made without focusing the
+		// rich text element.
+		await page.mouse.click( box.x - 5, box.y + box.height / 2, {
+			clickCount: 3,
+		} );
+
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'One two three' },
+				},
+			] );
+
+		// The store selection spans the whole paragraph, not collapsed and
+		// not extended into the next block (some browsers report the
+		// selection boundary in the next element at offset 0).
+		await expect
+			.poll( () =>
+				page.evaluate( () => {
+					const { getSelectionStart, getSelectionEnd } =
+						window.wp.data.select( 'core/block-editor' );
+					return {
+						startOffset: getSelectionStart().offset,
+						endOffset: getSelectionEnd().offset,
+					};
+				} )
+			)
+			.toEqual( {
+				startOffset: 0,
+				endOffset: 'One two three'.length,
+			} );
+	} );
+
 	test( 'should gradually multi-select', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?

Extracted from #79105. Two fixes to how the selection observer maps a native selection ending at the next element's boundary:

1. **Restrict the forward overshoot correction to triple clicks.** The correction (added in #64928 for triple clicks) fired for any forward selection ending at offset 0 of the next element. A keyboard selection extending to the same boundary (e.g. Shift+ArrowDown into a focusable block, where the browser reports the boundary at the element rather than its first text position) means to include the next block and must not be pulled back.
2. **Clamp the selection end offset to the rich text content length.** When the native selection overshoots past the rich text element, mapping the range leaves the end offset undefined, and dispatching that collapses the store selection to its start.

It also adds an e2e test for the triple click correction, which #64928 didn't add: a triple click starting on the canvas padding next to a paragraph, where the rich text element is not focused and the selection observer dispatches the selection to the store.

## Why?

Preparatory for #79105: with the writing flow wrapper as a shared editing host, everyday gestures hit both paths. On trunk they depend on browser-specific boundary reporting.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/editor/various/multi-block-selection.spec.js`
2. In the editor: triple click a paragraph followed by another block; only that paragraph is selected, and typing replaces its whole content.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)