### PR TITLE
Block JSON schema & PHP-only blocks: Add `autoRegister` support

### DIFF
--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -21,7 +21,8 @@
 		}
 	},
 	"supports": {
-		"align": true
+		"align": true,
+		"autoRegister": true
 	},
 	"styles": [
 		{

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -226,6 +226,11 @@
 					"type": "boolean",
 					"default": false
 				},
+				"autoRegister": {
+					"description": "Allows PHP-only blocks with a `render_callback` to appear in the block editor without JavaScript registration. The editor renders them with `ServerSideRender`. If a block uses an API version older than 3, or does not specify one, the editor uses version 3.",
+					"type": "boolean",
+					"default": false
+				},
 				"align": {
 					"description": "This property adds block controls which allow to change block’s alignment.",
 					"oneOf": [

--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -14,6 +14,10 @@ describe( 'block.json schema', () => {
 		[ 'packages/*/src/**/block.json', '{lib,phpunit,test}/**/block.json' ],
 		{ onlyFiles: true }
 	);
+	const invalidFiles = glob.sync(
+		[ 'test/integration/fixtures/block-schemas/*.json' ],
+		{ onlyFiles: true }
+	);
 	const ajv = new Ajv();
 
 	test( 'strictly adheres to the draft-07 meta schema', () => {
@@ -40,4 +44,15 @@ describe( 'block.json schema', () => {
 
 		expect( result ).toBe( true );
 	} );
+
+	test.each( invalidFiles )(
+		'rejects invalid block metadata in `%s`',
+		( filepath ) => {
+			const { $schema, ...blockMetadata } = require( filepath );
+
+			const result = ajv.validate( blockSchema, blockMetadata );
+
+			expect( result ).toBe( false );
+		}
+	);
 } );

--- a/test/integration/fixtures/block-schemas/invalid-auto-register.json
+++ b/test/integration/fixtures/block-schemas/invalid-auto-register.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "../../../../schemas/json/block.json",
+	"apiVersion": 3,
+	"name": "my-plugin/invalid-auto-register",
+	"title": "Invalid auto-registration",
+	"supports": {
+		"autoRegister": "yes"
+	}
+}


### PR DESCRIPTION
## What

Part of #79330.

Adds `autoRegister` to the `block.json` schema. Block authors will now get autocomplete for the setting, and values such as `"yes"` will show a schema error instead of being silently accepted.

## Why

`autoRegister` already works for PHP-only blocks, but the schema does not know about it yet.

## Testing Instructions

1. Open `test/integration/fixtures/block-schemas/invalid-auto-register.json` in an editor with JSON schema validation.
2. Check that `"autoRegister": "yes"` is marked as invalid.
3. Change the value to `true`, check that the error disappears, then undo the change.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.