### PR TITLE
Flaky tests: fix widgets global inserter

### DIFF
--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -51,8 +51,11 @@ test.describe( 'Widgets screen', () => {
 			'Update button should start out disabled'
 		).toBeDisabled();
 
-		const [ firstWidgetArea, secondWidgetArea ] =
-			await widgetsScreen.widgetAreas.all();
+		await expect
+			.poll( () => widgetsScreen.widgetAreas.count() )
+			.toBeGreaterThanOrEqual( 2 );
+		const firstWidgetArea = widgetsScreen.widgetAreas.first();
+		const secondWidgetArea = widgetsScreen.widgetAreas.nth( 1 );
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )


### PR DESCRIPTION

## What

Fixes #78924.

Fixes a race in the Widgets screen E2E test. The test could capture the widget areas before the editor had rendered them, leaving the later insertion steps without valid locators.

## How

The test waits for at least two widget areas, then uses lazy locators that resolve against the current DOM.

In local validation, the test failed in 35 of 40 runs before this change and passed all 40 runs afterward.

## Testing Instructions

1. Repeat the target test:
   `npm run test:e2e -- test/e2e/specs/widgets/editing-widgets.spec.js -g "Should insert content using the global inserter" --repeat-each=40`
2. Run the full spec:
   `npm run test:e2e -- test/e2e/specs/widgets/editing-widgets.spec.js`

---

I used Codex to help implement these changes. I guided the work, then tested and reviewed the result.
