### PR TITLE
Flaky tests: fix router navigate latest HTML

### DIFF
--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -78,15 +78,29 @@ test.describe( 'Router navigate', () => {
 		await expect( navigations ).toHaveText( '0' );
 		await expect( status ).toHaveText( 'idle' );
 
-		let resolveLink1: Function;
-		let resolveLink2: Function;
+		let resolveLink1: () => void;
+		let resolveLink2: () => void;
+		let resolveLink1Request: () => void;
+		let resolveLink2Request: () => void;
+		const link1Request = new Promise< void >( ( resolve ) => {
+			resolveLink1Request = resolve;
+		} );
+		const link2Request = new Promise< void >( ( resolve ) => {
+			resolveLink2Request = resolve;
+		} );
 
 		await page.route( link1, async ( route ) => {
-			await new Promise( ( r ) => ( resolveLink1 = r ) );
+			resolveLink1Request();
+			await new Promise< void >( ( resolve ) => {
+				resolveLink1 = resolve;
+			} );
 			await route.continue();
 		} );
 		await page.route( link2, async ( route ) => {
-			await new Promise( ( r ) => ( resolveLink2 = r ) );
+			resolveLink2Request();
+			await new Promise< void >( ( resolve ) => {
+				resolveLink2 = resolve;
+			} );
 			await route.continue();
 		} );
 
@@ -96,6 +110,7 @@ test.describe( 'Router navigate', () => {
 		await expect( navigations ).toHaveText( '2' );
 		await expect( status ).toHaveText( 'busy' );
 		await expect( title ).toHaveText( 'Main' );
+		await Promise.all( [ link1Request, link2Request ] );
 
 		await Promise.resolve().then( () => resolveLink2() );
 


### PR DESCRIPTION

## What

Fixes #78835.

This fixes a race in the router navigation E2E test. The test could call `resolveLink2()` before Playwright entered the second route handler, leaving the resolver undefined and failing with `resolveLink2 is not a function`.

## How

The test now waits for both intercepted requests to reach their route handlers before releasing either response. It can then complete the second request first and the earlier request last, while checking that the earlier response does not replace the latest navigation's HTML.

Locally, the test failed 25 times in 40 runs without this change. With the change applied, all 40 runs passed.

## Testing Instructions

1. Repeat the target test:
   `npm run test:e2e -- test/e2e/specs/interactivity/router-navigate.spec.ts -g "should update the HTML only for the latest navigation" --repeat-each=40`
2. Run the full spec:
   `npm run test:e2e -- test/e2e/specs/interactivity/router-navigate.spec.ts`

---

I used Codex to help implement these changes. I guided the work, then tested and reviewed the result.