### PR TITLE
Writing flow: synchronize cross-block selections before events that consume them

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -116,14 +116,20 @@ function getRichTextElement( node ) {
 export default function useSelectionObserver() {
 	const { multiSelect, selectBlock, selectionChange } =
 		useDispatch( blockEditorStore );
-	const { getBlockParents, getBlockSelectionStart, isMultiSelecting } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockParents,
+		getBlockSelectionStart,
+		getSelectionStart,
+		getSelectionEnd,
+		isMultiSelecting,
+	} = useSelect( blockEditorStore );
 	return useRefEffect(
 		( node ) => {
 			const { ownerDocument } = node;
 			const { defaultView } = ownerDocument;
 
 			let isTripleClick = false;
+			let processedSelection;
 
 			function onMouseDown( event ) {
 				isTripleClick = event.detail === 3;
@@ -139,6 +145,13 @@ export default function useSelectionObserver() {
 				if ( ! selection.rangeCount ) {
 					return;
 				}
+
+				processedSelection = {
+					anchorNode: selection.anchorNode,
+					anchorOffset: selection.anchorOffset,
+					focusNode: selection.focusNode,
+					focusOffset: selection.focusOffset,
+				};
 
 				const startNode = extractSelectionStartNode( selection );
 				const endNode = extractSelectionEndNode(
@@ -256,7 +269,7 @@ export default function useSelectionObserver() {
 								range,
 								__unstableIsEditableTree: true,
 							} );
-							selectionChange( {
+							const selectionUpdate = {
 								start: {
 									clientId: startClientId,
 									attributeKey:
@@ -280,7 +293,26 @@ export default function useSelectionObserver() {
 										richTextData.end ??
 										richTextData.text.length,
 								},
-							} );
+							};
+							const { start, end } = selectionUpdate;
+							const selectionStart = getSelectionStart();
+							const selectionEnd = getSelectionEnd();
+
+							// Skip the dispatch when the store already holds
+							// the same selection, e.g. when the `mouseup`
+							// after a drag re-processes the selection that
+							// the last `selectionchange` event already
+							// dispatched.
+							if (
+								selectionStart.clientId !== start.clientId ||
+								selectionEnd.clientId !== end.clientId ||
+								selectionStart.attributeKey !==
+									start.attributeKey ||
+								selectionStart.offset !== start.offset ||
+								selectionEnd.offset !== end.offset
+							) {
+								selectionChange( selectionUpdate );
+							}
 						} else {
 							selectBlock( startClientId );
 						}
@@ -349,6 +381,58 @@ export default function useSelectionObserver() {
 				}
 			}
 
+			// The native `selectionchange` event is asynchronous: an event
+			// that consumes the store selection can fire before the store
+			// has received a cross-block selection that was just made, and
+			// its handlers then act on the previous selection. Synchronize
+			// on capture, before any handler runs. Selections within a
+			// single block are synchronized the same way by rich text
+			// itself; the snapshot skips selections that have already been
+			// processed.
+			function ensureCrossBlockSelectionSync( event ) {
+				const selection = defaultView.getSelection();
+
+				if ( ! selection.rangeCount || selection.isCollapsed ) {
+					return;
+				}
+
+				if (
+					processedSelection &&
+					processedSelection.anchorNode === selection.anchorNode &&
+					processedSelection.anchorOffset ===
+						selection.anchorOffset &&
+					processedSelection.focusNode === selection.focusNode &&
+					processedSelection.focusOffset === selection.focusOffset
+				) {
+					return;
+				}
+
+				const startClientId = getBlockClientId(
+					extractSelectionStartNode( selection )
+				);
+				const endClientId = getBlockClientId(
+					extractSelectionEndNode( selection, isTripleClick )
+				);
+
+				if ( startClientId !== endClientId ) {
+					onSelectionChange( event );
+				}
+			}
+
+			const consumingEvents = [
+				'keydown',
+				'beforeinput',
+				'copy',
+				'cut',
+				'paste',
+			];
+			consumingEvents.forEach( ( eventType ) =>
+				ownerDocument.addEventListener(
+					eventType,
+					ensureCrossBlockSelectionSync,
+					true
+				)
+			);
 			ownerDocument.addEventListener(
 				'selectionchange',
 				onSelectionChange
@@ -357,6 +441,13 @@ export default function useSelectionObserver() {
 			node.addEventListener( 'mousedown', onMouseDown );
 			node.addEventListener( 'keydown', onKeyDown );
 			return () => {
+				consumingEvents.forEach( ( eventType ) =>
+					ownerDocument.removeEventListener(
+						eventType,
+						ensureCrossBlockSelectionSync,
+						true
+					)
+				);
 				ownerDocument.removeEventListener(
 					'selectionchange',
 					onSelectionChange


### PR DESCRIPTION
## What?

Update the store with a cross-block selection right before any event that acts on it: `keydown`, `beforeinput`, `copy`, `cut` and `paste`. The single-block counterpart landed in #80151; this covers selections that span blocks, which the selection observer owns.

## Why?

The store receives cross-block selections from the asynchronous `selectionchange` event. When a consuming event arrives first, its handlers act on the previous selection: the clipboard handler copies or replaces the wrong blocks, and typing or pressing Enter over a fresh selection goes through writing flow reading a stale multi-selection.

## How?

The observer's `selectionchange` handler is also called on capture of the five events when the native selection spans blocks. A snapshot of the last processed selection skips the work when the store is already up to date; without it, re-processing would re-dispatch `multiSelect`, which announces the selection to screen readers on every call.

Also, the single-block dispatch now skips selections the store already holds: the `mouseup` after a drag re-processed the selection that the last `selectionchange` event had already dispatched, re-rendering for nothing.

Extracted from #79105.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
