### PR TITLE
Preview dropdown: simplify viewport style state descriptions

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -136,7 +136,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Desktop' ),
 			icon: desktop,
 			info: isResponsiveEditing
-				? __( 'Edit across all breakpoints.' )
+				? __( 'Edit all viewports.' )
 				: __( 'Preview desktop viewport.' ),
 		},
 		...( hasTabletViewport
@@ -146,7 +146,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						label: __( 'Tablet' ),
 						icon: tablet,
 						info: isResponsiveEditing
-							? __( 'Make tablet exclusive style changes.' )
+							? __( 'Edit tablet only.' )
 							: __( 'Preview tablet viewport.' ),
 					},
 			  ]
@@ -158,7 +158,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						label: __( 'Mobile' ),
 						icon: mobile,
 						info: isResponsiveEditing
-							? __( 'Make mobile exclusive style changes.' )
+							? __( 'Edit mobile only.' )
 							: __( 'Preview mobile viewport.' ),
 					},
 			  ]
@@ -194,7 +194,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							role="menuitemcheckbox"
 							onClick={ handleResponsiveEditingChange }
 							info={ __(
-								'Style changes apply only to the current viewport.'
+								'Style changes apply only to the selected viewport.'
 							) }
 						>
 							{ __( 'Responsive editing' ) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -136,7 +136,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Desktop' ),
 			icon: desktop,
 			info: isResponsiveEditing
-				? __( 'Edit all viewports.' )
+				? __( 'Style all viewports.' )
 				: __( 'Preview desktop viewport.' ),
 		},
 		...( hasTabletViewport
@@ -146,7 +146,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						label: __( 'Tablet' ),
 						icon: tablet,
 						info: isResponsiveEditing
-							? __( 'Edit tablet only.' )
+							? __( 'Style tablet only.' )
 							: __( 'Preview tablet viewport.' ),
 					},
 			  ]
@@ -158,7 +158,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						label: __( 'Mobile' ),
 						icon: mobile,
 						info: isResponsiveEditing
-							? __( 'Edit mobile only.' )
+							? __( 'Style mobile only.' )
 							: __( 'Preview mobile viewport.' ),
 					},
 			  ]


### PR DESCRIPTION
When testing responsive styling, the change in height was driving me a bit nuts. This  PR shortens and aligns the responsive editing descriptions so the menu no longer changes height by changing the following:

- Desktop: "Edit across all breakpoints." -> "Edit all viewports."
- Tablet: "Make tablet exclusive style changes." -> "Edit tablet only."
- Mobile: "Make mobile exclusive style changes." -> "Edit mobile only."

The verb "Edit" now mirrors the "Preview ..." descriptions used when Responsive editing is off so there's a bit more consistency there. Finally, the Responsive editing toggle description now says "selected viewport" instead of "current viewport" for a bit more clarity to indicate folks select which option they want to change.

## Before

https://github.com/user-attachments/assets/1cbabc48-f05a-4880-8458-6a65fb0cb2da

## After

https://github.com/user-attachments/assets/e21f14ea-da20-4b84-b1bf-d72c5f4ce3cc

## Use of AI Tools

Used Claude to brainstorm, test, and commit the PR. Decided on final phrasing myself. 

