### PR TITLE
Media Inserter: Omit page arg from requests for the first set of results

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -92,8 +92,12 @@ export function useMediaResults( category, query = {}, refreshKey ) {
 			lastQueryKeyRef.current = key;
 			lastFetchRef.current = category.fetch;
 			lastSourceRef.current = category.name;
+			// Omit the default first page so sources that forward the query to a
+			// strict external API don't receive an unexpected `page` arg.
+			const { page, ...queryWithoutPage } = query;
+			const fetchQuery = page > 1 ? query : queryWithoutPage;
 			const { mediaItems, totalItems, totalPages } = normalizeFetchResult(
-				await category.fetch?.( query )
+				await category.fetch?.( fetchQuery )
 			);
 			if ( request === lastRequestRef.current ) {
 				// Set together so the grid and the pager never disagree.

--- a/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
@@ -78,6 +78,41 @@ describe( 'useMediaResults', () => {
 		expect( result.current.mediaList ).toEqual( [ { id: 1 } ] );
 	} );
 
+	it( 'omits the default first page from the fetch query', async () => {
+		const category = createCategory( 'images', [ { id: 1 } ] );
+		renderHook( () =>
+			useMediaResults(
+				category,
+				{ per_page: 20, page: 1, search: '' },
+				0
+			)
+		);
+		await waitFor( () =>
+			expect( category.fetch ).toHaveBeenCalledWith( {
+				per_page: 20,
+				search: '',
+			} )
+		);
+	} );
+
+	it( 'passes `page` to the fetch query when paging past the first page', async () => {
+		const category = createCategory( 'images', [ { id: 1 } ] );
+		renderHook( () =>
+			useMediaResults(
+				category,
+				{ per_page: 20, page: 2, search: '' },
+				0
+			)
+		);
+		await waitFor( () =>
+			expect( category.fetch ).toHaveBeenCalledWith( {
+				per_page: 20,
+				page: 2,
+				search: '',
+			} )
+		);
+	} );
+
 	it( 'leaves paging totals undefined for an array-returning source', async () => {
 		const category = createCategory( 'images', [ { id: 1 } ] );
 		const { result } = renderHook( () =>


### PR DESCRIPTION
## What?

Follow-up to:

* https://github.com/WordPress/gutenberg/pull/80038#discussion_r3569870388

In the media inserter, we recently added pagination to the core media categories. This PR adjusts the category fetch call to omit the `page` arg if we're on the first page of results.

## Why?

Raised by @ntsekouras on the PR that introduce the pagination (https://github.com/WordPress/gutenberg/pull/80038#discussion_r3569870388) that it's possible that 3rd party registered categories might use APIs that don't support a `page` arg, in which case if the consumer is just passing along the args directly to their API, they might result in a 400 request.

Whereas if we omit the `page` arg when on the first page of results, `page: 1` gets handily set for us automatically for core media categories by `core-data` in `getQueryParts`:

https://github.com/WordPress/gutenberg/blob/d0ab89720c103f8dad6200c92c8c432df85e441f/packages/core-data/src/queried-data/get-query-parts.js#L40

So, this should effectively be a no-op PR that adds a little hardening.

## How?

* In the media inserter's `useMediaResults` hook, only include the `page` arg into the query that's passed to the category's `fetch` method when on a page higher than 1.

## Testing Instructions

* On a site with more than 20 images, open up the media inserter and check that pagination works across multiple pages
* Double-check that the Openverse category still works as on trunk

If you want to be more thorough, more detailed testing steps are included in #80038

### Screenshots

For a quick refresher, this is the pagination we're talking about:

<img width="1276" height="857" alt="image" src="https://github.com/user-attachments/assets/6529b07c-4a75-46da-89b1-7329c848e99d" />

## Use of AI Tools

Claude Code