### PR TITLE
Rich text: synchronize the selection when the value is read

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/before-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/before-input-rules.js
@@ -25,12 +25,14 @@ const wrapSelectionSettings = [ '`', '"', "'", '“”', '‘’' ];
 export default ( props ) => ( element ) => {
 	function onInput( event ) {
 		const { inputType, data } = event;
-		const { value, onChange, registry } = props.current;
+		const { getValue, onChange, registry } = props.current;
 
 		// Only run the rules when inserting text.
 		if ( inputType !== 'insertText' ) {
 			return;
 		}
+
+		const value = getValue();
 
 		if ( isCollapsed( value ) ) {
 			return;

--- a/packages/block-editor/src/components/rich-text/event-listeners/delete.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/delete.js
@@ -20,9 +20,10 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const { value, onMerge, onRemove } = props.current;
+		const { getValue, onMerge, onRemove } = props.current;
 
 		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
+			const value = getValue();
 			const { start, end, text } = value;
 			const isReverse = keyCode === BACKSPACE;
 			const hasActiveFormats =

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -41,7 +41,7 @@ export default ( props ) => ( element ) => {
 		}
 
 		const {
-			value,
+			getValue,
 			onChange,
 			disableLineBreaks,
 			onSplitAtEnd,
@@ -51,6 +51,7 @@ export default ( props ) => ( element ) => {
 
 		event.preventDefault();
 
+		const value = getValue();
 		const { text, start, end } = value;
 
 		if ( event.shiftKey ) {

--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -23,7 +23,7 @@ export default ( props ) => ( element ) => {
 		const {
 			disableFormats,
 			onChange,
-			value,
+			getValue,
 			formatTypes,
 			tagName,
 			onReplace,
@@ -42,6 +42,8 @@ export default ( props ) => ( element ) => {
 		if ( event.defaultPrevented ) {
 			return;
 		}
+
+		const value = getValue();
 
 		const { plainText, html } = getPasteEventData( event );
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Widen React peer dependency ranges to `^18 || ^19` to support both React 18 and React 19 environments ([#80024](https://github.com/WordPress/gutenberg/pull/80024)).
 
+### Bug Fixes
+
+-   `useRichText`: `getValue()` now synchronizes the value's selection with the DOM selection instead of returning offsets from the last `selectionchange` event, which is asynchronous, so a handler could act one selection change behind the DOM (e.g. splitting or inserting at a stale caret position) ([#80134](https://github.com/WordPress/gutenberg/pull/80134)).
+
 ## 7.50.0 (2026-07-01)
 
 ## 7.49.0 (2026-06-24)

--- a/packages/rich-text/src/hook/event-listeners/copy-handler.js
+++ b/packages/rich-text/src/hook/event-listeners/copy-handler.js
@@ -16,16 +16,17 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
 export default ( props ) => ( element ) => {
 	function onCopy( event ) {
-		const { record } = props.current;
+		const { getValue } = props.current;
 		const { ownerDocument } = element;
+		const value = getValue();
 		if (
-			isCollapsed( record.current ) ||
+			isCollapsed( value ) ||
 			! element.contains( ownerDocument.activeElement )
 		) {
 			return;
 		}
 
-		const selectedRecord = slice( record.current );
+		const selectedRecord = slice( value );
 		const plainText = getTextContent( selectedRecord );
 		const html = toHTMLString( { value: selectedRecord } );
 		event.clipboardData.setData( 'text/plain', plainText );

--- a/packages/rich-text/src/hook/event-listeners/format-boundaries.js
+++ b/packages/rich-text/src/hook/event-listeners/format-boundaries.js
@@ -29,15 +29,16 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const { record, applyRecord, forceRender } = props.current;
+		const { record, applyRecord, forceRender, getValue } = props.current;
+		const value = getValue();
 		const {
 			text,
 			formats,
 			start,
 			end,
 			activeFormats: currentActiveFormats = [],
-		} = record.current;
-		const collapsed = isCollapsed( record.current );
+		} = value;
+		const collapsed = isCollapsed( value );
 		const { defaultView } = element.ownerDocument;
 		// To do: ideally, we should look at visual position instead.
 		const { direction } = defaultView.getComputedStyle( element );
@@ -90,6 +91,11 @@ export default ( props ) => ( element ) => {
 		const origin = isReverse ? formatsAfter : formatsBefore;
 		const source = isIncreasing ? destination : origin;
 		const newActiveFormats = source.slice( 0, newActiveFormatsLength );
+		// Only the active formats change: base the new record on the current
+		// record, not the value derived from the DOM selection. Writing
+		// derived offsets here would hide a pending selection change from
+		// the `selectionchange` handler, which would then never dispatch it
+		// to the store.
 		const newValue = {
 			...record.current,
 			activeFormats: newActiveFormats,

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -63,14 +63,12 @@ export default ( props ) => ( element ) => {
 	const { ownerDocument } = element;
 	const { defaultView } = ownerDocument;
 
-	let isComposing = false;
-
 	function onInput( event ) {
 		// Do not trigger a change if characters are being composed. Browsers
 		// will usually emit a final `input` event when the characters are
 		// composed. As of December 2019, Safari doesn't support
 		// nativeEvent.isComposing.
-		if ( isComposing ) {
+		if ( props.current.isComposingRef.current ) {
 			return;
 		}
 
@@ -80,8 +78,19 @@ export default ( props ) => ( element ) => {
 			inputType = event.inputType;
 		}
 
-		const { record, applyRecord, createRecord, handleChange } =
-			props.current;
+		const {
+			record,
+			applyRecord,
+			createRecord,
+			handleChange,
+			preInputValueRef,
+		} = props.current;
+
+		// The value as of right before this input, pinned by the
+		// `beforeinput` listener. The record itself may be a `selectionchange`
+		// event behind: the native event is asynchronous.
+		const preInputValue = preInputValueRef.current ?? record.current;
+		preInputValueRef.current = undefined;
 
 		// The browser formatted something or tried to insert HTML. Overwrite
 		// it. It will be handled later by the format library if needed.
@@ -95,13 +104,13 @@ export default ( props ) => ( element ) => {
 		}
 
 		const currentValue = createRecord();
-		const { start, activeFormats: oldActiveFormats = [] } = record.current;
+		const { start, activeFormats: oldActiveFormats = [] } = preInputValue;
 
 		// When a non-collapsed selection is deleted (not replaced with new
 		// text), the old active formats refer to the deleted content and
 		// should not be carried forward.
 		const clearFormats =
-			! isCollapsed( record.current ) && currentValue.start <= start;
+			! isCollapsed( preInputValue ) && currentValue.start <= start;
 
 		// Update the formats between the last and new caret position.
 		const change = updateFormats( {
@@ -137,7 +146,7 @@ export default ( props ) => ( element ) => {
 
 		// In case of a keyboard event, ignore selection changes during
 		// composition.
-		if ( isComposing ) {
+		if ( props.current.isComposingRef.current ) {
 			return;
 		}
 
@@ -189,7 +198,7 @@ export default ( props ) => ( element ) => {
 	}
 
 	function onCompositionStart() {
-		isComposing = true;
+		props.current.isComposingRef.current = true;
 		// `handleSelectionChange` returns early while composing, so the
 		// selection is not updated as characters are composed (which rerenders
 		// the component and might destroy internal browser editing state).
@@ -201,7 +210,7 @@ export default ( props ) => ( element ) => {
 	}
 
 	function onCompositionEnd() {
-		isComposing = false;
+		props.current.isComposingRef.current = false;
 		// Ensure the value is up-to-date for browsers that don't emit a final
 		// input event after composition.
 		onInput( { inputType: 'insertText' } );
@@ -267,6 +276,16 @@ export default ( props ) => ( element ) => {
 		onInput,
 		true
 	);
+	// Pin the value before the browser mutates the DOM for `onInput`, which
+	// needs the offsets from before the input.
+	const unsubscribeBeforeInput = subscribeDelegatedListener(
+		element,
+		'beforeinput',
+		() => {
+			props.current.preInputValueRef.current = props.current.getValue();
+		},
+		true
+	);
 	const unsubscribeCompositionStart = subscribeDelegatedListener(
 		element,
 		'compositionstart',
@@ -295,6 +314,7 @@ export default ( props ) => ( element ) => {
 
 	return () => {
 		unsubscribeInput();
+		unsubscribeBeforeInput();
 		unsubscribeCompositionStart();
 		unsubscribeCompositionEnd();
 		unsubscribeFocus();

--- a/packages/rich-text/src/hook/index.js
+++ b/packages/rich-text/src/hook/index.js
@@ -13,6 +13,7 @@ import { create, RichTextData } from '../create';
 import { apply } from '../to-dom';
 import { toHTMLString } from '../to-html-string';
 import { removeFormat } from '../remove-format';
+import { getActiveFormats } from '../get-active-formats';
 import { useDefaultStyle } from './use-default-style';
 import { useBoundaryStyle } from './use-boundary-style';
 import { useEventListeners } from './event-listeners';
@@ -65,6 +66,92 @@ function useRichTextBase( {
 	// Internal values are updated synchronously, unlike props and state.
 	const _valueRef = useRef( value );
 	const recordRef = useRef();
+
+	// Caches the value derived by `getValue`, keyed by the DOM selection and
+	// the record it was derived from. Any record change creates a new record
+	// object, so the record reference doubles as the cache invalidation for
+	// everything but the DOM selection itself.
+	const derivedValueCacheRef = useRef( {} );
+	// The value as of right before an input: set by a `beforeinput` listener
+	// and consumed by input handling, which computes the changed range from
+	// the offsets before the input, so they cannot be read after the fact.
+	const preInputValueRef = useRef();
+	// Owned by the input event listeners; read here so no selection is read
+	// while the user is composing text.
+	const isComposingRef = useRef( false );
+
+	/**
+	 * Returns the current value: the record, with its selection derived from
+	 * the DOM selection when the element owns it. The native
+	 * `selectionchange` event is asynchronous and coalesced, so the record's
+	 * offsets may be behind the DOM selection when read; the fresh offsets
+	 * are derived on demand instead. The record itself is not modified:
+	 * record and store synchronization stays on the `selectionchange` event
+	 * and on value changes, as before.
+	 */
+	function getValue() {
+		const element = ref.current;
+		const record = recordRef.current;
+
+		if ( ! element || isComposingRef.current ) {
+			return record;
+		}
+
+		if (
+			element.contentEditable !== 'true' ||
+			element.ownerDocument.activeElement !== element
+		) {
+			return record;
+		}
+
+		const { anchorNode, anchorOffset, focusNode, focusOffset } =
+			element.ownerDocument.defaultView.getSelection();
+		const cache = derivedValueCacheRef.current;
+
+		if (
+			cache.record === record &&
+			cache.anchorNode === anchorNode &&
+			cache.anchorOffset === anchorOffset &&
+			cache.focusNode === focusNode &&
+			cache.focusOffset === focusOffset
+		) {
+			return cache.value;
+		}
+
+		const { start, end, text } = createRecord();
+		let derivedValue = record;
+
+		// A text mismatch is reconciled by input handling; equal offsets
+		// need no derivation.
+		if (
+			text === record.text &&
+			( start !== record.start || end !== record.end )
+		) {
+			derivedValue = {
+				...record,
+				start,
+				end,
+				// _newActiveFormats may be set on arrow key navigation to
+				// control the right boundary position. If undefined,
+				// getActiveFormats will give the active formats according to
+				// the browser.
+				activeFormats: record._newActiveFormats,
+				_newActiveFormats: undefined,
+			};
+			derivedValue.activeFormats = getActiveFormats( derivedValue, [] );
+		}
+
+		derivedValueCacheRef.current = {
+			record,
+			anchorNode,
+			anchorOffset,
+			focusNode,
+			focusOffset,
+			value: derivedValue,
+		};
+
+		return derivedValue;
+	}
 
 	function setRecordFromProps() {
 		const activeFormats = recordRef.current?.activeFormats;
@@ -216,6 +303,9 @@ function useRichTextBase( {
 			isSelected,
 			onSelectionChange,
 			forceRender,
+			getValue,
+			preInputValueRef,
+			isComposingRef,
 		} ),
 		useRefEffect( () => {
 			applyFromProps();
@@ -225,12 +315,13 @@ function useRichTextBase( {
 
 	return {
 		value: recordRef.current,
-		// A function to get the most recent value so event handlers in
-		// useRichText implementations have access to it. For example when
-		// listening to input events, we internally update the state, but this
-		// state is not yet available to the input event handler because React
-		// may re-render asynchronously.
-		getValue: () => recordRef.current,
+		// A function to get the current value, so event handlers in
+		// useRichText implementations have access to it. The value rendered
+		// by React may be behind: internal updates happen synchronously while
+		// React re-renders asynchronously, and the record's selection is only
+		// as recent as the last (asynchronous) `selectionchange` event, so
+		// the selection is derived from the DOM on every call.
+		getValue,
 		onChange: handleChange,
 		ref: mergedRefs,
 	};


### PR DESCRIPTION
## What?

Makes `getValue()` the guaranteed-fresh read: it derives the value's selection from the DOM selection when the element owns it, instead of returning offsets from the last `selectionchange` event.

1. **Derive on read, memoized.** The derivation is cached by the DOM selection fields and the record it was derived from; since every record change creates a new record object, the record reference doubles as the cache invalidation. Nothing is recomputed unless the selection or the record changed.
2. **Reads change nothing.** `getValue()` does not modify the record; record and store synchronization stay on the `selectionchange` event and on value changes, exactly as before.
3. **Pin before input.** Input handling computes the changed range from the offsets *before* the input, which can't be read after the browser mutates the DOM, so a `beforeinput` listener pins the value for it.
4. **Consumers commit to `getValue()`.** The listeners that act on the current selection read it instead of the record or a rendered value: copy/cut and format boundaries in rich text; enter, delete, paste and the wrap-selection rules in block-editor.

## Why?

`selectionchange` is asynchronous and coalesced, so a handler could read offsets one selection change behind the DOM and act at the wrong position (Enter splitting at the wrong offset, delete merging at a false edge, paste inserting at a stale caret). Real input usually leaves a task boundary for `selectionchange` to win the race; synthesized and fast input does not, which is a recurring source of caret e2e flakiness. It also derisks #79105, where a focused editing host removes the focus lifecycle that otherwise papers over the gap.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/editor/various/rich-text.spec.js test/e2e/specs/editor/various/splitting-merging.spec.js test/e2e/specs/editor/various/writing-flow.spec.js test/e2e/specs/editor/various/undo.spec.js test/e2e/specs/editor/various/multi-block-selection.spec.js`
2. In the editor: typing, Enter/Backspace at block edges, arrow navigation across format boundaries, copy/cut/paste, IME composition, and typing a quote/backtick over a selected word all behave as before.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)