### PR TITLE
Notice: Fix low-contrast action controls on dark theme backgrounds

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Bug Fixes
 
+-   `Notice`: Fix low-contrast link/secondary action controls on dark theme backgrounds by pointing their accent color at the theme-aware `--wpds-color-foreground-interactive-brand` token.
 -   `SandBox`: Inject the resize script into the document `<head>` so an unclosed attribute quote in the sandboxed HTML can no longer swallow the script and leak its source as visible text in the preview. ([#79920](https://github.com/WordPress/gutenberg/pull/79920))
 -   `Divider`: Restore lower-specificity border styles so custom border colors can override the default divider color. ([#79534](https://github.com/WordPress/gutenberg/pull/79534))
 -   `Button`: Fix the focus ring for buttons rendered as links ([#79837](https://github.com/WordPress/gutenberg/pull/79837)).

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -60,6 +60,19 @@
 	margin-top: var(--wpds-dimension-gap-sm);
 }
 
+// The legacy `--wp-admin-theme-color` accent is a fixed value that does not
+// adapt to the theme background. On the tinted, dark surfaces used in a dark
+// theme, link/secondary/tertiary actions therefore fall below the minimum
+// contrast ratio. Redirect the accent to the theme-aware brand foreground
+// token for those variants — matching the outline/minimal treatment in the
+// `@wordpress/ui` Button. Primary actions keep the accent as their fill, so
+// they are intentionally excluded.
+.components-notice__action:not(.is-primary) {
+	--wp-components-color-accent: var(--wpds-color-foreground-interactive-brand);
+	--wp-components-color-accent-darker-10: var(--wpds-color-foreground-interactive-brand-active);
+	--wp-components-color-accent-darker-20: var(--wpds-color-foreground-interactive-brand-active);
+}
+
 .components-notice__dismiss {
 	grid-column: 2;
 	grid-row: 1;


### PR DESCRIPTION
Resolves #80211

## What?

Fixes the low-contrast link/secondary action controls in the `Notice` component (`@wordpress/components`) when rendered on a dark theme background.

## Why?

The legacy `--wp-admin-theme-color` accent is a **fixed** value (`#3858e9`) that does not adapt to the theme background. When a `Notice` is rendered under the design-system dark theme (`ThemeProvider` with a dark `background` seed), the surface, border, and text tokens all regenerate correctly and remain accessible — but the action controls do not.

The link and secondary/tertiary action buttons color themselves with that fixed accent, so on the tinted, dark notice surfaces they drop to roughly **2.2:1** contrast, below the WCAG minimum, and read as broken:

| Before (dark) | After (dark) |
| --- | --- |
| "Or click me instead!" (outline) and the link render in a dark `#3858e9` blue that barely separates from the dark surface. | Both render in the theme-aware light blue (`#8eb0ff`), clearly legible. |

The newer `@wordpress/ui` `Button` already solves this by using the theme-aware `--wpds-color-foreground-interactive-brand` token for its outline/minimal variants. This change brings the legacy components `Notice` in line.

## How?

Redirect the accent to the theme-aware brand foreground token for the notice's non-primary action controls, using the same CSS-variable override pattern the `Button` already uses for its destructive variant:

```scss
.components-notice__action:not(.is-primary) {
	--wp-components-color-accent: var(--wpds-color-foreground-interactive-brand);
	--wp-components-color-accent-darker-10: var(--wpds-color-foreground-interactive-brand-active);
	--wp-components-color-accent-darker-20: var(--wpds-color-foreground-interactive-brand-active);
}
```

Primary actions are intentionally excluded — they use the accent as their **fill**, so they must keep the solid brand background.

In light mode `--wpds-color-foreground-interactive-brand` resolves to `#3858e9` — identical to the previous value — so there is no visual change in light mode.

## Testing Instructions

1. Open Storybook and navigate to **Components → Feedback → Notice**.
2. Use the story with actions (primary button, secondary button, and a link).
3. Switch the Design System theme toolbar to **Dark**.
4. Confirm the secondary button border/text and the link are now legible (light blue) instead of dark blue, and that the primary button is unchanged.
5. Switch back to **Light** and confirm nothing changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)