### PR TITLE
Release: Fail changelog generation cleanly

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -242,8 +242,14 @@ jobs:
               run: |
                   IFS='.' read -r -a VERSION_ARRAY <<< "${VERSION}"
                   MILESTONE="Gutenberg ${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                  npm run other:changelog -- --milestone="$MILESTONE" --unreleased > release-notes.txt
-                  sed -ie '1,6d' release-notes.txt
+                  RELEASE_NOTES_TMP="$(mktemp)"
+                  trap 'rm -f "$RELEASE_NOTES_TMP"' EXIT
+                  npm run other:changelog -- --milestone="$MILESTONE" --unreleased > "$RELEASE_NOTES_TMP"
+                  sed '1,6d' "$RELEASE_NOTES_TMP" > release-notes.txt
+                  if [[ ! -s release-notes.txt ]]; then
+                    echo "Release notes are empty for milestone \"$MILESTONE\"." >&2
+                    exit 1
+                  fi
                   if [[ "${VERSION}" != *"rc"* ]]; then
                     # Include previous RCs' release notes, if any
                     CHANGELOG_REGEX="=\s[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?\s="

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -425,6 +425,8 @@ You must also ensure that all PRs being included are assigned to the GitHub Mile
 
 For example, if you are releasing version `12.5.4`, then all PRs picked for that release must be unassigned from the `12.6` Milestone and instead assigned to the `12.5` Milestone.
 
+If release-note generation reports that the milestone has no unreleased pull requests, verify that every cherry-picked PR is assigned to the release milestone before rerunning the workflow. Do not generate the notes from a different milestone.
+
 Once cherry picking is complete, you can also remove the `Backport to Gutenberg Minor Release` label from the PRs.
 
 Once you have the stable release branch in order and the correct Milestone assigned to your PRs you can _push the branch to GitHub_ and continue with the release process using the GitHub website GUI.

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -463,15 +463,13 @@ The process is identical to the one documented above when an RC is already out: 
 
 ### Troubleshooting
 
-> The release draft was created but it was empty/contained an error message
+> Release-note generation failed because no unreleased pull requests were found
 
-If you forget to assign the correct Milestone to your cherry picked PR(s) then the changelog may not be generated as you would expect.
+The workflow fails before creating a release draft. Verify that every cherry-picked PR is assigned to the release milestone, then rerun the workflow. Do not manually create the release notes or use a different milestone.
 
-It is important to always manually verify that the PRs shown in the changelog match up with those cherry picked to the release branch.
+If the milestone has been closed, you may reopen it for the release.
 
-Moreover, if the release includes only a single PR, then failing to assign the PR to the correct Milestone will cause an error to be displayed when generating the changelog. In this case you can edit the release notes to include details of the missing PR (manually copying the format from a previous release).
-
-If for any reason the Milestone has been closed, you may reopen it for the purposes of the release.
+After rerunning the workflow, manually verify that the PRs shown in the changelog match those cherry-picked to the release branch.
 
 > The draft release only contains 1 asset file. Other releases have x3.
 

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -5,17 +5,6 @@
  */
 const program = require( 'commander' );
 
-const catchException = ( command ) => {
-	return async ( ...args ) => {
-		try {
-			await command( ...args );
-		} catch ( error ) {
-			console.error( error );
-			process.exitCode = 1;
-		}
-	};
-};
-
 /**
  * Internal dependencies
  */
@@ -44,7 +33,7 @@ program
 	.description(
 		'Publishes to npm packages synced from the Gutenberg plugin (latest dist-tag, production version)'
 	)
-	.action( catchException( publishNpmGutenbergPlugin ) );
+	.action( publishNpmGutenbergPlugin );
 
 program
 	.command( 'publish-npm-packages-bugfix-latest' )
@@ -54,7 +43,7 @@ program
 	.description(
 		'Publishes to npm bugfixes for packages (latest dist-tag, production version)'
 	)
-	.action( catchException( publishNpmBugfixLatest ) );
+	.action( publishNpmBugfixLatest );
 
 program
 	.command( 'publish-npm-packages-wordpress-core' )
@@ -65,7 +54,7 @@ program
 	.description(
 		'Publishes to npm bugfixes targeting WordPress core (wp-X.Y dist-tag, production version)'
 	)
