### PR TITLE
[Gutenberg 23.5.2] Icons: Make WP_Icons_Registry::register() public

### DIFF
--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -241,6 +241,15 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
  * registry.
  */
 function gutenberg_override_wp_icons_registry() {
+	/*
+	 * The plugin registers the `core/` icons from its own manifest, so core's
+	 * registration would only re-register the same names on this registry.
+	 */
+	$wp_priority = has_action( 'init', '_wp_register_default_icons' );
+	if ( false !== $wp_priority ) {
+		remove_action( 'init', '_wp_register_default_icons', $wp_priority );
+	}
+
 	$reflection = new ReflectionClass( WP_Icons_Registry::class );
 	$property   = $reflection->getProperty( 'instance' );
 	/*

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -65,7 +65,7 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 	 * }
 	 * @return bool True if the icon was registered with success and false otherwise.
 	 */
-	protected function register( $icon_name, $icon_properties ) {
+	public function register( $icon_name, $icon_properties ) {
 		if ( ! isset( $icon_name ) || ! is_string( $icon_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/lib/compat/wordpress-7.0/class-wp-icons-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-icons-registry.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 		 * }
 		 * @return bool True if the icon was registered with success and false otherwise.
 		 */
-		protected function register( $icon_name, $icon_properties ) {
+		public function register( $icon_name, $icon_properties ) {
 			if ( ! isset( $icon_name ) || ! is_string( $icon_name ) ) {
 				_doing_it_wrong(
 					__METHOD__,

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -788,11 +788,17 @@ function gutenberg_register_entity_view_config_filters() {
 		$wp_callback = "_wp_get_entity_view_config_post_type_{$post_type}";
 		$gb_callback = "_gutenberg_get_entity_view_config_post_type_{$post_type}";
 
-		$filter_priority = has_filter( $hook, $wp_callback );
-		if ( false !== $filter_priority ) {
-			remove_filter( $hook, $wp_callback, $filter_priority );
+		// has_filter() returns the priority the callback was registered at.
+		$wp_priority = has_filter( $hook, $wp_callback );
+		if ( false !== $wp_priority ) {
+			remove_filter( $hook, $wp_callback, $wp_priority );
 		}
-		add_filter( $hook, $gb_callback, 10, 1 );
+		if ( function_exists( $gb_callback ) ) {
+			// Base definitions run before the default priority, so third-party
+			// callbacks registered at the default compose on top of them
+			// regardless of registration order.
+			add_filter( $hook, $gb_callback, 5, 1 );
+		}
 	}
 }
 add_action( 'init', 'gutenberg_register_entity_view_config_filters' );

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -788,8 +788,9 @@ function gutenberg_register_entity_view_config_filters() {
 		$wp_callback = "_wp_get_entity_view_config_post_type_{$post_type}";
 		$gb_callback = "_gutenberg_get_entity_view_config_post_type_{$post_type}";
 
-		if ( has_filter( $hook, $wp_callback ) ) {
-			remove_filter( $hook, $wp_callback );
+		$filter_priority = has_filter( $hook, $wp_callback );
+		if ( false !== $filter_priority ) {
+			remove_filter( $hook, $wp_callback, $filter_priority );
 		}
 		add_filter( $hook, $gb_callback, 10, 1 );
 	}


### PR DESCRIPTION
This PR is for the Gutenberg 23.5.2 release.

## What?

In https://github.com/WordPress/wordpress-develop/pull/11559, we are attempting to commit the icon APIs to core. This PR also introduces the public method `WP_Icons_Registry::register()`. However, the version of the Gutenberg plugin installed in the CI for wordpress-develop is 23.5.1, and in this version, the overridden method is still private, causing the following error in the CI:

```
PHP Fatal error:  Access level to WP_Icons_Registry_Gutenberg::register() must be public (as in class WP_Icons_Registry) in /var/www/src/wp-content/plugins/gutenberg/lib/class-wp-icons-registry-gutenberg.php on line 68

PHP Fatal error:  Access level to WP_Icons_Registry_Gutenberg::register() must be public (as in class WP_Icons_Registry) in /var/www/src/wp-content/plugins/gutenberg/lib/class-wp-icons-registry-gutenberg.php on line 68
```

This implies that a fatal error may occur in environments using the WordPress nightly and the Gutenberg plugin. This PR aims to prevent this fatal error in advance by making the overridden methods public.