### PR TITLE
Responsive editing: Apply crop dimensions to image block placeholder

### DIFF
--- a/packages/block-library/src/image/README.md
+++ b/packages/block-library/src/image/README.md
@@ -79,7 +79,7 @@ _Defined via the [`styles`](https://developer.wordpress.org/block-editor/referen
 
 _Defined via the [`selectors`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/) property in block.json._
 
-- **dimensions**: `.wp-block-image img`
+- **dimensions**: `.wp-block-image img, .wp-block-image .components-placeholder`
 - **border**: `.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder`
 - **shadow**: `.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder`
 - **filter**:

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -141,7 +141,7 @@
 		}
 	},
 	"selectors": {
-		"dimensions": ".wp-block-image img",
+		"dimensions": ".wp-block-image img, .wp-block-image .components-placeholder",
 		"border": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder",
 		"shadow": ".wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder",
 		"filter": {


### PR DESCRIPTION
## What?
Fixes a small thing I noticed when testing. The image block's placeholder doesn't have the selected aspect ratio applied to it if responsive editing is enabled and a tablet/mobile viewport selected.

For other blocks like cover and feature image, this does already work, so no changes need there. From what I understand, aspect ratio is supposed to be applied to the placeholder - it allows users creating patterns to use a placeholder state that takes up the correct amount of space (doesn't break the design).

## How?
Adjusts the selector in block.json

## Testing Instructions
1. From the viewport dropdown, select tablet or mobile, and enable responsive editing
2. Insert an image block and leave it in the placeholder state
3. Apply an aspect ratio to the image block (e.g 'square')

In trunk: The placeholder's size doesn't change size, the aspect ratio isn't applied
In this PR: The placeholder adopts the selected aspect ratio

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="500" alt="Screenshot 2026-07-13 at 2 18 10 pm" src="https://github.com/user-attachments/assets/ca87925d-fd65-4245-8a59-c1df53eb40d6" />

#### After
<img width="500" alt="Screenshot 2026-07-13 at 2 17 26 pm" src="https://github.com/user-attachments/assets/ecfecf26-4aa8-49c0-9e02-355af430fb22" />

## Use of AI Tools
None