### PR TITLE
Release: Make npm publishing rerunnable

### DIFF
--- a/docs/contributors/code/release/package-release-and-core-updates.md
+++ b/docs/contributors/code/release/package-release-and-core-updates.md
@@ -178,7 +178,7 @@ In order to start the publishing process for development version of npm packages
 To publish development packages to npm, select `development` from the "Release type" dropdown and leave empty "WordPress major release" input field. Finally, press the green "Run workflow" button. It triggers the npm publishing job, and this needs to be approved by a Gutenberg Core team member. Locate the ["Publish npm packages" action](https://github.com/WordPress/gutenberg/actions/workflows/publish-npm-packages.yml) for the current publishing, and have it [approved](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments#approving-or-rejecting-a-job).
 
 Behind the scenes, the release process is fully automated via `npm exec --no release-cli -- npm-next` command. It ensures
-the `wp/next` branch is synchronized with the latest release branch (`release/X.Y`) created for the Gutenberg plugin. To avoid collisions in the versioning of packages, we always include the newest commit's `sha`, for example, `@wordpress/block-editor@5.2.10-next.645224df70.0`.
+the `wp/next` branch is synchronized with the latest release branch (`release/X.Y`) created for the Gutenberg plugin. To avoid version collisions, development releases include a timestamp, for example, `@wordpress/block-editor@5.2.10-next.v.202607130915.0`.
 
 [plugin repository]: https://plugins.trac.wordpress.org/browser/gutenberg/
 [package release process]: https://github.com/WordPress/gutenberg/blob/HEAD/packages/README.md#releasing-packages

--- a/docs/contributors/code/release/package-release-and-core-updates.md
+++ b/docs/contributors/code/release/package-release-and-core-updates.md
@@ -46,23 +46,25 @@ Before restarting any mutating step, inspect the npm registry state for the pack
 For one package:
 
 ```sh
-npm view @wordpress/components@X.Y.Z version
+git rev-parse HEAD
+npm view @wordpress/components@X.Y.Z version gitHead --json
 npm dist-tag ls @wordpress/components
 ```
 
 To inspect all package versions from the current release branch:
 
 ```sh
+git rev-parse HEAD
 npx lerna list --json --no-private | jq -r '.[] | "\(.name)@\(.version)"' | while read package_version; do
 	package="${package_version%@*}"
 	version="${package_version##*@}"
 	echo "$package@$version"
-	npm view "$package@$version" version || true
+	npm view "$package@$version" version gitHead --json || true
 	npm dist-tag ls "$package"
 done
 ```
 
-Resume from the package versions that already exist on npm. If the expected versions exist and the expected dist-tags point to them, continue either with [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package), which publishes local package versions that are not yet on npm and skips the ones that already made it, or the workflow's generated recovery command when one is printed.
+Resume only when each target already on npm reports the expected version, its registry `gitHead` matches the prepared release commit printed by `git rev-parse HEAD`, and the expected dist-tag points to it. Then continue either with [`npx lerna publish from-package`](https://lerna.js.org/docs/features/version-and-publish#from-package), which publishes local package versions that are not yet on npm and skips the ones that already made it, or the workflow's generated recovery command when one is printed.
 
 When a workflow run prints branch or package-tag recovery commands after npm publishing succeeds but Git metadata publication fails, prefer those run-specific commands over starting a fresh release.
 

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -922,6 +922,22 @@ async function publishVersionedPackagesToNpm(
 		await publishRemainingPackages( await getPublishedPackageNames() );
 	}
 
+	// Lerna treats publish conflicts as successful "already published" results,
+	// so verify registry identity again before attaching Git metadata.
+	const finalPublishedPackageNames = new Set(
+		await getPublishedPackageNames()
+	);
+	const unpublishedPackageVersions = releasePackages
+		.filter( ( { name } ) => ! finalPublishedPackageNames.has( name ) )
+		.map( ( { name, version } ) => `${ name }@${ version }` );
+	if ( unpublishedPackageVersions.length ) {
+		throw new Error(
+			`npm publication verification failed for ${ unpublishedPackageVersions.join(
+				', '
+			) }.`
+		);
+	}
+
 	await pushNpmReleaseGitMetadataFn( {
 		gitWorkingDirectoryPath,
 		npmReleaseBranch,

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -660,16 +660,38 @@ function isNpmPackageVersionMissing( error ) {
 }
 
 /**
+ * Parses npm JSON command output.
+ *
+ * @param {string} output      Command stdout.
+ * @param {string} description Output description for error messages.
+ *
+ * @return {*} Parsed JSON output.
+ */
+function parseNpmJsonOutput( output, description ) {
+	try {
+		return JSON.parse( output );
+	} catch {
+		throw new Error(
+			`Unable to parse npm registry ${ description }: ${ output }`
+		);
+	}
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
+ * @param {string}   options.distTag                 The dist-tag used for npm publishing.
  * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.publishCommit           Release commit SHA.
  * @param {Array}    options.releasePackages         Packages to publish.
  * @param {Object}   deps                            Dependencies.
  * @param {Function} deps.commandFn                  Command runner.
+ *
+ * @return {Promise<string[]>} Correctly published package names.
  */
 async function runNpmPublishPreflight(
-	{ gitWorkingDirectoryPath, releasePackages },
+	{ distTag, gitWorkingDirectoryPath, publishCommit, releasePackages },
 	deps = {}
 ) {
 	const { commandFn = command } = deps;
@@ -679,25 +701,77 @@ async function runNpmPublishPreflight(
 		stdio: 'pipe',
 	} );
 
-	log( '>> Verifying target package versions are not already published.' );
+	log( '>> Verifying target package versions and dist-tags.' );
+	const publishedPackageNames = [];
 	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
 	// Keep the first hardening pass sequential so registry errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
+		let registryVersion;
 		try {
-			await commandFn( `npm view ${ name }@${ version } version --json`, {
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'pipe',
-			} );
+			const { stdout } = await commandFn(
+				`npm view ${ name }@${ version } version --json`,
+				{
+					cwd: gitWorkingDirectoryPath,
+					stdio: 'pipe',
+				}
+			);
+			registryVersion = parseNpmJsonOutput(
+				stdout,
+				`${ name }@${ version } version`
+			);
 		} catch ( error ) {
 			if ( isNpmPackageVersionMissing( error ) ) {
 				continue;
 			}
 			throw error;
 		}
-		throw new Error(
-			`${ name }@${ version } already exists in the npm registry.`
+
+		if ( registryVersion !== version ) {
+			throw new Error(
+				`Expected npm registry lookup for ${ name }@${ version } to return version ${ version }, got ${ registryVersion }.`
+			);
+		}
+
+		const { stdout: gitHeadOutput } = await commandFn(
+			`npm view ${ name }@${ version } gitHead --json`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'pipe',
+			}
 		);
+		const registryGitHead = parseNpmJsonOutput(
+			gitHeadOutput,
+			`${ name }@${ version } gitHead`
+		);
+		if ( registryGitHead !== publishCommit ) {
+			throw new Error(
+				`${ name }@${ version } exists in the npm registry with gitHead ${
+					registryGitHead || 'nothing'
+				}, expected ${ publishCommit }.`
+			);
+		}
+
+		const { stdout: distTagsOutput } = await commandFn(
+			`npm view ${ name } dist-tags --json`,
+			{
+				cwd: gitWorkingDirectoryPath,
+				stdio: 'pipe',
+			}
+		);
+		const distTags = parseNpmJsonOutput(
+			distTagsOutput,
+			`${ name } dist-tags`
+		);
+		if ( distTags[ distTag ] !== version ) {
+			throw new Error(
+				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${
+					distTags[ distTag ] || 'nothing'
+				}.`
+			);
+		}
+		publishedPackageNames.push( name );
 	}
+	return publishedPackageNames;
 }
 
 /**
@@ -812,20 +886,30 @@ async function publishVersionedPackagesToNpm(
 	const releasePackages = await getNpmReleasePackagesFn(
 		gitWorkingDirectoryPath
 	);
-	await runNpmPublishPreflightFn( {
-		gitWorkingDirectoryPath,
-		releasePackages,
-	} );
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	const publishCommand = `npx lerna publish from-package --dist-tag ${ distTag } --git-head ${ publishCommit } ${ yesFlag } ${ noVerifyAccessFlag }`;
+	const getPublishedPackageNames = () =>
+		runNpmPublishPreflightFn( {
+			distTag,
+			gitWorkingDirectoryPath,
+			publishCommit,
+			releasePackages,
+		} );
+	const publishRemainingPackages = async ( publishedPackageNames ) => {
+		if ( publishedPackageNames.length === releasePackages.length ) {
+			log( '>> All target package versions are already published.' );
+			return;
+		}
+		log( '>> Publishing modified packages to npm.' );
+		await commandFn( publishCommand, {
+			cwd: gitWorkingDirectoryPath,
+			stdio: 'inherit',
+		} );
+	};
 
-	log( '>> Publishing modified packages to npm.' );
+	const publishedPackageNames = await getPublishedPackageNames();
 	try {
-		await commandFn(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
+		await publishRemainingPackages( publishedPackageNames );
 	} catch {
 		log(
 			'>> Trying to finish failed publishing of modified npm packages.'
@@ -833,16 +917,9 @@ async function publishVersionedPackagesToNpm(
 		// A failed Lerna publish can leave temporary `gitHead` manifest changes.
 		// Reset to the version commit so `from-package` sees a clean tree on retry.
 		await git.reset( 'hard' );
-		await commandFn(
-			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'inherit',
-			}
-		);
+		await publishRemainingPackages( await getPublishedPackageNames() );
 	}
 
-	const publishCommit = await git.revparse( [ 'HEAD' ] );
 	await pushNpmReleaseGitMetadataFn( {
 		gitWorkingDirectoryPath,
 		npmReleaseBranch,
@@ -904,7 +981,7 @@ async function publishPackagesToNpm(
 		);
 
 		await commandFn(
-			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --build-metadata ${ beforeCommitHash } --no-private --no-push ${ yesFlag }`,
+			`npx lerna version pre${ minimumVersionBump } --preid next.v.${ timestamp } --no-private --no-push ${ yesFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -704,20 +704,20 @@ async function runNpmPublishPreflight(
 	log( '>> Verifying target package versions and dist-tags.' );
 	const publishedPackageNames = [];
 	// TODO: Consider bounded concurrency here if this preflight becomes too slow.
-	// Keep the first hardening pass sequential so registry errors stay easy to read.
+	// Keep registry checks sequential so errors stay easy to read.
 	for ( const { name, version } of releasePackages ) {
-		let registryVersion;
+		let registryPackage;
 		try {
 			const { stdout } = await commandFn(
-				`npm view ${ name }@${ version } version --json`,
+				`npm view ${ name }@${ version } version gitHead dist-tags --json`,
 				{
 					cwd: gitWorkingDirectoryPath,
 					stdio: 'pipe',
 				}
 			);
-			registryVersion = parseNpmJsonOutput(
+			registryPackage = parseNpmJsonOutput(
 				stdout,
-				`${ name }@${ version } version`
+				`${ name }@${ version } metadata`
 			);
 		} catch ( error ) {
 			if ( isNpmPackageVersionMissing( error ) ) {
@@ -726,25 +726,17 @@ async function runNpmPublishPreflight(
 			throw error;
 		}
 
+		const {
+			version: registryVersion,
+			gitHead: registryGitHead,
+			'dist-tags': distTags = {},
+		} = registryPackage;
 		if ( registryVersion !== version ) {
 			throw new Error(
 				`Expected npm registry lookup for ${ name }@${ version } to return version ${ version }, got ${ registryVersion }.`
 			);
 		}
 
-		const { stdout: gitHeadOutput } = await commandFn(
-			`npm view ${ name }@${ version } gitHead --json`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'pipe',
-			}
-		);
-		const registryGitHead = gitHeadOutput.trim()
-			? parseNpmJsonOutput(
-					gitHeadOutput,
-					`${ name }@${ version } gitHead`
-			  )
-			: null;
 		if ( registryGitHead !== publishCommit ) {
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry with gitHead ${
@@ -753,17 +745,6 @@ async function runNpmPublishPreflight(
 			);
 		}
 
-		const { stdout: distTagsOutput } = await commandFn(
-			`npm view ${ name } dist-tags --json`,
-			{
-				cwd: gitWorkingDirectoryPath,
-				stdio: 'pipe',
-			}
-		);
-		const distTags = parseNpmJsonOutput(
-			distTagsOutput,
-			`${ name } dist-tags`
-		);
 		if ( distTags[ distTag ] !== version ) {
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -27,7 +27,7 @@ const {
 } = require( './common' );
 const pluginConfig = require( '../config' );
 
-const NPM_RELEASE_GIT_PUSH_ATTEMPTS = 3;
+const NPM_RELEASE_PHASE_ATTEMPTS = 3;
 // Keep tag pushes small enough that GitHub ruleset validation handles each phase predictably.
 const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
 
@@ -480,14 +480,14 @@ function getNpmReleaseGitRecoveryCommands( {
 }
 
 /**
- * Runs a release metadata push phase with retry.
+ * Runs a release phase with retry.
  *
  * @param {string}   label     Phase label.
  * @param {Function} task      Task to retry.
  * @param {Object}   deps      Dependencies.
  * @param {Function} deps.wait Wait function.
  */
-async function runNpmReleaseGitPushPhase( label, task, deps = {} ) {
+async function runNpmReleasePhase( label, task, deps = {} ) {
 	const {
 		wait = ( delay ) =>
 			new Promise( ( resolve ) => setTimeout( resolve, delay ) ),
@@ -497,11 +497,11 @@ async function runNpmReleaseGitPushPhase( label, task, deps = {} ) {
 			await task();
 			return;
 		} catch ( err ) {
-			if ( attempt >= NPM_RELEASE_GIT_PUSH_ATTEMPTS ) {
+			if ( attempt >= NPM_RELEASE_PHASE_ATTEMPTS ) {
 				throw err;
 			}
 			log(
-				`>> ${ label } failed (attempt ${ attempt }/${ NPM_RELEASE_GIT_PUSH_ATTEMPTS }): ${
+				`>> ${ label } failed (attempt ${ attempt }/${ NPM_RELEASE_PHASE_ATTEMPTS }): ${
 					err.message
 				}, retrying in ${ attempt * 5 }s...`
 			);
@@ -749,7 +749,7 @@ async function runNpmPublishPreflight(
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${
 					distTags[ distTag ] || 'nothing'
-				}.`
+				}. This release is no longer retryable because the dist-tag has moved.`
 			);
 		}
 		publishedPackageNames.push( name );
@@ -777,7 +777,7 @@ async function pushNpmReleaseGitMetadata(
 ) {
 	const {
 		git = SimpleGit( gitWorkingDirectoryPath ),
-		runPhase = runNpmReleaseGitPushPhase,
+		runPhase = runNpmReleasePhase,
 		verifyRemoteNpmReleaseBranchFn = verifyRemoteNpmReleaseBranch,
 		verifyRemotePackageTagsFn = verifyRemotePackageTags,
 	} = deps;
@@ -848,6 +848,7 @@ async function pushNpmReleaseGitMetadata(
  * @param {Function} deps.getNpmReleasePackagesFn     Gets release package metadata.
  * @param {Function} deps.pushNpmReleaseGitMetadataFn Pushes Git metadata.
  * @param {Function} deps.runNpmPublishPreflightFn    Runs npm preflight.
+ * @param {Function} deps.runPhase                    Runs a retryable phase.
  */
 async function publishVersionedPackagesToNpm(
 	{
@@ -865,6 +866,7 @@ async function publishVersionedPackagesToNpm(
 		getNpmReleasePackagesFn = getNpmReleasePackages,
 		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
 		runNpmPublishPreflightFn = runNpmPublishPreflight,
+		runPhase = runNpmReleasePhase,
 	} = deps;
 	const releasePackages = await getNpmReleasePackagesFn(
 		gitWorkingDirectoryPath
@@ -905,19 +907,21 @@ async function publishVersionedPackagesToNpm(
 
 	// Lerna treats publish conflicts as successful "already published" results,
 	// so verify registry identity again before attaching Git metadata.
-	const finalPublishedPackageNames = new Set(
-		await getPublishedPackageNames()
-	);
-	const unpublishedPackageVersions = releasePackages
-		.filter( ( { name } ) => ! finalPublishedPackageNames.has( name ) )
-		.map( ( { name, version } ) => `${ name }@${ version }` );
-	if ( unpublishedPackageVersions.length ) {
-		throw new Error(
-			`npm publication verification failed for ${ unpublishedPackageVersions.join(
-				', '
-			) }.`
+	await runPhase( 'npm publication verification', async () => {
+		const finalPublishedPackageNames = new Set(
+			await getPublishedPackageNames()
 		);
-	}
+		const unpublishedPackageVersions = releasePackages
+			.filter( ( { name } ) => ! finalPublishedPackageNames.has( name ) )
+			.map( ( { name, version } ) => `${ name }@${ version }` );
+		if ( unpublishedPackageVersions.length ) {
+			throw new Error(
+				`npm publication verification failed for ${ unpublishedPackageVersions.join(
+					', '
+				) }.`
+			);
+		}
+	} );
 
 	await pushNpmReleaseGitMetadataFn( {
 		gitWorkingDirectoryPath,
@@ -1250,6 +1254,6 @@ module.exports = {
 	publishNpmBugfixWordPressCore,
 	publishNpmNext,
 	runNpmPublishPreflight,
-	runNpmReleaseGitPushPhase,
+	runNpmReleasePhase,
 	verifyRemotePackageTags,
 };

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -739,10 +739,12 @@ async function runNpmPublishPreflight(
 				stdio: 'pipe',
 			}
 		);
-		const registryGitHead = parseNpmJsonOutput(
-			gitHeadOutput,
-			`${ name }@${ version } gitHead`
-		);
+		const registryGitHead = gitHeadOutput.trim()
+			? parseNpmJsonOutput(
+					gitHeadOutput,
+					`${ name }@${ version } gitHead`
+			  )
+			: null;
 		if ( registryGitHead !== publishCommit ) {
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry with gitHead ${

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -749,7 +749,7 @@ async function runNpmPublishPreflight(
 			throw new Error(
 				`${ name }@${ version } exists in the npm registry, but dist-tag "${ distTag }" points to ${
 					distTags[ distTag ] || 'nothing'
-				}. This release is no longer retryable because the dist-tag has moved.`
+				}. If another release moved the dist-tag, this prepared release is not safe to resume.`
 			);
 		}
 		publishedPackageNames.push( name );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -348,7 +348,7 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).rejects.toThrow(
-			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0. This release is no longer retryable because the dist-tag has moved.'
+			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0. If another release moved the dist-tag, this prepared release is not safe to resume.'
 		);
 		expect( console ).toHaveLogged();
 	} );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -299,6 +299,31 @@ describe( 'runNpmPublishPreflight', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'fails with an actionable error when a published version has no gitHead', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'@wordpress/a11y@4.50.0 exists in the npm registry with gitHead nothing, expected publish-sha.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
 	it( 'fails when a published version has the wrong dist-tag', async () => {
 		const commandFn = jest
 			.fn()

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -223,15 +223,19 @@ describe( 'runNpmPublishPreflight', () => {
 				stderr: 'npm ERR! code E404',
 			} );
 
-		await runNpmPublishPreflight(
-			{
-				gitWorkingDirectoryPath: '/repo',
-				releasePackages: [
-					{ name: '@wordpress/a11y', version: '4.50.0' },
-				],
-			},
-			{ commandFn }
-		);
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).resolves.toEqual( [] );
 
 		expect( commandFn ).toHaveBeenNthCalledWith(
 			1,
@@ -246,13 +250,43 @@ describe( 'runNpmPublishPreflight', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'fails when a target package version already exists', async () => {
-		const commandFn = jest.fn().mockResolvedValue();
+	it( 'accepts a published version from the prepared commit with the expected dist-tag', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '"publish-sha"' } )
+			.mockResolvedValueOnce( { stdout: '{"latest":"4.50.0"}' } );
 
 		await expect(
 			runNpmPublishPreflight(
 				{
+					distTag: 'latest',
 					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).resolves.toEqual( [ '@wordpress/a11y' ] );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when a published version came from another commit', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '"other-sha"' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
 					releasePackages: [
 						{ name: '@wordpress/a11y', version: '4.50.0' },
 					],
@@ -260,7 +294,57 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).rejects.toThrow(
-			'@wordpress/a11y@4.50.0 already exists in the npm registry.'
+			'@wordpress/a11y@4.50.0 exists in the npm registry with gitHead other-sha, expected publish-sha.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when a published version has the wrong dist-tag', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
+			.mockResolvedValueOnce( { stdout: '"publish-sha"' } )
+			.mockResolvedValueOnce( { stdout: '{"latest":"4.49.0"}' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0.'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when the registry returns a different version', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( { stdout: '"4.49.0"' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'Expected npm registry lookup for @wordpress/a11y@4.50.0 to return version 4.50.0, got 4.49.0.'
 		);
 		expect( console ).toHaveLogged();
 	} );
@@ -351,7 +435,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			.mockResolvedValue( [
 				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
 			] );
-		const runNpmPublishPreflightFn = jest.fn();
+		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
 		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const git = {
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
@@ -376,13 +460,15 @@ describe( 'publishVersionedPackagesToNpm', () => {
 
 		expect( getNpmReleasePackagesFn ).toHaveBeenCalledWith( '/repo' );
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			distTag: 'latest',
 			gitWorkingDirectoryPath: '/repo',
+			publishCommit: 'publish-sha',
 			releasePackages: [
 				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
 			],
 		} );
 		expect( commandFn ).toHaveBeenCalledWith(
-			'npx lerna publish from-package --dist-tag latest --yes --no-verify-access',
+			'npx lerna publish from-package --dist-tag latest --git-head publish-sha --yes --no-verify-access',
 			{ cwd: '/repo', stdio: 'inherit' }
 		);
 		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
@@ -394,11 +480,15 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'resets temporary manifest changes before retrying from-package', async () => {
+	it( 'rechecks registry state before retrying from-package', async () => {
 		const commandFn = jest
 			.fn()
 			.mockRejectedValueOnce( new Error( 'partial publish' ) )
 			.mockResolvedValueOnce();
+		const runNpmPublishPreflightFn = jest
+			.fn()
+			.mockResolvedValueOnce( [] )
+			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
 		const git = {
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 			reset: jest.fn(),
@@ -414,25 +504,62 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest
-					.fn()
-					.mockResolvedValue( [
-						{ tagName: '@wordpress/a11y@4.50.0-next.0' },
-					] ),
+				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+					{
+						name: '@wordpress/a11y',
+						tagName: '@wordpress/a11y@4.50.0-next.0',
+					},
+					{
+						name: '@wordpress/blocks',
+						tagName: '@wordpress/blocks@14.20.0-next.0',
+					},
+				] ),
 				git,
 				pushNpmReleaseGitMetadataFn: jest.fn(),
-				runNpmPublishPreflightFn: jest.fn(),
+				runNpmPublishPreflightFn,
 			}
 		);
 
 		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 2 );
 		expect( git.reset ).toHaveBeenCalledWith( 'hard' );
-		expect( commandFn.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
-			git.reset.mock.invocationCallOrder[ 0 ]
-		);
 		expect( git.reset.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
-			commandFn.mock.invocationCallOrder[ 1 ]
+			runNpmPublishPreflightFn.mock.invocationCallOrder[ 1 ]
 		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips Lerna when all package versions are already published', async () => {
+		const commandFn = jest.fn();
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/latest',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+					{
+						name: '@wordpress/a11y',
+						tagName: '@wordpress/a11y@4.50.0',
+					},
+				] ),
+				git,
+				pushNpmReleaseGitMetadataFn: jest.fn(),
+				runNpmPublishPreflightFn: jest
+					.fn()
+					.mockResolvedValue( [ '@wordpress/a11y' ] ),
+			}
+		);
+
+		expect( commandFn ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
 } );
@@ -509,6 +636,11 @@ describe( 'publishPackagesToNpm', () => {
 						command.includes( '--no-push' )
 				)
 			).toBe( true );
+			expect(
+				commandFn.mock.calls.some( ( [ command ] ) =>
+					command.includes( '--build-metadata' )
+				)
+			).toBe( false );
 			expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
 				distTag,
 				gitWorkingDirectoryPath: '/repo',

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -244,7 +244,7 @@ describe( 'runNpmPublishPreflight', () => {
 		);
 		expect( commandFn ).toHaveBeenNthCalledWith(
 			2,
-			'npm view @wordpress/a11y@4.50.0 version --json',
+			'npm view @wordpress/a11y@4.50.0 version gitHead dist-tags --json',
 			{ cwd: '/repo', stdio: 'pipe' }
 		);
 		expect( console ).toHaveLogged();
@@ -254,9 +254,9 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce()
-			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
-			.mockResolvedValueOnce( { stdout: '"publish-sha"' } )
-			.mockResolvedValueOnce( { stdout: '{"latest":"4.50.0"}' } );
+			.mockResolvedValueOnce( {
+				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.50.0"}}',
+			} );
 
 		await expect(
 			runNpmPublishPreflight(
@@ -271,6 +271,7 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).resolves.toEqual( [ '@wordpress/a11y' ] );
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -278,8 +279,9 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce()
-			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
-			.mockResolvedValueOnce( { stdout: '"other-sha"' } );
+			.mockResolvedValueOnce( {
+				stdout: '{"version":"4.50.0","gitHead":"other-sha","dist-tags":{"latest":"4.50.0"}}',
+			} );
 
 		await expect(
 			runNpmPublishPreflight(
@@ -303,8 +305,9 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce()
-			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
-			.mockResolvedValueOnce( { stdout: '' } );
+			.mockResolvedValueOnce( {
+				stdout: '{"version":"4.50.0","dist-tags":{"latest":"4.50.0"}}',
+			} );
 
 		await expect(
 			runNpmPublishPreflight(
@@ -328,9 +331,9 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce()
-			.mockResolvedValueOnce( { stdout: '"4.50.0"' } )
-			.mockResolvedValueOnce( { stdout: '"publish-sha"' } )
-			.mockResolvedValueOnce( { stdout: '{"latest":"4.49.0"}' } );
+			.mockResolvedValueOnce( {
+				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
+			} );
 
 		await expect(
 			runNpmPublishPreflight(
@@ -354,7 +357,9 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce()
-			.mockResolvedValueOnce( { stdout: '"4.49.0"' } );
+			.mockResolvedValueOnce( {
+				stdout: '{"version":"4.49.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
+			} );
 
 		await expect(
 			runNpmPublishPreflight(

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -12,7 +12,7 @@ import {
 	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	runNpmPublishPreflight,
-	runNpmReleaseGitPushPhase,
+	runNpmReleasePhase,
 	verifyRemotePackageTags,
 } from '../packages';
 
@@ -348,7 +348,7 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).rejects.toThrow(
-			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0.'
+			'@wordpress/a11y@4.50.0 exists in the npm registry, but dist-tag "latest" points to 4.49.0. This release is no longer retryable because the dist-tag has moved.'
 		);
 		expect( console ).toHaveLogged();
 	} );
@@ -380,7 +380,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 } );
 
-describe( 'runNpmReleaseGitPushPhase', () => {
+describe( 'runNpmReleasePhase', () => {
 	it( 'retries a failed phase before surfacing success', async () => {
 		const task = jest
 			.fn()
@@ -388,7 +388,7 @@ describe( 'runNpmReleaseGitPushPhase', () => {
 			.mockResolvedValueOnce();
 		const wait = jest.fn();
 
-		await runNpmReleaseGitPushPhase( 'Package tag push', task, { wait } );
+		await runNpmReleasePhase( 'Package tag push', task, { wait } );
 
 		expect( task ).toHaveBeenCalledTimes( 2 );
 		expect( wait ).toHaveBeenCalledWith( 5000 );
@@ -609,6 +609,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		const commandFn = jest.fn().mockResolvedValue();
 		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
+		const runPhase = jest.fn( async ( _label, task ) => task() );
 		const git = {
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 		};
@@ -634,6 +635,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 					git,
 					pushNpmReleaseGitMetadataFn,
 					runNpmPublishPreflightFn,
+					runPhase,
 				}
 			)
 		).rejects.toThrow(
@@ -641,7 +643,56 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 2 );
+		expect( runPhase ).toHaveBeenCalledWith(
+			'npm publication verification',
+			expect.any( Function )
+		);
 		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'retries final registry verification after propagation lag', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const runNpmPublishPreflightFn = jest
+			.fn()
+			.mockResolvedValueOnce( [] )
+			.mockResolvedValueOnce( [] )
+			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
+		const wait = jest.fn();
+		const runPhase = ( label, task ) =>
+			runNpmReleasePhase( label, task, { wait } );
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await publishVersionedPackagesToNpm(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				npmReleaseBranch: 'wp/latest',
+				yesFlag: '--yes',
+			},
+			{
+				commandFn,
+				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+					{
+						name: '@wordpress/a11y',
+						tagName: '@wordpress/a11y@4.50.0',
+						version: '4.50.0',
+					},
+				] ),
+				git,
+				pushNpmReleaseGitMetadataFn,
+				runNpmPublishPreflightFn,
+				runPhase,
+			}
+		);
+
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 3 );
+		expect( wait ).toHaveBeenCalledWith( 5000 );
+		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -460,7 +460,10 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			.mockResolvedValue( [
 				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
 			] );
-		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
+		const runNpmPublishPreflightFn = jest
+			.fn()
+			.mockResolvedValueOnce( [] )
+			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
 		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const git = {
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
@@ -502,6 +505,11 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			packageTags: [ '@wordpress/a11y@4.50.0' ],
 			publishCommit: 'publish-sha',
 		} );
+		expect(
+			runNpmPublishPreflightFn.mock.invocationCallOrder[ 1 ]
+		).toBeLessThan(
+			pushNpmReleaseGitMetadataFn.mock.invocationCallOrder[ 0 ]
+		);
 		expect( console ).toHaveLogged();
 	} );
 
@@ -513,7 +521,11 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		const runNpmPublishPreflightFn = jest
 			.fn()
 			.mockResolvedValueOnce( [] )
-			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
+			.mockResolvedValueOnce( [ '@wordpress/a11y' ] )
+			.mockResolvedValueOnce( [
+				'@wordpress/a11y',
+				'@wordpress/blocks',
+			] );
 		const git = {
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 			reset: jest.fn(),
@@ -546,7 +558,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 
 		expect( commandFn ).toHaveBeenCalledTimes( 2 );
-		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 2 );
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 3 );
 		expect( git.reset ).toHaveBeenCalledWith( 'hard' );
 		expect( git.reset.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
 			runNpmPublishPreflightFn.mock.invocationCallOrder[ 1 ]
@@ -585,6 +597,46 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		);
 
 		expect( commandFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'does not push metadata when final registry verification is incomplete', async () => {
+		const commandFn = jest.fn().mockResolvedValue();
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
+		const git = {
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await expect(
+			publishVersionedPackagesToNpm(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					noVerifyAccessFlag: '--no-verify-access',
+					npmReleaseBranch: 'wp/latest',
+					yesFlag: '--yes',
+				},
+				{
+					commandFn,
+					getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+						{
+							name: '@wordpress/a11y',
+							tagName: '@wordpress/a11y@4.50.0',
+							version: '4.50.0',
+						},
+					] ),
+					git,
+					pushNpmReleaseGitMetadataFn,
+					runNpmPublishPreflightFn,
+				}
+			)
+		).rejects.toThrow(
+			'npm publication verification failed for @wordpress/a11y@4.50.0.'
+		);
+
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 2 );
+		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
 } );


### PR DESCRIPTION
Extracted from #79906. Builds on #79905. Prerequisite for #80190.

## What?

Makes the npm publication step safe to retry from the same prepared release commit after a partial registry publication.

This PR does not make a fresh release command resumable; #80190 and following stacked PRs add that durable orchestration.

## Why?

A retry can encounter versions already published by the first attempt. npm strips SemVer build metadata, and Lerna can treat publish conflicts as successful “already published” results, so the release must verify that existing registry entries belong to the prepared release commit before treating them as complete.

## How?

- Validates existing versions against the expected version, release commit (`gitHead`), and dist-tag.
- Skips Lerna when every target version is already correct and rechecks registry state before retrying.
- Verifies every target again after Lerna exits, with bounded retries for registry propagation lag, before any Git metadata is pushed.
- Passes the release commit explicitly through `--git-head`.
- Removes redundant build metadata from timestamped `next` versions so local and registry versions match exactly.

## Testing Instructions

```sh
npm run test:unit -- tools/release/commands/test/packages.js --runInBand
npm run lint:js -- tools/release/commands/packages.js tools/release/commands/test/packages.js
npm run build
```

### Testing Instructions for Keyboard

Not applicable; this does not change UI.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement, test, and adversarially review this change.
