### PR TITLE
Try: remove the rich text focus handler

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -8,12 +8,13 @@ import {
 	isTextField,
 	placeCaretAtHorizontalEdge,
 } from '@wordpress/dom';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { isInsideRootBlock } from '../../../utils/dom';
+import { getCollapsedSelectionPayload } from '../../../utils/dom-selection';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
@@ -32,6 +33,7 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 	const { isBlockSelected, isMultiSelecting, isZoomOut } = unlock(
 		useSelect( blockEditorStore )
 	);
+	const { selectionChange } = useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		// Check if the block is still selected at the time this effect runs.
@@ -88,6 +90,21 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 			}
 		}
 		placeCaretAtHorizontalEdge( target, isReverse );
+
+		// Dispatch the placed selection, like the focus event used to. The
+		// store would otherwise only receive the offsets from the
+		// asynchronous `selectionchange` event, which the next input event
+		// can beat: handlers acting before then (e.g. Enter right after a
+		// split) read an offset-less selection.
+		const selection = ownerDocument.defaultView.getSelection();
+
+		if ( selection.rangeCount && target.contains( selection.anchorNode ) ) {
+			const payload = getCollapsedSelectionPayload( selection );
+
+			if ( payload ) {
+				selectionChange( payload );
+			}
+		}
 	}, [ initialPosition, clientId ] );
 
 	return ref;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -60,6 +60,20 @@ export function useFocusHandler( clientId ) {
 					return;
 				}
 
+				// For editable targets, the caret is inside the target, so
+				// select the block without requesting initial caret
+				// placement (`null` also clears a pending placement from an
+				// earlier action). Placing the caret at the block start would
+				// move focus even when it arrives transiently, for example
+				// when React restores focus after a commit while a selection
+				// update for another block is still in flight. The
+				// `selectionchange` listeners refine the selection to offset
+				// level.
+				if ( event.target.isContentEditable ) {
+					selectBlock( clientId, null );
+					return;
+				}
+
 				selectBlock( clientId );
 			}
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/delete.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/delete.js
@@ -20,9 +20,11 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const { value, onMerge, onRemove } = props.current;
+		const { getValue, onMerge, onRemove, onSelectionChange } =
+			props.current;
 
 		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
+			const value = getValue();
 			const { start, end, text } = value;
 			const isReverse = keyCode === BACKSPACE;
 			const hasActiveFormats =
