### PR TITLE
Flaky tests: fix rich text backtick undo

### DIFF
--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -178,9 +178,11 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
+		// Wait until the backtick transformation is recorded as an automatic change.
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'Backspace' );
 
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: { content: '`a`' },


### PR DESCRIPTION
## What

Fixes #76178.

Fixes the flaky RichText test that checks Backspace undoing a backtick-to-code transform.

## How

The test now waits for the idle callback that marks the transform as a finished automatic change before pressing Backspace. It also polls the final block state instead of reading it once.

In the latest CI run, both failed attempts sent Backspace about 1 ms after `<code>a</code>` appeared, leaving the paragraph empty. I could not reproduce the failure locally before the change: 200/200 runs passed. After the change, the test passed 200/200 runs across Chromium, WebKit, and Firefox.

## Testing Instructions

1. Run:

   ```sh
   npm run test:e2e -- test/e2e/specs/editor/various/rich-text.spec.js -g "should undo backtick transform with backspace" --repeat-each=40
   ```

2. Run:

   ```sh
   npm run test:e2e -- test/e2e/specs/editor/various/rich-text.spec.js
   ```

---

I used Codex to implement these changes. I guided the work, then tested and reviewed the result.
