### PR TITLE
REST API: Apply unapplied EXIF orientation before image edits

### DIFF
--- a/backport-changelog/7.1/12492.md
+++ b/backport-changelog/7.1/12492.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12492
+
+* https://github.com/WordPress/gutenberg/pull/80144

--- a/lib/compat/wordpress-7.1/class-gutenberg-exif-orienting-image-editor-gd.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-exif-orienting-image-editor-gd.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Gutenberg_EXIF_Orienting_Image_Editor_GD class.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * GD image editor that applies any unapplied EXIF orientation on load.
+ *
+ * PLUGIN-ONLY SCAFFOLDING — none of this file is intended for WordPress
+ * core. In core, the fix this enables is a single line in
+ * `WP_REST_Attachments_Controller::edit_media_item()`, right after the
+ * editor is created:
+ *
+ *     $image_editor = wp_get_image_editor( $image_file_to_edit );
+ *     $image_editor->maybe_exif_rotate(); // <- the entire core fix.
+ *
+ * A plugin cannot add a line inside core's method, and core exposes no hook
+ * between loading the editor and applying the edit modifiers. The closest
+ * seam is the `wp_image_editors` filter (class selection), so the plugin
+ * swaps in this subclass, whose `load()` runs `maybe_exif_rotate()` at the
+ * same point in the sequence the core one-liner would.
+ *
+ * Delete this file, its Imagick sibling, and the `edit_media_item()`
+ * override in `Gutenberg_REST_Attachments_Controller_7_1` once the core
+ * change ships.
+ *
+ * @since 7.1.0
+ *
+ * @see Gutenberg_REST_Attachments_Controller_7_1::edit_media_item()
+ */
+class Gutenberg_EXIF_Orienting_Image_Editor_GD extends WP_Image_Editor_GD {
+	/**
+	 * Loads image from $this->file into editor and uprights it.
+	 *
+	 * @return true|WP_Error True if loaded successfully; WP_Error on failure.
+	 */
+	public function load() {
+		$loaded = parent::load();
+
+		if ( true === $loaded ) {
+			// A failed rotation (e.g. missing EXIF support) degrades to
+			// editing the raw pixels, matching previous behavior.
+			$this->maybe_exif_rotate();
+		}
+
+		return $loaded;
+	}
+}

--- a/lib/compat/wordpress-7.1/class-gutenberg-exif-orienting-image-editor-imagick.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-exif-orienting-image-editor-imagick.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Gutenberg_EXIF_Orienting_Image_Editor_Imagick class.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Imagick image editor that applies any unapplied EXIF orientation on load.
+ *
+ * PLUGIN-ONLY SCAFFOLDING — none of this file is intended for WordPress
+ * core. In core, the fix this enables is a single line in
+ * `WP_REST_Attachments_Controller::edit_media_item()`, right after the
+ * editor is created:
+ *
+ *     $image_editor = wp_get_image_editor( $image_file_to_edit );
+ *     $image_editor->maybe_exif_rotate(); // <- the entire core fix.
+ *
+ * A plugin cannot add a line inside core's method, and core exposes no hook
+ * between loading the editor and applying the edit modifiers. The closest
+ * seam is the `wp_image_editors` filter (class selection), so the plugin
+ * swaps in this subclass, whose `load()` runs `maybe_exif_rotate()` at the
+ * same point in the sequence the core one-liner would.
+ *
+ * Delete this file, its GD sibling, and the `edit_media_item()` override in
+ * `Gutenberg_REST_Attachments_Controller_7_1` once the core change ships.
+ *
+ * @since 7.1.0
+ *
+ * @see Gutenberg_REST_Attachments_Controller_7_1::edit_media_item()
+ */
+class Gutenberg_EXIF_Orienting_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
+	/**
+	 * Loads image from $this->file into editor and uprights it.
+	 *
+	 * @return true|WP_Error True if loaded successfully; WP_Error on failure.
+	 */
+	public function load() {
+		$loaded = parent::load();
+
+		if ( true === $loaded ) {
+			// A failed rotation (e.g. missing EXIF support) degrades to
+			// editing the raw pixels, matching previous behavior.
+			$this->maybe_exif_rotate();
+		}
+
+		return $loaded;
+	}
+}

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php
@@ -94,6 +94,78 @@ class Gutenberg_REST_Attachments_Controller_7_1 extends WP_REST_Attachments_Cont
 	}
 
 	/**
+	 * Applies edits to a media item and creates a new attachment record.
+	 *
+	 * Unlike core (as of 7.1), uprights the image before applying the
+	 * requested edits. Core edits the file from
+	 * `wp_get_original_image_path()`, whose EXIF orientation may still be
+	 * unapplied: client-side uploads deliberately preserve the tag, and
+	 * server-side uploads only bake the rotation into the scaled copy,
+	 * never the original. Clients build the edit modifiers against the
+	 * oriented preview (browsers apply the tag at render), so editing the
+	 * raw pixels lands rotations and crops in the wrong frame — e.g.
+	 * rotating an EXIF-oriented iPhone photo appears to do nothing.
+	 *
+	 * PLUGIN-ONLY SCAFFOLDING: in core, the entire fix is one line inside
+	 * this method, after the editor is created —
+	 * `$image_editor->maybe_exif_rotate();`. A plugin cannot reach that
+	 * local variable, so it swaps the editor classes for subclasses that
+	 * upright on load instead. Remove this override and both
+	 * `Gutenberg_EXIF_Orienting_Image_Editor_*` classes once the core
+	 * change ships.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
+	 */
+	public function edit_media_item( $request ) {
+		add_filter( 'wp_image_editors', array( __CLASS__, '_use_exif_orienting_image_editors' ) );
+
+		$response = parent::edit_media_item( $request );
+
+		remove_filter( 'wp_image_editors', array( __CLASS__, '_use_exif_orienting_image_editors' ) );
+
+		return $response;
+	}
+
+	/**
+	 * Swaps the default image editors for EXIF-orienting subclasses.
+	 *
+	 * Mapped per class (rather than prepended) so a site's filtered editor
+	 * preference order is preserved.
+	 *
+	 * Only public because the hook system must be able to call it; it is
+	 * plugin-only scaffolding (see `edit_media_item()`), not an API.
+	 *
+	 * @since 7.1.0
+	 * @access private
+	 *
+	 * @param string[] $editors Image editor class names.
+	 * @return string[] Image editor class names.
+	 */
+	public static function _use_exif_orienting_image_editors( $editors ) {
+		// The parent editor classes are loaded lazily by core immediately
+		// before this filter fires (see `_wp_image_editor_choose()`), so the
+		// subclasses must not be required any earlier than this.
+		require_once __DIR__ . '/class-gutenberg-exif-orienting-image-editor-imagick.php';
+		require_once __DIR__ . '/class-gutenberg-exif-orienting-image-editor-gd.php';
+
+		$replacements = array(
+			'WP_Image_Editor_Imagick' => 'Gutenberg_EXIF_Orienting_Image_Editor_Imagick',
+			'WP_Image_Editor_GD'      => 'Gutenberg_EXIF_Orienting_Image_Editor_GD',
+		);
+
+		foreach ( $editors as $index => $editor ) {
+			if ( isset( $replacements[ $editor ] ) ) {
+				$editors[ $index ] = $replacements[ $editor ];
+			}
+		}
+
+		return $editors;
+	}
+
+	/**
 	 * Retrieves the query params for collections of attachments.
 	 *
 	 * @since 4.7.0

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -8,10 +8,11 @@
 /**
  * REST API controller for media attachments.
  *
- * Extends the core attachments controller to add client-side media processing
- * functionality including sideload support and sub-size generation control.
+ * Extends the 7.1 compat attachments controller (multi-media-type filtering,
+ * EXIF-aware edits) to add client-side media processing functionality
+ * including sideload support and sub-size generation control.
  */
