### PR TITLE
CODEOWNERS: Exclude stylelint suppressions.json from /tools ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,7 @@
 /bin                                            @ntwb @nerrad @ajitbohra @manzoorwanijk
 /tools                                          @manzoorwanijk
 /tools/eslint/suppressions.json
+/tools/stylelint/stylelint-suppressions.json
 /packages/babel-plugin-import-jsx-pragma        @ntwb @nerrad @ajitbohra
 /packages/babel-plugin-makepot                  @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @ntwb @nerrad @ajitbohra


### PR DESCRIPTION
## What?

Follow up to #80125

Excludes `tools/stylelint/stylelint-suppressions.json` from the `/tools` CODEOWNERS rule.

## Why?

Same reason as #80125 — the suppressions file changes frequently and results in unnecessary review-request notifications, but it was missed in that PR, which only covered the eslint suppressions file.

## How?

Adds a pattern for `tools/stylelint/stylelint-suppressions.json` with no owner after the `/tools` rule, so the last-matching-pattern-wins behavior un-assigns ownership for that file while keeping it for everything else under `/tools`.

## Testing Instructions

1. Verify that changes to `tools/stylelint/stylelint-suppressions.json` no longer request a review from @manzoorwanijk.
2. Verify that changes to other files under `/tools` still request a review from @manzoorwanijk.

## Use of AI Tools

This PR was authored with the help of Claude Code and reviewed by a human.
