### PR TITLE
Deprecated image cropper: tidy up styles and classnames

### DIFF
--- a/packages/block-editor/src/components/image-editor/style.scss
+++ b/packages/block-editor/src/components/image-editor/style.scss
@@ -1,0 +1,33 @@
+// `wp-block-image` class prefixes are used for back compat.
+// This component was previously in the block library package.
+.wp-block-image__crop-area {
+	position: relative;
+	max-width: 100%;
+	width: 100%;
+	overflow: hidden;
+
+	// stylelint-disable selector-class-pattern -- react-easy-crop library class names.
+	.reactEasyCrop_Container {
+		// The linked Image block has `pointer-events: none` applied. Override it
+		// here to enable the crop action.
+		pointer-events: auto;
+
+		// This removes the border from the img within the image cropper so it
+		// can be applied to the cropper itself. This then allows the image to be
+		// cropped within the visual border providing more accurate editing and
+		// smoother UX.
+		.reactEasyCrop_Image {
+			border: none;
+			border-radius: 0; // Prevent's theme.json radius bleeding into cropper.
+		}
+	}
+
+	// stylelint-enable selector-class-pattern
+}
+
+.wp-block-image__zoom {
+	.components-popover__content {
+		min-width: 260px;
+		overflow: visible !important;
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -38,6 +38,7 @@
 @use "./components/grid/style.scss" as *;
 @use "./components/height-control/style.scss" as *;
 @use "./components/iframe/style.scss" as *;
+@use "./components/image-editor/style.scss" as *;
 @use "./components/inserter-list-item/style.scss" as *;
 @use "./components/inspector-controls/styles.scss" as *;
 @use "./components/inspector-controls-tabs/style.scss" as *;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -123,49 +123,6 @@ figure.wp-block-image:not(.wp-block) {
 	position: relative;
 }
 
-.wp-block-image__crop-area {
-	position: relative;
-	max-width: 100%;
-	width: 100%;
-	overflow: hidden;
-
-	// stylelint-disable selector-class-pattern -- react-easy-crop library class names.
-	.reactEasyCrop_Container {
-		// The linked Image block has `pointer-events: none` applied. Override it
-		// here to enable the crop action.
-		pointer-events: auto;
-
-		// This removes the border from the img within the image cropper so it
-		// can be applied to the cropper itself. This then allows the image to be
-		// cropped within the visual border providing more accurate editing and
-		// smoother UX.
-		.reactEasyCrop_Image {
-			border: none;
-			border-radius: 0; // Prevent's theme.json radius bleeding into cropper.
-		}
-	}
-	// stylelint-enable selector-class-pattern
-}
-
-.wp-block-image__crop-icon {
-	padding: 0 8px;
-	min-width: 48px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	svg {
-		fill: currentColor;
-	}
-}
-
-.wp-block-image__zoom {
-	.components-popover__content {
-		min-width: 260px;
-		overflow: visible !important;
-	}
-}
-
 .wp-block-image__toolbar_content_textarea__container {
 	padding: $grid-unit;
 }
@@ -174,4 +131,3 @@ figure.wp-block-image:not(.wp-block) {
 	// Corresponds to the size of the textarea in the block inspector.
 	width: 250px;
 }
-


### PR DESCRIPTION
## What?
I noticed in https://github.com/WordPress/gutenberg/pull/80162#discussion_r3568432008 that there are some stray references to the old image editor that can be tidied up.

Here's what I found that looks incorrect:
- ~~`.wp-block-image .wp-block-image__crop-area` is referenced in the image block's block.json selectors. This feature has been removed so the selectors aren't needed~~ (dropped from this PR due to complexity in backporting the change)
- The image block has styles associated with `.wp-block-image__crop-icon` that are now dead styles
- The image block has styles associated with `.wp-block-image__crop-area` and `.wp-block-image__zoom`. These styles should have been moved to the block editor package in #31607 with the related components. The selectors should have been changed to the `wp-block-editor` prefix at the time, but that ship has now sailed (https://veloria.dev/search/c7b345b6-1822-4699-9420-9bd5672d2613).

## Testing Instructions
It's mostly a code quality change so not much to test. The only two things that will be fixed:
- No more unnecessary `.wp-block-image .wp-block-image__crop-area` styles
- Importers of the deprecated cropping tools who don't load the block library will now have the correct cropping tool styles (as long as they're loading the block editor style sheet).

## Use of AI Tools
None