@@ -39,6 +41,11 @@ export default ( props ) => ( element ) => {
 			}
 
 			if ( onMerge ) {
+				// `mergeBlocks` restores the caret from the store selection,
+				// which may not have received the current selection yet: the
+				// native `selectionchange` event is asynchronous. The merge
+				// consumes the selection, so synchronize it first.
+				onSelectionChange( start, end );
 				onMerge( ! isReverse );
 			}
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/index.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/index.js
@@ -45,14 +45,11 @@ export function useEventListeners( props ) {
 
 	return useRefEffect(
 		( element ) => {
-			if ( ! props.isSelected ) {
-				return;
-			}
 			const cleanups = refEffects.map( ( effect ) => effect( element ) );
 			return () => {
 				cleanups.forEach( ( cleanup ) => cleanup() );
 			};
 		},
-		[ refEffects, props.isSelected ]
+		[ refEffects ]
 	);
 }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -412,7 +412,6 @@ export function RichTextWrapper(
 						onReplace,
 						selectionChange,
 						onSelectionChange,
-						isSelected,
 						disableFormats,
 						value,
 						tagName,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -411,6 +411,7 @@ export function RichTextWrapper(
 						formatTypes,
 						onReplace,
 						selectionChange,
+						onSelectionChange,
 						isSelected,
 						disableFormats,
 						value,

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -20,7 +20,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { getBlockClientId } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
-import { getCollapsedSelectionPayload } from './utils';
+import { getCollapsedSelectionPayload } from '../../utils/dom-selection';
 
 /**
  * Returns true if the element should consider edge navigation upon a keyboard

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -20,6 +20,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { getBlockClientId } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
+import { getCollapsedSelectionPayload } from './utils';
 
 /**
  * Returns true if the element should consider edge navigation upon a keyboard
@@ -171,7 +172,7 @@ export default function useArrowNav() {
 		hasMultiSelection,
 		__unstableIsFullySelected,
 	} = useSelect( blockEditorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 	return useRefEffect( ( node ) => {
 		// Here a DOMRect is stored while moving the caret vertically so
 		// vertical position of the start position can be restored. This is to
@@ -189,6 +190,39 @@ export default function useArrowNav() {
 				node
 			);
 			return closestTabbable && getBlockClientId( closestTabbable );
+		}
+
+		/**
+		 * Synchronizes the store selection with the caret that was just
+		 * placed in another block, like the focus event used to. The store
+		 * would otherwise only learn about the crossing from the
+		 * asynchronous `selectionchange` event, and anything consuming the
+		 * store selection (or a value rendered from it) before that event
+		 * is processed acts on the block the caret came from.
+		 *
+		 * @param {HTMLElement} destination The element the caret was placed
+		 *                                  in.
+		 */
+		function syncCrossBlockSelection( destination ) {
+			const selection = node.ownerDocument.defaultView.getSelection();
+
+			if ( ! selection.rangeCount ) {
+				return;
+			}
+
+			// The placement may not produce a text selection (e.g. a
+			// focusable block without text): the selection still points at
+			// where the caret came from, and focus handling selects the
+			// destination block instead.
+			if ( ! destination.contains( selection.anchorNode ) ) {
+				return;
+			}
+
+			const payload = getCollapsedSelectionPayload( selection );
+
+			if ( payload ) {
+				selectionChange( payload );
+			}
 		}
 
 		function onKeyDown( event ) {
@@ -302,6 +336,7 @@ export default function useArrowNav() {
 						altKey ? ! isReverse : isReverse,
 						altKey ? undefined : verticalRect
 					);
+					syncCrossBlockSelection( closestTabbable );
 					event.preventDefault();
 				}
 			} else if (
@@ -316,6 +351,9 @@ export default function useArrowNav() {
 					node
 				);
 				placeCaretAtHorizontalEdge( closestTabbable, isReverse );
+				if ( closestTabbable ) {
+					syncCrossBlockSelection( closestTabbable );
+				}
 				event.preventDefault();
 			}
 		}

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -20,7 +20,8 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
-import { getCollapsedSelectionPayload, setClipboardBlocks } from './utils';
+import { setClipboardBlocks } from './utils';
+import { getCollapsedSelectionPayload } from '../../utils/dom-selection';
 import { getPasteEventData } from '../../utils/pasting';
 
 export default function useClipboardHandler() {

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -20,7 +20,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
-import { setClipboardBlocks } from './utils';
+import { getCollapsedSelectionPayload, setClipboardBlocks } from './utils';
 import { getPasteEventData } from '../../utils/pasting';
 
 export default function useClipboardHandler() {
@@ -28,6 +28,7 @@ export default function useClipboardHandler() {
 	const {
 		getBlocksByClientId,
 		getSelectedBlockClientIds,
+		getSelectionStart,
 		hasMultiSelection,
 		getSettings,
 		getBlockName,
@@ -42,6 +43,7 @@ export default function useClipboardHandler() {
 		flashBlock,
 		removeBlocks,
 		replaceBlocks,
+		selectionChange,
 		__unstableDeleteSelection,
 		__unstableExpandSelection,
 		__unstableSplitSelection,
@@ -53,6 +55,37 @@ export default function useClipboardHandler() {
 			if ( event.defaultPrevented ) {
 				// This was likely already handled in rich-text/use-paste-handler.js.
 				return;
+			}
+
+			// This handler acts on the store selection, which may not have
+			// received the current caret position yet: the native
+			// `selectionchange` event that dispatches it is asynchronous, so
+			// it can still be pending when the clipboard event arrives, for
+			// example right after an arrow key moved the caret into another
+			// block. Synchronize the store selection first. Only trust the
+			// native selection when it agrees with focus: for a selected
+			// block without text selection (e.g. an image), the native
+			// selection may still point at a previously edited block.
+			const selection = node.ownerDocument.defaultView.getSelection();
+			if (
+				selection.rangeCount &&
+				selection.isCollapsed &&
+				node.contains( selection.anchorNode ) &&
+				node.ownerDocument.activeElement?.contains(
+					selection.anchorNode
+				)
+			) {
+				const payload = getCollapsedSelectionPayload( selection );
+				const { clientId, attributeKey, offset } = payload?.start ?? {};
+				const start = getSelectionStart();
+				if (
+					payload &&
+					( start.clientId !== clientId ||
+						start.attributeKey !== attributeKey ||
+						start.offset !== offset )
+				) {
+					selectionChange( payload );
+				}
 			}
 
 			const selectedBlockClientIds = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -11,7 +11,10 @@ import { isSelectionForward } from '@wordpress/dom';
  */
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
-import { getCollapsedSelectionPayload, getRichTextElement } from './utils';
+import {
+	getCollapsedSelectionPayload,
+	getRichTextElement,
+} from '../../utils/dom-selection';
 
 /**
  * Extract the selection start node from the selection. When the anchor node is

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -11,6 +11,7 @@ import { isSelectionForward } from '@wordpress/dom';
  */
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
+import { getCollapsedSelectionPayload, getRichTextElement } from './utils';
 
 /**
  * Extract the selection start node from the selection. When the anchor node is
@@ -104,12 +105,6 @@ function setContentEditableWrapper( node, value ) {
 	}
 }
 
-function getRichTextElement( node ) {
-	const element =
-		node.nodeType === node.ELEMENT_NODE ? node : node.parentElement;
-	return element?.closest( '[data-wp-block-attribute-key]' );
-}
-
 /**
  * Sets a multi-selection based on the native selection across blocks.
  */
@@ -171,6 +166,26 @@ export default function useSelectionObserver() {
 								? startNode
 								: startNode.parentElement;
 						element = element?.closest( '[contenteditable]' );
+
+						// Moving focus into the element does not fire a
+						// `selectionchange` event (the selection is already
+						// inside it), so nothing else will dispatch the
+						// observed selection to the store. Dispatch it before
+						// moving focus so the focus handler finds the block
+						// already selected.
+						const payload =
+							getCollapsedSelectionPayload( selection );
+
+						if ( payload ) {
+							selectionChange( payload );
+						} else {
+							const clientId = getBlockClientId( startNode );
+
+							if ( clientId ) {
+								selectBlock( clientId );
+							}
+						}
+
 						element?.focus();
 					}
 					return;

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -10,65 +10,14 @@ import {
 	getBlockTransforms,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/pasting';
 import { store as blockEditorStore } from '../../store';
-import { getBlockClientId } from '../../utils/dom';
 
 export const requiresWrapperOnCopy = Symbol( 'requiresWrapperOnCopy' );
-
-/**
- * Returns the rich text element containing the given node, if any.
- *
- * @param {Node} node Node to search from.
- *
- * @return {Element|undefined} The rich text element.
- */
-export function getRichTextElement( node ) {
-	const element =
-		node.nodeType === node.ELEMENT_NODE ? node : node.parentElement;
-	return element?.closest( '[data-wp-block-attribute-key]' );
-}
-
-/**
- * Builds a store selection payload for a collapsed native selection inside a
- * rich text element.
- *
- * @param {Selection} selection The native selection.
- *
- * @return {Object|undefined} A payload for the `selectionChange` action, or
- *                            undefined when the selection is not inside a
- *                            rich text element.
- */
-export function getCollapsedSelectionPayload( selection ) {
-	const richTextElement = getRichTextElement( selection.anchorNode );
-
-	if ( ! richTextElement ) {
-		return;
-	}
-
-	const clientId = getBlockClientId( richTextElement );
-
-	if ( ! clientId ) {
-		return;
-	}
-
-	const { start } = create( {
-		element: richTextElement,
-		range: selection.getRangeAt( 0 ),
-		__unstableIsEditableTree: true,
-	} );
-	const attributeKey = richTextElement.dataset.wpBlockAttributeKey;
-	const offset = start ?? 0;
-	return {
-		start: { clientId, attributeKey, offset },
-		end: { clientId, attributeKey, offset },
-	};
-}
 
 /**
  * Sets the clipboard data for the provided blocks, with both HTML and plain

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -10,14 +10,65 @@ import {
 	getBlockTransforms,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/pasting';
 import { store as blockEditorStore } from '../../store';
+import { getBlockClientId } from '../../utils/dom';
 
 export const requiresWrapperOnCopy = Symbol( 'requiresWrapperOnCopy' );
+
+/**
+ * Returns the rich text element containing the given node, if any.
+ *
+ * @param {Node} node Node to search from.
+ *
+ * @return {Element|undefined} The rich text element.
+ */
+export function getRichTextElement( node ) {
+	const element =
+		node.nodeType === node.ELEMENT_NODE ? node : node.parentElement;
+	return element?.closest( '[data-wp-block-attribute-key]' );
+}
+
+/**
+ * Builds a store selection payload for a collapsed native selection inside a
+ * rich text element.
+ *
+ * @param {Selection} selection The native selection.
+ *
+ * @return {Object|undefined} A payload for the `selectionChange` action, or
+ *                            undefined when the selection is not inside a
+ *                            rich text element.
+ */
+export function getCollapsedSelectionPayload( selection ) {
+	const richTextElement = getRichTextElement( selection.anchorNode );
+
+	if ( ! richTextElement ) {
+		return;
+	}
+
+	const clientId = getBlockClientId( richTextElement );
+
+	if ( ! clientId ) {
+		return;
+	}
+
+	const { start } = create( {
+		element: richTextElement,
+		range: selection.getRangeAt( 0 ),
+		__unstableIsEditableTree: true,
+	} );
+	const attributeKey = richTextElement.dataset.wpBlockAttributeKey;
+	const offset = start ?? 0;
+	return {
+		start: { clientId, attributeKey, offset },
+		end: { clientId, attributeKey, offset },
+	};
+}
 
 /**
  * Sets the clipboard data for the provided blocks, with both HTML and plain

--- a/packages/block-editor/src/utils/dom-selection.js
+++ b/packages/block-editor/src/utils/dom-selection.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { create } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockClientId } from './dom';
+
+/**
+ * Returns the rich text element containing the given node, if any.
+ *
+ * @param {Node} node Node to search from.
+ *
+ * @return {Element|undefined} The rich text element.
+ */
+export function getRichTextElement( node ) {
+	const element =
+		node.nodeType === node.ELEMENT_NODE ? node : node.parentElement;
+	return element?.closest( '[data-wp-block-attribute-key]' );
+}
+
+/**
+ * Builds a store selection payload for a collapsed native selection inside a
+ * rich text element.
+ *
+ * @param {Selection} selection The native selection.
+ *
+ * @return {Object|undefined} A payload for the `selectionChange` action, or
+ *                            undefined when the selection is not inside a
+ *                            rich text element.
+ */
+export function getCollapsedSelectionPayload( selection ) {
+	const richTextElement = getRichTextElement( selection.anchorNode );
+
+	if ( ! richTextElement ) {
+		return;
+	}
+
+	const clientId = getBlockClientId( richTextElement );
+
+	if ( ! clientId ) {
+		return;
+	}
+
+	const { start } = create( {
+		element: richTextElement,
+		range: selection.getRangeAt( 0 ),
+		__unstableIsEditableTree: true,
+	} );
+	const attributeKey = richTextElement.dataset.wpBlockAttributeKey;
+	const offset = start ?? 0;
+	return {
+		start: { clientId, attributeKey, offset },
+		end: { clientId, attributeKey, offset },
+	};
+}

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -207,56 +207,6 @@ export default ( props ) => ( element ) => {
 		onInput( { inputType: 'insertText' } );
 	}
 
-	function onFocus( event ) {
-		// `focusin` bubbles from focusable descendants too — only act
-		// when focus lands on the editable itself.
-		if ( event.target !== element ) {
-			return;
-		}
-
-		// `contentEditable` can be false even on a tabindex'd element
-		// (e.g. a paragraph with a locked block binding). When that's the
-		// case the rich text isn't actually being edited and shouldn't
-		// claim selection — block-editor's `use-focus-handler.js` will
-		// dispatch `selectionChange(clientId)` to keep `attributeKey`
-		// unset for the wrapper-level focus.
-		if ( element.contentEditable !== 'true' ) {
-			return;
-		}
-
-		const { record, isSelected, onSelectionChange, applyRecord } =
-			props.current;
-
-		// When the whole editor is editable, let writing flow handle
-		// selection.
-		if ( element.parentElement.closest( '[contenteditable="true"]' ) ) {
-			return;
-		}
-
-		if ( ! isSelected ) {
-			// We know for certain that on focus, the old selection is invalid.
-			// It will be recalculated on the next mouseup, keyup, or touchend
-			// event.
-			const index = undefined;
-
-			record.current = {
-				...record.current,
-				start: index,
-				end: index,
-				activeFormats: EMPTY_ACTIVE_FORMATS,
-			};
-		} else {
-			applyRecord( record.current, { domOnly: true } );
-		}
-
-		onSelectionChange( record.current.start, record.current.end );
-
-		// There is no selection change event when the element is focused, so
-		// we need to manually trigger it. The selection is also not available
-		// yet in this call stack.
-		window.queueMicrotask( handleSelectionChange );
-	}
-
 	// `input` and `compositionend` must run before block-editor's
 	// `input-rules.js` element-level listeners, which call `getValue()`
 	// reading `record.current` updated by our `onInput`. Use capture phase
@@ -278,11 +228,6 @@ export default ( props ) => ( element ) => {
 		onCompositionEnd,
 		true
 	);
-	const unsubscribeFocus = subscribeDelegatedListener(
-		element,
-		'focusin',
-		onFocus
-	);
 	// Permanently subscribed rather than added on focus and removed on blur:
 	// `handleSelectionChange` checks whether the element is focused itself,
 	// and the shared underlying delegated listener keeps the number of native
@@ -297,7 +242,6 @@ export default ( props ) => ( element ) => {
 		unsubscribeInput();
 		unsubscribeCompositionStart();
 		unsubscribeCompositionEnd();
-		unsubscribeFocus();
 		unsubscribeSelectionChange();
 	};
 };


### PR DESCRIPTION
## What?

An experiment extracted from the #79105 discussions: remove rich text's `onFocus` handler entirely and make selection observation the only writer of selection into the store.

1. **Remove the focus handler.** It was the entry synchronization point: reset the record's stale selection on focus, dispatch to the store, apply the record, and manually trigger a sync (focus alone produces no `selectionchange`).
2. **Always attach rich text event listeners.** Attaching only while the block is store-selected leaves a window where events arrive at a focused element before the asynchronous selection dispatch catches up and no handler exists, so input falls through to the browser (rapid Enter produced invalid paragraphs). Every listener already scopes itself to its own element or checks the event target.
3. **Dispatch the observed selection when a multi-selection collapses.** The selection observer moved focus into the destination and relied on the focus event to dispatch. Moving focus into an element that already contains the selection fires no further `selectionchange`, so the observer now dispatches what it observes before moving focus.
4. **Select without initial caret placement for editable focus targets.** The caret is already inside a contentEditable focus target, so the block focus handler selects the block with `initialPosition: null`. Requesting placement would move the caret to the block start even when focus arrives transiently (React restoring focus after a commit while a selection update for another block is in flight), and `null` also clears a stale pending placement so it cannot replay against the transient focus.
5. **Actions synchronize what they consume.** Block merging dispatches its selection before `onMerge` (`mergeBlocks` restores the caret from the store selection), and the writing flow clipboard handler reconciles the store selection from the DOM before acting on it.
6. **Placers dispatch what they place.** Arrow navigation places the caret in the next block programmatically. Without the focus event, the asynchronous `selectionchange` can lose the race against the next input event, so both store consumers and rendered-value consumers act on the block the caret came from. The placement sites (arrow navigation and the initial caret placement in `use-focus-first-element`, which covers entry after a split) now dispatch the selection they placed, and React re-renders on a microtask before the next event task.

## Why?

The focus event is the one synchronization point that a focused editing host (#79105, `supports.editableRoot`) cannot produce: the caret moves between blocks natively without focus events, and every host-mode shim on that branch exists to replace what `onFocus` does here. If trunk works without the focus handler, driven by selection observation plus synchronous dispatch at the few sites that place or consume the selection, then trunk and host mode converge on one mechanism and the shims stop being shims.

Locally (headless macOS), the full copy-cut-paste, list, multi-block-selection, splitting-merging, block-deletion, rich-text and writing-flow suites pass across chromium, firefox and webkit; the two remaining intermittent failures reproduce at the same rate on plain trunk. Draft to let the full CI matrix surface what focus paths this misses (tab navigation, a11y flows, cross-browser).

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
