### PR TITLE
Widget Primitives: Ship as a script module

### DIFF
--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Enhancements
 
--   Ship the package as a WordPress script module (`wpScriptModuleExports`),
-    so consumers resolve one shared instance from the import map instead of
-    bundling their own copy ([#80149](https://github.com/WordPress/gutenberg/pull/80149)).
+-   Ship the package as a WordPress script module
+    (`wpScriptModuleExports`) ([#80149](https://github.com/WordPress/gutenberg/pull/80149)).
 
 ### Documentation
 

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Ship the package as a WordPress script module (`wpScriptModuleExports`),
+    so consumers resolve one shared instance from the import map instead of
+    bundling their own copy ([#80149](https://github.com/WordPress/gutenberg/pull/80149)).
+
 ### Documentation
 
 -   Spell out the accepted field-type name syntax: lowercase kebab-case

--- a/packages/widget-primitives/package.json
+++ b/packages/widget-primitives/package.json
@@ -41,6 +41,7 @@
 		"./package.json": "./package.json"
 	},
 	"wpScript": false,
+	"wpScriptModuleExports": "./build-module/index.mjs",
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {


### PR DESCRIPTION
## What

Ships `@wordpress/widget-primitives` as a WordPress script module (`wpScriptModuleExports`).

## Why

The package holds module-scope state: the field type registry is a `Map` in the module. Bundled, the package produces one copy per consumer bundle, so state registered against one copy is invisible to every other, and the package is duplicated across consumers.

As a script module it resolves one shared, singly-evaluated instance from the import map. Consumers externalize the package instead of bundling their own copy. The dedup and the single-instance guarantee compound as more consumers appear (route bundles, and independently built widget render modules).

## How

- `packages/widget-primitives/package.json`: add `wpScriptModuleExports`, so wp-build emits `build/modules/widget-primitives/` and consumers externalize the package to the import map instead of bundling it.

## Testing

1. Build (`npm run build`) and confirm `build/modules/widget-primitives/` exists and is registered in `build/modules.php`.
2. Confirm a module consumer (e.g. the dashboard route asset, `build/routes/dashboard/content.min.asset.php`) lists `@wordpress/widget-primitives` as a module dependency instead of bundling it.

## Follow-ups

- [ ] Move the dashboard's field type registration into the page init module without inflating it. The `location` control it registers pulls in the `@wordpress/ui` autocomplete stack, which isn't a script module yet, so it inlines into the init module (on the critical path). Fix by externalizing `@wordpress/ui` as a shared module, or by loading the control as a separate script module (the `@wordpress/latex-to-mathml` pattern). Tracked in #TBD.