-class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controller {
+class Gutenberg_REST_Attachments_Controller extends Gutenberg_REST_Attachments_Controller_7_1 {
 	/**
 	 * Image size token for the source-format original preserved alongside a
 	 * client-generated derivative (e.g. the HEIC file kept next to its JPEG).

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -55,6 +55,8 @@ add_filter( 'upload_mimes', 'gutenberg_add_heic_upload_mimes' );
  */
 function gutenberg_filter_attachment_post_type_args( array $args, string $post_type ): array {
 	if ( 'attachment' === $post_type ) {
+		// Parent class of the controller below.
+		require_once __DIR__ . '/../compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php';
 		require_once __DIR__ . '/class-gutenberg-rest-attachments-controller.php';
 
 		$args['rest_controller_class'] = Gutenberg_REST_Attachments_Controller::class;


### PR DESCRIPTION

> [!NOTE]
> If this looks good I'll go ahead and create a Core backport patch

## What

Fixes image edits (rotate, crop, flip) landing in the wrong frame for photos whose EXIF orientation tag was never applied to their pixels, most visibly iPhone JPEGs. Rotating such a photo in the media editor modal or the Image block cropper previously appeared to do nothing.

See conversation https://github.com/WordPress/gutenberg/issues/77582#issuecomment-4950032307


## Why

The `/wp/v2/media/{id}/edit` endpoint edits the file from `wp_get_original_image_path()`. That original often still carries an unapplied EXIF orientation tag: client-side uploads preserve it deliberately, and server-side uploads only bake the rotation into the scaled copy, never the original. 

Browsers apply the tag when rendering, so clients build their edit modifiers against the upright preview while the server applies them to the raw, unrotated pixels.

For an orientation 6 photo, a 90° rotation request produced pixels identical to what the user was already seeing, so the edit looked like a no-op. Crops had the same frame mismatch.

## How

`Gutenberg_REST_Attachments_Controller_7_1::edit_media_item()` now swaps the image editors for subclasses that call `maybe_exif_rotate()` on load, scoped to the request via the `wp_image_editors` filter. Edits then run in the same upright frame the client previewed.

Two new editor subclasses (`Gutenberg_EXIF_Orienting_Image_Editor_Imagick` and `_GD`) in `lib/compat/wordpress-7.1/`. These are plugin-only scaffolding, documented as such: in core the entire fix is one line in `edit_media_item()`, after the editor is created (`$image_editor->maybe_exif_rotate();`). 

## Manual testing

1. Upload a JPEG with an EXIF orientation tag, for example a portrait photo taken on an iPhone (`packages/vips/src/test/fixtures/exif-rotated-90cw.jpg` works too).
2. Open it in the media editor modal, rotate it 90°, and save.
3. Confirm the saved image is actually rotated. Before this change it looked identical to the original.
4. Repeat with a crop: crop a distinctive corner and confirm the saved crop matches the region you framed.
5. Edit the saved (already upright) copy again and rotate once more. Confirm it rotates exactly once, with no double rotation.
6. Check for regressions on regular images


### Before


https://github.com/user-attachments/assets/d204067f-d8cf-4110-a658-e599103de8d5



### After
https://github.com/user-attachments/assets/a8cbbf0a-fe0f-40db-be08-d0739b9e1e05

