### PR TITLE
Rich text: synchronize the selection before events that consume it

### DIFF
--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -118,7 +118,8 @@ export default ( props ) => ( element ) => {
 
 	/**
 	 * Syncs the selection to local state. A callback for the `selectionchange`
-	 * event.
+	 * event, and for the capture phase of events that consume the selection,
+	 * which run before `selectionchange` is delivered.
 	 */
 	function handleSelectionChange() {
 		const { record, applyRecord, createRecord, onSelectionChange } =
@@ -144,6 +145,20 @@ export default ( props ) => ( element ) => {
 		}
 
 		const selection = defaultView.getSelection();
+
+		// Skip selections that have already been processed, such as the
+		// `selectionchange` event for a selection that was synchronized on
+		// capture of a consuming event, or coalesced duplicates.
+		if (
+			selectionSnapshot &&
+			selectionSnapshot.anchorNode === selection.anchorNode &&
+			selectionSnapshot.anchorOffset === selection.anchorOffset &&
+			selectionSnapshot.focusNode === selection.focusNode &&
+			selectionSnapshot.focusOffset === selection.focusOffset
+		) {
+			return;
+		}
+
 		selectionSnapshot = {
 			anchorNode: selection.anchorNode,
 			anchorOffset: selection.anchorOffset,
@@ -196,35 +211,6 @@ export default ( props ) => ( element ) => {
 		record.current = newValue;
 		applyRecord( newValue, { domOnly: true } );
 		onSelectionChange( start, end );
-	}
-
-	/**
-	 * The native `selectionchange` event is asynchronous and coalesced: the
-	 * record and the store selection can be one selection behind the DOM when
-	 * an event that acts on them arrives, regardless of how the selection got
-	 * there. Synchronize before any other handler runs (capture phase on the
-	 * document), so anything consuming the record, the store selection, or a
-	 * value rendered from them acts on the current selection. The snapshot
-	 * comparison skips the work when the selection was already processed.
-	 */
-	function ensureSelectionSync() {
-		if ( ownerDocument.activeElement !== element ) {
-			return;
-		}
-
-		const selection = defaultView.getSelection();
-
-		if (
-			selectionSnapshot &&
-			selectionSnapshot.anchorNode === selection.anchorNode &&
-			selectionSnapshot.anchorOffset === selection.anchorOffset &&
-			selectionSnapshot.focusNode === selection.focusNode &&
-			selectionSnapshot.focusOffset === selection.focusOffset
-		) {
-			return;
-		}
-
-		handleSelectionChange();
 	}
 
 	function onCompositionStart() {
@@ -334,8 +320,13 @@ export default ( props ) => ( element ) => {
 		'selectionchange',
 		handleSelectionChange
 	);
-	// The events that act on the record or the store selection. Capture phase
-	// on the document runs before element- and window-level handlers.
+	// The native `selectionchange` event is asynchronous and coalesced: the
+	// record and the store selection can be one selection behind the DOM when
+	// an event that acts on them arrives, regardless of how the selection got
+	// there. Synchronize on capture of the events that consume the record,
+	// the store selection, or a value rendered from them, before any other
+	// handler runs. The snapshot comparison in `handleSelectionChange` skips
+	// selections that have already been processed.
 	const unsubscribeEnsureSelectionSync = [
 		'keydown',
 		'beforeinput',
@@ -346,7 +337,7 @@ export default ( props ) => ( element ) => {
 		subscribeDelegatedListener(
 			ownerDocument,
 			eventType,
-			ensureSelectionSync,
+			handleSelectionChange,
 			true
 		)
 	);

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -146,28 +146,36 @@ export default ( props ) => ( element ) => {
 
 		const selection = defaultView.getSelection();
 
-		// Skip selections that have already been processed, such as the
-		// `selectionchange` event for a selection that was synchronized on
-		// capture of a consuming event, or coalesced duplicates.
+		// Skip selections that have already been processed into the current
+		// record, such as the `selectionchange` event for a selection that
+		// was synchronized on capture of a consuming event, or coalesced
+		// duplicates. The offsets the processing produced are compared to
+		// the record too: the record's selection may be rewritten from
+		// (possibly stale) props on render without the DOM selection moving,
+		// in which case the selection must be processed again.
 		if (
 			selectionSnapshot &&
 			selectionSnapshot.anchorNode === selection.anchorNode &&
 			selectionSnapshot.anchorOffset === selection.anchorOffset &&
 			selectionSnapshot.focusNode === selection.focusNode &&
-			selectionSnapshot.focusOffset === selection.focusOffset
+			selectionSnapshot.focusOffset === selection.focusOffset &&
+			selectionSnapshot.processedStart === record.current.start &&
+			selectionSnapshot.processedEnd === record.current.end
 		) {
 			return;
 		}
+
+		const { start, end, text } = createRecord();
+		const oldRecord = record.current;
 
 		selectionSnapshot = {
 			anchorNode: selection.anchorNode,
 			anchorOffset: selection.anchorOffset,
 			focusNode: selection.focusNode,
 			focusOffset: selection.focusOffset,
+			processedStart: start,
+			processedEnd: end,
 		};
-
-		const { start, end, text } = createRecord();
-		const oldRecord = record.current;
 
 		// Fallback mechanism for IE11, which doesn't support the input event.
 		// Any input results in a selection change.

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -114,6 +114,8 @@ export default ( props ) => ( element ) => {
 		handleChange( change );
 	}
 
+	let selectionSnapshot;
+
 	/**
 	 * Syncs the selection to local state. A callback for the `selectionchange`
 	 * event.
@@ -140,6 +142,14 @@ export default ( props ) => ( element ) => {
 		if ( isComposing ) {
 			return;
 		}
+
+		const selection = defaultView.getSelection();
+		selectionSnapshot = {
+			anchorNode: selection.anchorNode,
+			anchorOffset: selection.anchorOffset,
+			focusNode: selection.focusNode,
+			focusOffset: selection.focusOffset,
+		};
 
 		const { start, end, text } = createRecord();
 		const oldRecord = record.current;
@@ -186,6 +196,35 @@ export default ( props ) => ( element ) => {
 		record.current = newValue;
 		applyRecord( newValue, { domOnly: true } );
 		onSelectionChange( start, end );
+	}
+
+	/**
+	 * The native `selectionchange` event is asynchronous and coalesced: the
+	 * record and the store selection can be one selection behind the DOM when
+	 * an event that acts on them arrives, regardless of how the selection got
+	 * there. Synchronize before any other handler runs (capture phase on the
+	 * document), so anything consuming the record, the store selection, or a
+	 * value rendered from them acts on the current selection. The snapshot
+	 * comparison skips the work when the selection was already processed.
+	 */
+	function ensureSelectionSync() {
+		if ( ownerDocument.activeElement !== element ) {
+			return;
+		}
+
+		const selection = defaultView.getSelection();
+
+		if (
+			selectionSnapshot &&
+			selectionSnapshot.anchorNode === selection.anchorNode &&
+			selectionSnapshot.anchorOffset === selection.anchorOffset &&
+			selectionSnapshot.focusNode === selection.focusNode &&
+			selectionSnapshot.focusOffset === selection.focusOffset
+		) {
+			return;
+		}
+
+		handleSelectionChange();
 	}
 
 	function onCompositionStart() {
@@ -245,6 +284,9 @@ export default ( props ) => ( element ) => {
 				end: index,
 				activeFormats: EMPTY_ACTIVE_FORMATS,
 			};
+			// The record no longer reflects the selection, so a matching
+			// snapshot must not skip synchronization.
+			selectionSnapshot = undefined;
 		} else {
 			applyRecord( record.current, { domOnly: true } );
 		}
@@ -292,6 +334,22 @@ export default ( props ) => ( element ) => {
 		'selectionchange',
 		handleSelectionChange
 	);
+	// The events that act on the record or the store selection. Capture phase
+	// on the document runs before element- and window-level handlers.
+	const unsubscribeEnsureSelectionSync = [
+		'keydown',
+		'beforeinput',
+		'copy',
+		'cut',
+		'paste',
+	].map( ( eventType ) =>
+		subscribeDelegatedListener(
+			ownerDocument,
+			eventType,
+			ensureSelectionSync,
+			true
+		)
+	);
 
 	return () => {
 		unsubscribeInput();
@@ -299,5 +357,8 @@ export default ( props ) => ( element ) => {
 		unsubscribeCompositionEnd();
 		unsubscribeFocus();
 		unsubscribeSelectionChange();
+		unsubscribeEnsureSelectionSync.forEach( ( unsubscribe ) =>
+			unsubscribe()
+		);
 	};
 };


### PR DESCRIPTION
## What?

Update the rich text selection (record and store) right before any event that acts on it: `keydown`, `beforeinput`, `copy`, `cut` and `paste`.

## Why?

The browser fires `selectionchange` asynchronously, so when one of these events arrives first, handlers act on the previous selection: the caret ends up in the wrong place, and selection-dependent e2e tests flake. Fast input can always win that race, however the selection was moved (click, arrow key, split).

Syncing at these events is enough: only a handful of events act on the selection, while there are countless ways to move it.

## How?

The existing `selectionchange` handler is also subscribed on capture of the five events, so it runs before any other handler, with all its guards unchanged. A snapshot of the last processed selection keeps repeat calls down to a few property comparisons: real work only happens when the selection moved and its `selectionchange` event hasn't been processed yet, which is exactly the race being closed. The snapshot also verifies the record still holds the processed offsets, since a render can rewrite the record without the selection moving, and it is cleared when the focus handler resets the record.

Extracted from #79105, which uses the same mechanism for blocks whose caret moves between blocks without focus events.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
