### PR TITLE
Add Table of Contents e2e user story coverage

### DIFF
--- a/packages/e2e-tests/plugins/table-of-contents-heading-source.php
+++ b/packages/e2e-tests/plugins/table-of-contents-heading-source.php
@@ -8,7 +8,7 @@
  */
 
 /**
- * Enqueues the test block used by Table of Contents e2e coverage.
+ * Enqueues the test block used by Table of Contents e2e coverage in the block editor.
  */
 function gutenberg_test_table_of_contents_heading_source_enqueue() {
 	wp_enqueue_script(
@@ -24,4 +24,4 @@ function gutenberg_test_table_of_contents_heading_source_enqueue() {
 	);
 }
 
-add_action( 'init', 'gutenberg_test_table_of_contents_heading_source_enqueue' );
+add_action( 'enqueue_block_editor_assets', 'gutenberg_test_table_of_contents_heading_source_enqueue' );

--- a/packages/e2e-tests/plugins/table-of-contents-heading-source.php
+++ b/packages/e2e-tests/plugins/table-of-contents-heading-source.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Table of Contents Heading Source
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-table-of-contents-heading-source
+ */
+
+/**
+ * Enqueues the test block used by Table of Contents e2e coverage.
+ */
+function gutenberg_test_table_of_contents_heading_source_enqueue() {
+	wp_enqueue_script(
+		'gutenberg-test-table-of-contents-heading-source',
+		plugins_url( 'table-of-contents-heading-source/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-block-editor',
+			'wp-element',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'table-of-contents-heading-source/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'gutenberg_test_table_of_contents_heading_source_enqueue' );

--- a/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
+++ b/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
@@ -62,7 +62,7 @@
 		attributes: {
 			content: {
 				type: 'string',
-				default: 'Unregistered heading-like source',
+				default: 'Plain heading-like block',
 			},
 			anchor: {
 				type: 'string',

--- a/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
+++ b/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
@@ -1,0 +1,83 @@
+( function () {
+	const { registerBlockType } = wp.blocks;
+	const { useBlockProps } = wp.blockEditor;
+	const { createElement: el } = wp.element;
+
+	registerBlockType( 'e2e-tests/table-of-contents-heading-source', {
+		apiVersion: 3,
+		title: 'ToC Heading Source',
+		description: 'A test block that renders a heading-like section.',
+		category: 'text',
+		attributes: {
+			content: {
+				type: 'string',
+				default: 'Plugin heading source',
+			},
+			anchor: {
+				type: 'string',
+				default: 'plugin-heading-source',
+			},
+			level: {
+				type: 'number',
+				default: 2,
+			},
+		},
+		edit: function Edit( { attributes } ) {
+			const TagName = `h${ attributes.level }`;
+
+			return el(
+				TagName,
+				useBlockProps( { id: attributes.anchor } ),
+				attributes.content
+			);
+		},
+		save: function Save( { attributes } ) {
+			const TagName = `h${ attributes.level }`;
+
+			return el(
+				TagName,
+				useBlockProps.save( { id: attributes.anchor } ),
+				attributes.content
+			);
+		},
+	} );
+
+	registerBlockType( 'e2e-tests/table-of-contents-heading-like', {
+		apiVersion: 3,
+		title: 'ToC Heading Like',
+		description: 'A test block that renders a heading-like section.',
+		category: 'text',
+		attributes: {
+			content: {
+				type: 'string',
+				default: 'Unregistered heading-like source',
+			},
+			anchor: {
+				type: 'string',
+				default: 'unregistered-heading-like-source',
+			},
+			level: {
+				type: 'number',
+				default: 2,
+			},
+		},
+		edit: function Edit( { attributes } ) {
+			const TagName = `h${ attributes.level }`;
+
+			return el(
+				TagName,
+				useBlockProps( { id: attributes.anchor } ),
+				attributes.content
+			);
+		},
+		save: function Save( { attributes } ) {
+			const TagName = `h${ attributes.level }`;
+
+			return el(
+				TagName,
+				useBlockProps.save( { id: attributes.anchor } ),
+				attributes.content
+			);
+		},
+	} );
+} )();

--- a/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
+++ b/packages/e2e-tests/plugins/table-of-contents-heading-source/index.js
@@ -3,6 +3,18 @@
 	const { useBlockProps } = wp.blockEditor;
 	const { createElement: el } = wp.element;
 
+	function getHeadingTagName( level ) {
+		return Number.isInteger( level ) && level >= 1 && level <= 6
+			? `h${ level }`
+			: 'h2';
+	}
+
+	function getAnchorProps( anchor ) {
+		return typeof anchor === 'string' && anchor !== ''
+			? { id: anchor }
+			: {};
+	}
+
 	registerBlockType( 'e2e-tests/table-of-contents-heading-source', {
 		apiVersion: 3,
 		title: 'ToC Heading Source',
@@ -23,20 +35,20 @@
 			},
 		},
 		edit: function Edit( { attributes } ) {
-			const TagName = `h${ attributes.level }`;
+			const TagName = getHeadingTagName( attributes.level );
 
 			return el(
 				TagName,
-				useBlockProps( { id: attributes.anchor } ),
+				useBlockProps( getAnchorProps( attributes.anchor ) ),
 				attributes.content
 			);
 		},
 		save: function Save( { attributes } ) {
-			const TagName = `h${ attributes.level }`;
+			const TagName = getHeadingTagName( attributes.level );
 
 			return el(
 				TagName,
-				useBlockProps.save( { id: attributes.anchor } ),
+				useBlockProps.save( getAnchorProps( attributes.anchor ) ),
 				attributes.content
 			);
 		},
@@ -62,20 +74,20 @@
 			},
 		},
 		edit: function Edit( { attributes } ) {
-			const TagName = `h${ attributes.level }`;
+			const TagName = getHeadingTagName( attributes.level );
 
 			return el(
 				TagName,
-				useBlockProps( { id: attributes.anchor } ),
+				useBlockProps( getAnchorProps( attributes.anchor ) ),
 				attributes.content
 			);
 		},
 		save: function Save( { attributes } ) {
-			const TagName = `h${ attributes.level }`;
+			const TagName = getHeadingTagName( attributes.level );
 
 			return el(
 				TagName,
-				useBlockProps.save( { id: attributes.anchor } ),
+				useBlockProps.save( getAnchorProps( attributes.anchor ) ),
 				attributes.content
 			);
 		},

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -1,0 +1,902 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const CUSTOM_HEADING_SOURCE_PLUGIN =
+	'gutenberg-test-table-of-contents-heading-source';
+
+function headingBlock( { content, level = 2, anchor } ) {
+	const attributes = { level };
+	if ( anchor ) {
+		attributes.anchor = anchor;
+	}
+	const id = anchor ? ` id="${ anchor }"` : '';
+
+	return `<!-- wp:heading ${ JSON.stringify( attributes ) } -->
+<h${ level }${ id } class="wp-block-heading">${ content }</h${ level }>
+<!-- /wp:heading -->`;
+}
+
+function htmlBlock( content ) {
+	return `<!-- wp:html -->
+${ content }
+<!-- /wp:html -->`;
+}
+
+function tableOfContentsBlock( { headings, ordered = true } ) {
+	const attributes = { headings };
+	if ( ! ordered ) {
+		attributes.ordered = false;
+	}
+	const ListTag = ordered ? 'ol' : 'ul';
+	const items = headings
+		.map(
+			( { content, link } ) =>
+				`<li><a class="wp-block-table-of-contents__entry" href="${ link }">${ content }</a></li>`
+		)
+		.join( '' );
+
+	return `<!-- wp:table-of-contents ${ JSON.stringify( attributes ) } -->
+<nav class="wp-block-table-of-contents"><${ ListTag }>${ items }</${ ListTag }></nav>
+<!-- /wp:table-of-contents -->`;
+}
+
+function nestedTableOfContentsBlock() {
+	const headings = [
+		{ content: 'Main Section', level: 2, link: '#main-section' },
+		{ content: 'Subsection', level: 3, link: '#subsection' },
+	];
+
+	return `<!-- wp:table-of-contents ${ JSON.stringify( { headings } ) } -->
+<nav class="wp-block-table-of-contents"><ol><li><a class="wp-block-table-of-contents__entry" href="#main-section">Main Section</a><ol><li><a class="wp-block-table-of-contents__entry" href="#subsection">Subsection</a></li></ol></li></ol></nav>
+<!-- /wp:table-of-contents -->`;
+}
+
+function postContentWithTocAndHeadings( headings, extraBlocks = '' ) {
+	return [
+		'<!-- wp:table-of-contents /-->',
+		...headings.map( headingBlock ),
+		extraBlocks,
+	]
+		.filter( Boolean )
+		.join( '\n\n' );
+}
+
+function getTableOfContentsEditorBlock( editor ) {
+	return editor.canvas.getByRole( 'document', {
+		name: 'Block: Table of Contents',
+	} );
+}
+
+async function createPostWithContent( requestUtils, title, content ) {
+	return requestUtils.createPost( {
+		title,
+		content,
+		status: 'publish',
+	} );
+}
+
+async function updatePostContent( requestUtils, postId, content ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/posts/${ postId }`,
+		data: { content, status: 'publish' },
+	} );
+}
+
+async function openPostOnFrontend( page, postId, pageNumber = 1 ) {
+	const query = new URLSearchParams( { p: String( postId ) } );
+	if ( pageNumber > 1 ) {
+		query.set( 'page', String( pageNumber ) );
+	}
+	await page.goto( `/?${ query.toString() }` );
+}
+
+test.describe( 'Table of Contents', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-block-experiments',
+		] );
+		await requestUtils.activatePlugin( CUSTOM_HEADING_SOURCE_PLUGIN );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllPages(),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+			requestUtils.activateTheme( 'twentytwentyone' ),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( CUSTOM_HEADING_SOURCE_PLUGIN );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test.describe( 'Writing and editing', () => {
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
+		} );
+
+		test( 'updates in the editor as headings are added, removed, or reordered', async ( {
+			editor,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'First section', anchor: 'first-section' },
+				] )
+			);
+
+			const tableOfContents = getTableOfContentsEditorBlock( editor );
+			await expect(
+				tableOfContents.getByRole( 'link', { name: 'First section' } )
+			).toBeVisible();
+
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'First section', anchor: 'first-section' },
+					{ content: 'Second section', anchor: 'second-section' },
+				] )
+			);
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'First section',
+				'Second section',
+			] );
+
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'Second section', anchor: 'second-section' },
+				] )
+			);
+			await expect(
+				tableOfContents.getByRole( 'link', { name: 'Second section' } )
+			).toBeVisible();
+			await expect(
+				tableOfContents.getByRole( 'link', { name: 'First section' } )
+			).toHaveCount( 0 );
+
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'Second section', anchor: 'second-section' },
+					{ content: 'First section', anchor: 'first-section' },
+				] )
+			);
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'Second section',
+				'First section',
+			] );
+		} );
+
+		test( 'shows the same nested heading list in the editor and after publish', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'Preview section', anchor: 'preview-section' },
+					{
+						content: 'Preview subsection',
+						level: 3,
+						anchor: 'preview-subsection',
+					},
+				] )
+			);
+
+			const tableOfContents = getTableOfContentsEditorBlock( editor );
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'Preview section',
+				'Preview subsection',
+			] );
+			// Looking inside the parent list item checks nesting, not just text order.
+			await expect(
+				tableOfContents
+					.getByRole( 'listitem' )
+					.filter( { hasText: 'Preview section' } )
+					.first()
+					.getByRole( 'link', { name: 'Preview subsection' } )
+			).toBeVisible();
+
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
+
+			const frontendToc = page.getByRole( 'navigation', {
+				name: 'Table of Contents',
+			} );
+			await expect( frontendToc.getByRole( 'link' ) ).toHaveText( [
+				'Preview section',
+				'Preview subsection',
+			] );
+			// Looking inside the parent list item checks nesting, not just text order.
+			await expect(
+				frontendToc
+					.getByRole( 'listitem' )
+					.filter( { hasText: 'Preview section' } )
+					.first()
+					.getByRole( 'link', { name: 'Preview subsection' } )
+			).toBeVisible();
+		} );
+
+		test( 'limits visible heading levels in the editor and after publish when the block setting changes', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'Main section', anchor: 'main-section' },
+					{
+						content: 'Subsection',
+						level: 3,
+						anchor: 'subsection',
+					},
+					{
+						content: 'Detailed aside',
+						level: 4,
+						anchor: 'detailed-aside',
+					},
+				] )
+			);
+
+			await getTableOfContentsEditorBlock( editor ).click();
+			await editor.openDocumentSettingsSidebar();
+			await page
+				.getByRole( 'combobox', {
+					name: 'Include headings down to level',
+				} )
+				.selectOption( '3' );
+
+			const tableOfContents = getTableOfContentsEditorBlock( editor );
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'Main section',
+				'Subsection',
+			] );
+			// Heading 4 is deeper than the selected Heading 3 limit.
+			await expect(
+				tableOfContents.getByRole( 'link', {
+					name: 'Detailed aside',
+				} )
+			).toHaveCount( 0 );
+
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
+
+			const frontendToc = page.getByRole( 'navigation', {
+				name: 'Table of Contents',
+			} );
+			await expect( frontendToc.getByRole( 'link' ) ).toHaveText( [
+				'Main section',
+				'Subsection',
+			] );
+			await expect(
+				frontendToc.getByRole( 'link', { name: 'Detailed aside' } )
+			).toHaveCount( 0 );
+		} );
+
+		test( 'switches list styles in the editor and keeps the chosen style after publish', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{ content: 'List style section', anchor: 'list-style' },
+				] )
+			);
+
+			const tableOfContents = getTableOfContentsEditorBlock( editor );
+			const list = tableOfContents.getByRole( 'list' ).first();
+			await expect( list ).toHaveCSS( 'list-style-type', 'decimal' );
+
+			await getTableOfContentsEditorBlock( editor ).click();
+			await editor.clickBlockToolbarButton( 'Unordered' );
+			await expect( list ).toHaveCSS( 'list-style-type', 'disc' );
+
+			await editor.clickBlockToolbarButton( 'Ordered' );
+			await expect( list ).toHaveCSS( 'list-style-type', 'decimal' );
+
+			await editor.clickBlockToolbarButton( 'Unordered' );
+			// Use a non-default style for the published assertion below.
+			await expect( list ).toHaveCSS( 'list-style-type', 'disc' );
+
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
+
+			await expect(
+				page
+					.getByRole( 'navigation', { name: 'Table of Contents' } )
+					.getByRole( 'list' )
+					.first()
+			).toHaveCSS( 'list-style-type', 'disc' );
+		} );
+
+		test( 'shows an editor notice and does not render on the front of site when no headings exist', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( { name: 'core/table-of-contents' } );
+
+			const tableOfContents = getTableOfContentsEditorBlock( editor );
+			await expect( tableOfContents ).toContainText(
+				'Start adding Heading blocks to create a table of contents.'
+			);
+			await expect( tableOfContents ).toContainText(
+				'Headings with HTML anchors will be linked here.'
+			);
+
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
+			await expect(
+				page.getByRole( 'navigation', { name: 'Table of Contents' } )
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	test.describe( 'Reading and navigating', () => {
+		test( 'clicking a table of contents item on the front of site scrolls to the matching section', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Table of Contents navigation',
+				[
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Destination section',
+								level: 2,
+								link: '#destination-section',
+							},
+						],
+					} ),
+					// Push the target below the viewport so the click must move the reader to the section, not only update the URL hash.
+					'<!-- wp:spacer {"height":"1000px"} --><div style="height:1000px" aria-hidden="true" class="wp-block-spacer"></div><!-- /wp:spacer -->',
+					headingBlock( {
+						content: 'Destination section',
+						anchor: 'destination-section',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+
+			await page
+				.getByRole( 'navigation', { name: 'Table of Contents' } )
+				.getByRole( 'link', { name: 'Destination section' } )
+				.click();
+
+			await expect( page ).toHaveURL( /#destination-section$/ );
+			await expect(
+				page.locator( '#destination-section' )
+			).toBeInViewport();
+		} );
+
+		test( 'clicking a front-of-site hash link keeps the reader on the post page', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Valid table of contents links',
+				[
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Reliable section',
+								level: 2,
+								link: '#reliable-section',
+							},
+						],
+					} ),
+					headingBlock( {
+						content: 'Reliable section',
+						anchor: 'reliable-section',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+			await page
+				.getByRole( 'navigation', { name: 'Table of Contents' } )
+				.getByRole( 'link', { name: 'Reliable section' } )
+				.click();
+
+			// This guards the "no broken page" story separately from scroll position.
+			await expect(
+				page.getByRole( 'heading', { name: 'Page not found' } )
+			).toHaveCount( 0 );
+			await expect(
+				page.getByRole( 'heading', { name: 'Reliable section' } )
+			).toBeVisible();
+		} );
+
+		test( 'clicking a front-of-site link to page 2 opens that page and section', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Paginated table of contents',
+				'Temporary content'
+			);
+			await updatePostContent(
+				requestUtils,
+				post.id,
+				[
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Second page section',
+								level: 2,
+								link: `/?p=${ post.id }&page=2#second-page-section`,
+							},
+						],
+					} ),
+					headingBlock( {
+						content: 'First page section',
+						anchor: 'first-page-section',
+					} ),
+					'<!-- wp:nextpage --><!--nextpage--><!-- /wp:nextpage -->',
+					headingBlock( {
+						content: 'Second page section',
+						anchor: 'second-page-section',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+			await page
+				.getByRole( 'navigation', { name: 'Table of Contents' } )
+				.getByRole( 'link', { name: 'Second page section' } )
+				.click();
+
+			// WordPress may use pretty or query pagination; either way the reader must land on page 2 at this section.
+			await expect( page ).toHaveURL(
+				/(\/2\/|[?&]page=2).*#second-page-section$/
+			);
+			await expect(
+				page.locator( '#second-page-section' )
+			).toBeInViewport();
+		} );
+
+		// Editor nesting is covered by the preview test above; this reader-story test checks the published structure.
+		test( 'viewing nested headings on the front of site shows subsections nested under their section', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Nested table of contents',
+				[
+					nestedTableOfContentsBlock(),
+					headingBlock( {
+						content: 'Main Section',
+						anchor: 'main-section',
+					} ),
+					headingBlock( {
+						content: 'Subsection',
+						level: 3,
+						anchor: 'subsection',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+
+			const tableOfContents = page.getByRole( 'navigation', {
+				name: 'Table of Contents',
+			} );
+			const mainItem = tableOfContents
+				.getByRole( 'listitem' )
+				.filter( { hasText: 'Main Section' } )
+				.first();
+			// Looking inside the parent list item checks nesting, not just text order.
+			await expect(
+				mainItem.getByRole( 'link', { name: 'Subsection' } )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Accessibility', () => {
+		test( 'is exposed as a distinct named region on the front of site', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Named table of contents',
+				[
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Named region section',
+								level: 2,
+								link: '#named-region-section',
+							},
+						],
+					} ),
+					headingBlock( {
+						content: 'Named region section',
+						anchor: 'named-region-section',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+
+			await expect(
+				page.getByRole( 'navigation', { name: 'Table of Contents' } )
+			).toBeVisible();
+		} );
+
+		test( 'keyboard focus reaches and moves through front-of-site links in predictable order', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Keyboard table of contents',
+				[
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Keyboard first',
+								level: 2,
+								link: '#keyboard-first',
+							},
+							{
+								content: 'Keyboard second',
+								level: 2,
+								link: '#keyboard-second',
+							},
+						],
+					} ),
+					headingBlock( {
+						content: 'Keyboard first',
+						anchor: 'keyboard-first',
+					} ),
+					headingBlock( {
+						content: 'Keyboard second',
+						anchor: 'keyboard-second',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+
+			const tableOfContents = page.getByRole( 'navigation', {
+				name: 'Table of Contents',
+			} );
+			const firstLink = tableOfContents.getByRole( 'link', {
+				name: 'Keyboard first',
+			} );
+			const secondLink = tableOfContents.getByRole( 'link', {
+				name: 'Keyboard second',
+			} );
+
+			for ( let i = 0; i < 20; i++ ) {
+				await page.keyboard.press( 'Tab' );
+				if (
+					await firstLink.evaluate( ( node ) =>
+						node.matches( ':focus' )
+					)
+				) {
+					break;
+				}
+			}
+			await expect( firstLink ).toBeFocused();
+			await page.keyboard.press( 'Tab' );
+			await expect( secondLink ).toBeFocused();
+		} );
+
+		test( 'is distinguishable from the site main menu on the front of site', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await createPostWithContent(
+				requestUtils,
+				'Distinct navigation regions',
+				[
+					htmlBlock(
+						'<nav aria-label="Main menu"><a href="/">Home</a></nav>'
+					),
+					tableOfContentsBlock( {
+						headings: [
+							{
+								content: 'Content navigation section',
+								level: 2,
+								link: '#content-navigation-section',
+							},
+						],
+					} ),
+					headingBlock( {
+						content: 'Content navigation section',
+						anchor: 'content-navigation-section',
+					} ),
+				].join( '\n\n' )
+			);
+
+			await openPostOnFrontend( page, post.id );
+
+			await expect(
+				page.getByRole( 'navigation', { name: 'Main menu' } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'navigation', { name: 'Table of Contents' } )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Placing the block across a site', () => {
+		test.beforeEach( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'emptytheme' );
+		} );
+
+		// Desired behavior: ToC in templates should list headings from the viewed post; trunk does not yet support template placement.
+		test.fixme(
+			'a table of contents added once to a shared template uses each viewed post heading list',
+			async ( { page, requestUtils } ) => {
+				await requestUtils.createTemplate( 'wp_template', {
+					// The single template slug makes this template apply to posts viewed on the front of site.
+					slug: 'single',
+					title: 'Single',
+					content: [
+						'<!-- wp:table-of-contents /-->',
+						'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+					].join( '\n\n' ),
+				} );
+
+				const firstPost = await createPostWithContent(
+					requestUtils,
+					'First templated post',
+					headingBlock( {
+						content: 'First post section',
+						anchor: 'first-post-section',
+					} )
+				);
+				const secondPost = await createPostWithContent(
+					requestUtils,
+					'Second templated post',
+					headingBlock( {
+						content: 'Second post section',
+						anchor: 'second-post-section',
+					} )
+				);
+
+				// The same ToC block lives in the template, so each post should populate it from the post being viewed.
+				await openPostOnFrontend( page, firstPost.id );
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', { name: 'First post section' } )
+				).toBeVisible();
+
+				await openPostOnFrontend( page, secondPost.id );
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', { name: 'Second post section' } )
+				).toBeVisible();
+			}
+		);
+
+		// Desired behavior: ToC in template editing should explain that it uses viewed post headings; trunk only shows the generic empty-heading placeholder.
+		test.fixme(
+			'template editing explains when a live example cannot be shown and the front of site uses the viewed post',
+			async ( { admin, editor, page, requestUtils } ) => {
+				await requestUtils.createTemplate( 'wp_template', {
+					slug: 'single',
+					title: 'Single',
+					content: [
+						'<!-- wp:table-of-contents /-->',
+						'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+					].join( '\n\n' ),
+				} );
+				const post = await createPostWithContent(
+					requestUtils,
+					'Template preview post',
+					headingBlock( {
+						content: 'Template preview section',
+						anchor: 'template-preview-section',
+					} )
+				);
+
+				await admin.visitSiteEditor( {
+					postId: 'emptytheme//single',
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+
+				await expect(
+					getTableOfContentsEditorBlock( editor )
+				).toContainText(
+					'This table of contents will show headings from the post being viewed.'
+				);
+
+				await openPostOnFrontend( page, post.id );
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', {
+							name: 'Template preview section',
+						} )
+				).toBeVisible();
+			}
+		);
+
+		// Desired behavior: ToC in templates should list only the viewed post's own headings.
+		test.fixme(
+			'only lists headings from the viewed post content boundary',
+			async ( { page, requestUtils } ) => {
+				await requestUtils.createTemplate( 'wp_template_part', {
+					slug: 'toc-header',
+					title: 'ToC Header',
+					content: headingBlock( {
+						content: 'Header template heading',
+						anchor: 'header-template-heading',
+					} ),
+				} );
+				await requestUtils.createTemplate( 'wp_template', {
+					slug: 'single',
+					title: 'Single',
+					content: [
+						'<!-- wp:template-part {"slug":"toc-header","tagName":"header","theme":"emptytheme"} /-->',
+						headingBlock( {
+							content: 'Template heading',
+							anchor: 'template-heading',
+						} ),
+						'<!-- wp:table-of-contents /-->',
+						'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+					].join( '\n\n' ),
+				} );
+				const post = await createPostWithContent(
+					requestUtils,
+					'Post headings only',
+					headingBlock( {
+						content: 'Actual post section',
+						anchor: 'actual-post-section',
+					} )
+				);
+
+				await openPostOnFrontend( page, post.id );
+
+				const tableOfContents = page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} );
+				await expect(
+					tableOfContents.getByRole( 'link', {
+						name: 'Actual post section',
+					} )
+				).toBeVisible();
+				// Template-level headings are outside the viewed post context and should be ignored.
+				await expect(
+					tableOfContents.getByText( 'Template heading' )
+				).toHaveCount( 0 );
+				// Template part headings, such as header/footer headings, should also be ignored.
+				await expect(
+					tableOfContents.getByText( 'Header template heading' )
+				).toHaveCount( 0 );
+			}
+		);
+
+		// Desired behavior: ToC in templates without post content should show a specific editor explanation; trunk only shows the generic empty-heading placeholder.
+		test.fixme(
+			'templates that do not render post content show an editor placeholder and render nothing to readers',
+			async ( { admin, editor, page, requestUtils } ) => {
+				await requestUtils.createTemplate( 'wp_template', {
+					slug: 'archive',
+					title: 'Archive',
+					content: '<!-- wp:table-of-contents /-->',
+				} );
+
+				await admin.visitSiteEditor( {
+					postId: 'emptytheme//archive',
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+				// TODO: Make this placeholder explain how users can fix the template, not only why no ToC can render.
+				await expect(
+					getTableOfContentsEditorBlock( editor )
+				).toContainText(
+					'Table of Contents needs a single post or page to list headings.'
+				);
+
+				await page.goto( '/?m=202001' );
+				await expect(
+					page.getByRole( 'navigation', {
+						name: 'Table of Contents',
+					} )
+				).toHaveCount( 0 );
+			}
+		);
+	} );
+
+	test.describe( 'Supporting content built with other blocks', () => {
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
+		} );
+
+		// This covers the author story that headings should count no matter which block created them.
+		// Desired behavior: ToC should extract heading elements from non-Heading blocks; trunk only observes core Heading blocks.
+		test.fixme(
+			'heading elements created by non-Heading blocks appear in the editor and after publish',
+			async ( { editor, page } ) => {
+				await editor.setContent(
+					[
+						'<!-- wp:table-of-contents /-->',
+						htmlBlock(
+							'<h2 id="custom-html-heading">Custom HTML heading</h2>'
+						),
+					].join( '\n\n' )
+				);
+
+				await expect(
+					getTableOfContentsEditorBlock( editor )
+				).toContainText( 'Custom HTML heading' );
+
+				const postId = await editor.publishPost();
+				await openPostOnFrontend( page, postId );
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', {
+							name: 'Custom HTML heading',
+						} )
+				).toBeVisible();
+			}
+		);
+
+		// Desired behavior: ToC should support plugin-registered heading sources; trunk has no custom heading-source contract yet.
+		test.fixme(
+			'a plugin-registered custom heading source appears in the editor and after publish while an unregistered heading-like block is ignored',
+			async ( { editor, page } ) => {
+				await editor.setContent(
+					[
+						'<!-- wp:table-of-contents /-->',
+						`<!-- wp:e2e-tests/table-of-contents-heading-source {"content":"Plugin heading source","anchor":"plugin-heading-source"} -->
+<h2 id="plugin-heading-source" class="wp-block-e2e-tests-table-of-contents-heading-source">Plugin heading source</h2>
+<!-- /wp:e2e-tests/table-of-contents-heading-source -->`,
+						`<!-- wp:e2e-tests/table-of-contents-heading-like {"content":"Unregistered heading-like source","anchor":"unregistered-heading-like-source"} -->
+<h2 id="unregistered-heading-like-source" class="wp-block-e2e-tests-table-of-contents-heading-like">Unregistered heading-like source</h2>
+<!-- /wp:e2e-tests/table-of-contents-heading-like -->`,
+					].join( '\n\n' )
+				);
+
+				await expect(
+					getTableOfContentsEditorBlock( editor )
+				).toContainText( 'Plugin heading source' );
+				// The heading-like block renders an h2 but is not the registered heading source.
+				await expect(
+					getTableOfContentsEditorBlock( editor ).getByText(
+						'Unregistered heading-like source'
+					)
+				).toHaveCount( 0 );
+
+				const postId = await editor.publishPost();
+				await openPostOnFrontend( page, postId );
+				const tableOfContents = page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} );
+				await expect(
+					tableOfContents.getByRole( 'link', {
+						name: 'Plugin heading source',
+					} )
+				).toBeVisible();
+				await expect(
+					tableOfContents.getByText(
+						'Unregistered heading-like source'
+					)
+				).toHaveCount( 0 );
+			}
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -24,6 +24,10 @@ ${ content }
 <!-- /wp:html -->`;
 }
 
+// This helper mirrors the current static saved ToC markup so reader-focused
+// tests can exercise frontend interactions without opening the editor. If the
+// block becomes dynamically rendered on the front of site, update these fixtures
+// to avoid depending on saved ToC markup.
 function tableOfContentsBlock( { headings, ordered = true } ) {
 	const attributes = { headings };
 	if ( ! ordered ) {

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -333,6 +333,69 @@ test.describe( 'Table of Contents', () => {
 	} );
 
 	test.describe( 'Reading and navigating', () => {
+		// Desired behavior: the front-of-site ToC should render from the current post headings even when content changes outside the editor; trunk only reflects headings captured when the block was last updated in the editor.
+		test.fixme(
+			'front-of-site table of contents reflects updated post headings',
+			async ( { admin, editor, page, requestUtils } ) => {
+				await admin.createNewPost();
+				await editor.setContent(
+					postContentWithTocAndHeadings( [
+						{
+							content: 'Original section',
+							anchor: 'original-section',
+						},
+					] )
+				);
+
+				const postId = await editor.publishPost();
+				await openPostOnFrontend( page, postId );
+
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', { name: 'Original section' } )
+				).toBeVisible();
+
+				// Update the post content without opening the editor so the reader view must reflect the current post headings.
+				await updatePostContent(
+					requestUtils,
+					postId,
+					postContentWithTocAndHeadings( [
+						{
+							content: 'Updated section',
+							anchor: 'updated-section',
+						},
+					] )
+				);
+
+				await openPostOnFrontend( page, postId );
+
+				const tableOfContents = page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} );
+				await expect(
+					tableOfContents.getByRole( 'link', {
+						name: 'Updated section',
+					} )
+				).toBeVisible();
+				await expect(
+					tableOfContents.getByRole( 'link', {
+						name: 'Original section',
+					} )
+				).toHaveCount( 0 );
+
+				await tableOfContents
+					.getByRole( 'link', { name: 'Updated section' } )
+					.click();
+				await expect( page ).toHaveURL( /#updated-section$/ );
+				await expect(
+					page.locator( '#updated-section' )
+				).toBeInViewport();
+			}
+		);
+
 		test( 'clicking a table of contents item on the front of site scrolls to the matching section', async ( {
 			page,
 			requestUtils,

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -924,7 +924,7 @@ test.describe( 'Table of Contents', () => {
 
 		// Desired behavior: ToC should support plugin-registered heading sources; trunk has no custom heading-source contract yet.
 		test.fixme(
-			'a plugin-registered custom heading source appears in the editor and after publish while an unregistered heading-like block is ignored',
+			'a plugin heading-source block appears in the editor and after publish while a plain heading-like block is ignored',
 			async ( { editor, page } ) => {
 				await editor.setContent(
 					[
@@ -932,8 +932,8 @@ test.describe( 'Table of Contents', () => {
 						`<!-- wp:e2e-tests/table-of-contents-heading-source {"content":"Plugin heading source","anchor":"plugin-heading-source"} -->
 <h2 id="plugin-heading-source" class="wp-block-e2e-tests-table-of-contents-heading-source">Plugin heading source</h2>
 <!-- /wp:e2e-tests/table-of-contents-heading-source -->`,
-						`<!-- wp:e2e-tests/table-of-contents-heading-like {"content":"Unregistered heading-like source","anchor":"unregistered-heading-like-source"} -->
-<h2 id="unregistered-heading-like-source" class="wp-block-e2e-tests-table-of-contents-heading-like">Unregistered heading-like source</h2>
+						`<!-- wp:e2e-tests/table-of-contents-heading-like {"content":"Plain heading-like block","anchor":"plain-heading-like-block"} -->
+<h2 id="plain-heading-like-block" class="wp-block-e2e-tests-table-of-contents-heading-like">Plain heading-like block</h2>
 <!-- /wp:e2e-tests/table-of-contents-heading-like -->`,
 					].join( '\n\n' )
 				);
