### PR TITLE
Block Inspector: Display inherited Global Styles breadcrumbs via label tooltip

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Inspector controls that inherit a value from Global Styles now expose a tooltip on the control label describing the breadcrumb path to the Global Styles source the value is inherited from (e.g. `Styles > Blocks > Group > Variations > Subtitle`). The tooltip is only shown in the block inspector, not in the Global Styles screens.
+
 ### Internal
 
 -   Extract a shared `getBlockBindingsContext` helper for assembling the context handed to block-bindings sources; only entries present in the surrounding block context are copied ([#79855](https://github.com/WordPress/gutenberg/pull/79855)).

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -39,7 +39,10 @@ import { getResolvedValue } from '@wordpress/global-styles-engine';
  * Internal dependencies
  */
 import { hasBackgroundImageValue } from '../global-styles/background-panel';
-import { InheritanceResetButton } from '../global-styles/inheritance';
+import {
+	InheritanceLabelTooltip,
+	InheritanceResetButton,
+} from '../global-styles/inheritance';
 import { setImmutably } from '../../utils/object';
 import MediaReplaceFlow from '../media-replace-flow';
 import { store as blockEditorStore } from '../../store';
@@ -135,6 +138,7 @@ function InspectorImagePreviewItem( {
 	toggleProps = {},
 	filename,
 	label,
+	labelTooltip,
 	onToggleCallback = noop,
 } ) {
 	const { isOpen, ...restToggleProps } = toggleProps;
@@ -157,12 +161,14 @@ function InspectorImagePreviewItem( {
 					} }
 				/>
 				<FlexBlock>
-					<Truncate
-						numberOfLines={ 1 }
-						className="block-editor-global-styles-background-panel__inspector-media-replace-title"
-					>
-						{ label }
-					</Truncate>
+					<InheritanceLabelTooltip labelTooltip={ labelTooltip }>
+						<Truncate
+							numberOfLines={ 1 }
+							className="block-editor-global-styles-background-panel__inspector-media-replace-title"
+						>
+							{ label }
+						</Truncate>
+					</InheritanceLabelTooltip>
 					<VisuallyHidden render={ <span /> }>
 						{ imgUrl
 							? sprintf(
@@ -191,6 +197,7 @@ function BackgroundControlsPanel( {
 	filename,
 	url: imgUrl,
 	children,
+	labelTooltip,
 	onToggle: onToggleCallback = noop,
 	hasImageValue,
 	onReset,
@@ -223,6 +230,7 @@ function BackgroundControlsPanel( {
 							imgUrl={ imgUrl }
 							filename={ filename }
 							label={ imgLabel }
+							labelTooltip={ labelTooltip }
 							toggleProps={ toggleProps }
 							as="button"
 							onToggleCallback={ onToggleCallback }
@@ -291,6 +299,7 @@ function BackgroundImageControls( {
 	displayInPanel,
 	defaultValues,
 	containerRef,
+	labelTooltip,
 } ) {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const { getSettings } = useSelect( blockEditorStore );
@@ -413,6 +422,7 @@ function BackgroundImageControls( {
 						imgUrl={ url }
 						filename={ title }
 						label={ imgLabel }
+						labelTooltip={ labelTooltip }
 					/>
 				}
 				renderToggle={ ( props ) => (
@@ -666,6 +676,7 @@ export default function BackgroundImagePanel( {
 	settings,
 	defaultValues = {},
 	showInheritanceLabelIndicators = true,
+	labelTooltip,
 } ) {
 	/*
 	 * Resolve inherited `ref` pointers for background controls.
@@ -752,6 +763,7 @@ export default function BackgroundImagePanel( {
 					label={ title }
 					filename={ title }
 					url={ url }
+					labelTooltip={ labelTooltip }
 					onToggle={ setIsDropDownOpen }
 					hasImageValue={ hasImageValue }
 					hasLocalOverride={ hasLocalOverride }
@@ -786,6 +798,7 @@ export default function BackgroundImagePanel( {
 					style={ value }
 					inheritedValue={ resolvedInheritedValue }
 					defaultValues={ defaultValues }
+					labelTooltip={ labelTooltip }
 					onResetImage={ () => {
 						setIsDropDownOpen( false );
 						resetBackground();

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -164,19 +164,22 @@ function createCornerUnitChangeHandler(
 /**
  * Control to display border radius options.
  *
- * @param {Object}        props               Component props.
- * @param {Function}      props.onChange      Callback to handle onChange.
- * @param {Object}        props.values        Border radius values.
- * @param {Object}        props.presets       Border radius presets.
- * @param {string}        [props.className]   Optional class name applied to the
- *                                            wrapping fieldset.
+ * @param {Object}        props                Component props.
+ * @param {Function}      props.onChange       Callback to handle onChange.
+ * @param {Object}        props.values         Border radius values.
+ * @param {Object}        props.presets        Border radius presets.
+ * @param {string}        [props.className]    Optional class name applied to the
+ *                                             wrapping fieldset.
  * @param {string|Object} [props.placeholder]
- *                                            Either a single placeholder string
- *                                            (linked mode) or an object with
- *                                            per-corner keys (`topLeft`,
- *                                            `topRight`, `bottomLeft`,
- *                                            `bottomRight`) to display as the
- *                                            placeholder on each unlinked input.
+ *                                             Either a single placeholder string
+ *                                             (linked mode) or an object with
+ *                                             per-corner keys (`topLeft`,
+ *                                             `topRight`, `bottomLeft`,
+ *                                             `bottomRight`) to display as the
+ *                                             placeholder on each unlinked input.
+ * @param {string}        [props.labelTooltip]
+ *                                             Tooltip text shown on the control
+ *                                             label.
  *
  * @return {Element}              Custom border radius control.
  */
@@ -186,6 +189,7 @@ export default function BorderRadiusControl( {
 	presets,
 	className,
 	placeholder,
+	labelTooltip,
 } ) {
 	const [ isLinked, setIsLinked ] = useState(
 		! hasDefinedValues( values ) || ! hasMixedValues( values )
@@ -234,7 +238,10 @@ export default function BorderRadiusControl( {
 			className={ clsx( 'components-border-radius-control', className ) }
 		>
 			<HStack className="components-border-radius-control__header">
-				<BaseControl.VisualLabel as="legend">
+				<BaseControl.VisualLabel
+					as="legend"
+					labelTooltip={ labelTooltip }
+				>
 					{ __( 'Radius' ) }
 				</BaseControl.VisualLabel>
 				<LinkedButton onClick={ toggleLinked } isLinked={ isLinked } />

--- a/packages/block-editor/src/components/dimension-control/index.js
+++ b/packages/block-editor/src/components/dimension-control/index.js
@@ -76,6 +76,7 @@ export default function DimensionControl( {
 	placeholder,
 	className,
 	dimensionSizes: dimensionSizesProp,
+	labelTooltip,
 } ) {
 	const [ dimensionSizesFromSettings, availableUnits ] = useSettings(
 		'dimensions.dimensionSizes',
@@ -158,7 +159,7 @@ export default function DimensionControl( {
 		<fieldset
 			className={ clsx( 'block-editor-dimension-control', className ) }
 		>
-			<BaseControl.VisualLabel as="legend">
+			<BaseControl.VisualLabel as="legend" labelTooltip={ labelTooltip }>
 				{ label }
 			</BaseControl.VisualLabel>
 			<PresetInputControl

--- a/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
+++ b/packages/block-editor/src/components/dimensions-tool/aspect-ratio-tool.js
@@ -30,6 +30,7 @@ import { InheritanceToolsPanelItem } from '../global-styles/inheritance';
  * @property {string}                       [className]        Additional CSS class on the wrapping panel item.
  * @property {boolean}                      [isInherited]      Whether the control is displaying an inherited Global Styles value.
  * @property {boolean}                      [hasLocalOverride] Whether a local value is overriding an inherited Global Styles value.
+ * @property {string}                       [labelTooltip]     Breadcrumb tooltip text for the inherited Global Styles source. Already gated by the caller, so it is rendered on the control label whenever truthy.
  */
 
 export default function AspectRatioTool( {
@@ -43,6 +44,7 @@ export default function AspectRatioTool( {
 	className,
 	isInherited,
 	hasLocalOverride,
+	labelTooltip,
 } ) {
 	// Match the CSS default so if the value is used directly in CSS it will look correct in the control.
 	const displayValue = value ?? 'auto';
@@ -99,6 +101,7 @@ export default function AspectRatioTool( {
 				value={ displayValue }
 				options={ options ?? aspectRatioOptions }
 				onChange={ onChange }
+				labelTooltip={ labelTooltip }
 			/>
 		</InheritanceToolsPanelItem>
 	);

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -18,7 +18,11 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -160,6 +164,7 @@ export default function BackgroundImagePanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -329,10 +334,18 @@ export default function BackgroundImagePanel( {
 		onChange( newValue );
 	};
 
-	const inheritanceProps = ( isInherited, hasLocalOverride, classNames ) =>
-		showInheritanceLabelIndicators
-			? getInheritanceProps( isInherited, hasLocalOverride, classNames )
-			: { className: classNames };
+	// The background image is stored as an object, so its source lives on the
+	// leaf sub-paths. Resolve the breadcrumb from the image leaves only (not
+	// size/position) so the tooltip reflects the inherited image itself.
+	const backgroundImageTooltipText = getCommonInheritanceTooltipText(
+		inheritedSources,
+		[
+			'background.backgroundImage.url',
+			'background.backgroundImage.id',
+			'background.backgroundImage.title',
+			'background.backgroundImage.source',
+		]
+	);
 
 	// The inherited value arrives already resolved (refs + theme-file pointers)
 	// with non-cascading root values dropped, so a presence check drives the
@@ -343,6 +356,12 @@ export default function BackgroundImagePanel( {
 		},
 	} );
 	const hasLocalBackgroundImage = hasBackgroundImageValue( value );
+	const backgroundImageInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		inheritedBackgroundImage && ! hasLocalBackgroundImage,
+		hasLocalBackgroundImage && inheritedBackgroundImage,
+		'block-editor-color-gradient-item'
+	);
 
 	return (
 		<Wrapper
@@ -354,11 +373,7 @@ export default function BackgroundImagePanel( {
 		>
 			{ showBackgroundImageControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						inheritedBackgroundImage && ! hasLocalBackgroundImage,
-						hasLocalBackgroundImage && inheritedBackgroundImage,
-						'block-editor-color-gradient-item'
-					) }
+					{ ...backgroundImageInheritance }
 					showLocalOverrideActionsInLabel={ false }
 					hasValue={ () => hasBackgroundImageValue( value ) }
 					label={ __( 'Image' ) }
@@ -376,6 +391,11 @@ export default function BackgroundImagePanel( {
 						showInheritanceLabelIndicators={
 							showInheritanceLabelIndicators
 						}
+						labelTooltip={
+							backgroundImageInheritance.isInherited
+								? backgroundImageTooltipText
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
@@ -390,6 +410,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userBackgroundColor === undefined &&
 						backgroundColor !== undefined
@@ -399,6 +420,7 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'background',
 							label: __( 'Color' ),
+							sourcePaths: [ 'color.background' ],
 							inheritedValue: backgroundColor,
 							// Resolve the slug from the same source as the
 							// displayed value (user value first, then the
@@ -440,6 +462,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						currentGradient === undefined &&
 						inheritedGradient !== undefined
@@ -449,6 +472,10 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'gradient',
 							label: __( 'Gradient' ),
+							sourcePaths: [
+								'background.gradient',
+								'color.gradient',
+							],
 							inheritedValue: inheritedGradient,
 							setValue: setGradient,
 							userValue: currentGradient,
@@ -477,6 +504,7 @@ export default function BackgroundImagePanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userLegacyColorGradient === undefined &&
 						legacyColorGradient !== undefined
@@ -486,6 +514,7 @@ export default function BackgroundImagePanel( {
 						{
 							key: 'gradient',
 							label: __( 'Gradient' ),
+							sourcePaths: [ 'color.gradient' ],
 							inheritedValue: legacyColorGradient,
 							setValue: setLegacyColorGradient,
 							userValue: userLegacyColorGradient,

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -21,7 +21,12 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -99,6 +104,7 @@ export default function BorderPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	name,
@@ -111,10 +117,35 @@ export default function BorderPanel( {
 		( rawValue ) => getValueFromVariable( { settings }, '', rawValue ),
 		[ settings ]
 	);
-	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
-		showInheritanceLabelIndicators
-			? getInheritanceProps( isInherited, hasLocalOverride, className )
-			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
+	const borderTooltipText = commonTooltipText( [
+		'border.color',
+		'border.style',
+		'border.width',
+		'border.top.color',
+		'border.top.style',
+		'border.top.width',
+		'border.right.color',
+		'border.right.style',
+		'border.right.width',
+		'border.bottom.color',
+		'border.bottom.style',
+		'border.bottom.width',
+		'border.left.color',
+		'border.left.style',
+		'border.left.width',
+	] );
+	const borderRadiusTooltipText = commonTooltipText( [
+		'border.radius',
+		'border.radius.topLeft',
+		'border.radius.topRight',
+		'border.radius.bottomLeft',
+		'border.radius.bottomRight',
+	] );
+	const shadowTooltipText = tooltipText( 'shadow' );
 	const encodeColorValue = ( colorValue ) => {
 		const allColors = colors.flatMap(
 			( { colors: originColors } ) => originColors
@@ -373,6 +404,24 @@ export default function BorderPanel( {
 		hasBorderControl,
 	} );
 
+	const borderInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isBorderPlaceholder,
+		isDefinedBorder( value?.border ) &&
+			!! inheritedBorder &&
+			isDefinedBorder( inheritedBorder )
+	);
+	const radiusInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isBorderRadiusPlaceholder,
+		hasBorderRadius() && inheritedBorderRadius !== undefined
+	);
+	const shadowInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isShadowPlaceholder,
+		hasShadow() && inheritedShadow !== undefined
+	);
+
 	return (
 		<Wrapper
 			resetAllFilter={ resetAllFilter }
@@ -383,12 +432,7 @@ export default function BorderPanel( {
 		>
 			{ ( showBorderWidth || showBorderColor ) && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isBorderPlaceholder,
-						isDefinedBorder( value?.border ) &&
-							!! inheritedBorder &&
-							isDefinedBorder( inheritedBorder )
-					) }
+					{ ...borderInheritance }
 					hasValue={ () => isDefinedBorder( value?.border ) }
 					label={ __( 'Border' ) }
 					onDeselect={ () => resetBorder() }
@@ -405,7 +449,14 @@ export default function BorderPanel( {
 						// `.components-base-control__label`, so the visible
 						// "Border" label has to be a `BaseControl` label to
 						// receive them.
-						<BaseControl.VisualLabel as="legend">
+						<BaseControl.VisualLabel
+							as="legend"
+							labelTooltip={
+								borderInheritance.isInherited
+									? borderTooltipText
+									: undefined
+							}
+						>
 							{ __( 'Border' ) }
 						</BaseControl.VisualLabel>
 					) }
@@ -424,10 +475,7 @@ export default function BorderPanel( {
 			) }
 			{ showBorderRadius && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isBorderRadiusPlaceholder,
-						hasBorderRadius() && inheritedBorderRadius !== undefined
-					) }
+					{ ...radiusInheritance }
 					hasValue={ hasBorderRadius }
 					label={ __( 'Radius' ) }
 					hasInlineEndToggle
@@ -441,15 +489,17 @@ export default function BorderPanel( {
 						onChange={ ( newValue ) => {
 							setBorderRadius( newValue || undefined );
 						} }
+						labelTooltip={
+							radiusInheritance.isInherited
+								? borderRadiusTooltipText
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasShadowControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isShadowPlaceholder,
-						hasShadow() && inheritedShadow !== undefined
-					) }
+					{ ...shadowInheritance }
 					label={ __( 'Shadow' ) }
 					hasValue={ hasShadow }
 					onDeselect={ resetShadow }
@@ -462,7 +512,14 @@ export default function BorderPanel( {
 					panelId={ panelId }
 				>
 					{ hasBorderControl ? (
-						<BaseControl.VisualLabel as="legend">
+						<BaseControl.VisualLabel
+							as="legend"
+							labelTooltip={
+								shadowInheritance.isInherited
+									? shadowTooltipText
+									: undefined
+							}
+						>
 							{ __( 'Shadow' ) }
 						</BaseControl.VisualLabel>
 					) : null }

--- a/packages/block-editor/src/components/global-styles/build-inherited-value.js
+++ b/packages/block-editor/src/components/global-styles/build-inherited-value.js
@@ -52,20 +52,61 @@ const TREE_STRUCTURAL_KEYS = new Set( [ 'blocks', 'variations', 'css' ] );
 // Empty inheritance data returned before Global Styles payloads settle.
 const EMPTY_INHERITANCE = Object.freeze( { value: {}, sources: {} } );
 
-// Source descriptors per inheritance layer. `layer` identifies which layer
-// supplied a leaf and drives inherited-value detection.
-const SOURCE_DESCRIPTORS = {
-	root: { layer: 'root' },
-	block: { layer: 'block' },
-	blockVariation: { layer: 'blockVariation' },
+// Breadcrumb part identifiers for each Global Styles inheritance layer.
+const SOURCE_BREADCRUMB_PARTS = {
+	styles: 'styles',
+	elements: 'elements',
+	blocks: 'blocks',
+	blockName: 'blockName',
+	variations: 'variations',
+	variationName: 'variationName',
 };
 
-function createSourceDescriptor( type ) {
+// Source descriptors per inheritance layer. `layer` identifies which layer
+// supplied a leaf and drives inherited-value detection; `breadcrumb` describes
+// the Global Styles path surfaced in the inspector label tooltip.
+const SOURCE_DESCRIPTORS = {
+	root: {
+		breadcrumb: [ SOURCE_BREADCRUMB_PARTS.styles ],
+		layer: 'root',
+	},
+	block: {
+		breadcrumb: [
+			SOURCE_BREADCRUMB_PARTS.styles,
+			SOURCE_BREADCRUMB_PARTS.blocks,
+			SOURCE_BREADCRUMB_PARTS.blockName,
+		],
+		layer: 'block',
+	},
+	blockVariation: {
+		breadcrumb: [
+			SOURCE_BREADCRUMB_PARTS.styles,
+			SOURCE_BREADCRUMB_PARTS.blocks,
+			SOURCE_BREADCRUMB_PARTS.blockName,
+			SOURCE_BREADCRUMB_PARTS.variations,
+			SOURCE_BREADCRUMB_PARTS.variationName,
+		],
+		layer: 'blockVariation',
+	},
+};
+
+function createSourceDescriptor(
+	type,
+	{ blockName, variation, blockStyles } = {}
+) {
 	const descriptor = SOURCE_DESCRIPTORS[ type ];
 	if ( ! descriptor ) {
 		return null;
 	}
-	return { ...descriptor };
+	return {
+		...descriptor,
+		breadcrumb: [ ...descriptor.breadcrumb ],
+		blockName: blockName ?? null,
+		variation: variation ?? null,
+		variationTitle:
+			blockStyles?.find( ( style ) => style.name === variation )?.label ??
+			null,
+	};
 }
 
 function createContribution( styles, source ) {
@@ -81,8 +122,14 @@ function getPathKey( path ) {
 
 // Clone the descriptor so source-map entries can diverge as paths differ.
 function getSourceForPath( source, path ) {
+	const breadcrumb = [ ...source.breadcrumb ];
+	const [ maybeElementsKey, maybeElement ] = path;
+	if ( maybeElementsKey === 'elements' && maybeElement ) {
+		breadcrumb.push( SOURCE_BREADCRUMB_PARTS.elements, maybeElement );
+	}
 	return {
 		...source,
+		breadcrumb,
 		path: [ ...path ],
 	};
 }
@@ -339,6 +386,7 @@ function resolveThemeFileBackgroundImage( value, globalStyles, links ) {
  * @param {string}  args.blockName       Block name (e.g. `core/heading`).
  * @param {?string} [args.ownVariation]  Active block style variation slug, or null.
  * @param {Object}  [args.globalStyles]  The `settings[ globalStylesDataKey ]` payload.
+ * @param {Array}   [args.blockStyles]   Registered styles for the block type (for variation titles).
  * @param {?Object} [args.selectedState] Selected block style state, or null for the default state.
  * @param {?Object} [args._links]        Theme-file links (`settings[ globalStylesLinksDataKey ]`), used to resolve theme-file pointers.
  * @return {{ value: Object, sources: Object }} Merged panel-scoped payload and source map.
@@ -347,6 +395,7 @@ function computeResolvedStyles( {
 	blockName,
 	ownVariation = null,
 	globalStyles,
+	blockStyles = [],
 	selectedState = null,
 	_links = null,
 } = {} ) {
@@ -382,13 +431,17 @@ function computeResolvedStyles( {
 		block
 			? createContribution(
 					pickLayerRootContribution( block ),
-					createSourceDescriptor( 'block' )
+					createSourceDescriptor( 'block', { blockName } )
 			  )
 			: null,
 		variation
 			? createContribution(
 					pickLayerRootContribution( variation ),
-					createSourceDescriptor( 'blockVariation' )
+					createSourceDescriptor( 'blockVariation', {
+						blockName,
+						variation: ownVariation,
+						blockStyles,
+					} )
 			  )
 			: null,
 	];
@@ -411,7 +464,7 @@ function computeResolvedStyles( {
 						pickLayerRootContribution(
 							getStateSlice( block, selectedState )
 						),
-						createSourceDescriptor( 'block' )
+						createSourceDescriptor( 'block', { blockName } )
 				  )
 				: null,
 			variation
@@ -419,7 +472,11 @@ function computeResolvedStyles( {
 						pickLayerRootContribution(
 							getStateSlice( variation, selectedState )
 						),
-						createSourceDescriptor( 'blockVariation' )
+						createSourceDescriptor( 'blockVariation', {
+							blockName,
+							variation: ownVariation,
+							blockStyles,
+						} )
 				  )
 				: null
 		);
@@ -454,7 +511,7 @@ function computeResolvedStyles( {
 }
 
 // Shared memo for `resolveStyles`, keyed by Global Styles object identity and
-// a `(blockName, ownVariation, selectedState)` composite.
+// a `(blockName, ownVariation, blockStyles, selectedState)` composite.
 const memo = new WeakMap();
 
 /**
@@ -475,6 +532,9 @@ export function resolveStyles( args ) {
 		inner = new Map();
 		memo.set( globalStyles, inner );
 	}
+	const blockStylesKey = ( args.blockStyles || [] )
+		.map( ( { name, label } ) => `${ name }:${ label }` )
+		.join( ',' );
 	const selectedStateKey = args.selectedState
 		? `${ args.selectedState.viewport ?? '' }:${
 				args.selectedState.pseudo ?? ''
@@ -484,6 +544,8 @@ export function resolveStyles( args ) {
 		( args.blockName || '' ) +
 		'\u0001' +
 		( args.ownVariation || '' ) +
+		'\u0001' +
+		blockStylesKey +
 		'\u0001' +
 		selectedStateKey;
 	if ( inner.has( key ) ) {

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -28,6 +28,8 @@ import ColorGradientControl from '../colors-gradients/control';
 import { unlock } from '../../lock-unlock';
 import {
 	getInheritanceProps,
+	getCommonInheritanceTooltipText,
+	InheritanceLabelTooltip,
 	InheritanceResetButton,
 	InheritanceToolsPanelItem,
 } from './inheritance';
@@ -113,7 +115,7 @@ const popoverProps = {
 	shift: true,
 };
 
-const LabeledColorIndicators = ( { indicators, label } ) => (
+const LabeledColorIndicators = ( { indicators, label, labelTooltip } ) => (
 	<HStack justify="flex-start">
 		<ZStack isLayered={ false } offset={ -8 }>
 			{ indicators.map( ( indicator, index ) => (
@@ -123,7 +125,9 @@ const LabeledColorIndicators = ( { indicators, label } ) => (
 			) ) }
 		</ZStack>
 		<FlexItem className="block-editor-panel-color-gradient-settings__color-name">
-			{ label }
+			<InheritanceLabelTooltip labelTooltip={ labelTooltip }>
+				{ label }
+			</InheritanceLabelTooltip>
 		</FlexItem>
 	</HStack>
 );
@@ -208,6 +212,7 @@ export default function ColorGradientDropdownItem( {
 	isPlaceholder = false,
 	hasInheritedValue = false,
 	showInheritanceLabelIndicators = true,
+	inheritedSources = {},
 } ) {
 	const colorGradientDropdownButtonRef = useRef( undefined );
 	const itemClassName = clsx( 'block-editor-color-gradient-item', className );
@@ -216,9 +221,19 @@ export default function ColorGradientDropdownItem( {
 	// actions and the override label indicator.
 	const hasLocalOverride =
 		showInheritanceLabelIndicators && hasValue() && hasInheritedValue;
-	const inheritanceProps = showInheritanceLabelIndicators
-		? getInheritanceProps( isPlaceholder, hasLocalOverride, itemClassName )
-		: { className: itemClassName };
+	const tabSourcePaths = tabs.flatMap( ( tab ) => tab.sourcePaths ?? [] );
+	const inheritanceProps = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isPlaceholder,
+		hasLocalOverride,
+		itemClassName
+	);
+	// The label lives inside the dropdown toggle rather than a `BaseControl`
+	// label, so it is wrapped directly with `InheritanceLabelTooltip` instead of
+	// via the native `labelTooltip` prop.
+	const labelTooltip = inheritanceProps.isInherited
+		? getCommonInheritanceTooltipText( inheritedSources, tabSourcePaths )
+		: undefined;
 	return (
 		<InheritanceToolsPanelItem
 			{ ...inheritanceProps }
@@ -252,6 +267,7 @@ export default function ColorGradientDropdownItem( {
 								<LabeledColorIndicators
 									indicators={ indicators }
 									label={ label }
+									labelTooltip={ labelTooltip }
 								/>
 							</Button>
 							{ hasValue() &&

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -142,6 +142,7 @@ export default function ColorPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources = {},
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -301,6 +302,10 @@ export default function ColorPanel( {
 		showLinkPanel && {
 			key: 'link',
 			label: __( 'Link' ),
+			sourcePaths: [
+				'elements.link.color.text',
+				'elements.link.:hover.color.text',
+			],
 			hasValue: hasLink,
 			resetValue: resetLink,
 			isShownByDefault: defaultControls.link,
@@ -319,6 +324,7 @@ export default function ColorPanel( {
 				{
 					key: 'link',
 					label: __( 'Default' ),
+					sourcePaths: [ 'elements.link.color.text' ],
 					inheritedValue: linkColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.link?.color?.text,
@@ -332,6 +338,7 @@ export default function ColorPanel( {
 				{
 					key: 'hover',
 					label: __( 'Hover' ),
+					sourcePaths: [ 'elements.link.:hover.color.text' ],
 					inheritedValue: hoverLinkColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.link?.[ ':hover' ]?.color
@@ -453,6 +460,11 @@ export default function ColorPanel( {
 		items.push( {
 			key: name,
 			label: elementLabel,
+			sourcePaths: [
+				`elements.${ name }.color.text`,
+				`elements.${ name }.color.background`,
+				`elements.${ name }.color.gradient`,
+			],
 			hasValue: hasElement,
 			resetValue: resetElement,
 			isShownByDefault: defaultControls[ name ],
@@ -471,6 +483,7 @@ export default function ColorPanel( {
 				hasSolidColors && {
 					key: 'text',
 					label: __( 'Text' ),
+					sourcePaths: [ `elements.${ name }.color.text` ],
 					inheritedValue: elementTextColor,
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.[ name ]?.color?.text,
@@ -484,6 +497,7 @@ export default function ColorPanel( {
 					supportsBackground && {
 						key: 'background',
 						label: __( 'Background' ),
+						sourcePaths: [ `elements.${ name }.color.background` ],
 						inheritedValue: elementBackgroundColor,
 						inheritedSlug: extractPresetSlug(
 							inheritedValue?.elements?.[ name ]?.color
@@ -498,6 +512,7 @@ export default function ColorPanel( {
 					supportsBackground && {
 						key: 'gradient',
 						label: __( 'Gradient' ),
+						sourcePaths: [ `elements.${ name }.color.gradient` ],
 						inheritedValue: elementGradient,
 						setValue: setElementGradient,
 						userValue: elementGradientUserColor,
@@ -517,7 +532,7 @@ export default function ColorPanel( {
 			label={ label }
 		>
 			{ items.map( ( item ) => {
-				const { key, ...restItem } = item;
+				const { key, sourcePaths, ...restItem } = item;
 				return (
 					<ColorGradientDropdownItem
 						key={ key }
@@ -525,6 +540,7 @@ export default function ColorPanel( {
 						showInheritanceLabelIndicators={
 							showInheritanceLabelIndicators
 						}
+						inheritedSources={ inheritedSources }
 						colorGradientControlSettings={ {
 							colors,
 							disableCustomColors: ! areCustomSolidsEnabled,

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,7 +33,12 @@ import {
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -322,6 +327,7 @@ export default function DimensionsPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -351,11 +357,10 @@ export default function DimensionsPanel( {
 			rawValue
 		);
 	};
-	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
-		showInheritanceLabelIndicators
-			? getInheritanceProps( isInherited, hasLocalOverride, className )
-			: {};
-
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
 	const showSpacingPresetsControl = hasSpacingPresets( settings );
 	const units = useCustomUnits( {
 		availableUnits: settings?.spacing?.units || [
@@ -490,6 +495,18 @@ export default function DimensionsPanel( {
 		hasValue( value?.spacing?.padding ) &&
 		Object.keys( value?.spacing?.padding ).length;
 	const resetPaddingValue = () => setPaddingValues( undefined );
+	const paddingTooltipText = commonTooltipText( [
+		'spacing.padding.top',
+		'spacing.padding.right',
+		'spacing.padding.bottom',
+		'spacing.padding.left',
+	] );
+	const paddingInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isPaddingInherited,
+		hasPaddingValue() && hasInheritedPadding,
+		{ 'tools-panel-item-spacing': showSpacingPresetsControl }
+	);
 	const onMouseOverPadding = () => onVisualize( 'padding' );
 
 	// Margin
@@ -526,6 +543,18 @@ export default function DimensionsPanel( {
 		hasValue( value?.spacing?.margin ) &&
 		Object.keys( value?.spacing?.margin ).length;
 	const resetMarginValue = () => setMarginValues( undefined );
+	const marginTooltipText = commonTooltipText( [
+		'spacing.margin.top',
+		'spacing.margin.right',
+		'spacing.margin.bottom',
+		'spacing.margin.left',
+	] );
+	const marginInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isMarginInherited,
+		hasMarginValue() && hasInheritedMargin,
+		{ 'tools-panel-item-spacing': showSpacingPresetsControl }
+	);
 	const onMouseOverMargin = () => onVisualize( 'margin' );
 
 	// Block Gap
@@ -573,6 +602,21 @@ export default function DimensionsPanel( {
 	};
 	const resetGapValue = () => setGapValue( undefined );
 	const hasGapValue = () => hasValue( value?.spacing?.blockGap );
+	const gapTooltipText = commonTooltipText( [
+		'spacing.blockGap',
+		'spacing.blockGap.top',
+		'spacing.blockGap.left',
+	] );
+	const gapInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isGapPlaceholder,
+		hasGapValue() && inheritedGapRaw !== undefined,
+		{
+			'tools-panel-item-spacing': showSpacingPresetsControl,
+			// If UnitControl is used, should be single-column.
+			'single-column': ! showSpacingPresetsControl && ! isAxialGap,
+		}
+	);
 
 	// Min Height
 	const showMinHeightControl = hasMinHeight( settings );
@@ -713,6 +757,42 @@ export default function DimensionsPanel( {
 
 	const onMouseLeaveControls = () => onVisualize( false );
 
+	const contentSizeInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isContentSizePlaceholder,
+		hasUserSetContentSizeValue() && inheritedContentSizeValue !== undefined
+	);
+	const wideSizeInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isWideSizePlaceholder,
+		hasUserSetWideSizeValue() && inheritedWideSizeValue !== undefined
+	);
+	const minHeightInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isMinHeightPlaceholder,
+		hasMinHeightValue() && inheritedMinHeightValue !== undefined
+	);
+	const minWidthInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isMinWidthPlaceholder,
+		hasMinWidthValue() && inheritedMinWidthValue !== undefined
+	);
+	const heightInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isHeightPlaceholder,
+		hasHeightValue() && inheritedHeightValue !== undefined
+	);
+	const widthInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isWidthPlaceholder,
+		hasWidthValue() && inheritedWidthValue !== undefined
+	);
+	const aspectRatioInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isAspectRatioPlaceholder,
+		hasAspectRatioValue() && inheritedAspectRatioValue !== undefined
+	);
+
 	return (
 		<Wrapper
 			resetAllFilter={ resetAllFilter }
@@ -727,11 +807,7 @@ export default function DimensionsPanel( {
 			) }
 			{ showContentSizeControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isContentSizePlaceholder,
-						hasUserSetContentSizeValue() &&
-							inheritedContentSizeValue !== undefined
-					) }
+					{ ...contentSizeInheritance }
 					label={ __( 'Content width' ) }
 					hasValue={ hasUserSetContentSizeValue }
 					onDeselect={ resetContentSizeValue }
@@ -754,6 +830,11 @@ export default function DimensionsPanel( {
 							setContentSizeValue( nextContentSize );
 						} }
 						units={ units }
+						labelTooltip={
+							contentSizeInheritance.isInherited
+								? tooltipText( 'layout.contentSize' )
+								: undefined
+						}
 						prefix={
 							<InputControlPrefixWrapper variant="icon">
 								<Icon icon={ alignNone } />
@@ -764,11 +845,7 @@ export default function DimensionsPanel( {
 			) }
 			{ showWideSizeControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isWideSizePlaceholder,
-						hasUserSetWideSizeValue() &&
-							inheritedWideSizeValue !== undefined
-					) }
+					{ ...wideSizeInheritance }
 					label={ __( 'Wide width' ) }
 					hasValue={ hasUserSetWideSizeValue }
 					onDeselect={ resetWideSizeValue }
@@ -790,6 +867,11 @@ export default function DimensionsPanel( {
 							setWideSizeValue( nextWideSize );
 						} }
 						units={ units }
+						labelTooltip={
+							wideSizeInheritance.isInherited
+								? tooltipText( 'layout.wideSize' )
+								: undefined
+						}
 						prefix={
 							<InputControlPrefixWrapper variant="icon">
 								<Icon icon={ stretchWide } />
@@ -807,14 +889,7 @@ export default function DimensionsPanel( {
 					isShownByDefault={
 						defaultControls.padding ?? DEFAULT_CONTROLS.padding
 					}
-					{ ...inheritanceProps(
-						isPaddingInherited,
-						hasPaddingValue() && hasInheritedPadding,
-						{
-							'tools-panel-item-spacing':
-								showSpacingPresetsControl,
-						}
-					) }
+					{ ...paddingInheritance }
 					panelId={ panelId }
 				>
 					{ ! showSpacingPresetsControl && (
@@ -826,6 +901,11 @@ export default function DimensionsPanel( {
 							units={ units }
 							allowReset={ false }
 							splitOnAxis={ isAxialPadding }
+							labelTooltip={
+								paddingInheritance.isInherited
+									? paddingTooltipText
+									: undefined
+							}
 							inputProps={ {
 								onMouseOver: onMouseOverPadding,
 								onMouseOut: onMouseLeaveControls,
@@ -845,6 +925,11 @@ export default function DimensionsPanel( {
 							allowReset={ false }
 							onMouseOver={ onMouseOverPadding }
 							onMouseOut={ onMouseLeaveControls }
+							labelTooltip={
+								paddingInheritance.isInherited
+									? paddingTooltipText
+									: undefined
+							}
 						/>
 					) }
 				</InheritanceToolsPanelItem>
@@ -858,14 +943,7 @@ export default function DimensionsPanel( {
 					isShownByDefault={
 						defaultControls.margin ?? DEFAULT_CONTROLS.margin
 					}
-					{ ...inheritanceProps(
-						isMarginInherited,
-						hasMarginValue() && hasInheritedMargin,
-						{
-							'tools-panel-item-spacing':
-								showSpacingPresetsControl,
-						}
-					) }
+					{ ...marginInheritance }
 					panelId={ panelId }
 				>
 					{ ! showSpacingPresetsControl && (
@@ -892,6 +970,11 @@ export default function DimensionsPanel( {
 							units={ units }
 							allowReset={ false }
 							splitOnAxis={ isAxialMargin }
+							labelTooltip={
+								marginInheritance.isInherited
+									? marginTooltipText
+									: undefined
+							}
 						/>
 					) }
 					{ showSpacingPresetsControl && (
@@ -905,6 +988,11 @@ export default function DimensionsPanel( {
 							allowReset={ false }
 							onMouseOver={ onMouseOverMargin }
 							onMouseOut={ onMouseLeaveControls }
+							labelTooltip={
+								marginInheritance.isInherited
+									? marginTooltipText
+									: undefined
+							}
 						/>
 					) }
 				</InheritanceToolsPanelItem>
@@ -918,17 +1006,7 @@ export default function DimensionsPanel( {
 					isShownByDefault={
 						defaultControls.blockGap ?? DEFAULT_CONTROLS.blockGap
 					}
-					{ ...inheritanceProps(
-						isGapPlaceholder,
-						hasGapValue() && inheritedGapRaw !== undefined,
-						{
-							'tools-panel-item-spacing':
-								showSpacingPresetsControl,
-							'single-column':
-								// If UnitControl is used, should be single-column.
-								! showSpacingPresetsControl && ! isAxialGap,
-						}
-					) }
+					{ ...gapInheritance }
 					panelId={ panelId }
 				>
 					{ ! showSpacingPresetsControl &&
@@ -942,6 +1020,11 @@ export default function DimensionsPanel( {
 								values={ gapValues }
 								allowReset={ false }
 								splitOnAxis={ isAxialGap }
+								labelTooltip={
+									gapInheritance.isInherited
+										? gapTooltipText
+										: undefined
+								}
 							/>
 						) : (
 							<UnitControl
@@ -955,6 +1038,11 @@ export default function DimensionsPanel( {
 										? inheritedGapRaw
 										: undefined
 								}
+								labelTooltip={
+									gapInheritance.isInherited
+										? gapTooltipText
+										: undefined
+								}
 							/>
 						) ) }
 					{ showSpacingPresetsControl && (
@@ -966,6 +1054,11 @@ export default function DimensionsPanel( {
 							sides={ isAxialGap ? gapSides : [ 'top' ] } // Use 'top' as the shorthand property in non-axial configurations.
 							values={ gapValues }
 							allowReset={ false }
+							labelTooltip={
+								gapInheritance.isInherited
+									? gapTooltipText
+									: undefined
+							}
 						/>
 					) }
 				</InheritanceToolsPanelItem>
@@ -987,11 +1080,7 @@ export default function DimensionsPanel( {
 			) }
 			{ showMinHeightControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isMinHeightPlaceholder,
-						hasMinHeightValue() &&
-							inheritedMinHeightValue !== undefined
-					) }
+					{ ...minHeightInheritance }
 					hasValue={ hasMinHeightValue }
 					label={ __( 'Minimum height' ) }
 					onDeselect={ resetMinHeightValue }
@@ -1017,16 +1106,17 @@ export default function DimensionsPanel( {
 								: undefined
 						}
 						dimensionSizes={ dimensions?.dimensionSizes }
+						labelTooltip={
+							minHeightInheritance.isInherited
+								? tooltipText( 'dimensions.minHeight' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ showMinWidthControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isMinWidthPlaceholder,
-						hasMinWidthValue() &&
-							inheritedMinWidthValue !== undefined
-					) }
+					{ ...minWidthInheritance }
 					hasValue={ hasMinWidthValue }
 					label={ __( 'Minimum width' ) }
 					onDeselect={ resetMinWidthValue }
@@ -1051,15 +1141,17 @@ export default function DimensionsPanel( {
 								: undefined
 						}
 						dimensionSizes={ dimensions?.dimensionSizes }
+						labelTooltip={
+							minWidthInheritance.isInherited
+								? tooltipText( 'dimensions.minWidth' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ showHeightControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isHeightPlaceholder,
-						hasHeightValue() && inheritedHeightValue !== undefined
-					) }
+					{ ...heightInheritance }
 					hasValue={ hasHeightValue }
 					label={ __( 'Height' ) }
 					onDeselect={ resetHeightValue }
@@ -1078,15 +1170,17 @@ export default function DimensionsPanel( {
 								: undefined
 						}
 						dimensionSizes={ dimensions?.dimensionSizes }
+						labelTooltip={
+							heightInheritance.isInherited
+								? tooltipText( 'dimensions.height' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ showWidthControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isWidthPlaceholder,
-						hasWidthValue() && inheritedWidthValue !== undefined
-					) }
+					{ ...widthInheritance }
 					hasValue={ hasWidthValue }
 					label={ __( 'Width' ) }
 					onDeselect={ resetWidthValue }
@@ -1103,6 +1197,11 @@ export default function DimensionsPanel( {
 							isWidthPlaceholder ? inheritedWidthValue : undefined
 						}
 						dimensionSizes={ dimensions?.dimensionSizes }
+						labelTooltip={
+							widthInheritance.isInherited
+								? tooltipText( 'dimensions.width' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
@@ -1112,11 +1211,12 @@ export default function DimensionsPanel( {
 					value={ aspectRatioValue }
 					onChange={ setAspectRatioValue }
 					panelId={ panelId }
-					{ ...inheritanceProps(
-						isAspectRatioPlaceholder,
-						hasAspectRatioValue() &&
-							inheritedAspectRatioValue !== undefined
-					) }
+					{ ...aspectRatioInheritance }
+					labelTooltip={
+						aspectRatioInheritance.isInherited
+							? tooltipText( 'dimensions.aspectRatio' )
+							: undefined
+					}
 					isShownByDefault={
 						defaultControls.aspectRatio ??
 						DEFAULT_CONTROLS.aspectRatio

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -32,6 +32,8 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import {
 	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceLabelTooltip,
 	InheritanceToolsPanelItem,
 	InheritanceResetButton,
 } from './inheritance';
@@ -107,7 +109,7 @@ const popoverProps = {
 	headerTitle: __( 'Duotone' ),
 };
 
-const LabeledColorIndicator = ( { indicator, label } ) => (
+const LabeledColorIndicator = ( { indicator, label, labelTooltip } ) => (
 	<HStack justify="flex-start">
 		<ZStack isLayered={ false } offset={ -8 }>
 			<Flex expanded={ false }>
@@ -122,12 +124,14 @@ const LabeledColorIndicator = ( { indicator, label } ) => (
 			className="block-editor-panel-duotone-settings__label"
 			title={ label }
 		>
-			{ label }
+			<InheritanceLabelTooltip labelTooltip={ labelTooltip }>
+				{ label }
+			</InheritanceLabelTooltip>
 		</FlexItem>
 	</HStack>
 );
 
-const renderToggle = ( duotone, resetConfig ) =>
+const renderToggle = ( duotone, resetConfig, labelTooltip ) =>
 	function Toggle( { onToggle, isOpen } ) {
 		const { hasLocalValue, hasLocalOverride, onReset } = resetConfig;
 		const duotoneButtonRef = useRef( undefined );
@@ -157,6 +161,7 @@ const renderToggle = ( duotone, resetConfig ) =>
 					<LabeledColorIndicator
 						indicator={ duotone }
 						label={ __( 'Duotone' ) }
+						labelTooltip={ labelTooltip }
 					/>
 				</Button>
 				{ hasLocalValue &&
@@ -183,6 +188,7 @@ export default function FiltersPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources,
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -190,10 +196,8 @@ export default function FiltersPanel( {
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
-	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
-		showInheritanceLabelIndicators
-			? getInheritanceProps( isInherited, hasLocalOverride, className )
-			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
 
 	// Duotone
 	const hasDuotoneEnabled = useHasDuotoneControl( settings );
@@ -241,6 +245,11 @@ export default function FiltersPanel( {
 		showInheritanceLabelIndicators &&
 		hasDuotone() &&
 		inheritedDuotone !== undefined;
+	const duotoneInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isDuotonePlaceholder,
+		hasDuotoneLocalOverride
+	);
 
 	const resetAllFilter = useCallback( ( previousValue ) => {
 		return {
@@ -261,11 +270,7 @@ export default function FiltersPanel( {
 		>
 			{ hasDuotoneEnabled && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isDuotonePlaceholder,
-						localDuotone !== undefined &&
-							inheritedDuotone !== undefined
-					) }
+					{ ...duotoneInheritance }
 					label={ __( 'Duotone' ) }
 					hasValue={ hasDuotone }
 					onDeselect={ resetDuotone }
@@ -278,11 +283,17 @@ export default function FiltersPanel( {
 					<Dropdown
 						popoverProps={ popoverProps }
 						className="block-editor-global-styles-filters-panel__dropdown"
-						renderToggle={ renderToggle( duotone, {
-							hasLocalValue: hasDuotone(),
-							hasLocalOverride: hasDuotoneLocalOverride,
-							onReset: resetDuotone,
-						} ) }
+						renderToggle={ renderToggle(
+							duotone,
+							{
+								hasLocalValue: hasDuotone(),
+								hasLocalOverride: hasDuotoneLocalOverride,
+								onReset: resetDuotone,
+							},
+							duotoneInheritance.isInherited
+								? tooltipText( 'filter.duotone' )
+								: undefined
+						) }
 						renderContent={ () => (
 							<DropdownContentWrapper paddingSize="small">
 								<MenuGroup label={ __( 'Duotone' ) }>

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -11,36 +11,130 @@ import {
 	Icon as WCIcon,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { Tooltip } from '@wordpress/ui';
+import { getBlockType } from '@wordpress/blocks';
 import { reset as resetIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
+const INHERITANCE_TOOLTIP_LINE_SEPARATOR = '\n';
+
+const BREADCRUMB_LABELS = {
+	styles: __( 'Styles' ),
+	elements: __( 'Elements' ),
+	blocks: __( 'Blocks' ),
+	variations: __( 'Variations' ),
+};
+
+function getBlockTitle( blockName ) {
+	return getBlockType( blockName )?.title ?? blockName;
+}
+
+function getVariationTitle( variation, blockStyles, variationTitle ) {
+	return (
+		variationTitle ??
+		blockStyles?.find( ( style ) => style.name === variation )?.label ??
+		variation
+	);
+}
+
+function getTranslatedBreadcrumb( source, blockStyles ) {
+	const breadcrumb = source?.breadcrumb;
+	const parts = breadcrumb
+		.map( ( part ) => {
+			if ( part === 'blockName' ) {
+				return getBlockTitle( source.blockName );
+			}
+			if ( part === 'variationName' ) {
+				return getVariationTitle(
+					source.variation,
+					blockStyles,
+					source.variationTitle
+				);
+			}
+			return BREADCRUMB_LABELS[ part ] ?? part;
+		} )
+		.filter( Boolean );
+	return parts.join( ' > ' );
+}
+
 /**
- * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
- * so its descendant label picks up the inherited-from-Global-Styles
- * visual treatment.
+ * Formats a source entry into user-facing tooltip text.
  *
- * When `isInherited` is true without a local override, the descendant
- * label text receives the inherited-from-Global-Styles treatment
- * (dotted underline). No dot is shown.
+ * @param {?Object} source      Source metadata.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+function getInheritanceTooltipText( source, blockStyles ) {
+	const breadcrumb = source?.breadcrumb;
+	if ( ! Array.isArray( breadcrumb ) || breadcrumb.length === 0 ) {
+		return undefined;
+	}
+	return [
+		__( 'Default inherited from:' ),
+		getTranslatedBreadcrumb( source, blockStyles ),
+	].join( INHERITANCE_TOOLTIP_LINE_SEPARATOR );
+}
+
+/**
+ * Formats a source entry from a source map path.
  *
- * When `hasLocalOverride` is true, a small reset dot is rendered as a
- * sibling of the control exposing a "Reset to inherited value" action.
+ * @param {?Object} sources     Source metadata keyed by dot path.
+ * @param {string}  path        Dot path.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+export function getInheritanceTooltipTextByPath( sources, path, blockStyles ) {
+	return getInheritanceTooltipText( sources?.[ path ], blockStyles );
+}
+
+/**
+ * Formats a tooltip for a compound control. A shared source is used only when
+ * all contributing paths resolve to the same breadcrumb; mixed sources receive
+ * a conservative summary.
  *
- * The two states are mutually exclusive at the source. If both are passed,
- * only the local-override class is returned.
+ * @param {?Object} sources     Source metadata keyed by dot path.
+ * @param {Array}   paths       Dot paths to inspect.
+ * @param {Array}   blockStyles Registered styles for the block type.
+ * @return {string|undefined} Tooltip text, or undefined when no source exists.
+ */
+export function getCommonInheritanceTooltipText( sources, paths, blockStyles ) {
+	const sourceEntries = paths
+		.map( ( path ) => sources?.[ path ] )
+		.filter( Boolean );
+	if ( sourceEntries.length === 0 ) {
+		return undefined;
+	}
+	const firstBreadcrumb = sourceEntries[ 0 ].breadcrumb?.join( ' > ' );
+	const hasCommonBreadcrumb = sourceEntries.every(
+		( source ) => source.breadcrumb?.join( ' > ' ) === firstBreadcrumb
+	);
+	if ( hasCommonBreadcrumb ) {
+		return getInheritanceTooltipText( sourceEntries[ 0 ], blockStyles );
+	}
+	return __( 'Default inherited from multiple Styles sources' );
+}
+
+/**
+ * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>` so its
+ * descendant label picks up the inherited-from-Global-Styles visual treatment.
  *
- * Returned object shape allows direct spread:
+ * When `isInherited` is true without a local override, the descendant label
+ * text gets the inherited-from-Global-Styles treatment (dotted underline). When
+ * `hasLocalOverride` is true, a reset dot is rendered next to the control. The
+ * two are mutually exclusive; if both are passed, only the override wins.
  *
- *     <InheritanceToolsPanelItem
- *         { ...getInheritanceProps( isInherited, hasLocalOverride ) }
- *         label={ __( 'Line height' ) }
- *         …
- *     >
+ * `showIndicators` gates the whole feature: when false (outside the inspector)
+ * neither the treatment nor the override state is applied, but any
+ * `baseClassName` still passes through so layout classes survive. The returned
+ * `isInherited` is likewise false, so callers can gate the breadcrumb tooltip
+ * on it and it can't drift from the label treatment.
  *
+ * @param {boolean}             showIndicators   Whether inheritance indicators
+ *                                               are enabled for the panel.
  * @param {boolean}             isInherited      Control is inheriting at rest.
- * @param {boolean}             hasLocalOverride Local override is set AND
- *                                               there is an inherited value
- *                                               being overridden.
+ * @param {boolean}             hasLocalOverride Local override is set AND there
+ *                                               is an inherited value being
+ *                                               overridden.
  * @param {string|Array|Object} [baseClassName]  Optional className(s) to fold
  *                                               into the returned `className`.
  *
@@ -48,19 +142,22 @@ import { __ } from '@wordpress/i18n';
  *                                  `InheritanceToolsPanelItem`.
  */
 export function getInheritanceProps(
+	showIndicators,
 	isInherited,
 	hasLocalOverride,
 	baseClassName
 ) {
-	const inheritedOnly = !! isInherited && ! hasLocalOverride;
+	const inheritedOnly =
+		showIndicators && !! isInherited && ! hasLocalOverride;
+	const hasOverride = showIndicators && !! hasLocalOverride;
 	const className = clsx( baseClassName, {
 		'is-inherited-from-global-styles': inheritedOnly,
-		'has-local-override-from-global-styles': !! hasLocalOverride,
+		'has-local-override-from-global-styles': hasOverride,
 	} );
 	return {
 		...( className ? { className } : {} ),
 		isInherited: inheritedOnly,
-		hasLocalOverride: !! hasLocalOverride,
+		hasLocalOverride: hasOverride,
 	};
 }
 
@@ -118,13 +215,62 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
 }
 
 /**
+ * Wraps label content in the inherited-from breadcrumb tooltip using the
+ * `@wordpress/ui` `Tooltip` — the same primitive the native `labelTooltip` prop
+ * renders through (see `LabelWithTooltip` in `@wordpress/components`), so both
+ * tooltip paths look and behave identically.
+ *
+ * For controls whose label is not rendered by a `BaseControl`/`InputControl`
+ * (color name, background image title, duotone), the native `labelTooltip`
+ * prop can't reach the label text, so it is wrapped directly here instead. When
+ * `labelTooltip` is falsy the children are returned unwrapped.
+ *
+ * @param {Object}                    props
+ * @param {?string}                   props.labelTooltip Breadcrumb tooltip text.
+ * @param {import('react').ReactNode} props.children     Label content to wrap.
+ *
+ * @return {import('react').ReactNode} Wrapped (or bare) label content.
+ */
+export function InheritanceLabelTooltip( { labelTooltip, children } ) {
+	if ( ! labelTooltip ) {
+		return children;
+	}
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<span className="global-styles-inheritance-tooltip-anchor">
+						{ children }
+					</span>
+				}
+			/>
+			<Tooltip.Popup className="global-styles-inheritance-tooltip-content">
+				{ labelTooltip
+					.split( INHERITANCE_TOOLTIP_LINE_SEPARATOR )
+					.map( ( line, index ) => (
+						<span
+							key={ index }
+							className="global-styles-inheritance-tooltip-content__line"
+						>
+							{ line }
+						</span>
+					) ) }
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+}
+
+/**
  * A `ToolsPanelItem` that reflects whether its control's value is inherited
  * from Global Styles or locally overridden. The two states are mutually
  * exclusive.
  *
  * - Inherited: the control label receives the inherited-from-Global-Styles
  *   treatment (dotted underline) via the `is-inherited-from-global-styles`
- *   class applied through `getInheritanceProps`. No dot is shown.
+ *   class applied through `getInheritanceProps`. The breadcrumb tooltip
+ *   pointing at the originating Global Styles source is rendered by the
+ *   control itself via its native `labelTooltip` prop, which the panels pass
+ *   in directly — this item is not involved in the tooltip. No dot is shown.
  * - Local override: a reset dot is rendered as a plain sibling of the control
  *   at the item's inline-end — never nested in the label — exposing the same
  *   one-click reset the `ToolsPanel` options menu performs via `onDeselect`.
@@ -135,7 +281,7 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
  *
  * @param {Object}                    props
  * @param {?string}                   props.className                         Item className.
- * @param {boolean}                   props.isInherited                       Value is inherited at rest. Accepted so the `getInheritanceProps` spread does not leak onto the underlying `ToolsPanelItem`; the inherited treatment is applied via `className`.
+ * @param {boolean}                   props.isInherited                       Value is inherited at rest. Applies the label treatment via `className` (through `getInheritanceProps`).
  * @param {boolean}                   props.hasLocalOverride                  Local override is set.
  * @param {import('react').ReactNode} props.label                             Control label.
  * @param {?Function}                 props.onDeselect                        Reset handler.
@@ -147,10 +293,10 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
  */
 export function InheritanceToolsPanelItem( {
 	className,
-	// Destructured (and unused) so the `getInheritanceProps` spread does not
-	// leak `isInherited` onto the underlying `ToolsPanelItem`. The inherited
-	// treatment is applied purely via `className`
-	// (`is-inherited-from-global-styles`).
+	// `isInherited`/`hasLocalOverride` are consumed here, not forwarded onto
+	// `ToolsPanelItem`: the label treatment and reset dot are driven entirely
+	// by `className` and `hasLocalOverride`, so passing them through would leak
+	// unknown attributes onto the DOM.
 	isInherited,
 	hasLocalOverride,
 	label,

--- a/packages/block-editor/src/components/global-styles/inheritance/style.scss
+++ b/packages/block-editor/src/components/global-styles/inheritance/style.scss
@@ -30,6 +30,25 @@
 	}
 }
 
+// The tooltip trigger wraps the visible label text inline, so the breadcrumb
+// tooltip is scoped to the label without wrapping the full control or
+// intercepting nested control tooltips. `.components-control-label__tooltip-anchor`
+// is rendered by the components `labelTooltip` prop (most controls);
+// `.global-styles-inheritance-tooltip-anchor` is rendered by
+// `InheritanceLabelTooltip` for the color, background image, and duotone labels
+// that are not produced by a `BaseControl`/`InputControl`.
+.components-control-label__tooltip-anchor,
+.global-styles-inheritance-tooltip-anchor {
+	// A transparent inline wrapper around the existing label text; inherit the
+	// label's own layout so truncation and the dotted treatment are unaffected.
+	display: inline;
+}
+
+// Breadcrumb tooltip content: render each line on its own row.
+.global-styles-inheritance-tooltip-content__line {
+	display: block;
+}
+
 // Local-override reset dot — a sibling of the control positioned at the item's
 // inline-end.
 .has-local-override-from-global-styles {

--- a/packages/block-editor/src/components/global-styles/inheritance/test/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/test/index.js
@@ -3,11 +3,16 @@
  */
 import { render, screen } from '@testing-library/react';
 import { click } from '@ariakit/test';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	BaseControl,
+} from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -50,7 +55,17 @@ describe( 'InheritanceResetButton', () => {
 
 describe( 'getInheritanceProps', () => {
 	test( 'returns explicit false state when neither flag is set', () => {
-		expect( getInheritanceProps( false, false ) ).toEqual( {
+		expect( getInheritanceProps( true, false, false ) ).toEqual( {
+			isInherited: false,
+			hasLocalOverride: false,
+		} );
+	} );
+
+	test( 'gates every flag off, but keeps the base className, when indicators are disabled', () => {
+		expect(
+			getInheritanceProps( false, true, true, 'single-column' )
+		).toEqual( {
+			className: 'single-column',
 			isInherited: false,
 			hasLocalOverride: false,
 		} );
@@ -60,7 +75,7 @@ describe( 'getInheritanceProps', () => {
 		// The inherited state is conveyed purely through the className hook
 		// (`is-inherited-from-global-styles`), which the SCSS uses to apply
 		// the dotted-underline label treatment. No dot is rendered.
-		expect( getInheritanceProps( true, false ) ).toEqual( {
+		expect( getInheritanceProps( true, true, false ) ).toEqual( {
 			className: 'is-inherited-from-global-styles',
 			isInherited: true,
 			hasLocalOverride: false,
@@ -68,7 +83,7 @@ describe( 'getInheritanceProps', () => {
 	} );
 
 	test( 'returns the local-override className when hasLocalOverride is set', () => {
-		expect( getInheritanceProps( false, true ) ).toEqual( {
+		expect( getInheritanceProps( true, false, true ) ).toEqual( {
 			className: 'has-local-override-from-global-styles',
 			isInherited: false,
 			hasLocalOverride: true,
@@ -78,7 +93,7 @@ describe( 'getInheritanceProps', () => {
 	test( 'returns ONLY the local-override className when both flags are passed (mutual exclusion)', () => {
 		// A buggy caller could pass both as `true`. The visual
 		// contract is mutual exclusion — local-override always wins.
-		const result = getInheritanceProps( true, true );
+		const result = getInheritanceProps( true, true, true );
 		expect( result.className ).toContain(
 			'has-local-override-from-global-styles'
 		);
@@ -90,25 +105,25 @@ describe( 'getInheritanceProps', () => {
 		// Common pattern: callers pass an undefined or null inherited
 		// value that we want to treat as "no local override" rather
 		// than letting it slip through as truthy.
-		expect( getInheritanceProps( undefined, undefined ) ).toEqual( {
+		expect( getInheritanceProps( true, undefined, undefined ) ).toEqual( {
 			isInherited: false,
 			hasLocalOverride: false,
 		} );
-		expect( getInheritanceProps( null, null ) ).toEqual( {
+		expect( getInheritanceProps( true, null, null ) ).toEqual( {
 			isInherited: false,
 			hasLocalOverride: false,
 		} );
-		expect( getInheritanceProps( '', '' ) ).toEqual( {
+		expect( getInheritanceProps( true, '', '' ) ).toEqual( {
 			isInherited: false,
 			hasLocalOverride: false,
 		} );
 		// Truthy non-boolean
-		expect( getInheritanceProps( 'inherited', 0 ) ).toEqual( {
+		expect( getInheritanceProps( true, 'inherited', 0 ) ).toEqual( {
 			className: 'is-inherited-from-global-styles',
 			isInherited: true,
 			hasLocalOverride: false,
 		} );
-		expect( getInheritanceProps( 0, 'local' ) ).toEqual( {
+		expect( getInheritanceProps( true, 0, 'local' ) ).toEqual( {
 			className: 'has-local-override-from-global-styles',
 			isInherited: false,
 			hasLocalOverride: true,
@@ -116,7 +131,9 @@ describe( 'getInheritanceProps', () => {
 	} );
 
 	test( 'merges a base className with the inherited class hook', () => {
-		expect( getInheritanceProps( true, false, 'single-column' ) ).toEqual( {
+		expect(
+			getInheritanceProps( true, true, false, 'single-column' )
+		).toEqual( {
 			className: 'single-column is-inherited-from-global-styles',
 			isInherited: true,
 			hasLocalOverride: false,
@@ -124,7 +141,9 @@ describe( 'getInheritanceProps', () => {
 	} );
 
 	test( 'merges a base className with the local-override class hook', () => {
-		expect( getInheritanceProps( false, true, 'single-column' ) ).toEqual( {
+		expect(
+			getInheritanceProps( true, false, true, 'single-column' )
+		).toEqual( {
 			className: 'single-column has-local-override-from-global-styles',
 			isInherited: false,
 			hasLocalOverride: true,
@@ -132,58 +151,101 @@ describe( 'getInheritanceProps', () => {
 	} );
 
 	test( 'returns just the base className when neither flag is set', () => {
-		expect( getInheritanceProps( false, false, 'single-column' ) ).toEqual(
-			{
-				className: 'single-column',
-				isInherited: false,
-				hasLocalOverride: false,
-			}
-		);
+		expect(
+			getInheritanceProps( true, false, false, 'single-column' )
+		).toEqual( {
+			className: 'single-column',
+			isInherited: false,
+			hasLocalOverride: false,
+		} );
 	} );
 } );
 
 describe( 'InheritanceToolsPanelItem inherited state', () => {
-	function renderInheritedItem( label, labelClassName ) {
+	function renderInheritedItem() {
 		return render(
 			<ToolsPanel label="Panel" panelId="panel">
 				<InheritanceToolsPanelItem
-					{ ...getInheritanceProps( true, false ) }
-					label={ label }
+					{ ...getInheritanceProps( true, true, false ) }
+					label="Line height"
 					panelId="panel"
 					isShownByDefault
 					hasValue={ () => false }
 				>
-					<div className={ labelClassName }>{ label }</div>
+					<div className="components-base-control__label">
+						Line height
+					</div>
 				</InheritanceToolsPanelItem>
 			</ToolsPanel>
 		);
 	}
 
-	// The SCSS treatment keys off the label class, and controls on a bare
-	// `UnitControl`/`NumberControl` expose `input-control__label` rather than
-	// the usual `base-control__label`, so guard both.
-	test.each( [
-		[ 'base-control', 'components-base-control__label' ],
-		[ 'input-control', 'components-input-control__label' ],
-	] )(
-		'nests the %s label inside the inherited-from-global-styles item',
-		( _name, labelClassName ) => {
-			renderInheritedItem( 'Line height', labelClassName );
-			const label = screen.getByText( 'Line height' );
-			expect( label ).toHaveClass( labelClassName );
-			expect(
-				// eslint-disable-next-line testing-library/no-node-access
-				label.closest( '.is-inherited-from-global-styles' )
-			).not.toBeNull();
-		}
-	);
-
 	test( 'does not render a reset dot in the inherited state', () => {
-		renderInheritedItem( 'Line height', 'components-base-control__label' );
+		renderInheritedItem();
 		expect(
 			screen.queryByRole( 'button', {
 				name: 'Reset to inherited value',
 			} )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'InheritanceToolsPanelItem breadcrumb tooltip', () => {
+	// A minimal labelled control. The panels pass the breadcrumb `labelTooltip`
+	// directly to the control, which renders it on its visible label text \u2014 the
+	// panel item itself is not involved in the tooltip.
+	function LabelledControl( props ) {
+		const id = useInstanceId( LabelledControl, 'line-height' );
+		return (
+			<BaseControl { ...props } id={ id } label="Line height">
+				<input aria-label="Line height" />
+			</BaseControl>
+		);
+	}
+
+	function renderItem( controlProps ) {
+		return render(
+			<ToolsPanel label="Panel" panelId="panel">
+				<InheritanceToolsPanelItem
+					{ ...getInheritanceProps( true, true, false ) }
+					label="Line height"
+					panelId="panel"
+					isShownByDefault
+					hasValue={ () => false }
+				>
+					<LabelledControl { ...controlProps } />
+				</InheritanceToolsPanelItem>
+			</ToolsPanel>
+		);
+	}
+
+	test( 'renders the breadcrumb tooltip on the control label and reveals it on hover', async () => {
+		const user = userEvent.setup();
+		renderItem( {
+			labelTooltip: 'Default inherited from:\nStyles > Heading',
+		} );
+
+		// No tooltip until the label is hovered.
+		expect(
+			screen.queryByText( /Styles > Heading/ )
+		).not.toBeInTheDocument();
+
+		await user.hover( screen.getByText( 'Line height' ) );
+
+		expect( await screen.findByText( /Styles > Heading/ ) ).toBeVisible();
+	} );
+
+	test( 'renders no breadcrumb tooltip when no source is provided (Global Styles screens)', async () => {
+		const user = userEvent.setup();
+		// Global Styles screens render panels without an inheritance provider,
+		// so the panels resolve `labelTooltip` to undefined and no tooltip is
+		// rendered.
+		renderItem( {} );
+
+		await user.hover( screen.getByText( 'Line height' ) );
+
+		expect(
+			screen.queryByText( /inherited from/i )
 		).not.toBeInTheDocument();
 	} );
 } );
@@ -207,22 +269,13 @@ describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
 		);
 	}
 
-	test( 'renders the reset dot as a sibling of the control, not inside the label', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		expect( resetButton ).toBeVisible();
-
-		// The reset dot is a plain sibling; it must never be nested inside
-		// the label (which would create an interactive-in-label a11y issue).
+	test( 'renders a reset dot in the local-override state', () => {
+		renderItem( { hasLocalOverride: true, onDeselect: () => {} } );
 		expect(
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.components-base-control__label' )
-		).toBeNull();
+			screen.getByRole( 'button', {
+				name: 'Reset to inherited value',
+			} )
+		).toBeVisible();
 	} );
 
 	test( 'does not render the item reset dot when showLocalOverrideActionsInLabel is false', () => {
@@ -247,35 +300,5 @@ describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
 			screen.getByRole( 'button', { name: 'Reset to inherited value' } )
 		);
 		expect( onDeselect ).toHaveBeenCalled();
-	} );
-
-	test( 'does not offset the reset dot by default', () => {
-		renderItem( { hasLocalOverride: true, onDeselect: () => {} } );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).not.toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
-	} );
-
-	test( 'offsets the reset dot when the control has an inline-end toggle', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			hasInlineEndToggle: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -17,26 +17,36 @@ import { resolveStyles } from './build-inherited-value';
 import { getVariationNameFromClass } from '../../hooks/block-style-variation';
 
 /**
- * Internal hook that reads the Global Styles payload and returns the wrapped
- * `{ styles }` shape the builder and ref-resolver helpers expect, along with
- * the theme-file `_links` map used to resolve theme-file pointers (e.g.
- * background images).
+ * Internal hook that reads the Global Styles payload and the block's
+ * registered styles, and returns the wrapped `{ styles }` shape the builder
+ * and ref-resolver helpers expect, along with the theme-file `_links` map used
+ * to resolve theme-file pointers (e.g. background images) and the block's
+ * registered styles (used for variation titles in breadcrumb tooltips).
  *
- * @return {{ globalStyles: ?Object, links: ?Object }} Wrapped Global Styles payload and links map.
+ * @param {?string} blockName Selected block name (e.g. `core/heading`).
+ * @return {{ globalStyles: ?Object, links: ?Object, blockStyles: Array }} Wrapped Global Styles payload, links map, and block styles.
  */
-function useRawGlobalStyles() {
-	const { rawGlobalStylesData, links } = useSelect( ( select ) => {
-		const settings = select( blockEditorStore ).getSettings();
-		return {
-			rawGlobalStylesData: settings[ globalStylesDataKey ] ?? null,
-			links: settings[ globalStylesLinksDataKey ] ?? null,
-		};
-	}, [] );
+function useRawGlobalStyles( blockName ) {
+	const { rawGlobalStylesData, links, blockStyles } = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			const blockStylesSelector = select( blocksStore ).getBlockStyles;
+			return {
+				rawGlobalStylesData: settings[ globalStylesDataKey ] ?? null,
+				links: settings[ globalStylesLinksDataKey ] ?? null,
+				blockStyles:
+					blockName && blockStylesSelector
+						? blockStylesSelector( blockName )
+						: [],
+			};
+		},
+		[ blockName ]
+	);
 	const globalStyles = useMemo(
 		() => ( rawGlobalStylesData ? { styles: rawGlobalStylesData } : null ),
 		[ rawGlobalStylesData ]
 	);
-	return { globalStyles, links };
+	return { globalStyles, links, blockStyles };
 }
 
 /**
@@ -93,7 +103,8 @@ export function useResolvedStyles(
 	selectedState = null
 ) {
 	const ownVariation = useOwnVariation( blockName, className );
-	const { globalStyles, links } = useRawGlobalStyles();
+	const { globalStyles, links, blockStyles } =
+		useRawGlobalStyles( blockName );
 
 	return useMemo( () => {
 		if ( ! blockName ) {
@@ -103,8 +114,16 @@ export function useResolvedStyles(
 			blockName,
 			ownVariation,
 			globalStyles,
+			blockStyles,
 			selectedState,
 			_links: links,
 		} );
-	}, [ blockName, ownVariation, globalStyles, selectedState, links ] );
+	}, [
+		blockName,
+		ownVariation,
+		globalStyles,
+		blockStyles,
+		selectedState,
+		links,
+	] );
 }

--- a/packages/block-editor/src/components/global-styles/test/build-inherited-value.js
+++ b/packages/block-editor/src/components/global-styles/test/build-inherited-value.js
@@ -12,6 +12,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { resolveStyles, privateHelpers } from '../build-inherited-value';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceTooltipTextByPath,
+} from '../inheritance';
 import { useResolvedStyles } from '../inherited-value-context';
 
 import { globalStylesDataKey } from '../../../store/private-keys';
@@ -468,6 +472,67 @@ describe( 'resolveStyles – merged output', () => {
 		} );
 	} );
 
+	describe( 'tooltip formatting', () => {
+		test( 'formats a source breadcrumb', () => {
+			expect(
+				getInheritanceTooltipTextByPath(
+					{
+						typography: {
+							breadcrumb: [
+								'styles',
+								'blocks',
+								'blockName',
+								'variations',
+								'variationName',
+							],
+							blockName: 'core/group',
+							variation: 'subtitle',
+							variationTitle: 'Subtitle',
+						},
+					},
+					'typography'
+				)
+			).toBe(
+				'Default inherited from:\nStyles > Blocks > Group > Variations > Subtitle'
+			);
+		} );
+
+		test( 'uses common source for compound controls when breadcrumbs match', () => {
+			expect(
+				getCommonInheritanceTooltipText(
+					{
+						'border.color': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+						'border.width': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+					},
+					[ 'border.color', 'border.width' ]
+				)
+			).toBe( 'Default inherited from:\nStyles > Blocks > Group' );
+		} );
+
+		test( 'uses conservative text for mixed-source compound controls', () => {
+			expect(
+				getCommonInheritanceTooltipText(
+					{
+						'border.color': {
+							breadcrumb: [ 'styles' ],
+						},
+						'border.width': {
+							breadcrumb: [ 'styles', 'blocks', 'blockName' ],
+							blockName: 'core/group',
+						},
+					},
+					[ 'border.color', 'border.width' ]
+				)
+			).toBe( 'Default inherited from multiple Styles sources' );
+		} );
+	} );
+
 	describe( 'source provenance', () => {
 		const gs = {
 			styles: {
@@ -502,15 +567,27 @@ describe( 'resolveStyles – merged output', () => {
 			const { value, sources } = resolveStyles( {
 				blockName: 'core/heading',
 				ownVariation: 'plain',
+				blockStyles: [ { name: 'plain', label: 'Plain' } ],
 				globalStyles: gs,
 			} );
 			expect( value.typography.fontSize ).toBe( '20px' );
 			expect( value.typography.lineHeight ).toBe( '1.5' );
 			expect( sources[ 'typography.fontSize' ] ).toMatchObject( {
+				breadcrumb: [
+					'styles',
+					'blocks',
+					'blockName',
+					'variations',
+					'variationName',
+				],
 				layer: 'blockVariation',
+				blockName: 'core/heading',
+				variation: 'plain',
+				variationTitle: 'Plain',
 				path: [ 'typography', 'fontSize' ],
 			} );
 			expect( sources[ 'typography.lineHeight' ] ).toMatchObject( {
+				breadcrumb: [ 'styles' ],
 				layer: 'root',
 			} );
 		} );
@@ -521,6 +598,7 @@ describe( 'resolveStyles – merged output', () => {
 				globalStyles: gs,
 			} );
 			expect( sources[ 'elements.link.color.text' ] ).toMatchObject( {
+				breadcrumb: [ 'styles', 'elements', 'link' ],
 				layer: 'root',
 				path: [ 'elements', 'link', 'color', 'text' ],
 			} );
@@ -541,7 +619,9 @@ describe( 'resolveStyles – memoization', () => {
 		} );
 		expect( a ).toBe( b );
 		expect( a.value.typography.fontSize ).toBe( '16px' );
-		expect( a.sources[ 'typography.fontSize' ].layer ).toBe( 'root' );
+		expect( a.sources[ 'typography.fontSize' ].breadcrumb ).toEqual( [
+			'styles',
+		] );
 	} );
 
 	test( 'different composite key → different result', () => {
@@ -648,8 +728,8 @@ describe( 'useResolvedStyles hook', () => {
 		// `elements` passthrough, not folded up to the top level.
 		expect( parsed.value.elements.h2.typography.fontSize ).toBe( '24px' );
 		expect(
-			parsed.sources[ 'elements.h2.typography.fontSize' ].layer
-		).toBe( 'root' );
+			parsed.sources[ 'elements.h2.typography.fontSize' ].breadcrumb
+		).toEqual( [ 'styles', 'elements', 'h2' ] );
 	} );
 } );
 

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -685,6 +685,12 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 						},
 					},
 				},
+				inheritedSources: {
+					'spacing.padding.top': { layer: 'block' },
+					'spacing.padding.right': { layer: 'block' },
+					'spacing.padding.bottom': { layer: 'block' },
+					'spacing.padding.left': { layer: 'block' },
+				},
 				settings: settingsWithSpacingPresets,
 			} );
 

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -38,7 +38,12 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getCommonInheritanceTooltipText,
+	getInheritanceProps,
+	getInheritanceTooltipTextByPath,
+	InheritanceToolsPanelItem,
+} from './inheritance';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -221,6 +226,7 @@ export default function TypographyPanel( {
 	value,
 	onChange,
 	inheritedValue = value,
+	inheritedSources = {},
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
@@ -230,10 +236,10 @@ export default function TypographyPanel( {
 } ) {
 	const { colors, allColors, areCustomSolidsEnabled, decodeValue } =
 		useColorGradientSettings( settings );
-	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
-		showInheritanceLabelIndicators
-			? getInheritanceProps( isInherited, hasLocalOverride, className )
-			: {};
+	const tooltipText = ( path ) =>
+		getInheritanceTooltipTextByPath( inheritedSources, path );
+	const commonTooltipText = ( paths ) =>
+		getCommonInheritanceTooltipText( inheritedSources, paths );
 
 	// Text color. Writes to `color.text` (unchanged storage path). The
 	// control is rendered here instead of the Color panel because text
@@ -777,6 +783,69 @@ export default function TypographyPanel( {
 		[ hasTextColorEnabled ]
 	);
 
+	const fontFamilyInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isFontFamilyPlaceholder,
+		hasFontFamily() && inheritedFontFamily !== undefined
+	);
+	const fontSizeInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isFontSizePlaceholder,
+		hasFontSize() && rawInheritedFontSize !== undefined
+	);
+	const fontAppearanceInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isFontAppearancePlaceholder,
+		hasFontAppearance() &&
+			( inheritedFontStyle !== undefined ||
+				inheritedFontWeight !== undefined )
+	);
+	const lineHeightInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isLineHeightPlaceholder,
+		hasLineHeight() && inheritedLineHeight !== undefined,
+		'single-column'
+	);
+	const letterSpacingInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isLetterSpacingPlaceholder,
+		hasLetterSpacing() && inheritedLetterSpacing !== undefined,
+		'single-column'
+	);
+	const textIndentInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isTextIndentPlaceholder,
+		hasTextIndent() && inheritedTextIndent !== undefined
+	);
+	const textColumnsInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isTextColumnsPlaceholder,
+		hasTextColumns() && inheritedTextColumns !== undefined,
+		'single-column'
+	);
+	const textDecorationInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isTextDecorationPlaceholder,
+		hasTextDecoration() && inheritedTextDecoration !== undefined,
+		'single-column'
+	);
+	const writingModeInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isWritingModePlaceholder,
+		hasWritingMode() && inheritedWritingMode !== undefined,
+		'single-column'
+	);
+	const textTransformInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isTextTransformPlaceholder,
+		hasTextTransform() && inheritedTextTransform !== undefined
+	);
+	const textAlignInheritance = getInheritanceProps(
+		showInheritanceLabelIndicators,
+		isTextAlignPlaceholder,
+		hasTextAlign() && inheritedTextAlign !== undefined
+	);
+
 	return (
 		<Wrapper
 			resetAllFilter={ resetAllFilter }
@@ -795,6 +864,7 @@ export default function TypographyPanel( {
 					showInheritanceLabelIndicators={
 						showInheritanceLabelIndicators
 					}
+					inheritedSources={ inheritedSources }
 					isPlaceholder={
 						userTextColor === undefined && textColor !== undefined
 					}
@@ -803,6 +873,7 @@ export default function TypographyPanel( {
 						{
 							key: 'text',
 							label: __( 'Color' ),
+							sourcePaths: [ 'color.text' ],
 							inheritedValue: textColor,
 							inheritedSlug:
 								extractPresetSlug(
@@ -829,10 +900,7 @@ export default function TypographyPanel( {
 			) }
 			{ hasFontFamilyEnabled && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isFontFamilyPlaceholder,
-						hasFontFamily() && inheritedFontFamily !== undefined
-					) }
+					{ ...fontFamilyInheritance }
 					label={ __( 'Font' ) }
 					hasValue={ hasFontFamily }
 					onDeselect={ resetFontFamily }
@@ -843,15 +911,17 @@ export default function TypographyPanel( {
 						fontFamilies={ fontFamilies }
 						value={ fontFamily }
 						onChange={ setFontFamily }
+						labelTooltip={
+							fontFamilyInheritance.isInherited
+								? tooltipText( 'typography.fontFamily' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasFontSizeEnabled && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isFontSizePlaceholder,
-						hasFontSize() && rawInheritedFontSize !== undefined
-					) }
+					{ ...fontSizeInheritance }
 					label={ __( 'Size' ) }
 					hasValue={ hasFontSize }
 					hasInlineEndToggle
@@ -867,17 +937,17 @@ export default function TypographyPanel( {
 						disableCustomFontSizes={ disableCustomFontSizes }
 						withReset={ false }
 						withSlider
+						labelTooltip={
+							fontSizeInheritance.isInherited
+								? tooltipText( 'typography.fontSize' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasAppearanceControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isFontAppearancePlaceholder,
-						hasFontAppearance() &&
-							( inheritedFontStyle !== undefined ||
-								inheritedFontWeight !== undefined )
-					) }
+					{ ...fontAppearanceInheritance }
 					label={ appearanceControlLabel }
 					hasValue={ hasFontAppearance }
 					onDeselect={ resetFontAppearance }
@@ -893,16 +963,20 @@ export default function TypographyPanel( {
 						hasFontStyles={ hasFontStyles }
 						hasFontWeights={ hasFontWeights }
 						fontFamilyFaces={ fontFamilyFaces }
+						labelTooltip={
+							fontAppearanceInheritance.isInherited
+								? commonTooltipText( [
+										'typography.fontStyle',
+										'typography.fontWeight',
+								  ] )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasLineHeightEnabled && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isLineHeightPlaceholder,
-						hasLineHeight() && inheritedLineHeight !== undefined,
-						'single-column'
-					) }
+					{ ...lineHeightInheritance }
 					label={ __( 'Line height' ) }
 					hasValue={ hasLineHeight }
 					onDeselect={ resetLineHeight }
@@ -924,17 +998,17 @@ export default function TypographyPanel( {
 								? getNumericPlaceholder( inheritedLineHeight )
 								: undefined
 						}
+						labelTooltip={
+							lineHeightInheritance.isInherited
+								? tooltipText( 'typography.lineHeight' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasLetterSpacingControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isLetterSpacingPlaceholder,
-						hasLetterSpacing() &&
-							inheritedLetterSpacing !== undefined,
-						'single-column'
-					) }
+					{ ...letterSpacingInheritance }
 					label={ __( 'Letter spacing' ) }
 					hasValue={ hasLetterSpacing }
 					onDeselect={ resetLetterSpacing }
@@ -959,15 +1033,17 @@ export default function TypographyPanel( {
 								  )
 								: undefined
 						}
+						labelTooltip={
+							letterSpacingInheritance.isInherited
+								? tooltipText( 'typography.letterSpacing' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasTextIndentControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isTextIndentPlaceholder,
-						hasTextIndent() && inheritedTextIndent !== undefined
-					) }
+					{ ...textIndentInheritance }
 					label={ __( 'Line indent' ) }
 					hasValue={ hasTextIndent }
 					onDeselect={ resetTextIndent }
@@ -991,6 +1067,11 @@ export default function TypographyPanel( {
 								? getNumericPlaceholder( inheritedTextIndent )
 								: undefined
 						}
+						labelTooltip={
+							textIndentInheritance.isInherited
+								? tooltipText( 'typography.textIndent' )
+								: undefined
+						}
 					/>
 					{ isGlobalStyles && (
 						<ToggleControl
@@ -1004,11 +1085,7 @@ export default function TypographyPanel( {
 			) }
 			{ hasTextColumnsControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isTextColumnsPlaceholder,
-						hasTextColumns() && inheritedTextColumns !== undefined,
-						'single-column'
-					) }
+					{ ...textColumnsInheritance }
 					label={ __( 'Columns' ) }
 					hasValue={ hasTextColumns }
 					onDeselect={ resetTextColumns }
@@ -1028,17 +1105,17 @@ export default function TypographyPanel( {
 						spinControls="custom"
 						value={ localTextColumns }
 						initialPosition={ 1 }
+						labelTooltip={
+							textColumnsInheritance.isInherited
+								? tooltipText( 'typography.textColumns' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasTextDecorationControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isTextDecorationPlaceholder,
-						hasTextDecoration() &&
-							inheritedTextDecoration !== undefined,
-						'single-column'
-					) }
+					{ ...textDecorationInheritance }
 					label={ __( 'Decoration' ) }
 					hasValue={ hasTextDecoration }
 					onDeselect={ resetTextDecoration }
@@ -1050,16 +1127,17 @@ export default function TypographyPanel( {
 						onChange={ setTextDecorationWithInheritedCommit }
 						size="__unstable-large"
 						__unstableInputWidth="auto"
+						labelTooltip={
+							textDecorationInheritance.isInherited
+								? tooltipText( 'typography.textDecoration' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasWritingModeControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isWritingModePlaceholder,
-						hasWritingMode() && inheritedWritingMode !== undefined,
-						'single-column'
-					) }
+					{ ...writingModeInheritance }
 					label={ __( 'Orientation' ) }
 					hasValue={ hasWritingMode }
 					onDeselect={ resetWritingMode }
@@ -1070,16 +1148,17 @@ export default function TypographyPanel( {
 						value={ writingMode }
 						onChange={ setWritingModeWithInheritedCommit }
 						size="__unstable-large"
+						labelTooltip={
+							writingModeInheritance.isInherited
+								? tooltipText( 'typography.writingMode' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasTextTransformControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isTextTransformPlaceholder,
-						hasTextTransform() &&
-							inheritedTextTransform !== undefined
-					) }
+					{ ...textTransformInheritance }
 					label={ __( 'Letter case' ) }
 					hasValue={ hasTextTransform }
 					onDeselect={ resetTextTransform }
@@ -1092,15 +1171,17 @@ export default function TypographyPanel( {
 						showNone
 						isBlock
 						size="__unstable-large"
+						labelTooltip={
+							textTransformInheritance.isInherited
+								? tooltipText( 'typography.textTransform' )
+								: undefined
+						}
 					/>
 				</InheritanceToolsPanelItem>
 			) }
 			{ hasTextAlignmentControl && (
 				<InheritanceToolsPanelItem
-					{ ...inheritanceProps(
-						isTextAlignPlaceholder,
-						hasTextAlign() && inheritedTextAlign !== undefined
-					) }
+					{ ...textAlignInheritance }
 					label={ __( 'Text alignment' ) }
 					hasValue={ hasTextAlign }
 					onDeselect={ resetTextAlign }
@@ -1112,6 +1193,11 @@ export default function TypographyPanel( {
 						onChange={ setTextAlignWithInheritedCommit }
 						options={ [ 'left', 'center', 'right', 'justify' ] }
 						size="__unstable-large"
+						labelTooltip={
+							textAlignInheritance.isInherited
+								? tooltipText( 'typography.textAlign' )
+								: undefined
+						}
 					/>
 
 					{ textAlign === 'justify' && (

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -79,6 +79,7 @@ export default function SpacingSizesControl( {
 	sides = ALL_SIDES,
 	useSelect,
 	values,
+	labelTooltip,
 } ) {
 	const spacingSizes = useSpacingSizes();
 	const inputValues = values || DEFAULT_VALUES;
@@ -144,6 +145,7 @@ export default function SpacingSizesControl( {
 				<BaseControl.VisualLabel
 					as="legend"
 					className="spacing-sizes-control__label"
+					labelTooltip={ labelTooltip }
 				>
 					{ label }
 				</BaseControl.VisualLabel>

--- a/packages/block-editor/src/components/text-alignment-control/index.js
+++ b/packages/block-editor/src/components/text-alignment-control/index.js
@@ -47,11 +47,12 @@ const DEFAULT_OPTIONS = [ 'left', 'center', 'right' ];
 /**
  * Control to facilitate text alignment selections.
  *
- * @param {Object}   props           Component props.
- * @param {string}   props.className Class name to add to the control.
- * @param {string}   props.value     Currently selected text alignment.
- * @param {Function} props.onChange  Handles change in text alignment selection.
- * @param {string[]} props.options   Array of text alignment options to display.
+ * @param {Object}   props              Component props.
+ * @param {string}   props.className    Class name to add to the control.
+ * @param {string}   props.value        Currently selected text alignment.
+ * @param {Function} props.onChange     Handles change in text alignment selection.
+ * @param {string[]} props.options      Array of text alignment options to display.
+ * @param {string}   props.labelTooltip Tooltip text shown on the control label.
  *
  * @return {Element} Text alignment control.
  */
@@ -60,6 +61,7 @@ export default function TextAlignmentControl( {
 	value,
 	onChange,
 	options = DEFAULT_OPTIONS,
+	labelTooltip,
 } ) {
 	const validOptions = useMemo(
 		() =>
@@ -77,6 +79,7 @@ export default function TextAlignmentControl( {
 		<ToggleGroupControl
 			isDeselectable
 			label={ __( 'Text alignment' ) }
+			labelTooltip={ labelTooltip }
 			className={ clsx(
 				'block-editor-text-alignment-control',
 				className

--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -34,10 +34,11 @@ const TEXT_DECORATIONS = [
 /**
  * Control to facilitate text decoration selections.
  *
- * @param {Object}   props           Component props.
- * @param {string}   props.value     Currently selected text decoration.
- * @param {Function} props.onChange  Handles change in text decoration selection.
- * @param {string}   props.className Additional class name to apply.
+ * @param {Object}   props              Component props.
+ * @param {string}   props.value        Currently selected text decoration.
+ * @param {Function} props.onChange     Handles change in text decoration selection.
+ * @param {string}   props.className    Additional class name to apply.
+ * @param {string}   props.labelTooltip Tooltip text shown on the control label.
  *
  * @return {Element} Text decoration control.
  */
@@ -45,11 +46,13 @@ export default function TextDecorationControl( {
 	value,
 	onChange,
 	className,
+	labelTooltip,
 } ) {
 	return (
 		<ToggleGroupControl
 			isDeselectable
 			label={ __( 'Decoration' ) }
+			labelTooltip={ labelTooltip }
 			className={ clsx(
 				'block-editor-text-decoration-control',
 				className

--- a/packages/block-editor/src/components/text-indent-control/index.js
+++ b/packages/block-editor/src/components/text-indent-control/index.js
@@ -31,6 +31,7 @@ import { useSettings } from '../../components/use-settings';
  * @param {string}                  props.help                 Help text to display below the control.
  * @param {string}                  props.className            Class name to add to the inner UnitControl.
  * @param {string}                  props.placeholder          Placeholder for the inner UnitControl.
+ * @param {string}                  props.labelTooltip         Tooltip text shown on the control label.
  *
  * @return {Element} Text indent control.
  */
@@ -43,6 +44,7 @@ export default function TextIndentControl( {
 	help,
 	className,
 	placeholder,
+	labelTooltip,
 	...otherProps
 } ) {
 	const [ availableUnits ] = useSettings( 'spacing.units' );
@@ -72,6 +74,7 @@ export default function TextIndentControl( {
 			<UnitControl
 				{ ...otherProps }
 				label={ __( 'Line indent' ) }
+				labelTooltip={ labelTooltip }
 				value={ value }
 				__unstableInputWidth={ __unstableInputWidth }
 				units={ units }
@@ -85,7 +88,7 @@ export default function TextIndentControl( {
 
 	return (
 		<View style={ hasBottomMargin ? { marginBottom: 12 } : undefined }>
-			<BaseControl.VisualLabel>
+			<BaseControl.VisualLabel labelTooltip={ labelTooltip }>
 				{ __( 'Line indent' ) }
 			</BaseControl.VisualLabel>
 			<Flex>

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -44,18 +44,25 @@ const TEXT_TRANSFORMS = [
 /**
  * Control to facilitate text transform selections.
  *
- * @param {Object}   props           Component props.
- * @param {string}   props.className Class name to add to the control.
- * @param {string}   props.value     Currently selected text transform.
- * @param {Function} props.onChange  Handles change in text transform selection.
+ * @param {Object}   props              Component props.
+ * @param {string}   props.className    Class name to add to the control.
+ * @param {string}   props.value        Currently selected text transform.
+ * @param {Function} props.onChange     Handles change in text transform selection.
+ * @param {string}   props.labelTooltip Tooltip text shown on the control label.
  *
  * @return {Element} Text transform control.
  */
-export default function TextTransformControl( { className, value, onChange } ) {
+export default function TextTransformControl( {
+	className,
+	value,
+	onChange,
+	labelTooltip,
+} ) {
 	return (
 		<ToggleGroupControl
 			isDeselectable
 			label={ __( 'Letter case' ) }
+			labelTooltip={ labelTooltip }
 			className={ clsx(
 				'block-editor-text-transform-control',
 				className

--- a/packages/block-editor/src/components/writing-mode-control/index.js
+++ b/packages/block-editor/src/components/writing-mode-control/index.js
@@ -29,18 +29,25 @@ const WRITING_MODES = [
 /**
  * Control to facilitate writing mode selections.
  *
- * @param {Object}   props           Component props.
- * @param {string}   props.className Class name to add to the control.
- * @param {string}   props.value     Currently selected writing mode.
- * @param {Function} props.onChange  Handles change in the writing mode selection.
+ * @param {Object}   props              Component props.
+ * @param {string}   props.className    Class name to add to the control.
+ * @param {string}   props.value        Currently selected writing mode.
+ * @param {Function} props.onChange     Handles change in the writing mode selection.
+ * @param {string}   props.labelTooltip Tooltip text shown on the control label.
  *
  * @return {Element} Writing Mode control.
  */
-export default function WritingModeControl( { className, value, onChange } ) {
+export default function WritingModeControl( {
+	className,
+	value,
+	onChange,
+	labelTooltip,
+} ) {
 	return (
 		<ToggleGroupControl
 			isDeselectable
 			label={ __( 'Orientation' ) }
+			labelTooltip={ labelTooltip }
 			className={ clsx( 'block-editor-writing-mode-control', className ) }
 			value={ value }
 			onChange={ ( newValue ) => {

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -193,11 +193,8 @@ export function BackgroundImagePanel( {
 		[ clientId ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const backgroundGradientSupported = hasBackgroundSupport(
 		name,
@@ -393,6 +390,7 @@ export function BackgroundImagePanel( {
 			}
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -170,11 +170,8 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
@@ -219,6 +216,7 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 			onChange={ onChange }
 			defaultControls={ defaultControls }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -95,11 +95,8 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 	const value = isStateSelected
@@ -152,6 +149,7 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 					isStateSelected ? undefined : setVisualizedProperty
 				}
 				inheritedValue={ inheritedValue }
+				inheritedSources={ inheritedSources }
 			/>
 			{ ! isStateSelected &&
 				!! settings?.spacing?.padding &&

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -114,7 +114,8 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 				: undefined,
 		[ clientId ]
 	);
-	const { value: inheritedValue } = useResolvedStyles( name, className );
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className );
 
 	const duotonePalette = useMultiOriginPresets( {
 		presetSetting: 'color.duotone',
@@ -166,6 +167,7 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 					} }
 					settings={ settings }
 					inheritedValue={ inheritedValue }
+					inheritedSources={ inheritedSources }
 				/>
 			</InspectorControls>
 			<BlockControls group="block" __experimentalShareWithChildBlocks>

--- a/packages/block-editor/src/hooks/elements.js
+++ b/packages/block-editor/src/hooks/elements.js
@@ -75,11 +75,8 @@ export function ElementsEdit( {
 		[ clientId, isEnabled ]
 	);
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
@@ -146,6 +143,7 @@ export function ElementsEdit( {
 			label={ label }
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -182,11 +182,8 @@ export function TypographyPanel( {
 
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 
-	const { value: inheritedValue } = useResolvedStyles(
-		name,
-		className,
-		selectedState
-	);
+	const { value: inheritedValue, sources: inheritedSources } =
+		useResolvedStyles( name, className, selectedState );
 
 	const value = useMemo( () => {
 		if ( isStateSelected ) {
@@ -270,6 +267,7 @@ export function TypographyPanel( {
 			defaultControls={ defaultControls }
 			contrastWarning={ contrastWarning }
 			inheritedValue={ inheritedValue }
+			inheritedSources={ inheritedSources }
 		/>
 	);
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Enhancements
 
+-   Add an optional `labelTooltip` prop to `BaseControl`, `BaseControl.VisualLabel`, `InputControl`, and the controls built on them (`SelectControl`, `RangeControl`, `ToggleGroupControl`, `UnitControl`, `NumberControl`, `FontSizePicker`, `BoxControl`, `CustomSelectControl`). When set, the visible label text is wrapped in a `Tooltip` showing the given text.
 -   Widen React peer dependency ranges to `^18 || ^19` to support both React 18 and React 19 environments ([#80024](https://github.com/WordPress/gutenberg/pull/80024)).
 -   `Button`: Align focus rings with the design system ([#78646](https://github.com/WordPress/gutenberg/pull/78646)).
 -   The `size` prop no longer has any effect and can be safely removed from the following:

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -13,6 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { VisuallyHidden } from '../visually-hidden';
+import { LabelWithTooltip } from '../utils/label-with-tooltip';
 import type { BaseControlProps, BaseControlVisualLabelProps } from './types';
 import {
 	Wrapper,
@@ -32,6 +33,7 @@ const UnconnectedBaseControl = (
 	const {
 		id,
 		label,
+		labelTooltip,
 		hideLabelFromVision = false,
 		help,
 		className,
@@ -52,7 +54,9 @@ const UnconnectedBaseControl = (
 							className="components-base-control__label"
 							htmlFor={ id }
 						>
-							{ label }
+							<LabelWithTooltip labelTooltip={ labelTooltip }>
+								{ label }
+							</LabelWithTooltip>
 						</StyledLabel>
 					) ) }
 				{ label &&
@@ -60,7 +64,9 @@ const UnconnectedBaseControl = (
 					( hideLabelFromVision ? (
 						<VisuallyHidden as="label">{ label }</VisuallyHidden>
 					) : (
-						<VisualLabel>{ label }</VisualLabel>
+						<VisualLabel labelTooltip={ labelTooltip }>
+							{ label }
+						</VisualLabel>
 					) ) }
 				{ children }
 			</StyledField>
@@ -80,7 +86,7 @@ const UnforwardedVisualLabel = (
 	props: WordPressComponentProps< BaseControlVisualLabelProps, 'span' >,
 	ref: ForwardedRef< any >
 ) => {
-	const { className, children, ...restProps } = props;
+	const { className, children, labelTooltip, ...restProps } = props;
 
 	return (
 		<StyledVisualLabel
@@ -88,7 +94,9 @@ const UnforwardedVisualLabel = (
 			{ ...restProps }
 			className={ clsx( 'components-base-control__label', className ) }
 		>
-			{ children }
+			<LabelWithTooltip labelTooltip={ labelTooltip }>
+				{ children }
+			</LabelWithTooltip>
 		</StyledVisualLabel>
 	);
 };

--- a/packages/components/src/base-control/test/index.tsx
+++ b/packages/components/src/base-control/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -49,5 +50,45 @@ describe( 'BaseControl', () => {
 			// eslint-disable-next-line testing-library/no-node-access
 			help.closest( `#${ textarea.getAttribute( 'aria-describedby' ) }` )
 		).toBeVisible();
+	} );
+
+	describe( 'labelTooltip', () => {
+		it( 'should wrap the label text in a tooltip and reveal it on hover', async () => {
+			const user = userEvent.setup();
+			render(
+				<MyBaseControl
+					label="Text"
+					labelTooltip="Inherited from Styles"
+				/>
+			);
+
+			// No tooltip until the label is hovered.
+			expect(
+				screen.queryByText( 'Inherited from Styles' )
+			).not.toBeInTheDocument();
+
+			await user.hover( screen.getByText( 'Text' ) );
+
+			expect(
+				await screen.findByText( 'Inherited from Styles' )
+			).toBeVisible();
+		} );
+
+		it( 'should wrap a VisualLabel in a tooltip and reveal it on hover', async () => {
+			const user = userEvent.setup();
+			render(
+				<BaseControl>
+					<BaseControl.VisualLabel labelTooltip="Inherited from Styles">
+						Text
+					</BaseControl.VisualLabel>
+				</BaseControl>
+			);
+
+			await user.hover( screen.getByText( 'Text' ) );
+
+			expect(
+				await screen.findByText( 'Inherited from Styles' )
+			).toBeVisible();
+		} );
 	} );
 } );

--- a/packages/components/src/base-control/types.ts
+++ b/packages/components/src/base-control/types.ts
@@ -30,6 +30,11 @@ export type BaseControlProps = {
 	 */
 	label?: ReactNode;
 	/**
+	 * If provided, the visible label text is wrapped in a `Tooltip` showing this
+	 * text. Only applies when the label is visible (i.e. not `hideLabelFromVision`).
+	 */
+	labelTooltip?: string;
+	/**
 	 * If true, the label will only be visible to screen readers.
 	 *
 	 * @default false
@@ -47,4 +52,8 @@ export type BaseControlVisualLabelProps = {
 	 * The content to be displayed within the `BaseControl.VisualLabel`.
 	 */
 	children: ReactNode;
+	/**
+	 * If provided, the label content is wrapped in a `Tooltip` showing this text.
+	 */
+	labelTooltip?: string;
 };

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -67,6 +67,7 @@ function BoxControl( {
 	inputProps = defaultInputProps,
 	onChange = noop,
 	label = __( 'Box Control' ),
+	labelTooltip,
 	values: valuesProp,
 	units,
 	sides,
@@ -153,7 +154,10 @@ function BoxControl( {
 			role="group"
 			aria-labelledby={ headingId }
 		>
-			<BaseControl.VisualLabel id={ headingId }>
+			<BaseControl.VisualLabel
+				id={ headingId }
+				labelTooltip={ labelTooltip }
+			>
 				{ label }
 			</BaseControl.VisualLabel>
 			{ isLinked && (

--- a/packages/components/src/box-control/types.ts
+++ b/packages/components/src/box-control/types.ts
@@ -71,6 +71,11 @@ export type BoxControlProps = Pick< UnitControlProps, 'units' > &
 		 */
 		label?: string;
 		/**
+		 * If provided, the visible heading label is wrapped in a `Tooltip`
+		 * showing this text.
+		 */
+		labelTooltip?: string;
+		/**
 		 * A callback function when an input value changes.
 		 */
 		onChange: ( next: BoxControlValue ) => void;

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -95,6 +95,7 @@ function CustomSelect(
 		children,
 		hideLabelFromVision = false,
 		label,
+		labelTooltip,
 		size,
 		store,
 		className,
@@ -125,7 +126,10 @@ function CustomSelect(
 						<VisuallyHidden />
 					) : (
 						// @ts-expect-error `children` are passed via the render prop
-						<BaseControl.VisualLabel as="div" />
+						<BaseControl.VisualLabel
+							as="div"
+							labelTooltip={ labelTooltip }
+						/>
 					)
 				}
 			>

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -77,6 +77,11 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 * Accessible label for the control.
 	 */
 	label: string;
+	/**
+	 * A tooltip to show when hovering/focusing the label text. When provided,
+	 * the label text is wrapped in a `Tooltip`.
+	 */
+	labelTooltip?: string;
 };
 
 export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;

--- a/packages/components/src/custom-select-control/types.ts
+++ b/packages/components/src/custom-select-control/types.ts
@@ -52,6 +52,11 @@ export type CustomSelectProps< T extends CustomSelectOption > = {
 	 */
 	label: string;
 	/**
+	 * A tooltip to show when hovering/focusing the label text. When provided,
+	 * the label text is wrapped in a `Tooltip`.
+	 */
+	labelTooltip?: string;
+	/**
 	 * Function called with the control's internal state changes. The `selectedItem`
 	 * property contains the next selected item.
 	 */

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -40,6 +40,7 @@ const UnforwardedFontSizePicker = (
 		fallbackFontSize,
 		fontSizes = [],
 		disableCustomFontSizes = false,
+		labelTooltip,
 		onChange,
 		units: unitsProp = DEFAULT_UNITS,
 		value,
@@ -123,7 +124,7 @@ const UnforwardedFontSizePicker = (
 		>
 			<Spacer>
 				<Header className="components-font-size-picker__header">
-					<HeaderLabel id={ labelId }>
+					<HeaderLabel id={ labelId } labelTooltip={ labelTooltip }>
 						{ __( 'Font size' ) }
 					</HeaderLabel>
 					{ ! disableCustomFontSizes && (

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -17,6 +17,11 @@ export type FontSizePickerProps = {
 	 */
 	fontSizes?: FontSize[];
 	/**
+	 * If provided, the visible "Font size" label is wrapped in a `Tooltip`
+	 * showing this text.
+	 */
+	labelTooltip?: string;
+	/**
 	 * A function that receives the new font size value.
 	 * If onChange is called without any parameter, it should reset the value,
 	 * attending to what reset means in that context, e.g., set the font size to

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -48,6 +48,7 @@ export function UnforwardedInputControl(
 		isPressEnterToChange = false,
 		label,
 		labelPosition = 'top',
+		labelTooltip,
 		onChange = noop,
 		onValidate = noop,
 		onKeyDown = noop,
@@ -89,6 +90,7 @@ export function UnforwardedInputControl(
 				justify="left"
 				label={ label }
 				labelPosition={ labelPosition }
+				labelTooltip={ labelTooltip }
 				prefix={ prefix }
 				size={ size }
 				style={ style }

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -73,6 +73,7 @@ function InputBase(
 		id: idProp,
 		isBorderless = false,
 		label,
+		labelTooltip,
 		prefix,
 		size = 'default',
 		suffix,
@@ -104,6 +105,7 @@ function InputBase(
 				className="components-input-control__label"
 				hideLabelFromVision={ hideLabelFromVision }
 				labelPosition={ labelPosition }
+				labelTooltip={ labelTooltip }
 				htmlFor={ id }
 			>
 				{ label }

--- a/packages/components/src/input-control/label.tsx
+++ b/packages/components/src/input-control/label.tsx
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { VisuallyHidden } from '../visually-hidden';
+import { LabelWithTooltip } from '../utils/label-with-tooltip';
 import {
 	Label as BaseLabel,
 	LabelWrapper,
@@ -13,6 +14,7 @@ export default function Label( {
 	children,
 	hideLabelFromVision,
 	htmlFor,
+	labelTooltip,
 	...props
 }: WordPressComponentProps< InputControlLabelProps, 'label', false > ) {
 	if ( ! children ) {
@@ -30,7 +32,9 @@ export default function Label( {
 	return (
 		<LabelWrapper>
 			<BaseLabel htmlFor={ htmlFor } { ...props }>
-				{ children }
+				<LabelWithTooltip labelTooltip={ labelTooltip }>
+					{ children }
+				</LabelWithTooltip>
 			</BaseLabel>
 		</LabelWrapper>
 	);

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -178,6 +178,11 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 */
 	label?: ReactNode;
 	/**
+	 * If provided, the visible label text is wrapped in a `Tooltip` showing this
+	 * text. Only applies when the label is visible (i.e. not `hideLabelFromVision`).
+	 */
+	labelTooltip?: string;
+	/**
 	 * Whether to hide the border when not focused.
 	 *
 	 * @default false
@@ -215,6 +220,7 @@ export interface InputControlLabelProps {
 	children: ReactNode;
 	hideLabelFromVision?: BaseProps[ 'hideLabelFromVision' ];
 	labelPosition?: BaseProps[ 'labelPosition' ];
+	labelTooltip?: string;
 	size?: BaseProps[ 'size' ];
 }
 

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -81,6 +81,7 @@ function UnforwardedRangeControl(
 		initialPosition,
 		isShiftStepEnabled = true,
 		label,
+		labelTooltip,
 		marks = false,
 		max = 100,
 		min = 0,
@@ -235,6 +236,7 @@ function UnforwardedRangeControl(
 		<BaseControl
 			className={ classes }
 			label={ label }
+			labelTooltip={ labelTooltip }
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ `${ id }` }
 			help={ help }

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -135,6 +135,11 @@ export type RangeControlProps = Pick<
 		 */
 		label?: string;
 		/**
+		 * If provided, the visible label text is wrapped in a `Tooltip` showing
+		 * this text.
+		 */
+		labelTooltip?: string;
+		/**
 		 * Callback for when `RangeControl` input loses focus.
 		 *
 		 * @default () => void

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -57,6 +57,7 @@ function UnforwardedSelectControl< V extends string >(
 		hideLabelFromVision,
 		id: idProp,
 		label,
+		labelTooltip,
 		multiple = false,
 		onChange,
 		options = [],
@@ -103,6 +104,7 @@ function UnforwardedSelectControl< V extends string >(
 				id={ id }
 				isBorderless={ variant === 'minimal' }
 				label={ label }
+				labelTooltip={ labelTooltip }
 				size={ size }
 				suffix={
 					suffix || ( ! multiple && <SelectControlChevronDown /> )

--- a/packages/components/src/select-control/types.ts
+++ b/packages/components/src/select-control/types.ts
@@ -16,6 +16,7 @@ type SelectControlBaseProps< V extends string > = Pick<
 	| 'disabled'
 	| 'hideLabelFromVision'
 	| 'label'
+	| 'labelTooltip'
 	| 'labelPosition'
 	| 'prefix'
 	| 'size'

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -39,6 +39,7 @@ function UnconnectedToggleGroupControl(
 		isDeselectable = false,
 		id,
 		label,
+		labelTooltip,
 		hideLabelFromVision = false,
 		help,
 		onChange,
@@ -51,6 +52,7 @@ function UnconnectedToggleGroupControl(
 		id,
 		help,
 		label,
+		labelTooltip,
 		hideLabelFromVision,
 	} );
 

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -79,6 +79,11 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	label: string;
 	/**
+	 * If provided, the visible label text is wrapped in a `Tooltip` showing this
+	 * text.
+	 */
+	labelTooltip?: string;
+	/**
 	 * If true, the label will only be visible to screen readers.
 	 *
 	 * @default false

--- a/packages/components/src/utils/label-with-tooltip.tsx
+++ b/packages/components/src/utils/label-with-tooltip.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import type { ReactElement, ReactNode } from 'react';
+import { Tooltip } from '@wordpress/ui';
+
+type LabelWithTooltipProps = {
+	/**
+	 * Tooltip text shown when hovering/focusing the label. When omitted the
+	 * label content is rendered unchanged.
+	 */
+	labelTooltip?: string;
+	/**
+	 * The label content to (optionally) wrap in a tooltip anchor.
+	 */
+	children: ReactNode;
+};
+
+/**
+ * Wraps label content in a `Tooltip` anchor when `labelTooltip` is provided,
+ * otherwise returns the children untouched.
+ *
+ * Shared by the control label primitives (`BaseControl`,
+ * `BaseControl.VisualLabel`, `InputControl`) so the `labelTooltip` prop renders
+ * a consistent, natively-anchored tooltip on the visible label text — no
+ * portals. Uses the `@wordpress/ui` `Tooltip` so it matches tooltips wrapped
+ * manually elsewhere (e.g. the Global Styles inheritance breadcrumb labels).
+ *
+ * @param props
+ * @param props.labelTooltip Tooltip text.
+ * @param props.children     Label content.
+ */
+export function LabelWithTooltip( {
+	labelTooltip,
+	children,
+}: LabelWithTooltipProps ): ReactElement {
+	if ( ! labelTooltip ) {
+		return <>{ children }</>;
+	}
+
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={
+					<span className="components-control-label__tooltip-anchor">
+						{ children }
+					</span>
+				}
+			/>
+			<Tooltip.Popup>
+				{ labelTooltip.split( '\n' ).map( ( line, index ) => (
+					// Render each breadcrumb segment on its own line.
+					<span key={ index } style={ { display: 'block' } }>
+						{ line }
+					</span>
+				) ) }
+			</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+}


### PR DESCRIPTION
## What?

Follow up to #77894.

Adds a way to render an adornment and tooltip around a control's label, so the block inspector can show where an inherited Global Styles value comes from via a breadcrumb path (e.g. `Styles > Mobile > Paragraph > Variation`).

## Why?

#77894 lands the display of inherited Global Styles values but stops short of the "inherited from…" tooltip. There was no supported way to attach an adornment or tooltip to a control label without reaching into the DOM.

This gives `BaseControl`, `InputControl`, and `UnitControl` a proper API for it.

## How?

- Adds an optional prop to the affected components to render an adornment next to the label.
- Wires the inherited style source data through to build the breadcrumb tooltip.

## Alternative Solutions

An earlier exploration injected the adornment and tooltip into existing control labels via `createPortal`. It was always a hack aimed at avoiding updates to the public API of commonly used components. That PR (#79992) has been closed in favour of this approach.

## Testing Instructions

1. Apply Global Styles to a block and open the inspector.
2. Confirm inherited controls show the dotted underline and, on hover, a tooltip with the inheritance breadcrumb path.
3. Confirm the breadcrumb matches where the value actually comes from (root, block type, variation, state, viewport).

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="281" height="99" alt="Screenshot 2026-07-12 at 4 46 02 pm" src="https://github.com/user-attachments/assets/eb5f609e-f340-4d65-b359-1f1029a90e46" /> | <img width="301" height="108" alt="Screenshot 2026-07-12 at 4 44 53 pm" src="https://github.com/user-attachments/assets/220c8961-9f07-417d-b80a-8062356e92c9" /> |