### PR TITLE
Observe typing on the writing flow node

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -14,7 +14,7 @@ import BlockTools from '../block-tools';
 import EditorStyles from '../editor-styles';
 import Iframe from '../iframe';
 import WritingFlow from '../writing-flow';
-import { useMouseMoveTypingReset } from '../observe-typing';
+import { useMouseMoveTypingReset, useTypingObserver } from '../observe-typing';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useBlockCommands } from '../use-block-commands';
 import { store as blockEditorStore } from '../../store';
@@ -60,7 +60,14 @@ export function ExperimentalBlockCanvas( {
 	const resetTypingRef = useMouseMoveTypingReset();
 	const clearerRef = useBlockSelectionClearer();
 	const localRef = useRef();
-	const contentRef = useMergeRefs( [ contentRefProp, clearerRef, localRef ] );
+	// Attached to the same node as the writing flow ref: the iframe body,
+	// or the WritingFlow element when the canvas is not iframed.
+	const contentRef = useMergeRefs( [
+		contentRefProp,
+		clearerRef,
+		localRef,
+		useTypingObserver(),
+	] );
 	const zoomLevel = useSelect(
 		( select ) => unlock( select( blockEditorStore ) ).getZoomLevel(),
 		[]

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -35,7 +35,6 @@ import {
 	BlockEditContextProvider,
 	DEFAULT_BLOCK_EDIT_CONTEXT,
 } from '../block-edit/context';
-import { useTypingObserver } from '../observe-typing';
 import { ZoomOutSeparator } from './zoom-out-separator';
 import { unlock } from '../../lock-unlock';
 
@@ -113,7 +112,6 @@ function Root( { className, ...settings } ) {
 			ref: useMergeRefs( [
 				useBlockSelectionClearer(),
 				useInBetweenInserter(),
-				useTypingObserver(),
 			] ),
 			className: clsx( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -10,7 +10,6 @@ import {
 	BlockList,
 	store as blockEditorStore,
 	__unstableUseTypewriter as useTypewriter,
-	__unstableUseTypingObserver as useTypingObserver,
 	useSettings,
 	RecursionProvider,
 	privateApis as blockEditorPrivateApis,
@@ -303,7 +302,6 @@ function VisualEditor( {
 		blockListLayout?.type === 'default' && ! hasPostContentAtRootLevel
 			? fallbackLayout
 			: blockListLayout;
-	const observeTypingRef = useTypingObserver();
 	const titleRef = useRef();
 	useEffect( () => {
 		if ( ! autoFocus || ! isCleanNewPost() ) {
@@ -452,7 +450,6 @@ function VisualEditor( {
 								}
 							) }
 							contentEditable={ false }
-							ref={ observeTypingRef }
 							style={ {
 								// This is using inline styles so it's applied
 								// within the editor iframe.


### PR DESCRIPTION
## What?

Extracted from #79105. Moves the typing observer from its two call sites, both inside the writing flow node (the block list root container and the visual editor's post title wrapper), to the block canvas's `contentRef`, which attaches to the same node as the writing flow ref: the iframe body, or the `WritingFlow` element when the canvas is not iframed.

> [!NOTE]
> Requires #80133 (merged): the iframe body mounts in the Iframe component's own commit, and without that fix a conditional ref passed in through `contentRef` missed its next update (the observer's `isTyping` listener swap), leaving the editor stuck in the typing state. The earlier CI failures on this PR were that bug.

## Why?

Preparatory for #79105 (`supports.editableRoot`): while a focused editing host holds the selection, key events target the host, so listeners bound to elements below it never fire. With the observer on the writing flow node, those events satisfy the observer's existing target checks with no changes: the observed node contains itself. The same already applies on trunk when the node becomes the multi-selection editing host.

On trunk, one observer replaces two: the node contains both the post title and the block list.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/editor/various/is-typing.spec.js`
2. `npm run test:e2e -- test/e2e/specs/editor/various/multi-block-selection.spec.js`
3. In the editor: type in a paragraph and in the post title (the block toolbar hides), press Escape (it returns), multi-select blocks with shift+click (the toolbar appears), and type into a block toolbar dropdown (it stays open).

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
