### PR TITLE
Playlist: Fix track insertion

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -78,7 +78,7 @@ const PlaylistTrackEdit = ( {
 	] );
 
 	useUploadMediaFromBlobURL( {
-		src: temporaryURL,
+		url: temporaryURL,
 		allowedTypes: ALLOWED_MEDIA_TYPES,
 		onChange: onSelectTrack,
 		onError: onUploadError,

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -53,7 +53,7 @@ const PlaylistTrackEdit = ( {
 	const showImages = context?.showImages ?? true;
 	const imageButton = useRef();
 	const blockProps = useBlockProps();
-	const { currentTrackClientId, setCurrentTrackClientId } =
+	const { currentTrackClientId, setCurrentTrackClientId, addTracks } =
 		useContext( PlaylistContext );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
@@ -158,7 +158,20 @@ const PlaylistTrackEdit = ( {
 					mediaURL={ src }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					onError={ onUploadError }
+					variant="toolbar"
 				/>
+				{ !! addTracks && (
+					<MediaReplaceFlow
+						name={ __( 'Add' ) }
+						onSelect={ addTracks }
+						accept="audio/*"
+						multiple
+						handleUpload={ false }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onError={ onUploadError }
+						variant="toolbar"
+					/>
+				) }
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -160,7 +160,9 @@ const PlaylistTrackEdit = ( {
 					onError={ onUploadError }
 					variant="toolbar"
 				/>
-				{ !! addTracks && (
+			</BlockControls>
+			{ !! addTracks && (
+				<BlockControls group="block">
 					<MediaReplaceFlow
 						name={ __( 'Add' ) }
 						onSelect={ addTracks }
@@ -171,8 +173,8 @@ const PlaylistTrackEdit = ( {
 						onError={ onUploadError }
 						variant="toolbar"
 					/>
-				) }
-			</BlockControls>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextControl

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -20,7 +20,9 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	BlockIcon: () => <span />,
 	InspectorControls: ( { children } ) => <div>{ children }</div>,
 	MediaPlaceholder: () => <div />,
-	MediaReplaceFlow: () => <div />,
+	MediaReplaceFlow: ( { name, onSelect } ) => (
+		<button onClick={ () => onSelect( {} ) }>{ name }</button>
+	),
 	MediaUpload: ( { render: renderMediaUpload } ) =>
 		renderMediaUpload( { open: jest.fn() } ),
 	MediaUploadCheck: ( { children } ) => <div>{ children }</div>,
@@ -72,12 +74,14 @@ const defaultAttributes = {
 function renderEdit( props = {} ) {
 	const setAttributes = jest.fn();
 	const setCurrentTrackClientId = props.setCurrentTrackClientId || jest.fn();
+	const addTracks = props.addTracks;
 
 	render(
 		<PlaylistContext.Provider
 			value={ {
 				currentTrackClientId: props.currentTrackClientId ?? null,
 				setCurrentTrackClientId,
+				addTracks,
 			} }
 		>
 			<PlaylistTrackEdit
@@ -182,5 +186,14 @@ describe( 'PlaylistTrackEdit', () => {
 				url: 'blob:https://example.com/temporary-track',
 			} )
 		);
+	} );
+
+	it( 'allows tracks to be added from the track toolbar', () => {
+		const addTracks = jest.fn();
+		renderEdit( { addTracks } );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
+
+		expect( addTracks ).toHaveBeenCalledWith( {} );
 	} );
 } );

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -13,6 +13,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import PlaylistTrackEdit from '../edit';
 import { PlaylistContext } from '../../playlist/context';
+import { useUploadMediaFromBlobURL } from '../../utils/hooks';
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	BlockControls: ( { children } ) => <div>{ children }</div>,
@@ -104,6 +105,7 @@ describe( 'PlaylistTrackEdit', () => {
 		useDispatch.mockReturnValue( {
 			createErrorNotice: jest.fn(),
 		} );
+		useUploadMediaFromBlobURL.mockClear();
 	} );
 
 	it( 'allows the track image alternative text to be edited', () => {
@@ -165,5 +167,20 @@ describe( 'PlaylistTrackEdit', () => {
 		} );
 
 		expect( setCurrentTrackClientId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uploads temporary blob tracks', () => {
+		renderEdit( {
+			attributes: {
+				blob: 'blob:https://example.com/temporary-track',
+				src: undefined,
+			},
+		} );
+
+		expect( useUploadMediaFromBlobURL ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'blob:https://example.com/temporary-track',
+			} )
+		);
 	} );
 } );

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -16,7 +16,9 @@ import { PlaylistContext } from '../../playlist/context';
 import { useUploadMediaFromBlobURL } from '../../utils/hooks';
 
 jest.mock( '@wordpress/block-editor', () => ( {
-	BlockControls: ( { children } ) => <div>{ children }</div>,
+	BlockControls: ( { children, group = 'default' } ) => (
+		<div data-testid={ `block-controls-${ group }` }>{ children }</div>
+	),
 	BlockIcon: () => <span />,
 	InspectorControls: ( { children } ) => <div>{ children }</div>,
 	MediaPlaceholder: () => <div />,
@@ -195,5 +197,22 @@ describe( 'PlaylistTrackEdit', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
 
 		expect( addTracks ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'renders the add track control in a different toolbar group from replace', () => {
+		renderEdit( { addTracks: jest.fn() } );
+
+		expect(
+			within( screen.getByTestId( 'block-controls-other' ) ).getByRole(
+				'button',
+				{ name: 'Replace' }
+			)
+		).toBeInTheDocument();
+		expect(
+			within( screen.getByTestId( 'block-controls-block' ) ).getByRole(
+				'button',
+				{ name: 'Add' }
+			)
+		).toBeInTheDocument();
 	} );
 } );

--- a/packages/block-library/src/playlist/context.js
+++ b/packages/block-library/src/playlist/context.js
@@ -6,4 +6,5 @@ import { createContext } from '@wordpress/element';
 export const PlaylistContext = createContext( {
 	currentTrackClientId: null,
 	setCurrentTrackClientId: () => {},
+	addTracks: undefined,
 } );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -46,6 +46,7 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const DEFAULT_WAVEFORM_STYLE = 'bars';
+const FILE_LIST_OBJECT_NAME = '[object FileList]';
 const WAVEFORM_STYLE_OPTIONS = [
 	{ label: _x( 'Bars', 'waveform style option' ), value: 'bars' },
 	{ label: _x( 'Mirror', 'waveform style option' ), value: 'mirror' },
@@ -56,11 +57,10 @@ const WAVEFORM_STYLE_OPTIONS = [
 ];
 
 function isFile( value ) {
-	return typeof File !== 'undefined' && value instanceof File;
-}
-
-function isFileList( value ) {
-	return typeof FileList !== 'undefined' && value instanceof FileList;
+	return (
+		Object.prototype.toString.call( value ) === '[object File]' ||
+		( typeof File !== 'undefined' && value instanceof File )
+	);
 }
 
 function isAudioFile( file ) {
@@ -182,7 +182,10 @@ const PlaylistEdit = ( {
 			}
 
 			let mediaItems = [ media ];
-			if ( isFileList( media ) ) {
+			if (
+				Object.prototype.toString.call( media ) ===
+				FILE_LIST_OBJECT_NAME
+			) {
 				mediaItems = Array.from( media );
 			} else if ( Array.isArray( media ) ) {
 				mediaItems = media;

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -16,7 +16,6 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 	InspectorControls,
-	InnerBlocks,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
@@ -77,7 +76,7 @@ const PlaylistEdit = ( {
 
 	const blockProps = useBlockProps();
 	const waveformPanelId = `${ clientId }-waveform`;
-	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
@@ -157,26 +156,63 @@ const PlaylistEdit = ( {
 		[ currentTrackClientId, setCurrentTrackClientId ]
 	);
 
+	const createTrackBlocks = useCallback( ( media ) => {
+		if ( ! media ) {
+			return [];
+		}
+
+		const mediaItems = Array.isArray( media ) ? media : [ media ];
+
+		return mediaItems
+			.map( getTrackAttributes )
+			.filter( ( track ) => !! track.src )
+			.map( ( track ) => createBlock( 'core/playlist-track', track ) );
+	}, [] );
+
 	const onSelectTracks = useCallback(
 		( media ) => {
-			if ( ! media ) {
+			const newBlocks = createTrackBlocks( media );
+			if ( newBlocks.length === 0 ) {
 				return;
 			}
 
-			if ( ! Array.isArray( media ) ) {
-				media = [ media ];
-			}
-
-			const trackList = media.map( getTrackAttributes );
-
-			const newBlocks = trackList.map( ( track ) =>
-				createBlock( 'core/playlist-track', track )
-			);
 			setCurrentTrackClientId( newBlocks[ 0 ]?.clientId ?? null );
 			// Replace the inner blocks with the new tracks.
 			replaceInnerBlocks( clientId, newBlocks );
 		},
-		[ replaceInnerBlocks, clientId, setCurrentTrackClientId ]
+		[
+			clientId,
+			createTrackBlocks,
+			replaceInnerBlocks,
+			setCurrentTrackClientId,
+		]
+	);
+
+	const onAddTracks = useCallback(
+		( media ) => {
+			const existingIds = new Set(
+				validTracks.map( ( block ) => block.attributes.id )
+			);
+			const newBlocks = createTrackBlocks( media ).filter(
+				( block ) => ! existingIds.has( block.attributes.id )
+			);
+			if ( newBlocks.length === 0 ) {
+				return;
+			}
+
+			const nextBlocks = [ ...validTracks, ...newBlocks ];
+			setCurrentTrackClientId( newBlocks[ 0 ].clientId );
+			replaceInnerBlocks( clientId, nextBlocks );
+			selectBlock( newBlocks[ 0 ].clientId );
+		},
+		[
+			clientId,
+			createTrackBlocks,
+			replaceInnerBlocks,
+			selectBlock,
+			setCurrentTrackClientId,
+			validTracks,
+		]
 	);
 
 	// Get current track data by finding the track with matching client ID.
@@ -305,14 +341,6 @@ const PlaylistEdit = ( {
 		} );
 	}
 
-	const hasSelectedChild = useSelect(
-		( select ) =>
-			select( blockEditorStore ).hasSelectedInnerBlock( clientId ),
-		[ clientId ]
-	);
-
-	const hasAnySelected = isSelected || hasSelectedChild;
-
 	const colorSettings = [];
 	if ( hasColors || hasGradients ) {
 		colorSettings.push(
@@ -357,7 +385,7 @@ const PlaylistEdit = ( {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		__experimentalAppenderTagName: 'li',
-		renderAppender: hasAnySelected && InnerBlocks.ButtonBlockAppender,
+		renderAppender: false,
 	} );
 
 	if ( tracks.length === 0 ) {
@@ -390,6 +418,17 @@ const PlaylistEdit = ( {
 				<MediaReplaceFlow
 					name={ __( 'Edit' ) }
 					onSelect={ onSelectTracks }
+					accept="audio/*"
+					multiple
+					mediaIds={ tracks
+						.filter( ( track ) => track.id )
+						.map( ( track ) => track.id ) }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					onError={ onUploadError }
+				/>
+				<MediaReplaceFlow
+					name={ __( 'Add' ) }
+					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple
 					mediaIds={ tracks

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -485,26 +485,11 @@ const PlaylistEdit = ( {
 		<>
 			<BlockControls group="other">
 				<MediaReplaceFlow
-					name={ __( 'Edit' ) }
-					onSelect={ onSelectTracks }
-					accept="audio/*"
-					multiple
-					handleUpload={ false }
-					mediaIds={ tracks
-						.filter( ( track ) => track.id )
-						.map( ( track ) => track.id ) }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					onError={ onUploadError }
-				/>
-				<MediaReplaceFlow
 					name={ __( 'Add' ) }
 					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple
 					handleUpload={ false }
-					mediaIds={ tracks
-						.filter( ( track ) => track.id )
-						.map( ( track ) => track.id ) }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					onError={ onUploadError }
 				/>
@@ -720,20 +705,20 @@ const PlaylistEdit = ( {
 						showPlayButtonArtwork={ showPlayButtonArtwork === true }
 					/>
 				</Disabled>
-				{ showTracklist && (
-					<ol
-						className={ clsx( 'wp-block-playlist__tracklist', {
-							'wp-block-playlist__tracklist-show-numbers':
-								showNumbers,
-							'wp-block-playlist__tracklist-length-is-hidden':
-								! showTrackLength,
-						} ) }
-					>
-						<PlaylistContext.Provider value={ playlistContext }>
-							{ innerBlocksProps.children }
-						</PlaylistContext.Provider>
-					</ol>
-				) }
+				<ol
+					className={ clsx( 'wp-block-playlist__tracklist', {
+						'wp-block-playlist__tracklist-is-hidden':
+							! showTracklist,
+						'wp-block-playlist__tracklist-show-numbers':
+							showNumbers,
+						'wp-block-playlist__tracklist-length-is-hidden':
+							! showTrackLength,
+					} ) }
+				>
+					<PlaylistContext.Provider value={ playlistContext }>
+						{ innerBlocksProps.children }
+					</PlaylistContext.Provider>
+				</ol>
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -175,11 +175,6 @@ const PlaylistEdit = ( {
 		}
 	}, [ currentTrackClientId, setCurrentTrackClientId, validTracks ] );
 
-	const playlistContext = useMemo(
-		() => ( { currentTrackClientId, setCurrentTrackClientId } ),
-		[ currentTrackClientId, setCurrentTrackClientId ]
-	);
-
 	const createTrackBlocks = useCallback(
 		( media ) => {
 			if ( ! media ) {
@@ -277,6 +272,15 @@ const PlaylistEdit = ( {
 			setCurrentTrackClientId,
 			validTracks,
 		]
+	);
+
+	const playlistContext = useMemo(
+		() => ( {
+			currentTrackClientId,
+			setCurrentTrackClientId,
+			addTracks: onAddTracks,
+		} ),
+		[ currentTrackClientId, onAddTracks, setCurrentTrackClientId ]
 	);
 
 	// Get current track data by finding the track with matching client ID.

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -31,6 +31,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { __, _x } from '@wordpress/i18n';
 import { playlist as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { createBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -42,7 +43,10 @@ import { PlaylistContext } from './context';
 import { getTrackAttributes } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const AUDIO_FILE_EXTENSION =
+	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const DEFAULT_WAVEFORM_STYLE = 'bars';
+const FILE_LIST_OBJECT_NAME = '[object FileList]';
 const WAVEFORM_STYLE_OPTIONS = [
 	{ label: _x( 'Bars', 'waveform style option' ), value: 'bars' },
 	{ label: _x( 'Mirror', 'waveform style option' ), value: 'mirror' },
@@ -51,6 +55,23 @@ const WAVEFORM_STYLE_OPTIONS = [
 	{ label: _x( 'Dots', 'waveform style option' ), value: 'dots' },
 	{ label: _x( 'Seekbar', 'waveform style option' ), value: 'seekbar' },
 ];
+
+function isFile( value ) {
+	return (
+		Object.prototype.toString.call( value ) === '[object File]' ||
+		( typeof File !== 'undefined' && value instanceof File )
+	);
+}
+
+function isAudioFile( file ) {
+	return file.type
+		? file.type.startsWith( 'audio/' )
+		: AUDIO_FILE_EXTENSION.test( file.name );
+}
+
+function getTrackIdentifier( track ) {
+	return track.id ?? track.src ?? track.blob;
+}
 
 const PlaylistEdit = ( {
 	attributes,
@@ -102,9 +123,12 @@ const PlaylistEdit = ( {
 	const waveformBackgroundGradientValue = waveformBackgroundGradient;
 	let waveformColorGradientChange;
 	let waveformBackgroundColorGradientChange;
-	function onUploadError( message ) {
-		createErrorNotice( message, { type: 'snackbar' } );
-	}
+	const onUploadError = useCallback(
+		( message ) => {
+			createErrorNotice( message, { type: 'snackbar' } );
+		},
+		[ createErrorNotice ]
+	);
 	const [ currentTrackClientId, setCurrentTrackClientId ] = useState( null );
 
 	const { innerBlockTracks } = useSelect(
@@ -156,18 +180,55 @@ const PlaylistEdit = ( {
 		[ currentTrackClientId, setCurrentTrackClientId ]
 	);
 
-	const createTrackBlocks = useCallback( ( media ) => {
-		if ( ! media ) {
-			return [];
-		}
+	const createTrackBlocks = useCallback(
+		( media ) => {
+			if ( ! media ) {
+				return [];
+			}
 
-		const mediaItems = Array.isArray( media ) ? media : [ media ];
+			let mediaItems = [ media ];
+			if (
+				Object.prototype.toString.call( media ) ===
+				FILE_LIST_OBJECT_NAME
+			) {
+				mediaItems = Array.from( media );
+			} else if ( Array.isArray( media ) ) {
+				mediaItems = media;
+			}
+			let hasInvalidFile = false;
 
-		return mediaItems
-			.map( getTrackAttributes )
-			.filter( ( track ) => !! track.src )
-			.map( ( track ) => createBlock( 'core/playlist-track', track ) );
-	}, [] );
+			const blocks = mediaItems
+				.map( ( mediaItem ) => {
+					if ( isFile( mediaItem ) ) {
+						if ( ! isAudioFile( mediaItem ) ) {
+							hasInvalidFile = true;
+							return null;
+						}
+
+						return createBlock( 'core/playlist-track', {
+							blob: createBlobURL( mediaItem ),
+							title: mediaItem.name,
+						} );
+					}
+
+					const track = getTrackAttributes( mediaItem );
+
+					return track.src
+						? createBlock( 'core/playlist-track', track )
+						: null;
+				} )
+				.filter( Boolean );
+
+			if ( hasInvalidFile ) {
+				onUploadError(
+					__( 'Only audio files can be added to a playlist.' )
+				);
+			}
+
+			return blocks;
+		},
+		[ onUploadError ]
+	);
 
 	const onSelectTracks = useCallback(
 		( media ) => {
@@ -191,10 +252,13 @@ const PlaylistEdit = ( {
 	const onAddTracks = useCallback(
 		( media ) => {
 			const existingIds = new Set(
-				validTracks.map( ( block ) => block.attributes.id )
+				validTracks
+					.map( ( block ) => getTrackIdentifier( block.attributes ) )
+					.filter( Boolean )
 			);
 			const newBlocks = createTrackBlocks( media ).filter(
-				( block ) => ! existingIds.has( block.attributes.id )
+				( block ) =>
+					! existingIds.has( getTrackIdentifier( block.attributes ) )
 			);
 			if ( newBlocks.length === 0 ) {
 				return;
@@ -405,6 +469,7 @@ const PlaylistEdit = ( {
 					onSelect={ onSelectTracks }
 					accept="audio/*"
 					multiple
+					handleUpload={ false }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					onError={ onUploadError }
 				/>
@@ -420,6 +485,7 @@ const PlaylistEdit = ( {
 					onSelect={ onSelectTracks }
 					accept="audio/*"
 					multiple
+					handleUpload={ false }
 					mediaIds={ tracks
 						.filter( ( track ) => track.id )
 						.map( ( track ) => track.id ) }
@@ -431,6 +497,7 @@ const PlaylistEdit = ( {
 					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple
+					handleUpload={ false }
 					mediaIds={ tracks
 						.filter( ( track ) => track.id )
 						.map( ( track ) => track.id ) }
@@ -624,6 +691,15 @@ const PlaylistEdit = ( {
 				</ToolsPanel>
 			</InspectorControls>
 			<figure { ...blockProps }>
+				<MediaPlaceholder
+					onSelect={ onAddTracks }
+					accept="audio/*"
+					multiple
+					handleUpload={ false }
+					disableMediaButtons
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					onError={ onUploadError }
+				/>
 				<Disabled isDisabled={ ! isSelected }>
 					<WaveformPlayer
 						src={ currentTrackData?.src }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -46,7 +46,6 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const DEFAULT_WAVEFORM_STYLE = 'bars';
-const FILE_LIST_OBJECT_NAME = '[object FileList]';
 const WAVEFORM_STYLE_OPTIONS = [
 	{ label: _x( 'Bars', 'waveform style option' ), value: 'bars' },
 	{ label: _x( 'Mirror', 'waveform style option' ), value: 'mirror' },
@@ -57,10 +56,11 @@ const WAVEFORM_STYLE_OPTIONS = [
 ];
 
 function isFile( value ) {
-	return (
-		Object.prototype.toString.call( value ) === '[object File]' ||
-		( typeof File !== 'undefined' && value instanceof File )
-	);
+	return typeof File !== 'undefined' && value instanceof File;
+}
+
+function isFileList( value ) {
+	return typeof FileList !== 'undefined' && value instanceof FileList;
 }
 
 function isAudioFile( file ) {
@@ -182,10 +182,7 @@ const PlaylistEdit = ( {
 			}
 
 			let mediaItems = [ media ];
-			if (
-				Object.prototype.toString.call( media ) ===
-				FILE_LIST_OBJECT_NAME
-			) {
+			if ( isFileList( media ) ) {
 				mediaItems = Array.from( media );
 			} else if ( Array.isArray( media ) ) {
 				mediaItems = media;

--- a/packages/block-library/src/playlist/editor.scss
+++ b/packages/block-library/src/playlist/editor.scss
@@ -1,10 +1,3 @@
-.wp-block-playlist {
-	li.block-list-appender.block-list-appender {
-		position: initial;
-		margin-top: var(--wp--preset--spacing--30, 1em);
-	}
-}
-
 .wp-block-playlist__waveform-color-controls {
 	display: grid;
 	grid-column: 1 / -1;

--- a/packages/block-library/src/playlist/editor.scss
+++ b/packages/block-library/src/playlist/editor.scss
@@ -1,3 +1,7 @@
+.wp-block-playlist {
+	position: relative;
+}
+
 .wp-block-playlist__waveform-color-controls {
 	display: grid;
 	grid-column: 1 / -1;

--- a/packages/block-library/src/playlist/editor.scss
+++ b/packages/block-library/src/playlist/editor.scss
@@ -1,7 +1,3 @@
-.wp-block-playlist {
-	position: relative;
-}
-
 .wp-block-playlist__waveform-color-controls {
 	display: grid;
 	grid-column: 1 / -1;

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import PlaylistEdit from '../edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: {},
+	BlockControls: ( { children } ) => <div>{ children }</div>,
+	BlockIcon: () => <span />,
+	InspectorControls: ( { children } ) => <div>{ children }</div>,
+	MediaPlaceholder: () => <div />,
+	MediaReplaceFlow: () => <div />,
+	useBlockProps: () => ( { className: 'wp-block-playlist' } ),
+	useInnerBlocksProps: ( blockProps ) => ( {
+		...blockProps,
+		children: <li data-testid="playlist-track" />,
+	} ),
+	__experimentalColorGradientSettingsDropdown: () => <div />,
+	__experimentalUseMultipleOriginColorsAndGradients: () => ( {
+		colors: [],
+		gradients: [],
+		disableCustomColors: true,
+		disableCustomGradients: true,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( name, attributes ) => ( {
+		name,
+		attributes,
+		clientId: 'new-track',
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/blob', () => ( {
+	createBlobURL: jest.fn( () => 'blob:track' ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Disabled: ( { children } ) => <div>{ children }</div>,
+	SelectControl: () => <div />,
+	ToggleControl: () => <div />,
+	__experimentalToolsPanel: ( { children } ) => <div>{ children }</div>,
+	__experimentalToolsPanelItem: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+	_x: ( text ) => text,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	playlist: 'playlist',
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: {},
+} ) );
+
+jest.mock( '../../utils/caption', () => ( {
+	Caption: () => <figcaption />,
+} ) );
+
+jest.mock( '../../utils/hooks', () => ( {
+	useToolsPanelDropdownMenuProps: () => ( {} ),
+} ) );
+
+jest.mock( '../../utils/waveform-player', () => ( {
+	WaveformPlayer: () => <div />,
+} ) );
+
+const defaultAttributes = {
+	order: 'asc',
+	showTracklist: true,
+	showNumbers: true,
+	showImages: true,
+	showPlayButtonArtwork: false,
+	showArtists: true,
+	showTrackLength: true,
+};
+
+describe( 'PlaylistEdit', () => {
+	beforeEach( () => {
+		useDispatch.mockReturnValue( {
+			createErrorNotice: jest.fn(),
+			replaceInnerBlocks: jest.fn(),
+			selectBlock: jest.fn(),
+		} );
+		useSelect.mockReturnValue( {
+			innerBlockTracks: [
+				{
+					clientId: 'track-1',
+					attributes: {
+						id: 1,
+						src: 'https://example.com/audio.mp3',
+						title: 'Sample track',
+					},
+				},
+			],
+		} );
+	} );
+
+	it( 'keeps track blocks mounted when the tracklist is hidden', () => {
+		render(
+			<PlaylistEdit
+				attributes={ {
+					...defaultAttributes,
+					showTracklist: false,
+				} }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		const tracklist = screen.getByRole( 'list' );
+
+		expect( tracklist ).toHaveClass(
+			'wp-block-playlist__tracklist-is-hidden'
+		);
+		expect( screen.getByTestId( 'playlist-track' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #80186

Improves how tracks are added to the Playlist block so new audio files are appended to the existing playlist instead of leaving an inline placeholder in the block canvas.

This PR adds toolbar-based Add controls for Playlist and Playlist Track blocks, keeps the populated Playlist block available as an audio drop zone, supports temporary blob tracks for local files, filters duplicate selected tracks when appending, and keeps track blocks mounted when the track list is hidden.

## Why?
The inline appender expanded the selected Playlist block and left an inserted media placeholder that could not be dismissed or undone without removing it.

Keeping hidden track blocks mounted also preserves the child block behavior and current-track state when the track list display setting is disabled.

## How?
- Replaces the populated Playlist block's inline inner-block appender with toolbar Add flows.
- Shares an `addTracks` callback with Playlist Track blocks through playlist context.
- Creates playlist-track blocks from selected media items or local audio `File` objects, using blob URLs until upload completes.
- Appends only new tracks by comparing track IDs, source URLs, or blob URLs.
- Renders the track list container even when visually hidden so inner blocks stay mounted.

## Testing Instructions
1. Open a post or page.
2. Insert a Playlist block and select at least one audio file.
3. Select the Playlist block and use the toolbar `Add` control to add another audio file.
4. Confirm the new track is appended without an inline placeholder appearing in the block canvas.
5. Select an individual Playlist Track block and use its toolbar `Add` control to add another audio file.
6. Drag a local audio file onto a populated Playlist block and confirm it is appended and uploaded.
7. Disable the Playlist block's track list setting and confirm the playlist remains editable without the track blocks being removed.

### Testing Instructions for Keyboard
1. Open a post or page and insert a Playlist block with at least one audio file.
2. Use the keyboard to focus the Playlist block toolbar.
3. Open the `Add` control, choose another audio file, and confirm the added track is appended without a persistent inline placeholder.
4. Focus an individual Playlist Track block, open its toolbar `Add` control, and confirm another track can be appended.

## Screenshots or screencast

N/A

## Use of AI Tools

This PR was authored with assistance from OpenAI Codex. The generated changes were reviewed before submission.
