### PR TITLE
Tab List: Fix page-level horizontal overflow by constraining flex row scroll to the tablist container

### DIFF
--- a/packages/block-library/src/tab-list/style.scss
+++ b/packages/block-library/src/tab-list/style.scss
@@ -31,9 +31,6 @@
 	text-transform: inherit;
 	text-align: inherit;
 
-	// Ensure keyboard-focused tabs scroll into view within the tab list.
-	scroll-margin: 24px;
-
 	&[aria-selected="true"]::before {
 		content: "";
 		position: absolute;

--- a/packages/block-library/src/tab-list/style.scss
+++ b/packages/block-library/src/tab-list/style.scss
@@ -1,3 +1,7 @@
+.wp-block-tab-list {
+	overflow-x: auto;
+}
+
 :where(.wp-block-tab-list button) {
 	box-sizing: border-box;
 	color: inherit;
@@ -26,6 +30,9 @@
 	letter-spacing: inherit;
 	text-transform: inherit;
 	text-align: inherit;
+
+	// Ensure keyboard-focused tabs scroll into view within the tab list.
+	scroll-margin: 24px;
 
 	&[aria-selected="true"]::before {
 		content: "";


### PR DESCRIPTION
## What?

Closes #80078


When many tabs are added to the Tabs block, the `wp-block-tab-list` flex container overflows the page width and creates a page-level horizontal scrollbar.

## Why

The flex layout is intentionally `nowrap` (tabs stay on a single row), but there was no `overflow-x` rule on the container. Once the total tab width exceeds the content column, the overflow is propagated all the way to the page.

## How

- Added `overflow-x: auto` to `.wp-block-tab-list`, the tab list now scrolls within its own container instead of overflowing the page.

This approach is already established in the codebase: `StyledTabList` in `@wordpress/components/src/tabs/styles.ts` applies `overflow-x: auto` for the same reason.

## Testing Instructions

1. Insert the Tabs block (enable experimental blocks in Gutenberg settings)
2. Add 15+ tabs until the tab row exceeds the content width
3. Verify: **no page-level horizontal scrollbar appears**
4. Verify: the tab list scrolls horizontally within its container
5. Verify: Arrow-key navigation scrolls the focused tab into view

## Screencast

### Before


https://github.com/user-attachments/assets/1fb93665-e76d-4c94-a491-3d070406f3f5


### After

https://github.com/user-attachments/assets/aeebb4fa-29f5-42c9-9020-552004aa393f



