### PR TITLE
Fix misplaced @ts-expect-error in PreferencesModalTabs

### DIFF
--- a/packages/preferences/src/components/preferences-modal-tabs/index.tsx
+++ b/packages/preferences/src/components/preferences-modal-tabs/index.tsx
@@ -110,10 +110,10 @@ export default function PreferencesModalTabs( {
 							<ItemGroup>
 								{ tabs.map( ( tab ) => {
 									return (
+										// @ts-expect-error: Navigator.Button is currently typed in a way that prevents Item from being passed in
 										<Navigator.Button
 											key={ tab.name }
 											path={ `/${ tab.name }` }
-											// @ts-expect-error: Navigator.Button is currently typed in a way that prevents Item from being passed in
 											as={ Item }
 											isAction
 										>


### PR DESCRIPTION
## What

Moves a `@ts-expect-error` comment in `PreferencesModalTabs` from above the `as={ Item }` prop to above the `<Navigator.Button>` opening tag.

## Why

`@ts-expect-error` only suppresses the diagnostic reported on the line immediately following it. Previously that was the `as={ Item }` line, which is where TypeScript used to report the overload mismatch for this JSX element.

Two recent trunk changes shifted where TS attributes that error:
- The View→non-Emotion migration (#79443) changed `Item`'s underlying type.
- The TypeScript 7.0 upgrade (#80083) changed how overload-mismatch diagnostics for polymorphic/overloaded JSX components are attributed — now to the JSX opening tag itself, rather than any individual prop line below it.

As a result, TS started reporting the error on the `<Navigator.Button>` opening tag instead of the `as` prop line. The directive, still sitting above `as`, no longer suppressed anything (flagged as "unused"), while the real error surfaced one line up, unsuppressed — breaking the `tsc --build` step of `npm run dev` / `npm run build`.

## How

Moved the `@ts-expect-error` comment from directly above `as={ Item }` to directly above the `<Navigator.Button>` opening tag, matching where TypeScript now attributes the diagnostic. The underlying type mismatch is unchanged and intentional (Item's props aren't currently compatible with `Navigator.Button`'s `as` prop typing) — this only relocates the suppression to where it's actually needed.
