### PR TITLE
Editor: Render post preview action as a menu item

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   Render the "Preview in new tab" action with the shared menu item pattern so its typography matches sibling menu items ([#80195](https://github.com/WordPress/gutenberg/pull/80195)).
 -   External images are now sideloaded on the server when uploaded to the media library, via a new `mediaSideloadFromUrl` block editor setting, so the upload works when the editor is cross-origin isolated (e.g. with client-side media processing enabled) ([#79409](https://github.com/WordPress/gutenberg/pull/79409)).
 
 ### Enhancements

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -167,7 +167,7 @@ async function writeInterstitialIntoPreviewWindow( previewWindow ) {
 	}
 }
 
-function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
+function usePostPreview( { forceIsAutosaveable, onPreview } ) {
 	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
 		useSelect( ( select ) => {
 			const editor = select( editorStore );
@@ -198,11 +198,11 @@ function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
 
 	const targetId = `wp-preview-${ postId }`;
 
-	const openPreviewWindow = async ( event ) => {
-		// Our Preview button has its 'href' and 'target' set correctly for a11y
-		// purposes. Unfortunately, though, we can't rely on the default 'click'
-		// handler since sometimes it incorrectly opens a new tab instead of reusing
-		// the existing one.
+	const handlePreviewClick = async ( event ) => {
+		// Preserve native link semantics with `href` and `target`, but intercept the
+		// click because the final preview URL may depend on an asynchronous save.
+		// Opening the named window synchronously also prevents popup blocking and
+		// ensures subsequent previews reuse the same tab.
 		// https://github.com/WordPress/gutenberg/pull/8330
 		event.preventDefault();
 
@@ -230,10 +230,9 @@ function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
 
 	return {
 		href,
-		target: targetId,
-		accessibleWhenDisabled: true,
-		disabled: ! isSaveable,
-		onClick: openPreviewWindow,
+		handlePreviewClick,
+		isSaveable,
+		targetId,
 	};
 }
 
@@ -247,17 +246,25 @@ function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
  * @return {React.ReactNode} The rendered menu item.
  */
 export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
-	const previewProps = usePostPreviewProps( {
+	const preview = usePostPreview( {
 		forceIsAutosaveable,
 		onPreview,
 	} );
 
-	if ( ! previewProps ) {
+	if ( ! preview ) {
 		return null;
 	}
 
+	const { handlePreviewClick, href, isSaveable, targetId } = preview;
+
 	return (
-		<MenuItem icon={ external } { ...previewProps }>
+		<MenuItem
+			href={ href }
+			target={ targetId }
+			disabled={ ! isSaveable }
+			onClick={ handlePreviewClick }
+			icon={ external }
+		>
 			{ __( 'Preview in new tab' ) }
 		</MenuItem>
 	);
@@ -285,14 +292,16 @@ export default function PostPreviewButton( {
 	role,
 	onPreview,
 } ) {
-	const previewProps = usePostPreviewProps( {
+	const preview = usePostPreview( {
 		forceIsAutosaveable,
 		onPreview,
 	} );
 
-	if ( ! previewProps ) {
+	if ( ! preview ) {
 		return null;
 	}
+
+	const { handlePreviewClick, href, isSaveable, targetId } = preview;
 
 	return (
 		<Button
@@ -300,7 +309,11 @@ export default function PostPreviewButton( {
 			className={ className || 'editor-post-preview' }
 			role={ role }
 			size="compact"
-			{ ...previewProps }
+			href={ href }
+			target={ targetId }
+			accessibleWhenDisabled
+			disabled={ ! isSaveable }
+			onClick={ handlePreviewClick }
 		>
 			{ textContent || (
 				<>

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -167,7 +167,7 @@ async function writeInterstitialIntoPreviewWindow( previewWindow ) {
 	}
 }
 
-function usePostPreview( { forceIsAutosaveable, onPreview } ) {
+function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
 	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
 		useSelect( ( select ) => {
 			const editor = select( editorStore );
@@ -196,7 +196,7 @@ function usePostPreview( { forceIsAutosaveable, onPreview } ) {
 		return null;
 	}
 
-	const targetId = `wp-preview-${ postId }`;
+	const target = `wp-preview-${ postId }`;
 
 	const handlePreviewClick = async ( event ) => {
 		// Preserve native link semantics with `href` and `target`, but intercept the
@@ -207,7 +207,7 @@ function usePostPreview( { forceIsAutosaveable, onPreview } ) {
 		event.preventDefault();
 
 		// Open up a Preview tab if needed. This is where we'll show the preview.
-		const previewWindow = window.open( '', targetId );
+		const previewWindow = window.open( '', target );
 
 		// Focus the Preview tab. This might not do anything, depending on the browser's
 		// and user's preferences.
@@ -230,9 +230,9 @@ function usePostPreview( { forceIsAutosaveable, onPreview } ) {
 
 	return {
 		href,
-		handlePreviewClick,
-		isSaveable,
-		targetId,
+		target,
+		disabled: ! isSaveable,
+		onClick: handlePreviewClick,
 	};
 }
 
@@ -246,25 +246,17 @@ function usePostPreview( { forceIsAutosaveable, onPreview } ) {
  * @return {React.ReactNode} The rendered menu item.
  */
 export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
-	const preview = usePostPreview( {
+	const previewProps = usePostPreviewProps( {
 		forceIsAutosaveable,
 		onPreview,
 	} );
 
-	if ( ! preview ) {
+	if ( ! previewProps ) {
 		return null;
 	}
 
-	const { handlePreviewClick, href, isSaveable, targetId } = preview;
-
 	return (
-		<MenuItem
-			href={ href }
-			target={ targetId }
-			disabled={ ! isSaveable }
-			onClick={ handlePreviewClick }
-			icon={ external }
-		>
+		<MenuItem icon={ external } { ...previewProps }>
 			{ __( 'Preview in new tab' ) }
 		</MenuItem>
 	);
@@ -292,16 +284,14 @@ export default function PostPreviewButton( {
 	role,
 	onPreview,
 } ) {
-	const preview = usePostPreview( {
+	const previewProps = usePostPreviewProps( {
 		forceIsAutosaveable,
 		onPreview,
 	} );
 
-	if ( ! preview ) {
+	if ( ! previewProps ) {
 		return null;
 	}
-
-	const { handlePreviewClick, href, isSaveable, targetId } = preview;
 
 	return (
 		<Button
@@ -309,11 +299,8 @@ export default function PostPreviewButton( {
 			className={ className || 'editor-post-preview' }
 			role={ role }
 			size="compact"
-			href={ href }
-			target={ targetId }
 			accessibleWhenDisabled
-			disabled={ ! isSaveable }
-			onClick={ handlePreviewClick }
+			{ ...previewProps }
 		>
 			{ textContent || (
 				<>

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element';
-import { Button, Path, SVG } from '@wordpress/components';
+import { Button, MenuItem, Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import { store as coreStore } from '@wordpress/core-data';
+import { external } from '@wordpress/icons';
 import { VisuallyHidden } from '@wordpress/ui';
 
 /**
@@ -166,28 +167,7 @@ async function writeInterstitialIntoPreviewWindow( previewWindow ) {
 	}
 }
 
-/**
- * Renders a button that opens a new window or tab for the preview,
- * writes the interstitial message to this window, and then navigates
- * to the actual preview link. The button is not rendered if the post
- * is not viewable and disabled if the post is not saveable.
- *
- * @param {Object}   props                     The component props.
- * @param {string}   props.className           The class name for the button.
- * @param {string}   props.textContent         The text content for the button.
- * @param {boolean}  props.forceIsAutosaveable Whether to force autosave.
- * @param {string}   props.role                The role attribute for the button.
- * @param {Function} props.onPreview           The callback function for preview event.
- *
- * @return {React.ReactNode} The rendered button component.
- */
-export default function PostPreviewButton( {
-	className,
-	textContent,
-	forceIsAutosaveable,
-	role,
-	onPreview,
-} ) {
+function usePostPreviewProps( { forceIsAutosaveable, onPreview } ) {
 	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
 		useSelect( ( select ) => {
 			const editor = select( editorStore );
@@ -248,17 +228,79 @@ export default function PostPreviewButton( {
 	// just link to the post's URL.
 	const href = previewLink || currentPostLink;
 
+	return {
+		href,
+		target: targetId,
+		accessibleWhenDisabled: true,
+		disabled: ! isSaveable,
+		onClick: openPreviewWindow,
+	};
+}
+
+/**
+ * Renders the post preview action as a menu item.
+ *
+ * @param {Object}   props                     The component props.
+ * @param {boolean}  props.forceIsAutosaveable Whether to force autosave.
+ * @param {Function} props.onPreview           The callback function for the preview event.
+ *
+ * @return {React.ReactNode} The rendered menu item.
+ */
+export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
+	const previewProps = usePostPreviewProps( {
+		forceIsAutosaveable,
+		onPreview,
+	} );
+
+	if ( ! previewProps ) {
+		return null;
+	}
+
+	return (
+		<MenuItem icon={ external } { ...previewProps }>
+			{ __( 'Preview in new tab' ) }
+		</MenuItem>
+	);
+}
+
+/**
+ * Renders a button that opens a new window or tab for the preview,
+ * writes the interstitial message to this window, and then navigates
+ * to the actual preview link. The button is not rendered if the post
+ * is not viewable and disabled if the post is not saveable.
+ *
+ * @param {Object}   props                     The component props.
+ * @param {string}   props.className           The class name for the button.
+ * @param {string}   props.textContent         The text content for the button.
+ * @param {boolean}  props.forceIsAutosaveable Whether to force autosave.
+ * @param {string}   props.role                The role attribute for the button.
+ * @param {Function} props.onPreview           The callback function for preview event.
+ *
+ * @return {React.ReactNode} The rendered button component.
+ */
+export default function PostPreviewButton( {
+	className,
+	textContent,
+	forceIsAutosaveable,
+	role,
+	onPreview,
+} ) {
+	const previewProps = usePostPreviewProps( {
+		forceIsAutosaveable,
+		onPreview,
+	} );
+
+	if ( ! previewProps ) {
+		return null;
+	}
+
 	return (
 		<Button
 			variant={ ! className ? 'tertiary' : undefined }
 			className={ className || 'editor-post-preview' }
-			href={ href }
-			target={ targetId }
-			accessibleWhenDisabled
-			disabled={ ! isSaveable }
-			onClick={ openPreviewWindow }
 			role={ role }
 			size="compact"
+			{ ...previewProps }
 		>
 			{ textContent || (
 				<>

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -12,7 +12,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import PostPreviewButton from '..';
+import PostPreviewButton, { PostPreviewMenuItem } from '..';
 
 jest.useRealTimers();
 
@@ -137,6 +137,16 @@ describe( 'PostPreviewButton', () => {
 		expect(
 			within( button ).getByText( '(opens in a new tab)' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'should render the menu variant with the shared menu item pattern.', () => {
+		mockUseSelect();
+
+		render( <PostPreviewMenuItem /> );
+
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+		).toHaveClass( 'components-menu-item__button' );
 	} );
 
 	it( 'should be accessibly disabled if post is not saveable.', () => {

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
 	jest.fn()
 );
 
-function mockUseSelect( overrides, dispatchOverrides ) {
+function mockUseSelect( overrides ) {
 	useSelect.mockImplementation( ( map ) =>
 		map( () => ( {
 			getPostType: () => ( { viewable: true } ),
@@ -35,7 +35,6 @@ function mockUseSelect( overrides, dispatchOverrides ) {
 	);
 	useDispatch.mockImplementation( () => ( {
 		__unstableSaveForPreview: () => Promise.resolve(),
-		...dispatchOverrides,
 	} ) );
 }
 
@@ -155,7 +154,6 @@ describe( 'PostPreviewButton', () => {
 		expect( menuItem.tagName ).toBe( 'A' );
 		expect( menuItem ).toHaveAttribute( 'href', url );
 		expect( menuItem ).toHaveAttribute( 'target', 'wp-preview-123' );
-		expect( menuItem ).toHaveClass( 'components-menu-item__button' );
 	} );
 
 	it( 'should be accessibly disabled if post is not saveable.', () => {
@@ -247,27 +245,6 @@ describe( 'PostPreviewButton', () => {
 		await user.click( screen.getByRole( 'link' ) );
 
 		expect( global.open ).toHaveBeenCalledWith( '', 'wp-preview-123' );
-	} );
-
-	it( 'should navigate the preview window after saving', async () => {
-		const user = userEvent.setup();
-		const url = 'https://wordpress.org/?preview=true';
-		const saveForPreview = jest.fn().mockResolvedValue( url );
-
-		mockUseSelect(
-			{
-				getEditedPostPreviewLink: () => url,
-				isEditedPostSaveable: () => true,
-			},
-			{ __unstableSaveForPreview: saveForPreview }
-		);
-
-		render( <PostPreviewButton /> );
-
-		await user.click( screen.getByRole( 'link' ) );
-
-		expect( saveForPreview ).toHaveBeenCalled();
-		expect( setLocation ).toHaveBeenCalledWith( url );
 	} );
 
 	it( 'should display a `Generating preview` message while waiting for autosaving', async () => {

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
 	jest.fn()
 );
 
-function mockUseSelect( overrides ) {
+function mockUseSelect( overrides, dispatchOverrides ) {
 	useSelect.mockImplementation( ( map ) =>
 		map( () => ( {
 			getPostType: () => ( { viewable: true } ),
@@ -35,6 +35,7 @@ function mockUseSelect( overrides ) {
 	);
 	useDispatch.mockImplementation( () => ( {
 		__unstableSaveForPreview: () => Promise.resolve(),
+		...dispatchOverrides,
 	} ) );
 }
 
@@ -139,14 +140,22 @@ describe( 'PostPreviewButton', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the menu variant with the shared menu item pattern.', () => {
-		mockUseSelect();
+	it( 'should render the menu variant as a link with the shared menu item pattern.', () => {
+		const url = 'https://wordpress.org';
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => url,
+			isEditedPostSaveable: () => true,
+		} );
 
 		render( <PostPreviewMenuItem /> );
 
-		expect(
-			screen.getByRole( 'menuitem', { name: 'Preview in new tab' } )
-		).toHaveClass( 'components-menu-item__button' );
+		const menuItem = screen.getByRole( 'menuitem', {
+			name: 'Preview in new tab',
+		} );
+		expect( menuItem.tagName ).toBe( 'A' );
+		expect( menuItem ).toHaveAttribute( 'href', url );
+		expect( menuItem ).toHaveAttribute( 'target', 'wp-preview-123' );
+		expect( menuItem ).toHaveClass( 'components-menu-item__button' );
 	} );
 
 	it( 'should be accessibly disabled if post is not saveable.', () => {
@@ -238,6 +247,27 @@ describe( 'PostPreviewButton', () => {
 		await user.click( screen.getByRole( 'link' ) );
 
 		expect( global.open ).toHaveBeenCalledWith( '', 'wp-preview-123' );
+	} );
+
+	it( 'should navigate the preview window after saving', async () => {
+		const user = userEvent.setup();
+		const url = 'https://wordpress.org/?preview=true';
+		const saveForPreview = jest.fn().mockResolvedValue( url );
+
+		mockUseSelect(
+			{
+				getEditedPostPreviewLink: () => url,
+				isEditedPostSaveable: () => true,
+			},
+			{ __unstableSaveForPreview: saveForPreview }
+		);
+
+		render( <PostPreviewButton /> );
+
+		await user.click( screen.getByRole( 'link' ) );
+
+		expect( saveForPreview ).toHaveBeenCalled();
+		expect( setLocation ).toHaveBeenCalledWith( url );
 	} );
 
 	it( 'should display a `Generating preview` message while waiting for autosaving', async () => {

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -12,7 +12,6 @@ import {
 	MenuGroup,
 	MenuItem,
 	MenuItemsChoice,
-	Icon as WCIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
@@ -28,7 +27,7 @@ import { VisuallyHidden } from '@wordpress/ui';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import PostPreviewButton from '../post-preview-button';
+import { PostPreviewMenuItem } from '../post-preview-button';
 import { VIEWPORT_STATE_BY_DEVICE_TYPE } from '../../utils/device-type';
 import { unlock } from '../../lock-unlock';
 
@@ -239,17 +238,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					) }
 					{ isViewable && (
 						<MenuGroup>
-							<PostPreviewButton
-								className="editor-preview-dropdown__button-external"
-								role="menuitem"
+							<PostPreviewMenuItem
 								forceIsAutosaveable={ forceIsAutosaveable }
-								aria-label={ __( 'Preview in new tab' ) }
-								textContent={
-									<>
-										{ __( 'Preview in new tab' ) }
-										<WCIcon icon={ external } />
-									</>
-								}
 								onPreview={ onClose }
 							/>
 						</MenuGroup>

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -2,9 +2,3 @@
 	padding-right: 4px;
 	padding-left: 6px;
 }
-
-.editor-preview-dropdown__button-external {
-	width: 100%;
-	display: flex;
-	justify-content: space-between;
-}


### PR DESCRIPTION
Follow-up to #80093.

## What?

Renders “Preview in new tab” with the shared `MenuItem` pattern in the View dropdown.

## Why?

The action used a custom `Button`, so its typography and icon layout could differ from sibling menu items.

## How?

Adds a menu-item presentation that shares the existing preview state and save flow. When enabled, the action still renders as an anchor with its preview URL and named target; the click is intercepted only to open or reuse the tab before the asynchronous preview save finishes.

Removes the custom layout styles that are no longer needed.

## Testing Instructions

Open a post, open the View dropdown, and confirm “Preview in new tab” matches the typography and layout of the other menu items. Activate “Preview in new tab” and confirm the preview opens in a new tab.

1. Run `npm run test:unit packages/editor/src/components/post-preview-button/test -- --runInBand`.
2. Run `npm run lint:js -- packages/editor/src/components/post-preview-button/index.js packages/editor/src/components/post-preview-button/test/index.js packages/editor/src/components/preview-dropdown/index.js`.
3. Run `npm run lint:css -- packages/editor/src/components/preview-dropdown/style.scss`.
4. Run `npm run build`.

### Testing Instructions for Keyboard

1. Focus the View button and press Enter or Space.
2. Use the arrow keys to reach “Preview in new tab”.
3. Press Enter and confirm the menu closes and the preview opens in a new tab.
4. Reopen the menu and press Escape to confirm focus returns to the View button.

## Screenshots or screencast

| Before | After |
|---|---|
| <img width="2568" height="1998" alt="Screenshot 2026-07-13 at 18 18 52" src="https://github.com/user-attachments/assets/6117c669-5ceb-4fbc-a628-77bf11a6367f" /> | <img width="2568" height="2002" alt="Screenshot 2026-07-13 at 17 57 20" src="https://github.com/user-attachments/assets/a4b09697-8722-4dcd-b033-3e890b20c67f" /> |


## Use of AI Tools

Implemented and verified with assistance from OpenAI Codex.
