### PR TITLE
Release: Add durable npm release state for better recoverability

### DIFF
--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -23,12 +23,17 @@ const repositoryPathOption = [
 	'--repository-path <repository-path>',
 	'Relative path to the git repository.',
 ];
+const releaseIdOption = [
+	'--release-id <release-id>',
+	'Stable identifier used to resume the same release.',
+];
 
 program
 	.command( 'publish-npm-packages-latest' )
 	.alias( 'npm-latest' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm packages synced from the Gutenberg plugin (latest dist-tag, production version)'
@@ -39,6 +44,7 @@ program
 	.command( 'publish-npm-packages-bugfix-latest' )
 	.alias( 'npm-bugfix' )
 	.option( ...ciOption )
+	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm bugfixes for packages (latest dist-tag, production version)'
@@ -50,6 +56,7 @@ program
 	.alias( 'npm-wp' )
 	.requiredOption( '--wp-version <wpVersion>', 'WordPress version' )
 	.option( ...ciOption )
+	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm bugfixes targeting WordPress core (wp-X.Y dist-tag, production version)'
@@ -61,6 +68,7 @@ program
 	.alias( 'npm-next' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
 		'Publishes to npm development version of packages (next dist-tag, prerelease version)'

--- a/tools/release/commands/common.js
+++ b/tools/release/commands/common.js
@@ -19,7 +19,7 @@ async function findPluginReleaseBranchName(
 	deps = {}
 ) {
 	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
-	await git.fetch( 'origin', 'trunk' );
+	await git.fetch( 'origin', 'trunk', [ '--depth=1' ] );
 	const mainPackageJson = JSON.parse(
 		await git.show( 'FETCH_HEAD:package.json' )
 	);

--- a/tools/release/commands/common.js
+++ b/tools/release/commands/common.js
@@ -5,25 +5,24 @@ const semver = require( 'semver' );
 const SimpleGit = require( 'simple-git' );
 
 /**
- * Internal dependencies
- */
-const { readJSONFile } = require( '../lib/utils' );
-
-/**
  * Finds the name of the current plugin release branch based on the version in
- * the package.json file and the latest `trunk` branch in `git`.
+ * the package.json file at the latest `trunk` commit in `git`.
  *
  * @param {string} gitWorkingDirectoryPath Path to the project's working directory.
+ * @param {Object} deps                    Dependencies.
+ * @param {Object} deps.git                Git client.
  *
  * @return {string} Name of the plugin release branch.
  */
-async function findPluginReleaseBranchName( gitWorkingDirectoryPath ) {
-	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( 'origin', 'trunk' )
-		.checkout( 'trunk' );
-
-	const packageJsonPath = gitWorkingDirectoryPath + '/package.json';
-	const mainPackageJson = readJSONFile( packageJsonPath );
+async function findPluginReleaseBranchName(
+	gitWorkingDirectoryPath,
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	await git.fetch( 'origin', 'trunk' );
+	const mainPackageJson = JSON.parse(
+		await git.show( 'FETCH_HEAD:package.json' )
+	);
 	const mainParsedVersion = semver.parse( mainPackageJson.version );
 
 	return 'release/' + mainParsedVersion.major + '.' + mainParsedVersion.minor;

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -34,7 +34,7 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
 /**
  * Release type names.
  *
- * @typedef {('latest'|'bugfix'|'patch'|'next')} ReleaseType
+ * @typedef {('latest'|'bugfix'|'wp'|'next')} ReleaseType
  */
 
 /**
@@ -93,8 +93,7 @@ async function checkoutNpmReleaseBranch( {
 }
 
 /**
- * Checks out the npm release branch and syncs it with the changes from
- * the last plugin release.
+ * Syncs the checked-out npm release branch with the last plugin release.
  *
  * @param {string}           pluginReleaseBranch The plugin release branch name.
  * @param {WPPackagesConfig} config              The config object.
@@ -109,8 +108,6 @@ async function runNpmReleaseBranchSyncStep( pluginReleaseBranch, config ) {
 		npmReleaseBranch,
 	} = config;
 	await runStep( 'Syncing the npm release branch', abortMessage, async () => {
-		await checkoutNpmReleaseBranch( config );
-
 		if ( interactive ) {
 			await askForConfirmation(
 				`The branch is ready for sync with the latest plugin release changes applied to "${ pluginReleaseBranch }". Proceed?`,
@@ -136,13 +133,9 @@ async function runNpmReleaseBranchSyncStep( pluginReleaseBranch, config ) {
 			.fetch( 'origin', pluginReleaseBranch, [ '--depth=1' ] )
 			.raw( 'checkout', `origin/${ pluginReleaseBranch }`, '--', '.' );
 
-		const { commit: commitHash } = await repo.commit(
+		await repo.commit(
 			`Merge changes published in the Gutenberg plugin "${ pluginReleaseBranch }" branch`
 		);
-
-		if ( commitHash ) {
-			await runPushGitChangesStep( config );
-		}
 
 		log(
 			'>> The local npm release branch ' +
@@ -307,39 +300,33 @@ async function updatePackages( config ) {
 		.add( [ './*' ] )
 		.commit( 'Update changelog files' );
 
-	if ( commitHash ) {
-		await runPushGitChangesStep( config );
-	}
-
 	log( '>> Changelog files have been updated successfully.' );
 
 	return commitHash;
 }
 
 /**
- * Push the local Git Changes the remote repository.
+ * Records the release route immediately before changelog and version commits.
  *
- * @param {WPPackagesConfig} config Command config.
+ * @param {?string}          pluginReleaseBranch Plugin release branch, when synced.
+ * @param {WPPackagesConfig} config              Command config.
+ * @param {Object}           deps                Dependencies.
+ * @param {Object}           deps.git            Git client.
  */
-async function runPushGitChangesStep( {
-	gitWorkingDirectoryPath,
-	interactive,
-	npmReleaseBranch,
-} ) {
-	const abortMessage = `Aborting! Make sure to push changes applied to npm release branch "${ npmReleaseBranch }" manually.`;
-	await runStep( 'Pushing the release branch', abortMessage, async () => {
-		if ( interactive ) {
-			await askForConfirmation(
-				'The release branch is going to be pushed to the remote repository. Continue?',
-				true,
-				abortMessage
-			);
-		}
-		await SimpleGit( gitWorkingDirectoryPath ).push(
-			'origin',
-			npmReleaseBranch
-		);
-	} );
+async function createNpmReleaseMarker(
+	pluginReleaseBranch,
+	config,
+	deps = {}
+) {
+	const { gitWorkingDirectoryPath, releaseType } = config;
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const source = pluginReleaseBranch ? ` from ${ pluginReleaseBranch }` : '';
+	await git.raw(
+		'commit',
+		'--allow-empty',
+		'-m',
+		`chore(release): prepare npm ${ releaseType }${ source }`
+	);
 }
 
 /**
@@ -393,6 +380,235 @@ async function getNpmReleasePackages( gitWorkingDirectoryPath, deps = {} ) {
 			version,
 		} ) )
 		.sort( ( a, b ) => a.tagName.localeCompare( b.tagName ) );
+}
+
+/**
+ * Returns public packages versioned by an exact prepared release commit.
+ *
+ * @param {string} gitWorkingDirectoryPath Git working directory path.
+ * @param {string} publishCommit           Prepared release commit SHA.
+ * @param {Object} deps                    Dependencies.
+ * @param {Object} deps.git                Git client.
+ *
+ * @return {Promise<Array<{ name: string, version: string, tagName: string }>>} Package metadata.
+ */
+async function getPreparedNpmReleasePackages(
+	gitWorkingDirectoryPath,
+	publishCommit,
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const changedPaths = (
+		await git.raw(
+			'diff-tree',
+			'--no-commit-id',
+			'--name-only',
+			'-r',
+			`${ publishCommit }^`,
+			publishCommit,
+			'--',
+			'packages/*/package.json'
+		)
+	)
+		.split( '\n' )
+		.filter( Boolean );
+
+	const packages = await Promise.all(
+		changedPaths.map( async ( packageJSONPath ) => {
+			const packageJson = JSON.parse(
+				await git.raw(
+					'show',
+					`${ publishCommit }:${ packageJSONPath }`
+				)
+			);
+			const previousPackageJson = JSON.parse(
+				await git.raw(
+					'show',
+					`${ publishCommit }^:${ packageJSONPath }`
+				)
+			);
+			return { packageJson, previousPackageJson };
+		} )
+	);
+
+	return packages
+		.filter(
+			( { packageJson, previousPackageJson } ) =>
+				packageJson.private !== true &&
+				packageJson.version !== previousPackageJson.version
+		)
+		.map( ( { packageJson: { name, version } } ) => ( {
+			name,
+			tagName: `${ name }@${ version }`,
+			version,
+		} ) )
+		.sort( ( a, b ) => a.tagName.localeCompare( b.tagName ) );
+}
+
+/**
+ * Reconstructs prepared release state from the exact checked-out commit.
+ *
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
+ *
+ * @return {Promise<Object>} Prepared release state.
+ */
+async function getPreparedNpmReleaseState( config, deps = {} ) {
+	const { distTag, gitWorkingDirectoryPath, npmReleaseBranch, releaseType } =
+		config;
+	const {
+		getPreparedNpmReleasePackagesFn = getPreparedNpmReleasePackages,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		verifyRemoteNpmReleaseBranchFn = verifyRemoteNpmReleaseBranch,
+	} = deps;
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	const publishSubject = (
+		await git.raw( 'show', '-s', '--format=%s', publishCommit )
+	).trim();
+	if ( publishSubject !== 'chore(release): publish' ) {
+		throw new Error(
+			`Expected ${ publishCommit } to be an npm version commit.`
+		);
+	}
+
+	const releasePackages = await getPreparedNpmReleasePackagesFn(
+		gitWorkingDirectoryPath,
+		publishCommit
+	);
+	if ( releasePackages.length === 0 ) {
+		throw new Error(
+			`Prepared npm release commit ${ publishCommit } contains no versioned public packages.`
+		);
+	}
+
+	const parentDescription = (
+		await git.raw(
+			'show',
+			'-s',
+			'--format=%H%x00%s',
+			`${ publishCommit }^`
+		)
+	).trim();
+	const [ parentCommit, parentSubject ] = parentDescription.split( '\0' );
+	const changelogCommit =
+		parentSubject === 'Update changelog files' ? parentCommit : null;
+	const markerCommit = `${ publishCommit }${ changelogCommit ? '^^' : '^' }`;
+	const markerSubject = (
+		await git.raw( 'show', '-s', '--format=%s', markerCommit )
+	).trim();
+	const markerMatch = markerSubject.match(
+		/^chore\(release\): prepare npm (latest|bugfix|wp|next)(?: from (.+))?$/
+	);
+	const markerReleaseType = markerMatch?.[ 1 ];
+	const pluginReleaseBranch = markerMatch?.[ 2 ] || null;
+	const hasExpectedSource =
+		( releaseType === 'latest' &&
+			pluginReleaseBranch?.startsWith( 'release/' ) ) ||
+		( releaseType === 'next' && pluginReleaseBranch === 'trunk' ) ||
+		( [ 'bugfix', 'wp' ].includes( releaseType ) &&
+			pluginReleaseBranch === null );
+	if ( markerReleaseType !== releaseType || ! hasExpectedSource ) {
+		throw new Error(
+			`Prepared npm release commit ${ publishCommit } does not match the ${ releaseType } release route.`
+		);
+	}
+
+	await verifyRemoteNpmReleaseBranchFn( {
+		gitWorkingDirectoryPath,
+		npmReleaseBranch,
+		publishCommit,
+	} );
+
+	return {
+		changelogCommit,
+		distTag,
+		npmReleaseBranch,
+		pluginReleaseBranch,
+		publishCommit,
+		releasePackages,
+		releaseType,
+	};
+}
+
+/**
+ * Returns package tags that have not been pushed after validating that every
+ * existing remote tag belongs to the prepared release commit.
+ *
+ * @param {Map<string, string>} remoteTagShas Remote tag SHAs.
+ * @param {string[]}            packageTags   Package tag names.
+ * @param {string}              publishCommit Prepared release commit SHA.
+ *
+ * @return {string[]} Missing package tag names.
+ */
+function getMissingRemotePackageTags(
+	remoteTagShas,
+	packageTags,
+	publishCommit
+) {
+	const conflictingTag = packageTags.find( ( tagName ) => {
+		const remoteSha = remoteTagShas.get( tagName );
+		return remoteSha && remoteSha !== publishCommit;
+	} );
+	if ( conflictingTag ) {
+		throw new Error(
+			`Package tag ${ conflictingTag } points to ${ remoteTagShas.get(
+				conflictingTag
+			) }, expected ${ publishCommit }.`
+		);
+	}
+
+	return packageTags.filter( ( tagName ) => ! remoteTagShas.has( tagName ) );
+}
+
+/**
+ * Returns prepared state when the checked-out release branch still needs to be
+ * published or finalized. Package tags are the durable completion marker.
+ *
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
+ *
+ * @return {Promise<?Object>} Pending prepared release state.
+ */
+async function getPendingPreparedNpmReleaseState( config, deps = {} ) {
+	const { gitWorkingDirectoryPath } = config;
+	const {
+		getPreparedNpmReleasePackagesFn = getPreparedNpmReleasePackages,
+		getPreparedNpmReleaseStateFn = getPreparedNpmReleaseState,
+		getRemoteTagShasFn = getRemoteTagShas,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+	} = deps;
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	const publishSubject = (
+		await git.raw( 'show', '-s', '--format=%s', publishCommit )
+	).trim();
+	if ( publishSubject !== 'chore(release): publish' ) {
+		return null;
+	}
+
+	const releasePackages = await getPreparedNpmReleasePackagesFn(
+		gitWorkingDirectoryPath,
+		publishCommit
+	);
+	if ( releasePackages.length === 0 ) {
+		return null;
+	}
+	const packageTags = releasePackages.map( ( { tagName } ) => tagName );
+	const remoteTagShas = await getRemoteTagShasFn(
+		gitWorkingDirectoryPath,
+		packageTags
+	);
+	if (
+		getMissingRemotePackageTags( remoteTagShas, packageTags, publishCommit )
+			.length === 0
+	) {
+		return null;
+	}
+
+	const releaseState = await getPreparedNpmReleaseStateFn( config );
+	log(
+		`>> Reusing pending npm release prepared at ${ releaseState.publishCommit }.`
+	);
+	return releaseState;
 }
 
 /**
@@ -681,6 +897,7 @@ function parseNpmJsonOutput( output, description ) {
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
+ * @param {boolean}  [options.checkAccess]           Whether to validate npm package access.
  * @param {string}   options.distTag                 The dist-tag used for npm publishing.
  * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
  * @param {string}   options.publishCommit           Release commit SHA.
@@ -691,15 +908,23 @@ function parseNpmJsonOutput( output, description ) {
  * @return {Promise<string[]>} Correctly published package names.
  */
 async function runNpmPublishPreflight(
-	{ distTag, gitWorkingDirectoryPath, publishCommit, releasePackages },
+	{
+		checkAccess = true,
+		distTag,
+		gitWorkingDirectoryPath,
+		publishCommit,
+		releasePackages,
+	},
 	deps = {}
 ) {
 	const { commandFn = command } = deps;
-	log( '>> Checking npm package access.' );
-	await commandFn( 'npm access list packages @wordpress --json', {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'pipe',
-	} );
+	if ( checkAccess ) {
+		log( '>> Checking npm package access.' );
+		await commandFn( 'npm access list packages @wordpress --json', {
+			cwd: gitWorkingDirectoryPath,
+			stdio: 'pipe',
+		} );
+	}
 
 	log( '>> Verifying target package versions and dist-tags.' );
 	const publishedPackageNames = [];
@@ -822,7 +1047,7 @@ async function pushNpmReleaseGitMetadata(
 		}
 	} catch ( error ) {
 		log(
-			'>> npm publication completed, but Git metadata did not finish. Use these recovery commands after checking the remote state:\n\n' +
+			'>> npm release Git metadata did not finish. Use these recovery commands after checking the remote state:\n\n' +
 				getNpmReleaseGitRecoveryCommands( {
 					npmReleaseBranch,
 					packageTags,
@@ -834,28 +1059,28 @@ async function pushNpmReleaseGitMetadata(
 }
 
 /**
- * Publishes locally versioned packages, then pushes and verifies Git metadata.
+ * Publishes packages from an exact prepared release commit.
  *
- * @param {Object}   options                          Options.
- * @param {string}   options.distTag                  The dist-tag used for npm publishing.
- * @param {string}   options.gitWorkingDirectoryPath  Git working directory path.
- * @param {string}   options.noVerifyAccessFlag       Lerna no-verify-access flag.
- * @param {string}   options.npmReleaseBranch         Npm release branch.
- * @param {string}   options.yesFlag                  Lerna yes flag.
- * @param {Object}   deps                             Dependencies.
- * @param {Function} deps.commandFn                   Command runner.
- * @param {Object}   deps.git                         Git client.
- * @param {Function} deps.getNpmReleasePackagesFn     Gets release package metadata.
- * @param {Function} deps.pushNpmReleaseGitMetadataFn Pushes Git metadata.
- * @param {Function} deps.runNpmPublishPreflightFn    Runs npm preflight.
- * @param {Function} deps.runPhase                    Runs a retryable phase.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.distTag                 The dist-tag used for npm publishing.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}   options.noVerifyAccessFlag      Lerna no-verify-access flag.
+ * @param {string}   options.publishCommit           Prepared release commit SHA.
+ * @param {Array}    options.releasePackages         Packages to publish.
+ * @param {string}   options.yesFlag                 Lerna yes flag.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.commandFn                  Command runner.
+ * @param {Object}   deps.git                        Git client.
+ * @param {Function} deps.runNpmPublishPreflightFn   Runs npm preflight.
+ * @param {Function} deps.runPhase                   Runs a retryable phase.
  */
 async function publishVersionedPackagesToNpm(
 	{
 		distTag,
 		gitWorkingDirectoryPath,
 		noVerifyAccessFlag,
-		npmReleaseBranch,
+		publishCommit,
+		releasePackages,
 		yesFlag,
 	},
 	deps = {}
@@ -863,15 +1088,20 @@ async function publishVersionedPackagesToNpm(
 	const {
 		commandFn = command,
 		git = SimpleGit( gitWorkingDirectoryPath ),
-		getNpmReleasePackagesFn = getNpmReleasePackages,
-		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
 		runNpmPublishPreflightFn = runNpmPublishPreflight,
 		runPhase = runNpmReleasePhase,
 	} = deps;
-	const releasePackages = await getNpmReleasePackagesFn(
-		gitWorkingDirectoryPath
-	);
-	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	const checkedOutCommit = await git.revparse( [ 'HEAD' ] );
+	if ( checkedOutCommit !== publishCommit ) {
+		throw new Error(
+			`Expected prepared npm release commit ${ publishCommit }, found ${ checkedOutCommit }.`
+		);
+	}
+	if ( ( await git.raw( 'status', '--porcelain' ) ).trim() ) {
+		throw new Error(
+			`Prepared npm release checkout ${ publishCommit } has uncommitted changes.`
+		);
+	}
 	const publishCommand = `npx lerna publish from-package --dist-tag ${ distTag } --git-head ${ publishCommit } ${ yesFlag } ${ noVerifyAccessFlag }`;
 	const getPublishedPackageNames = () =>
 		runNpmPublishPreflightFn( {
@@ -901,12 +1131,20 @@ async function publishVersionedPackagesToNpm(
 		);
 		// A failed Lerna publish can leave temporary `gitHead` manifest changes.
 		// Reset to the version commit so `from-package` sees a clean tree on retry.
-		await git.reset( 'hard' );
-		await publishRemainingPackages( await getPublishedPackageNames() );
+		await git.raw( 'reset', '--hard', publishCommit );
+		try {
+			await publishRemainingPackages( await getPublishedPackageNames() );
+		} catch ( error ) {
+			await git.raw( 'reset', '--hard', publishCommit );
+			log(
+				`>> Rerun the publish phase for prepared commit ${ publishCommit }; registry validation will accept packages that finished publishing.`
+			);
+			throw error;
+		}
 	}
 
 	// Lerna treats publish conflicts as successful "already published" results,
-	// so verify registry identity again before attaching Git metadata.
+	// so verify registry identity again before finishing the publish phase.
 	await runPhase( 'npm publication verification', async () => {
 		const finalPublishedPackageNames = new Set(
 			await getPublishedPackageNames()
@@ -922,26 +1160,63 @@ async function publishVersionedPackagesToNpm(
 			);
 		}
 	} );
-
-	await pushNpmReleaseGitMetadataFn( {
-		gitWorkingDirectoryPath,
-		npmReleaseBranch,
-		packageTags: releasePackages.map( ( { tagName } ) => tagName ),
-		publishCommit,
-	} );
 }
 
 /**
- * Publishes all changed packages to npm.
+ * Prepares npm release Git metadata, or reuses the exact pending prepared
+ * commit when an earlier preparation run already pushed it.
  *
  * @param {WPPackagesConfig} config Command config.
  * @param {Object}           deps   Dependencies.
  *
- * @return {?string} The optional commit's hash when packages published to npm.
+ * @return {Promise<?Object>} Prepared release state.
  */
-async function publishPackagesToNpm(
+async function prepareNpmRelease( config, deps = {} ) {
+	const {
+		checkoutNpmReleaseBranchFn = checkoutNpmReleaseBranch,
+		createNpmReleaseMarkerFn = createNpmReleaseMarker,
+		findPluginReleaseBranchNameFn = findPluginReleaseBranchName,
+		getPendingPreparedNpmReleaseStateFn = getPendingPreparedNpmReleaseState,
+		preparePackagesForNpmFn = preparePackagesForNpm,
+		runNpmReleaseBranchSyncStepFn = runNpmReleaseBranchSyncStep,
+		updatePackagesFn = updatePackages,
+	} = deps;
+
+	await checkoutNpmReleaseBranchFn( config );
+	const pendingReleaseState =
+		await getPendingPreparedNpmReleaseStateFn( config );
+	if ( pendingReleaseState ) {
+		return pendingReleaseState;
+	}
+
+	let pluginReleaseBranch = null;
+	if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
+		pluginReleaseBranch =
+			config.releaseType === 'next'
+				? 'trunk'
+				: await findPluginReleaseBranchNameFn(
+						config.gitWorkingDirectoryPath
+				  );
+	}
+	if ( pluginReleaseBranch ) {
+		await runNpmReleaseBranchSyncStepFn( pluginReleaseBranch, config );
+	}
+	await createNpmReleaseMarkerFn( pluginReleaseBranch, config );
+	await updatePackagesFn( config );
+	return preparePackagesForNpmFn( config );
+}
+
+/**
+ * Versions packages and pushes the exact prepared release commit.
+ * Package tags remain local until npm publication succeeds.
+ *
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
+ *
+ * @return {Promise<?Object>} Prepared commit and package metadata.
+ */
+async function preparePackagesForNpm(
 	{
-		distTag,
 		gitWorkingDirectoryPath,
 		interactive,
 		minimumVersionBump,
@@ -952,21 +1227,14 @@ async function publishPackagesToNpm(
 ) {
 	const {
 		commandFn = command,
+		getNpmReleasePackagesFn = getNpmReleasePackages,
 		git = SimpleGit( gitWorkingDirectoryPath ),
-		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
+		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
 	} = deps;
 	log( '>> Installing npm packages.' );
 	await commandFn( 'npm ci', {
 		cwd: gitWorkingDirectoryPath,
 	} );
-
-	log( '>> Current npm user:' );
-	await commandFn( 'npm whoami', {
-		cwd: gitWorkingDirectoryPath,
-		stdio: 'inherit',
-	} );
-
-	const beforeCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
 
 	// Timestamp is the current time in `YYYYMMDDHHMM` format.
 	const timestamp = new Date()
@@ -975,9 +1243,6 @@ async function publishPackagesToNpm(
 		.replace( /[-:T]/g, '' );
 
 	const yesFlag = interactive ? '' : '--yes';
-	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
-	// Keep version commits and package tags local until npm publishing succeeds,
-	// then push and verify Git metadata explicitly.
 	if ( releaseType === 'next' ) {
 		log(
 			'>> Bumping version of public packages changed since the last release.'
@@ -1003,94 +1268,155 @@ async function publishPackagesToNpm(
 		);
 	}
 
-	await publishVersionedPackagesToNpmFn( {
-		distTag,
+	const releasePackages = await getNpmReleasePackagesFn(
+		gitWorkingDirectoryPath
+	);
+	if ( releasePackages.length === 0 ) {
+		log( '>> No package versions were prepared.' );
+		return;
+	}
+	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	await pushNpmReleaseGitMetadataFn( {
 		gitWorkingDirectoryPath,
-		noVerifyAccessFlag,
 		npmReleaseBranch,
-		yesFlag,
+		packageTags: [],
+		publishCommit,
 	} );
 
-	const afterCommitHash = await git.revparse( [ '--short', 'HEAD' ] );
-	if ( afterCommitHash === beforeCommitHash ) {
-		return;
-	}
-
-	return afterCommitHash;
+	return { publishCommit, releasePackages };
 }
 
 /**
- * Prepares the npm release branch and changelog updates.
+ * Validates and publishes an exact prepared release checkout.
  *
  * @param {WPPackagesConfig} config Command config.
  * @param {Object}           deps   Dependencies.
- *
- * @return {Promise<Object>} Release state needed by finalization.
- */
-async function prepareNpmRelease( config, deps = {} ) {
-	const {
-		checkoutNpmReleaseBranchFn = checkoutNpmReleaseBranch,
-		findPluginReleaseBranchNameFn = findPluginReleaseBranchName,
-		runNpmReleaseBranchSyncStepFn = runNpmReleaseBranchSyncStep,
-		updatePackagesFn = updatePackages,
-	} = deps;
-	let pluginReleaseBranch;
-	if ( [ 'latest', 'next' ].includes( config.releaseType ) ) {
-		pluginReleaseBranch =
-			config.releaseType === 'next'
-				? 'trunk'
-				: await findPluginReleaseBranchNameFn(
-						config.gitWorkingDirectoryPath
-				  );
-		await runNpmReleaseBranchSyncStepFn( pluginReleaseBranch, config );
-	} else {
-		await checkoutNpmReleaseBranchFn( config );
-	}
-
-	return {
-		changelogCommit: await updatePackagesFn( config ),
-		pluginReleaseBranch,
-	};
-}
-
-/**
- * Publishes the packages prepared in the current checkout.
- *
- * @param {WPPackagesConfig} config Command config.
- * @param {Object}           deps   Dependencies.
- *
- * @return {Promise<?string>} The npm version commit hash.
  */
 async function publishPreparedPackagesToNpm( config, deps = {} ) {
-	const { publishPackagesToNpmFn = publishPackagesToNpm } = deps;
-	return publishPackagesToNpmFn( config );
+	const { gitWorkingDirectoryPath, interactive } = config;
+	const {
+		commandFn = command,
+		getPreparedNpmReleaseStateFn = getPreparedNpmReleaseState,
+		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
+	} = deps;
+	const releaseState = await getPreparedNpmReleaseStateFn( config );
+
+	log( '>> Installing npm packages.' );
+	await commandFn( 'npm ci', { cwd: gitWorkingDirectoryPath } );
+	log( '>> Current npm user:' );
+	await commandFn( 'npm whoami', {
+		cwd: gitWorkingDirectoryPath,
+		stdio: 'inherit',
+	} );
+
+	await publishVersionedPackagesToNpmFn(
+		{
+			distTag: releaseState.distTag,
+			gitWorkingDirectoryPath,
+			noVerifyAccessFlag: interactive ? '' : '--no-verify-access',
+			publishCommit: releaseState.publishCommit,
+			releasePackages: releaseState.releasePackages,
+			yesFlag: interactive ? '' : '--yes',
+		},
+		{ commandFn }
+	);
 }
 
 /**
- * Backports the prepared release commits after publication.
+ * Backports release commits and pushes package tags after npm publication.
  *
- * @param {WPPackagesConfig} config                           Command config.
- * @param {Object}           releaseState                     Prepared release state.
- * @param {?string}          releaseState.changelogCommit     Changelog commit.
- * @param {?string}          releaseState.pluginReleaseBranch Plugin release branch.
- * @param {?string}          releaseState.publishCommit       Version commit.
- * @param {Object}           deps                             Dependencies.
+ * @param {WPPackagesConfig} config Command config.
+ * @param {Object}           deps   Dependencies.
  */
-async function finalizePreparedNpmRelease(
-	config,
-	{ changelogCommit, pluginReleaseBranch, publishCommit },
-	deps = {}
-) {
-	const { backportCommitsToBranchFn = backportCommitsToBranch } = deps;
-	if ( ! [ 'latest', 'bugfix' ].includes( config.releaseType ) ) {
+async function finalizePreparedNpmRelease( config, deps = {} ) {
+	const { gitWorkingDirectoryPath, releaseType } = config;
+	const {
+		backportCommitsToBranchFn = backportCommitsToBranch,
+		getPreparedNpmReleaseStateFn = getPreparedNpmReleaseState,
+		getRemoteTagShasFn = getRemoteTagShas,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		pushNpmReleaseGitMetadataFn = pushNpmReleaseGitMetadata,
+		runNpmPublishPreflightFn = runNpmPublishPreflight,
+	} = deps;
+	const releaseState = await getPreparedNpmReleaseStateFn( config );
+	const packageTags = releaseState.releasePackages.map(
+		( { tagName } ) => tagName
+	);
+	const remoteTagShas = await getRemoteTagShasFn(
+		gitWorkingDirectoryPath,
+		packageTags
+	);
+	const missingPackageTags = getMissingRemotePackageTags(
+		remoteTagShas,
+		packageTags,
+		releaseState.publishCommit
+	);
+	if ( missingPackageTags.length === 0 ) {
+		log( '>> The prepared npm release is already finalized.' );
 		return;
 	}
 
-	const commits = [ changelogCommit, publishCommit ].filter( Boolean );
-	await backportCommitsToBranchFn( 'trunk', commits, config );
-	if ( config.releaseType === 'latest' && pluginReleaseBranch ) {
-		await backportCommitsToBranchFn( pluginReleaseBranch, commits, config );
+	const publishedPackageNames = await runNpmPublishPreflightFn( {
+		checkAccess: false,
+		distTag: releaseState.distTag,
+		gitWorkingDirectoryPath,
+		publishCommit: releaseState.publishCommit,
+		releasePackages: releaseState.releasePackages,
+	} );
+	if (
+		publishedPackageNames.length !== releaseState.releasePackages.length
+	) {
+		throw new Error(
+			`Prepared npm release commit ${ releaseState.publishCommit } is not fully published.`
+		);
 	}
+
+	if ( [ 'latest', 'bugfix' ].includes( releaseType ) ) {
+		const commits = [
+			releaseState.changelogCommit,
+			releaseState.publishCommit,
+		].filter( Boolean );
+		await backportCommitsToBranchFn( 'trunk', commits, config );
+		if ( releaseType === 'latest' ) {
+			await backportCommitsToBranchFn(
+				releaseState.pluginReleaseBranch,
+				commits,
+				config
+			);
+		}
+	}
+
+	for ( const tagName of missingPackageTags ) {
+		let localTagCommit;
+		try {
+			localTagCommit = (
+				( await git.raw( 'rev-list', '-n', '1', tagName ) ) || ''
+			).trim();
+		} catch {
+			// The tag has not been created in this checkout yet.
+		}
+		if ( localTagCommit && localTagCommit !== releaseState.publishCommit ) {
+			throw new Error(
+				`Package tag ${ tagName } points to ${ localTagCommit }, expected ${ releaseState.publishCommit }.`
+			);
+		}
+		if ( ! localTagCommit ) {
+			await git.raw(
+				'tag',
+				'-a',
+				tagName,
+				releaseState.publishCommit,
+				'-m',
+				tagName
+			);
+		}
+	}
+	await pushNpmReleaseGitMetadataFn( {
+		gitWorkingDirectoryPath,
+		npmReleaseBranch: releaseState.npmReleaseBranch,
+		packageTags: missingPackageTags,
+		publishCommit: releaseState.publishCommit,
+	} );
 }
 
 /**
@@ -1099,11 +1425,14 @@ async function finalizePreparedNpmRelease(
  * @param {string}           branchName Selected branch name.
  * @param {string[]}         commits    The list of commits to backport.
  * @param {WPPackagesConfig} config     Command config.
+ * @param {Object}           deps       Dependencies.
+ * @param {Object}           deps.repo  Git client.
  */
 async function backportCommitsToBranch(
 	branchName,
 	commits,
-	{ abortMessage, gitWorkingDirectoryPath, interactive }
+	{ abortMessage, gitWorkingDirectoryPath, interactive },
+	deps = {}
 ) {
 	if ( commits.length === 0 ) {
 		return;
@@ -1119,7 +1448,7 @@ async function backportCommitsToBranch(
 
 	log( `>> Backporting commits to "${ branchName }".` );
 
-	const repo = SimpleGit( gitWorkingDirectoryPath );
+	const { repo = SimpleGit( gitWorkingDirectoryPath ) } = deps;
 
 	/*
 	 * Reset any local changes and replace them with the origin branch's copy.
@@ -1132,6 +1461,13 @@ async function backportCommitsToBranch(
 	await repo.fetch().checkout( branchName ).pull( 'origin', branchName );
 
 	for ( const commitHash of commits ) {
+		const cherryStatus = (
+			await repo.raw( 'cherry', 'HEAD', commitHash, `${ commitHash }^` )
+		).trim();
+		if ( ! cherryStatus.startsWith( '+' ) ) {
+			log( `>> Commit ${ commitHash } is already backported.` );
+			continue;
+		}
 		await repo.raw( 'cherry-pick', commitHash );
 	}
 
@@ -1189,9 +1525,12 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 		);
 	}
 
-	const releaseState = await prepareNpmReleaseFn( config );
-	releaseState.publishCommit = await publishPreparedPackagesToNpmFn( config );
-	await finalizePreparedNpmReleaseFn( config, releaseState );
+	const hasPreparedRelease = Boolean( await prepareNpmReleaseFn( config ) );
+
+	if ( hasPreparedRelease ) {
+		await publishPreparedPackagesToNpmFn( config );
+		await finalizePreparedNpmReleaseFn( config );
+	}
 
 	await runStep(
 		'Cleaning the temporary folders',
@@ -1204,10 +1543,12 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 			)
 	);
 
-	log(
-		'\n>> 🎉 WordPress packages are now published!\n\n',
-		'Let also people know on WordPress Slack and celebrate together.'
-	);
+	if ( hasPreparedRelease ) {
+		log(
+			'\n>> 🎉 WordPress packages are now published!\n\n',
+			'Let also people know on WordPress Slack and celebrate together.'
+		);
+	}
 }
 
 /**
@@ -1291,15 +1632,20 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	backportCommitsToBranch,
+	createNpmReleaseMarker,
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getPendingPreparedNpmReleaseState,
+	getPreparedNpmReleasePackages,
+	getPreparedNpmReleaseState,
 	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
 	prepareNpmRelease,
-	publishPackagesToNpm,
+	preparePackagesForNpm,
 	publishPreparedPackagesToNpm,
 	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
@@ -1307,8 +1653,8 @@ module.exports = {
 	publishNpmBugfixLatest,
 	publishNpmBugfixWordPressCore,
 	publishNpmNext,
+	runPackagesRelease,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
-	runPackagesRelease,
 	verifyRemotePackageTags,
 };

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -548,11 +548,12 @@ async function getPreparedNpmReleasePackages(
 	deps = {}
 ) {
 	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
-	const changedPaths = (
+	const changedManifests = (
 		await git.raw(
 			'diff-tree',
 			'--no-commit-id',
-			'--name-only',
+			'--name-status',
+			'--diff-filter=AM',
 			'-r',
 			`${ publishCommit }^`,
 			publishCommit,
@@ -561,22 +562,29 @@ async function getPreparedNpmReleasePackages(
 		)
 	)
 		.split( '\n' )
-		.filter( Boolean );
+		.filter( Boolean )
+		.map( ( line ) => {
+			const [ status, packageJSONPath ] = line.split( '\t' );
+			return { packageJSONPath, status };
+		} );
 
 	const packages = await Promise.all(
-		changedPaths.map( async ( packageJSONPath ) => {
+		changedManifests.map( async ( { packageJSONPath, status } ) => {
 			const packageJson = JSON.parse(
 				await git.raw(
 					'show',
 					`${ publishCommit }:${ packageJSONPath }`
 				)
 			);
-			const previousPackageJson = JSON.parse(
-				await git.raw(
-					'show',
-					`${ publishCommit }^:${ packageJSONPath }`
-				)
-			);
+			const previousPackageJson =
+				status === 'A'
+					? null
+					: JSON.parse(
+							await git.raw(
+								'show',
+								`${ publishCommit }^:${ packageJSONPath }`
+							)
+					  );
 			return { packageJson, previousPackageJson };
 		} )
 	);
@@ -585,7 +593,8 @@ async function getPreparedNpmReleasePackages(
 		.filter(
 			( { packageJson, previousPackageJson } ) =>
 				packageJson.private !== true &&
-				packageJson.version !== previousPackageJson.version
+				( previousPackageJson === null ||
+					packageJson.version !== previousPackageJson.version )
 		)
 		.map( ( { packageJson: { name, version } } ) => ( {
 			name,

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -4,6 +4,7 @@
 const path = require( 'path' );
 const fs = require( 'fs' );
 const readline = require( 'readline' );
+const { randomUUID } = require( 'crypto' );
 const { join } = require( 'path' );
 const { command } = require( 'execa' );
 const glob = require( 'fast-glob' );
@@ -47,6 +48,7 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
  * @typedef WPPackagesCommandOptions
  *
  * @property {boolean} [ci]             Disables interactive mode when executed in CI mode.
+ * @property {string}  [releaseId]      Stable identifier used to resume the same release.
  * @property {string}  [repositoryPath] Relative path to the git repository.
  * @property {SemVer}  [semver]         The selected semantic versioning. Defaults to `patch`.
  * @property {string}  [wpVersion]      The major WordPress version number, example: `6.0`.
@@ -61,18 +63,44 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
  * @property {boolean}     interactive             Whether to run in interactive mode.
  * @property {SemVer}      minimumVersionBump      The selected minimum version bump.
  * @property {string}      npmReleaseBranch        The selected branch for npm release.
+ * @property {string}      releaseId               Stable identifier for this release invocation.
  * @property {ReleaseType} releaseType             The selected release type.
  */
 
 /**
+ * Parses an npm release marker commit subject.
+ *
+ * @param {string} subject Commit subject.
+ *
+ * @return {?Object} Parsed marker fields.
+ */
+function parseNpmReleaseMarkerSubject( subject ) {
+	const match = subject.match(
+		/^chore\(release\): (prepare|finalize) npm (latest|bugfix|wp|next)(?: from (.+?))? \[release-id: ([A-Za-z0-9._-]+)\]$/
+	);
+	if ( ! match ) {
+		return null;
+	}
+	return {
+		phase: match[ 1 ],
+		pluginReleaseBranch: match[ 3 ] || null,
+		releaseId: match[ 4 ],
+		releaseType: match[ 2 ],
+	};
+}
+
+/**
  * Checks out the npm release branch.
  *
- * @param {WPPackagesConfig} options The config object.
+ * @param {WPPackagesConfig} options  The config object.
+ * @param {Object}           deps     Dependencies.
+ * @param {Object}           deps.git Git client.
  */
-async function checkoutNpmReleaseBranch( {
-	gitWorkingDirectoryPath,
-	npmReleaseBranch,
-} ) {
+async function checkoutNpmReleaseBranch(
+	{ gitWorkingDirectoryPath, npmReleaseBranch },
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
 	/*
 	 * Create the release branch.
 	 *
@@ -82,9 +110,8 @@ async function checkoutNpmReleaseBranch( {
 	 * Lerna assumes that all packages need publishing if it can't access
 	 * the necessary information.
 	 */
-	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( 'origin', npmReleaseBranch, [ '--depth=999' ] )
-		.checkout( npmReleaseBranch );
+	await git.fetch( 'origin', npmReleaseBranch, [ '--depth=999' ] );
+	await git.raw( 'checkout', '-B', npmReleaseBranch, 'FETCH_HEAD' );
 	log(
 		'>> The local npm release branch ' +
 			formats.success( npmReleaseBranch ) +
@@ -318,15 +345,138 @@ async function createNpmReleaseMarker(
 	config,
 	deps = {}
 ) {
-	const { gitWorkingDirectoryPath, releaseType } = config;
+	const { gitWorkingDirectoryPath, releaseId, releaseType } = config;
 	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
 	const source = pluginReleaseBranch ? ` from ${ pluginReleaseBranch }` : '';
 	await git.raw(
 		'commit',
 		'--allow-empty',
 		'-m',
-		`chore(release): prepare npm ${ releaseType }${ source }`
+		`chore(release): prepare npm ${ releaseType }${ source } [release-id: ${ releaseId }]`
 	);
+}
+
+/**
+ * Checks whether a commit is the exact finalization marker for a prepared release.
+ *
+ * @param {string}      markerCommit                    Marker commit SHA.
+ * @param {Object}      options                         Options.
+ * @param {string}      options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string}      options.publishCommit           Prepared release commit SHA.
+ * @param {string}      options.releaseId               Stable release identifier.
+ * @param {ReleaseType} options.releaseType             Release type.
+ * @param {Object}      deps                            Dependencies.
+ * @param {Object}      deps.git                        Git client.
+ *
+ * @return {Promise<boolean>} Whether the commit is the expected marker.
+ */
+async function isNpmReleaseFinalizationMarker(
+	markerCommit,
+	{ gitWorkingDirectoryPath, publishCommit, releaseId, releaseType },
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const description = (
+		await git.raw( 'show', '-s', '--format=%P%x00%T%x00%s', markerCommit )
+	).trim();
+	const [ parents, markerTree, markerSubject ] = description.split( '\0' );
+	const publishTree = (
+		await git.revparse( [ `${ publishCommit }^{tree}` ] )
+	).trim();
+	const marker = parseNpmReleaseMarkerSubject( markerSubject );
+	return (
+		parents === publishCommit &&
+		markerTree === publishTree &&
+		marker?.phase === 'finalize' &&
+		marker.pluginReleaseBranch === null &&
+		marker.releaseId === releaseId &&
+		marker.releaseType === releaseType
+	);
+}
+
+/**
+ * Advances the release branch only after finalization has completed.
+ *
+ * @param {Object}           releaseState                  Prepared release state.
+ * @param {string}           releaseState.npmReleaseBranch Npm release branch.
+ * @param {string}           releaseState.publishCommit    Prepared release commit SHA.
+ * @param {ReleaseType}      releaseState.releaseType      Release type.
+ * @param {WPPackagesConfig} config                        Command config.
+ * @param {Object}           deps                          Dependencies.
+ * @param {Function}         deps.getRemoteBranchShaFn     Gets the remote branch SHA.
+ * @param {Object}           deps.git                      Git client.
+ * @param {Function}         deps.isFinalizationMarkerFn   Checks finalization markers.
+ * @param {Function}         deps.runPhase                 Runs a retryable phase.
+ */
+async function createNpmReleaseFinalizationMarker(
+	releaseState,
+	config,
+	deps = {}
+) {
+	const { gitWorkingDirectoryPath } = config;
+	const { npmReleaseBranch, publishCommit, releaseId, releaseType } =
+		releaseState;
+	const {
+		getRemoteBranchShaFn = getRemoteBranchSha,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		isFinalizationMarkerFn = isNpmReleaseFinalizationMarker,
+		runPhase = runNpmReleasePhase,
+	} = deps;
+	const finalizationCommit = (
+		await git.raw(
+			'commit-tree',
+			`${ publishCommit }^{tree}`,
+			'-p',
+			publishCommit,
+			'-m',
+			`chore(release): finalize npm ${ releaseType } [release-id: ${ releaseId }]`
+		)
+	).trim();
+
+	await runPhase( 'Finalization marker push', async () => {
+		const remoteSha = await getRemoteBranchShaFn(
+			gitWorkingDirectoryPath,
+			npmReleaseBranch
+		);
+		if ( remoteSha !== publishCommit ) {
+			if ( ! remoteSha ) {
+				throw new Error(
+					`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit } or its finalization marker, got nothing.`
+				);
+			}
+			if ( remoteSha !== finalizationCommit ) {
+				await git.fetch( 'origin', npmReleaseBranch, [
+					'--depth=999',
+				] );
+				if (
+					! ( await isFinalizationMarkerFn(
+						remoteSha,
+						{
+							gitWorkingDirectoryPath,
+							publishCommit,
+							releaseId,
+							releaseType,
+						},
+						{ git }
+					) )
+				) {
+					throw new Error(
+						`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit } or its finalization marker, got ${
+							remoteSha || 'nothing'
+						}.`
+					);
+				}
+			}
+			log( '>> The npm release is already marked as finalized.' );
+			return;
+		}
+		log( '>> Recording completed npm release.' );
+		await git.raw(
+			'push',
+			'origin',
+			`${ finalizationCommit }:refs/heads/${ npmReleaseBranch }`
+		);
+	} );
 }
 
 /**
@@ -458,10 +608,13 @@ async function getPreparedNpmReleaseState( config, deps = {} ) {
 		config;
 	const {
 		getPreparedNpmReleasePackagesFn = getPreparedNpmReleasePackages,
+		getRemoteBranchShaFn = getRemoteBranchSha,
 		git = SimpleGit( gitWorkingDirectoryPath ),
-		verifyRemoteNpmReleaseBranchFn = verifyRemoteNpmReleaseBranch,
+		isFinalizationMarkerFn = isNpmReleaseFinalizationMarker,
+		publishCommit: preparedPublishCommit,
 	} = deps;
-	const publishCommit = await git.revparse( [ 'HEAD' ] );
+	const publishCommit =
+		preparedPublishCommit || ( await git.revparse( [ 'HEAD' ] ) );
 	const publishSubject = (
 		await git.raw( 'show', '-s', '--format=%s', publishCommit )
 	).trim();
@@ -496,36 +649,64 @@ async function getPreparedNpmReleaseState( config, deps = {} ) {
 	const markerSubject = (
 		await git.raw( 'show', '-s', '--format=%s', markerCommit )
 	).trim();
-	const markerMatch = markerSubject.match(
-		/^chore\(release\): prepare npm (latest|bugfix|wp|next)(?: from (.+))?$/
-	);
-	const markerReleaseType = markerMatch?.[ 1 ];
-	const pluginReleaseBranch = markerMatch?.[ 2 ] || null;
+	const marker = parseNpmReleaseMarkerSubject( markerSubject );
+	const markerReleaseType = marker?.releaseType;
+	const pluginReleaseBranch = marker?.pluginReleaseBranch || null;
+	const releaseId = marker?.releaseId;
 	const hasExpectedSource =
 		( releaseType === 'latest' &&
 			pluginReleaseBranch?.startsWith( 'release/' ) ) ||
 		( releaseType === 'next' && pluginReleaseBranch === 'trunk' ) ||
 		( [ 'bugfix', 'wp' ].includes( releaseType ) &&
 			pluginReleaseBranch === null );
-	if ( markerReleaseType !== releaseType || ! hasExpectedSource ) {
+	if (
+		marker?.phase !== 'prepare' ||
+		markerReleaseType !== releaseType ||
+		! hasExpectedSource
+	) {
 		throw new Error(
 			`Prepared npm release commit ${ publishCommit } does not match the ${ releaseType } release route.`
 		);
 	}
 
-	await verifyRemoteNpmReleaseBranchFn( {
+	const remoteSha = await getRemoteBranchShaFn(
 		gitWorkingDirectoryPath,
-		npmReleaseBranch,
-		publishCommit,
-	} );
+		npmReleaseBranch
+	);
+	let isFinalized = false;
+	if ( remoteSha !== publishCommit ) {
+		if ( ! remoteSha ) {
+			throw new Error(
+				`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit } or its finalization marker, got nothing.`
+			);
+		}
+		await git.fetch( 'origin', npmReleaseBranch, [ '--depth=999' ] );
+		isFinalized = await isFinalizationMarkerFn(
+			remoteSha,
+			{
+				gitWorkingDirectoryPath,
+				publishCommit,
+				releaseId,
+				releaseType,
+			},
+			{ git }
+		);
+		if ( ! isFinalized ) {
+			throw new Error(
+				`Expected origin/${ npmReleaseBranch } to point to ${ publishCommit } or its finalization marker, got ${ remoteSha }.`
+			);
+		}
+	}
 
 	return {
 		changelogCommit,
 		distTag,
+		isFinalized,
 		npmReleaseBranch,
 		pluginReleaseBranch,
 		publishCommit,
 		releasePackages,
+		releaseId,
 		releaseType,
 	};
 }
@@ -562,7 +743,7 @@ function getMissingRemotePackageTags(
 
 /**
  * Returns prepared state when the checked-out release branch still needs to be
- * published or finalized. Package tags are the durable completion marker.
+ * published or finalized, or identifies the finalization marker at HEAD.
  *
  * @param {WPPackagesConfig} config Command config.
  * @param {Object}           deps   Dependencies.
@@ -577,13 +758,33 @@ async function getPendingPreparedNpmReleaseState( config, deps = {} ) {
 		getRemoteTagShasFn = getRemoteTagShas,
 		git = SimpleGit( gitWorkingDirectoryPath ),
 	} = deps;
-	const publishCommit = await git.revparse( [ 'HEAD' ] );
-	const publishSubject = (
-		await git.raw( 'show', '-s', '--format=%s', publishCommit )
+	const headCommit = await git.revparse( [ 'HEAD' ] );
+	const headSubject = (
+		await git.raw( 'show', '-s', '--format=%s', headCommit )
 	).trim();
-	if ( publishSubject !== 'chore(release): publish' ) {
-		return null;
+	if ( headSubject !== 'chore(release): publish' ) {
+		const marker = parseNpmReleaseMarkerSubject( headSubject );
+		if ( marker?.phase !== 'finalize' ) {
+			return null;
+		}
+		const publishCommit = await git.revparse( [ `${ headCommit }^` ] );
+		const releaseState = await getPreparedNpmReleaseStateFn(
+			{ ...config, releaseType: marker.releaseType },
+			{ ...deps, git, publishCommit }
+		);
+		if (
+			! releaseState.isFinalized ||
+			releaseState.publishCommit !== publishCommit ||
+			releaseState.releaseId !== marker.releaseId ||
+			releaseState.releaseType !== marker.releaseType
+		) {
+			throw new Error(
+				`Invalid npm release finalization marker ${ headCommit }.`
+			);
+		}
+		return releaseState;
 	}
+	const publishCommit = headCommit;
 
 	const releasePackages = await getPreparedNpmReleasePackagesFn(
 		gitWorkingDirectoryPath,
@@ -597,12 +798,7 @@ async function getPendingPreparedNpmReleaseState( config, deps = {} ) {
 		gitWorkingDirectoryPath,
 		packageTags
 	);
-	if (
-		getMissingRemotePackageTags( remoteTagShas, packageTags, publishCommit )
-			.length === 0
-	) {
-		return null;
-	}
+	getMissingRemotePackageTags( remoteTagShas, packageTags, publishCommit );
 
 	const releaseState = await getPreparedNpmReleaseStateFn( config );
 	log(
@@ -1173,6 +1369,7 @@ async function publishVersionedPackagesToNpm(
  */
 async function prepareNpmRelease( config, deps = {} ) {
 	const {
+		askForConfirmationFn = askForConfirmation,
 		checkoutNpmReleaseBranchFn = checkoutNpmReleaseBranch,
 		createNpmReleaseMarkerFn = createNpmReleaseMarker,
 		findPluginReleaseBranchNameFn = findPluginReleaseBranchName,
@@ -1185,8 +1382,35 @@ async function prepareNpmRelease( config, deps = {} ) {
 	await checkoutNpmReleaseBranchFn( config );
 	const pendingReleaseState =
 		await getPendingPreparedNpmReleaseStateFn( config );
-	if ( pendingReleaseState ) {
+	if ( pendingReleaseState && ! pendingReleaseState.isFinalized ) {
+		if (
+			pendingReleaseState.releaseId !== config.releaseId ||
+			pendingReleaseState.releaseType !== config.releaseType
+		) {
+			throw new Error(
+				`NpmRelease: A ${ pendingReleaseState.releaseType } release from invocation ${ pendingReleaseState.releaseId } is still pending. Resume it with --release-id ${ pendingReleaseState.releaseId } before starting another release.`
+			);
+		}
 		return pendingReleaseState;
+	}
+	if (
+		pendingReleaseState?.isFinalized &&
+		pendingReleaseState.releaseId === config.releaseId &&
+		pendingReleaseState.releaseType === config.releaseType
+	) {
+		return pendingReleaseState;
+	}
+	if ( pendingReleaseState?.isFinalized ) {
+		if ( config.interactive ) {
+			await askForConfirmationFn(
+				`The previous npm release (${ pendingReleaseState.releaseId }) is finalized. Start a new ${ config.releaseType } release?`,
+				false,
+				config.abortMessage
+			);
+		}
+		log(
+			`>> Starting release ${ config.releaseId } after finalized release ${ pendingReleaseState.releaseId }.`
+		);
 	}
 
 	let pluginReleaseBranch = null;
@@ -1300,6 +1524,10 @@ async function publishPreparedPackagesToNpm( config, deps = {} ) {
 		publishVersionedPackagesToNpmFn = publishVersionedPackagesToNpm,
 	} = deps;
 	const releaseState = await getPreparedNpmReleaseStateFn( config );
+	if ( releaseState.isFinalized ) {
+		log( '>> The prepared npm release is already finalized.' );
+		return;
+	}
 
 	log( '>> Installing npm packages.' );
 	await commandFn( 'npm ci', { cwd: gitWorkingDirectoryPath } );
@@ -1332,6 +1560,7 @@ async function finalizePreparedNpmRelease( config, deps = {} ) {
 	const { gitWorkingDirectoryPath, releaseType } = config;
 	const {
 		backportCommitsToBranchFn = backportCommitsToBranch,
+		createNpmReleaseFinalizationMarkerFn = createNpmReleaseFinalizationMarker,
 		getPreparedNpmReleaseStateFn = getPreparedNpmReleaseState,
 		getRemoteTagShasFn = getRemoteTagShas,
 		git = SimpleGit( gitWorkingDirectoryPath ),
@@ -1339,6 +1568,10 @@ async function finalizePreparedNpmRelease( config, deps = {} ) {
 		runNpmPublishPreflightFn = runNpmPublishPreflight,
 	} = deps;
 	const releaseState = await getPreparedNpmReleaseStateFn( config );
+	if ( releaseState.isFinalized ) {
+		log( '>> The prepared npm release is already finalized.' );
+		return;
+	}
 	const packageTags = releaseState.releasePackages.map(
 		( { tagName } ) => tagName
 	);
@@ -1351,11 +1584,6 @@ async function finalizePreparedNpmRelease( config, deps = {} ) {
 		packageTags,
 		releaseState.publishCommit
 	);
-	if ( missingPackageTags.length === 0 ) {
-		log( '>> The prepared npm release is already finalized.' );
-		return;
-	}
-
 	const publishedPackageNames = await runNpmPublishPreflightFn( {
 		checkAccess: false,
 		distTag: releaseState.distTag,
@@ -1369,6 +1597,11 @@ async function finalizePreparedNpmRelease( config, deps = {} ) {
 		throw new Error(
 			`Prepared npm release commit ${ releaseState.publishCommit } is not fully published.`
 		);
+	}
+	if ( missingPackageTags.length === 0 ) {
+		log( '>> Package tags are already pushed; recording finalization.' );
+		await createNpmReleaseFinalizationMarkerFn( releaseState, config );
+		return;
 	}
 
 	if ( [ 'latest', 'bugfix' ].includes( releaseType ) ) {
@@ -1417,6 +1650,7 @@ async function finalizePreparedNpmRelease( config, deps = {} ) {
 		packageTags: missingPackageTags,
 		publishCommit: releaseState.publishCommit,
 	} );
+	await createNpmReleaseFinalizationMarkerFn( releaseState, config );
 }
 
 /**
@@ -1525,7 +1759,13 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 		);
 	}
 
-	const hasPreparedRelease = Boolean( await prepareNpmReleaseFn( config ) );
+	const releaseState = await prepareNpmReleaseFn( config );
+	const hasPreparedRelease = Boolean(
+		releaseState && ! releaseState.isFinalized
+	);
+	if ( releaseState?.isFinalized ) {
+		log( '>> This npm release invocation is already finalized.' );
+	}
 
 	if ( hasPreparedRelease ) {
 		await publishPreparedPackagesToNpmFn( config );
@@ -1554,15 +1794,35 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 /**
  * Gets config object.
  *
- * @param {ReleaseType}              releaseType The selected release type.
- * @param {WPPackagesCommandOptions} options     Command options.
+ * @param {ReleaseType}              releaseType            The selected release type.
+ * @param {WPPackagesCommandOptions} options                Command options.
+ * @param {Object}                   deps                   Dependencies.
+ * @param {Function}                 deps.createReleaseIdFn Creates a release ID.
+ * @param {?string}                  deps.githubRunId       GitHub Actions run ID.
  *
  * @return {WPPackagesConfig} The config object.
  */
 function getConfig(
 	releaseType,
-	{ ci, repositoryPath, semver = 'patch', wpVersion }
+	{ ci, releaseId, repositoryPath, semver = 'patch', wpVersion },
+	deps = {}
 ) {
+	const {
+		createReleaseIdFn = randomUUID,
+		githubRunId = process.env.GITHUB_RUN_ID,
+	} = deps;
+	const stableReleaseId =
+		releaseId ?? githubRunId ?? ( ci ? null : createReleaseIdFn() );
+	if ( ! stableReleaseId ) {
+		throw new Error(
+			'NpmRelease: A stable release ID is required in non-interactive mode. Pass --release-id or run in GitHub Actions.'
+		);
+	}
+	if ( ! /^[A-Za-z0-9._-]+$/.test( stableReleaseId ) ) {
+		throw new Error(
+			'NpmRelease: The release ID may contain only letters, numbers, dots, underscores, and hyphens.'
+		);
+	}
 	let distTag = 'latest';
 	let npmReleaseBranch = 'wp/latest';
 	if ( releaseType === 'next' ) {
@@ -1581,6 +1841,7 @@ function getConfig(
 		interactive: ! ci,
 		minimumVersionBump: semver,
 		npmReleaseBranch,
+		releaseId: stableReleaseId,
 		releaseType,
 	};
 }
@@ -1633,10 +1894,13 @@ async function publishNpmNext( options ) {
 
 module.exports = {
 	backportCommitsToBranch,
+	checkoutNpmReleaseBranch,
+	createNpmReleaseFinalizationMarker,
 	createNpmReleaseMarker,
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getConfig,
 	getPendingPreparedNpmReleaseState,
 	getPreparedNpmReleasePackages,
 	getPreparedNpmReleaseState,
@@ -1644,6 +1908,8 @@ module.exports = {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	isNpmReleaseFinalizationMarker,
+	parseNpmReleaseMarkerSubject,
 	prepareNpmRelease,
 	preparePackagesForNpm,
 	publishPreparedPackagesToNpm,

--- a/tools/release/commands/test/common.js
+++ b/tools/release/commands/test/common.js
@@ -1,7 +1,26 @@
 /**
  * Internal dependencies
  */
-import { calculateVersionBumpFromChangelog } from '../common';
+import {
+	calculateVersionBumpFromChangelog,
+	findPluginReleaseBranchName,
+} from '../common';
+
+describe( 'findPluginReleaseBranchName', () => {
+	it( 'reads the version from the fetched trunk commit without changing branches', async () => {
+		const git = {
+			fetch: jest.fn().mockResolvedValue(),
+			show: jest.fn().mockResolvedValue( '{ "version": "18.7.0" }' ),
+		};
+
+		await expect(
+			findPluginReleaseBranchName( '/repo', { git } )
+		).resolves.toBe( 'release/18.7' );
+
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( git.show ).toHaveBeenCalledWith( 'FETCH_HEAD:package.json' );
+	} );
+} );
 
 describe( 'calculateVersionBumpFromChangelog', () => {
 	it( 'should return null when no lines provided', () => {

--- a/tools/release/commands/test/common.js
+++ b/tools/release/commands/test/common.js
@@ -17,7 +17,9 @@ describe( 'findPluginReleaseBranchName', () => {
 			findPluginReleaseBranchName( '/repo', { git } )
 		).resolves.toBe( 'release/18.7' );
 
-		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'trunk', [
+			'--depth=1',
+		] );
 		expect( git.show ).toHaveBeenCalledWith( 'FETCH_HEAD:package.json' );
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -2,119 +2,112 @@
  * Internal dependencies
  */
 import {
+	backportCommitsToBranch,
+	createNpmReleaseMarker,
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
+	getPendingPreparedNpmReleaseState,
+	getPreparedNpmReleasePackages,
+	getPreparedNpmReleaseState,
 	getRemoteBranchSha,
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
 	prepareNpmRelease,
-	publishPackagesToNpm,
+	preparePackagesForNpm,
+	publishPreparedPackagesToNpm,
 	publishVersionedPackagesToNpm,
 	pushNpmReleaseGitMetadata,
+	runPackagesRelease,
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
-	runPackagesRelease,
 	verifyRemotePackageTags,
 } from '../packages';
 
-describe( 'prepareNpmRelease', () => {
-	it.each( [
-		[ 'latest', 'release/23.5' ],
-		[ 'next', 'trunk' ],
-		[ 'bugfix', undefined ],
-		[ 'wp', undefined ],
-	] )(
-		'prepares a %s release',
-		async ( releaseType, expectedPluginReleaseBranch ) => {
-			const config = {
-				gitWorkingDirectoryPath: '/repo',
-				releaseType,
-			};
-			const checkoutNpmReleaseBranchFn = jest.fn();
-			const findPluginReleaseBranchNameFn = jest
+describe( 'backportCommitsToBranch', () => {
+	it( 'skips commits whose patches are already present', async () => {
+		const repo = {
+			checkout: jest.fn().mockReturnThis(),
+			fetch: jest.fn().mockReturnThis(),
+			pull: jest.fn().mockResolvedValue(),
+			push: jest.fn().mockResolvedValue(),
+			raw: jest
 				.fn()
-				.mockResolvedValue( 'release/23.5' );
-			const runNpmReleaseBranchSyncStepFn = jest.fn();
-			const updatePackagesFn = jest
-				.fn()
-				.mockResolvedValue( 'changelog-sha' );
+				.mockResolvedValueOnce( '- existing-sha' )
+				.mockResolvedValueOnce( '+ new-sha' )
+				.mockResolvedValueOnce(),
+		};
 
-			await expect(
-				prepareNpmRelease( config, {
-					checkoutNpmReleaseBranchFn,
-					findPluginReleaseBranchNameFn,
-					runNpmReleaseBranchSyncStepFn,
-					updatePackagesFn,
-				} )
-			).resolves.toEqual( {
-				changelogCommit: 'changelog-sha',
-				pluginReleaseBranch: expectedPluginReleaseBranch,
-			} );
-			expect( findPluginReleaseBranchNameFn.mock.calls ).toEqual(
-				releaseType === 'latest' ? [ [ '/repo' ] ] : []
-			);
-			expect( checkoutNpmReleaseBranchFn.mock.calls ).toEqual(
-				[ 'bugfix', 'wp' ].includes( releaseType ) ? [ [ config ] ] : []
-			);
-			expect( runNpmReleaseBranchSyncStepFn.mock.calls ).toEqual(
-				expectedPluginReleaseBranch
-					? [ [ expectedPluginReleaseBranch, config ] ]
-					: []
-			);
-			expect( updatePackagesFn ).toHaveBeenCalledTimes( 1 );
-			expect( updatePackagesFn ).toHaveBeenCalledWith( config );
-		}
-	);
+		await backportCommitsToBranch(
+			'trunk',
+			[ 'existing-sha', 'new-sha' ],
+			{
+				abortMessage: 'Aborting!',
+				gitWorkingDirectoryPath: '/repo',
+				interactive: false,
+			},
+			{ repo }
+		);
+
+		expect( repo.raw ).toHaveBeenNthCalledWith(
+			1,
+			'cherry',
+			'HEAD',
+			'existing-sha',
+			'existing-sha^'
+		);
+		expect( repo.raw ).toHaveBeenNthCalledWith(
+			2,
+			'cherry',
+			'HEAD',
+			'new-sha',
+			'new-sha^'
+		);
+		expect( repo.raw ).toHaveBeenNthCalledWith(
+			3,
+			'cherry-pick',
+			'new-sha'
+		);
+		expect( repo.push ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( console ).toHaveLogged();
+	} );
 } );
 
-describe( 'finalizePreparedNpmRelease', () => {
-	it.each( [
-		[ 'latest', 'release/23.5', [ 'trunk', 'release/23.5' ] ],
-		[ 'bugfix', undefined, [ 'trunk' ] ],
-		[ 'next', undefined, [] ],
-		[ 'wp', undefined, [] ],
-	] )(
-		'finalizes a %s release',
-		async ( releaseType, pluginReleaseBranch, expectedBranches ) => {
-			const config = { releaseType };
-			const backportCommitsToBranchFn = jest.fn();
-			const commits = [ 'changelog-sha', 'publish-sha' ];
+describe( 'createNpmReleaseMarker', () => {
+	it( 'records the release type and synced source branch', async () => {
+		const git = { raw: jest.fn().mockResolvedValue() };
 
-			await finalizePreparedNpmRelease(
-				config,
-				{
-					changelogCommit: commits[ 0 ],
-					pluginReleaseBranch,
-					publishCommit: commits[ 1 ],
-				},
-				{ backportCommitsToBranchFn }
-			);
+		await createNpmReleaseMarker(
+			'release/23.5',
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releaseType: 'latest',
+			},
+			{ git }
+		);
 
-			expect( backportCommitsToBranchFn.mock.calls ).toEqual(
-				expectedBranches.map( ( branch ) => [
-					branch,
-					commits,
-					config,
-				] )
-			);
-		}
-	);
+		expect( git.raw ).toHaveBeenCalledWith(
+			'commit',
+			'--allow-empty',
+			'-m',
+			'chore(release): prepare npm latest from release/23.5'
+		);
+	} );
 } );
 
 describe( 'runPackagesRelease', () => {
-	it( 'runs the release lifecycle in order', async () => {
-		const config = {
-			gitWorkingDirectoryPath: '/repo',
-			interactive: false,
-		};
-		const releaseState = { changelogCommit: 'changelog-sha' };
-		const prepareNpmReleaseFn = jest.fn().mockResolvedValue( releaseState );
-		const publishPreparedPackagesToNpmFn = jest
-			.fn()
-			.mockResolvedValue( 'publish-sha' );
+	const getTestConfig = () => ( {
+		abortMessage: 'Aborting!',
+		gitWorkingDirectoryPath: '/repo',
+		interactive: false,
+	} );
+
+	it( 'runs the durable release lifecycle in order', async () => {
+		const config = getTestConfig();
 		const finalizePreparedNpmReleaseFn = jest.fn();
+		const prepareNpmReleaseFn = jest.fn().mockResolvedValue( true );
+		const publishPreparedPackagesToNpmFn = jest.fn();
 
 		await runPackagesRelease( config, [], {
 			finalizePreparedNpmReleaseFn,
@@ -127,10 +120,7 @@ describe( 'runPackagesRelease', () => {
 		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledTimes( 1 );
 		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledWith( config );
 		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledTimes( 1 );
-		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledWith( config, {
-			changelogCommit: 'changelog-sha',
-			publishCommit: 'publish-sha',
-		} );
+		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledWith( config );
 		expect(
 			prepareNpmReleaseFn.mock.invocationCallOrder[ 0 ]
 		).toBeLessThan(
@@ -141,6 +131,21 @@ describe( 'runPackagesRelease', () => {
 		).toBeLessThan(
 			finalizePreparedNpmReleaseFn.mock.invocationCallOrder[ 0 ]
 		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'stops after prepare when no packages were versioned', async () => {
+		const finalizePreparedNpmReleaseFn = jest.fn();
+		const publishPreparedPackagesToNpmFn = jest.fn();
+
+		await runPackagesRelease( getTestConfig(), [], {
+			finalizePreparedNpmReleaseFn,
+			prepareNpmReleaseFn: jest.fn(),
+			publishPreparedPackagesToNpmFn,
+		} );
+
+		expect( publishPreparedPackagesToNpmFn ).not.toHaveBeenCalled();
+		expect( finalizePreparedNpmReleaseFn ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
 } );
@@ -203,6 +208,230 @@ describe( 'getNpmReleasePackages', () => {
 			},
 		] );
 		expect( git.raw ).toHaveBeenCalledWith( 'tag', '--points-at', 'HEAD' );
+	} );
+} );
+
+describe( 'getPreparedNpmReleasePackages', () => {
+	it( 'derives public version changes from the exact prepared commit', async () => {
+		const manifestByRef = {
+			'publish-sha:packages/a11y/package.json':
+				'{"name":"@wordpress/a11y","version":"4.50.0"}',
+			'publish-sha^:packages/a11y/package.json':
+				'{"name":"@wordpress/a11y","version":"4.49.0"}',
+			'publish-sha:packages/blocks/package.json':
+				'{"name":"@wordpress/blocks","version":"14.20.0"}',
+			'publish-sha^:packages/blocks/package.json':
+				'{"name":"@wordpress/blocks","version":"14.20.0"}',
+			'publish-sha:packages/private/package.json':
+				'{"name":"@wordpress/private","private":true,"version":"2.0.0"}',
+			'publish-sha^:packages/private/package.json':
+				'{"name":"@wordpress/private","private":true,"version":"1.0.0"}',
+		};
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce(
+					'packages/a11y/package.json\npackages/blocks/package.json\npackages/private/package.json\n'
+				)
+				.mockImplementation( ( commandName, manifestRef ) =>
+					Promise.resolve( manifestByRef[ manifestRef ] )
+				),
+		};
+
+		await expect(
+			getPreparedNpmReleasePackages( '/repo', 'publish-sha', {
+				git,
+			} )
+		).resolves.toEqual( [
+			{
+				name: '@wordpress/a11y',
+				tagName: '@wordpress/a11y@4.50.0',
+				version: '4.50.0',
+			},
+		] );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'show',
+			'publish-sha:packages/a11y/package.json'
+		);
+	} );
+} );
+
+describe( 'getPreparedNpmReleaseState', () => {
+	const releasePackages = [
+		{
+			name: '@wordpress/a11y',
+			tagName: '@wordpress/a11y@4.50.0',
+			version: '4.50.0',
+		},
+	];
+
+	it( 'reconstructs release state from commit ancestry', async () => {
+		const verifyRemoteNpmReleaseBranchFn = jest.fn();
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'chore(release): publish\n' )
+				.mockResolvedValueOnce(
+					'changelog-sha\u0000Update changelog files\n'
+				)
+				.mockResolvedValueOnce(
+					'chore(release): prepare npm latest from release/23.5\n'
+				),
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await expect(
+			getPreparedNpmReleaseState(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					npmReleaseBranch: 'wp/latest',
+					releaseType: 'latest',
+				},
+				{
+					getPreparedNpmReleasePackagesFn: jest
+						.fn()
+						.mockResolvedValue( releasePackages ),
+					git,
+					verifyRemoteNpmReleaseBranchFn,
+				}
+			)
+		).resolves.toEqual( {
+			changelogCommit: 'changelog-sha',
+			distTag: 'latest',
+			npmReleaseBranch: 'wp/latest',
+			pluginReleaseBranch: 'release/23.5',
+			publishCommit: 'publish-sha',
+			releasePackages,
+			releaseType: 'latest',
+		} );
+		expect( verifyRemoteNpmReleaseBranchFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			publishCommit: 'publish-sha',
+		} );
+	} );
+
+	it( 'rejects a prepared commit from another release route', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'chore(release): publish\n' )
+				.mockResolvedValueOnce(
+					'marker-sha\u0000chore(release): prepare npm bugfix\n'
+				)
+				.mockResolvedValueOnce(
+					'chore(release): prepare npm bugfix\n'
+				),
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+
+		await expect(
+			getPreparedNpmReleaseState(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					npmReleaseBranch: 'wp/latest',
+					releaseType: 'latest',
+				},
+				{
+					getPreparedNpmReleasePackagesFn: jest
+						.fn()
+						.mockResolvedValue( releasePackages ),
+					git,
+				}
+			)
+		).rejects.toThrow(
+			'Prepared npm release commit publish-sha does not match the latest release route.'
+		);
+	} );
+} );
+
+describe( 'getPendingPreparedNpmReleaseState', () => {
+	const releasePackages = [
+		{
+			name: '@wordpress/a11y',
+			tagName: '@wordpress/a11y@4.50.0',
+			version: '4.50.0',
+		},
+	];
+	const config = {
+		gitWorkingDirectoryPath: '/repo',
+	};
+
+	it( 'reuses a prepared commit whose package tags are still missing', async () => {
+		const releaseState = { publishCommit: 'publish-sha' };
+		const getPreparedNpmReleaseStateFn = jest
+			.fn()
+			.mockResolvedValue( releaseState );
+
+		await expect(
+			getPendingPreparedNpmReleaseState( config, {
+				getPreparedNpmReleasePackagesFn: jest
+					.fn()
+					.mockResolvedValue( releasePackages ),
+				getPreparedNpmReleaseStateFn,
+				getRemoteTagShasFn: jest.fn().mockResolvedValue( new Map() ),
+				git: {
+					raw: jest
+						.fn()
+						.mockResolvedValue( 'chore(release): publish\n' ),
+					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+				},
+			} )
+		).resolves.toBe( releaseState );
+		expect( getPreparedNpmReleaseStateFn ).toHaveBeenCalledWith( config );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'allows a new preparation after every package tag is finalized', async () => {
+		const getPreparedNpmReleaseStateFn = jest.fn();
+
+		await expect(
+			getPendingPreparedNpmReleaseState( config, {
+				getPreparedNpmReleasePackagesFn: jest
+					.fn()
+					.mockResolvedValue( releasePackages ),
+				getPreparedNpmReleaseStateFn,
+				getRemoteTagShasFn: jest
+					.fn()
+					.mockResolvedValue(
+						new Map( [
+							[ '@wordpress/a11y@4.50.0', 'publish-sha' ],
+						] )
+					),
+				git: {
+					raw: jest
+						.fn()
+						.mockResolvedValue( 'chore(release): publish\n' ),
+					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+				},
+			} )
+		).resolves.toBeNull();
+		expect( getPreparedNpmReleaseStateFn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects package tags that point to another commit', async () => {
+		await expect(
+			getPendingPreparedNpmReleaseState( config, {
+				getPreparedNpmReleasePackagesFn: jest
+					.fn()
+					.mockResolvedValue( releasePackages ),
+				getRemoteTagShasFn: jest
+					.fn()
+					.mockResolvedValue(
+						new Map( [ [ '@wordpress/a11y@4.50.0', 'other-sha' ] ] )
+					),
+				git: {
+					raw: jest
+						.fn()
+						.mockResolvedValue( 'chore(release): publish\n' ),
+					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+				},
+			} )
+		).rejects.toThrow(
+			'Package tag @wordpress/a11y@4.50.0 points to other-sha, expected publish-sha.'
+		);
 	} );
 } );
 
@@ -344,6 +573,33 @@ describe( 'verifyRemotePackageTags', () => {
 } );
 
 describe( 'runNpmPublishPreflight', () => {
+	it( 'can validate public registry state without checking npm access', async () => {
+		const commandFn = jest.fn().mockRejectedValueOnce( {
+			stderr: 'npm ERR! code E404',
+		} );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					checkAccess: false,
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).resolves.toEqual( [] );
+		expect( commandFn ).toHaveBeenCalledTimes( 1 );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npm view @wordpress/a11y@4.50.0 version gitHead dist-tags --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
 	it( 'uses the npm access command supported by current npm versions', async () => {
 		const commandFn = jest
 			.fn()
@@ -587,63 +843,51 @@ describe( 'pushNpmReleaseGitMetadata', () => {
 } );
 
 describe( 'publishVersionedPackagesToNpm', () => {
-	it( 'preflights, publishes from package, and pushes metadata', async () => {
+	const releasePackages = [
+		{
+			name: '@wordpress/a11y',
+			tagName: '@wordpress/a11y@4.50.0',
+			version: '4.50.0',
+		},
+	];
+
+	it( 'preflights and publishes from the exact prepared commit', async () => {
 		const commandFn = jest.fn().mockResolvedValue();
-		const getNpmReleasePackagesFn = jest
-			.fn()
-			.mockResolvedValue( [
-				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
-			] );
 		const runNpmPublishPreflightFn = jest
 			.fn()
 			.mockResolvedValueOnce( [] )
 			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
-		const pushNpmReleaseGitMetadataFn = jest.fn();
-		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
-		};
 
 		await publishVersionedPackagesToNpm(
 			{
 				distTag: 'latest',
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
-				npmReleaseBranch: 'wp/latest',
+				publishCommit: 'publish-sha',
+				releasePackages,
 				yesFlag: '--yes',
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn,
-				git,
-				pushNpmReleaseGitMetadataFn,
+				git: {
+					raw: jest.fn().mockResolvedValue( '' ),
+					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+				},
 				runNpmPublishPreflightFn,
 			}
 		);
 
-		expect( getNpmReleasePackagesFn ).toHaveBeenCalledWith( '/repo' );
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
 			distTag: 'latest',
 			gitWorkingDirectoryPath: '/repo',
 			publishCommit: 'publish-sha',
-			releasePackages: [
-				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
-			],
+			releasePackages,
 		} );
 		expect( commandFn ).toHaveBeenCalledWith(
 			'npx lerna publish from-package --dist-tag latest --git-head publish-sha --yes --no-verify-access',
 			{ cwd: '/repo', stdio: 'inherit' }
 		);
-		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
-			gitWorkingDirectoryPath: '/repo',
-			npmReleaseBranch: 'wp/latest',
-			packageTags: [ '@wordpress/a11y@4.50.0' ],
-			publishCommit: 'publish-sha',
-		} );
-		expect(
-			runNpmPublishPreflightFn.mock.invocationCallOrder[ 1 ]
-		).toBeLessThan(
-			pushNpmReleaseGitMetadataFn.mock.invocationCallOrder[ 0 ]
-		);
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 2 );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -661,40 +905,49 @@ describe( 'publishVersionedPackagesToNpm', () => {
 				'@wordpress/blocks',
 			] );
 		const git = {
+			raw: jest.fn().mockResolvedValue( '' ),
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
-			reset: jest.fn(),
 		};
+		const nextReleasePackages = [
+			{
+				name: '@wordpress/a11y',
+				tagName: '@wordpress/a11y@4.50.0-next.0',
+				version: '4.50.0-next.0',
+			},
+			{
+				name: '@wordpress/blocks',
+				tagName: '@wordpress/blocks@14.20.0-next.0',
+				version: '14.20.0-next.0',
+			},
+		];
 
 		await publishVersionedPackagesToNpm(
 			{
 				distTag: 'next',
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
-				npmReleaseBranch: 'wp/next',
+				publishCommit: 'publish-sha',
+				releasePackages: nextReleasePackages,
 				yesFlag: '--yes',
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
-					{
-						name: '@wordpress/a11y',
-						tagName: '@wordpress/a11y@4.50.0-next.0',
-					},
-					{
-						name: '@wordpress/blocks',
-						tagName: '@wordpress/blocks@14.20.0-next.0',
-					},
-				] ),
 				git,
-				pushNpmReleaseGitMetadataFn: jest.fn(),
 				runNpmPublishPreflightFn,
 			}
 		);
 
 		expect( commandFn ).toHaveBeenCalledTimes( 2 );
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 3 );
-		expect( git.reset ).toHaveBeenCalledWith( 'hard' );
-		expect( git.reset.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+		expect( git.raw ).toHaveBeenCalledWith(
+			'reset',
+			'--hard',
+			'publish-sha'
+		);
+		const resetCall = git.raw.mock.calls.findIndex(
+			( [ commandName ] ) => commandName === 'reset'
+		);
+		expect( git.raw.mock.invocationCallOrder[ resetCall ] ).toBeLessThan(
 			runNpmPublishPreflightFn.mock.invocationCallOrder[ 1 ]
 		);
 		expect( console ).toHaveLogged();
@@ -702,28 +955,21 @@ describe( 'publishVersionedPackagesToNpm', () => {
 
 	it( 'skips Lerna when all package versions are already published', async () => {
 		const commandFn = jest.fn();
-		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
-		};
-
 		await publishVersionedPackagesToNpm(
 			{
 				distTag: 'latest',
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
-				npmReleaseBranch: 'wp/latest',
+				publishCommit: 'publish-sha',
+				releasePackages,
 				yesFlag: '--yes',
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
-					{
-						name: '@wordpress/a11y',
-						tagName: '@wordpress/a11y@4.50.0',
-					},
-				] ),
-				git,
-				pushNpmReleaseGitMetadataFn: jest.fn(),
+				git: {
+					raw: jest.fn().mockResolvedValue( '' ),
+					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+				},
 				runNpmPublishPreflightFn: jest
 					.fn()
 					.mockResolvedValue( [ '@wordpress/a11y' ] ),
@@ -734,14 +980,10 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'does not push metadata when final registry verification is incomplete', async () => {
+	it( 'fails when final registry verification is incomplete', async () => {
 		const commandFn = jest.fn().mockResolvedValue();
-		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
 		const runPhase = jest.fn( async ( _label, task ) => task() );
-		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
-		};
 
 		await expect(
 			publishVersionedPackagesToNpm(
@@ -749,20 +991,16 @@ describe( 'publishVersionedPackagesToNpm', () => {
 					distTag: 'latest',
 					gitWorkingDirectoryPath: '/repo',
 					noVerifyAccessFlag: '--no-verify-access',
-					npmReleaseBranch: 'wp/latest',
+					publishCommit: 'publish-sha',
+					releasePackages,
 					yesFlag: '--yes',
 				},
 				{
 					commandFn,
-					getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
-						{
-							name: '@wordpress/a11y',
-							tagName: '@wordpress/a11y@4.50.0',
-							version: '4.50.0',
-						},
-					] ),
-					git,
-					pushNpmReleaseGitMetadataFn,
+					git: {
+						raw: jest.fn().mockResolvedValue( '' ),
+						revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+					},
 					runNpmPublishPreflightFn,
 					runPhase,
 				}
@@ -776,13 +1014,11 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			'npm publication verification',
 			expect.any( Function )
 		);
-		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'retries final registry verification after propagation lag', async () => {
 		const commandFn = jest.fn().mockResolvedValue();
-		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const runNpmPublishPreflightFn = jest
 			.fn()
 			.mockResolvedValueOnce( [] )
@@ -792,6 +1028,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 		const runPhase = ( label, task ) =>
 			runNpmReleasePhase( label, task, { wait } );
 		const git = {
+			raw: jest.fn().mockResolvedValue( '' ),
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 		};
 
@@ -800,20 +1037,13 @@ describe( 'publishVersionedPackagesToNpm', () => {
 				distTag: 'latest',
 				gitWorkingDirectoryPath: '/repo',
 				noVerifyAccessFlag: '--no-verify-access',
-				npmReleaseBranch: 'wp/latest',
+				publishCommit: 'publish-sha',
+				releasePackages,
 				yesFlag: '--yes',
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
-					{
-						name: '@wordpress/a11y',
-						tagName: '@wordpress/a11y@4.50.0',
-						version: '4.50.0',
-					},
-				] ),
 				git,
-				pushNpmReleaseGitMetadataFn,
 				runNpmPublishPreflightFn,
 				runPhase,
 			}
@@ -821,13 +1051,85 @@ describe( 'publishVersionedPackagesToNpm', () => {
 
 		expect( runNpmPublishPreflightFn ).toHaveBeenCalledTimes( 3 );
 		expect( wait ).toHaveBeenCalledWith( 5000 );
-		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalled();
 		expect( console ).toHaveLogged();
+	} );
+
+	it( 'rejects a dirty prepared checkout before registry access', async () => {
+		const commandFn = jest.fn();
+		const runNpmPublishPreflightFn = jest.fn();
+
+		await expect(
+			publishVersionedPackagesToNpm(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					noVerifyAccessFlag: '--no-verify-access',
+					publishCommit: 'publish-sha',
+					releasePackages,
+					yesFlag: '--yes',
+				},
+				{
+					commandFn,
+					git: {
+						raw: jest
+							.fn()
+							.mockResolvedValue(
+								' M packages/a11y/package.json'
+							),
+						revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+					},
+					runNpmPublishPreflightFn,
+				}
+			)
+		).rejects.toThrow(
+			'Prepared npm release checkout publish-sha has uncommitted changes.'
+		);
+		expect( runNpmPublishPreflightFn ).not.toHaveBeenCalled();
+		expect( commandFn ).not.toHaveBeenCalled();
 	} );
 } );
 
-describe( 'publishPackagesToNpm', () => {
-	const getConfig = ( releaseType ) => ( {
+describe( 'prepareNpmRelease', () => {
+	it( 'reuses a pending prepared commit without mutating the branch', async () => {
+		const pendingReleaseState = { publishCommit: 'publish-sha' };
+		const checkoutNpmReleaseBranchFn = jest.fn();
+		const createNpmReleaseMarkerFn = jest.fn();
+		const findPluginReleaseBranchNameFn = jest.fn();
+		const preparePackagesForNpmFn = jest.fn();
+		const runNpmReleaseBranchSyncStepFn = jest.fn();
+		const updatePackagesFn = jest.fn();
+
+		await expect(
+			prepareNpmRelease(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					releaseType: 'latest',
+				},
+				{
+					checkoutNpmReleaseBranchFn,
+					createNpmReleaseMarkerFn,
+					findPluginReleaseBranchNameFn,
+					getPendingPreparedNpmReleaseStateFn: jest
+						.fn()
+						.mockResolvedValue( pendingReleaseState ),
+					preparePackagesForNpmFn,
+					runNpmReleaseBranchSyncStepFn,
+					updatePackagesFn,
+				}
+			)
+		).resolves.toBe( pendingReleaseState );
+
+		expect( checkoutNpmReleaseBranchFn ).toHaveBeenCalled();
+		expect( findPluginReleaseBranchNameFn ).not.toHaveBeenCalled();
+		expect( runNpmReleaseBranchSyncStepFn ).not.toHaveBeenCalled();
+		expect( createNpmReleaseMarkerFn ).not.toHaveBeenCalled();
+		expect( updatePackagesFn ).not.toHaveBeenCalled();
+		expect( preparePackagesForNpmFn ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'preparePackagesForNpm', () => {
+	const getTestConfig = ( releaseType ) => ( {
 		distTag: releaseType === 'next' ? 'next' : 'latest',
 		gitWorkingDirectoryPath: '/repo',
 		interactive: false,
@@ -862,35 +1164,48 @@ describe( 'publishPackagesToNpm', () => {
 			'wp/6.9',
 		],
 	] )(
-		'routes %s releases through the shared metadata publishing path',
+		'prepares durable Git metadata for %s releases',
 		async ( releaseType, versionCommand, distTag, npmReleaseBranch ) => {
 			const commandFn = jest.fn().mockResolvedValue();
 			const git = {
-				revparse: jest
-					.fn()
-					.mockResolvedValueOnce( 'before-sha' )
-					.mockResolvedValueOnce( 'after-sha' ),
+				revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 			};
-			const publishVersionedPackagesToNpmFn = jest.fn();
+			const releasePackages = [
+				{
+					name: '@wordpress/a11y',
+					tagName: '@wordpress/a11y@4.50.0',
+					version: '4.50.0',
+				},
+			];
+			const pushNpmReleaseGitMetadataFn = jest.fn();
 			const config = {
-				...getConfig( releaseType ),
+				...getTestConfig( releaseType ),
 				distTag,
 				npmReleaseBranch,
 			};
 
-			await publishPackagesToNpm( config, {
-				commandFn,
-				git,
-				publishVersionedPackagesToNpmFn,
+			await expect(
+				preparePackagesForNpm( config, {
+					commandFn,
+					getNpmReleasePackagesFn: jest
+						.fn()
+						.mockResolvedValue( releasePackages ),
+					git,
+					pushNpmReleaseGitMetadataFn,
+				} )
+			).resolves.toEqual( {
+				publishCommit: 'publish-sha',
+				releasePackages,
 			} );
 
 			expect( commandFn ).toHaveBeenCalledWith( 'npm ci', {
 				cwd: '/repo',
 			} );
-			expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
-				cwd: '/repo',
-				stdio: 'inherit',
-			} );
+			expect(
+				commandFn.mock.calls.some( ( [ command ] ) =>
+					command.startsWith( 'npm whoami' )
+				)
+			).toBe( false );
 			expect(
 				commandFn.mock.calls.some(
 					( [ command ] ) =>
@@ -903,14 +1218,245 @@ describe( 'publishPackagesToNpm', () => {
 					command.includes( '--build-metadata' )
 				)
 			).toBe( false );
-			expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith( {
-				distTag,
+			expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
 				gitWorkingDirectoryPath: '/repo',
-				noVerifyAccessFlag: '--no-verify-access',
 				npmReleaseBranch,
-				yesFlag: '--yes',
+				packageTags: [],
+				publishCommit: 'publish-sha',
 			} );
 			expect( console ).toHaveLogged();
 		}
 	);
+
+	it( 'does not push when versioning creates no package release', async () => {
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+
+		await expect(
+			preparePackagesForNpm( getTestConfig( 'next' ), {
+				commandFn: jest.fn().mockResolvedValue(),
+				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [] ),
+				git: { revparse: jest.fn() },
+				pushNpmReleaseGitMetadataFn,
+			} )
+		).resolves.toBeUndefined();
+		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'publishPreparedPackagesToNpm', () => {
+	it( 'installs and publishes from reconstructed release state', async () => {
+		const releaseState = {
+			distTag: 'latest',
+			publishCommit: 'publish-sha',
+			releasePackages: [
+				{
+					name: '@wordpress/a11y',
+					tagName: '@wordpress/a11y@4.50.0',
+					version: '4.50.0',
+				},
+			],
+		};
+		const commandFn = jest.fn().mockResolvedValue();
+		const publishVersionedPackagesToNpmFn = jest.fn();
+
+		await publishPreparedPackagesToNpm(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				interactive: false,
+			},
+			{
+				commandFn,
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( releaseState ),
+				publishVersionedPackagesToNpmFn,
+			}
+		);
+
+		expect( commandFn ).toHaveBeenCalledWith( 'npm ci', { cwd: '/repo' } );
+		expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
+			cwd: '/repo',
+			stdio: 'inherit',
+		} );
+		expect( publishVersionedPackagesToNpmFn ).toHaveBeenCalledWith(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				noVerifyAccessFlag: '--no-verify-access',
+				publishCommit: 'publish-sha',
+				releasePackages: releaseState.releasePackages,
+				yesFlag: '--yes',
+			},
+			{ commandFn }
+		);
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'finalizePreparedNpmRelease', () => {
+	const releaseState = {
+		changelogCommit: 'changelog-sha',
+		distTag: 'latest',
+		npmReleaseBranch: 'wp/latest',
+		pluginReleaseBranch: 'release/23.5',
+		publishCommit: 'publish-sha',
+		releasePackages: [
+			{
+				name: '@wordpress/a11y',
+				tagName: '@wordpress/a11y@4.50.0',
+				version: '4.50.0',
+			},
+			{
+				name: '@wordpress/blocks',
+				tagName: '@wordpress/blocks@14.20.0',
+				version: '14.20.0',
+			},
+		],
+		releaseType: 'latest',
+	};
+
+	it( 'backports idempotently and pushes only missing final tags', async () => {
+		const backportCommitsToBranchFn = jest.fn();
+		const git = { raw: jest.fn().mockResolvedValue() };
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const runNpmPublishPreflightFn = jest
+			.fn()
+			.mockResolvedValue( [ '@wordpress/a11y', '@wordpress/blocks' ] );
+
+		await finalizePreparedNpmRelease(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releaseType: 'latest',
+			},
+			{
+				backportCommitsToBranchFn,
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( releaseState ),
+				getRemoteTagShasFn: jest
+					.fn()
+					.mockResolvedValue(
+						new Map( [
+							[ '@wordpress/a11y@4.50.0', 'publish-sha' ],
+						] )
+					),
+				git,
+				pushNpmReleaseGitMetadataFn,
+				runNpmPublishPreflightFn,
+			}
+		);
+
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			checkAccess: false,
+			distTag: 'latest',
+			gitWorkingDirectoryPath: '/repo',
+			publishCommit: 'publish-sha',
+			releasePackages: releaseState.releasePackages,
+		} );
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
+			'trunk',
+			[ 'changelog-sha', 'publish-sha' ],
+			expect.objectContaining( { releaseType: 'latest' } )
+		);
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledWith(
+			'release/23.5',
+			[ 'changelog-sha', 'publish-sha' ],
+			expect.objectContaining( { releaseType: 'latest' } )
+		);
+		expect( git.raw ).toHaveBeenCalledWith(
+			'tag',
+			'-a',
+			'@wordpress/blocks@14.20.0',
+			'publish-sha',
+			'-m',
+			'@wordpress/blocks@14.20.0'
+		);
+		expect( pushNpmReleaseGitMetadataFn ).toHaveBeenCalledWith( {
+			gitWorkingDirectoryPath: '/repo',
+			npmReleaseBranch: 'wp/latest',
+			packageTags: [ '@wordpress/blocks@14.20.0' ],
+			publishCommit: 'publish-sha',
+		} );
+	} );
+
+	it( 'does nothing when every final tag is already remote', async () => {
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const runNpmPublishPreflightFn = jest.fn();
+
+		await finalizePreparedNpmRelease(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releaseType: 'latest',
+			},
+			{
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( releaseState ),
+				getRemoteTagShasFn: jest
+					.fn()
+					.mockResolvedValue(
+						new Map(
+							releaseState.releasePackages.map(
+								( { tagName } ) => [ tagName, 'publish-sha' ]
+							)
+						)
+					),
+				git: { raw: jest.fn() },
+				pushNpmReleaseGitMetadataFn,
+				runNpmPublishPreflightFn,
+			}
+		);
+
+		expect( runNpmPublishPreflightFn ).not.toHaveBeenCalled();
+		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'reuses local tags created by the prepare phase', async () => {
+		const nextReleaseState = {
+			...releaseState,
+			distTag: 'next',
+			npmReleaseBranch: 'wp/next',
+			pluginReleaseBranch: 'trunk',
+			releasePackages: [ releaseState.releasePackages[ 0 ] ],
+			releaseType: 'next',
+		};
+		const git = {
+			raw: jest.fn().mockResolvedValue( 'publish-sha\n' ),
+		};
+
+		await finalizePreparedNpmRelease(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releaseType: 'next',
+			},
+			{
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( nextReleaseState ),
+				getRemoteTagShasFn: jest.fn().mockResolvedValue( new Map() ),
+				git,
+				pushNpmReleaseGitMetadataFn: jest.fn(),
+				runNpmPublishPreflightFn: jest
+					.fn()
+					.mockResolvedValue( [ '@wordpress/a11y' ] ),
+			}
+		);
+
+		expect( git.raw ).toHaveBeenCalledWith(
+			'rev-list',
+			'-n',
+			'1',
+			'@wordpress/a11y@4.50.0'
+		);
+		expect( git.raw ).not.toHaveBeenCalledWith(
+			'tag',
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.anything()
+		);
+	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -3,8 +3,11 @@
  */
 import {
 	backportCommitsToBranch,
+	checkoutNpmReleaseBranch,
+	createNpmReleaseFinalizationMarker,
 	createNpmReleaseMarker,
 	finalizePreparedNpmRelease,
+	getConfig,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
 	getPendingPreparedNpmReleaseState,
@@ -14,6 +17,7 @@ import {
 	getRemoteTagShas,
 	getTagPushCommands,
 	getTagRefspec,
+	isNpmReleaseFinalizationMarker,
 	prepareNpmRelease,
 	preparePackagesForNpm,
 	publishPreparedPackagesToNpm,
@@ -74,6 +78,37 @@ describe( 'backportCommitsToBranch', () => {
 	} );
 } );
 
+describe( 'checkoutNpmReleaseBranch', () => {
+	it( 'resets an existing local branch to the fetched remote head', async () => {
+		const git = {
+			fetch: jest.fn().mockResolvedValue(),
+			raw: jest.fn().mockResolvedValue(),
+		};
+
+		await checkoutNpmReleaseBranch(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				npmReleaseBranch: 'wp/latest',
+			},
+			{ git }
+		);
+
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'wp/latest', [
+			'--depth=999',
+		] );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'checkout',
+			'-B',
+			'wp/latest',
+			'FETCH_HEAD'
+		);
+		expect( git.fetch.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			git.raw.mock.invocationCallOrder[ 0 ]
+		);
+		expect( console ).toHaveLogged();
+	} );
+} );
+
 describe( 'createNpmReleaseMarker', () => {
 	it( 'records the release type and synced source branch', async () => {
 		const git = { raw: jest.fn().mockResolvedValue() };
@@ -82,6 +117,7 @@ describe( 'createNpmReleaseMarker', () => {
 			'release/23.5',
 			{
 				gitWorkingDirectoryPath: '/repo',
+				releaseId: 'run-123',
 				releaseType: 'latest',
 			},
 			{ git }
@@ -91,8 +127,187 @@ describe( 'createNpmReleaseMarker', () => {
 			'commit',
 			'--allow-empty',
 			'-m',
-			'chore(release): prepare npm latest from release/23.5'
+			'chore(release): prepare npm latest from release/23.5 [release-id: run-123]'
 		);
+	} );
+} );
+
+describe( 'isNpmReleaseFinalizationMarker', () => {
+	it( 'accepts an exact child marker with the prepared release tree', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					'publish-sha\u0000tree-sha\u0000chore(release): finalize npm latest [release-id: run-123]\n'
+				),
+			revparse: jest.fn().mockResolvedValue( 'tree-sha\n' ),
+		};
+
+		await expect(
+			isNpmReleaseFinalizationMarker(
+				'finalization-sha',
+				{
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releaseId: 'run-123',
+					releaseType: 'latest',
+				},
+				{ git }
+			)
+		).resolves.toBe( true );
+	} );
+
+	it.each( [
+		[
+			'another parent',
+			'other-sha\u0000tree-sha\u0000chore(release): finalize npm latest [release-id: run-123]\n',
+		],
+		[
+			'another tree',
+			'publish-sha\u0000other-tree\u0000chore(release): finalize npm latest [release-id: run-123]\n',
+		],
+	] )( 'rejects a marker with %s', async ( _label, description ) => {
+		await expect(
+			isNpmReleaseFinalizationMarker(
+				'finalization-sha',
+				{
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releaseId: 'run-123',
+					releaseType: 'latest',
+				},
+				{
+					git: {
+						raw: jest.fn().mockResolvedValue( description ),
+						revparse: jest.fn().mockResolvedValue( 'tree-sha\n' ),
+					},
+				}
+			)
+		).resolves.toBe( false );
+	} );
+} );
+
+describe( 'createNpmReleaseFinalizationMarker', () => {
+	it( 'advances the release branch after finalization completes', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'finalization-sha\n' )
+				.mockResolvedValueOnce(),
+		};
+		const runPhase = jest.fn( ( description, callback ) => callback() );
+		const releaseState = {
+			npmReleaseBranch: 'wp/latest',
+			publishCommit: 'publish-sha',
+			releaseId: 'run-123',
+			releaseType: 'latest',
+		};
+
+		await createNpmReleaseFinalizationMarker(
+			releaseState,
+			{ gitWorkingDirectoryPath: '/repo' },
+			{
+				getRemoteBranchShaFn: jest
+					.fn()
+					.mockResolvedValue( 'publish-sha' ),
+				git,
+				runPhase,
+			}
+		);
+
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			1,
+			'commit-tree',
+			'publish-sha^{tree}',
+			'-p',
+			'publish-sha',
+			'-m',
+			'chore(release): finalize npm latest [release-id: run-123]'
+		);
+		expect( runPhase ).toHaveBeenCalledWith(
+			'Finalization marker push',
+			expect.any( Function )
+		);
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			2,
+			'push',
+			'origin',
+			'finalization-sha:refs/heads/wp/latest'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'recovers when a successful marker push loses its acknowledgement', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'finalization-sha\n' )
+				.mockRejectedValueOnce( new Error( 'Connection closed' ) ),
+		};
+		const getRemoteBranchShaFn = jest
+			.fn()
+			.mockResolvedValueOnce( 'publish-sha' )
+			.mockResolvedValueOnce( 'finalization-sha' );
+		const runPhase = jest.fn( async ( _description, callback ) => {
+			await expect( callback() ).rejects.toThrow( 'Connection closed' );
+			await callback();
+		} );
+
+		await createNpmReleaseFinalizationMarker(
+			{
+				npmReleaseBranch: 'wp/latest',
+				publishCommit: 'publish-sha',
+				releaseId: 'run-123',
+				releaseType: 'latest',
+			},
+			{ gitWorkingDirectoryPath: '/repo' },
+			{ getRemoteBranchShaFn, git, runPhase }
+		);
+
+		expect( getRemoteBranchShaFn ).toHaveBeenCalledTimes( 2 );
+		expect( git.raw ).toHaveBeenCalledTimes( 2 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'accepts an equivalent marker without truncating release history', async () => {
+		const git = {
+			fetch: jest.fn().mockResolvedValue(),
+			raw: jest.fn().mockResolvedValue( 'local-finalization-sha\n' ),
+		};
+		const isFinalizationMarkerFn = jest.fn().mockResolvedValue( true );
+
+		await createNpmReleaseFinalizationMarker(
+			{
+				npmReleaseBranch: 'wp/latest',
+				publishCommit: 'publish-sha',
+				releaseId: 'run-123',
+				releaseType: 'latest',
+			},
+			{ gitWorkingDirectoryPath: '/repo' },
+			{
+				getRemoteBranchShaFn: jest
+					.fn()
+					.mockResolvedValue( 'remote-finalization-sha' ),
+				git,
+				isFinalizationMarkerFn,
+				runPhase: jest.fn( ( _description, callback ) => callback() ),
+			}
+		);
+
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'wp/latest', [
+			'--depth=999',
+		] );
+		expect( isFinalizationMarkerFn ).toHaveBeenCalledWith(
+			'remote-finalization-sha',
+			expect.objectContaining( {
+				publishCommit: 'publish-sha',
+				releaseId: 'run-123',
+				releaseType: 'latest',
+			} ),
+			{ git }
+		);
+		expect( git.raw ).toHaveBeenCalledTimes( 1 );
+		expect( console ).toHaveLogged();
 	} );
 } );
 
@@ -141,6 +356,24 @@ describe( 'runPackagesRelease', () => {
 		await runPackagesRelease( getTestConfig(), [], {
 			finalizePreparedNpmReleaseFn,
 			prepareNpmReleaseFn: jest.fn(),
+			publishPreparedPackagesToNpmFn,
+		} );
+
+		expect( publishPreparedPackagesToNpmFn ).not.toHaveBeenCalled();
+		expect( finalizePreparedNpmReleaseFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'stops when the same release invocation is already finalized', async () => {
+		const finalizePreparedNpmReleaseFn = jest.fn();
+		const publishPreparedPackagesToNpmFn = jest.fn();
+
+		await runPackagesRelease( getTestConfig(), [], {
+			finalizePreparedNpmReleaseFn,
+			prepareNpmReleaseFn: jest.fn().mockResolvedValue( {
+				isFinalized: true,
+				releaseId: 'run-123',
+			} ),
 			publishPreparedPackagesToNpmFn,
 		} );
 
@@ -266,7 +499,9 @@ describe( 'getPreparedNpmReleaseState', () => {
 	];
 
 	it( 'reconstructs release state from commit ancestry', async () => {
-		const verifyRemoteNpmReleaseBranchFn = jest.fn();
+		const getRemoteBranchShaFn = jest
+			.fn()
+			.mockResolvedValue( 'publish-sha' );
 		const git = {
 			raw: jest
 				.fn()
@@ -275,7 +510,7 @@ describe( 'getPreparedNpmReleaseState', () => {
 					'changelog-sha\u0000Update changelog files\n'
 				)
 				.mockResolvedValueOnce(
-					'chore(release): prepare npm latest from release/23.5\n'
+					'chore(release): prepare npm latest from release/23.5 [release-id: run-123]\n'
 				),
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 		};
@@ -293,23 +528,82 @@ describe( 'getPreparedNpmReleaseState', () => {
 						.fn()
 						.mockResolvedValue( releasePackages ),
 					git,
-					verifyRemoteNpmReleaseBranchFn,
+					getRemoteBranchShaFn,
 				}
 			)
 		).resolves.toEqual( {
 			changelogCommit: 'changelog-sha',
 			distTag: 'latest',
+			isFinalized: false,
 			npmReleaseBranch: 'wp/latest',
 			pluginReleaseBranch: 'release/23.5',
 			publishCommit: 'publish-sha',
 			releasePackages,
+			releaseId: 'run-123',
 			releaseType: 'latest',
 		} );
-		expect( verifyRemoteNpmReleaseBranchFn ).toHaveBeenCalledWith( {
-			gitWorkingDirectoryPath: '/repo',
-			npmReleaseBranch: 'wp/latest',
-			publishCommit: 'publish-sha',
-		} );
+		expect( getRemoteBranchShaFn ).toHaveBeenCalledWith(
+			'/repo',
+			'wp/latest'
+		);
+	} );
+
+	it( 'recognizes a release finalized by an earlier split-phase run', async () => {
+		const git = {
+			fetch: jest.fn().mockResolvedValue(),
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'chore(release): publish\n' )
+				.mockResolvedValueOnce(
+					'changelog-sha\u0000Update changelog files\n'
+				)
+				.mockResolvedValueOnce(
+					'chore(release): prepare npm latest from release/23.5 [release-id: run-123]\n'
+				),
+			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+		};
+		const isFinalizationMarkerFn = jest.fn().mockResolvedValue( true );
+
+		await expect(
+			getPreparedNpmReleaseState(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					npmReleaseBranch: 'wp/latest',
+					releaseType: 'latest',
+				},
+				{
+					getPreparedNpmReleasePackagesFn: jest
+						.fn()
+						.mockResolvedValue( releasePackages ),
+					getRemoteBranchShaFn: jest
+						.fn()
+						.mockResolvedValue( 'finalization-sha' ),
+					git,
+					isFinalizationMarkerFn,
+					publishCommit: 'publish-sha',
+				}
+			)
+		).resolves.toEqual(
+			expect.objectContaining( {
+				isFinalized: true,
+				publishCommit: 'publish-sha',
+				releaseId: 'run-123',
+			} )
+		);
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'wp/latest', [
+			'--depth=999',
+		] );
+		expect( git.revparse ).not.toHaveBeenCalled();
+		expect( isFinalizationMarkerFn ).toHaveBeenCalledWith(
+			'finalization-sha',
+			expect.objectContaining( {
+				publishCommit: 'publish-sha',
+				releaseId: 'run-123',
+				releaseType: 'latest',
+			} ),
+			{ git }
+		);
 	} );
 
 	it( 'rejects a prepared commit from another release route', async () => {
@@ -318,10 +612,10 @@ describe( 'getPreparedNpmReleaseState', () => {
 				.fn()
 				.mockResolvedValueOnce( 'chore(release): publish\n' )
 				.mockResolvedValueOnce(
-					'marker-sha\u0000chore(release): prepare npm bugfix\n'
+					'marker-sha\u0000chore(release): prepare npm bugfix [release-id: run-123]\n'
 				)
 				.mockResolvedValueOnce(
-					'chore(release): prepare npm bugfix\n'
+					'chore(release): prepare npm bugfix [release-id: run-123]\n'
 				),
 			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 		};
@@ -357,6 +651,9 @@ describe( 'getPendingPreparedNpmReleaseState', () => {
 	];
 	const config = {
 		gitWorkingDirectoryPath: '/repo',
+		npmReleaseBranch: 'wp/latest',
+		releaseId: 'run-123',
+		releaseType: 'latest',
 	};
 
 	it( 'reuses a prepared commit whose package tags are still missing', async () => {
@@ -384,8 +681,11 @@ describe( 'getPendingPreparedNpmReleaseState', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'allows a new preparation after every package tag is finalized', async () => {
-		const getPreparedNpmReleaseStateFn = jest.fn();
+	it( 'reuses a prepared commit until finalization is recorded', async () => {
+		const releaseState = { publishCommit: 'publish-sha' };
+		const getPreparedNpmReleaseStateFn = jest
+			.fn()
+			.mockResolvedValue( releaseState );
 
 		await expect(
 			getPendingPreparedNpmReleaseState( config, {
@@ -407,8 +707,73 @@ describe( 'getPendingPreparedNpmReleaseState', () => {
 					revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
 				},
 			} )
-		).resolves.toBeNull();
-		expect( getPreparedNpmReleaseStateFn ).not.toHaveBeenCalled();
+		).resolves.toBe( releaseState );
+		expect( getPreparedNpmReleaseStateFn ).toHaveBeenCalledWith( config );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'returns the finalized release identity recorded at HEAD', async () => {
+		const getPreparedNpmReleasePackagesFn = jest.fn();
+		const releaseState = {
+			isFinalized: true,
+			publishCommit: 'publish-sha',
+			releaseId: 'run-123',
+			releaseType: 'latest',
+		};
+		const getPreparedNpmReleaseStateFn = jest
+			.fn()
+			.mockResolvedValue( releaseState );
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					'chore(release): finalize npm latest [release-id: run-123]\n'
+				),
+			revparse: jest
+				.fn()
+				.mockResolvedValueOnce( 'finalization-sha' )
+				.mockResolvedValueOnce( 'publish-sha' ),
+		};
+		await expect(
+			getPendingPreparedNpmReleaseState( config, {
+				getPreparedNpmReleasePackagesFn,
+				getPreparedNpmReleaseStateFn,
+				git,
+			} )
+		).resolves.toBe( releaseState );
+		expect( getPreparedNpmReleasePackagesFn ).not.toHaveBeenCalled();
+		expect( getPreparedNpmReleaseStateFn ).toHaveBeenCalledWith(
+			expect.objectContaining( { releaseType: 'latest' } ),
+			expect.objectContaining( { git, publishCommit: 'publish-sha' } )
+		);
+	} );
+
+	it( 'rejects a marker whose parent is not a valid prepared release', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValue(
+					'chore(release): finalize npm latest [release-id: run-123]\n'
+				),
+			revparse: jest
+				.fn()
+				.mockResolvedValueOnce( 'finalization-sha' )
+				.mockResolvedValueOnce( 'publish-sha' ),
+		};
+
+		await expect(
+			getPendingPreparedNpmReleaseState( config, {
+				getPreparedNpmReleaseStateFn: jest.fn().mockResolvedValue( {
+					isFinalized: false,
+					publishCommit: 'publish-sha',
+					releaseId: 'run-123',
+					releaseType: 'latest',
+				} ),
+				git,
+			} )
+		).rejects.toThrow(
+			'Invalid npm release finalization marker finalization-sha.'
+		);
 	} );
 
 	it( 'rejects package tags that point to another commit', async () => {
@@ -1091,7 +1456,12 @@ describe( 'publishVersionedPackagesToNpm', () => {
 
 describe( 'prepareNpmRelease', () => {
 	it( 'reuses a pending prepared commit without mutating the branch', async () => {
-		const pendingReleaseState = { publishCommit: 'publish-sha' };
+		const pendingReleaseState = {
+			isFinalized: false,
+			publishCommit: 'publish-sha',
+			releaseId: 'run-123',
+			releaseType: 'latest',
+		};
 		const checkoutNpmReleaseBranchFn = jest.fn();
 		const createNpmReleaseMarkerFn = jest.fn();
 		const findPluginReleaseBranchNameFn = jest.fn();
@@ -1103,6 +1473,7 @@ describe( 'prepareNpmRelease', () => {
 			prepareNpmRelease(
 				{
 					gitWorkingDirectoryPath: '/repo',
+					releaseId: 'run-123',
 					releaseType: 'latest',
 				},
 				{
@@ -1125,6 +1496,127 @@ describe( 'prepareNpmRelease', () => {
 		expect( createNpmReleaseMarkerFn ).not.toHaveBeenCalled();
 		expect( updatePackagesFn ).not.toHaveBeenCalled();
 		expect( preparePackagesForNpmFn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects a pending release from another invocation', async () => {
+		const createNpmReleaseMarkerFn = jest.fn();
+		const preparePackagesForNpmFn = jest.fn();
+
+		await expect(
+			prepareNpmRelease(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					releaseId: 'run-456',
+					releaseType: 'latest',
+				},
+				{
+					checkoutNpmReleaseBranchFn: jest.fn(),
+					createNpmReleaseMarkerFn,
+					getPendingPreparedNpmReleaseStateFn: jest
+						.fn()
+						.mockResolvedValue( {
+							isFinalized: false,
+							publishCommit: 'publish-sha',
+							releaseId: 'run-123',
+							releaseType: 'latest',
+						} ),
+					preparePackagesForNpmFn,
+				}
+			)
+		).rejects.toThrow(
+			'A latest release from invocation run-123 is still pending.'
+		);
+
+		expect( createNpmReleaseMarkerFn ).not.toHaveBeenCalled();
+		expect( preparePackagesForNpmFn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns a finalized state for the same release invocation', async () => {
+		const finalizedReleaseState = {
+			isFinalized: true,
+			releaseId: 'run-123',
+			releaseType: 'latest',
+		};
+		const createNpmReleaseMarkerFn = jest.fn();
+		const preparePackagesForNpmFn = jest.fn();
+
+		await expect(
+			prepareNpmRelease(
+				{
+					gitWorkingDirectoryPath: '/repo',
+					releaseId: 'run-123',
+					releaseType: 'latest',
+				},
+				{
+					checkoutNpmReleaseBranchFn: jest.fn(),
+					createNpmReleaseMarkerFn,
+					getPendingPreparedNpmReleaseStateFn: jest
+						.fn()
+						.mockResolvedValue( finalizedReleaseState ),
+					preparePackagesForNpmFn,
+				}
+			)
+		).resolves.toBe( finalizedReleaseState );
+
+		expect( createNpmReleaseMarkerFn ).not.toHaveBeenCalled();
+		expect( preparePackagesForNpmFn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prepares a new release after another invocation finalized', async () => {
+		const askForConfirmationFn = jest.fn().mockResolvedValue();
+		const createNpmReleaseMarkerFn = jest.fn();
+		const preparePackagesForNpmFn = jest
+			.fn()
+			.mockResolvedValue( { publishCommit: 'new-publish-sha' } );
+		const runNpmReleaseBranchSyncStepFn = jest.fn();
+		const updatePackagesFn = jest.fn();
+
+		await expect(
+			prepareNpmRelease(
+				{
+					abortMessage: 'Aborting!',
+					gitWorkingDirectoryPath: '/repo',
+					interactive: true,
+					releaseId: 'run-456',
+					releaseType: 'latest',
+				},
+				{
+					askForConfirmationFn,
+					checkoutNpmReleaseBranchFn: jest.fn(),
+					createNpmReleaseMarkerFn,
+					findPluginReleaseBranchNameFn: jest
+						.fn()
+						.mockResolvedValue( 'release/23.5' ),
+					getPendingPreparedNpmReleaseStateFn: jest
+						.fn()
+						.mockResolvedValue( {
+							isFinalized: true,
+							releaseId: 'run-123',
+							releaseType: 'latest',
+						} ),
+					preparePackagesForNpmFn,
+					runNpmReleaseBranchSyncStepFn,
+					updatePackagesFn,
+				}
+			)
+		).resolves.toEqual( { publishCommit: 'new-publish-sha' } );
+
+		expect( askForConfirmationFn ).toHaveBeenCalledWith(
+			'The previous npm release (run-123) is finalized. Start a new latest release?',
+			false,
+			'Aborting!'
+		);
+		expect( runNpmReleaseBranchSyncStepFn ).toHaveBeenCalledWith(
+			'release/23.5',
+			expect.objectContaining( { releaseId: 'run-456' } )
+		);
+		expect( createNpmReleaseMarkerFn ).toHaveBeenCalledWith(
+			'release/23.5',
+			expect.objectContaining( { releaseId: 'run-456' } )
+		);
+		expect( updatePackagesFn ).toHaveBeenCalled();
+		expect( preparePackagesForNpmFn ).toHaveBeenCalled();
+		expect( console ).toHaveLogged();
 	} );
 } );
 
@@ -1248,6 +1740,7 @@ describe( 'publishPreparedPackagesToNpm', () => {
 	it( 'installs and publishes from reconstructed release state', async () => {
 		const releaseState = {
 			distTag: 'latest',
+			isFinalized: false,
 			publishCommit: 'publish-sha',
 			releasePackages: [
 				{
@@ -1292,12 +1785,36 @@ describe( 'publishPreparedPackagesToNpm', () => {
 		);
 		expect( console ).toHaveLogged();
 	} );
+
+	it( 'does not publish a release that is already finalized', async () => {
+		const commandFn = jest.fn();
+		const publishVersionedPackagesToNpmFn = jest.fn();
+
+		await publishPreparedPackagesToNpm(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				interactive: false,
+			},
+			{
+				commandFn,
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( { isFinalized: true } ),
+				publishVersionedPackagesToNpmFn,
+			}
+		);
+
+		expect( commandFn ).not.toHaveBeenCalled();
+		expect( publishVersionedPackagesToNpmFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
 } );
 
 describe( 'finalizePreparedNpmRelease', () => {
 	const releaseState = {
 		changelogCommit: 'changelog-sha',
 		distTag: 'latest',
+		isFinalized: false,
 		npmReleaseBranch: 'wp/latest',
 		pluginReleaseBranch: 'release/23.5',
 		publishCommit: 'publish-sha',
@@ -1313,11 +1830,43 @@ describe( 'finalizePreparedNpmRelease', () => {
 				version: '14.20.0',
 			},
 		],
+		releaseId: 'run-123',
 		releaseType: 'latest',
 	};
 
+	it( 'does not finalize a release that is already finalized', async () => {
+		const backportCommitsToBranchFn = jest.fn();
+		const createNpmReleaseFinalizationMarkerFn = jest.fn();
+		const getRemoteTagShasFn = jest.fn();
+		const pushNpmReleaseGitMetadataFn = jest.fn();
+
+		await finalizePreparedNpmRelease(
+			{
+				gitWorkingDirectoryPath: '/repo',
+				releaseType: 'latest',
+			},
+			{
+				backportCommitsToBranchFn,
+				createNpmReleaseFinalizationMarkerFn,
+				getPreparedNpmReleaseStateFn: jest
+					.fn()
+					.mockResolvedValue( { isFinalized: true } ),
+				getRemoteTagShasFn,
+				git: { raw: jest.fn() },
+				pushNpmReleaseGitMetadataFn,
+			}
+		);
+
+		expect( getRemoteTagShasFn ).not.toHaveBeenCalled();
+		expect( backportCommitsToBranchFn ).not.toHaveBeenCalled();
+		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
+		expect( createNpmReleaseFinalizationMarkerFn ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+
 	it( 'backports idempotently and pushes only missing final tags', async () => {
 		const backportCommitsToBranchFn = jest.fn();
+		const createNpmReleaseFinalizationMarkerFn = jest.fn();
 		const git = { raw: jest.fn().mockResolvedValue() };
 		const pushNpmReleaseGitMetadataFn = jest.fn();
 		const runNpmPublishPreflightFn = jest
@@ -1331,6 +1880,7 @@ describe( 'finalizePreparedNpmRelease', () => {
 			},
 			{
 				backportCommitsToBranchFn,
+				createNpmReleaseFinalizationMarkerFn,
 				getPreparedNpmReleaseStateFn: jest
 					.fn()
 					.mockResolvedValue( releaseState ),
@@ -1378,11 +1928,18 @@ describe( 'finalizePreparedNpmRelease', () => {
 			packageTags: [ '@wordpress/blocks@14.20.0' ],
 			publishCommit: 'publish-sha',
 		} );
+		expect( createNpmReleaseFinalizationMarkerFn ).toHaveBeenCalledWith(
+			releaseState,
+			expect.objectContaining( { releaseType: 'latest' } )
+		);
 	} );
 
-	it( 'does nothing when every final tag is already remote', async () => {
+	it( 'records finalization when every final tag is already remote', async () => {
+		const createNpmReleaseFinalizationMarkerFn = jest.fn();
 		const pushNpmReleaseGitMetadataFn = jest.fn();
-		const runNpmPublishPreflightFn = jest.fn();
+		const runNpmPublishPreflightFn = jest
+			.fn()
+			.mockResolvedValue( [ '@wordpress/a11y', '@wordpress/blocks' ] );
 
 		await finalizePreparedNpmRelease(
 			{
@@ -1390,6 +1947,7 @@ describe( 'finalizePreparedNpmRelease', () => {
 				releaseType: 'latest',
 			},
 			{
+				createNpmReleaseFinalizationMarkerFn,
 				getPreparedNpmReleaseStateFn: jest
 					.fn()
 					.mockResolvedValue( releaseState ),
@@ -1408,8 +1966,18 @@ describe( 'finalizePreparedNpmRelease', () => {
 			}
 		);
 
-		expect( runNpmPublishPreflightFn ).not.toHaveBeenCalled();
+		expect( runNpmPublishPreflightFn ).toHaveBeenCalledWith( {
+			checkAccess: false,
+			distTag: 'latest',
+			gitWorkingDirectoryPath: '/repo',
+			publishCommit: 'publish-sha',
+			releasePackages: releaseState.releasePackages,
+		} );
 		expect( pushNpmReleaseGitMetadataFn ).not.toHaveBeenCalled();
+		expect( createNpmReleaseFinalizationMarkerFn ).toHaveBeenCalledWith(
+			releaseState,
+			expect.objectContaining( { releaseType: 'latest' } )
+		);
 		expect( console ).toHaveLogged();
 	} );
 
@@ -1432,6 +2000,7 @@ describe( 'finalizePreparedNpmRelease', () => {
 				releaseType: 'next',
 			},
 			{
+				createNpmReleaseFinalizationMarkerFn: jest.fn(),
 				getPreparedNpmReleaseStateFn: jest
 					.fn()
 					.mockResolvedValue( nextReleaseState ),
@@ -1457,6 +2026,68 @@ describe( 'finalizePreparedNpmRelease', () => {
 			expect.anything(),
 			expect.anything(),
 			expect.anything()
+		);
+	} );
+} );
+
+describe( 'getConfig', () => {
+	it( 'uses the stable GitHub Actions run ID in CI', () => {
+		expect(
+			getConfig(
+				'latest',
+				{ ci: true },
+				{
+					createReleaseIdFn: jest.fn(),
+					githubRunId: '123456789',
+				}
+			)
+		).toEqual(
+			expect.objectContaining( {
+				interactive: false,
+				releaseId: '123456789',
+			} )
+		);
+	} );
+
+	it( 'prefers an explicit release ID', () => {
+		expect(
+			getConfig(
+				'latest',
+				{ ci: true, releaseId: 'manual-release' },
+				{ githubRunId: '123456789' }
+			).releaseId
+		).toBe( 'manual-release' );
+	} );
+
+	it( 'requires a stable release ID outside interactive mode', () => {
+		expect( () =>
+			getConfig( 'latest', { ci: true }, { githubRunId: null } )
+		).toThrow( 'A stable release ID is required in non-interactive mode.' );
+	} );
+
+	it( 'creates a release ID for a new interactive invocation', () => {
+		expect(
+			getConfig(
+				'latest',
+				{ ci: false },
+				{
+					createReleaseIdFn: jest
+						.fn()
+						.mockReturnValue( 'generated-release' ),
+					githubRunId: null,
+				}
+			).releaseId
+		).toBe( 'generated-release' );
+	} );
+
+	it( 'rejects release IDs that cannot be recorded unambiguously', () => {
+		expect( () =>
+			getConfig( 'latest', {
+				ci: true,
+				releaseId: 'invalid release',
+			} )
+		).toThrow(
+			'The release ID may contain only letters, numbers, dots, underscores, and hyphens.'
 		);
 	} );
 } );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -464,7 +464,7 @@ describe( 'getPreparedNpmReleasePackages', () => {
 			raw: jest
 				.fn()
 				.mockResolvedValueOnce(
-					'packages/a11y/package.json\npackages/blocks/package.json\npackages/private/package.json\n'
+					'M\tpackages/a11y/package.json\nM\tpackages/blocks/package.json\nM\tpackages/private/package.json\n'
 				)
 				.mockImplementation( ( commandName, manifestRef ) =>
 					Promise.resolve( manifestByRef[ manifestRef ] )
@@ -486,6 +486,42 @@ describe( 'getPreparedNpmReleasePackages', () => {
 			'show',
 			'publish-sha:packages/a11y/package.json'
 		);
+	} );
+
+	it( 'includes added public packages and excludes removed manifests', async () => {
+		const git = {
+			raw: jest
+				.fn()
+				.mockResolvedValueOnce( 'A\tpackages/new/package.json\n' )
+				.mockResolvedValueOnce(
+					'{"name":"@wordpress/new","version":"1.0.0"}'
+				),
+		};
+
+		await expect(
+			getPreparedNpmReleasePackages( '/repo', 'publish-sha', {
+				git,
+			} )
+		).resolves.toEqual( [
+			{
+				name: '@wordpress/new',
+				tagName: '@wordpress/new@1.0.0',
+				version: '1.0.0',
+			},
+		] );
+		expect( git.raw ).toHaveBeenNthCalledWith(
+			1,
+			'diff-tree',
+			'--no-commit-id',
+			'--name-status',
+			'--diff-filter=AM',
+			'-r',
+			'publish-sha^',
+			'publish-sha',
+			'--',
+			'packages/*/package.json'
+		);
+		expect( git.raw ).toHaveBeenCalledTimes( 2 );
 	} );
 } );
 


### PR DESCRIPTION
Follow-up to #80190. Followed by #80202 and #79906.

## What?

Makes a prepared npm release durable and recoverable while keeping the existing single-command workflow.

## Why?

Publishing and finalization must be safely rerunnable from a fresh checkout after a partial failure, without adopting another run's state or starting a second release.

## How?

- Records the release route and stable release ID in Git, then reconstructs the exact package set from the prepared commit.
- Pushes and verifies the prepared release branch before publishing to npm.
- Validates the checkout, npm registry state, remote branch, and package tags before each irreversible phase.
- Records completion with an exact finalization marker whose parent, tree, route, and release ID are verified.
- Keeps retries idempotent across lost push acknowledgements, partial tag pushes, backports, and split-phase reruns.
- Preserves the release branch history depth needed by Lerna.

CLI phase selection is intentionally left to the next PR in the stack.

## Testing Instructions

```sh
npm run test:unit -- tools/release/commands/test/common.js tools/release/commands/test/packages.js --runInBand
npm run lint:js -- tools/release/cli.js tools/release/commands/common.js tools/release/commands/packages.js tools/release/commands/test/common.js tools/release/commands/test/packages.js
node tools/release/cli.js publish-npm-packages-latest --help
npm run build
```

### Testing Instructions for Keyboard

Not applicable; this changes release tooling only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to help split, adversarially review, and verify the implementation and draft this description. I reviewed the resulting changes.
