### PR TITLE
Fix Color Picker Cursor Shaking Issue

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 ## 37.0.0 (2026-07-14)
 
+### Internal
+
+-   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).
+
+## 37.0.0 (2026-07-14)
+
 ### Enhancements
 
 -   `ControlWithError`: Remove redundant inline aria-live region for validation error messages to prevent duplicate announcements. ([#79600](https://github.com/WordPress/gutenberg/pull/79600)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Bug Fixes
 
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
--   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
 
 ### TypeScript
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
+-   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
 
 ### TypeScript
 
@@ -22,12 +23,6 @@
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).
 -   `ToggleGroupControl`: Migrate styles from Emotion to SCSS Modules and use WPDS tokens for migrated visual values ([#80381](https://github.com/WordPress/gutenberg/pull/80381)).
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
-
-## 37.0.0 (2026-07-14)
-
-### Internal
-
--   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).
 
 ## 37.0.0 (2026-07-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes
 
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
+-   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
+
 
 ### TypeScript
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,6 @@
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
 -   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
 
-
 ### TypeScript
 
 -   Improved performance of TypeScript types for internal polymorphic `WordPressComponent` component type ([#80364](https://github.com/WordPress/gutenberg/pull/80364)).

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -124,23 +124,25 @@ const UnconnectedColorPicker = (
 	// throttles its onChange callbacks using requestAnimationFrame.
 
 	const handleHSLAChange = useCallback(
-	    ( nextHSLA: HslaColor ) => {
-	        setInternalHSLA( ( prev ) => {
-	            const isPositionalDrag =
-	                nextHSLA.s !== prev.s || nextHSLA.l !== prev.l;
-	            const stabilizedHSLA = isPositionalDrag
-	                ? mergeHSLA( nextHSLA, prev )
-	                : nextHSLA;
-	            const previousHex = lastProducedHexRef.current;
-	            const nextHex = colord( stabilizedHSLA ).toHex();
-	            if ( nextHex !== previousHex ) {
-	                lastProducedHexRef.current = nextHex;
-	                setColor( nextHex );
-	            }
-	            return stabilizedHSLA;
-	        } );
-	    },
-	    [ setColor ]
+		( nextHSLA: HslaColor ) => {
+			setInternalHSLA( ( prev ) => {
+				const isPositionalDrag =
+					nextHSLA.s !== prev.s || nextHSLA.l !== prev.l;
+				const stabilizedHSLA = isPositionalDrag
+					? mergeHSLA( nextHSLA, prev )
+					: nextHSLA;
+				const previousHex = lastProducedHexRef.current;
+				const nextHex = colord( stabilizedHSLA ).toHex();
+
+				if ( nextHex !== previousHex ) {
+					lastProducedHexRef.current = nextHex;
+					setColor( nextHex );
+				}
+
+				return stabilizedHSLA;
+			} );
+		},
+		[ setColor ]
 	);
 
 	// Handler for components that provide Colord values (RGB, Hex inputs).

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -98,49 +98,41 @@ const UnconnectedColorPicker = (
 	// distinguish our own updates from external prop changes.
 	const lastProducedHexRef = useRef( safeColordColor.toHex() );
 
+	// While the user is dragging the visual picker, ignore color-prop sync.
+	const isPickerInteractingRef = useRef( false );
+
 	// Sync internalHSLA when the color prop changes externally (e.g.
 	// parent passes a new color that wasn't produced by our onChange).
 	useEffect( () => {
-		const incomingHex = safeColordColor.toHex();
+		if ( isPickerInteractingRef.current ) {
+			return;
+		}
 
-		// If this hex matches what we last produced, it's our own
-		// update arriving back — skip the sync to avoid overwriting
-		// internalHSLA with lossy round-tripped values.
-		if ( incomingHex === lastProducedHexRef.current ) {
+		// Compare by color equality, not hex string — rgb()/rgba()
+		// round-trips can differ in string form for the same color.
+		if ( safeColordColor.isEqual( lastProducedHexRef.current ) ) {
 			return;
 		}
 
 		// Genuinely external change — sync internalHSLA.
-		lastProducedHexRef.current = incomingHex;
+		lastProducedHexRef.current = safeColordColor.toHex();
 		const externalHSLA = safeColordColor.toHsl();
 		setInternalHSLA( ( prev ) => mergeHSLA( externalHSLA, prev ) );
 	}, [ safeColordColor ] );
 
-	// Handler for HSL-aware components (Picker, HSL inputs) that
-	// provide raw HSLA values without information loss.
-	// Uses direct setColor (not debounced) to prevent race conditions
-	// where a stale debounced hex would overwrite newer internalHSLA.
-	// This is safe performance-wise because react-colorful internally
-	// throttles its onChange callbacks using requestAnimationFrame.
-
+	// Handler for HSL inputs (and the HSVA picker after conversion to HSLA).
+	// Updates the local HSLA state, then notifies the parent only when the
+	// resulting color changes. Uses setColor directly (not debounced) to
+	// avoid races with the debounced hex/RGB updates.
 	const handleHSLAChange = useCallback(
 		( nextHSLA: HslaColor ) => {
-			setInternalHSLA( ( prev ) => {
-				const isPositionalDrag =
-					nextHSLA.s !== prev.s || nextHSLA.l !== prev.l;
-				const stabilizedHSLA = isPositionalDrag
-					? mergeHSLA( nextHSLA, prev )
-					: nextHSLA;
-				const previousHex = lastProducedHexRef.current;
-				const nextHex = colord( stabilizedHSLA ).toHex();
-
-				if ( nextHex !== previousHex ) {
-					lastProducedHexRef.current = nextHex;
-					setColor( nextHex );
-				}
-
-				return stabilizedHSLA;
-			} );
+			setInternalHSLA( nextHSLA );
+			const previousHex = lastProducedHexRef.current;
+			const nextHex = colord( nextHSLA ).toHex();
+			if ( ! colord( nextHex ).isEqual( previousHex ) ) {
+				lastProducedHexRef.current = nextHex;
+				setColor( nextHex );
+			}
 		},
 		[ setColor ]
 	);
@@ -217,6 +209,12 @@ const UnconnectedColorPicker = (
 				onChange={ handleHSLAChange }
 				hsla={ internalHSLA }
 				enableAlpha={ enableAlpha }
+				onInteractionStart={ () => {
+					isPickerInteractingRef.current = true;
+				} }
+				onInteractionEnd={ () => {
+					isPickerInteractingRef.current = false;
+				} }
 			/>
 			<AuxiliaryColorArtefactWrapper>
 				<AuxiliaryColorArtefactHStackHeader justify="space-between">

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -124,21 +124,23 @@ const UnconnectedColorPicker = (
 	// throttles its onChange callbacks using requestAnimationFrame.
 
 	const handleHSLAChange = useCallback(
-		( nextHSLA: HslaColor ) => {
-			// No mergeHSLA here — this handler receives the user's explicit
-			// choice from the picker or HSL inputs, with no lossy conversion.
-			setInternalHSLA( nextHSLA );
-			const previousHex = lastProducedHexRef.current;
-			const nextHex = colord( nextHSLA ).toHex();
-			// Only notify parent when the hex actually changes. This
-			// avoids firing onChange for H/S changes on achromatic
-			// colors (e.g. adjusting hue on pure white).
-			if ( nextHex !== previousHex ) {
-				lastProducedHexRef.current = nextHex;
-				setColor( nextHex );
-			}
-		},
-		[ setColor ]
+	    ( nextHSLA: HslaColor ) => {
+	        setInternalHSLA( ( prev ) => {
+	            const isPositionalDrag =
+	                nextHSLA.s !== prev.s || nextHSLA.l !== prev.l;
+	            const stabilizedHSLA = isPositionalDrag
+	                ? mergeHSLA( nextHSLA, prev )
+	                : nextHSLA;
+	            const previousHex = lastProducedHexRef.current;
+	            const nextHex = colord( stabilizedHSLA ).toHex();
+	            if ( nextHex !== previousHex ) {
+	                lastProducedHexRef.current = nextHex;
+	                setColor( nextHex );
+	            }
+	            return stabilizedHSLA;
+	        } );
+	    },
+	    [ setColor ]
 	);
 
 	// Handler for components that provide Colord values (RGB, Hex inputs).

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -98,7 +98,8 @@ const UnconnectedColorPicker = (
 	// distinguish our own updates from external prop changes.
 	const lastProducedHexRef = useRef( safeColordColor.toHex() );
 
-	// While the user is dragging the visual picker, ignore color-prop sync.
+	// While the user is dragging the visual picker, ignore color-prop sync
+	// so delayed/stale controlled echoes cannot overwrite internalHSLA mid-drag.
 	const isPickerInteractingRef = useRef( false );
 
 	// Sync internalHSLA when the color prop changes externally (e.g.
@@ -120,10 +121,11 @@ const UnconnectedColorPicker = (
 		setInternalHSLA( ( prev ) => mergeHSLA( externalHSLA, prev ) );
 	}, [ safeColordColor ] );
 
-	// Handler for HSL inputs (and the HSVA picker after conversion to HSLA).
-	// Updates the local HSLA state, then notifies the parent only when the
-	// resulting color changes. Uses setColor directly (not debounced) to
-	// avoid races with the debounced hex/RGB updates.
+	// Handler for HSL inputs (and the HSVA picker after it converts to HSLA).
+	// Apply the user's HSLA, then notify the parent only when the color
+	// actually changes. setColor must not run inside setInternalHSLA
+	// (state updaters must be pure). Uses direct setColor (not debounced)
+	// to avoid races with hex/RGB's debouncedSetColor.
 	const handleHSLAChange = useCallback(
 		( nextHSLA: HslaColor ) => {
 			setInternalHSLA( nextHSLA );

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -24,6 +24,36 @@ function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
 }
 
 /**
+ * Convert parent HSLA into HSVA for prop sync.
+ *
+ * At black/white, RGB round-trips collapse saturation to 0. Preserve the
+ * native HSVA saturation coordinate unless the HSL saturation channel itself
+ * changed (sibling hue/alpha/lightness edits must not snap the pointer).
+ */
+function toHsvaFromHsla(
+	hsla: HslaColor,
+	prevHsva: HsvaColor,
+	prevHsla: HslaColor | null
+): HsvaColor {
+	const converted = toHsva( hsla );
+
+	if ( hsla.l !== 0 && hsla.l !== 100 ) {
+		return converted;
+	}
+
+	const saturationChanged = prevHsla !== null && prevHsla.s !== hsla.s;
+
+	return {
+		h: hsla.h,
+		s: saturationChanged ? hsla.s : prevHsva.s,
+		v: hsla.l === 0 ? 0 : 100,
+		a: hsla.a,
+	};
+}
+
+/**
+ * Visual color surface.
+ *
  * Uses HSVA (react-colorful's native model) and keeps that value in local
  * state so HSLA↔hex round-trips cannot move the pointer
  * Parent ColorPicker still speaks HSLA for
@@ -32,6 +62,9 @@ function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
  * Prop sync from parent HSLA is suppressed for:
  * - pointer/touch drags (interaction flag), and
  * - any picker-originated update including keyboard (HSLA origin token).
+ *
+ * Achromatic HSL sibling edits (hue/alpha while at black/white) preserve
+ * native HSVA saturation unless saturation itself changed.
  */
 export const Picker = ( {
 	hsla,
@@ -41,8 +74,10 @@ export const Picker = ( {
 	onInteractionEnd,
 }: PickerProps ) => {
 	const [ hsva, setHsva ] = useState< HsvaColor >( () => toHsva( hsla ) );
-	// Last HSLA emitted by this picker - skip echoing it back into HSVA.
+	// Last HSLA emitted by this picker — skip echoing it back into HSVA.
 	const pickerOriginHslaRef = useRef< HslaColor | null >( null );
+	// Previous parent HSLA — detect which channel changed on achromatic sync.
+	const prevHslaRef = useRef< HslaColor >( hsla );
 	// Pointer/touch drag: never sync from HSLA mid-gesture (origin match alone
 	// can fail across rapid frames when parent gradient state re-renders).
 	const isPointerInteractingRef = useRef( false );
@@ -55,10 +90,14 @@ export const Picker = ( {
 			pickerOriginHslaRef.current &&
 			isSameHsla( pickerOriginHslaRef.current, hsla )
 		) {
+			prevHslaRef.current = hsla;
 			return;
 		}
 		pickerOriginHslaRef.current = null;
-		setHsva( toHsva( hsla ) );
+		setHsva( ( prev ) =>
+			toHsvaFromHsla( hsla, prev, prevHslaRef.current )
+		);
+		prevHslaRef.current = hsla;
 	}, [ hsla ] );
 
 	// Inline handlers so refs are not passed into a helper during render

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -26,9 +26,13 @@ function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
 /**
  * Convert parent HSLA into HSVA for prop sync.
  *
- * At black/white, RGB round-trips collapse saturation to 0. Preserve the
- * native HSVA saturation coordinate unless the HSL saturation channel itself
- * changed (sibling hue/alpha/lightness edits must not snap the pointer).
+ * At black, RGB round-trips collapse saturation to 0. Preserve the native
+ * HSVA saturation coordinate unless the HSL saturation channel itself
+ * changed (sibling hue/alpha edits must not snap the pointer).
+ *
+ * At white, only `v: 100, s: 0` is visually white — preserving a prior
+ * chromatic saturation would leave the pointer at the top-right and make
+ * the first keyboard step jump from white to a saturated color.
  */
 function toHsvaFromHsla(
 	hsla: HslaColor,
@@ -37,7 +41,8 @@ function toHsvaFromHsla(
 ): HsvaColor {
 	const converted = toHsva( hsla );
 
-	if ( hsla.l !== 0 && hsla.l !== 100 ) {
+	// White and chromatic colors use the converted value as-is.
+	if ( hsla.l !== 0 ) {
 		return converted;
 	}
 
@@ -46,7 +51,7 @@ function toHsvaFromHsla(
 	return {
 		h: hsla.h,
 		s: saturationChanged ? hsla.s : prevHsva.s,
-		v: hsla.l === 0 ? 0 : 100,
+		v: 0,
 		a: hsla.a,
 	};
 }
@@ -54,7 +59,7 @@ function toHsvaFromHsla(
 /**
  * Visual color surface.
  *
- * Uses HSVA (react-colorful's native model) and keeps that value in local
+ * Uses HSVA (react-colorful native model) and keeps that value in local
  * state so HSLA↔hex round-trips cannot move the pointer
  * Parent ColorPicker still speaks HSLA for
  * inputs and controlled value sync; conversion happens only at the boundary.
@@ -63,8 +68,9 @@ function toHsvaFromHsla(
  * - pointer/touch drags (interaction flag), and
  * - any picker-originated update including keyboard (HSLA origin token).
  *
- * Achromatic HSL sibling edits (hue/alpha while at black/white) preserve
- * native HSVA saturation unless saturation itself changed.
+ * Achromatic HSL sibling edits (hue/alpha while at black) preserve native
+ * HSVA saturation unless saturation itself changed. White always syncs to
+ * the converted `s: 0` visual coordinate.
  */
 export const Picker = ( {
 	hsla,
@@ -84,6 +90,10 @@ export const Picker = ( {
 
 	useEffect( () => {
 		if ( isPointerInteractingRef.current ) {
+			// Keep prevHsla in lockstep with parent updates during the gesture
+			// so a post-drag HSL sibling edit is not compared against pre-drag
+			// HSLA and mistaken for a saturation change.
+			prevHslaRef.current = hsla;
 			return;
 		}
 		if (

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -15,6 +15,9 @@ import type { PickerProps } from './types';
 function toHsva( hsla: PickerProps[ 'hsla' ] ): HsvaColor {
 	return {
 		...colord( hsla ).toHsv(),
+		// HSL and HSV share the hue angle. Color conversion collapses achromatic
+		// hue to 0, but HSLA retains the user's latent hue.
+		h: hsla.h,
 		a: hsla.a,
 	};
 }

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -24,11 +24,9 @@ function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
 }
 
 /**
- * Visual color surface.
- *
  * Uses HSVA (react-colorful's native model) and keeps that value in local
  * state so HSLA↔hex round-trips cannot move the pointer
- * (#80110, #75157, #80205). Parent ColorPicker still speaks HSLA for
+ * Parent ColorPicker still speaks HSLA for
  * inputs and controlled value sync; conversion happens only at the boundary.
  *
  * Prop sync from parent HSLA is suppressed for:
@@ -43,7 +41,7 @@ export const Picker = ( {
 	onInteractionEnd,
 }: PickerProps ) => {
 	const [ hsva, setHsva ] = useState< HsvaColor >( () => toHsva( hsla ) );
-	// Last HSLA emitted by this picker — skip echoing it back into HSVA.
+	// Last HSLA emitted by this picker - skip echoing it back into HSVA.
 	const pickerOriginHslaRef = useRef< HslaColor | null >( null );
 	// Pointer/touch drag: never sync from HSLA mid-gesture (origin match alone
 	// can fail across rapid frames when parent gradient state re-renders).

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -5,35 +5,12 @@ import type { PointerEvent } from 'react';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { HsvColorPicker, HsvaColorPicker } from 'react-colorful';
 import { colord } from 'colord';
-import type { HsvaColor } from 'react-colorful';
+import type { HslaColor, HsvaColor } from 'react-colorful';
 
 /**
  * Internal dependencies
  */
 import type { PickerProps } from './types';
-
-function getPointerCaptureProps( {
-	onInteractionStart,
-	onInteractionEnd,
-}: {
-	onInteractionStart?: () => void;
-	onInteractionEnd?: () => void;
-} ) {
-	return {
-		onPointerDown( { currentTarget, pointerId }: PointerEvent ) {
-			onInteractionStart?.();
-			currentTarget.setPointerCapture( pointerId );
-		},
-		onPointerUp( { currentTarget, pointerId }: PointerEvent ) {
-			currentTarget.releasePointerCapture( pointerId );
-			onInteractionEnd?.();
-		},
-		onPointerCancel( { currentTarget, pointerId }: PointerEvent ) {
-			currentTarget.releasePointerCapture( pointerId );
-			onInteractionEnd?.();
-		},
-	};
-}
 
 function toHsva( hsla: PickerProps[ 'hsla' ] ): HsvaColor {
 	return {
@@ -42,13 +19,21 @@ function toHsva( hsla: PickerProps[ 'hsla' ] ): HsvaColor {
 	};
 }
 
+function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
+	return a.h === b.h && a.s === b.s && a.l === b.l && a.a === b.a;
+}
+
 /**
  * Visual color surface.
  *
  * Uses HSVA (react-colorful's native model) and keeps that value in local
- * state while dragging so HSLA↔hex round-trips cannot move the pointer
- * Parent ColorPicker still speaks HSLA for
- * inputs and controlled value sync, conversion happens only at the boundary.
+ * state so HSLA↔hex round-trips cannot move the pointer
+ * (#80110, #75157, #80205). Parent ColorPicker still speaks HSLA for
+ * inputs and controlled value sync; conversion happens only at the boundary.
+ *
+ * Prop sync from parent HSLA is suppressed for:
+ * - pointer/touch drags (interaction flag), and
+ * - any picker-originated update including keyboard (HSLA origin token).
  */
 export const Picker = ( {
 	hsla,
@@ -58,31 +43,51 @@ export const Picker = ( {
 	onInteractionEnd,
 }: PickerProps ) => {
 	const [ hsva, setHsva ] = useState< HsvaColor >( () => toHsva( hsla ) );
-	const isInteractingRef = useRef( false );
+	// Last HSLA emitted by this picker — skip echoing it back into HSVA.
+	const pickerOriginHslaRef = useRef< HslaColor | null >( null );
+	// Pointer/touch drag: never sync from HSLA mid-gesture (origin match alone
+	// can fail across rapid frames when parent gradient state re-renders).
+	const isPointerInteractingRef = useRef( false );
 
-	// Sync from parent HSLA only when not dragging (HSL inputs / external).
 	useEffect( () => {
-		if ( isInteractingRef.current ) {
+		if ( isPointerInteractingRef.current ) {
 			return;
 		}
+		if (
+			pickerOriginHslaRef.current &&
+			isSameHsla( pickerOriginHslaRef.current, hsla )
+		) {
+			return;
+		}
+		pickerOriginHslaRef.current = null;
 		setHsva( toHsva( hsla ) );
 	}, [ hsla ] );
 
-	const pointerCaptureProps = getPointerCaptureProps( {
-		onInteractionStart: () => {
-			isInteractingRef.current = true;
+	// Inline handlers so refs are not passed into a helper during render
+	// (react-hooks/refs). Pointer capture also keeps drag working over iframes.
+	const pointerCaptureProps = {
+		onPointerDown( { currentTarget, pointerId }: PointerEvent ) {
+			isPointerInteractingRef.current = true;
 			onInteractionStart?.();
+			currentTarget.setPointerCapture( pointerId );
 		},
-		onInteractionEnd: () => {
-			isInteractingRef.current = false;
+		onPointerUp( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			isPointerInteractingRef.current = false;
 			onInteractionEnd?.();
 		},
-	} );
+		onPointerCancel( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			isPointerInteractingRef.current = false;
+			onInteractionEnd?.();
+		},
+	};
 
 	const handleChange = ( next: HsvaColor ) => {
 		setHsva( next );
-		const nextHsl = colord( next ).toHsl();
-		onChange( { ...nextHsl, a: next.a } );
+		const nextHsla: HslaColor = { ...colord( next ).toHsl(), a: next.a };
+		pickerOriginHslaRef.current = nextHsla;
+		onChange( nextHsla );
 	};
 
 	if ( enableAlpha ) {
@@ -95,11 +100,16 @@ export const Picker = ( {
 		);
 	}
 
+	// HsvColorPicker's equality checks enumerate own keys — never pass `a`,
+	// or every parent re-render looks like an external color change and the
+	// pointer jitters while dragging.
+	const hsv = { h: hsva.h, s: hsva.s, v: hsva.v };
+
 	return (
 		<HsvColorPicker
-			color={ hsva }
+			color={ hsv }
 			onChange={ ( next ) => {
-				handleChange( { ...next, a: hsla.a } );
+				handleChange( { ...next, a: hsva.a } );
 			} }
 			{ ...pointerCaptureProps }
 		/>

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -59,7 +59,7 @@ function toHsvaFromHsla(
 /**
  * Visual color surface.
  *
- * Uses HSVA (react-colorful native model) and keeps that value in local
+ * Uses HSVA (react-colorful's native model) and keeps that value in local
  * state so HSLA↔hex round-trips cannot move the pointer
  * Parent ColorPicker still speaks HSLA for
  * inputs and controlled value sync; conversion happens only at the boundary.

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -1,42 +1,105 @@
 /**
  * External dependencies
  */
-import { HslColorPicker, HslaColorPicker } from 'react-colorful';
+import type { PointerEvent } from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { HsvColorPicker, HsvaColorPicker } from 'react-colorful';
+import { colord } from 'colord';
+import type { HsvaColor } from 'react-colorful';
 
 /**
  * Internal dependencies
  */
 import type { PickerProps } from './types';
 
-// Pointer capture fortifies drag gestures so that they continue to work
-// while dragging outside the component over objects like iframes. If a
-// newer version of react-colorful begins to employ pointer capture this
-// will be redundant and should be removed.
-const pointerCaptureProps = {
-	onPointerDown( { currentTarget, pointerId }: React.PointerEvent ) {
-		currentTarget.setPointerCapture( pointerId );
-	},
-	onPointerUp( { currentTarget, pointerId }: React.PointerEvent ) {
-		currentTarget.releasePointerCapture( pointerId );
-	},
-};
+function getPointerCaptureProps( {
+	onInteractionStart,
+	onInteractionEnd,
+}: {
+	onInteractionStart?: () => void;
+	onInteractionEnd?: () => void;
+} ) {
+	return {
+		onPointerDown( { currentTarget, pointerId }: PointerEvent ) {
+			onInteractionStart?.();
+			currentTarget.setPointerCapture( pointerId );
+		},
+		onPointerUp( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			onInteractionEnd?.();
+		},
+		onPointerCancel( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			onInteractionEnd?.();
+		},
+	};
+}
 
-export const Picker = ( { hsla, enableAlpha, onChange }: PickerProps ) => {
+function toHsva( hsla: PickerProps[ 'hsla' ] ): HsvaColor {
+	return {
+		...colord( hsla ).toHsv(),
+		a: hsla.a,
+	};
+}
+
+/**
+ * Visual color surface.
+ *
+ * Uses HSVA (react-colorful's native model) and keeps that value in local
+ * state while dragging so HSLA↔hex round-trips cannot move the pointer
+ * Parent ColorPicker still speaks HSLA for
+ * inputs and controlled value sync, conversion happens only at the boundary.
+ */
+export const Picker = ( {
+	hsla,
+	enableAlpha,
+	onChange,
+	onInteractionStart,
+	onInteractionEnd,
+}: PickerProps ) => {
+	const [ hsva, setHsva ] = useState< HsvaColor >( () => toHsva( hsla ) );
+	const isInteractingRef = useRef( false );
+
+	// Sync from parent HSLA only when not dragging (HSL inputs / external).
+	useEffect( () => {
+		if ( isInteractingRef.current ) {
+			return;
+		}
+		setHsva( toHsva( hsla ) );
+	}, [ hsla ] );
+
+	const pointerCaptureProps = getPointerCaptureProps( {
+		onInteractionStart: () => {
+			isInteractingRef.current = true;
+			onInteractionStart?.();
+		},
+		onInteractionEnd: () => {
+			isInteractingRef.current = false;
+			onInteractionEnd?.();
+		},
+	} );
+
+	const handleChange = ( next: HsvaColor ) => {
+		setHsva( next );
+		const nextHsl = colord( next ).toHsl();
+		onChange( { ...nextHsl, a: next.a } );
+	};
+
 	if ( enableAlpha ) {
 		return (
-			<HslaColorPicker
-				color={ hsla }
-				onChange={ onChange }
+			<HsvaColorPicker
+				color={ hsva }
+				onChange={ handleChange }
 				{ ...pointerCaptureProps }
 			/>
 		);
 	}
 
 	return (
-		<HslColorPicker
-			color={ hsla }
-			onChange={ ( nextColor ) => {
-				onChange( { ...nextColor, a: hsla.a } );
+		<HsvColorPicker
+			color={ hsva }
+			onChange={ ( next ) => {
+				handleChange( { ...next, a: hsla.a } );
 			} }
 			{ ...pointerCaptureProps }
 		/>

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -378,6 +378,102 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
 		} );
 
+		it.each( [
+			[ 'black', 0 ],
+			[ 'white', 100 ],
+		] )(
+			'should allow saturation 50→0 at %s without firing onChange',
+			async ( _label, lightness ) => {
+				const onChange = jest.fn();
+
+				render(
+					<ControlledColorPicker
+						onChange={ onChange }
+						enableAlpha={ false }
+						initialColor="#000000"
+					/>
+				);
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				await userEvent.setup().selectOptions( formatSelector, 'hsl' );
+
+				const hueSlider = screen
+					.getAllByRole( 'slider', { name: 'Hue' } )
+					.at( -1 )!;
+				const saturationSlider = screen.getByRole( 'slider', {
+					name: 'Saturation',
+				} );
+				const lightnessSlider = screen.getByRole( 'slider', {
+					name: 'Lightness',
+				} );
+				const saturationNumberInput = screen.getByRole( 'spinbutton', {
+					name: 'Saturation',
+				} );
+
+				// Build hsl(200, 50%, lightness%) via HSL controls.
+				fireEvent.change( hueSlider, { target: { value: 200 } } );
+				fireEvent.change( saturationSlider, { target: { value: 50 } } );
+				fireEvent.change( lightnessSlider, {
+					target: { value: lightness },
+				} );
+				await waitFor( () =>
+					expect( lightnessSlider ).toHaveValue( String( lightness ) )
+				);
+
+				expect( saturationSlider ).toHaveValue( '50' );
+				expect( saturationNumberInput ).toHaveValue( 50 );
+				onChange.mockClear();
+
+				fireEvent.change( saturationSlider, { target: { value: 0 } } );
+
+				expect( saturationSlider ).toHaveValue( '0' );
+				expect( saturationNumberInput ).toHaveValue( 0 );
+				expect( onChange ).not.toHaveBeenCalled();
+			}
+		);
+
+		it( 'should fire onChange once per real color change in controlled mode', async () => {
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#2ad5d5" // hsl(180, 67%, 50%)
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await userEvent.setup().selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+
+			fireEvent.change( lightnessSlider, { target: { value: 40 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '40' )
+			);
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+			fireEvent.change( lightnessSlider, { target: { value: 30 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '30' )
+			);
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			onChange.mockClear();
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 90 } } );
+			expect( onChange ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should reset saturation to 0 when a mid-gray is entered via hex input', async () => {
 			const user = userEvent.setup();
 
@@ -499,6 +595,207 @@ describe( 'ColorPicker', () => {
 				expect( onChange ).toHaveBeenLastCalledWith( expected );
 			} );
 		} );
+	} );
+
+	describe( 'visual picker', () => {
+		const mockInteractiveBounds = ( interactive: HTMLElement ) => {
+			interactive.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100,
+					right: 100,
+					bottom: 100,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+		};
+
+		it( 'preserves saturation when keyboard-navigating to black in controlled mode', () => {
+			const onChange = jest.fn();
+
+			// Saturated red with mid brightness — HSVA s stays high at black.
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			// Pointer is a presentational sibling; no accessible role.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toBeTruthy();
+
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+
+			// react-colorful reads which/keyCode (37–40), not event.key.
+			// From v≈80, 5% steps need at least 16 ArrowDown presses to reach black.
+			colorSlider.focus();
+			for ( let i = 0; i < 20; i++ ) {
+				fireEvent.keyDown( colorSlider, {
+					key: 'ArrowDown',
+					keyCode: 40,
+					which: 40,
+				} );
+			}
+
+			expect( pointer ).toHaveStyle( { top: '100%', left: leftBefore } );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+		} );
+
+		it( 'preserves saturation when pointer selects black in controlled mode', () => {
+			const onChange = jest.fn();
+
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const interactive = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( interactive );
+
+			// Pointer is a presentational sibling; no accessible role.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+
+			// Click the bottom of the saturation surface (v = 0) at ~80% saturation.
+			fireEvent.mouseDown( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			// Lossy HSVA→HSLA→HSVA sync would snap left to 0%.
+			expect( pointer ).not.toHaveStyle( { left: '0%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+		} );
+
+		it.each( [
+			[ 'black', 0, '100%' ],
+			[ 'white', 100, '0%' ],
+		] as const )(
+			'preserves visual saturation when HSL hue is edited at %s',
+			async ( _label, lightness, expectedTop ) => {
+				const user = userEvent.setup();
+
+				// Saturated mid-brightness red — HSVA s stays high at extremes.
+				const { container } = render(
+					<ControlledColorPicker
+						enableAlpha={ false }
+						initialColor="#cc0000"
+					/>
+				);
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				await user.selectOptions( formatSelector, 'hsl' );
+
+				const lightnessSlider = screen.getByRole( 'slider', {
+					name: 'Lightness',
+				} );
+				fireEvent.change( lightnessSlider, {
+					target: { value: lightness },
+				} );
+				await waitFor( () =>
+					expect( lightnessSlider ).toHaveValue( String( lightness ) )
+				);
+
+				// Pointer is a presentational sibling; no accessible role.
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				const pointer = container.querySelector(
+					'.react-colorful__saturation-pointer'
+				) as HTMLElement;
+				expect( pointer ).toBeTruthy();
+				const leftBefore = pointer.style.left;
+				expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+				expect( pointer ).toHaveStyle( { top: expectedTop } );
+
+				// Sibling HSL edit at the achromatic boundary must not reset
+				// native HSVA saturation via lossy HSLA→HSVA prop sync.
+				const hueSlider = screen
+					.getAllByRole( 'slider', { name: 'Hue' } )
+					.at( -1 )!;
+				fireEvent.change( hueSlider, { target: { value: 200 } } );
+				await waitFor( () =>
+					expect( hueSlider ).toHaveValue( '200' )
+				);
+
+				expect( pointer ).toHaveStyle( {
+					top: expectedTop,
+					left: leftBefore,
+				} );
+			}
+		);
+
+		it.each( [
+			[ 'black', 0, '100%' ],
+			[ 'white', 100, '0%' ],
+		] as const )(
+			'updates visual saturation when HSL saturation is edited at %s',
+			async ( _label, lightness, expectedTop ) => {
+				const user = userEvent.setup();
+
+				const { container } = render(
+					<ControlledColorPicker
+						enableAlpha={ false }
+						initialColor="#cc0000"
+					/>
+				);
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				await user.selectOptions( formatSelector, 'hsl' );
+
+				const lightnessSlider = screen.getByRole( 'slider', {
+					name: 'Lightness',
+				} );
+				fireEvent.change( lightnessSlider, {
+					target: { value: lightness },
+				} );
+				await waitFor( () =>
+					expect( lightnessSlider ).toHaveValue( String( lightness ) )
+				);
+
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				const pointer = container.querySelector(
+					'.react-colorful__saturation-pointer'
+				) as HTMLElement;
+				expect( pointer ).toHaveStyle( { top: expectedTop } );
+				expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+
+				const saturationSlider = screen.getByRole( 'slider', {
+					name: 'Saturation',
+				} );
+				fireEvent.change( saturationSlider, {
+					target: { value: 25 },
+				} );
+				await waitFor( () =>
+					expect( saturationSlider ).toHaveValue( '25' )
+				);
+
+				// Explicit saturation edits should move the visual coordinate.
+				expect( pointer ).toHaveStyle( {
+					top: expectedTop,
+					left: '25%',
+				} );
+			}
+		);
 	} );
 
 	describe.each( [

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -733,9 +733,7 @@ describe( 'ColorPicker', () => {
 					.getAllByRole( 'slider', { name: 'Hue' } )
 					.at( -1 )!;
 				fireEvent.change( hueSlider, { target: { value: 200 } } );
-				await waitFor( () =>
-					expect( hueSlider ).toHaveValue( '200' )
-				);
+				await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
 
 				expect( pointer ).toHaveStyle( {
 					top: expectedTop,
@@ -777,7 +775,9 @@ describe( 'ColorPicker', () => {
 					'.react-colorful__saturation-pointer'
 				) as HTMLElement;
 				expect( pointer ).toHaveStyle( { top: expectedTop } );
-				expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+				expect( parseFloat( pointer.style.left ) ).toBeGreaterThan(
+					50
+				);
 
 				const saturationSlider = screen.getByRole( 'slider', {
 					name: 'Saturation',

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -688,114 +688,248 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
 		} );
 
-		it.each( [
-			[ 'black', 0, '100%' ],
-			[ 'white', 100, '0%' ],
-		] as const )(
-			'preserves visual saturation when HSL hue is edited at %s',
-			async ( _label, lightness, expectedTop ) => {
-				const user = userEvent.setup();
+		it( 'preserves saturation after a full pointer drag to black then HSL hue edit', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
 
-				// Saturated mid-brightness red — HSVA s stays high at extremes.
-				const { container } = render(
-					<ControlledColorPicker
-						enableAlpha={ false }
-						initialColor="#cc0000"
-					/>
-				);
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
 
-				const formatSelector = screen.getByRole( 'combobox' );
-				await user.selectOptions( formatSelector, 'hsl' );
+			const interactive = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( interactive );
 
-				const lightnessSlider = screen.getByRole( 'slider', {
-					name: 'Lightness',
-				} );
-				fireEvent.change( lightnessSlider, {
-					target: { value: lightness },
-				} );
-				await waitFor( () =>
-					expect( lightnessSlider ).toHaveValue( String( lightness ) )
-				);
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
 
-				// Pointer is a presentational sibling; no accessible role.
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				const pointer = container.querySelector(
-					'.react-colorful__saturation-pointer'
-				) as HTMLElement;
-				expect( pointer ).toBeTruthy();
-				const leftBefore = pointer.style.left;
-				expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
-				expect( pointer ).toHaveStyle( { top: expectedTop } );
+			// Full pointer lifecycle so isPointerInteractingRef is exercised
+			// and prevHslaRef stays in sync across mid-gesture parent updates.
+			fireEvent.pointerDown( interactive, {
+				pointerId: 1,
+				buttons: 1,
+				pageX: 80,
+				pageY: 50,
+				clientX: 80,
+				clientY: 50,
+			} );
+			fireEvent.mouseDown( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 50,
+				clientX: 80,
+				clientY: 50,
+			} );
+			fireEvent.mouseMove( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+			fireEvent.pointerUp( interactive, {
+				pointerId: 1,
+				buttons: 0,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+			fireEvent.mouseUp( interactive, {
+				buttons: 0,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
 
-				// Sibling HSL edit at the achromatic boundary must not reset
-				// native HSVA saturation via lossy HSLA→HSVA prop sync.
-				const hueSlider = screen
-					.getAllByRole( 'slider', { name: 'Hue' } )
-					.at( -1 )!;
-				fireEvent.change( hueSlider, { target: { value: 200 } } );
-				await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+			const leftAfterDrag = pointer.style.left;
 
-				expect( pointer ).toHaveStyle( {
-					top: expectedTop,
-					left: leftBefore,
-				} );
-			}
-		);
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
 
-		it.each( [
-			[ 'black', 0, '100%' ],
-			[ 'white', 100, '0%' ],
-		] as const )(
-			'updates visual saturation when HSL saturation is edited at %s',
-			async ( _label, lightness, expectedTop ) => {
-				const user = userEvent.setup();
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
 
-				const { container } = render(
-					<ControlledColorPicker
-						enableAlpha={ false }
-						initialColor="#cc0000"
-					/>
-				);
+			// Stale prevHslaRef would mistake the hue edit for a saturation
+			// change and snap the pointer to left: 0%.
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftAfterDrag,
+			} );
+		} );
 
-				const formatSelector = screen.getByRole( 'combobox' );
-				await user.selectOptions( formatSelector, 'hsl' );
+		it( 'places the pointer at s:0 when HSL lightness is set to white', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
 
-				const lightnessSlider = screen.getByRole( 'slider', {
-					name: 'Lightness',
-				} );
-				fireEvent.change( lightnessSlider, {
-					target: { value: lightness },
-				} );
-				await waitFor( () =>
-					expect( lightnessSlider ).toHaveValue( String( lightness ) )
-				);
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
 
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				const pointer = container.querySelector(
-					'.react-colorful__saturation-pointer'
-				) as HTMLElement;
-				expect( pointer ).toHaveStyle( { top: expectedTop } );
-				expect( parseFloat( pointer.style.left ) ).toBeGreaterThan(
-					50
-				);
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
 
-				const saturationSlider = screen.getByRole( 'slider', {
-					name: 'Saturation',
-				} );
-				fireEvent.change( saturationSlider, {
-					target: { value: 25 },
-				} );
-				await waitFor( () =>
-					expect( saturationSlider ).toHaveValue( '25' )
-				);
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '100' )
+			);
+			expect( onChange ).toHaveBeenLastCalledWith( '#ffffff' );
 
-				// Explicit saturation edits should move the visual coordinate.
-				expect( pointer ).toHaveStyle( {
-					top: expectedTop,
-					left: '25%',
-				} );
-			}
-		);
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			// Only v:100,s:0 is white; a preserved chromatic s leaves the
+			// pointer at top-right and makes the next key step jump to red.
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			colorSlider.focus();
+			fireEvent.keyDown( colorSlider, {
+				key: 'ArrowDown',
+				keyCode: 40,
+				which: 40,
+			} );
+
+			expect( onChange ).not.toHaveBeenLastCalledWith( '#f50000' );
+			expect( onChange ).not.toHaveBeenLastCalledWith( '#cc0000' );
+		} );
+
+		it( 'preserves visual saturation when HSL hue is edited at black', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftBefore,
+			} );
+		} );
+
+		it( 'keeps the white visual coordinate at s:0 when HSL hue is edited', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '100' )
+			);
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+		} );
+
+		it( 'updates visual saturation when HSL saturation is edited at black', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+
+			const saturationSlider = screen.getByRole( 'slider', {
+				name: 'Saturation',
+			} );
+			fireEvent.change( saturationSlider, {
+				target: { value: 25 },
+			} );
+			await waitFor( () =>
+				expect( saturationSlider ).toHaveValue( '25' )
+			);
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: '25%',
+			} );
+		} );
 	} );
 
 	describe.each( [

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -889,6 +889,77 @@ describe( 'ColorPicker', () => {
 			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
 		} );
 
+		it( 'uses the HSL hue when leaving white through the visual surface', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			await user.selectOptions( screen.getByRole( 'combobox' ), 'hsl' );
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( colorSlider );
+			onChange.mockClear();
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 50,
+				pageY: 0,
+				clientX: 50,
+				clientY: 0,
+			} );
+
+			expect( onChange ).toHaveBeenLastCalledWith( '#80d4ff' );
+		} );
+
+		it( 'uses the HSL hue when leaving a mid-gray through the visual surface', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#808080"
+				/>
+			);
+
+			await user.selectOptions( screen.getByRole( 'combobox' ), 'hsl' );
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( colorSlider );
+			onChange.mockClear();
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 50,
+				pageY: 50,
+				clientX: 50,
+				clientY: 50,
+			} );
+
+			expect( onChange ).toHaveBeenLastCalledWith( '#416c81' );
+		} );
+
 		it( 'updates visual saturation when HSL saturation is edited at black', async () => {
 			const user = userEvent.setup();
 

--- a/packages/components/src/color-picker/types.ts
+++ b/packages/components/src/color-picker/types.ts
@@ -59,6 +59,8 @@ export interface PickerProps {
 	hsla: HslaColor;
 	enableAlpha: boolean;
 	onChange: ( nextHsla: HslaColor ) => void;
+	onInteractionStart?: () => void;
+	onInteractionEnd?: () => void;
 }
 
 export interface ColorInputProps {

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -131,6 +131,8 @@ function ControlPoints( {
 }: ControlPointsProps ) {
 	const controlPointMoveStateRef =
 		useRef< ControlPointMoveState >( undefined );
+	const controlPointsRef = useRef( controlPoints );
+	controlPointsRef.current = controlPoints;
 
 	const onMouseMove = ( event: MouseEvent ) => {
 		if (
@@ -285,7 +287,7 @@ function ControlPoints( {
 										onChange={ ( color ) => {
 											onChange(
 												updateControlPointColor(
-													controlPoints,
+													controlPointsRef.current,
 													index,
 													colord(
 														color
@@ -342,6 +344,14 @@ function InsertPoint( {
 	__experimentalIsRenderedInSidebar,
 }: InsertPointProps ) {
 	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
+	// Keep the ColorPicker controlled so parent gradient updates during
+	// drag do not reset it to the default white and jitter
+	const [ pickerColor, setPickerColor ] = useState( '#ffffff' );
+	const controlPointsRef = useRef( controlPoints );
+	controlPointsRef.current = controlPoints;
+	const alreadyInsertedRef = useRef( alreadyInsertedPoint );
+	alreadyInsertedRef.current = alreadyInsertedPoint;
+
 	return (
 		<GradientColorPickerDropdown
 			isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
@@ -359,6 +369,7 @@ function InsertPoint( {
 							onCloseInserter();
 						} else {
 							setAlreadyInsertedPoint( false );
+							setPickerColor( '#ffffff' );
 							onOpenInserter();
 						}
 						onToggle();
@@ -371,11 +382,14 @@ function InsertPoint( {
 				<DropdownContentWrapper paddingSize="none">
 					<ColorPicker
 						enableAlpha={ ! disableAlpha }
+						color={ pickerColor }
 						onChange={ ( color ) => {
-							if ( ! alreadyInsertedPoint ) {
+							setPickerColor( color );
+							const points = controlPointsRef.current;
+							if ( ! alreadyInsertedRef.current ) {
 								onChange(
 									addControlPoint(
-										controlPoints,
+										points,
 										insertPosition,
 										colord( color ).toRgbString()
 									)
@@ -384,7 +398,7 @@ function InsertPoint( {
 							} else {
 								onChange(
 									updateControlPointColorByPosition(
-										controlPoints,
+										points,
 										insertPosition,
 										colord( color ).toRgbString()
 									)

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -131,8 +131,6 @@ function ControlPoints( {
 }: ControlPointsProps ) {
 	const controlPointMoveStateRef =
 		useRef< ControlPointMoveState >( undefined );
-	const controlPointsRef = useRef( controlPoints );
-	controlPointsRef.current = controlPoints;
 
 	const onMouseMove = ( event: MouseEvent ) => {
 		if (
@@ -287,7 +285,7 @@ function ControlPoints( {
 										onChange={ ( color ) => {
 											onChange(
 												updateControlPointColor(
-													controlPointsRef.current,
+													controlPoints,
 													index,
 													colord(
 														color
@@ -344,14 +342,6 @@ function InsertPoint( {
 	__experimentalIsRenderedInSidebar,
 }: InsertPointProps ) {
 	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
-	// Keep the ColorPicker controlled so parent gradient updates during
-	// drag do not reset it to the default white and jitter
-	const [ pickerColor, setPickerColor ] = useState( '#ffffff' );
-	const controlPointsRef = useRef( controlPoints );
-	controlPointsRef.current = controlPoints;
-	const alreadyInsertedRef = useRef( alreadyInsertedPoint );
-	alreadyInsertedRef.current = alreadyInsertedPoint;
-
 	return (
 		<GradientColorPickerDropdown
 			isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
@@ -369,7 +359,6 @@ function InsertPoint( {
 							onCloseInserter();
 						} else {
 							setAlreadyInsertedPoint( false );
-							setPickerColor( '#ffffff' );
 							onOpenInserter();
 						}
 						onToggle();
@@ -382,14 +371,11 @@ function InsertPoint( {
 				<DropdownContentWrapper paddingSize="none">
 					<ColorPicker
 						enableAlpha={ ! disableAlpha }
-						color={ pickerColor }
 						onChange={ ( color ) => {
-							setPickerColor( color );
-							const points = controlPointsRef.current;
-							if ( ! alreadyInsertedRef.current ) {
+							if ( ! alreadyInsertedPoint ) {
 								onChange(
 									addControlPoint(
-										points,
+										controlPoints,
 										insertPosition,
 										colord( color ).toRgbString()
 									)
@@ -398,7 +384,7 @@ function InsertPoint( {
 							} else {
 								onChange(
 									updateControlPointColorByPosition(
-										points,
+										controlPoints,
 										insertPosition,
 										colord( color ).toRgbString()
 									)

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -28,6 +28,8 @@ describe( 'CustomGradientPicker', () => {
 		it( 'preserves visual saturation when setting a new stop color through black', async () => {
 			const { container } = render( <ControlledCustomGradientPicker /> );
 
+			// Presentational gradient bar markup; no accessible roles.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const markers = container.querySelector(
 				'.components-custom-gradient-picker__markers-container'
 			) as HTMLElement;
@@ -44,12 +46,14 @@ describe( 'CustomGradientPicker', () => {
 					toJSON: () => ( {} ),
 				} ) as DOMRect;
 
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const bar = container.querySelector(
 				'.components-custom-gradient-picker__gradient-bar'
 			) as HTMLElement;
 			// Hover mid-bar so the insert-point control appears (away from 0%/100%).
 			fireEvent.mouseMove( bar, { clientX: 100 } );
 
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const insertButton = container.querySelector(
 				'.components-custom-gradient-picker__insert-point-dropdown'
 			) as HTMLElement;
@@ -70,6 +74,8 @@ describe( 'CustomGradientPicker', () => {
 					toJSON: () => ( {} ),
 				} ) as DOMRect;
 
+			// Choose a saturated mid-brightness color — creates the new stop and
+			// exercises parent gradient updates while picking.
 			fireEvent.mouseDown( colorSlider, {
 				buttons: 1,
 				pageX: 80,
@@ -78,6 +84,8 @@ describe( 'CustomGradientPicker', () => {
 				clientY: 20,
 			} );
 
+			// ColorPicker content is portaled; pointer has no accessible role.
+			// eslint-disable-next-line testing-library/no-node-access
 			const pointer = document.querySelector(
 				'.react-colorful__saturation-pointer'
 			) as HTMLElement;
@@ -86,6 +94,7 @@ describe( 'CustomGradientPicker', () => {
 			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
 
 			// Keyboard to black — must not reset saturation via HSVA↔HSLA echo
+			// while the gradient parent keeps updating (#80110 / #80205).
 			colorSlider.focus();
 			for ( let i = 0; i < 20; i++ ) {
 				fireEvent.keyDown( colorSlider, {

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -28,7 +28,6 @@ describe( 'CustomGradientPicker', () => {
 		it( 'preserves visual saturation when setting a new stop color through black', async () => {
 			const { container } = render( <ControlledCustomGradientPicker /> );
 
-			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const markers = container.querySelector(
 				'.components-custom-gradient-picker__markers-container'
 			) as HTMLElement;
@@ -45,14 +44,12 @@ describe( 'CustomGradientPicker', () => {
 					toJSON: () => ( {} ),
 				} ) as DOMRect;
 
-			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const bar = container.querySelector(
 				'.components-custom-gradient-picker__gradient-bar'
 			) as HTMLElement;
 			// Hover mid-bar so the insert-point control appears (away from 0%/100%).
 			fireEvent.mouseMove( bar, { clientX: 100 } );
 
-			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			const insertButton = container.querySelector(
 				'.components-custom-gradient-picker__insert-point-dropdown'
 			) as HTMLElement;
@@ -73,8 +70,6 @@ describe( 'CustomGradientPicker', () => {
 					toJSON: () => ( {} ),
 				} ) as DOMRect;
 
-			// Choose a saturated mid-brightness color — creates the new stop and
-			// exercises parent gradient updates while picking.
 			fireEvent.mouseDown( colorSlider, {
 				buttons: 1,
 				pageX: 80,
@@ -83,8 +78,6 @@ describe( 'CustomGradientPicker', () => {
 				clientY: 20,
 			} );
 
-			// ColorPicker content is portaled; pointer has no accessible role.
-			// eslint-disable-next-line testing-library/no-node-access
 			const pointer = document.querySelector(
 				'.react-colorful__saturation-pointer'
 			) as HTMLElement;
@@ -93,7 +86,6 @@ describe( 'CustomGradientPicker', () => {
 			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
 
 			// Keyboard to black — must not reset saturation via HSVA↔HSLA echo
-			// while the gradient parent keeps updating (#80110 / #80205).
 			colorSlider.focus();
 			for ( let i = 0; i < 20; i++ ) {
 				fireEvent.keyDown( colorSlider, {

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -1,15 +1,124 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import CustomGradientPicker from '../';
 
+function ControlledCustomGradientPicker( {
+	initialValue = 'linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)',
+}: {
+	initialValue?: string;
+} ) {
+	const [ value, setValue ] = useState( initialValue );
+	return <CustomGradientPicker value={ value } onChange={ setValue } />;
+}
+
 describe( 'CustomGradientPicker', () => {
+	describe( 'new gradient stop color picker', () => {
+		it( 'preserves visual saturation when setting a new stop color through black', async () => {
+			const { container } = render( <ControlledCustomGradientPicker /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const markers = container.querySelector(
+				'.components-custom-gradient-picker__markers-container'
+			) as HTMLElement;
+			markers.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					x: 0,
+					width: 200,
+					top: 0,
+					height: 20,
+					right: 200,
+					bottom: 20,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const bar = container.querySelector(
+				'.components-custom-gradient-picker__gradient-bar'
+			) as HTMLElement;
+			// Hover mid-bar so the insert-point control appears (away from 0%/100%).
+			fireEvent.mouseMove( bar, { clientX: 100 } );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const insertButton = container.querySelector(
+				'.components-custom-gradient-picker__insert-point-dropdown'
+			) as HTMLElement;
+			expect( insertButton ).toBeTruthy();
+			fireEvent.click( insertButton );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			colorSlider.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100,
+					right: 100,
+					bottom: 100,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+
+			// Choose a saturated mid-brightness color — creates the new stop and
+			// exercises parent gradient updates while picking.
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 20,
+				clientX: 80,
+				clientY: 20,
+			} );
+
+			// ColorPicker content is portaled; pointer has no accessible role.
+			// eslint-disable-next-line testing-library/no-node-access
+			const pointer = document.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toBeTruthy();
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+
+			// Keyboard to black — must not reset saturation via HSVA↔HSLA echo
+			// while the gradient parent keeps updating (#80110 / #80205).
+			colorSlider.focus();
+			for ( let i = 0; i < 20; i++ ) {
+				fireEvent.keyDown( colorSlider, {
+					key: 'ArrowDown',
+					keyCode: 40,
+					which: 40,
+				} );
+			}
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftBefore,
+			} );
+
+			// Close the portaled popover so later tests are not affected by
+			// asynchronous Popover position updates.
+			fireEvent.click( insertButton );
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'slider', { name: 'Color' } )
+				).not.toBeInTheDocument();
+			} );
+		} );
+	} );
+
 	describe( 'GradientTypePicker angle persistence', () => {
 		it( 'should restore the previous linear angle when switching from radial back to linear', async () => {
 			const user = userEvent.setup();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/80110

When applying a Gradient background to a block and adding a new color stop, moving the color picker cursor inside the color picker box causes the cursor to continuously shake/jitter instead of moving smoothly to the selected position.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Prevent cursor jitter in the Gradient color picker caused by unstable HSLA values during color updates.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Use `mergeHSLA` to preserve HSLA values before generating the hex value.

## Testing Instructions
- Create any post/page.
- Add any block (e.g. Paragraph).
- In Block settings, apply a Gradient background.
- On the gradient color bar, click the + (add color stop) button.
- In the color picker that opens, move the color cursor slightly within the picker box.
- See Issue.

## Additional Notes
- This only happens while setting the color for the new stop.
- While dragging the cursor, some points shake/jitter and some points remain in place.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/9139f45d-5f90-4f54-a9d6-025a03f52947

## Use of AI Tools
- Yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
