### PR TITLE
Icon block: When the default icon is unregistered, nothing is displayed

### DIFF
--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -75,14 +75,26 @@ export function Edit( { attributes, setAttributes } ) {
 	const borderProps = useBorderProps( attributes );
 	const dimensionsProps = useDimensionsProps( attributes );
 
-	const { selectedIcon, allIcons = [] } = useSelect(
+	const {
+		selectedIcon,
+		allIcons = [],
+		hasResolvedSelectedIcon,
+	} = useSelect(
 		( select ) => {
-			const { getEntityRecord, getEntityRecords } =
+			const { getEntityRecord, getEntityRecords, hasFinishedResolution } =
 				select( coreDataStore );
+
+			const selectedIconQueryArgs = [ 'root', 'icon', icon ];
 			return {
 				selectedIcon: icon
-					? getEntityRecord( 'root', 'icon', icon )
+					? getEntityRecord( ...selectedIconQueryArgs )
 					: null,
+				hasResolvedSelectedIcon:
+					! icon ||
+					hasFinishedResolution(
+						'getEntityRecord',
+						selectedIconQueryArgs
+					),
 				allIcons: isInserterOpen
 					? getEntityRecords( 'root', 'icon' )
 					: undefined,
@@ -219,7 +231,7 @@ export function Edit( { attributes, setAttributes } ) {
 			{ blockControls }
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				{ icon && ! iconToDisplay && (
+				{ icon && hasResolvedSelectedIcon && ! iconToDisplay && (
 					<Notice status="warning" isDismissible={ false }>
 						{ __(
 							'Icon not found. The icon may have been unregistered or removed.'

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -75,26 +75,14 @@ export function Edit( { attributes, setAttributes } ) {
 	const borderProps = useBorderProps( attributes );
 	const dimensionsProps = useDimensionsProps( attributes );
 
-	const {
-		selectedIcon,
-		allIcons = [],
-		hasResolvedSelectedIcon,
-	} = useSelect(
+	const { selectedIcon, allIcons = [] } = useSelect(
 		( select ) => {
-			const { getEntityRecord, getEntityRecords, hasFinishedResolution } =
+			const { getEntityRecord, getEntityRecords } =
 				select( coreDataStore );
-
-			const selectedIconQueryArgs = [ 'root', 'icon', icon ];
 			return {
 				selectedIcon: icon
-					? getEntityRecord( ...selectedIconQueryArgs )
+					? getEntityRecord( 'root', 'icon', icon )
 					: null,
-				hasResolvedSelectedIcon:
-					! icon ||
-					hasFinishedResolution(
-						'getEntityRecord',
-						selectedIconQueryArgs
-					),
 				allIcons: isInserterOpen
 					? getEntityRecords( 'root', 'icon' )
 					: undefined,
@@ -231,7 +219,7 @@ export function Edit( { attributes, setAttributes } ) {
 			{ blockControls }
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				{ icon && hasResolvedSelectedIcon && ! iconToDisplay && (
+				{ icon && ! iconToDisplay && (
 					<Notice status="warning" isDismissible={ false }>
 						{ __(
 							'Icon not found. The icon may have been unregistered or removed.'

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
-	Notice,
 	TextControl,
 	ToolbarButton,
 	__experimentalToolsPanel as ToolsPanel,
@@ -219,14 +218,7 @@ export function Edit( { attributes, setAttributes } ) {
 			{ blockControls }
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				{ icon && ! iconToDisplay && (
-					<Notice status="warning" isDismissible={ false }>
-						{ __(
-							'Icon not found. The icon may have been unregistered or removed.'
-						) }
-					</Notice>
-				) }
-				{ icon && iconToDisplay && (
+				{ icon ? (
 					<HtmlRenderer
 						html={ iconToDisplay }
 						wrapperProps={ {
@@ -246,8 +238,7 @@ export function Edit( { attributes, setAttributes } ) {
 							},
 						} }
 					/>
-				) }
-				{ ! icon && (
+				) : (
 					<IconPlaceholder
 						className={ clsx(
 							borderProps.className,

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -218,7 +218,7 @@ export function Edit( { attributes, setAttributes } ) {
 			{ blockControls }
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				{ icon ? (
+				{ iconToDisplay ? (
 					<HtmlRenderer
 						html={ iconToDisplay }
 						wrapperProps={ {

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
+	Notice,
 	TextControl,
 	ToolbarButton,
 	__experimentalToolsPanel as ToolsPanel,
@@ -218,7 +219,14 @@ export function Edit( { attributes, setAttributes } ) {
 			{ blockControls }
 			{ inspectorControls }
 			<div { ...useBlockProps() }>
-				{ icon ? (
+				{ icon && ! iconToDisplay && (
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'Icon not found. The icon may have been unregistered or removed.'
+						) }
+					</Notice>
+				) }
+				{ icon && iconToDisplay && (
 					<HtmlRenderer
 						html={ iconToDisplay }
 						wrapperProps={ {
@@ -238,7 +246,8 @@ export function Edit( { attributes, setAttributes } ) {
 							},
 						} }
 					/>
-				) : (
+				) }
+				{ ! icon && (
 					<IconPlaceholder
 						className={ clsx(
 							borderProps.className,

--- a/packages/block-library/src/icon/index.php
+++ b/packages/block-library/src/icon/index.php
@@ -90,9 +90,7 @@ function render_block_core_icon( $attributes ) {
 	);
 
 	if ( '' === $svg ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
-		// Return a comment for debugging when the icon is not found.
-		return sprintf( '<!-- wp:icon: icon "%s" not found --><div %s></div>', esc_attr( $attributes['icon'] ), $wrapper_attributes );
+		return;
 	}
 
 	$processor = new WP_HTML_Tag_Processor( $svg );

--- a/packages/block-library/src/icon/index.php
+++ b/packages/block-library/src/icon/index.php
@@ -90,7 +90,9 @@ function render_block_core_icon( $attributes ) {
 	);
 
 	if ( '' === $svg ) {
-		return;
+		$wrapper_attributes = get_block_wrapper_attributes();
+		// Return a comment for debugging when the icon is not found.
+		return sprintf( '<!-- wp:icon: icon "%s" not found --><div %s></div>', esc_attr( $attributes['icon'] ), $wrapper_attributes );
 	}
 
 	$processor = new WP_HTML_Tag_Processor( $svg );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/79669

<!-- In a few words, what is the PR actually doing? -->

## Why?
When the default icon is unregistered, nothing is displayed

## How?
 Display warning within the block in case the icon is not found.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Unregister the core/info icon.
- Add icon block on a page.
- Warning will appear that icon is unregistered or removed.

## Screenshots or screencast <!-- if applicable -->

<img width="1189" height="404" alt="icon-block" src="https://github.com/user-attachments/assets/44d0f176-c2d2-4988-a369-fcd72a33489b" />


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Used for: Base code generation and testing.
