### PR TITLE
Latest Posts: Fix slow category selection with large category lists

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -162,13 +162,10 @@ function Controls( { attributes, setAttributes } ) {
 			label: name,
 		} ) );
 	const categorySuggestions =
-		categoriesList?.reduce(
-			( accumulator, category ) => ( {
-				...accumulator,
-				[ category.name ]: category,
-			} ),
-			{}
-		) ?? {};
+		categoriesList?.reduce( ( accumulator, category ) => {
+			accumulator[ category.name ] = category;
+			return accumulator;
+		}, {} ) ?? {};
 	const selectCategories = ( tokens ) => {
 		const hasNoSuggestion = tokens.some(
 			( token ) =>


### PR DESCRIPTION
## What?
Noticed while testing #80191.

## Why?
The `categorySuggestions` map was built with a `reduce` that spreads the accumulator on every iteration (`{ ...accumulator }`), making it O(n²). On sites with large category lists (~5k terms), this ran ~25M operations and rebuilt on every render, causing noticeable lag with every control change.

Replaced the spread with an in-place mutation of the accumulator, reducing it to O(n). The reducer seeds a fresh object each run, so no shared state is mutated.

## Testing Instructions
1. Create/seed ~5k categories.
2. Create a page.
3. Add a Latest Posts block.
4. Try changing any control. Change should be responsive.
5. Repeat the same on the trunk. Notice the lag.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="658" height="260" alt="CleanShot 2026-07-13 at 18 28 58" src="https://github.com/user-attachments/assets/ce0df947-c16c-4cfc-b0a5-d445a5cb4d94" />

## Use of AI Tools

Assisted with naming O(n²) and O(n), I can never remember these things.