-	.action( catchException( publishNpmBugfixWordPressCore ) );
+	.action( publishNpmBugfixWordPressCore );
 
 program
 	.command( 'publish-npm-packages-next' )
@@ -76,7 +65,7 @@ program
 	.description(
 		'Publishes to npm development version of packages (next dist-tag, prerelease version)'
 	)
-	.action( catchException( publishNpmNext ) );
+	.action( publishNpmNext );
 
 program
 	.command( 'release-plugin-changelog' )
@@ -88,7 +77,7 @@ program
 		"Only include PRs that haven't been included in a release yet"
 	)
 	.description( 'Generates a changelog from merged Pull Requests' )
-	.action( catchException( getReleaseChangelog ) );
+	.action( getReleaseChangelog );
 
 program
 	.command( 'performance-tests [branches...]' )
@@ -109,6 +98,27 @@ program
 	.description(
 		'Runs performance tests on two separate branches and outputs the result'
 	)
-	.action( catchException( runPerformanceTests ) );
+	.action( runPerformanceTests );
 
-program.parse( process.argv );
+/**
+ * Runs the release CLI and reports command failures.
+ *
+ * @param {string[]}                    args        Command-line arguments.
+ * @param {import('commander').Command} commandLine Commander program to run.
+ */
+async function run( args = process.argv, commandLine = program ) {
+	try {
+		await commandLine.parseAsync( args );
+	} catch ( error ) {
+		console.error(
+			error instanceof Error ? error.message : String( error )
+		);
+		process.exitCode = 1;
+	}
+}
+
+if ( require.main === module ) {
+	run();
+}
+
+module.exports = { run };

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -110,9 +110,11 @@ async function run( args = process.argv, commandLine = program ) {
 	try {
 		await commandLine.parseAsync( args );
 	} catch ( error ) {
-		console.error(
-			error instanceof Error ? error.message : String( error )
-		);
+		let errorMessage = String( error );
+		if ( error instanceof Error ) {
+			errorMessage = process.env.DEBUG ? error.stack : error.message;
+		}
+		console.error( errorMessage );
 		process.exitCode = 1;
 	}
 }

--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -710,19 +710,21 @@ async function fetchAllPullRequests( octokit, settings ) {
 		latestReleaseInSeries ? latestReleaseInSeries.published_at : undefined
 	);
 
-	if ( ! issues.length ) {
+	const pullRequests = issues.filter( ( issue ) => issue.pull_request );
+
+	if ( ! pullRequests.length ) {
 		if ( settings.unreleased ) {
 			throw new Error(
-				'There are no unreleased pull requests associated with the milestone.'
+				`There are no unreleased pull requests associated with milestone "${ milestoneTitle }". Release coordinator: verify that every cherry-picked pull request is assigned to this milestone before rerunning the release.`
 			);
 		} else {
 			throw new Error(
-				'There are no pull requests associated with the milestone.'
+				`There are no pull requests associated with milestone "${ milestoneTitle }".`
 			);
 		}
 	}
 
-	return issues.filter( ( issue ) => issue.pull_request );
+	return pullRequests;
 }
 
 /**
@@ -1019,25 +1021,13 @@ async function createChangelog( settings ) {
 		auth: settings.token,
 	} );
 
-	let releaselog = '';
+	const pullRequests = await fetchAllPullRequests( octokit, settings );
 
-	try {
-		const pullRequests = await fetchAllPullRequests( octokit, settings );
+	const changelog = getChangelog( pullRequests );
+	const contributorProps = getContributorProps( pullRequests );
+	const contributorsList = getContributorsList( pullRequests );
 
-		const changelog = getChangelog( pullRequests );
-		const contributorProps = getContributorProps( pullRequests );
-		const contributorsList = getContributorsList( pullRequests );
-
-		releaselog = releaselog.concat(
-			changelog,
-			contributorProps,
-			contributorsList
-		);
-	} catch ( error ) {
-		if ( error instanceof Error ) {
-			releaselog = formats.error( error.stack );
-		}
-	}
+	const releaselog = changelog.concat( contributorProps, contributorsList );
 
 	log( releaselog );
 }
@@ -1089,4 +1079,6 @@ module.exports = {
 	getUniqueByUsername,
 	skipCreatedByBots,
 	mapLabelsToFeatures,
+	createChangelog,
+	fetchAllPullRequests,
 };

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -1,6 +1,16 @@
 /**
  * Internal dependencies
  */
