### PR TITLE
Block Supports: Improve handling of block class name to avoid fatal

### DIFF
--- a/backport-changelog/7.1/12516.md
+++ b/backport-changelog/7.1/12516.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12516
+
+* https://github.com/WordPress/gutenberg/pull/80214

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -235,11 +235,16 @@ function gutenberg_render_block_style_variation_class_name( $block_content, $blo
 		return $block_content;
 	}
 
+	$block_class_name = $block['attrs']['className'];
+	if ( ! is_string( $block_class_name ) ) {
+		return $block_content;
+	}
+
 	/*
 	 * Matches a class prefixed by `is-style`, followed by the
 	 * variation slug, then `--`, and finally an instance number.
 	 */
-	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block['attrs']['className'], $matches );
+	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block_class_name, $matches );
 
 	if ( empty( $matches ) ) {
 		return $block_content;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1159,7 +1159,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// Check if the block has an active style variation with a blockGap value.
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.
 		$variation_block_gap_value = null;
-		$block_class_name          = $block['attrs']['className'] ?? '';
+		$block_class_name          = is_string( $block['attrs']['className'] ?? null )
+			? $block['attrs']['className']
+			: '';
 		if ( $block_class_name && str_contains( $block_class_name, 'is-style-' ) && $block_name ) {
 			$styles_registry   = WP_Block_Styles_Registry::get_instance();
 			$registered_styles = $styles_registry->get_registered_styles_for_block( $block_name );

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -350,6 +350,8 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that a non-string `className` attribute does not cause a fatal
 	 * error and the block content is returned unmodified.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_class_name
 	 */
 	public function test_block_style_variation_class_name_with_non_string_class_name() {
 		$block = array(
@@ -371,6 +373,8 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	/**
 	 * Tests to ensure that there are no references to an undefined array key
 	 * if `className` is not assigned.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_class_name
 	 */
 	public function test_block_style_variation_class_name_with_missing_class_name() {
 		$block = array(

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -346,4 +346,43 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $variation_data, 'Variation data with resolved ref values does not match' );
 	}
+
+	/**
+	 * Tests that a non-string `className` attribute does not cause a fatal
+	 * error and the block content is returned unmodified.
+	 */
+	public function test_block_style_variation_class_name_with_non_string_class_name() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => array( '0', '1' ),
+			),
+		);
+
+		$block_content = "<p class=\"0 1\">Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			gutenberg_render_block_style_variation_class_name( $block_content, $block ),
+			'Block content should be returned unchanged when className is not a string'
+		);
+	}
+
+	/**
+	 * Tests to ensure that there are no references to an undefined array key
+	 * if `className` is not assigned.
+	 */
+	public function test_block_style_variation_class_name_with_missing_class_name() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(),
+		);
+
+		$block_content = "<p>Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			gutenberg_render_block_style_variation_class_name( $block_content, $block )
+		);
+	}
 }

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1128,6 +1128,8 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that a non-string `className` attribute does not cause a fatal
 	 * when checking for style variation layout styles.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
 	 */
 	public function test_layout_support_flag_with_non_string_class_name() {
 		$block_content = '<div class="wp-block-group 0 1"></div>';
@@ -1141,9 +1143,10 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertIsString(
+		$this->assertSame(
+			'<div class="wp-block-group 0 1 is-layout-constrained wp-block-group-is-layout-constrained"></div>',
 			gutenberg_render_layout_support_flag( $block_content, $block ),
-			'Layout support should return content unchanged without fatalling when className is not a string'
+			'Layout support should render the expected markup when className is not a string'
 		);
 	}
 }

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1124,4 +1124,26 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that a non-string `className` attribute does not cause a fatal
+	 * when checking for style variation layout styles.
+	 */
+	public function test_layout_support_flag_with_non_string_class_name() {
+		$block_content = '<div class="wp-block-group 0 1"></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'className' => array( '0', '1' ),
+				'layout'    => array(
+					'type' => 'constrained',
+				),
+			),
+		);
+
+		$this->assertIsString(
+			gutenberg_render_layout_support_flag( $block_content, $block ),
+			'Layout support should return content unchanged without fatalling when className is not a string'
+		);
+	}
 }


### PR DESCRIPTION
## What?

Adds defensive guards to block classname attribute handling to avoid fatal errors for corrupted block content.

This is similar to the issue fixed in #78841.

## Why?

Fixes fatal errors that can occur when operating on specific corrupted block content.

While this should be rare in practice because blocks don't normally emit this markup, because the logic is operating on raw block attributes, it needs to be especially defensive about the values that it works with.

## How?

Adds additional `is_string` checks before operating on the `className` attribute as if it were a string.

## Testing Instructions

Verify included unit tests pass: 

```
npm run test:unit:php:base -- --filter 'block_style_variation_class_name_with_|layout_support_flag_with_non_string'
```

(See ["PHP testing" instructions](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/testing-overview.md#php-testing) for prerequisites)

You can also verify this in the real-world:

Example block snippet to insert in HTML editor:

```html
<!-- wp:group {"className":["0","1"]} -->
<div class="wp-block-group 0 1"><!-- wp:paragraph -->
<p>error</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

In the current version of Gutenberg and WordPress 7.0, you won't be able to save a post with that snippet due to the fatal error in `lib/block-supports/layout.php`. On this branch you will be able to save the content and preview it on the frontend. Once you have a saved post, disable the plugin (or change back to `trunk`) and observe that the post fatals on the frontend without the fix due to the fatal logic in `lib/block-supports/block-style-variations.php`.

## Screenshots or screencast <!-- if applicable -->

The screenshots below show the errors being resolved in these changes: (the "before" state)

<img width="1367" height="977" alt="image" src="https://github.com/user-attachments/assets/1e665792-dff6-42a4-aa51-b6685b7736b8" />

<img width="1367" height="977" alt="image" src="https://github.com/user-attachments/assets/6aaad2b5-933d-4d95-be84-b2a63f86b635" />

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to research and implement TDD failing test case. The runtime code was implemented myself, with advisement from the AI model around empty attribute handling.