### PR TITLE
Rich text: route event listeners by selection ownership

### DIFF
--- a/packages/block-editor/src/components/rich-text/event-listeners/before-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/before-input-rules.js
@@ -1,9 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { insert, isCollapsed } from '@wordpress/rich-text';
+import {
+	insert,
+	isCollapsed,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
 import { applyFilters } from '@wordpress/hooks';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -11,7 +14,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 /**
  * When typing over a selection, the selection will we wrapped by a matching
@@ -84,10 +87,10 @@ export default ( props ) => ( element ) => {
 		// call few lines above has fully updated the data store state and rerendered
 		// all affected components.
 		window.queueMicrotask( () => {
-			event.target.dispatchEvent( newEvent );
+			element.dispatchEvent( newEvent );
 		} );
 		event.preventDefault();
 	}
 
-	return subscribeDelegatedListener( element, 'beforeinput', onInput, true );
+	return subscribeOwnedListener( element, 'beforeinput', onInput, true );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/delete.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/delete.js
@@ -2,15 +2,18 @@
  * WordPress dependencies
  */
 import { DELETE, BACKSPACE } from '@wordpress/keycodes';
-import { isCollapsed, isEmpty } from '@wordpress/rich-text';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+import {
+	isCollapsed,
+	isEmpty,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default ( props ) => ( element ) => {
 	function onKeyDown( event ) {
@@ -54,5 +57,5 @@ export default ( props ) => ( element ) => {
 		}
 	}
 
-	return subscribeDelegatedListener( element, 'keydown', onKeyDown );
+	return subscribeOwnedListener( element, 'keydown', onKeyDown );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { ENTER } from '@wordpress/keycodes';
-import { insert, remove } from '@wordpress/rich-text';
+import {
+	insert,
+	remove,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
 import { privateApis as composePrivateApis } from '@wordpress/compose';
 
 /**
@@ -10,6 +14,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
  */
 import { unlock } from '../../../lock-unlock';
 
+const { subscribeOwnedListener, ownsSelection } = unlock( richTextPrivateApis );
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
 export default ( props ) => ( element ) => {
@@ -31,8 +36,9 @@ export default ( props ) => ( element ) => {
 		}
 
 		// The event listener is attached to the window, so we need to check if
-		// the target is the element.
-		if ( event.target !== element ) {
+		// the target is the element, or whether the element owns the
+		// selection through a focused editing host.
+		if ( event.target !== element && ! ownsSelection( element ) ) {
 			return;
 		}
 
@@ -90,7 +96,7 @@ export default ( props ) => ( element ) => {
 	);
 	// Capture phase so this runs before ancestor (writing flow) bubble
 	// handlers, matching the timing of the previous raw element listener.
-	const unsubscribeKeyDownDeprecated = subscribeDelegatedListener(
+	const unsubscribeKeyDownDeprecated = subscribeOwnedListener(
 		element,
 		'keydown',
 		onKeyDownDeprecated,

--- a/packages/block-editor/src/components/rich-text/event-listeners/input-events.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-events.js
@@ -1,14 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default ( props ) => ( element ) => {
 	const { inputEvents } = props.current;
@@ -18,5 +19,5 @@ export default ( props ) => ( element ) => {
 		}
 	}
 
-	return subscribeDelegatedListener( element, 'input', onInput );
+	return subscribeOwnedListener( element, 'input', onInput );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
@@ -1,9 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { insert, toHTMLString } from '@wordpress/rich-text';
+import {
+	insert,
+	toHTMLString,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
 import { getBlockTransforms, findTransform } from '@wordpress/blocks';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,7 +19,7 @@ import {
 } from '../../../utils/selection';
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export function findSelection( blocks ) {
 	let i = blocks.length;
@@ -160,13 +163,13 @@ export default ( props ) => ( element ) => {
 
 	// Capture phase so these run before ancestor (writing flow) bubble
 	// handlers, matching the timing of the previous raw element listeners.
-	const unsubscribeInput = subscribeDelegatedListener(
+	const unsubscribeInput = subscribeOwnedListener(
 		element,
 		'input',
 		onInput,
 		true
 	);
-	const unsubscribeCompositionEnd = subscribeDelegatedListener(
+	const unsubscribeCompositionEnd = subscribeOwnedListener(
 		element,
 		'compositionend',
 		onInput,

--- a/packages/block-editor/src/components/rich-text/event-listeners/insert-replacement-text.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/insert-replacement-text.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -9,7 +10,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 /**
  * When the browser is about to auto correct, add an undo level so the user can
@@ -29,5 +30,5 @@ export default ( props ) => ( element ) => {
 			.__unstableMarkLastChangeAsPersistent();
 	}
 
-	return subscribeDelegatedListener( element, 'beforeinput', onInput );
+	return subscribeOwnedListener( element, 'beforeinput', onInput );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { pasteHandler } from '@wordpress/blocks';
-import { isEmpty, insert, create } from '@wordpress/rich-text';
+import {
+	isEmpty,
+	insert,
+	create,
+	privateApis as richTextPrivateApis,
+} from '@wordpress/rich-text';
 import { isURL } from '@wordpress/url';
 import { privateApis as composePrivateApis } from '@wordpress/compose';
 
@@ -15,6 +20,7 @@ import { getPasteEventData } from '../../../utils/pasting';
 import { unlock } from '../../../lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { ownsSelection } = unlock( richTextPrivateApis );
 
 /** @typedef {import('@wordpress/rich-text').RichTextValue} RichTextValue */
 
@@ -34,8 +40,14 @@ export default ( props ) => ( element ) => {
 		} = props.current;
 
 		// The event listener is attached to the window, so we need to check if
-		// the target is the element or inside the element.
-		if ( ! element.contains( event.target ) ) {
+		// the target is the element or inside the element. When a focused
+		// editing host owns the element's selection, the event targets the
+		// host instead; the element then owns the paste when it contains
+		// the selection.
+		if (
+			! element.contains( event.target ) &&
+			! ownsSelection( element )
+		) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/remove-browser-shortcuts.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/remove-browser-shortcuts.js
@@ -2,14 +2,15 @@
  * WordPress dependencies
  */
 import { isKeyboardEvent } from '@wordpress/keycodes';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 /**
  * Hook to prevent default behaviors for key combinations otherwise handled
@@ -25,5 +26,5 @@ export default () => ( node ) => {
 			event.preventDefault();
 		}
 	}
-	return subscribeDelegatedListener( node, 'keydown', onKeydown, true );
+	return subscribeOwnedListener( node, 'keydown', onKeydown, true );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/shortcuts.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/shortcuts.js
@@ -1,14 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default ( props ) => ( element ) => {
 	const { keyboardShortcuts } = props.current;
@@ -18,5 +19,5 @@ export default ( props ) => ( element ) => {
 		}
 	}
 
-	return subscribeDelegatedListener( element, 'keydown', onKeyDown, true );
+	return subscribeOwnedListener( element, 'keydown', onKeyDown, true );
 };

--- a/packages/block-editor/src/components/rich-text/event-listeners/undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/undo-automatic-change.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { BACKSPACE, ESCAPE } from '@wordpress/keycodes';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default ( props ) => ( element ) => {
 	function onKeyDown( event ) {
@@ -42,5 +43,5 @@ export default ( props ) => ( element ) => {
 		__experimentalUndo();
 	}
 
-	return subscribeDelegatedListener( element, 'keydown', onKeyDown );
+	return subscribeOwnedListener( element, 'keydown', onKeyDown );
 };

--- a/packages/block-library/src/list-item/hooks/use-enter.js
+++ b/packages/block-library/src/list-item/hooks/use-enter.js
@@ -6,10 +6,8 @@ import {
 	getDefaultBlockName,
 	cloneBlock,
 } from '@wordpress/blocks';
-import {
-	useRefEffect,
-	privateApis as composePrivateApis,
-} from '@wordpress/compose';
+import { useRefEffect } from '@wordpress/compose';
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -20,7 +18,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import useOutdentListItem from './use-outdent-list-item';
 import { unlock } from '../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default function useEnter( clientId ) {
 	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
@@ -90,11 +88,6 @@ export default function useEnter( clientId ) {
 
 		// Capture phase so we run before writing-flow's ancestor-bubble
 		// keydown handlers that gate on `event.defaultPrevented`.
-		return subscribeDelegatedListener(
-			element,
-			'keydown',
-			onKeyDown,
-			true
-		);
+		return subscribeOwnedListener( element, 'keydown', onKeyDown, true );
 	}, [] );
 }

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -1,10 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	useRefEffect,
-	privateApis as composePrivateApis,
-} from '@wordpress/compose';
+import { useRefEffect } from '@wordpress/compose';
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 import { SPACE, TAB } from '@wordpress/keycodes';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -16,7 +14,7 @@ import useIndentListItem from './use-indent-list-item';
 import useOutdentListItem from './use-outdent-list-item';
 import { unlock } from '../../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export default function useSpace( clientId ) {
 	const { getSelectionStart, getSelectionEnd, getBlockIndex } =
@@ -63,7 +61,7 @@ export default function useSpace( clientId ) {
 
 			// Capture phase so we run before writing-flow's ancestor-bubble
 			// keydown handlers that gate on `event.defaultPrevented`.
-			return subscribeDelegatedListener(
+			return subscribeOwnedListener(
 				element,
 				'keydown',
 				onKeyDown,

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -2,10 +2,8 @@
  * WordPress dependencies
  */
 import { useRef } from '@wordpress/element';
-import {
-	useRefEffect,
-	privateApis as composePrivateApis,
-} from '@wordpress/compose';
+import { useRefEffect } from '@wordpress/compose';
+import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -21,7 +19,7 @@ import {
  */
 import { unlock } from '../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 export function useOnEnter( props ) {
 	const { batch } = useRegistry();
@@ -131,11 +129,6 @@ export function useOnEnter( props ) {
 
 		// Capture phase so we run before writing-flow's ancestor-bubble
 		// keydown handlers that gate on `event.defaultPrevented`.
-		return subscribeDelegatedListener(
-			element,
-			'keydown',
-			onKeyDown,
-			true
-		);
+		return subscribeOwnedListener( element, 'keydown', onKeyDown, true );
 	}, [] );
 }

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -8,18 +8,14 @@ import {
 	useReducer,
 	useRef,
 } from '@wordpress/element';
-import {
-	useInstanceId,
-	useMergeRefs,
-	useRefEffect,
-	privateApis as composePrivateApis,
-} from '@wordpress/compose';
+import { useInstanceId, useMergeRefs, useRefEffect } from '@wordpress/compose';
 import {
 	create,
 	slice,
 	insert,
 	isCollapsed,
 	getTextContent,
+	privateApis as richTextPrivateApis,
 } from '@wordpress/rich-text';
 import { speak } from '@wordpress/a11y';
 import { isAppleOS } from '@wordpress/keycodes';
@@ -43,7 +39,7 @@ import type {
 import getNodeText from '../utils/get-node-text';
 import { unlock } from '../lock-unlock';
 
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
 const EMPTY_FILTERED_OPTIONS: KeyedOption[] = [];
 
@@ -409,7 +405,7 @@ export function useAutocompleteProps( options: UseAutocompleteProps ) {
 			// fire at bubble phase and gate on `event.defaultPrevented`,
 			// so firing in capture lets us preventDefault first when the
 			// popover is active.
-			return subscribeDelegatedListener(
+			return subscribeOwnedListener(
 				element,
 				'keydown',
 				_onKeyDown,

--- a/packages/rich-text/src/hook/event-listeners/delete.js
+++ b/packages/rich-text/src/hook/event-listeners/delete.js
@@ -2,15 +2,12 @@
  * WordPress dependencies
  */
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { remove } from '../../remove';
-import { unlock } from '../../lock-unlock';
-
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+import { subscribeOwnedListener } from '../../subscribe-owned-listener';
 
 export default ( props ) => ( element ) => {
 	function onKeyDown( event ) {
@@ -35,5 +32,5 @@ export default ( props ) => ( element ) => {
 		}
 	}
 
-	return subscribeDelegatedListener( element, 'keydown', onKeyDown );
+	return subscribeOwnedListener( element, 'keydown', onKeyDown );
 };

--- a/packages/rich-text/src/hook/event-listeners/format-boundaries.js
+++ b/packages/rich-text/src/hook/event-listeners/format-boundaries.js
@@ -2,15 +2,12 @@
  * WordPress dependencies
  */
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import { privateApis as composePrivateApis } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { isCollapsed } from '../../is-collapsed';
-import { unlock } from '../../lock-unlock';
-
-const { subscribeDelegatedListener } = unlock( composePrivateApis );
+import { subscribeOwnedListener } from '../../subscribe-owned-listener';
 
 const EMPTY_ACTIVE_FORMATS = [];
 
@@ -99,5 +96,5 @@ export default ( props ) => ( element ) => {
 		forceRender();
 	}
 
-	return subscribeDelegatedListener( element, 'keydown', onKeyDown, true );
+	return subscribeOwnedListener( element, 'keydown', onKeyDown, true );
 };

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -9,6 +9,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
 import { getActiveFormats } from '../../get-active-formats';
 import { isCollapsed } from '../../is-collapsed';
 import { updateFormats } from '../../update-formats';
+import { subscribeOwnedListener } from '../../subscribe-owned-listener';
 import { unlock } from '../../lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
@@ -297,18 +298,18 @@ export default ( props ) => ( element ) => {
 	// `input-rules.js` element-level listeners, which call `getValue()`
 	// reading `record.current` updated by our `onInput`. Use capture phase
 	// so we fire before any ancestor bubble handlers.
-	const unsubscribeInput = subscribeDelegatedListener(
+	const unsubscribeInput = subscribeOwnedListener(
 		element,
 		'input',
 		onInput,
 		true
 	);
-	const unsubscribeCompositionStart = subscribeDelegatedListener(
+	const unsubscribeCompositionStart = subscribeOwnedListener(
 		element,
 		'compositionstart',
 		onCompositionStart
 	);
-	const unsubscribeCompositionEnd = subscribeDelegatedListener(
+	const unsubscribeCompositionEnd = subscribeOwnedListener(
 		element,
 		'compositionend',
 		onCompositionEnd,

--- a/packages/rich-text/src/owns-selection.js
+++ b/packages/rich-text/src/owns-selection.js
@@ -1,0 +1,37 @@
+/**
+ * Returns true when the element owns the document selection: either the
+ * element itself has focus, or its contentEditable editing host has focus
+ * (e.g. an editable block editor canvas wrapper) and the selection is fully
+ * contained within the element.
+ *
+ * @param {HTMLElement} element The editable element.
+ *
+ * @return {boolean} Whether the element owns the document selection.
+ */
+export function ownsSelection( element ) {
+	const { ownerDocument } = element;
+	const { activeElement } = ownerDocument;
+
+	if ( activeElement === element ) {
+		return true;
+	}
+
+	if (
+		! activeElement ||
+		! activeElement.isContentEditable ||
+		! element.isContentEditable ||
+		! activeElement.contains( element )
+	) {
+		return false;
+	}
+
+	const selection = ownerDocument.defaultView.getSelection();
+	const { anchorNode, focusNode } = selection;
+
+	return (
+		!! anchorNode &&
+		!! focusNode &&
+		element.contains( anchorNode ) &&
+		element.contains( focusNode )
+	);
+}

--- a/packages/rich-text/src/private-apis.js
+++ b/packages/rich-text/src/private-apis.js
@@ -7,6 +7,8 @@ import { KeyboardShortcutContext, InputEventContext } from './contexts';
 import { RichTextShortcut } from './keyboard-shortcut';
 import { RichTextInputEvent } from './input-event';
 import { shortcutsListener, inputEventsListener } from './event-listeners';
+import { ownsSelection } from './owns-selection';
+import { subscribeOwnedListener } from './subscribe-owned-listener';
 
 /**
  * Private @wordpress/rich-text APIs.
@@ -20,4 +22,6 @@ lock( privateApis, {
 	RichTextInputEvent,
 	shortcutsListener,
 	inputEventsListener,
+	ownsSelection,
+	subscribeOwnedListener,
 } );

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as composePrivateApis } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { ownsSelection } from './owns-selection';
+import { unlock } from './lock-unlock';
+
+const { subscribeDelegatedListener } = unlock( composePrivateApis );
+
+/**
+ * Subscribes a callback for events owned by the given editable element:
+ * events targeting the element or its descendants, and events targeting a
+ * focused editing host (e.g. an editable block editor canvas wrapper) while
+ * the element contains the selection. In the latter case events target the
+ * host, never the element, so an element-bound listener would not fire.
+ *
+ * @param {HTMLElement} element   The editable element.
+ * @param {string}      eventType DOM event name.
+ * @param {Function}    callback  Listener to be invoked with the event.
+ * @param {boolean}     capture   Use the capture phase. Defaults to `false`.
+ *
+ * @return {Function} Unsubscribe function.
+ */
+export function subscribeOwnedListener(
+	element,
+	eventType,
+	callback,
+	capture = false
+) {
+	return subscribeDelegatedListener(
+		element.ownerDocument,
+		eventType,
+		( event ) => {
+			if (
+				! element.contains( event.target ) &&
+				! ownsSelection( element )
+			) {
+				return;
+			}
+			callback( event );
+		},
+		capture
+	);
+}


### PR DESCRIPTION
## What?

Route rich text event listeners by selection ownership instead of event target alone. A new private `subscribeOwnedListener` (in `@wordpress/rich-text`) invokes the callback when the element contains the event target, or when a focused contentEditable host contains the element and the selection is fully inside it. All rich text listeners in `rich-text`, `block-editor`, `block-library` (paragraph and list item Enter/Space) and the `Autocomplete` keyboard listener subscribe through it.

## Why?

Events inside a focused editing host target the host, never the editable element, so element-bound listeners miss them. Trunk has one such host today: the multi-selection wrapper, which stays editable (and focused) briefly after a selection collapses back into one block; keystrokes in that window bypass the block's handlers. The `editableRoot` work (#79105) makes this the normal editing state, and this migration is the bulk of its diff.

This is also the keystone of making input handling selection-driven rather than target-driven (see the single-editing-host plan in #63255): once listeners follow the selection, per-block listener attachment stops being a structural assumption.

## How?

For a focused editable element, ownership reduces to the target containment check the listeners already performed, so behavior is unchanged in the common case. Listeners with manual target checks (Enter, paste) keep them, extended with the ownership check. Listeners move from element-level to document-level delegation; relative order is preserved because the shared delegated listener dispatches in subscription order and the rich text ref attaches first.

Extracted from #79105.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