+jest.mock( '@octokit/rest' );
+jest.mock( '../../lib/milestone' );
+jest.mock( '../../lib/logger', () => ( {
+	log: jest.fn(),
+	formats: {
+		title: jest.fn( ( message ) => message ),
+		error: jest.fn( ( message ) => message ),
+	},
+} ) );
+
 import {
 	getNormalizedTitle,
 	reword,
@@ -20,9 +30,18 @@ import {
 	getContributorProps,
 	getContributorsList,
 	mapLabelsToFeatures,
+	createChangelog,
+	fetchAllPullRequests,
 } from '../changelog';
 import _pullRequests from './fixtures/pull-requests.json';
 import botPullRequestFixture from './fixtures/bot-pull-requests.json';
+
+const Octokit = require( '@octokit/rest' );
+const {
+	getMilestoneByTitle,
+	getIssuesByMilestone,
+} = require( '../../lib/milestone' );
+const { log } = require( '../../lib/logger' );
 
 /**
  * pull-requests.json is a static snapshot of real data from the GitHub API.
@@ -32,6 +51,88 @@ import botPullRequestFixture from './fixtures/bot-pull-requests.json';
  * See: https://github.com/WordPress/gutenberg/pull/38777#discussion_r808992346.
  */
 const pullRequests = _pullRequests.concat( botPullRequestFixture );
+
+describe( 'createChangelog', () => {
+	const settings = {
+		owner: 'WordPress',
+		repo: 'gutenberg',
+		milestone: 'Gutenberg 23.5',
+		unreleased: false,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Octokit.mockImplementation( () => ( {} ) );
+	} );
+
+	it( 'keeps successful changelog output unchanged', async () => {
+		getMilestoneByTitle.mockResolvedValue( {
+			number: 235,
+			title: settings.milestone,
+		} );
+		getIssuesByMilestone.mockResolvedValue( pullRequests );
+
+		await createChangelog( settings );
+
+		expect( log ).toHaveBeenCalledTimes( 2 );
+		expect( log ).toHaveBeenNthCalledWith(
+			2,
+			getChangelog( pullRequests ) +
+				getContributorProps( pullRequests ) +
+				getContributorsList( pullRequests )
+		);
+	} );
+
+	it( 'does not swallow operational errors', async () => {
+		getMilestoneByTitle.mockRejectedValue(
+			new Error( 'GitHub request failed.' )
+		);
+
+		await expect( createChangelog( settings ) ).rejects.toThrow(
+			'GitHub request failed.'
+		);
+		expect( log ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'fetchAllPullRequests', () => {
+	it( 'explains how to recover when a milestone has no unreleased pull requests', async () => {
+		const milestone = 'Gutenberg 23.5';
+		const octokit = {
+			repos: {
+				listReleases: {
+					endpoint: {
+						merge: jest.fn().mockReturnValue( {} ),
+					},
+				},
+			},
+			paginate: {
+				iterator: jest.fn().mockReturnValue(
+					( async function* () {
+						yield { data: [] };
+					} )()
+				),
+			},
+		};
+
+		getMilestoneByTitle.mockResolvedValue( {
+			number: 235,
+			title: milestone,
+		} );
+		getIssuesByMilestone.mockResolvedValue( [ { number: 123 } ] );
+
+		await expect(
+			fetchAllPullRequests( octokit, {
+				owner: 'WordPress',
+				repo: 'gutenberg',
+				milestone,
+				unreleased: true,
+			} )
+		).rejects.toThrow(
+			'There are no unreleased pull requests associated with milestone "Gutenberg 23.5". Release coordinator: verify that every cherry-picked pull request is assigned to this milestone before rerunning the release.'
+		);
+	} );
+} );
 
 describe( 'getNormalizedTitle', () => {
 	const DEFAULT_ISSUE = {

--- a/tools/release/test/cli.js
+++ b/tools/release/test/cli.js
@@ -4,26 +4,44 @@
 const path = require( 'path' );
 const { spawnSync } = require( 'child_process' );
 
+const cliPath = path.resolve( __dirname, '../cli.js' );
+const script = `
+	const { Command } = require( 'commander' );
+	const { run } = require( ${ JSON.stringify( cliPath ) } );
+	const program = new Command();
+	program.command( 'reject' ).action( async () => {
+		await Promise.resolve();
+		throw new Error( 'Unable to generate the changelog.' );
+	} );
+	run( [ 'node', 'release-cli', 'reject' ], program );
+`;
+
+function runRejectedCommand( debug = false ) {
+	return spawnSync( process.execPath, [ '-e', script ], {
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			DEBUG: debug ? '1' : '',
+		},
+	} );
+}
+
 describe( 'release CLI', () => {
 	it( 'waits for rejected async commands and reports a clean failure', () => {
-		const cliPath = path.resolve( __dirname, '../cli.js' );
-		const script = `
-			const { Command } = require( 'commander' );
-			const { run } = require( ${ JSON.stringify( cliPath ) } );
-			const program = new Command();
-			program.command( 'reject' ).action( async () => {
-				await Promise.resolve();
-				throw new Error( 'Unable to generate the changelog.' );
-			} );
-			run( [ 'node', 'release-cli', 'reject' ], program );
-		`;
-
-		const result = spawnSync( process.execPath, [ '-e', script ], {
-			encoding: 'utf8',
-		} );
+		const result = runRejectedCommand();
 
 		expect( result.status ).toBe( 1 );
 		expect( result.stdout ).toBe( '' );
 		expect( result.stderr ).toBe( 'Unable to generate the changelog.\n' );
+	} );
+
+	it( 'prints the stack to stderr when debugging is enabled', () => {
+		const result = runRejectedCommand( true );
+
+		expect( result.status ).toBe( 1 );
+		expect( result.stdout ).toBe( '' );
+		expect( result.stderr ).toMatch(
+			/^Error: Unable to generate the changelog\.\n\s+at /
+		);
 	} );
 } );

--- a/tools/release/test/cli.js
+++ b/tools/release/test/cli.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const { spawnSync } = require( 'child_process' );
+
+describe( 'release CLI', () => {
+	it( 'waits for rejected async commands and reports a clean failure', () => {
+		const cliPath = path.resolve( __dirname, '../cli.js' );
+		const script = `
+			const { Command } = require( 'commander' );
+			const { run } = require( ${ JSON.stringify( cliPath ) } );
+			const program = new Command();
+			program.command( 'reject' ).action( async () => {
+				await Promise.resolve();
+				throw new Error( 'Unable to generate the changelog.' );
+			} );
+			run( [ 'node', 'release-cli', 'reject' ], program );
+		`;
+
+		const result = spawnSync( process.execPath, [ '-e', script ], {
+			encoding: 'utf8',
+		} );
+
+		expect( result.status ).toBe( 1 );
+		expect( result.stdout ).toBe( '' );
+		expect( result.stderr ).toBe( 'Unable to generate the changelog.\n' );
+	} );
+} );


### PR DESCRIPTION
Related: #79906, #79858

Failure example: https://github.com/WordPress/gutenberg/actions/runs/29234693925/job/86767423226

## What?

Make the release CLI await asynchronous commands and fail changelog generation cleanly when release-note generation cannot complete.

## Why?

The plugin ZIP workflow redirects changelog stdout to `release-notes.txt`. Changelog errors were caught and printed as stack traces to stdout, while Commander was not awaiting asynchronous actions, so a real release precondition failure could be treated as successful release-note output.

## How?

- Await Commander actions with `parseAsync()` and report rejected commands concisely on stderr with a non-zero exit status, while preserving full stderr stacks when `DEBUG` is set.
- Let changelog-generation errors propagate and fail when the selected milestone has no unreleased pull requests.
- Tell the release coordinator to verify cherry-picked PR milestone assignments.
- Write release notes through a temporary file and reject empty output before publishing the artifact.
- Document the milestone recovery step for point releases.

## Testing Instructions

1. Run `npm run test:unit -- tools/release/commands/test/changelog.js tools/release/test/cli.js --runInBand`.
2. Run `npm run lint:js -- tools/release/cli.js tools/release/test/cli.js tools/release/commands/changelog.js tools/release/commands/test/changelog.js`.
3. Run `git diff HEAD^ HEAD --check`.

## Use of AI Tools

This PR was authored with Codex. I reviewed the implementation and test results.