### PR TITLE
Fix/palette management discoverability

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bug Fixes
 
+-   `PaletteEdit`: Make color and gradient management actions easier to discover ([#79897](https://github.com/WordPress/gutenberg/issues/79897)).
 -   `SandBox`: Inject the resize script into the document `<head>` so an unclosed attribute quote in the sandboxed HTML can no longer swallow the script and leak its source as visible text in the preview. ([#79920](https://github.com/WordPress/gutenberg/pull/79920))
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -511,7 +511,13 @@ export function PaletteEdit( {
 													} }
 													className="components-palette-edit__menu-button"
 												>
-													{ __( 'Show details' ) }
+													{ isGradient
+														? __(
+																'Manage gradients'
+														  )
+														: __(
+																'Manage colors'
+														  ) }
 												</Button>
 											) }
 											{ ! canOnlyChangeValues && (

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -211,6 +211,72 @@ describe( 'PaletteEdit', () => {
 		expect( screen.getByText( 'Test empty message' ) ).toBeVisible();
 	} );
 
+	it.each( [
+		{
+			palette: 'color',
+			props: { colors },
+			optionsLabel: 'Color options',
+			manageLabel: 'Manage colors',
+		},
+		{
+			palette: 'gradient',
+			props: { gradients },
+			optionsLabel: 'Gradient options',
+			manageLabel: 'Manage gradients',
+		},
+	] )(
+		'shows a clear management action for a $palette palette',
+		async ( { props, optionsLabel, manageLabel } ) => {
+			render( <PaletteEdit { ...defaultProps } { ...props } /> );
+
+			await click(
+				screen.getByRole( 'button', {
+					name: optionsLabel,
+				} )
+			);
+
+			expect(
+				screen.getByRole( 'button', {
+					name: manageLabel,
+				} )
+			).toBeVisible();
+		}
+	);
+
+	it( 'returns to the palette after managing colors', async () => {
+		render( <PaletteEdit { ...defaultProps } colors={ colors } /> );
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Color options',
+			} )
+		);
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Manage colors',
+			} )
+		);
+
+		expect( screen.getByDisplayValue( 'Primary' ) ).toBeVisible();
+
+		await click( screen.getByRole( 'button', { name: 'Done' } ) );
+
+		expect(
+			screen.queryByDisplayValue( 'Primary' )
+		).not.toBeInTheDocument();
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Color options',
+			} )
+		);
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Manage colors',
+			} )
+		).toBeVisible();
+	} );
+
 	it( 'shows an option to remove all colors', async () => {
 		render( <PaletteEdit { ...defaultProps } colors={ colors } /> );
 
@@ -350,7 +416,7 @@ describe( 'PaletteEdit', () => {
 		);
 		await click(
 			screen.getByRole( 'button', {
-				name: 'Show details',
+				name: 'Manage colors',
 			} )
 		);
 		await click( screen.getByRole( 'button', { name: 'Edit: Primary' } ) );
@@ -383,7 +449,7 @@ describe( 'PaletteEdit', () => {
 		);
 		await click(
 			screen.getByRole( 'button', {
-				name: 'Show details',
+				name: 'Manage colors',
 			} )
 		);
 		await click( screen.getByRole( 'button', { name: 'Edit: Primary' } ) );


### PR DESCRIPTION
## What?

Closes #79897

Renames “Show details” to “Manage colors” or “Manage gradients” in the palette options menu.

## Why?

“Show details” does not clearly communicate that users can edit or delete custom palette entries.

## How?

Adds palette-specific labels and updates the related component tests.

## Testing Instructions

1. Open Site Editor → Styles → Colors → Edit palette.
2. Add a custom color if none exists, then select **Done**.
3. Open the Custom palette’s three-dot menu.
4. Confirm **Manage colors** appears.
5. Select the Gradient tab and confirm **Manage gradients** appears for custom gradients.
6. Confirm the options open the corresponding editing controls.

### Testing Instructions for Keyboard

1. Navigate through the steps above using `Tab`, `Shift+Tab`, `Enter`, and arrow keys.
2. Confirm the menu items are reachable and correctly announced.
3. Confirm focus moves into the palette controls after selecting the manage option.

## Use of AI Tools

OpenAI Codex assisted with tests, and PR documentation. The changes were implemented, reviewed and tested by the contributor.