### PR TITLE
Typewriter: remove the block selection gate

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -3,261 +3,230 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 import { computeCaretRect, getScrollContainer } from '@wordpress/dom';
-import { useSelect } from '@wordpress/data';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
-
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../store';
 
 const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;
 
 export function useTypewriter() {
-	const hasSelectedBlock = useSelect(
-		( select ) => select( blockEditorStore ).hasSelectedBlock(),
-		[]
-	);
+	return useRefEffect( ( node ) => {
+		const { ownerDocument } = node;
+		const { defaultView } = ownerDocument;
 
-	return useRefEffect(
-		( node ) => {
-			if ( ! hasSelectedBlock ) {
+		let scrollResizeRafId;
+		let onKeyDownRafId;
+
+		let caretRect;
+
+		function onScrollResize() {
+			if ( scrollResizeRafId ) {
 				return;
 			}
 
-			const { ownerDocument } = node;
-			const { defaultView } = ownerDocument;
-
-			let scrollResizeRafId;
-			let onKeyDownRafId;
-
-			let caretRect;
-
-			function onScrollResize() {
-				if ( scrollResizeRafId ) {
-					return;
-				}
-
-				scrollResizeRafId = defaultView.requestAnimationFrame( () => {
-					computeCaretRectangle();
-					scrollResizeRafId = null;
-				} );
-			}
-
-			function onKeyDown( event ) {
-				// Ensure the any remaining request is cancelled.
-				if ( onKeyDownRafId ) {
-					defaultView.cancelAnimationFrame( onKeyDownRafId );
-				}
-
-				// Use an animation frame for a smooth result.
-				onKeyDownRafId = defaultView.requestAnimationFrame( () => {
-					maintainCaretPosition( event );
-					onKeyDownRafId = null;
-				} );
-			}
-
-			/**
-			 * Maintains the scroll position after a selection change caused by a
-			 * keyboard event.
-			 *
-			 * @param {KeyboardEvent} event Keyboard event.
-			 */
-			function maintainCaretPosition( { keyCode } ) {
-				if ( ! isSelectionEligibleForScroll() ) {
-					return;
-				}
-
-				const currentCaretRect = computeCaretRect( defaultView );
-
-				if ( ! currentCaretRect ) {
-					return;
-				}
-
-				// If for some reason there is no position set to be scrolled to, let
-				// this be the position to be scrolled to in the future.
-				if ( ! caretRect ) {
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				// Even though enabling the typewriter effect for arrow keys results in
-				// a pleasant experience, it may not be the case for everyone, so, for
-				// now, let's disable it.
-				if ( arrowKeyCodes.has( keyCode ) ) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				const diff = currentCaretRect.top - caretRect.top;
-
-				if ( diff === 0 ) {
-					return;
-				}
-
-				const scrollContainer = getScrollContainer( node );
-
-				// The page must be scrollable.
-				if ( ! scrollContainer ) {
-					return;
-				}
-
-				const windowScroll =
-					scrollContainer === ownerDocument.body ||
-					scrollContainer === ownerDocument.documentElement;
-				const scrollY = windowScroll
-					? defaultView.scrollY
-					: scrollContainer.scrollTop;
-				const scrollContainerY = windowScroll
-					? 0
-					: scrollContainer.getBoundingClientRect().top;
-				const relativeScrollPosition = windowScroll
-					? caretRect.top / defaultView.innerHeight
-					: ( caretRect.top - scrollContainerY ) /
-					  ( defaultView.innerHeight - scrollContainerY );
-
-				// If the scroll position is at the start, the active editable element
-				// is the last one, and the caret is positioned within the initial
-				// trigger percentage of the page, do not scroll the page.
-				// The typewriter effect should not kick in until an empty page has been
-				// filled with the initial trigger percentage or the user scrolls
-				// intentionally down.
-				if (
-					scrollY === 0 &&
-					relativeScrollPosition < initialTriggerPercentage &&
-					isLastEditableNode()
-				) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				const scrollContainerHeight = windowScroll
-					? defaultView.innerHeight
-					: scrollContainer.clientHeight;
-
-				// Abort if the target scroll position would scroll the caret out of
-				// view.
-				if (
-					// The caret is under the lower fold.
-					caretRect.top + caretRect.height >
-						scrollContainerY + scrollContainerHeight ||
-					// The caret is above the upper fold.
-					caretRect.top < scrollContainerY
-				) {
-					// Reset the caret position to maintain.
-					caretRect = currentCaretRect;
-					return;
-				}
-
-				if ( windowScroll ) {
-					defaultView.scrollBy( 0, diff );
-				} else {
-					scrollContainer.scrollTop += diff;
-				}
-			}
-
-			/**
-			 * Adds a `selectionchange` listener to reset the scroll position to be
-			 * maintained.
-			 */
-			function addSelectionChangeListener() {
-				ownerDocument.addEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
-			}
-
-			/**
-			 * Resets the scroll position to be maintained during a `selectionchange`
-			 * event. Also removes the listener, so it acts as a one-time listener.
-			 */
-			function computeCaretRectOnSelectionChange() {
-				ownerDocument.removeEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
+			scrollResizeRafId = defaultView.requestAnimationFrame( () => {
 				computeCaretRectangle();
-			}
+				scrollResizeRafId = null;
+			} );
+		}
 
-			/**
-			 * Resets the scroll position to be maintained.
-			 */
-			function computeCaretRectangle() {
-				if ( isSelectionEligibleForScroll() ) {
-					caretRect = computeCaretRect( defaultView );
-				}
-			}
-
-			/**
-			 * Checks if the current situation is eligible for scroll:
-			 * - There should be one and only one block selected.
-			 * - The component must contain the selection.
-			 * - The active element must be contenteditable.
-			 */
-			function isSelectionEligibleForScroll() {
-				return (
-					node.contains( ownerDocument.activeElement ) &&
-					ownerDocument.activeElement.isContentEditable
-				);
-			}
-
-			function isLastEditableNode() {
-				const editableNodes = node.querySelectorAll(
-					'[contenteditable="true"]'
-				);
-				const lastEditableNode =
-					editableNodes[ editableNodes.length - 1 ];
-				return lastEditableNode === ownerDocument.activeElement;
-			}
-
-			// When the user scrolls or resizes, the scroll position should be
-			// reset.
-			defaultView.addEventListener( 'scroll', onScrollResize, true );
-			defaultView.addEventListener( 'resize', onScrollResize, true );
-
-			node.addEventListener( 'keydown', onKeyDown );
-			node.addEventListener( 'keyup', maintainCaretPosition );
-			node.addEventListener( 'mousedown', addSelectionChangeListener );
-			node.addEventListener( 'touchstart', addSelectionChangeListener );
-
-			return () => {
-				defaultView.removeEventListener(
-					'scroll',
-					onScrollResize,
-					true
-				);
-				defaultView.removeEventListener(
-					'resize',
-					onScrollResize,
-					true
-				);
-
-				node.removeEventListener( 'keydown', onKeyDown );
-				node.removeEventListener( 'keyup', maintainCaretPosition );
-				node.removeEventListener(
-					'mousedown',
-					addSelectionChangeListener
-				);
-				node.removeEventListener(
-					'touchstart',
-					addSelectionChangeListener
-				);
-
-				ownerDocument.removeEventListener(
-					'selectionchange',
-					computeCaretRectOnSelectionChange
-				);
-
-				defaultView.cancelAnimationFrame( scrollResizeRafId );
+		function onKeyDown( event ) {
+			// Ensure the any remaining request is cancelled.
+			if ( onKeyDownRafId ) {
 				defaultView.cancelAnimationFrame( onKeyDownRafId );
-			};
-		},
-		[ hasSelectedBlock ]
-	);
+			}
+
+			// Use an animation frame for a smooth result.
+			onKeyDownRafId = defaultView.requestAnimationFrame( () => {
+				maintainCaretPosition( event );
+				onKeyDownRafId = null;
+			} );
+		}
+
+		/**
+		 * Maintains the scroll position after a selection change caused by a
+		 * keyboard event.
+		 *
+		 * @param {KeyboardEvent} event Keyboard event.
+		 */
+		function maintainCaretPosition( { keyCode } ) {
+			if ( ! isSelectionEligibleForScroll() ) {
+				return;
+			}
+
+			const currentCaretRect = computeCaretRect( defaultView );
+
+			if ( ! currentCaretRect ) {
+				return;
+			}
+
+			// If for some reason there is no position set to be scrolled to, let
+			// this be the position to be scrolled to in the future.
+			if ( ! caretRect ) {
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			// Even though enabling the typewriter effect for arrow keys results in
+			// a pleasant experience, it may not be the case for everyone, so, for
+			// now, let's disable it.
+			if ( arrowKeyCodes.has( keyCode ) ) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			const diff = currentCaretRect.top - caretRect.top;
+
+			if ( diff === 0 ) {
+				return;
+			}
+
+			const scrollContainer = getScrollContainer( node );
+
+			// The page must be scrollable.
+			if ( ! scrollContainer ) {
+				return;
+			}
+
+			const windowScroll =
+				scrollContainer === ownerDocument.body ||
+				scrollContainer === ownerDocument.documentElement;
+			const scrollY = windowScroll
+				? defaultView.scrollY
+				: scrollContainer.scrollTop;
+			const scrollContainerY = windowScroll
+				? 0
+				: scrollContainer.getBoundingClientRect().top;
+			const relativeScrollPosition = windowScroll
+				? caretRect.top / defaultView.innerHeight
+				: ( caretRect.top - scrollContainerY ) /
+				  ( defaultView.innerHeight - scrollContainerY );
+
+			// If the scroll position is at the start, the active editable element
+			// is the last one, and the caret is positioned within the initial
+			// trigger percentage of the page, do not scroll the page.
+			// The typewriter effect should not kick in until an empty page has been
+			// filled with the initial trigger percentage or the user scrolls
+			// intentionally down.
+			if (
+				scrollY === 0 &&
+				relativeScrollPosition < initialTriggerPercentage &&
+				isLastEditableNode()
+			) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			const scrollContainerHeight = windowScroll
+				? defaultView.innerHeight
+				: scrollContainer.clientHeight;
+
+			// Abort if the target scroll position would scroll the caret out of
+			// view.
+			if (
+				// The caret is under the lower fold.
+				caretRect.top + caretRect.height >
+					scrollContainerY + scrollContainerHeight ||
+				// The caret is above the upper fold.
+				caretRect.top < scrollContainerY
+			) {
+				// Reset the caret position to maintain.
+				caretRect = currentCaretRect;
+				return;
+			}
+
+			if ( windowScroll ) {
+				defaultView.scrollBy( 0, diff );
+			} else {
+				scrollContainer.scrollTop += diff;
+			}
+		}
+
+		/**
+		 * Adds a `selectionchange` listener to reset the scroll position to be
+		 * maintained.
+		 */
+		function addSelectionChangeListener() {
+			ownerDocument.addEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+		}
+
+		/**
+		 * Resets the scroll position to be maintained during a `selectionchange`
+		 * event. Also removes the listener, so it acts as a one-time listener.
+		 */
+		function computeCaretRectOnSelectionChange() {
+			ownerDocument.removeEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+			computeCaretRectangle();
+		}
+
+		/**
+		 * Resets the scroll position to be maintained.
+		 */
+		function computeCaretRectangle() {
+			if ( isSelectionEligibleForScroll() ) {
+				caretRect = computeCaretRect( defaultView );
+			}
+		}
+
+		/**
+		 * Checks if the current situation is eligible for scroll:
+		 * - The component must contain the selection.
+		 * - The active element must be contenteditable.
+		 */
+		function isSelectionEligibleForScroll() {
+			return (
+				node.contains( ownerDocument.activeElement ) &&
+				ownerDocument.activeElement.isContentEditable
+			);
+		}
+
+		function isLastEditableNode() {
+			const editableNodes = node.querySelectorAll(
+				'[contenteditable="true"]'
+			);
+			const lastEditableNode = editableNodes[ editableNodes.length - 1 ];
+			return lastEditableNode === ownerDocument.activeElement;
+		}
+
+		// When the user scrolls or resizes, the scroll position should be
+		// reset.
+		defaultView.addEventListener( 'scroll', onScrollResize, true );
+		defaultView.addEventListener( 'resize', onScrollResize, true );
+
+		node.addEventListener( 'keydown', onKeyDown );
+		node.addEventListener( 'keyup', maintainCaretPosition );
+		node.addEventListener( 'mousedown', addSelectionChangeListener );
+		node.addEventListener( 'touchstart', addSelectionChangeListener );
+
+		return () => {
+			defaultView.removeEventListener( 'scroll', onScrollResize, true );
+			defaultView.removeEventListener( 'resize', onScrollResize, true );
+
+			node.removeEventListener( 'keydown', onKeyDown );
+			node.removeEventListener( 'keyup', maintainCaretPosition );
+			node.removeEventListener( 'mousedown', addSelectionChangeListener );
+			node.removeEventListener(
+				'touchstart',
+				addSelectionChangeListener
+			);
+
+			ownerDocument.removeEventListener(
+				'selectionchange',
+				computeCaretRectOnSelectionChange
+			);
+
+			defaultView.cancelAnimationFrame( scrollResizeRafId );
+			defaultView.cancelAnimationFrame( onKeyDownRafId );
+		};
+	}, [] );
 }
 
 function Typewriter( { children } ) {


### PR DESCRIPTION
## What?

Extracted from #79105. Removes the `hasSelectedBlock` store subscription that gated the typewriter's event listeners, attaching them unconditionally.

> [!NOTE]
> Best reviewed with whitespace changes hidden: dropping the dependency array argument lets Prettier collapse the `useRefEffect` call, which re-indents its whole callback. The actual change is 6 insertions, 37 deletions.

## Why?

The gate is redundant: `maintainCaretPosition` already no-ops unless a contenteditable element within the container holds focus, so the listeners detached and reattached on every change in selection existence for no behavioral gain. It is also unreliable under #79105 (`supports.editableRoot`), where the writing flow wrapper holds focus: a transient selection update can leave the subscription stale, deactivating the typewriter while a block is selected.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/editor/various/typewriter.spec.js`
2. In the editor, fill a post past the bottom of the viewport and keep typing: the caret keeps its vertical position (typewriter effect), and arrow keys, scrolling, and clicking still reset the maintained position.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
