### PR TITLE
Release: Extract npm release lifecycle

### DIFF
--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -1020,6 +1020,80 @@ async function publishPackagesToNpm(
 }
 
 /**
+ * Prepares the npm release branch and changelog updates.
+ *
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
+ *
+ * @return {Promise<Object>} Release state needed by finalization.
+ */
+async function prepareNpmRelease( config, deps = {} ) {
+	const {
+		checkoutNpmReleaseBranchFn = checkoutNpmReleaseBranch,
+		findPluginReleaseBranchNameFn = findPluginReleaseBranchName,
+		runNpmReleaseBranchSyncStepFn = runNpmReleaseBranchSyncStep,
+		updatePackagesFn = updatePackages,
+	} = deps;
+	let pluginReleaseBranch;
+	if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
+		pluginReleaseBranch =
+			config.releaseType === 'next'
+				? 'trunk'
+				: await findPluginReleaseBranchNameFn(
+						config.gitWorkingDirectoryPath
+				  );
+		await runNpmReleaseBranchSyncStepFn( pluginReleaseBranch, config );
+	} else {
+		await checkoutNpmReleaseBranchFn( config );
+	}
+
+	return {
+		changelogCommit: await updatePackagesFn( config ),
+		pluginReleaseBranch,
+	};
+}
+
+/**
+ * Publishes the packages prepared in the current checkout.
+ *
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
+ *
+ * @return {Promise<?string>} The npm version commit hash.
+ */
+async function publishPreparedPackagesToNpm( config, deps = {} ) {
+	const { publishPackagesToNpmFn = publishPackagesToNpm } = deps;
+	return publishPackagesToNpmFn( config );
+}
+
+/**
+ * Backports the prepared release commits after publication.
+ *
+ * @param {WPPackagesConfig} config                           Command config.
+ * @param {Object}           releaseState                     Prepared release state.
+ * @param {?string}          releaseState.changelogCommit     Changelog commit.
+ * @param {?string}          releaseState.pluginReleaseBranch Plugin release branch.
+ * @param {?string}          releaseState.publishCommit       Version commit.
+ * @param {Object}           deps                             Dependencies.
+ */
+async function finalizePreparedNpmRelease(
+	config,
+	{ changelogCommit, pluginReleaseBranch, publishCommit },
+	deps = {}
+) {
+	const { backportCommitsToBranchFn = backportCommitsToBranch } = deps;
+	if ( ! [ 'latest', 'bugfix' ].includes( config.releaseType ) ) {
+		return;
+	}
+
+	const commits = [ changelogCommit, publishCommit ].filter( Boolean );
+	await backportCommitsToBranchFn( 'trunk', commits, config );
+	if ( config.releaseType === 'latest' && pluginReleaseBranch ) {
+		await backportCommitsToBranchFn( pluginReleaseBranch, commits, config );
+	}
+}
+
+/**
  * Backports commits from the release branch to the selected branch.
  *
  * @param {string}           branchName Selected branch name.
@@ -1071,10 +1145,16 @@ async function backportCommitsToBranch(
  *
  * @param {WPPackagesConfig} config         Command config.
  * @param {string[]}         customMessages Custom messages to print in the terminal.
+ * @param {Object}           deps           Dependencies.
  *
- * @return {Promise<Object>} GitHub release object.
+ * @return {Promise<void>}
  */
