### PR TITLE
Rich text: cut through the record instead of execCommand

### DIFF
--- a/packages/rich-text/src/hook/event-listeners/copy-handler.js
+++ b/packages/rich-text/src/hook/event-listeners/copy-handler.js
@@ -9,6 +9,7 @@ import { privateApis as composePrivateApis } from '@wordpress/compose';
 import { toHTMLString } from '../../to-html-string';
 import { isCollapsed } from '../../is-collapsed';
 import { slice } from '../../slice';
+import { remove } from '../../remove';
 import { getTextContent } from '../../get-text-content';
 import { unlock } from '../../lock-unlock';
 
@@ -16,7 +17,7 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
 export default ( props ) => ( element ) => {
 	function onCopy( event ) {
-		const { record } = props.current;
+		const { record, handleChange } = props.current;
 		const { ownerDocument } = element;
 		if (
 			isCollapsed( record.current ) ||
@@ -34,7 +35,11 @@ export default ( props ) => ( element ) => {
 		event.preventDefault();
 
 		if ( event.type === 'cut' ) {
-			ownerDocument.execCommand( 'delete' );
+			// Remove the selection through the record rather than the
+			// deprecated `execCommand( 'delete' )`. The record is
+			// synchronized on capture of the `cut` event, and `handleChange`
+			// processes the removal like any input.
+			handleChange( remove( record.current ) );
 		}
 	}
 


### PR DESCRIPTION
## What?

Delete the cut selection through the rich text record instead of `execCommand( 'delete' )`.

## Why?

Cut interception (added with footnotes in #51201, so the clipboard gets the serialized value) deleted the selection by delegating to the browser: `execCommand` mutates the DOM and fires `input`, so the removal flowed through the normal input pipeline. But `execCommand` is deprecated, and its behavior depends on which element holds focus; when a focused editing host owns the selection (#79105), it can remove the element itself.

#63671 already made this exact change and it ran on trunk for a month; the revert (#65414) targeted that PR's wrapper-toggling regressions and took this along incidentally. The one historical caveat, the record lagging the DOM selection at event time, is gone since #80151: the record is synchronized on capture of the `cut` event before this handler runs.

## How?

`handleChange( remove( record.current ) )` removes the selected content and processes the change like any input, including the undo entry.

Extracted from #79105.

Written with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
