### PR TITLE
Release: Expose durable npm release phases

### DIFF
--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -19,6 +19,11 @@ const { runPerformanceTests } = require( './commands/performance' );
 
 const semverOption = [ '--semver <semver>', 'Semantic Versioning', 'patch' ];
 const ciOption = [ '-c, --ci', 'Run in CI (non interactive)' ];
+const phaseOption = [
+	'--phase <phase>',
+	'Release phase: prepare, publish, finalize, or all.',
+	'all',
+];
 const repositoryPathOption = [
 	'--repository-path <repository-path>',
 	'Relative path to the git repository.',
@@ -33,6 +38,7 @@ program
 	.alias( 'npm-latest' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...phaseOption )
 	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
@@ -44,6 +50,7 @@ program
 	.command( 'publish-npm-packages-bugfix-latest' )
 	.alias( 'npm-bugfix' )
 	.option( ...ciOption )
+	.option( ...phaseOption )
 	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
@@ -56,6 +63,7 @@ program
 	.alias( 'npm-wp' )
 	.requiredOption( '--wp-version <wpVersion>', 'WordPress version' )
 	.option( ...ciOption )
+	.option( ...phaseOption )
 	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(
@@ -68,6 +76,7 @@ program
 	.alias( 'npm-next' )
 	.option( ...semverOption )
 	.option( ...ciOption )
+	.option( ...phaseOption )
 	.option( ...releaseIdOption )
 	.option( ...repositoryPathOption )
 	.description(

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -39,6 +39,12 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
  */
 
 /**
+ * Npm release phases.
+ *
+ * @typedef {('prepare'|'publish'|'finalize'|'all')} ReleasePhase
+ */
+
+/**
  * Semantic Versioning labels.
  *
  * @typedef {('major'|'minor'|'patch')} SemVer
@@ -47,24 +53,26 @@ const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
 /**
  * @typedef WPPackagesCommandOptions
  *
- * @property {boolean} [ci]             Disables interactive mode when executed in CI mode.
- * @property {string}  [releaseId]      Stable identifier used to resume the same release.
- * @property {string}  [repositoryPath] Relative path to the git repository.
- * @property {SemVer}  [semver]         The selected semantic versioning. Defaults to `patch`.
- * @property {string}  [wpVersion]      The major WordPress version number, example: `6.0`.
+ * @property {boolean}      [ci]             Disables interactive mode when executed in CI mode.
+ * @property {ReleasePhase} [phase]          The release phase. Defaults to `all`.
+ * @property {string}       [releaseId]      Stable identifier used to resume the same release.
+ * @property {string}       [repositoryPath] Relative path to the git repository.
+ * @property {SemVer}       [semver]         The selected semantic versioning. Defaults to `patch`.
+ * @property {string}       [wpVersion]      The major WordPress version number, example: `6.0`.
  */
 
 /**
  * @typedef WPPackagesConfig
  *
- * @property {string}      abortMessage            Abort Message.
- * @property {string}      distTag                 The dist-tag used for npm publishing.
- * @property {string}      gitWorkingDirectoryPath Git working directory path.
- * @property {boolean}     interactive             Whether to run in interactive mode.
- * @property {SemVer}      minimumVersionBump      The selected minimum version bump.
- * @property {string}      npmReleaseBranch        The selected branch for npm release.
- * @property {string}      releaseId               Stable identifier for this release invocation.
- * @property {ReleaseType} releaseType             The selected release type.
+ * @property {string}       abortMessage            Abort Message.
+ * @property {string}       distTag                 The dist-tag used for npm publishing.
+ * @property {string}       gitWorkingDirectoryPath Git working directory path.
+ * @property {boolean}      interactive             Whether to run in interactive mode.
+ * @property {SemVer}       minimumVersionBump      The selected minimum version bump.
+ * @property {string}       npmReleaseBranch        The selected branch for npm release.
+ * @property {ReleasePhase} phase                   The release phase.
+ * @property {string}       releaseId               Stable identifier for this release invocation.
+ * @property {ReleaseType}  releaseType             The selected release type.
  */
 
 /**
@@ -1738,6 +1746,14 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 	}
 
 	const temporaryFolders = [];
+	if (
+		[ 'publish', 'finalize' ].includes( config.phase ) &&
+		! config.gitWorkingDirectoryPath
+	) {
+		throw new Error(
+			`The ${ config.phase } phase requires --repository-path pointing to the prepared release checkout.`
+		);
+	}
 	if ( ! config.gitWorkingDirectoryPath ) {
 		const gitPath = getRandomTemporaryPath();
 		config.gitWorkingDirectoryPath = gitPath;
@@ -1759,16 +1775,27 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 		);
 	}
 
-	const releaseState = await prepareNpmReleaseFn( config );
-	const hasPreparedRelease = Boolean(
-		releaseState && ! releaseState.isFinalized
-	);
-	if ( releaseState?.isFinalized ) {
-		log( '>> This npm release invocation is already finalized.' );
+	let hasPreparedRelease = true;
+	if ( [ 'prepare', 'all' ].includes( config.phase ) ) {
+		const releaseState = await prepareNpmReleaseFn( config );
+		hasPreparedRelease = Boolean(
+			releaseState && ! releaseState.isFinalized
+		);
+		if ( releaseState?.isFinalized ) {
+			log( '>> This npm release invocation is already finalized.' );
+		}
+		if ( config.phase === 'prepare' && hasPreparedRelease ) {
+			log( '>> npm release preparation finished.' );
+		}
 	}
 
-	if ( hasPreparedRelease ) {
+	if ( hasPreparedRelease && [ 'publish', 'all' ].includes( config.phase ) ) {
 		await publishPreparedPackagesToNpmFn( config );
+	}
+	if (
+		hasPreparedRelease &&
+		[ 'finalize', 'all' ].includes( config.phase )
+	) {
 		await finalizePreparedNpmReleaseFn( config );
 	}
 
@@ -1783,7 +1810,10 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
 			)
 	);
 
-	if ( hasPreparedRelease ) {
+	if (
+		hasPreparedRelease &&
+		[ 'finalize', 'all' ].includes( config.phase )
+	) {
 		log(
 			'\n>> 🎉 WordPress packages are now published!\n\n',
 			'Let also people know on WordPress Slack and celebrate together.'
@@ -1804,9 +1834,21 @@ async function runPackagesRelease( config, customMessages, deps = {} ) {
  */
 function getConfig(
 	releaseType,
-	{ ci, releaseId, repositoryPath, semver = 'patch', wpVersion },
+	{
+		ci,
+		phase = 'all',
+		releaseId,
+		repositoryPath,
+		semver = 'patch',
+		wpVersion,
+	},
 	deps = {}
 ) {
+	if ( ! [ 'prepare', 'publish', 'finalize', 'all' ].includes( phase ) ) {
+		throw new Error(
+			`Unknown npm release phase "${ phase }". Expected prepare, publish, finalize, or all.`
+		);
+	}
 	const {
 		createReleaseIdFn = randomUUID,
 		githubRunId = process.env.GITHUB_RUN_ID,
@@ -1841,6 +1883,7 @@ function getConfig(
 		interactive: ! ci,
 		minimumVersionBump: semver,
 		npmReleaseBranch,
+		phase,
 		releaseId: stableReleaseId,
 		releaseType,
 	};
@@ -1898,9 +1941,9 @@ module.exports = {
 	createNpmReleaseFinalizationMarker,
 	createNpmReleaseMarker,
 	finalizePreparedNpmRelease,
+	getConfig,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
-	getConfig,
 	getPendingPreparedNpmReleaseState,
 	getPreparedNpmReleasePackages,
 	getPreparedNpmReleaseState,

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -312,40 +312,68 @@ describe( 'createNpmReleaseFinalizationMarker', () => {
 } );
 
 describe( 'runPackagesRelease', () => {
-	const getTestConfig = () => ( {
+	const getTestConfig = ( phase ) => ( {
 		abortMessage: 'Aborting!',
 		gitWorkingDirectoryPath: '/repo',
 		interactive: false,
+		phase,
 	} );
 
-	it( 'runs the durable release lifecycle in order', async () => {
-		const config = getTestConfig();
-		const finalizePreparedNpmReleaseFn = jest.fn();
-		const prepareNpmReleaseFn = jest.fn().mockResolvedValue( true );
-		const publishPreparedPackagesToNpmFn = jest.fn();
+	it.each( [ 'publish', 'finalize' ] )(
+		'requires a prepared checkout for the %s phase',
+		async ( phase ) => {
+			await expect(
+				runPackagesRelease(
+					{
+						...getTestConfig( phase ),
+						gitWorkingDirectoryPath: undefined,
+					},
+					[]
+				)
+			).rejects.toThrow(
+				`The ${ phase } phase requires --repository-path pointing to the prepared release checkout.`
+			);
+			expect( console ).toHaveLogged();
+		}
+	);
+
+	it.each( [
+		[ 'prepare', [ 'prepare' ] ],
+		[ 'publish', [ 'publish' ] ],
+		[ 'finalize', [ 'finalize' ] ],
+		[ 'all', [ 'prepare', 'publish', 'finalize' ] ],
+	] )( 'runs only the %s phase steps', async ( phase, expectedSteps ) => {
+		const config = getTestConfig( phase );
+		const phaseSteps = {
+			finalize: jest.fn(),
+			prepare: jest.fn().mockResolvedValue( true ),
+			publish: jest.fn(),
+		};
 
 		await runPackagesRelease( config, [], {
-			finalizePreparedNpmReleaseFn,
-			prepareNpmReleaseFn,
-			publishPreparedPackagesToNpmFn,
+			finalizePreparedNpmReleaseFn: phaseSteps.finalize,
+			prepareNpmReleaseFn: phaseSteps.prepare,
+			publishPreparedPackagesToNpmFn: phaseSteps.publish,
 		} );
 
-		expect( prepareNpmReleaseFn ).toHaveBeenCalledTimes( 1 );
-		expect( prepareNpmReleaseFn ).toHaveBeenCalledWith( config );
-		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledTimes( 1 );
-		expect( publishPreparedPackagesToNpmFn ).toHaveBeenCalledWith( config );
-		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledTimes( 1 );
-		expect( finalizePreparedNpmReleaseFn ).toHaveBeenCalledWith( config );
-		expect(
-			prepareNpmReleaseFn.mock.invocationCallOrder[ 0 ]
-		).toBeLessThan(
-			publishPreparedPackagesToNpmFn.mock.invocationCallOrder[ 0 ]
+		expect( phaseSteps.prepare.mock.calls ).toEqual(
+			expectedSteps.includes( 'prepare' ) ? [ [ config ] ] : []
 		);
-		expect(
-			publishPreparedPackagesToNpmFn.mock.invocationCallOrder[ 0 ]
-		).toBeLessThan(
-			finalizePreparedNpmReleaseFn.mock.invocationCallOrder[ 0 ]
+		expect( phaseSteps.publish.mock.calls ).toEqual(
+			expectedSteps.includes( 'publish' ) ? [ [ config ] ] : []
 		);
+		expect( phaseSteps.finalize.mock.calls ).toEqual(
+			expectedSteps.includes( 'finalize' ) ? [ [ config ] ] : []
+		);
+		const actualSteps = Object.entries( phaseSteps )
+			.filter( ( [ , step ] ) => step.mock.calls.length )
+			.sort(
+				( [ , first ], [ , second ] ) =>
+					first.mock.invocationCallOrder[ 0 ] -
+					second.mock.invocationCallOrder[ 0 ]
+			)
+			.map( ( [ step ] ) => step );
+		expect( actualSteps ).toEqual( expectedSteps );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -353,7 +381,7 @@ describe( 'runPackagesRelease', () => {
 		const finalizePreparedNpmReleaseFn = jest.fn();
 		const publishPreparedPackagesToNpmFn = jest.fn();
 
-		await runPackagesRelease( getTestConfig(), [], {
+		await runPackagesRelease( getTestConfig( 'all' ), [], {
 			finalizePreparedNpmReleaseFn,
 			prepareNpmReleaseFn: jest.fn(),
 			publishPreparedPackagesToNpmFn,
@@ -368,7 +396,7 @@ describe( 'runPackagesRelease', () => {
 		const finalizePreparedNpmReleaseFn = jest.fn();
 		const publishPreparedPackagesToNpmFn = jest.fn();
 
-		await runPackagesRelease( getTestConfig(), [], {
+		await runPackagesRelease( getTestConfig( 'all' ), [], {
 			finalizePreparedNpmReleaseFn,
 			prepareNpmReleaseFn: jest.fn().mockResolvedValue( {
 				isFinalized: true,
@@ -380,6 +408,16 @@ describe( 'runPackagesRelease', () => {
 		expect( publishPreparedPackagesToNpmFn ).not.toHaveBeenCalled();
 		expect( finalizePreparedNpmReleaseFn ).not.toHaveBeenCalled();
 		expect( console ).toHaveLogged();
+	} );
+
+	it( 'does not report a successful preparation when nothing was prepared', async () => {
+		await runPackagesRelease( getTestConfig( 'prepare' ), [], {
+			prepareNpmReleaseFn: jest.fn(),
+		} );
+
+		expect( console ).not.toHaveLoggedWith(
+			'>> npm release preparation finished.'
+		);
 	} );
 } );
 
@@ -1627,6 +1665,7 @@ describe( 'preparePackagesForNpm', () => {
 		interactive: false,
 		minimumVersionBump: 'patch',
 		npmReleaseBranch: releaseType === 'next' ? 'wp/next' : 'wp/latest',
+		phase: 'prepare',
 		releaseType,
 	} );
 
@@ -2031,6 +2070,33 @@ describe( 'finalizePreparedNpmRelease', () => {
 } );
 
 describe( 'getConfig', () => {
+	it( 'configures independent release phases', () => {
+		expect(
+			getConfig(
+				'next',
+				{
+					ci: true,
+					phase: 'publish',
+					repositoryPath: '/repo',
+				},
+				{ githubRunId: '123456789' }
+			)
+		).toEqual(
+			expect.objectContaining( {
+				distTag: 'next',
+				interactive: false,
+				npmReleaseBranch: 'wp/next',
+				phase: 'publish',
+			} )
+		);
+	} );
+
+	it( 'rejects unknown release phases', () => {
+		expect( () => getConfig( 'latest', { phase: 'resume' } ) ).toThrow(
+			'Unknown npm release phase "resume". Expected prepare, publish, finalize, or all.'
+		);
+	} );
+
 	it( 'uses the stable GitHub Actions run ID in CI', () => {
 		expect(
 			getConfig(


### PR DESCRIPTION
Stacked on #80201. Follow-up workflow integration: #79906.

## What?

Exposes the durable npm release lifecycle as `prepare`, `publish`, `finalize`, and `all` CLI phases.

## Why?

The release workflow needs to run each durable phase in a separate fresh job while preserving the existing all-in-one command.

## How?

- Adds the `--phase` option to the four npm release commands.
- Validates phase values and requires a prepared checkout for publish and finalize.
- Runs only the requested lifecycle step, with `all` remaining the default.

## Testing Instructions

```sh
npm run test:unit -- tools/release/commands/test/common.js tools/release/commands/test/packages.js --runInBand
npm run lint:js -- tools/release/cli.js tools/release/commands/packages.js tools/release/commands/test/packages.js
npm run build
```

### Testing Instructions for Keyboard

Not applicable; this changes release tooling only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to help split and verify the implementation and draft this description. I reviewed the resulting changes.
