### PR TITLE
Block Editor: Simplify layout panel selector getter

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -308,12 +308,12 @@ function LayoutPanelPure( {
 		isResponsiveEditing,
 	} = useSelect(
 		( select ) => {
-			const blockEditorSelect = select( blockEditorStore );
-			const { getBlockAttributes, getSettings } = blockEditorSelect;
 			const {
+				getBlockAttributes,
+				getSettings,
 				getSelectedBlockStyleState,
 				isResponsiveEditing: getIsResponsiveEditing,
-			} = unlock( blockEditorSelect );
+			} = unlock( select( blockEditorStore ) );
 			return {
 				activeBlockVariation: select(
 					blocksStore


### PR DESCRIPTION
## What?
A minor follow-up to #80037.

PR combines a selector getter. There's no need to grab public and private selectors separately.

## Testing Instructions
Smoke test behavior from #80037. It should be working as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
