### PR TITLE
Editor: Describe inline revision diffs with aria-describedby

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -29,6 +29,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { DIFF_DESCRIPTION_IDS } from './diff-format-types';
 
 const { parseRawBlock } = unlock( blocksPrivateApis );
 
@@ -562,7 +563,10 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 				removedSlice,
 				{
 					type: 'revision/diff-removed',
-					attributes: { title: __( 'Removed' ) },
+					attributes: {
+						title: __( 'Removed' ),
+						ariaDescribedBy: DIFF_DESCRIPTION_IDS.removed,
+					},
 				},
 				0,
 				part.value.length
@@ -580,7 +584,10 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 				addedSlice,
 				{
 					type: 'revision/diff-added',
-					attributes: { title: __( 'Added' ) },
+					attributes: {
+						title: __( 'Added' ),
+						ariaDescribedBy: DIFF_DESCRIPTION_IDS.added,
+					},
 				},
 				0,
 				part.value.length
@@ -634,11 +641,20 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 							changed: 'revision/diff-format-changed',
 						}[ type ];
 
+						const descriptionId = {
+							added: DIFF_DESCRIPTION_IDS.formatAdded,
+							removed: DIFF_DESCRIPTION_IDS.formatRemoved,
+							changed: DIFF_DESCRIPTION_IDS.formatChanged,
+						}[ type ];
+
 						const marked = applyFormat(
 							rangeSlice,
 							{
 								type: formatType,
-								attributes: { title: description },
+								attributes: {
+									title: description,
+									ariaDescribedBy: descriptionId,
+								},
 							},
 							0,
 							i - rangeStart

--- a/packages/editor/src/components/post-revisions-preview/diff-format-types.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-format-types.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
+import { useRefEffect } from '@wordpress/compose';
 
 const DIFF_FORMAT_TYPES = [
 	{
@@ -10,41 +11,91 @@ const DIFF_FORMAT_TYPES = [
 		title: __( 'Removed' ),
 		tagName: 'del',
 		className: 'revision-diff-removed',
+		descriptionId: 'revision-diff-description-removed',
 	},
 	{
 		name: 'revision/diff-added',
 		title: __( 'Added' ),
 		tagName: 'ins',
 		className: 'revision-diff-added',
+		descriptionId: 'revision-diff-description-added',
 	},
 	{
 		name: 'revision/diff-format-added',
 		title: __( 'Format added' ),
 		tagName: 'span',
 		className: 'revision-diff-format-added',
+		descriptionId: 'revision-diff-description-format-added',
 	},
 	{
 		name: 'revision/diff-format-removed',
 		title: __( 'Format removed' ),
 		tagName: 'span',
 		className: 'revision-diff-format-removed',
+		descriptionId: 'revision-diff-description-format-removed',
 	},
 	{
 		name: 'revision/diff-format-changed',
 		title: __( 'Format changed' ),
 		tagName: 'span',
 		className: 'revision-diff-format-changed',
+		descriptionId: 'revision-diff-description-format-changed',
 	},
 ];
 
+/**
+ * IDs of the visually hidden description elements referenced by
+ * `aria-describedby` on inline diff formats, keyed by diff type.
+ * The `title` attribute alone is unreliable as an accessible description —
+ * screen readers may ignore it in low-verbosity modes — so the formats also
+ * reference these elements, which `useDiffDescriptionsRef` renders into the
+ * editor canvas document.
+ */
+export const DIFF_DESCRIPTION_IDS = {
+	removed: 'revision-diff-description-removed',
+	added: 'revision-diff-description-added',
+	formatAdded: 'revision-diff-description-format-added',
+	formatRemoved: 'revision-diff-description-format-removed',
+	formatChanged: 'revision-diff-description-format-changed',
+};
+
 export function registerDiffFormatTypes() {
-	for ( const formatType of DIFF_FORMAT_TYPES ) {
+	for ( const { descriptionId, ...formatType } of DIFF_FORMAT_TYPES ) {
 		registerFormatType( formatType.name, {
 			...formatType,
-			attributes: { title: 'title' },
+			attributes: { title: 'title', ariaDescribedBy: 'aria-describedby' },
 			edit: () => null,
 		} );
 	}
+}
+
+/**
+ * Hook returning a ref callback that renders the visually hidden elements
+ * describing each inline diff format into the document that hosts the ref
+ * element (the editor canvas iframe). Inline diff formats reference these
+ * elements via `aria-describedby`, which must resolve within the same
+ * document, and — unlike `title` — is announced reliably by screen readers.
+ *
+ * @return {Function} Ref callback for an element inside the canvas document.
+ */
+export function useDiffDescriptionsRef() {
+	return useRefEffect( ( element ) => {
+		const { ownerDocument } = element;
+		const container = ownerDocument.createElement( 'div' );
+		// Hidden elements are still used for the accessible description
+		// computation when referenced by `aria-describedby`.
+		container.hidden = true;
+		for ( const { descriptionId, title } of DIFF_FORMAT_TYPES ) {
+			const description = ownerDocument.createElement( 'span' );
+			description.id = descriptionId;
+			description.textContent = title;
+			container.appendChild( description );
+		}
+		ownerDocument.body.appendChild( container );
+		return () => {
+			container.remove();
+		};
+	}, [] );
 }
 
 export function unregisterDiffFormatTypes() {

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import { Spinner } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -21,6 +22,7 @@ import VisualEditor from '../visual-editor';
 import {
 	registerDiffFormatTypes,
 	unregisterDiffFormatTypes,
+	useDiffDescriptionsRef,
 } from './diff-format-types';
 import { useDiffMarkers } from './diff-markers';
 
@@ -137,7 +139,9 @@ function DiffStyleOverrides( { showDiff } ) {
 }
 
 function CanvasContent( { showDiff } ) {
-	const [ contentRef, diffMarkers ] = useDiffMarkers();
+	const [ markersRef, diffMarkers ] = useDiffMarkers();
+	const descriptionsRef = useDiffDescriptionsRef();
+	const contentRef = useMergeRefs( [ markersRef, descriptionsRef ] );
 	return (
 		<>
 			<VisualEditor contentRef={ contentRef } />

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -230,7 +230,7 @@ describe( 'diffRevisionContent', () => {
 				attributes: {
 					// Inline diff: "existing" → "modified"
 					content:
-						'This is some <del title="Removed" class="revision-diff-removed">existing</del><ins title="Added" class="revision-diff-added">modified</ins> content',
+						'This is some <del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">existing</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">modified</ins> content',
 					__revisionDiffStatus: {
 						status: 'modified',
 					},
@@ -427,7 +427,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'Second block content<ins title="Added" class="revision-diff-added"> modified</ins>',
+						'Second block content<ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added"> modified</ins>',
 					__revisionDiffStatus: {
 						status: 'modified',
 					},
@@ -523,7 +523,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'Original tail content sentence<ins title="Added" class="revision-diff-added"> rewritten</ins>',
+						'Original tail content sentence<ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added"> rewritten</ins>',
 					__revisionDiffStatus: { status: 'modified' },
 				},
 			},
@@ -800,7 +800,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								// B→D modification with inline diff
 								content:
-									'<del title="Removed" class="revision-diff-removed">B</del><ins title="Added" class="revision-diff-added">D</ins>',
+									'<del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">B</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">D</ins>',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},
@@ -859,7 +859,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								// jumps→leaps modification with inline diff
 								content:
-									'The quick brown fox <del title="Removed" class="revision-diff-removed">jumps</del><ins title="Added" class="revision-diff-added">leaps</ins> over the lazy dog',
+									'The quick brown fox <del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">jumps</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">leaps</ins> over the lazy dog',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},
@@ -1056,7 +1056,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <strong><span title="1 format added" class="revision-diff-format-added">world</span></strong>',
+							'Hello <strong><span title="1 format added" aria-describedby="revision-diff-description-format-added" class="revision-diff-format-added">world</span></strong>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1084,7 +1084,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
+							'Hello <strong><del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">world</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">everyone</ins></strong>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1136,7 +1136,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://new-site.com"><span title="1 format changed" class="revision-diff-format-changed">our site</span></a> today',
+							'Visit <a href="https://new-site.com"><span title="1 format changed" aria-describedby="revision-diff-description-format-changed" class="revision-diff-format-changed">our site</span></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1166,7 +1166,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://example.com"><del title="Removed" class="revision-diff-removed">our</del><ins title="Added" class="revision-diff-added">the</ins> <del title="Removed" class="revision-diff-removed">site</del><ins title="Added" class="revision-diff-added">website</ins></a> today',
+							'Visit <a href="https://example.com"><del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">our</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">the</ins> <del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">site</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">website</ins></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1216,7 +1216,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<span title="1 format removed" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" class="revision-diff-format-removed">italic</span> text',
+							'<span title="1 format removed" aria-describedby="revision-diff-description-format-removed" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" aria-describedby="revision-diff-description-format-removed" class="revision-diff-format-removed">italic</span> text',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1244,7 +1244,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <em><span title="1 format added, 1 format removed" class="revision-diff-format-changed">world</span></em>',
+							'Hello <em><span title="1 format added, 1 format removed" aria-describedby="revision-diff-description-format-changed" class="revision-diff-format-changed">world</span></em>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1291,7 +1291,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong>world</strong>!',
+							'<del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">Hello</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">Goodbye</ins> <strong>world</strong>!',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1329,7 +1329,7 @@ describe( 'diffRevisionContent', () => {
 							name: 'core/paragraph',
 							attributes: {
 								content:
-									'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
+									'<del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">Hello</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">Goodbye</ins> <strong><del title="Removed" aria-describedby="revision-diff-description-removed" class="revision-diff-removed">world</del><ins title="Added" aria-describedby="revision-diff-description-added" class="revision-diff-added">everyone</ins></strong>',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},

--- a/packages/editor/src/components/post-revisions-preview/test/diff-format-types.js
+++ b/packages/editor/src/components/post-revisions-preview/test/diff-format-types.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useDiffDescriptionsRef,
+	DIFF_DESCRIPTION_IDS,
+} from '../diff-format-types';
+
+function TestComponent() {
+	const ref = useDiffDescriptionsRef();
+	return <div ref={ ref } />;
+}
+
+const EXPECTED_DESCRIPTIONS = {
+	[ DIFF_DESCRIPTION_IDS.removed ]: 'Removed',
+	[ DIFF_DESCRIPTION_IDS.added ]: 'Added',
+	[ DIFF_DESCRIPTION_IDS.formatAdded ]: 'Format added',
+	[ DIFF_DESCRIPTION_IDS.formatRemoved ]: 'Format removed',
+	[ DIFF_DESCRIPTION_IDS.formatChanged ]: 'Format changed',
+};
+
+describe( 'useDiffDescriptionsRef', () => {
+	it( 'renders a visually hidden description element for every inline diff format', () => {
+		render( <TestComponent /> );
+
+		for ( const [ id, text ] of Object.entries( EXPECTED_DESCRIPTIONS ) ) {
+			const description = screen.getByText( text );
+			expect( description ).toHaveAttribute( 'id', id );
+			expect( description ).not.toBeVisible();
+		}
+	} );
+
+	it( 'removes the description elements on unmount', () => {
+		const { unmount } = render( <TestComponent /> );
+
+		unmount();
+
+		for ( const text of Object.values( EXPECTED_DESCRIPTIONS ) ) {
+			expect( screen.queryByText( text ) ).not.toBeInTheDocument();
+		}
+	} );
+} );


### PR DESCRIPTION
## What?

Part of #77530.
Core tracking ticket: https://core.trac.wordpress.org/ticket/65122

Gives the inline diff formats in Visual History (`del`, `ins`, and the format-change spans) a reliable accessible description: each one now carries `aria-describedby` pointing at a visually hidden description element rendered into the canvas document.

## Why?

From @joedolson's audit in #77530:

> Inline edits use the `title` attribute to communicate to screen readers. This works, but will have somewhat inconsistent support, since screen readers may ignore it in low-verbosity modes. Using something like `aria-describedby` pointing to a container would be more reliable.

The `title` attribute maps to an ARIA description in the accessibility tree, but that mapping is exactly what low-verbosity modes drop. An explicit `aria-describedby` reference wins the description computation and is announced consistently.

## How?

- `diff-format-types.js` registers `aria-describedby` as a format attribute alongside `title`, and exports a new `useDiffDescriptionsRef()` hook. The hook appends a hidden container of description elements (`Removed`, `Added`, `Format added`, `Format removed`, `Format changed`) to the document that hosts the ref element. That matters because the canvas is an iframe, and `aria-describedby` only resolves within the same document.
- `block-diff.js` adds the matching `ariaDescribedBy` attribute at the three `applyFormat()` call sites.
- `revisions-canvas.js` merges the new ref with the existing diff-markers ref on the canvas content element.

One trade-off worth flagging: the format-change spans previously carried detailed counts in `title` ("2 formats added, 1 format removed"). Those stay in `title` for the mouse tooltip, but the `aria-describedby` description is the generic per-type text ("Format added"), since the referenced elements are static. If you'd rather screen reader users get the detailed counts, the descriptions container would need to be built per-instance from the diff output. I kept this version minimal, but happy to build that instead if it's the right call.

I considered injecting the descriptions through the existing `usePrivateStyleOverride` assets channel (how the removed-blocks SVG filter gets into the iframe), but that channel renders inside an `<svg>` element, which is no place for HTML description elements. So the injection is ref-based instead, next to the existing diff-markers pattern.

## Testing Instructions

1. Create a post with a paragraph, save, edit the paragraph text (change a few words, bold one of them), and save again.
2. Open the post's Visual History and enable the diff view.
3. Inspect a `del`/`ins`/format-change span in the canvas iframe: each should have `aria-describedby` pointing at an element with the corresponding ID (`revision-diff-description-removed`, `-added`, `-format-*`), and that hidden container should exist in the iframe's `body`.
4. Unit tests: `npm run test:unit packages/editor/src/components/post-revisions-preview`

To be upfront about the verification boundary: the unit tests prove the DOM structure (attributes present, correct IDs, hidden container mounted and cleaned up), but I haven't been able to run this against a live screen reader on this machine, so I'd appreciate an AT confirmation during review.

### Testing Instructions for Keyboard

1. With a screen reader running (NVDA/VoiceOver), navigate into the revision content and read through a changed paragraph.
2. Removed text should be described as "Removed", added text as "Added", and format-only changes as "Format added/removed/changed", including in verbosity configurations where `title`-based descriptions are not announced.

Props @thisismyurl.

## Use of AI Tools

(full disclosure: AI helped me identify the issue and verify my work)
