### PR TITLE
Sync changes from core for view-config version handling

### DIFF
--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -195,12 +195,8 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		return $config;
 	}
 
-	// The functions keep the container close to the documented shape (set() and
-	// update_properties() reject unknown keys), but a documented key may
-	// still be missing — dropped by a null reset patch, or omitted by a callback
-	// returning its own off-shape container. Normalize either way: drop
-	// undocumented keys and backfill any dropped documented keys from the
-	// defaults.
+	// Backfill any dropped keys with their defaults, then discard any keys the
+	// filter introduced that are not part of the documented configuration shape.
 	return array_intersect_key( array_merge( $config, $filtered->get_config() ), $config );
 }
 
@@ -330,10 +326,8 @@ function _gutenberg_get_entity_view_config_post_type_page( $data ) {
 
 	$data->set( 'default_layouts', $default_layouts, 1 );
 	$data->set( 'default_view', $default_view, 1 );
-	// Append the status views onto the inherited base "all items" view rather
-	// than replacing it, so its post-type-specific title is kept. The version
-	// is pinned to the literal this patch was authored against as an extra guard,
-	// so a future LATEST_VERSION bump migrates it instead of silently skipping it.
+	// Append the status views, thereby preserving the base "all items" view,
+	// so its post-type-specific title is kept.
 	$data->update_view_list_items( array_column( $view_list, null, 'slug' ), 1 );
 
 	return $data;

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -165,8 +165,9 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Successive filters share the same container, so their patches compose and
-	 * a later null field patch reaches a member contributed by an earlier filter.
+	 * Successive filters share the same Gutenberg_View_Config_Data instance, so
+	 * their effects compose: a later filter can remove a form field that an
+	 * earlier one added.
 	 */
 	public function test_filters_compose_across_the_chain() {
 		add_filter(


### PR DESCRIPTION
## What?

Ports some comment changes from the core backport PR: https://github.com/WordPress/wordpress-develop/pull/12391