@@ -941,10 +941,10 @@ test.describe( 'Table of Contents', () => {
 				await expect(
 					getTableOfContentsEditorBlock( editor )
 				).toContainText( 'Plugin heading source' );
-				// The heading-like block renders an h2 but is not the registered heading source.
+				// Both test blocks are registered block types; only the heading-source block represents the future ToC opt-in contract.
 				await expect(
 					getTableOfContentsEditorBlock( editor ).getByText(
-						'Unregistered heading-like source'
+						'Plain heading-like block'
 					)
 				).toHaveCount( 0 );
 
@@ -959,9 +959,7 @@ test.describe( 'Table of Contents', () => {
 					} )
 				).toBeVisible();
 				await expect(
-					tableOfContents.getByText(
-						'Unregistered heading-like source'
-					)
+					tableOfContents.getByText( 'Plain heading-like block' )
 				).toHaveCount( 0 );
 			}
 		);


### PR DESCRIPTION
## What

Part of #42229.

Adds Playwright e2e coverage for the Table of Contents block user stories documented in the issue. The coverage includes active tests for current supported behavior and `test.fixme` coverage for desired behavior that trunk does not yet support.

## Why

The Table of Contents block is being considered for stabilization, but it lacks automated coverage for the expected user-facing behavior. These tests document the desired behavior in code and provide a confidence layer for future work on dynamic rendering, template placement, accessibility, and support for headings created by other blocks.

## How

Adds a focused Table of Contents e2e spec covering editor behavior, front-of-site reading/navigation behavior, accessibility, template placement expectations, and support for non-Heading/custom heading-source blocks.

Adds a test-only e2e plugin used to document the desired custom heading-source behavior.

Documents desired but currently unsupported behavior with `test.fixme` after observing those failures against trunk.

**Note**: it is expected that as contributors begin to implement features required the relevant `fixme` tests should be uncommented to provide coverage.

## Testing Instructions

1. Run `npm run wp-env-test status`.
2. Start the test environment if needed with `npm run wp-env-test start`.
3. Run `npm run test:e2e -- test/e2e/specs/editor/blocks/table-of-contents.spec.js`.
4. Confirm the active tests pass and the desired-behavior tests are skipped as `test.fixme`.
