### PR TITLE
Use playlist icon for Playlist block

### DIFF
--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -28,7 +28,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __, _x } from '@wordpress/i18n';
-import { audio as icon } from '@wordpress/icons';
+import { playlist as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 
 /**

--- a/packages/block-library/src/playlist/index.js
+++ b/packages/block-library/src/playlist/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { audio as icon } from '@wordpress/icons';
+import { playlist as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the Playlist block to use the new shared `playlist` icon from `@wordpress/icons`.

## Why?
The Playlist block now has a dedicated icon, so it should no longer reuse the generic audio icon in the inserter and media placeholder.

## How?
Imports `playlist` instead of `audio` in the Playlist block registration and edit component.

## Testing Instructions
1. Open a post or page in the editor.
2. Open the block inserter.
3. Confirm the Playlist block uses the playlist icon.
4. Insert a Playlist block and confirm the media placeholder also uses the playlist icon.

### Testing Instructions for Keyboard
Use the keyboard to open the inserter, search for Playlist, and confirm the icon is shown before inserting the block.

## Screenshots or screencast
<img width="342" height="163" alt="Screenshot 2026-07-13 at 11 26 38" src="https://github.com/user-attachments/assets/1732a4bc-2f06-4e5f-81ad-ea452bb8bf6b" />

## Use of AI Tools

OpenAI Codex was used to make the import change and verify the diff.

## Verification

Ran `git diff --check`. JS lint was not run because dependencies are not installed in this workspace, and the first commit attempt hit a missing local Husky shim.