-async function runPackagesRelease( config, customMessages ) {
+async function runPackagesRelease( config, customMessages, deps = {} ) {
+	const {
+		finalizePreparedNpmReleaseFn = finalizePreparedNpmRelease,
+		prepareNpmReleaseFn = prepareNpmRelease,
+		publishPreparedPackagesToNpmFn = publishPreparedPackagesToNpm,
+	} = deps;
 	log(
 		formats.title(
 			'\n💃 Time to publish WordPress packages to npm 🕺\n\n'
@@ -1109,38 +1189,9 @@ async function runPackagesRelease( config, customMessages ) {
 		);
 	}
 
-	let pluginReleaseBranch;
-	if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
-		pluginReleaseBranch =
-			config.releaseType === 'next'
-				? 'trunk'
-				: await findPluginReleaseBranchName(
-						config.gitWorkingDirectoryPath
-				  );
-		await runNpmReleaseBranchSyncStep( pluginReleaseBranch, config );
-	} else {
-		await checkoutNpmReleaseBranch( config );
-	}
-
-	const commitHashChangelogUpdates = await updatePackages( config );
-
-	const commitHashNpmPublish = await publishPackagesToNpm( config );
-
-	if ( [ 'latest', 'bugfix' ].includes( config.releaseType ) ) {
-		const commits = [
-			commitHashChangelogUpdates,
-			commitHashNpmPublish,
-		].filter( Boolean );
-		await backportCommitsToBranch( 'trunk', commits, config );
-
-		if ( config.releaseType === 'latest' && pluginReleaseBranch ) {
-			await backportCommitsToBranch(
-				pluginReleaseBranch,
-				commits,
-				config
-			);
-		}
-	}
+	const releaseState = await prepareNpmReleaseFn( config );
+	releaseState.publishCommit = await publishPreparedPackagesToNpmFn( config );
+	await finalizePreparedNpmReleaseFn( config, releaseState );
 
 	await runStep(
 		'Cleaning the temporary folders',
@@ -1240,13 +1291,16 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
 	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	prepareNpmRelease,
 	publishPackagesToNpm,
+	publishPreparedPackagesToNpm,
 	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	publishNpmGutenbergPlugin,
@@ -1255,5 +1309,6 @@ module.exports = {
 	publishNpmNext,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
+	runPackagesRelease,
 	verifyRemotePackageTags,
 };

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -20,61 +20,87 @@ import {
 } from '../packages';
 
 describe( 'prepareNpmRelease', () => {
-	it( 'prepares the release branch and returns finalization state', async () => {
-		const config = {
-			gitWorkingDirectoryPath: '/repo',
-			releaseType: 'latest',
-		};
-		const runNpmReleaseBranchSyncStepFn = jest.fn();
+	it.each( [
+		[ 'latest', 'release/23.5' ],
+		[ 'next', 'trunk' ],
+		[ 'bugfix', undefined ],
+		[ 'wp', undefined ],
+	] )(
+		'prepares a %s release',
+		async ( releaseType, expectedPluginReleaseBranch ) => {
+			const config = {
+				gitWorkingDirectoryPath: '/repo',
+				releaseType,
+			};
+			const checkoutNpmReleaseBranchFn = jest.fn();
+			const findPluginReleaseBranchNameFn = jest
+				.fn()
+				.mockResolvedValue( 'release/23.5' );
+			const runNpmReleaseBranchSyncStepFn = jest.fn();
+			const updatePackagesFn = jest
+				.fn()
+				.mockResolvedValue( 'changelog-sha' );
 
-		await expect(
-			prepareNpmRelease( config, {
-				findPluginReleaseBranchNameFn: jest
-					.fn()
-					.mockResolvedValue( 'release/23.5' ),
-				runNpmReleaseBranchSyncStepFn,
-				updatePackagesFn: jest
-					.fn()
-					.mockResolvedValue( 'changelog-sha' ),
-			} )
-		).resolves.toEqual( {
-			changelogCommit: 'changelog-sha',
-			pluginReleaseBranch: 'release/23.5',
-		} );
-		expect( runNpmReleaseBranchSyncStepFn ).toHaveBeenCalledWith(
-			'release/23.5',
-			config
-		);
-	} );
+			await expect(
+				prepareNpmRelease( config, {
+					checkoutNpmReleaseBranchFn,
+					findPluginReleaseBranchNameFn,
+					runNpmReleaseBranchSyncStepFn,
+					updatePackagesFn,
+				} )
+			).resolves.toEqual( {
+				changelogCommit: 'changelog-sha',
+				pluginReleaseBranch: expectedPluginReleaseBranch,
+			} );
+			expect( findPluginReleaseBranchNameFn.mock.calls ).toEqual(
+				releaseType === 'latest' ? [ [ '/repo' ] ] : []
+			);
+			expect( checkoutNpmReleaseBranchFn.mock.calls ).toEqual(
+				[ 'bugfix', 'wp' ].includes( releaseType ) ? [ [ config ] ] : []
+			);
+			expect( runNpmReleaseBranchSyncStepFn.mock.calls ).toEqual(
+				expectedPluginReleaseBranch
+					? [ [ expectedPluginReleaseBranch, config ] ]
+					: []
+			);
+			expect( updatePackagesFn ).toHaveBeenCalledTimes( 1 );
+			expect( updatePackagesFn ).toHaveBeenCalledWith( config );
+		}
+	);
 } );
 
 describe( 'finalizePreparedNpmRelease', () => {
-	it( 'backports the prepared commits to stable branches', async () => {
-		const config = { releaseType: 'latest' };
-		const backportCommitsToBranchFn = jest.fn();
-		const commits = [ 'changelog-sha', 'publish-sha' ];
+	it.each( [
+		[ 'latest', 'release/23.5', [ 'trunk', 'release/23.5' ] ],
+		[ 'bugfix', undefined, [ 'trunk' ] ],
+		[ 'next', undefined, [] ],
+		[ 'wp', undefined, [] ],
+	] )(
+		'finalizes a %s release',
+		async ( releaseType, pluginReleaseBranch, expectedBranches ) => {
+			const config = { releaseType };
+			const backportCommitsToBranchFn = jest.fn();
+			const commits = [ 'changelog-sha', 'publish-sha' ];
 
-		await finalizePreparedNpmRelease(
-			config,
-			{
-				changelogCommit: commits[ 0 ],
-				pluginReleaseBranch: 'release/23.5',
-				publishCommit: commits[ 1 ],
-			},
-			{ backportCommitsToBranchFn }
-		);
+			await finalizePreparedNpmRelease(
+				config,
+				{
+					changelogCommit: commits[ 0 ],
+					pluginReleaseBranch,
+					publishCommit: commits[ 1 ],
+				},
+				{ backportCommitsToBranchFn }
+			);
 
-		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
-			'trunk',
-			commits,
-			config
-		);
-		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
-			'release/23.5',
-			commits,
-			config
-		);
-	} );
+			expect( backportCommitsToBranchFn.mock.calls ).toEqual(
+				expectedBranches.map( ( branch ) => [
+					branch,
+					commits,
+					config,
+				] )
+			);
+		}
+	);
 } );
 
 describe( 'runPackagesRelease', () => {
@@ -96,10 +122,25 @@ describe( 'runPackagesRelease', () => {
 			publishPreparedPackagesToNpmFn,
 		} );
 
+		expect( prepareNpmReleaseFn ).toHaveBeenCalledTimes( 1 );
+		expect( prepareNpmReleaseFn ).toHaveBeenCalledWith( config );
+		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledTimes( 1 );
+		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledWith( config );
+		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledTimes( 1 );
 		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledWith( config, {
 			changelogCommit: 'changelog-sha',
 			publishCommit: 'publish-sha',
 		} );
+		expect(
+			prepareNpmReleaseFn.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan(
+			publishPreparedPackagesToNpmFn.mock.invocationCallOrder[ 0 ]
+		);
+		expect(
+			publishPreparedPackagesToNpmFn.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan(
+			finalizePreparedNpmReleaseFn.mock.invocationCallOrder[ 0 ]
+		);
 		expect( console ).toHaveLogged();
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -2,19 +2,107 @@
  * Internal dependencies
  */
 import {
+	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
 	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	prepareNpmRelease,
 	publishPackagesToNpm,
 	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
+	runPackagesRelease,
 	verifyRemotePackageTags,
 } from '../packages';
+
+describe( 'prepareNpmRelease', () => {
+	it( 'prepares the release branch and returns finalization state', async () => {
+		const config = {
+			gitWorkingDirectoryPath: '/repo',
+			releaseType: 'latest',
+		};
+		const runNpmReleaseBranchSyncStepFn = jest.fn();
+
+		await expect(
+			prepareNpmRelease( config, {
+				findPluginReleaseBranchNameFn: jest
+					.fn()
+					.mockResolvedValue( 'release/23.5' ),
+				runNpmReleaseBranchSyncStepFn,
+				updatePackagesFn: jest
+					.fn()
+					.mockResolvedValue( 'changelog-sha' ),
+			} )
+		).resolves.toEqual( {
+			changelogCommit: 'changelog-sha',
+			pluginReleaseBranch: 'release/23.5',
+		} );
+		expect( runNpmReleaseBranchSyncStepFn ).toHaveBeenCalledWith(
+			'release/23.5',
+			config
+		);
+	} );
+} );
+
+describe( 'finalizePreparedNpmRelease', () => {
+	it( 'backports the prepared commits to stable branches', async () => {
+		const config = { releaseType: 'latest' };
+		const backportCommitsToBranchFn = jest.fn();
+		const commits = [ 'changelog-sha', 'publish-sha' ];
+
+		await finalizePreparedNpmRelease(
+			config,
+			{
+				changelogCommit: commits[ 0 ],
+				pluginReleaseBranch: 'release/23.5',
+				publishCommit: commits[ 1 ],
+			},
+			{ backportCommitsToBranchFn }
+		);
+
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
+			'trunk',
+			commits,
+			config
+		);
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
+			'release/23.5',
+			commits,
+			config
+		);
+	} );
+} );
+
+describe( 'runPackagesRelease', () => {
+	it( 'runs the release lifecycle in order', async () => {
+		const config = {
+			gitWorkingDirectoryPath: '/repo',
+			interactive: false,
+		};
+		const releaseState = { changelogCommit: 'changelog-sha' };
+		const prepareNpmReleaseFn = jest.fn().mockResolvedValue( releaseState );
+		const publishPreparedPackagesToNpmFn = jest
+			.fn()
+			.mockResolvedValue( 'publish-sha' );
+		const finalizePreparedNpmReleaseFn = jest.fn();
+
+		await runPackagesRelease( config, [], {
+			finalizePreparedNpmReleaseFn,
+			prepareNpmReleaseFn,
+			publishPreparedPackagesToNpmFn,
+		} );
+
+		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledWith( config, {
+			changelogCommit: 'changelog-sha',
+			publishCommit: 'publish-sha',
+		} );
+		expect( console ).toHaveLogged();
+	} );
+} );
 
 describe( 'getNpmReleasePackages', () => {
 	it( 'returns public packages tagged at HEAD', async () => {


### PR DESCRIPTION
Follow-up to #80187.

## What?

Extracts the npm release workflow into explicit prepare, publish, and finalize lifecycle functions without changing its behavior.

## Why?

This isolates the structural refactor from the durable recovery and CLI orchestration changes in follow-up PRs.

## How?

- Moves branch synchronization and changelog updates into `prepareNpmRelease`.
- Keeps npm publishing behind `publishPreparedPackagesToNpm`.
- Moves backports into `finalizePreparedNpmRelease`.
- Runs all three steps sequentially through the existing commands.

## Testing Instructions

```sh
npm run test:unit -- tools/release/commands/test/packages.js --runInBand
npm run lint:js -- tools/release/commands/packages.js tools/release/commands/test/packages.js
npm run build
```

### Testing Instructions for Keyboard

Not applicable; this changes release tooling only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to help split and verify the implementation and draft this description. I reviewed the resulting changes.
