### PR TITLE
Playlist icon: Fix bug with missing viewbox.

### DIFF
--- a/packages/icons/src/library/playlist.svg
+++ b/packages/icons/src/library/playlist.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
 	<path d="M16.1 5.7h-.3c-1 0-2.2 0-2.8.6-.3.4-.5.9-.5 1.6v7.3c0 .7-.2 1.7-.7 2.5C11.3 19 10 20 8.5 20 6.6 20 5 18.4 5 16.5S6.6 13 8.5 13c1 0 1.9.4 2.5 1V7.9c0-1.1.3-2 .9-2.6 1-1 2.6-1 3.8-1h.4zM20 15.75h-5v-1.5h5zM20 10.75h-5v-1.5h5z" />
 </svg>


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/80168#issuecomment-4956395645

Adds the missing viewbox.

## Testing Instructions

npm run storybook:dev, icons, library, Playlist, choose size 32 and it should be larger

## Screenshots or screencast <!-- if applicable -->

<img width="418" height="190" alt="image" src="https://github.com/user-attachments/assets/805078c7-aa3d-42dd-89cf-29b51d220d49" />

## Use of AI Tools

No