### PR TITLE
Private APIs: Remove design system packages from packages using private APIs

### DIFF
--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Enhancements
 
-- Allow `@wordpress/global-styles-engine` to opt in to private APIs. ([#79104](https://github.com/WordPress/gutenberg/pull/79104))
+-   Allow `@wordpress/global-styles-engine` to opt in to private APIs ([#79104](https://github.com/WordPress/gutenberg/pull/79104)).
+
+### Code Quality
+
+-   Remove `@wordpress/theme` and `@wordpress/ui` from private API usage, as they no longer use private APIs ([#80215](https://github.com/WordPress/gutenberg/pull/80215)).
 
 ## 1.50.0 (2026-07-01)
 
@@ -16,7 +20,7 @@
 
 ### Enhancements
 
-- Allow `@wordpress/storybook` to opt in to private APIs. ([#78814](https://github.com/WordPress/gutenberg/pull/78814))
+-   Allow `@wordpress/storybook` to opt in to private APIs ([#78814](https://github.com/WordPress/gutenberg/pull/78814)).
 
 ## 1.47.0 (2026-05-27)
 

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -42,7 +42,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/routes',
 	'@wordpress/storybook',
 	'@wordpress/sync',
-	'@wordpress/theme',
 	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',
@@ -51,7 +50,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/upload-media',
 	'@wordpress/global-styles-engine',
 	'@wordpress/global-styles-ui',
-	'@wordpress/ui',
 	'@wordpress/views',
 	'@wordpress/widget-dashboard',
 ];


### PR DESCRIPTION
## What?

Updates `@wordpress/private-apis` internal list of packages using private APIs to reflect the fact that `@wordpress/theme` and `@wordpress/ui` no longer use private APIs.

Follow-up to: https://github.com/WordPress/gutenberg/pull/78958#issuecomment-4783348434

## Why?

This list should reflect the current reality of packages using private APIs.

Tracking issue for `@wordpress/ui` removing private APIs: #75319

#78958 removed API locking from `@wordpress/theme`.

Timing-wise, this also pairs well with ongoing stabilization of the theme package , which was promoted to a stable package in #80049.

## Testing Instructions

I suppose you could try to use the `lock` or `unlock` mechanism with this package name and verify that it no longer allows you to lock or unlock.

## Use of AI Tools

No AI was used.