### PR TITLE
Make playlist pause button visually match play button

### DIFF
--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -37,6 +37,14 @@ $waveform-player-height: 100px;
 			width: 3rem;
 			height: 3rem;
 		}
+
+		.waveform-icon-pause svg {
+			// The pause icon's two full-height bars read larger than the
+			// play triangle at the same SVG box size, so optically scale it
+			// down to match the play icon's visual weight.
+			width: 2.625rem;
+			height: 2.625rem;
+		}
 	}
 
 	.waveform-player.has-play-button-artwork {


### PR DESCRIPTION
## What?

Makes the Playlist block waveform player pause icon visually match the size of the play icon.

## Why?

The pause icon looked slightly larger than the play icon in the Playlist block player. Both icons used the same SVG box size, but the pause icon's two full-height bars have more visual weight than the play triangle, making the control feel uneven when toggling between states.

## How?

Adds a Playlist block stylesheet override that optically scales down only the pause SVG inside the waveform player button. The button dimensions and play icon size stay unchanged, and the CSS includes a comment explaining the visual adjustment.

## Testing Instructions

- Add a Playlist block.
- Add or select an audio track.
- Play the track from the waveform player.
- Confirm the pause icon appears visually balanced with the play icon.
- Pause and play the track a few times to compare the icon states.

## Use of AI Tools

This PR was prepared with assistance from OpenAI Codex for implementation and PR description drafting. The changes were reviewed and committed by the PR author.