### PR TITLE
Flaky tests: fix writing flow arrow navigation

### DIFF
--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1299,9 +1299,12 @@ class WritingFlowUtils {
 		await this.editor.canvas
 			.locator( 'role=button[name="Two columns; equal split"i]' )
 			.click();
-		await this.editor.canvas
-			.locator( '.is-selected >> role=button[name="Add block"i]' )
-			.click();
+
+		const firstColumn = this.editor.canvas.getByRole( 'document', {
+			name: 'Block: Column (1 of 2)',
+		} );
+		await firstColumn.focus();
+		await firstColumn.getByRole( 'button', { name: 'Add block' } ).click();
 		await this.page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 		);


### PR DESCRIPTION
## What

Fixes #39607.

Fixes the flaky arrow-navigation E2E test without bypassing the editor UI used to set it up.

## How

The test still inserts the Columns block, chooses the 50/50 variation, adds paragraphs through each column's inserter, and uses the toolbar and keyboard to create the trailing paragraph. It now focuses the first column before clicking its Add block button, matching the existing setup for the second column.

In the failed trace, the click moved focus into the first column, but the inserter stayed closed with `aria-expanded="false"`. Focusing the column first removes that focus transition from the click.

The original test failed 4 times in 120 local runs. With this change, all 120 runs passed: 40 each in Chromium, WebKit, and Firefox. The full spec passed 125/126 tests; the remaining WebKit failure is in an unrelated test and also failed 5/5 times directly on `origin/trunk`.

## Testing Instructions

1. Repeat the target test:
   `npm run test:e2e -- test/e2e/specs/editor/various/writing-flow.spec.js -g "Should navigate inner blocks with arrow keys" --repeat-each=40`
2. Run the full spec:
   `npm run test:e2e -- test/e2e/specs/editor/various/writing-flow.spec.js`

---

I used Codex to help implement these changes. I guided the work, then tested and reviewed the result.
