### PR TITLE
useMergeRefs: apply ref changes after out-of-render attachment

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Widen React peer dependency ranges to `^18 || ^19` to support both React 18 and React 19 environments ([#80024](https://github.com/WordPress/gutenberg/pull/80024)).
 
+### Bug Fixes
+
+-   `useMergeRefs`: Apply ref changes when the element attached outside a render of the calling component (e.g. a merged ref passed to a child that mounts the element in its own commit); previously the first ref change after such an attachment was skipped, leaving stale callbacks on the element ([#80133](https://github.com/WordPress/gutenberg/pull/80133)).
+
 ## 8.3.0 (2026-07-01)
 
 ## 8.2.0 (2026-06-24)

--- a/packages/compose/src/hooks/use-merge-refs/index.ts
+++ b/packages/compose/src/hooks/use-merge-refs/index.ts
@@ -80,7 +80,6 @@ export default function useMergeRefs< T >(
 	refs: Ref< T >[]
 ): RefCallback< T > {
 	const elementRef = useRef< T | null >( null );
-	const isAttachedRef = useRef( false );
 	// The refs that are attached to the element: set when the element
 	// attaches, and kept in sync when a changed ref is swapped on render.
 	const attachedRefsRef = useRef< Ref< T >[] >( [] );
@@ -103,7 +102,9 @@ export default function useMergeRefs< T >(
 	// during this commit, the ref callback has already been called with the
 	// current refs, which compare equal here.
 	useLayoutEffect( () => {
-		if ( isAttachedRef.current === false ) {
+		const element = elementRef.current;
+
+		if ( element === null ) {
 			return;
 		}
 
@@ -111,10 +112,7 @@ export default function useMergeRefs< T >(
 			const attachedRef = attachedRefsRef.current[ index ];
 			if ( ref !== attachedRef ) {
 				detachRef( attachedRef, index, cleanupsRef.current );
-				cleanupsRef.current[ index ] = assignRef(
-					ref,
-					elementRef.current as T
-				);
+				cleanupsRef.current[ index ] = assignRef( ref, element );
 			}
 		} );
 
@@ -127,7 +125,6 @@ export default function useMergeRefs< T >(
 		// Update the element so it can be used when calling ref callbacks on a
 		// dependency change.
 		elementRef.current = value;
-		isAttachedRef.current = value !== null;
 
 		// When an element changes, the current ref callback should be called
 		// with the new element and the attached one with `null`.

--- a/packages/compose/src/hooks/use-merge-refs/index.ts
+++ b/packages/compose/src/hooks/use-merge-refs/index.ts
@@ -81,8 +81,9 @@ export default function useMergeRefs< T >(
 ): RefCallback< T > {
 	const elementRef = useRef< T | null >( null );
 	const isAttachedRef = useRef( false );
-	const didElementChangeRef = useRef( false );
-	const previousRefsRef = useRef< Ref< T >[] >( [] );
+	// The refs that are attached to the element: set when the element
+	// attaches, and kept in sync when a changed ref is swapped on render.
+	const attachedRefsRef = useRef< Ref< T >[] >( [] );
 	const currentRefsRef = useRef( refs );
 	// Position-indexed cleanups returned by inner ref callbacks. A slot is
 	// `undefined` when the ref at that position did not return a cleanup (or
@@ -93,34 +94,32 @@ export default function useMergeRefs< T >(
 	// always has access to the current refs.
 	currentRefsRef.current = refs;
 
-	// If any of the refs change, call the previous ref with `null` and the new
-	// ref with the node, except when the element changes in the same cycle, in
-	// which case the ref callbacks will already have been called.
+	// If any of the refs change, call the attached ref with `null` and the
+	// new ref with the node. Comparing against the refs that are attached to
+	// the element, rather than the previous render's refs, also covers an
+	// element that attaches outside a render of this component (a merged ref
+	// passed to a child that mounts the element in its own commit): the
+	// change is still detected on the next render. When the element attached
+	// during this commit, the ref callback has already been called with the
+	// current refs, which compare equal here.
 	useLayoutEffect( () => {
-		if (
-			didElementChangeRef.current === false &&
-			isAttachedRef.current === true
-		) {
-			refs.forEach( ( ref, index ) => {
-				const previousRef = previousRefsRef.current[ index ];
-				if ( ref !== previousRef ) {
-					detachRef( previousRef, index, cleanupsRef.current );
-					cleanupsRef.current[ index ] = assignRef(
-						ref,
-						elementRef.current as T
-					);
-				}
-			} );
+		if ( isAttachedRef.current === false ) {
+			return;
 		}
 
-		previousRefsRef.current = refs;
-	}, refs );
+		refs.forEach( ( ref, index ) => {
+			const attachedRef = attachedRefsRef.current[ index ];
+			if ( ref !== attachedRef ) {
+				detachRef( attachedRef, index, cleanupsRef.current );
+				cleanupsRef.current[ index ] = assignRef(
+					ref,
+					elementRef.current as T
+				);
+			}
+		} );
 
-	// No dependencies, must be reset after every render so ref callbacks are
-	// correctly called after a ref change.
-	useLayoutEffect( () => {
-		didElementChangeRef.current = false;
-	} );
+		attachedRefsRef.current = refs;
+	}, refs );
 
 	// There should be no dependencies so that `callback` is only called when
 	// the node changes.
@@ -128,18 +127,18 @@ export default function useMergeRefs< T >(
 		// Update the element so it can be used when calling ref callbacks on a
 		// dependency change.
 		elementRef.current = value;
-
-		didElementChangeRef.current = true;
 		isAttachedRef.current = value !== null;
 
 		// When an element changes, the current ref callback should be called
-		// with the new element and the previous one with `null`.
+		// with the new element and the attached one with `null`.
 		if ( value === null ) {
-			previousRefsRef.current.forEach( ( ref, index ) => {
+			attachedRefsRef.current.forEach( ( ref, index ) => {
 				detachRef( ref, index, cleanupsRef.current );
 			} );
+			attachedRefsRef.current = [];
 		} else {
-			currentRefsRef.current.forEach( ( ref, index ) => {
+			attachedRefsRef.current = currentRefsRef.current;
+			attachedRefsRef.current.forEach( ( ref, index ) => {
 				cleanupsRef.current[ index ] = assignRef( ref, value );
 			} );
 		}

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -342,6 +342,74 @@ describe( 'useMergeRefs', () => {
 			],
 			[ [], [] ],
 			[ [], [] ],
+		] );
+	} );
+
+	it( 'should work for dependency change after attachment outside a render of the owner', () => {
+		// The merged ref is created by a parent, but the element is mounted
+		// by a child in a commit of its own (e.g. the editor iframe portals
+		// the canvas body once the iframe document is available). The parent
+		// does not render in that commit, so the hook must still detect and
+		// apply a later ref change on the parent's next render.
+		function Child( { mergedRefs } ) {
+			const [ attached, setAttached ] = useState( false );
+			return (
+				<>
+					<button onClick={ () => setAttached( true ) } />
+					{ attached && <ul ref={ mergedRefs } /> }
+				</>
+			);
+		}
+
+		function Parent( { count } ) {
+			function refCallback1( value ) {
+				refCallback1.history.push( value );
+			}
+
+			refCallback1.history = [];
+
+			function refCallback2( value ) {
+				refCallback2.history.push( value );
+			}
+
+			refCallback2.history = [];
+
+			renderCallback( [ refCallback1.history, refCallback2.history ] );
+
+			const ref1 = useCallback( refCallback1, [] );
+			const ref2 = useCallback( refCallback2, [ count ] );
+			return <Child mergedRefs={ useMergeRefs( [ ref1, ref2 ] ) } />;
+		}
+
+		const { rerender, unmount } = render( <Parent count={ 1 } /> );
+
+		// Mount the element in a child-only commit: the parent does not
+		// render.
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		const originalElement = screen.getByRole( 'list' );
+
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [ originalElement ] ],
+		] );
+
+		rerender( <Parent count={ 2 } /> );
+
+		// The dependency change must still swap the second ref: the initial
+		// function called with null, the new function with the attached node.
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [ originalElement, null ] ],
+			[ [], [ originalElement ] ],
+		] );
+
+		unmount();
+
+		expect( renderCallback.history ).toEqual( [
+			[
+				[ originalElement, null ],
+				[ originalElement, null ],
+			],
+			[ [], [ originalElement, null ] ],
 		] );
 	} );
 } );


### PR DESCRIPTION
## What?

Fixes `useMergeRefs` missing a ref update when the element attaches outside a render of the calling component, and simplifies the hook: it now diffs against the refs actually attached to the element instead of the previous render's refs guarded by an `element just changed` flag. This removes one of the two `useLayoutEffect` calls (the per-render flag reset) and two of the six `useRef` calls.

## Why?

The flag is reset by a layout effect of the calling component, which assumes the element always attaches during one of the caller's renders. When the merged ref is passed to a child that mounts the element in a commit of its own (e.g. the editor iframe portals the canvas body once the iframe document is available), the caller doesn't render in that commit, the flag is never reset, and the caller's next render skips the diff: a ref that changed in that render is neither detached nor attached.

Found in #80131, where a typing observer merged into BlockCanvas's `contentRef` missed its `isTyping` listener swap, leaving the editor stuck in the typing state. Reproduction depends on whether an unrelated caller re-render lands in between: local Chromium passed, CI and Firefox failed.

## How?

The merged ref callback records which refs it attached; the layout effect diffs the current refs against that list and keeps it in sync. An element attached during the caller's own commit compares equal by construction, since ref callbacks run before layout effects. Includes a regression test (child-only mount commit, then a dependency change) that fails against the previous implementation.

## Testing Instructions

1. `npm run test:unit -- packages/compose/src/hooks/use-merge-refs`

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
