### PR TITLE
Add missing docblocks to client-assets.php

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -451,6 +451,9 @@ remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
 
+/**
+ * Enqueues the LaTeX to MathML loader script module in the block editor.
+ */
 add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_latex_to_mathml_loader' );
 function gutenberg_enqueue_latex_to_mathml_loader() {
 	wp_enqueue_script_module( '@wordpress/latex-to-mathml/loader' );
@@ -487,6 +490,9 @@ function gutenberg_enqueue_video_conversion_loader() {
 	wp_enqueue_script_module( '@wordpress/video-conversion/loader' );
 }
 
+/**
+ * Enqueues the core abilities script module in the admin screens.
+ */
 add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_core_abilities' );
 function gutenberg_enqueue_core_abilities() {
 	wp_enqueue_script_module( '@wordpress/core-abilities' );


### PR DESCRIPTION
### What and Why?

Missing DocBlock tags in lib/client-assets.php.

### How?

Added missing DocBlocks to gutenberg_enqueue_latex_to_mathml_loader() and gutenberg_enqueue_core_abilities().

### Testing Instructions

1. Open lib/client-assets.php.
2. Verify that both gutenberg_enqueue_latex_to_mathml_loader() and gutenberg_enqueue_core_abilities() now have proper DocBlock tags.
