### PR TITLE
Cover Block: Fix unsaveable state when clearing an embed video background

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -243,8 +243,7 @@ function CoverEdit( {
 		if ( ! currentAttrs.isUserOverlayColor ) {
 			newOverlayColor = averageBackgroundColor;
 			setOverlayColor( newOverlayColor );
-
-			// Make undo revert the next setAttributes and the previous setOverlayColor.
+			// Fold next attribute change into the same undo level as the setOverlayColor above.
 			__unstableMarkNextChangeAsNotPersistent();
 		}
 
@@ -302,11 +301,13 @@ function CoverEdit( {
 
 	const onClearMedia = () => {
 		let newOverlayColor = overlayColor.color;
-		if ( ! isUserOverlayColor ) {
+
+		// Skip for embeds, which never auto-assign an overlay color; otherwise
+		// the non-persistent flag lands on the media reset itself (unsaveable).
+		if ( ! isUserOverlayColor && overlayColor.color ) {
 			newOverlayColor = DEFAULT_OVERLAY_COLOR;
 			setOverlayColor( undefined );
-
-			// Make undo revert the next setAttributes and the previous setOverlayColor.
+			// Fold next attribute change into the same undo level as the setOverlayColor above.
 			__unstableMarkNextChangeAsNotPersistent();
 		}
 
@@ -341,8 +342,7 @@ function CoverEdit( {
 		);
 
 		setOverlayColor( newOverlayColor );
-
-		// Make undo revert the next setAttributes and the previous setOverlayColor.
+		// Fold next attribute change into the same undo level as the setOverlayColor above.
 		__unstableMarkNextChangeAsNotPersistent();
 
 		setAttributes( {
@@ -549,8 +549,7 @@ function CoverEdit( {
 					if ( ! currentAttrs.isUserOverlayColor ) {
 						newOverlayColor = averageBackgroundColor;
 						setOverlayColor( newOverlayColor );
-
-						// Make undo revert the next setAttributes and the previous setOverlayColor.
+						// Fold next attribute change into the same undo level as the setOverlayColor above.
 						__unstableMarkNextChangeAsNotPersistent();
 					}
 
@@ -604,8 +603,7 @@ function CoverEdit( {
 			} else {
 				setOverlayColor( undefined );
 			}
-
-			// Make undo revert the next setAttributes and the previous setOverlayColor.
+			// Fold next attribute change into the same undo level as the setOverlayColor above.
 			__unstableMarkNextChangeAsNotPersistent();
 		}
 


### PR DESCRIPTION
## What?
Noticed while testing #80092.

Clearing an embedded video background via "Clear Media" left the block in a state that prevented saving, making clearing Embedded URLs almost impossible.

## Why?
`onClearMedia` calls `__unstableMarkNextChangeAsNotPersistent()` to fold the overlay-color reset and the media reset into a single undo step. For image and video backgrounds, this is fine — an overlay color is auto-assigned (the media's
average color), so `setOverlayColor( undefined )` is a real persistent change the flag pairs with.

Embeds never auto-assign an overlay color, so `setOverlayColor( undefined )` is a no-op and the non-persistent flag lands on the media-reset `setAttributes` instead. That routes the change through `onInput` rather than `onChange`, which doesn't serialize content or dirty the post, so the cleared state can't be saved.

## How?
Only mark the next change non-persistent when there's actually an auto-assigned overlay color to clear (`! isUserOverlayColor && overlayColor.color`).

## Testing Instructions
1. Add a Cover block, set an embedded video (e.g., a YouTube URL) as background.
2. Clear the media via the "Reset" block control menu item.
3. Confirm the post becomes dirty and saves; reload and confirm the media stays cleared.
4. Repeat with an image/video background to confirm no regression.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
