### PR TITLE
UI: improve component code readability in Storybook

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Internal
 
+-   Improve Storybook "Show code" snippets for design system component stories by using explicit `render` functions with direct child composition ([#80129](https://github.com/WordPress/gutenberg/pull/80129)).
 -   Add an explicit return type to an internal overlay focus helper so the published type definitions stay self-contained ([#79684](https://github.com/WordPress/gutenberg/pull/79684)).
 -   Enforce CSS Module class selector naming for component-library packages ([#79504](https://github.com/WordPress/gutenberg/pull/79504)).
 -   Update `@base-ui/react` from `1.5.0` to [`1.6.0`](https://github.com/mui/base-ui/releases/tag/v1.6.0) ([#79408](https://github.com/WordPress/gutenberg/pull/79408)).

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -37,17 +37,15 @@ type Story = StoryObj< typeof AlertDialog.Root >;
  * is blocked.
  */
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Move to trash?"
-					description="This post will be moved to trash. You can restore it later."
-				/>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				title="Move to trash?"
+				description="This post will be moved to trash. You can restore it later."
+			/>
+		</AlertDialog.Root>
+	),
 };
 
 /**
@@ -55,38 +53,34 @@ export const Default: Story = {
  * The confirm button uses error/danger coloring.
  */
 export const Irreversible: Story = {
-	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Delete permanently</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					intent="irreversible"
-					title="Delete permanently?"
-					description="This action cannot be undone. All data will be lost."
-					confirmButtonText="Delete permanently"
-				/>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Delete permanently</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				intent="irreversible"
+				title="Delete permanently?"
+				description="This action cannot be undone. All data will be lost."
+				confirmButtonText="Delete permanently"
+			/>
+		</AlertDialog.Root>
+	),
 };
 
 /**
  * Example with custom button labels for both confirm and cancel buttons.
  */
 export const CustomLabels: Story = {
-	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Send feedback</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Send feedback?"
-					description="Your feedback helps us improve. Would you like to send it now?"
-					confirmButtonText="Send feedback"
-					cancelButtonText="Not now"
-				/>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Send feedback</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				title="Send feedback?"
+				description="Your feedback helps us improve. Would you like to send it now?"
+				confirmButtonText="Send feedback"
+				cancelButtonText="Not now"
+			/>
+		</AlertDialog.Root>
+	),
 };
 
 /**
@@ -95,29 +89,27 @@ export const CustomLabels: Story = {
  * accessibility (`aria-describedby`); `children` adds supplementary detail.
  */
 export const WithCustomContent: Story = {
-	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Remove pages</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Remove 3 pages?"
-					description="These pages will be moved to trash."
-					confirmButtonText="Delete pages"
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Remove pages</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				title="Remove 3 pages?"
+				description="These pages will be moved to trash."
+				confirmButtonText="Delete pages"
+			>
+				<ul
+					style={ {
+						margin: 'var(--wpds-dimension-gap-sm) 0 0',
+						paddingInlineStart: 'var(--wpds-dimension-gap-lg)',
+					} }
 				>
-					<ul
-						style={ {
-							margin: 'var(--wpds-dimension-gap-sm) 0 0',
-							paddingInlineStart: 'var(--wpds-dimension-gap-lg)',
-						} }
-					>
-						<Text render={ <li /> }>About us</Text>
-						<Text render={ <li /> }>Contact</Text>
-						<Text render={ <li /> }>Privacy policy</Text>
-					</ul>
-				</AlertDialog.Popup>
-			</>
-		),
-	},
+					<Text render={ <li /> }>About us</Text>
+					<Text render={ <li /> }>Contact</Text>
+					<Text render={ <li /> }>Privacy policy</Text>
+				</ul>
+			</AlertDialog.Popup>
+		</AlertDialog.Root>
+	),
 };
 
 /**
@@ -139,22 +131,20 @@ export const WithCustomContent: Story = {
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
-	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Move to trash?"
-					description="This post will be moved to trash. You can restore it later."
-					portal={
-						<AlertDialog.Portal
-							style={ { '--wp-ui-dialog-z-index': '9999' } }
-						/>
-					}
-				/>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				title="Move to trash?"
+				description="This post will be moved to trash. You can restore it later."
+				portal={
+					<AlertDialog.Portal
+						style={ { '--wp-ui-dialog-z-index': '9999' } }
+					/>
+				}
+			/>
+		</AlertDialog.Root>
+	),
 };
 
 const menuPopupStyles: React.CSSProperties = {
@@ -188,7 +178,7 @@ const menuItemStyles: React.CSSProperties = {
  * component (not ready yet).
  */
 export const MenuTrigger: Story = {
-	render: () => {
+	render: ( {} ) => {
 		const [ menuOpen, setMenuOpen ] = useState( false );
 		return (
 			<>
@@ -397,9 +387,11 @@ function ScrollableContent() {
  * independently.
  */
 export const Scrollable: Story = {
-	args: {
-		children: <ScrollableContent />,
-	},
+	render: ( {} ) => (
+		<AlertDialog.Root>
+			<ScrollableContent />
+		</AlertDialog.Root>
+	),
 };
 
 /**

--- a/packages/ui/src/badge/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/badge/stories/usage-guidelines.story.tsx
@@ -25,7 +25,7 @@ export default meta;
 type Story = StoryObj< typeof Badge >;
 
 export const AllIntents: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="high">high</Badge>
 			<Badge intent="medium">medium</Badge>
@@ -39,7 +39,7 @@ export const AllIntents: Story = {
 };
 
 export const High: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="high">Payment declined</Badge>
 			<Badge intent="high">Security issue</Badge>
@@ -48,7 +48,7 @@ export const High: Story = {
 };
 
 export const Medium: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="medium">Approval required</Badge>
 			<Badge intent="medium">Review needed</Badge>
@@ -57,7 +57,7 @@ export const Medium: Story = {
 };
 
 export const Low: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="low">Pending</Badge>
 			<Badge intent="low">Queued</Badge>
@@ -66,7 +66,7 @@ export const Low: Story = {
 };
 
 export const Informational: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="informational">Scheduled</Badge>
 			<Badge intent="informational">Beta</Badge>
@@ -75,7 +75,7 @@ export const Informational: Story = {
 };
 
 export const Draft: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="draft">Draft</Badge>
 			<Badge intent="draft">Unpublished</Badge>
@@ -84,7 +84,7 @@ export const Draft: Story = {
 };
 
 export const Stable: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="stable">Healthy</Badge>
 			<Badge intent="stable">Active</Badge>
@@ -93,7 +93,7 @@ export const Stable: Story = {
 };
 
 export const None: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="none">Inactive</Badge>
 			<Badge intent="none">Expired</Badge>
@@ -102,7 +102,7 @@ export const None: Story = {
 };
 
 export const CommentStatus: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="none">Approved</Badge>
 			<Badge intent="medium">Approval required</Badge>
@@ -111,7 +111,7 @@ export const CommentStatus: Story = {
 };
 
 export const PageStatus: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="none">Published</Badge>
 			<Badge intent="low">Pending</Badge>
@@ -123,7 +123,7 @@ export const PageStatus: Story = {
 };
 
 export const PluginStatus: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="stable">Active</Badge>
 			<Badge intent="none">Inactive</Badge>
@@ -132,7 +132,7 @@ export const PluginStatus: Story = {
 };
 
 export const TextOnlyBadges: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<Badge intent="stable">Active</Badge>
 			<Badge intent="medium">Review needed</Badge>
@@ -142,7 +142,7 @@ export const TextOnlyBadges: Story = {
 };
 
 export const WithAdjacentContentIcon: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Stack direction="column" gap="sm">
 			<Stack direction="row" gap="sm" align="center">
 				<Icon icon={ page } size={ 24 } />
@@ -159,7 +159,7 @@ export const WithAdjacentContentIcon: Story = {
 };
 
 export const IncorrectBadgeWithIcon: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			{ /* @ts-expect-error Demonstrating incorrect Badge usage with icon children. */ }
 			<Badge intent="stable">

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -154,15 +154,12 @@ export const AllTonesAndVariants: Story = {
 
 export const WithIcon: Story = {
 	...Default,
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<Button.Icon icon={ wordpress } />
-				Button
-			</>
-		),
-	},
+	render: ( { children: _children, ...args } ) => (
+		<Button { ...args }>
+			<Button.Icon icon={ wordpress } />
+			Button
+		</Button>
+	),
 };
 
 export const Loading: Story = {

--- a/packages/ui/src/button/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/button/stories/usage-guidelines.story.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj;
  * `<button>` and support loading and pressed states.
  */
 export const UseButtonForActions: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Tooltip.Provider delay={ 0 }>
 			<Stack direction="row" gap="sm" wrap="wrap" align="center">
 				<Button type="submit">Save changes</Button>
@@ -49,7 +49,7 @@ export const UseButtonForActions: Story = {
  * the user is going more clearly than a button-shaped control.
  */
 export const UseLinkForInlineNavigation: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Text variant="body-md" render={ <p /> }>
 			{ createInterpolateElement(
 				'Read the <DocumentationLink /> for more details, or <ExternalLink />.',
@@ -78,7 +78,7 @@ export const UseLinkForInlineNavigation: Story = {
  * styling set clearer expectations than a button-shaped control.
  */
 export const UseLinkButtonForNavigation: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Stack direction="column" gap="md">
 			<Text variant="body-md" render={ <p /> }>
 				Standalone navigation calls to action can use `LinkButton` when

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -51,30 +51,26 @@ export default meta;
 type Story = StoryObj< typeof Card.Root >;
 
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Card title</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						This is the main content area. It can contain any
-						elements. This is the main content area. It can contain
-						any elements. This is the main content area. It can
-						contain any elements. This is the main content area. It
-						can contain any elements. This is the main content area.
-						It can contain any elements. This is the main content
-						area. It can contain any elements.
-					</Text>
-					<Text>
-						This is the main content area. It can contain any
-						elements.
-					</Text>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Card title</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<Text>
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+				</Text>
+				<Text>
+					This is the main content area. It can contain any elements.
+				</Text>
+			</Card.Content>
+		</Card.Root>
+	),
 };
 
 /**
@@ -82,8 +78,8 @@ export const Default: Story = {
  * with no padding around it.
  */
 export const FullBleedCoverOnly: Story = {
-	args: {
-		children: (
+	render: ( {} ) => (
+		<Card.Root>
 			<Card.Content>
 				<Card.FullBleed>
 					<div
@@ -95,8 +91,8 @@ export const FullBleedCoverOnly: Story = {
 					/>
 				</Card.FullBleed>
 			</Card.Content>
-		),
-	},
+		</Card.Root>
+	),
 };
 
 /**
@@ -105,26 +101,24 @@ export const FullBleedCoverOnly: Story = {
  * bottom edges while the header retains its normal padding.
  */
 export const FullBleedCoverWithHeader: Story = {
-	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Card title</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Card title</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</Card.Content>
+		</Card.Root>
+	),
 };
 
 /**
@@ -132,40 +126,38 @@ export const FullBleedCoverWithHeader: Story = {
  * edge-to-edge. Useful for images, dividers, or embedded content.
  */
 export const WithFullBleed: Story = {
-	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Featured image</Card.Title>
-				</Card.Header>
-				<Card.Content render={ <Stack direction="column" gap="lg" /> }>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 160,
-								background:
-									'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Text>Content below the full-bleed area.</Text>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Featured image</Card.Title>
+			</Card.Header>
+			<Card.Content render={ <Stack direction="column" gap="lg" /> }>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 160,
+							background:
+								'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Text>Content below the full-bleed area.</Text>
+			</Card.Content>
+		</Card.Root>
+	),
 };
 
 /**
  * A minimal card with only a header.
  */
 export const HeaderOnly: Story = {
-	args: {
-		children: (
+	render: ( {} ) => (
+		<Card.Root>
 			<Card.Header>
 				<Card.Title>Simple card</Card.Title>
 			</Card.Header>
-		),
-	},
+		</Card.Root>
+	),
 };
 
 /**
@@ -174,30 +166,28 @@ export const HeaderOnly: Story = {
  * that follows inside the header is padded normally.
  */
 export const FullBleedHeroWithTitle: Story = {
-	args: {
-		children: (
-			<>
-				<Card.Header render={ <Stack direction="column" gap="lg" /> }>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Card.Title>Hero image card</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						The image above bleeds to the card&apos;s top and side
-						edges.
-					</Text>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root>
+			<Card.Header render={ <Stack direction="column" gap="lg" /> }>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Card.Title>Hero image card</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<Text>
+					The image above bleeds to the card&apos;s top and side
+					edges.
+				</Text>
+			</Card.Content>
+		</Card.Root>
+	),
 };
 
 /**
@@ -206,29 +196,27 @@ export const FullBleedHeroWithTitle: Story = {
  * below.
  */
 export const FullBleedHeroOnly: Story = {
-	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						The image above bleeds to the card&apos;s top and side
-						edges.
-					</Text>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root>
+			<Card.Header>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</Card.Header>
+			<Card.Content>
+				<Text>
+					The image above bleeds to the card&apos;s top and side
+					edges.
+				</Text>
+			</Card.Content>
+		</Card.Root>
+	),
 };
 
 /**
@@ -237,17 +225,14 @@ export const FullBleedHeroOnly: Story = {
  * `Card.Title` renders as an `<h2>`.
  */
 export const CustomSemantics: Story = {
-	args: {
-		render: <section />,
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title render={ <h2 /> }>Section heading</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>Semantically meaningful card content.</Text>
-				</Card.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Card.Root render={ <section /> }>
+			<Card.Header>
+				<Card.Title render={ <h2 /> }>Section heading</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<Text>Semantically meaningful card content.</Text>
+			</Card.Content>
+		</Card.Root>
+	),
 };

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -50,26 +50,22 @@ type Story = StoryObj< typeof CollapsibleCard.Root >;
  * A collapsible card that is open by default.
  */
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>
-						Collapsible card (closed by default)
-					</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>
-						This is the collapsible content area. It can contain any
-						elements, just like a regular Card.Content.
-					</Text>
-					<Text>
-						When collapsed, only the header and chevron are visible.
-					</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<CollapsibleCard.Root>
+			<CollapsibleCard.Header>
+				<Card.Title>Collapsible card (closed by default)</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Text>
+					This is the collapsible content area. It can contain any
+					elements, just like a regular Card.Content.
+				</Text>
+				<Text>
+					When collapsed, only the header and chevron are visible.
+				</Text>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	),
 };
 
 /**
@@ -79,40 +75,32 @@ export const InitiallyOpened: Story = {
 	// `defaultOpen` (uncontrolled) and `open` (controlled) should not be
 	// used together — disable the `open` control to avoid confusion.
 	argTypes: { open: { control: false } },
-	args: {
-		...Default.args,
-		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Collapsed by default</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>This content was hidden until you expanded it.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header>
+				<Card.Title>Collapsed by default</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Text>This content was hidden until you expanded it.</Text>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	),
 };
 
 /**
  * A disabled collapsible card cannot be toggled by the user.
  */
 export const Disabled: Story = {
-	args: {
-		...Default.args,
-		disabled: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Disabled card</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>The header is not interactive when disabled.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<CollapsibleCard.Root disabled>
+			<CollapsibleCard.Header>
+				<Card.Title>Disabled card</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Text>The header is not interactive when disabled.</Text>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	),
 };
 
 /**
@@ -121,7 +109,7 @@ export const Disabled: Story = {
  */
 export const Stacked: Story = {
 	parameters: { controls: { disable: true } },
-	render: () => (
+	render: ( {} ) => (
 		<div
 			style={ {
 				display: 'flex',
@@ -175,7 +163,7 @@ export const Stacked: Story = {
  */
 export const WithHeadingElement: Story = {
 	parameters: { controls: { disable: true } },
-	render: () => (
+	render: ( {} ) => (
 		<div
 			style={ {
 				display: 'flex',
@@ -275,7 +263,6 @@ export const ComparedToCard: Story = {
 	// used together — disable the `open` control to avoid confusion.
 	argTypes: { open: { control: false } },
 	args: {
-		...Default.args,
 		defaultOpen: true,
 	},
 	render: ( { open, defaultOpen, onOpenChange, disabled, ...restArgs } ) => (
@@ -325,27 +312,24 @@ export const ComparedToCard: Story = {
  */
 export const FullBleedCoverWithHeader: Story = {
 	argTypes: { open: { control: false } },
-	args: {
-		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Card title</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</CollapsibleCard.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header>
+				<Card.Title>Card title</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	),
 };
 
 /**
@@ -355,28 +339,25 @@ export const FullBleedCoverWithHeader: Story = {
  */
 export const WithFullBleed: Story = {
 	argTypes: { open: { control: false } },
-	args: {
-		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Featured image</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content
-					render={ <Stack direction="column" gap="lg" /> }
-				>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 160,
-								background:
-									'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Text>Content below the full-bleed area.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header>
+				<Card.Title>Featured image</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content
+				render={ <Stack direction="column" gap="lg" /> }
+			>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 160,
+							background:
+								'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Text>Content below the full-bleed area.</Text>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	),
 };

--- a/packages/ui/src/collapsible/stories/index.story.tsx
+++ b/packages/ui/src/collapsible/stories/index.story.tsx
@@ -22,45 +22,37 @@ export default meta;
 type Story = StoryObj< typeof Collapsible.Root >;
 
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>Collapsible content here.</p>
-				</Collapsible.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Collapsible.Root>
+			<Collapsible.Trigger>Toggle</Collapsible.Trigger>
+			<Collapsible.Panel>
+				<p>Collapsible content here.</p>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	),
 };
 
 export const DefaultOpen: Story = {
 	argTypes: { open: { control: false } },
-	args: {
-		defaultOpen: true,
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>This panel is open by default.</p>
-				</Collapsible.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Collapsible.Root defaultOpen>
+			<Collapsible.Trigger>Toggle</Collapsible.Trigger>
+			<Collapsible.Panel>
+				<p>This panel is open by default.</p>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	),
 };
 
 export const Disabled: Story = {
-	args: {
-		disabled: true,
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle (disabled)</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>This content cannot be toggled.</p>
-				</Collapsible.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Collapsible.Root disabled>
+			<Collapsible.Trigger>Toggle (disabled)</Collapsible.Trigger>
+			<Collapsible.Panel>
+				<p>This content cannot be toggled.</p>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	),
 };
 
 /**
@@ -71,27 +63,25 @@ export const Disabled: Story = {
  * match — improving discoverability without sacrificing the collapsed layout.
  */
 export const HiddenUntilFound: Story = {
-	render: function HiddenUntilFound() {
-		return (
-			<div>
-				<p>
-					Use the browser&apos;s find-in-page (Ctrl/Cmd+F) to search
-					for &quot;hidden treasure&quot;. The collapsed panel will
-					automatically expand to reveal the match.
-				</p>
-				<Collapsible.Root>
-					<Collapsible.Trigger>Expand to reveal</Collapsible.Trigger>
-					<Collapsible.Panel hiddenUntilFound>
-						<p>
-							This is the hidden treasure that can be found via
-							the browser&apos;s built-in page search even while
-							the panel is collapsed.
-						</p>
-					</Collapsible.Panel>
-				</Collapsible.Root>
-			</div>
-		);
-	},
+	render: ( {} ) => (
+		<div>
+			<p>
+				Use the browser&apos;s find-in-page (Ctrl/Cmd+F) to search for
+				&quot;hidden treasure&quot;. The collapsed panel will
+				automatically expand to reveal the match.
+			</p>
+			<Collapsible.Root>
+				<Collapsible.Trigger>Expand to reveal</Collapsible.Trigger>
+				<Collapsible.Panel hiddenUntilFound>
+					<p>
+						This is the hidden treasure that can be found via the
+						browser&apos;s built-in page search even while the panel
+						is collapsed.
+					</p>
+				</Collapsible.Panel>
+			</Collapsible.Root>
+		</div>
+	),
 };
 
 export const Controlled: Story = {
@@ -99,7 +89,7 @@ export const Controlled: Story = {
 		open: { control: false },
 		defaultOpen: { control: false },
 	},
-	render: function Controlled() {
+	render: function Controlled( {} ) {
 		const [ open, setOpen ] = useState( false );
 		return (
 			<Collapsible.Root open={ open } onOpenChange={ setOpen }>

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -43,29 +43,27 @@ type Story = StoryObj< typeof Dialog.Root >;
  * what happens when clicking the close icon.
  */
 export const _Default: Story = {
-	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup>
-					<Dialog.Header>
-						<Dialog.Title>Welcome</Dialog.Title>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<Dialog.Description>
-							This dialog demonstrates best practices for
-							informational dialogs. It includes a close icon
-							because dismissing it is safe and expected.
-						</Dialog.Description>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Dialog.Root>
+			<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+			<Dialog.Popup>
+				<Dialog.Header>
+					<Dialog.Title>Welcome</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description>
+						This dialog demonstrates best practices for
+						informational dialogs. It includes a close icon because
+						dismissing it is safe and expected.
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	),
 };
 
 const ALL_SIZES = [ 'small', 'medium', 'large', 'stretch', 'full' ] as const;
@@ -135,9 +133,11 @@ function SizePlaygroundContent() {
 }
 
 export const AllSizes: Story = {
-	args: {
-		children: <SizePlaygroundContent />,
-	},
+	render: ( {} ) => (
+		<Dialog.Root>
+			<SizePlaygroundContent />
+		</Dialog.Root>
+	),
 };
 
 /**
@@ -158,35 +158,33 @@ export const AllSizes: Story = {
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
-	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup
-					portal={
-						<Dialog.Portal
-							style={ { '--wp-ui-dialog-z-index': '9999' } }
-						/>
-					}
-				>
-					<Dialog.Header>
-						<Dialog.Title>Custom z-index</Dialog.Title>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<Dialog.Description>
-							The backdrop and popup render at `z-index: 9999` via
-							the `--wp-ui-dialog-z-index` CSS custom property,
-							set on `Dialog.Portal` through the `portal` prop.
-						</Dialog.Description>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Dialog.Root>
+			<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+			<Dialog.Popup
+				portal={
+					<Dialog.Portal
+						style={ { '--wp-ui-dialog-z-index': '9999' } }
+					/>
+				}
+			>
+				<Dialog.Header>
+					<Dialog.Title>Custom z-index</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description>
+						The backdrop and popup render at `z-index: 9999` via the
+						`--wp-ui-dialog-z-index` CSS custom property, set on
+						`Dialog.Portal` through the `portal` prop.
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	),
 };
 
 function StickyToggle( {
@@ -307,9 +305,11 @@ function ScrollableContent() {
  * dialog and stay in sync.
  */
 export const Scrollable: Story = {
-	args: {
-		children: <ScrollableContent />,
-	},
+	render: ( {} ) => (
+		<Dialog.Root>
+			<ScrollableContent />
+		</Dialog.Root>
+	),
 };
 
 /**
@@ -320,29 +320,26 @@ export const Scrollable: Story = {
  * keeps its `<h2>` element while being visually hidden.
  */
 export const WithVisuallyHiddenTitle: Story = {
-	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup>
-					<Dialog.Header>
-						<VisuallyHidden render={ <Dialog.Title /> }>
-							Accessible dialog heading
-						</VisuallyHidden>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<p style={ { margin: 0 } }>
-							This dialog has a visually hidden title. Inspect the
-							DOM or use a screen reader to verify the heading is
-							present.
-						</p>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Dialog.Root>
+			<Dialog.Trigger>Open Dialog</Dialog.Trigger>
+			<Dialog.Popup>
+				<Dialog.Header>
+					<VisuallyHidden render={ <Dialog.Title /> }>
+						Accessible dialog heading
+					</VisuallyHidden>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<p style={ { margin: 0 } }>
+						This dialog has a visually hidden title. Inspect the DOM
+						or use a screen reader to verify the heading is present.
+					</p>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	),
 };

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -42,27 +42,25 @@ type Story = StoryObj< typeof Drawer.Root >;
  * experiment with `swipeDirection` and `modal`.
  */
 export const _Default: Story = {
-	args: {
-		children: (
-			<>
-				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-				<Drawer.Popup>
-					<Drawer.Header>
-						<Drawer.Title>Navigation</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							Browse through the available sections below.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Done</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Drawer.Root>
+			<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Navigation</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						Browse through the available sections below.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Done</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	),
 };
 
 const directions = [
@@ -128,13 +126,6 @@ export const Controlled: Story = {
 		const [ open, setOpen ] = useState( false );
 		return (
 			<Drawer.Root { ...args } open={ open } onOpenChange={ setOpen }>
-				{ args.children }
-			</Drawer.Root>
-		);
-	},
-	args: {
-		children: (
-			<>
 				<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
 				<Drawer.Popup>
 					<Drawer.Header>
@@ -151,8 +142,8 @@ export const Controlled: Story = {
 						<Drawer.Action>Close</Drawer.Action>
 					</Drawer.Footer>
 				</Drawer.Popup>
-			</>
-		),
+			</Drawer.Root>
+		);
 	},
 	argTypes: {
 		open: { control: false },
@@ -167,33 +158,26 @@ export const Controlled: Story = {
  * Users can interact with content behind the drawer while it is open.
  */
 export const NonModal: Story = {
-	args: {
-		swipeDirection: 'right',
-		modal: false,
-		children: (
-			<>
-				<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
-				<Drawer.Popup>
-					<Drawer.Header>
-						<Drawer.Title>Non-Modal</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							This drawer does not trap focus and allows
-							interaction with the rest of the page while open.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Close</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
-	},
-	render: function NonModalRender( args ) {
-		return <Drawer.Root { ...args }>{ args.children }</Drawer.Root>;
-	},
+	render: ( {} ) => (
+		<Drawer.Root swipeDirection="right" modal={ false }>
+			<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
+			<Drawer.Popup>
+				<Drawer.Header>
+					<Drawer.Title>Non-Modal</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						This drawer does not trap focus and allows interaction
+						with the rest of the page while open.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	),
 };
 
 const ALL_SIZES: NonNullable<
@@ -285,36 +269,34 @@ function DirectionSelector( {
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
-	args: {
-		children: (
-			<>
-				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-				<Drawer.Popup
-					portal={
-						<Drawer.Portal
-							style={ { '--wp-ui-drawer-z-index': '9999' } }
-						/>
-					}
-				>
-					<Drawer.Header>
-						<Drawer.Title>Custom z-index</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							The backdrop, viewport, and popup render at
-							`z-index: 9999` via the `--wp-ui-drawer-z-index` CSS
-							custom property, set on `Drawer.Portal` through the
-							`portal` prop.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Got it</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Drawer.Root>
+			<Drawer.Trigger>Open Drawer</Drawer.Trigger>
+			<Drawer.Popup
+				portal={
+					<Drawer.Portal
+						style={ { '--wp-ui-drawer-z-index': '9999' } }
+					/>
+				}
+			>
+				<Drawer.Header>
+					<Drawer.Title>Custom z-index</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						The backdrop, viewport, and popup render at `z-index:
+						9999` via the `--wp-ui-drawer-z-index` CSS custom
+						property, set on `Drawer.Portal` through the `portal`
+						prop.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Got it</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	),
 };
 
 /**

--- a/packages/ui/src/empty-state/stories/index.story.tsx
+++ b/packages/ui/src/empty-state/stories/index.story.tsx
@@ -31,47 +31,43 @@ export default meta;
 type Story = StoryObj< typeof EmptyState.Root >;
 
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<EmptyState.Icon icon={ search } />
-				<EmptyState.Title>No results found</EmptyState.Title>
-				<EmptyState.Description>
-					Try adjusting your search or filter to find what you&apos;re
-					looking for.
-				</EmptyState.Description>
-				<EmptyState.Actions>
-					<Button variant="outline">Clear filters</Button>
-					<Button>Add item</Button>
-				</EmptyState.Actions>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<EmptyState.Root>
+			<EmptyState.Icon icon={ search } />
+			<EmptyState.Title>No results found</EmptyState.Title>
+			<EmptyState.Description>
+				Try adjusting your search or filter to find what you&apos;re
+				looking for.
+			</EmptyState.Description>
+			<EmptyState.Actions>
+				<Button variant="outline">Clear filters</Button>
+				<Button>Add item</Button>
+			</EmptyState.Actions>
+		</EmptyState.Root>
+	),
 };
 
 export const WithCustomVisual: Story = {
-	args: {
-		children: (
-			<>
-				<EmptyState.Visual>
-					<svg
-						width="50"
-						height="50"
-						viewBox="0 0 50 50"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<circle cx="25" cy="25" r="25" fill="currentColor" />
-					</svg>
-				</EmptyState.Visual>
-				<EmptyState.Title>All caught up!</EmptyState.Title>
-				<EmptyState.Description>
-					You&apos;ve completed all your tasks. Great work!
-				</EmptyState.Description>
-				<EmptyState.Actions>
-					<Button>Create new task</Button>
-				</EmptyState.Actions>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<EmptyState.Root>
+			<EmptyState.Visual>
+				<svg
+					width="50"
+					height="50"
+					viewBox="0 0 50 50"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<circle cx="25" cy="25" r="25" fill="currentColor" />
+				</svg>
+			</EmptyState.Visual>
+			<EmptyState.Title>All caught up!</EmptyState.Title>
+			<EmptyState.Description>
+				You&apos;ve completed all your tasks. Great work!
+			</EmptyState.Description>
+			<EmptyState.Actions>
+				<Button>Create new task</Button>
+			</EmptyState.Actions>
+		</EmptyState.Root>
+	),
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -52,29 +52,29 @@ type Story = StoryObj< typeof Autocomplete.Root >;
 export const Default: Story = {
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Enter a URL" type="url" />
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
 	},
+	render: ( { items = URLS } ) => (
+		<Autocomplete.Root items={ items }>
+			<Autocomplete.Input placeholder="Enter a URL" type="url" />
+			<Autocomplete.Popup>
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>
+		</Autocomplete.Root>
+	),
 };
 
 /**
@@ -226,55 +226,55 @@ export const Inline: Story = {
 export const WithSearchIconAndClearButton: Story = {
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.InputGroup>
-					<Autocomplete.Input
-						placeholder="Search URLs"
-						type="url"
-						render={
-							<Input
-								prefix={
-									<InputLayout.Slot padding="minimal">
-										<Icon icon={ search } />
-									</InputLayout.Slot>
-								}
-								suffix={
-									<InputLayout.Slot padding="minimal">
-										<Autocomplete.Clear />
-									</InputLayout.Slot>
-								}
-							/>
-						}
-					/>
-				</Autocomplete.InputGroup>
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
 	},
+	render: ( { items = URLS } ) => (
+		<Autocomplete.Root items={ items }>
+			<Autocomplete.InputGroup>
+				<Autocomplete.Input
+					placeholder="Search URLs"
+					type="url"
+					render={
+						<Input
+							prefix={
+								<InputLayout.Slot padding="minimal">
+									<Icon icon={ search } />
+								</InputLayout.Slot>
+							}
+							suffix={
+								<InputLayout.Slot padding="minimal">
+									<Autocomplete.Clear />
+								</InputLayout.Slot>
+							}
+						/>
+					}
+				/>
+			</Autocomplete.InputGroup>
+			<Autocomplete.Popup>
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>
+		</Autocomplete.Root>
+	),
 };
 
 /**
  * Experimental: Textarea with inline autocomplete triggered by `@`.
  */
 export const TextareaInlineAutocomplete: Story = {
-	render: function Template() {
+	render: function Template( {} ) {
 		const textareaRef = useRef< HTMLTextAreaElement >( null );
 		const [ value, setValue ] = useState( '' );
 		const [ open, setOpen ] = useState( false );
@@ -424,34 +424,34 @@ export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Enter a URL" type="url" />
-				<Autocomplete.Popup
-					portal={
-						<Autocomplete.Portal
-							style={ { '--wp-ui-autocomplete-z-index': '9999' } }
-						/>
-					}
-				>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
 	},
+	render: ( { items = URLS } ) => (
+		<Autocomplete.Root items={ items }>
+			<Autocomplete.Input placeholder="Enter a URL" type="url" />
+			<Autocomplete.Popup
+				portal={
+					<Autocomplete.Portal
+						style={ { '--wp-ui-autocomplete-z-index': '9999' } }
+					/>
+				}
+			>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>
+		</Autocomplete.Root>
+	),
 };
 
 /**
@@ -461,39 +461,39 @@ export const WithCustomZIndex: Story = {
 export const Grouped: Story = {
 	args: {
 		items: GROUPED_COMMANDS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Type a command" />
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( group: FixtureGroup ) => (
-									<Autocomplete.Group
-										key={ group.label }
-										items={ group.items }
-									>
-										<Autocomplete.GroupLabel>
-											{ group.label }
-										</Autocomplete.GroupLabel>
-										<Autocomplete.Collection>
-											{ ( item: FixtureItem ) => (
-												<Autocomplete.Item
-													key={ item.id }
-													value={ item }
-												>
-													{ item.value }
-												</Autocomplete.Item>
-											) }
-										</Autocomplete.Collection>
-									</Autocomplete.Group>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
 	},
+	render: ( { items = GROUPED_COMMANDS } ) => (
+		<Autocomplete.Root items={ items }>
+			<Autocomplete.Input placeholder="Type a command" />
+			<Autocomplete.Popup>
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( group: FixtureGroup ) => (
+								<Autocomplete.Group
+									key={ group.label }
+									items={ group.items }
+								>
+									<Autocomplete.GroupLabel>
+										{ group.label }
+									</Autocomplete.GroupLabel>
+									<Autocomplete.Collection>
+										{ ( item: FixtureItem ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.Group>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>
+		</Autocomplete.Root>
+	),
 };

--- a/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
@@ -43,65 +43,65 @@ const inputWrapperStyle = {
 export const Default: Story = {
 	args: {
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger />
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
 	},
+	render: ( { items = ITEMS } ) => (
+		<Combobox.Root items={ items }>
+			<Combobox.Trigger />
+			<Combobox.Popup>
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>
+		</Combobox.Root>
+	),
 };
 
 export const Compact: Story = {
 	args: {
 		defaultValue: ITEMS[ 0 ],
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger size="compact" />
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-										size="compact"
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
 	},
+	render: ( { items = ITEMS, defaultValue } ) => (
+		<Combobox.Root items={ items } defaultValue={ defaultValue }>
+			<Combobox.Trigger size="compact" />
+			<Combobox.Popup>
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+									size="compact"
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>
+		</Combobox.Root>
+	),
 };
 
 /**
@@ -116,34 +116,31 @@ export const DetachedInline: Story = {
 		items: ITEMS,
 		multiple: true,
 		inline: true,
-		children: (
-			<>
-				<Combobox.Input placeholder="Search" />
-				<div
-					style={ {
-						minHeight: '200px',
-						maxHeight: '200px',
-						marginTop: 8,
-						overflow: 'auto',
-					} }
-				>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.Collection>
-							{ ( item: FixtureItem ) => (
-								<Combobox.Item
-									key={ item.value }
-									value={ item }
-								>
-									{ item.label }
-								</Combobox.Item>
-							) }
-						</Combobox.Collection>
-					</Combobox.List>
-				</div>
-			</>
-		),
 	},
+	render: ( { items = ITEMS, multiple, inline } ) => (
+		<Combobox.Root items={ items } multiple={ multiple } inline={ inline }>
+			<Combobox.Input placeholder="Search" />
+			<div
+				style={ {
+					minHeight: '200px',
+					maxHeight: '200px',
+					marginTop: 8,
+					overflow: 'auto',
+				} }
+			>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.Collection>
+						{ ( item: FixtureItem ) => (
+							<Combobox.Item key={ item.value } value={ item }>
+								{ item.label }
+							</Combobox.Item>
+						) }
+					</Combobox.Collection>
+				</Combobox.List>
+			</div>
+		</Combobox.Root>
+	),
 };
 
 export const Creatable: Story = {
@@ -280,67 +277,67 @@ export const WithCustomTriggerAndItem: Story = {
 	args: {
 		items: ITEMS,
 		defaultValue: ITEMS[ 0 ],
-		children: (
-			<>
-				<Combobox.Trigger>
-					{ ( item: FixtureItem ) => (
-						<span
-							style={ {
-								display: 'flex',
-								alignItems: 'center',
-								gap: 8,
-							} }
-						>
-							<img
-								src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
-								alt=""
-								width="20"
-								style={ {
-									borderRadius: '50%',
-								} }
-							/>
-							{ item.label }
-						</span>
-					) }
-				</Combobox.Trigger>
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-										aria-describedby={ `description-${ item.value }` }
-									>
-										<div
-											style={ {
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'space-between',
-												flexGrow: 1,
-											} }
-										>
-											<span>{ item.label }</span>
-											<span
-												id={ `description-${ item.value }` }
-												aria-hidden="true"
-											>
-												99 in stock
-											</span>
-										</div>
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
 	},
+	render: ( { items = ITEMS, defaultValue } ) => (
+		<Combobox.Root items={ items } defaultValue={ defaultValue }>
+			<Combobox.Trigger>
+				{ ( item: FixtureItem ) => (
+					<span
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+						} }
+					>
+						<img
+							src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
+							alt=""
+							width="20"
+							style={ {
+								borderRadius: '50%',
+							} }
+						/>
+						{ item.label }
+					</span>
+				) }
+			</Combobox.Trigger>
+			<Combobox.Popup>
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+									aria-describedby={ `description-${ item.value }` }
+								>
+									<div
+										style={ {
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'space-between',
+											flexGrow: 1,
+										} }
+									>
+										<span>{ item.label }</span>
+										<span
+											id={ `description-${ item.value }` }
+											aria-hidden="true"
+										>
+											99 in stock
+										</span>
+									</div>
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>
+		</Combobox.Root>
+	),
 };
 
 /**
@@ -362,37 +359,37 @@ export const WithCustomZIndex: Story = {
 	args: {
 		defaultValue: ITEMS[ 0 ],
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger />
-				<Combobox.Popup
-					positioner={
-						<Combobox.Positioner
-							style={ {
-								'--wp-ui-combobox-z-index': '9999',
-							} }
-						/>
-					}
-				>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
 	},
+	render: ( { items = ITEMS, defaultValue } ) => (
+		<Combobox.Root items={ items } defaultValue={ defaultValue }>
+			<Combobox.Trigger />
+			<Combobox.Popup
+				positioner={
+					<Combobox.Positioner
+						style={ {
+							'--wp-ui-combobox-z-index': '9999',
+						} }
+					/>
+				}
+			>
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>
+		</Combobox.Root>
+	),
 };

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -29,19 +29,15 @@ export default meta;
  * you can simply place your control in the `render` prop of `Field.Control`.
  */
 export const Default: StoryObj< typeof Field.Root > = {
-	args: {
-		children: (
-			<>
-				<Field.Label>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-				<Field.Description>
-					The accessible description.
-				</Field.Description>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Field.Root>
+			<Field.Label>Label</Field.Label>
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+			/>
+			<Field.Description>The accessible description.</Field.Description>
+		</Field.Root>
+	),
 };
 
 const MyNonRefForwardingControl = (
@@ -113,16 +109,14 @@ export const UsingAriaLabelledby: StoryObj< typeof Field.Root > = {
  * hidden but remains accessible to screen readers.
  */
 export const HiddenLabel: StoryObj< typeof Field.Root > = {
-	args: {
-		children: (
-			<>
-				<Field.Label hideFromVision>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Field.Root>
+			<Field.Label hideFromVision>Label</Field.Label>
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+			/>
+		</Field.Root>
+	),
 };
 
 /**
@@ -136,15 +130,13 @@ export const HiddenLabel: StoryObj< typeof Field.Root > = {
  * so the readout is not unnecessarily verbose for screen reader users.
  */
 export const WithDetails: StoryObj< typeof Field.Root > = {
-	args: {
-		children: (
-			<>
-				<Field.Label>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-				<Field.Details>{ DETAILS_EXAMPLE }</Field.Details>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Field.Root>
+			<Field.Label>Label</Field.Label>
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+			/>
+			<Field.Details>{ DETAILS_EXAMPLE }</Field.Details>
+		</Field.Root>
+	),
 };

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -23,22 +23,20 @@ export default meta;
 type Story = StoryObj< typeof Fieldset.Root >;
 
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<Fieldset.Legend>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-				<Fieldset.Description>
-					This is a description for the entire fieldset.
-				</Fieldset.Description>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Fieldset.Root>
+			<Fieldset.Legend>Legend</Fieldset.Legend>
+			{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ) }
+			<Fieldset.Description>
+				This is a description for the entire fieldset.
+			</Fieldset.Description>
+		</Fieldset.Root>
+	),
 };
 
 /**
@@ -46,19 +44,17 @@ export const Default: Story = {
  * hidden but remains accessible to screen readers.
  */
 export const HiddenLegend: Story = {
-	args: {
-		children: (
-			<>
-				<Fieldset.Legend hideFromVision>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Fieldset.Root>
+			<Fieldset.Legend hideFromVision>Legend</Fieldset.Legend>
+			{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ) }
+		</Fieldset.Root>
+	),
 };
 
 /**
@@ -72,18 +68,16 @@ export const HiddenLegend: Story = {
  * so the readout is not unnecessarily verbose for screen reader users.
  */
 export const WithDetails: Story = {
-	args: {
-		children: (
-			<>
-				<Fieldset.Legend>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-				<Fieldset.Details>{ DETAILS_EXAMPLE }</Fieldset.Details>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Fieldset.Root>
+			<Fieldset.Legend>Legend</Fieldset.Legend>
+			{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ) }
+			<Fieldset.Details>{ DETAILS_EXAMPLE }</Fieldset.Details>
+		</Fieldset.Root>
+	),
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -23,49 +23,79 @@ export default meta;
 
 type Story = StoryObj< typeof Select.Root >;
 
-const defaultItems = Array.from( { length: 6 }, ( _, index ) => ( {
-	value: `item-${ index + 1 }`,
-	label: `Item ${ index + 1 }`,
-} ) );
+type SelectStoryItem = {
+	value: string | null;
+	label: string;
+	disabled?: boolean;
+};
+
+type SelectStoryArgs = {
+	items?: readonly SelectStoryItem[];
+	defaultValue?: SelectStoryItem | string | null;
+	disabled?: boolean;
+};
+
+function resolveItems(
+	items: unknown,
+	fallback: readonly SelectStoryItem[]
+): SelectStoryItem[] {
+	return Array.isArray( items )
+		? ( items as SelectStoryItem[] )
+		: [ ...fallback ];
+}
+
+const defaultItems: SelectStoryItem[] = Array.from(
+	{ length: 6 },
+	( _, index ) => ( {
+		value: `item-${ index + 1 }`,
+		label: `Item ${ index + 1 }`,
+	} )
+);
 
 export const Default: Story = {
 	args: {
 		items: defaultItems,
 	},
-	render: ( { items = defaultItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 export const Compact: Story = {
 	args: {
 		...Default.args,
 	},
-	render: ( { items = defaultItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger size="compact" />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item
-						key={ item.value }
-						value={ item }
-						size="compact"
-					>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger size="compact" />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item
+							key={ item.value }
+							value={ item }
+							size="compact"
+						>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 /**
@@ -106,21 +136,24 @@ export const WithCustomPlaceholder: Story = {
 	args: {
 		items: defaultItems,
 	},
-	render: ( { items = defaultItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger placeholder="Choose an item" />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger placeholder="Choose an item" />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
-const nullValueOptionItems = [
+const nullValueOptionItems: SelectStoryItem[] = [
 	{ value: null, label: 'Select theme' },
 	{ value: 'system', label: 'System default' },
 	{ value: 'light', label: 'Light' },
@@ -136,21 +169,24 @@ export const WithNullValueOption: Story = {
 	args: {
 		items: nullValueOptionItems,
 	},
-	render: ( { items = nullValueOptionItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item
-						key={ item.value ?? 'null' }
-						value={ item.value }
-					>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, nullValueOptionItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item
+							key={ item.value ?? 'null' }
+							value={ item.value }
+						>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 /**
@@ -163,24 +199,27 @@ export const Labeling: Story = {
 	args: {
 		...Default.args,
 	},
-	render: ( { items = defaultItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger aria-label="User role" />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger aria-label="User role" />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 const longItemValue =
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
 
-const overflowItems = [
+const overflowItems: SelectStoryItem[] = [
 	{
 		value: 'long-item',
 		label: longItemValue,
@@ -196,18 +235,22 @@ export const WithOverflow: Story = {
 		items: overflowItems,
 		defaultValue: overflowItems[ 0 ],
 	},
-	render: ( { items = overflowItems, defaultValue } ) => (
-		<Select.Root items={ items } defaultValue={ defaultValue }>
-			<Select.Trigger />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const { defaultValue } = args as SelectStoryArgs;
+		const items = resolveItems( args.items, overflowItems );
+		return (
+			<Select.Root items={ items } defaultValue={ defaultValue }>
+				<Select.Trigger />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 export const Disabled: Story = {
@@ -216,25 +259,29 @@ export const Disabled: Story = {
 		defaultValue: defaultItems[ 0 ],
 		disabled: true,
 	},
-	render: ( { items = defaultItems, defaultValue, disabled } ) => (
-		<Select.Root
-			items={ items }
-			defaultValue={ defaultValue }
-			disabled={ disabled }
-		>
-			<Select.Trigger />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const { defaultValue, disabled } = args as SelectStoryArgs;
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root
+				items={ items }
+				defaultValue={ defaultValue }
+				disabled={ disabled }
+			>
+				<Select.Trigger />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
-const disabledItemItems = [
+const disabledItemItems: SelectStoryItem[] = [
 	{
 		value: 'item-1',
 		label: 'Item 1',
@@ -251,25 +298,29 @@ export const WithDisabledItem: Story = {
 		items: disabledItemItems,
 		defaultValue: disabledItemItems[ 0 ],
 	},
-	render: ( { items = disabledItemItems, defaultValue } ) => (
-		<Select.Root items={ items } defaultValue={ defaultValue }>
-			<Select.Trigger />
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item
-						key={ item.value }
-						value={ item }
-						disabled={ item.disabled }
-					>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const { defaultValue } = args as SelectStoryArgs;
+		const items = resolveItems( args.items, disabledItemItems );
+		return (
+			<Select.Root items={ items } defaultValue={ defaultValue }>
+				<Select.Trigger />
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item
+							key={ item.value }
+							value={ item }
+							disabled={ item.disabled }
+						>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
-const customOptions = [
+const customOptions: SelectStoryItem[] = [
 	{
 		value: 'user-1',
 		label: 'User 1 (Admin)',
@@ -289,38 +340,42 @@ export const WithCustomTriggerAndItem: Story = {
 		items: customOptions,
 		defaultValue: customOptions[ 0 ],
 	},
-	render: ( { items = customOptions, defaultValue } ) => (
-		<Select.Root items={ items } defaultValue={ defaultValue }>
-			<Select.Trigger>
-				{ ( item ) => (
-					<span
-						style={ {
-							display: 'flex',
-							alignItems: 'center',
-							gap: 8,
-						} }
-					>
-						<img
-							src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
-							alt=""
-							width="20"
+	render: ( args ) => {
+		const { defaultValue } = args as SelectStoryArgs;
+		const items = resolveItems( args.items, customOptions );
+		return (
+			<Select.Root items={ items } defaultValue={ defaultValue }>
+				<Select.Trigger>
+					{ ( item ) => (
+						<span
 							style={ {
-								borderRadius: '50%',
+								display: 'flex',
+								alignItems: 'center',
+								gap: 8,
 							} }
-						/>
-						{ item.label }
-					</span>
-				) }
-			</Select.Trigger>
-			<Select.Popup>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+						>
+							<img
+								src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
+								alt=""
+								width="20"
+								style={ {
+									borderRadius: '50%',
+								} }
+							/>
+							{ item.label }
+						</span>
+					) }
+				</Select.Trigger>
+				<Select.Popup>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };
 
 /**
@@ -344,22 +399,25 @@ export const WithCustomZIndex: Story = {
 	args: {
 		...Default.args,
 	},
-	render: ( { items = defaultItems } ) => (
-		<Select.Root items={ items }>
-			<Select.Trigger />
-			<Select.Popup
-				portal={
-					<Select.Portal
-						style={ { '--wp-ui-select-z-index': '9999' } }
-					/>
-				}
-			>
-				{ items.map( ( item ) => (
-					<Select.Item key={ item.value } value={ item }>
-						{ item.label }
-					</Select.Item>
-				) ) }
-			</Select.Popup>
-		</Select.Root>
-	),
+	render: ( args ) => {
+		const items = resolveItems( args.items, defaultItems );
+		return (
+			<Select.Root items={ items }>
+				<Select.Trigger />
+				<Select.Popup
+					portal={
+						<Select.Portal
+							style={ { '--wp-ui-select-z-index': '9999' } }
+						/>
+					}
+				>
+					{ items.map( ( item ) => (
+						<Select.Item key={ item.value } value={ item }>
+							{ item.label }
+						</Select.Item>
+					) ) }
+				</Select.Popup>
+			</Select.Root>
+		);
+	},
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -31,41 +31,41 @@ const defaultItems = Array.from( { length: 6 }, ( _, index ) => ( {
 export const Default: Story = {
 	args: {
 		items: defaultItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = defaultItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 export const Compact: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger size="compact" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value }
-							value={ item }
-							size="compact"
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = defaultItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger size="compact" />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item
+						key={ item.value }
+						value={ item }
+						size="compact"
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 /**
@@ -78,24 +78,24 @@ export const Compact: Story = {
  */
 export const Minimal: Story = {
 	args: {
-		children: (
-			<>
-				<Select.Trigger size="small" variant="minimal" />
-				<Select.Popup>
-					{ Array.from( { length: 6 }, ( _, index ) => (
-						<Select.Item
-							key={ index }
-							value={ `${ index + 1 }` }
-							size="small"
-						>
-							{ `${ index + 1 }` }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 		defaultValue: '1',
 	},
+	render: ( { defaultValue } ) => (
+		<Select.Root defaultValue={ defaultValue }>
+			<Select.Trigger size="small" variant="minimal" />
+			<Select.Popup>
+				{ Array.from( { length: 6 }, ( _, index ) => (
+					<Select.Item
+						key={ index }
+						value={ `${ index + 1 }` }
+						size="small"
+					>
+						{ `${ index + 1 }` }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 /**
@@ -105,19 +105,19 @@ export const Minimal: Story = {
 export const WithCustomPlaceholder: Story = {
 	args: {
 		items: defaultItems,
-		children: (
-			<>
-				<Select.Trigger placeholder="Choose an item" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = defaultItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger placeholder="Choose an item" />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 const nullValueOptionItems = [
@@ -135,22 +135,22 @@ const nullValueOptionItems = [
 export const WithNullValueOption: Story = {
 	args: {
 		items: nullValueOptionItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ nullValueOptionItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value ?? 'null' }
-							value={ item.value }
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = nullValueOptionItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item
+						key={ item.value ?? 'null' }
+						value={ item.value }
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 /**
@@ -162,19 +162,19 @@ export const WithNullValueOption: Story = {
 export const Labeling: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger aria-label="User role" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = defaultItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger aria-label="User role" />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 const longItemValue =
@@ -194,40 +194,44 @@ const overflowItems = [
 export const WithOverflow: Story = {
 	args: {
 		items: overflowItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ overflowItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 		defaultValue: overflowItems[ 0 ],
 	},
+	render: ( { items = overflowItems, defaultValue } ) => (
+		<Select.Root items={ items } defaultValue={ defaultValue }>
+			<Select.Trigger />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 export const Disabled: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 		defaultValue: defaultItems[ 0 ],
 		disabled: true,
 	},
+	render: ( { items = defaultItems, defaultValue, disabled } ) => (
+		<Select.Root
+			items={ items }
+			defaultValue={ defaultValue }
+			disabled={ disabled }
+		>
+			<Select.Trigger />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 const disabledItemItems = [
@@ -245,24 +249,24 @@ const disabledItemItems = [
 export const WithDisabledItem: Story = {
 	args: {
 		items: disabledItemItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ disabledItemItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value }
-							value={ item }
-							disabled={ item.disabled }
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 		defaultValue: disabledItemItems[ 0 ],
 	},
+	render: ( { items = disabledItemItems, defaultValue } ) => (
+		<Select.Root items={ items } defaultValue={ defaultValue }>
+			<Select.Trigger />
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item
+						key={ item.value }
+						value={ item }
+						disabled={ item.disabled }
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 const customOptions = [
@@ -283,40 +287,40 @@ const customOptions = [
 export const WithCustomTriggerAndItem: Story = {
 	args: {
 		items: customOptions,
-		children: (
-			<>
-				<Select.Trigger>
-					{ ( item ) => (
-						<span
-							style={ {
-								display: 'flex',
-								alignItems: 'center',
-								gap: 8,
-							} }
-						>
-							<img
-								src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
-								alt=""
-								width="20"
-								style={ {
-									borderRadius: '50%',
-								} }
-							/>
-							{ item.label }
-						</span>
-					) }
-				</Select.Trigger>
-				<Select.Popup>
-					{ customOptions.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 		defaultValue: customOptions[ 0 ],
 	},
+	render: ( { items = customOptions, defaultValue } ) => (
+		<Select.Root items={ items } defaultValue={ defaultValue }>
+			<Select.Trigger>
+				{ ( item ) => (
+					<span
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+						} }
+					>
+						<img
+							src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
+							alt=""
+							width="20"
+							style={ {
+								borderRadius: '50%',
+							} }
+						/>
+						{ item.label }
+					</span>
+				) }
+			</Select.Trigger>
+			<Select.Popup>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };
 
 /**
@@ -339,23 +343,23 @@ export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup
-					portal={
-						<Select.Portal
-							style={ { '--wp-ui-select-z-index': '9999' } }
-						/>
-					}
-				>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
 	},
+	render: ( { items = defaultItems } ) => (
+		<Select.Root items={ items }>
+			<Select.Trigger />
+			<Select.Popup
+				portal={
+					<Select.Portal
+						style={ { '--wp-ui-select-z-index': '9999' } }
+					/>
+				}
+			>
+				{ items.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>
+		</Select.Root>
+	),
 };

--- a/packages/ui/src/form/select-control/stories/index.story.tsx
+++ b/packages/ui/src/form/select-control/stories/index.story.tsx
@@ -175,21 +175,25 @@ export const WithCustomTriggerAndItems: Story = {
 		label: 'Label',
 		description: 'This is the description.',
 		triggerContent: ( item ) => <User user={ item } />,
-		children: (
-			<>
-				{ userOptions.map( ( item ) => (
-					<SelectControl.Item
-						key={ item.value }
-						value={ item }
-						label={ item.label }
-					>
-						<User user={ item } />
-					</SelectControl.Item>
-				) ) }
-			</>
-		),
 		defaultValue: userOptions[ 0 ],
 	},
+	render: ( { items = userOptions, triggerContent, ...args } ) => (
+		<SelectControl
+			{ ...args }
+			items={ items }
+			triggerContent={ triggerContent }
+		>
+			{ items.map( ( item ) => (
+				<SelectControl.Item
+					key={ item.value }
+					value={ item }
+					label={ item.label }
+				>
+					<User user={ item } />
+				</SelectControl.Item>
+			) ) }
+		</SelectControl>
+	),
 };
 
 /**
@@ -202,19 +206,19 @@ export const WithCustomTriggerAndItems: Story = {
 export const WithItemsArrayAndPartialCustomization: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				{ Default.args?.items?.map( ( item ) => (
-					<SelectControl.Item
-						key={ item.value ?? 'null' }
-						value={ item }
-						label={ item.label }
-						disabled={ item.disabled }
-					>
-						✨ { item.label }
-					</SelectControl.Item>
-				) ) }
-			</>
-		),
 	},
+	render: ( { items = defaultItems, ...args } ) => (
+		<SelectControl { ...args } items={ items }>
+			{ items.map( ( item ) => (
+				<SelectControl.Item
+					key={ item.value ?? 'null' }
+					value={ item }
+					label={ item.label }
+					disabled={ item.disabled }
+				>
+					✨ { item.label }
+				</SelectControl.Item>
+			) ) }
+		</SelectControl>
+	),
 };

--- a/packages/ui/src/form/select-control/stories/index.story.tsx
+++ b/packages/ui/src/form/select-control/stories/index.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SelectControl } from '../';
+import type { SelectItem } from '../types';
 import {
 	WITH_DETAILS_DESCRIPTION,
 	DETAILS_EXAMPLE,
@@ -20,7 +21,7 @@ export default meta;
 
 type Story = StoryObj< typeof SelectControl >;
 
-const defaultItems = [
+const defaultItems: SelectItem[] = [
 	{
 		value: '1',
 		label: 'Item 1',
@@ -52,7 +53,7 @@ export const WithCustomPlaceholder: Story = {
 	},
 };
 
-const nullValueOptionItems = [
+const nullValueOptionItems: SelectItem[] = [
 	{
 		value: null,
 		label: 'Select theme',
@@ -102,7 +103,7 @@ export const WithDetails: Story = {
 	},
 };
 
-const disabledOptionItems = [
+const disabledOptionItems: SelectItem[] = [
 	{
 		value: '1',
 		label: 'Item 1',
@@ -123,7 +124,7 @@ export const WithDisabledOption: Story = {
 	},
 };
 
-const userOptions: React.ComponentProps< typeof SelectControl >[ 'items' ] = [
+const userOptions: SelectItem[] = [
 	{
 		value: '1',
 		label: 'User 1 (Admin)',

--- a/packages/ui/src/link-button/stories/index.story.tsx
+++ b/packages/ui/src/link-button/stories/index.story.tsx
@@ -135,15 +135,12 @@ export const AllTonesAndVariants: Story = {
 
 export const WithIcon: Story = {
 	...Default,
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<LinkButton.Icon icon={ wordpress } />
-				Link button
-			</>
-		),
-	},
+	render: ( { children: _children, ...args } ) => (
+		<LinkButton { ...args }>
+			<LinkButton.Icon icon={ wordpress } />
+			Link button
+		</LinkButton>
+	),
 };
 
 export const OpenInNewTab: Story = {

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -25,140 +25,167 @@ export default meta;
 type Story = StoryObj< typeof Notice.Root >;
 
 export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<Notice.Title>Notice Title</Notice.Title>
-				<Notice.Description>
-					Description text with details about this notification.
-				</Notice.Description>
-				<Notice.Actions>
-					<Notice.ActionButton>Primary button</Notice.ActionButton>
-					<Notice.ActionButton variant="outline">
-						Secondary button
-					</Notice.ActionButton>
-					<Notice.ActionLink href="#">Link</Notice.ActionLink>
-				</Notice.Actions>
-				<Notice.CloseIcon />
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root>
+			<Notice.Title>Notice Title</Notice.Title>
+			<Notice.Description>
+				Description text with details about this notification.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 export const Info: Story = {
-	...Default,
-	args: {
-		...Default.args,
-		intent: 'info',
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="info">
+			<Notice.Title>Notice Title</Notice.Title>
+			<Notice.Description>
+				Description text with details about this notification.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 export const Warning: Story = {
-	...Default,
-	args: {
-		...Default.args,
-		intent: 'warning',
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="warning">
+			<Notice.Title>Notice Title</Notice.Title>
+			<Notice.Description>
+				Description text with details about this notification.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 export const Success: Story = {
-	...Default,
-	args: {
-		...Default.args,
-		intent: 'success',
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="success">
+			<Notice.Title>Notice Title</Notice.Title>
+			<Notice.Description>
+				Description text with details about this notification.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 export const Error: Story = {
-	...Default,
-	args: {
-		...Default.args,
-		intent: 'error',
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="error">
+			<Notice.Title>Notice Title</Notice.Title>
+			<Notice.Description>
+				Description text with details about this notification.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 /**
  * Omit Notice.CloseIcon to make the notice non-dismissable.
  */
 export const NonDismissible: Story = {
-	args: {
-		intent: 'warning',
-		children: (
-			<>
-				<Notice.Title>Action Required</Notice.Title>
-				<Notice.Description>
-					This notice cannot be dismissed by the user.
-				</Notice.Description>
-				<Notice.Actions>
-					<Notice.ActionButton>Take Action</Notice.ActionButton>
-					<Notice.ActionLink href="#">Visit link</Notice.ActionLink>
-				</Notice.Actions>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="warning">
+			<Notice.Title>Action Required</Notice.Title>
+			<Notice.Description>
+				This notice cannot be dismissed by the user.
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton>Take Action</Notice.ActionButton>
+				<Notice.ActionLink href="#">Visit link</Notice.ActionLink>
+			</Notice.Actions>
+		</Notice.Root>
+	),
 };
 
 /**
  * Pass `icon={ null }` to hide the default decorative icon.
  */
 export const WithoutIcon: Story = {
-	args: {
-		intent: 'info',
-		icon: null,
-		children: (
-			<>
-				<Notice.Title>No Icon</Notice.Title>
-				<Notice.Description>
-					This notice has no decorative icon displayed.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="info" icon={ null }>
+			<Notice.Title>No Icon</Notice.Title>
+			<Notice.Description>
+				This notice has no decorative icon displayed.
+			</Notice.Description>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 export const WithoutActions: Story = {
-	args: {
-		intent: 'info',
-		children: (
-			<>
-				<Notice.Title>Simple Notice</Notice.Title>
-				<Notice.Description>
-					A dismissable notice without any action buttons or links.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="info">
+			<Notice.Title>Simple Notice</Notice.Title>
+			<Notice.Description>
+				A dismissable notice without any action buttons or links.
+			</Notice.Description>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 /**
  * Title only, no description or actions.
  */
 export const TitleOnly: Story = {
-	args: {
-		children: (
-			<>
-				<Notice.Title>Just a title</Notice.Title>
-				<Notice.CloseIcon />
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root>
+			<Notice.Title>Just a title</Notice.Title>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };
 
 /**
  * Description only, no title or actions.
  */
 export const DescriptionOnly: Story = {
-	args: {
-		intent: 'info',
-		children: (
-			<>
-				<Notice.Description>
-					Just a description without title or actions.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Notice.Root intent="info">
+			<Notice.Description>
+				Just a description without title or actions.
+			</Notice.Description>
+			<Notice.CloseIcon />
+		</Notice.Root>
+	),
 };

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -36,29 +36,22 @@ export default meta;
 type Story = StoryObj< typeof Popover.Root >;
 
 export const Default: Story = {
-	argTypes: {
-		children: { control: { type: 'text' } },
-	},
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Popover title
-					</Popover.Title>
-					<Popover.Description>
-						Popover description
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Open Popover</Popover.Trigger>
+			<Popover.Popup>
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Popover title
+				</Popover.Title>
+				<Popover.Description>Popover description</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -66,25 +59,21 @@ export const Default: Story = {
  * from the popup content when an arrow indicator is not desired.
  */
 export const NoArrow: Story = {
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Popover title
-					</Popover.Title>
-					<Popover.Description>
-						Popover description
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Open Popover</Popover.Trigger>
+			<Popover.Popup>
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Popover title
+				</Popover.Title>
+				<Popover.Description>Popover description</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -95,7 +84,7 @@ export const NoArrow: Story = {
  */
 export const Positioning: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const sides = [ 'top', 'right', 'bottom', 'left' ] as const;
 		const aligns = [ 'start', 'center', 'end' ] as const;
 
@@ -150,41 +139,39 @@ export const Positioning: Story = {
  * close action — matching the Dialog close-icon pattern.
  */
 export const WithCloseButton: Story = {
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Settings</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<div
-						style={ {
-							display: 'flex',
-							justifyContent: 'space-between',
-							alignItems: 'center',
-							marginBottom: 'var(--wpds-dimension-gap-sm)',
-						} }
-					>
-						<Popover.Title>Settings</Popover.Title>
-						<Popover.Close
-							render={
-								<IconButton
-									variant="minimal"
-									size="compact"
-									tone="neutral"
-									icon={ close }
-									label="Close"
-								/>
-							}
-						/>
-					</div>
-					<Popover.Description>
-						Configure your notification preferences and display
-						settings.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Settings</Popover.Trigger>
+			<Popover.Popup>
+				<Popover.Arrow />
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						marginBottom: 'var(--wpds-dimension-gap-sm)',
+					} }
+				>
+					<Popover.Title>Settings</Popover.Title>
+					<Popover.Close
+						render={
+							<IconButton
+								variant="minimal"
+								size="compact"
+								tone="neutral"
+								icon={ close }
+								label="Close"
+							/>
+						}
+					/>
+				</div>
+				<Popover.Description>
+					Configure your notification preferences and display
+					settings.
+				</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -201,27 +188,7 @@ export const Controlled: Story = {
 		onOpenChange: { control: false },
 		defaultOpen: { control: false },
 	},
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Toggle Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Controlled Popover
-					</Popover.Title>
-					<Popover.Description>
-						This popover is controlled by external state.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
-	render: function Render( args ) {
+	render: function Render( {} ) {
 		const [ isOpen, setIsOpen ] = useState( false );
 		const checkboxId = useId();
 		const checkboxRef = useRef< HTMLInputElement >( null );
@@ -236,7 +203,6 @@ export const Controlled: Story = {
 				} }
 			>
 				<Popover.Root
-					{ ...args }
 					open={ isOpen }
 					onOpenChange={ ( nextOpen, eventDetails ) => {
 						if (
@@ -256,7 +222,22 @@ export const Controlled: Story = {
 
 						setIsOpen( nextOpen );
 					} }
-				/>
+				>
+					<Popover.Trigger>Toggle Popover</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Arrow />
+						<Popover.Title
+							style={ {
+								marginBottom: 'var(--wpds-dimension-gap-xs)',
+							} }
+						>
+							Controlled Popover
+						</Popover.Title>
+						<Popover.Description>
+							This popover is controlled by external state.
+						</Popover.Description>
+					</Popover.Popup>
+				</Popover.Root>
 
 				<label htmlFor={ checkboxId } ref={ labelRef }>
 					<input
@@ -288,86 +269,83 @@ export const Controlled: Story = {
  */
 export const Modal: Story = {
 	argTypes: { modal: { control: false } },
-	args: {
-		modal: true,
-		children: (
-			<>
-				<Popover.Trigger>Edit Settings</Popover.Trigger>
-				<Popover.Popup backdrop>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Settings
-					</Popover.Title>
-					<form
+	render: ( {} ) => (
+		<Popover.Root modal>
+			<Popover.Trigger>Edit Settings</Popover.Trigger>
+			<Popover.Popup backdrop>
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Settings
+				</Popover.Title>
+				<form
+					style={ {
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 'var(--wpds-dimension-gap-sm)',
+						marginTop: 'var(--wpds-dimension-gap-sm)',
+					} }
+					onSubmit={ ( e ) => e.preventDefault() }
+				>
+					<label
+						htmlFor="popover-test-name-id"
 						style={ {
 							display: 'flex',
 							flexDirection: 'column',
-							gap: 'var(--wpds-dimension-gap-sm)',
-							marginTop: 'var(--wpds-dimension-gap-sm)',
+							gap: 'var(--wpds-dimension-gap-xs)',
+							fontSize: 'inherit',
 						} }
-						onSubmit={ ( e ) => e.preventDefault() }
 					>
-						<label
-							htmlFor="popover-test-name-id"
+						Name
+						<input
+							// eslint-disable-next-line no-restricted-syntax
+							id="popover-test-name-id"
+							type="text"
+							placeholder="Enter your name"
+						/>
+					</label>
+					<label
+						htmlFor="popover-test-email-id"
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 'var(--wpds-dimension-gap-xs)',
+							fontSize: 'inherit',
+						} }
+					>
+						Email
+						<input
+							// eslint-disable-next-line no-restricted-syntax
+							id="popover-test-email-id"
+							type="email"
+							placeholder="Enter your email"
+						/>
+					</label>
+					<div
+						style={ {
+							display: 'flex',
+							justifyContent: 'flex-end',
+							gap: 'var(--wpds-dimension-gap-sm)',
+							marginTop: 'var(--wpds-dimension-gap-xs)',
+						} }
+					>
+						<Popover.Close
 							style={ {
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 'var(--wpds-dimension-gap-xs)',
-								fontSize: 'inherit',
+								all: 'unset',
+								cursor: 'pointer',
 							} }
 						>
-							Name
-							<input
-								// eslint-disable-next-line no-restricted-syntax
-								id="popover-test-name-id"
-								type="text"
-								placeholder="Enter your name"
-							/>
-						</label>
-						<label
-							htmlFor="popover-test-email-id"
-							style={ {
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 'var(--wpds-dimension-gap-xs)',
-								fontSize: 'inherit',
-							} }
-						>
-							Email
-							<input
-								// eslint-disable-next-line no-restricted-syntax
-								id="popover-test-email-id"
-								type="email"
-								placeholder="Enter your email"
-							/>
-						</label>
-						<div
-							style={ {
-								display: 'flex',
-								justifyContent: 'flex-end',
-								gap: 'var(--wpds-dimension-gap-sm)',
-								marginTop: 'var(--wpds-dimension-gap-xs)',
-							} }
-						>
-							<Popover.Close
-								style={ {
-									all: 'unset',
-									cursor: 'pointer',
-								} }
-							>
-								Cancel
-							</Popover.Close>
-							<button type="submit">Save</button>
-						</div>
-					</form>
-				</Popover.Popup>
-			</>
-		),
-	},
+							Cancel
+						</Popover.Close>
+						<button type="submit">Save</button>
+					</div>
+				</form>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -375,26 +353,24 @@ export const Modal: Story = {
  * making it a blank positioning container for fully custom content.
  */
 export const Unstyled: Story = {
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Unstyled</Popover.Trigger>
-				<Popover.Popup variant="unstyled">
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Custom Styled
-					</Popover.Title>
-					<Popover.Description>
-						This popup has no default styling — the consumer
-						controls all visual appearance.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Open Unstyled</Popover.Trigger>
+			<Popover.Popup variant="unstyled">
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Custom Styled
+				</Popover.Title>
+				<Popover.Description>
+					This popup has no default styling — the consumer controls
+					all visual appearance.
+				</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -406,15 +382,14 @@ export const Unstyled: Story = {
  * the trigger element in place.
  */
 export const OverlayPlacement: Story = {
-	args: { defaultOpen: true },
 	argTypes: { defaultOpen: { control: false } },
-	render: function Render( { children: _children, ...args } ) {
+	render: function Render( {} ) {
 		const [ popupRef, popupSize ] = useMeasure< HTMLDivElement >();
 		const [ triggerRef, triggerSize ] = useMeasure< HTMLButtonElement >();
 
 		return (
 			<div style={ { padding: '4rem', textAlign: 'center' } }>
-				<Popover.Root { ...args }>
+				<Popover.Root defaultOpen>
 					<Popover.Trigger ref={ triggerRef }>
 						Trigger (covered by popover)
 					</Popover.Trigger>
@@ -470,7 +445,7 @@ export const OverlayPlacement: Story = {
  */
 export const Inline: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const inlineContainerRef = useRef< HTMLSpanElement >( null );
 
 		return (
@@ -522,7 +497,7 @@ export const Inline: Story = {
  */
 export const CollisionAvoidance: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const [ boundary, setBoundary ] = useState< HTMLElement | null >(
 			null
 		);
@@ -614,9 +589,8 @@ export const CollisionAvoidance: Story = {
  * position across document boundaries.
  */
 export const CrossIframe: Story = {
-	args: { defaultOpen: true },
 	argTypes: { defaultOpen: { control: false } },
-	render: function Render( { children: _children, ...args } ) {
+	render: function Render( {} ) {
 		const portalContainerRef = useRef< HTMLDivElement >( null );
 		const [ iframeBoundary, setIframeBoundary ] =
 			useState< HTMLIFrameElement | null >( null );
@@ -646,7 +620,7 @@ export const CrossIframe: Story = {
 								marginInline: 'auto',
 							} }
 						>
-							<Popover.Root { ...args }>
+							<Popover.Root defaultOpen>
 								<Popover.Trigger
 									style={ {
 										padding: 8,
@@ -714,34 +688,32 @@ export const CrossIframe: Story = {
  */
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup
-					portal={
-						<Popover.Portal
-							style={ { '--wp-ui-popover-z-index': '9999' } }
-						/>
-					}
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Open Popover</Popover.Trigger>
+			<Popover.Popup
+				portal={
+					<Popover.Portal
+						style={ { '--wp-ui-popover-z-index': '9999' } }
+					/>
+				}
+			>
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
 				>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Custom z-index
-					</Popover.Title>
-					<Popover.Description>
-						This popover renders at `z-index: 9999` via the
-						`--wp-ui-popover-z-index` CSS custom property, set on
-						`Popover.Portal` through the `portal` prop.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
-	},
+					Custom z-index
+				</Popover.Title>
+				<Popover.Description>
+					This popover renders at `z-index: 9999` via the
+					`--wp-ui-popover-z-index` CSS custom property, set on
+					`Popover.Portal` through the `portal` prop.
+				</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -760,7 +732,7 @@ export const WithCustomZIndex: Story = {
  */
 export const Anchor: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const [ elementAnchor, setElementAnchor ] =
 			useState< HTMLElement | null >( null );
 		const refAnchor = useRef< HTMLDivElement >( null );
@@ -909,33 +881,31 @@ export const Anchor: Story = {
  * becomes widespread.
  */
 export const ToolbarVariant: Story = {
-	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Toolbar</Popover.Trigger>
-				<Popover.Popup
-					variant="unstyled"
-					style={ {
-						display: 'flex',
-						gap: 'var(--wpds-dimension-gap-xs)',
-						padding: '4px 8px',
-						border: '1px solid #1e1e1e',
-						borderRadius: 2,
-						background: '#fff',
-						fontSize: 13,
-					} }
-				>
-					<VisuallyHidden render={ <Popover.Title /> }>
-						Formatting
-					</VisuallyHidden>
-					<button type="button">B</button>
-					<button type="button">I</button>
-					<button type="button">U</button>
-					<button type="button">Link</button>
-				</Popover.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Popover.Root>
+			<Popover.Trigger>Open Toolbar</Popover.Trigger>
+			<Popover.Popup
+				variant="unstyled"
+				style={ {
+					display: 'flex',
+					gap: 'var(--wpds-dimension-gap-xs)',
+					padding: '4px 8px',
+					border: '1px solid #1e1e1e',
+					borderRadius: 2,
+					background: '#fff',
+					fontSize: 13,
+				} }
+			>
+				<VisuallyHidden render={ <Popover.Title /> }>
+					Formatting
+				</VisuallyHidden>
+				<button type="button">B</button>
+				<button type="button">I</button>
+				<button type="button">U</button>
+				<button type="button">Link</button>
+			</Popover.Popup>
+		</Popover.Root>
+	),
 };
 
 /**
@@ -951,9 +921,8 @@ export const ToolbarVariant: Story = {
  */
 export const ViewportConstrainedSize: Story = {
 	name: 'Viewport-Constrained Size',
-	args: { defaultOpen: true },
 	argTypes: { defaultOpen: { control: false } },
-	render: function Render( { children: _children, ...args } ) {
+	render: function Render( {} ) {
 		return (
 			<div
 				style={ {
@@ -963,7 +932,7 @@ export const ViewportConstrainedSize: Story = {
 					padding: '60px 2rem',
 				} }
 			>
-				<Popover.Root { ...args }>
+				<Popover.Root defaultOpen>
 					<Popover.Trigger>Show Content</Popover.Trigger>
 					<Popover.Popup
 						positioner={ <Popover.Positioner side="bottom" /> }
@@ -1016,7 +985,7 @@ export const ViewportConstrainedSize: Story = {
 export const OnOpenChangeDetails: Story = {
 	name: 'onOpenChange Details',
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const [ log, setLog ] = useState< string[] >( [] );
 
 		return (
@@ -1077,7 +1046,7 @@ export const OnOpenChangeDetails: Story = {
  */
 export const InitialFocus: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render() {
+	render: function Render( {} ) {
 		const emailRef = useRef< HTMLInputElement >( null );
 		const nameId = useId();
 		const emailId = useId();
@@ -1159,13 +1128,10 @@ export const InitialFocus: Story = {
  */
 export const TrapFocus: Story = {
 	argTypes: { modal: { control: false } },
-	args: {
-		modal: 'trap-focus' as const,
-	},
-	render: function Render( args ) {
+	render: function Render( {} ) {
 		return (
 			<div style={ { display: 'flex', gap: '2rem' } }>
-				<Popover.Root { ...args }>
+				<Popover.Root modal="trap-focus">
 					<Popover.Trigger>Open</Popover.Trigger>
 					<Popover.Popup>
 						<Popover.Arrow />
@@ -1217,9 +1183,9 @@ export const TrapFocus: Story = {
  */
 export const HoverTrigger: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render( args ) {
+	render: function Render( {} ) {
 		return (
-			<Popover.Root { ...args }>
+			<Popover.Root>
 				<Popover.Trigger openOnHover delay={ 200 } closeDelay={ 150 }>
 					Hover me
 				</Popover.Trigger>
@@ -1254,7 +1220,7 @@ export const HoverTrigger: Story = {
  */
 export const Infotip: Story = {
 	parameters: { controls: { disable: true } },
-	render: function Render( args ) {
+	render: function Render( {} ) {
 		return (
 			<div
 				style={ {
@@ -1264,7 +1230,7 @@ export const Infotip: Story = {
 				} }
 			>
 				<span>Label</span>
-				<Popover.Root { ...args }>
+				<Popover.Root>
 					<Popover.Trigger
 						openOnHover
 						delay={ 200 }

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -27,18 +27,18 @@ const DemoBox = ( { variant }: { variant?: 'lg' } ) => (
 type Story = StoryObj< typeof Stack >;
 
 export const Default: Story = {
+	render: ( { gap } ) => (
+		<Stack gap={ gap }>
+			<DemoBox />
+			<DemoBox variant="lg" />
+			<DemoBox />
+			<DemoBox />
+			<DemoBox variant="lg" />
+			<DemoBox />
+		</Stack>
+	),
 	args: {
 		gap: 'md',
-		children: (
-			<>
-				<DemoBox />
-				<DemoBox variant="lg" />
-				<DemoBox />
-				<DemoBox />
-				<DemoBox variant="lg" />
-				<DemoBox />
-			</>
-		),
 	},
 	argTypes: {
 		align: {
@@ -89,25 +89,25 @@ export const Default: Story = {
 };
 
 export const Nested: Story = {
-	...Default,
+	render: ( { gap, align, justify } ) => (
+		<Stack gap={ gap } align={ align } justify={ justify }>
+			<DemoBox variant="lg" />
+			<Stack gap="lg">
+				<DemoBox />
+				<DemoBox />
+			</Stack>
+			<DemoBox variant="lg" />
+			<Stack direction="column">
+				<DemoBox />
+				<DemoBox />
+			</Stack>
+			<DemoBox variant="lg" />
+		</Stack>
+	),
 	args: {
-		...Default.args,
+		gap: 'md',
 		align: 'center',
 		justify: 'center',
-		children: (
-			<>
-				<DemoBox variant="lg" />
-				<Stack gap="lg">
-					<DemoBox />
-					<DemoBox />
-				</Stack>
-				<DemoBox variant="lg" />
-				<Stack direction="column">
-					<DemoBox />
-					<DemoBox />
-				</Stack>
-				<DemoBox variant="lg" />
-			</>
-		),
 	},
+	argTypes: Default.argTypes,
 };

--- a/packages/ui/src/tabs/stories/index.story.tsx
+++ b/packages/ui/src/tabs/stories/index.story.tsx
@@ -35,51 +35,45 @@ const ThemedParagraph = ( { children }: { children: React.ReactNode } ) => {
 };
 
 export const Default: StoryObj< typeof Tabs.Root > = {
-	args: {
-		defaultValue: 'tab1',
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab1">
+			<Tabs.List>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };
 
 export const Minimal: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<Tabs.List variant="minimal">
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab1">
+			<Tabs.List variant="minimal">
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };
 
 export const SizeAndOverflowPlayground: StoryObj< typeof Tabs.Root > = {
@@ -143,6 +137,7 @@ export const SizeAndOverflowPlayground: StoryObj< typeof Tabs.Root > = {
 				</button>
 				<Tabs.Root
 					{ ...props }
+					defaultValue="tab4"
 					style={ {
 						...props.style,
 						width: '20rem',
@@ -195,50 +190,59 @@ export const SizeAndOverflowPlayground: StoryObj< typeof Tabs.Root > = {
 			</div>
 		);
 	},
-	args: {
-		...Default.args,
-		defaultValue: 'tab4',
-	},
 };
 
 export const Vertical: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		orientation: 'vertical',
-		style: {
-			minWidth: '320px',
-			display: 'grid',
-			gridTemplateColumns: '120px 1fr',
-			gap: '24px',
-		},
-	},
+	render: ( {} ) => (
+		<Tabs.Root
+			defaultValue="tab1"
+			orientation="vertical"
+			style={ {
+				minWidth: '320px',
+				display: 'grid',
+				gridTemplateColumns: '120px 1fr',
+				gap: '24px',
+			} }
+		>
+			<Tabs.List>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };
 
 export const WithDisabledTab: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		defaultValue: 'tab3',
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1" disabled>
-						Tab 1
-					</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab3">
+			<Tabs.List>
+				<Tabs.Tab value="tab1" disabled>
+					Tab 1
+				</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };
 
 const LinkIcon = ( props: React.SVGProps< SVGSVGElement > ) => {
@@ -272,111 +276,95 @@ const tabWithIconsData = [
 ];
 
 export const WithTabIconsAndTooltips: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					{ tabWithIconsData.map(
-						( { value, label, icon: Icon } ) => (
-							<Tooltip.Root key={ value }>
-								<Tooltip.Trigger
-									aria-label={ label }
-									render={ <Tabs.Tab value={ value } /> }
-								>
-									{ /* TODO: potentially refactor with new Icon component */ }
-									<Icon
-										style={ {
-											width: '20px',
-											height: '20px',
-										} }
-									/>
-								</Tooltip.Trigger>
-								<Tooltip.Popup
-									positioner={
-										<Tooltip.Positioner
-											align="center"
-											side="top"
-										/>
-									}
-								>
-									{ label }
-								</Tooltip.Popup>
-							</Tooltip.Root>
-						)
-					) }
-				</Tabs.List>
-				{ tabWithIconsData.map( ( { value, label } ) => (
-					<Tabs.Panel value={ value } key={ value }>
-						<ThemedParagraph>
-							Selected tab: { label }
-						</ThemedParagraph>
-					</Tabs.Panel>
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab1">
+			<Tabs.List>
+				{ tabWithIconsData.map( ( { value, label, icon: Icon } ) => (
+					<Tooltip.Root key={ value }>
+						<Tooltip.Trigger
+							aria-label={ label }
+							render={ <Tabs.Tab value={ value } /> }
+						>
+							{ /* TODO: potentially refactor with new Icon component */ }
+							<Icon
+								style={ {
+									width: '20px',
+									height: '20px',
+								} }
+							/>
+						</Tooltip.Trigger>
+						<Tooltip.Popup
+							positioner={
+								<Tooltip.Positioner align="center" side="top" />
+							}
+						>
+							{ label }
+						</Tooltip.Popup>
+					</Tooltip.Root>
 				) ) }
-			</>
-		),
-	},
+			</Tabs.List>
+			{ tabWithIconsData.map( ( { value, label } ) => (
+				<Tabs.Panel value={ value } key={ value }>
+					<ThemedParagraph>Selected tab: { label }</ThemedParagraph>
+				</Tabs.Panel>
+			) ) }
+		</Tabs.Root>
+	),
 };
 
 export const WithPanelsAlwaysMounted: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab1">
+			<Tabs.List>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1" keepMounted>
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2" keepMounted>
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3" keepMounted>
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };
 
 export const WithNonFocusablePanels: StoryObj< typeof Tabs.Root > = {
-	args: {
-		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tabs.Root defaultValue="tab1">
+			<Tabs.List>
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>
+			<Tabs.Panel value="tab1" tabIndex={ -1 }>
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab2" tabIndex={ -1 }>
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>
+			<Tabs.Panel value="tab3" tabIndex={ -1 }>
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>
+		</Tabs.Root>
+	),
 };

--- a/packages/ui/src/text/stories/index.story.tsx
+++ b/packages/ui/src/text/stories/index.story.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
  * Use the `render` prop to render a heading element with the appropriate level.
  */
 export const AllVariants: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Stack
 			direction="column"
 			gap="lg"
@@ -60,7 +60,7 @@ export const AllVariants: Story = {
 };
 
 export const WithRenderProp: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Stack direction="column" gap="md">
 			<Text variant="heading-2xl" render={ <h1 /> }>
 				Page Title

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -24,14 +24,12 @@ const meta: Meta< typeof Tooltip.Root > = {
 export default meta;
 
 export const Default: StoryObj< typeof Tooltip.Root > = {
-	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup>Save</Tooltip.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tooltip.Root>
+			<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+			<Tooltip.Popup>Save</Tooltip.Popup>
+		</Tooltip.Root>
+	),
 };
 
 /**
@@ -40,11 +38,15 @@ export const Default: StoryObj< typeof Tooltip.Root > = {
  * component conditionally (which could cause reconciliation issues).
  */
 export const Disabled: StoryObj< typeof Tooltip.Root > = {
-	...Default,
 	args: {
-		...Default.args,
 		disabled: true,
 	},
+	render: ( { disabled } ) => (
+		<Tooltip.Root disabled={ disabled }>
+			<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+			<Tooltip.Popup>Save</Tooltip.Popup>
+		</Tooltip.Root>
+	),
 };
 
 /**
@@ -55,7 +57,7 @@ export const Disabled: StoryObj< typeof Tooltip.Root > = {
  * (`side="top"`, `align="center"`, `sideOffset={ 4 }`).
  */
 export const Positioning: StoryObj< typeof Tooltip.Root > = {
-	render: () => (
+	render: ( {} ) => (
 		<div
 			style={ {
 				display: 'flex',
@@ -107,24 +109,22 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
  * more — for fine-grained placement.
  */
 export const WithCustomPositioner: StoryObj< typeof Tooltip.Root > = {
-	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup
-					positioner={
-						<Tooltip.Positioner
-							side="right"
-							align="start"
-							sideOffset={ 16 }
-						/>
-					}
-				>
-					Save
-				</Tooltip.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tooltip.Root>
+			<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+			<Tooltip.Popup
+				positioner={
+					<Tooltip.Positioner
+						side="right"
+						align="start"
+						sideOffset={ 16 }
+					/>
+				}
+			>
+				Save
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	),
 };
 
 /**
@@ -145,22 +145,20 @@ export const WithCustomPositioner: StoryObj< typeof Tooltip.Root > = {
  */
 export const WithCustomZIndex: StoryObj< typeof Tooltip.Root > = {
 	name: 'With Custom z-index',
-	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup
-					portal={
-						<Tooltip.Portal
-							style={ { '--wp-ui-tooltip-z-index': '9999' } }
-						/>
-					}
-				>
-					Save
-				</Tooltip.Popup>
-			</>
-		),
-	},
+	render: ( {} ) => (
+		<Tooltip.Root>
+			<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
+			<Tooltip.Popup
+				portal={
+					<Tooltip.Portal
+						style={ { '--wp-ui-tooltip-z-index': '9999' } }
+					/>
+				}
+			>
+				Save
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	),
 };
 
 /**
@@ -169,7 +167,7 @@ export const WithCustomZIndex: StoryObj< typeof Tooltip.Root > = {
  * the same delay configuration.
  */
 export const WithProvider: StoryObj< typeof Tooltip.Root > = {
-	render: () => (
+	render: ( {} ) => (
 		<Tooltip.Provider delay={ 0 }>
 			<div style={ { display: 'flex', gap: '1rem' } }>
 				<Tooltip.Root>

--- a/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/tooltip/stories/usage-guidelines.story.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj;
  * must have its own accessible name via `aria-label`.
  */
 export const RecommendedUsage: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<Tooltip.Provider delay={ 0 }>
 			<div style={ { display: 'flex', gap: '0.25rem' } }>
 				<Tooltip.Root>
@@ -61,7 +61,7 @@ export const RecommendedUsage: Story = {
  * to touch and screen reader users.
  */
 export const InfotipWithPopover: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<div
 			style={ {
 				display: 'flex',
@@ -109,7 +109,7 @@ export const InfotipWithPopover: Story = {
  * making it the easiest way to provide a tooltip for icon-only actions.
  */
 export const IconButtonWithTooltip: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<div style={ { display: 'flex', gap: '0.25rem' } }>
 			<IconButton icon={ formatBold } label="Bold" size="compact" />
 			<IconButton icon={ formatItalic } label="Italic" size="compact" />

--- a/packages/ui/src/visually-hidden/stories/index.story.tsx
+++ b/packages/ui/src/visually-hidden/stories/index.story.tsx
@@ -18,7 +18,7 @@ export default meta;
 type Story = StoryObj< typeof VisuallyHidden >;
 
 export const Default: Story = {
-	render: () => (
+	render: ( {} ) => (
 		<>
 			<VisuallyHidden>This should not show.</VisuallyHidden>
 			<div>
@@ -36,7 +36,7 @@ export const Default: Story = {
  * while hiding the label text visually.
  */
 export const WithCustomElement: Story = {
-	render: function WithCustomElementStory() {
+	render: function WithCustomElementStory( {} ) {
 		const inputId = useId();
 		return (
 			<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Follow-up to https://github.com/WordPress/gutenberg/pull/77382#issuecomment-4731307918

Pairs with https://github.com/WordPress/gutenberg/pull/80132 which adds `displayName`s.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Avoids `<React.Fragment>`  appearing in code examples

<!-- In a few words, what is the PR actually doing? -->


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Cleaner code previews and copy-paste for docs consumers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Switch from `args: { children: () }` to replacing rendering fully with `render` prop.

Passes dummy `{}` just to work around a known Storybook quirk: otherwise Storybook will show: `render: () => ()` as part of the code snippet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Run `npm run storybook:dev`
Smoke test different stories and code snippets.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="1047" height="718" alt="image" src="https://github.com/user-attachments/assets/61b39059-8f7e-4a4d-a609-56d2b4f25de4" />

### After

<img width="1055" height="679" alt="image" src="https://github.com/user-attachments/assets/aed908bb-4b3a-4b15-8af3-274685e9c30f" />

When combined with https://github.com/WordPress/gutenberg/pull/80132: 

<img width="1039" height="688" alt="image" src="https://github.com/user-attachments/assets/9091bd6f-caf9-49cb-865b-06ea61da2248" />

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
