### PR TITLE
Notes: Replace blur-deselect bookkeeping with useFocusOutside

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -36,6 +36,7 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 	const blockElement = useBlockElement( clientId );
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 	const { selectNote } = unlock( useDispatch( editorStore ) );
+	const { getSelectedNote } = unlock( useSelect( editorStore ) );
 	const isSubmittingRef = useRef( false );
 
 	/*
@@ -57,8 +58,16 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 		if ( isSubmittingRef.current ) {
 			return;
 		}
-		toggleBlockSpotlight( clientId, false );
-		selectNote( undefined );
+
+		/*
+		 * Selection may have moved on before this deferred callback runs; only
+		 * clear it while this still owns the selection, or it would wipe out the
+		 * newly selected note.
+		 */
+		if ( getSelectedNote() === 'new' ) {
+			toggleBlockSpotlight( clientId, false );
+			selectNote( undefined );
+		}
 	} );
 
 	const unselectNote = () => {

--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -82,8 +82,7 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 			style={
 				floating ? { opacity: ! floating.y ? 0 : undefined } : undefined
 			}
-			onFocus={ focusOutside.onFocus }
-			onBlur={ focusOutside.onBlur }
+			{ ...focusOutside }
 		>
 			<NoteCard>
 				<NoteForm

--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -48,7 +48,7 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 		// Keep the form open when focus returns to it, e.g. on link popover Escape.
 		if (
 			event.relatedTarget?.closest(
-				'.editor-collab-sidebar-panel__thread'
+				'.editor-collab-sidebar-panel__add-note'
 			)
 		) {
 			return;
@@ -74,7 +74,7 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 	return (
 		<FloatingContainer
 			floating={ floating }
-			className="editor-collab-sidebar-panel__thread is-selected"
+			className="editor-collab-sidebar-panel__add-note is-selected"
 			gap="md"
 			tabIndex={ 0 }
 			aria-label={ __( 'New note' ) }

--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
+import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	store as blockEditorStore,
@@ -36,9 +37,29 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 	const { toggleBlockSpotlight } = unlock( useDispatch( blockEditorStore ) );
 	const { selectNote } = unlock( useDispatch( editorStore ) );
 	const isSubmittingRef = useRef( false );
-	const cancelPendingDismissRef = useRef( undefined );
 
-	useEffect( () => () => cancelPendingDismissRef.current?.(), [] );
+	/*
+	 * Dismiss the form once focus leaves it. `useFocusOutside` keeps the form
+	 * open while focus stays in UI it owns: format popovers (e.g. the Cmd+K
+	 * link UI) portal out of the form's DOM, but their focus events still
+	 * bubble here through the React tree. It also ignores window/tab blur.
+	 */
+	const focusOutside = useFocusOutside( ( event ) => {
+		// Keep the form open when focus returns to it, e.g. on link popover Escape.
+		if (
+			event.relatedTarget?.closest(
+				'.editor-collab-sidebar-panel__thread'
+			)
+		) {
+			return;
+		}
+		// Never dismiss mid-submit; clicking "Add note" blurs before it settles.
+		if ( isSubmittingRef.current ) {
+			return;
+		}
+		toggleBlockSpotlight( clientId, false );
+		selectNote( undefined );
+	} );
 
 	const unselectNote = () => {
 		selectNote( undefined );
@@ -61,69 +82,8 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 			style={
 				floating ? { opacity: ! floating.y ? 0 : undefined } : undefined
 			}
-			onFocus={ () => {
-				/*
-				 * Focus landing anywhere in UI owned by the form cancels a
-				 * pending dismissal from `onBlur`. This covers focus returning
-				 * to the form itself as well as format popovers (e.g. the
-				 * Cmd+K link UI): they portal out of the form's DOM, but their
-				 * focus events still bubble here through the React tree.
-				 */
-				cancelPendingDismissRef.current?.();
-			} }
-			onBlur={ ( event ) => {
-				// Don't deselect notes when the browser window/tab loses focus.
-				if ( ! document.hasFocus() ) {
-					return;
-				}
-				/*
-				 * Prevent blur from closing the form while the async submit
-				 * is in progress. Clicking "Add note" moves focus away,
-				 * triggering blur before onSubmit completes.
-				 */
-				if ( isSubmittingRef.current ) {
-					return;
-				}
-				const container = event.currentTarget;
-				// Focus staying within the form never dismisses it.
-				if (
-					event.relatedTarget &&
-					container.contains( event.relatedTarget )
-				) {
-					return;
-				}
-				/*
-				 * The blur is ambiguous at this point: focus may be moving to
-				 * a format popover that belongs to the form (which cancels the
-				 * dismissal via `onFocus` above), and rich-text re-renders
-				 * briefly drop focus to the body while typing. Re-check on the
-				 * next frame where focus actually settled and dismiss only
-				 * when it has truly left the form.
-				 */
-				const { defaultView } = container.ownerDocument;
-				cancelPendingDismissRef.current?.();
-				const frame = defaultView.requestAnimationFrame( () => {
-					cancelPendingDismissRef.current = undefined;
-					/*
-					 * A submit may have started between the blur and this
-					 * frame (e.g. Safari fires button-click blurs with no
-					 * relatedTarget); never dismiss mid-submit.
-					 */
-					if ( isSubmittingRef.current ) {
-						return;
-					}
-					const active = container.ownerDocument.activeElement;
-					if ( active && container.contains( active ) ) {
-						return;
-					}
-					toggleBlockSpotlight( clientId, false );
-					selectNote( undefined );
-				} );
-				cancelPendingDismissRef.current = () => {
-					defaultView.cancelAnimationFrame( frame );
-					cancelPendingDismissRef.current = undefined;
-				};
-			} }
+			onFocus={ focusOutside.onFocus }
+			onBlur={ focusOutside.onBlur }
 		>
 			<NoteCard>
 				<NoteForm

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -101,6 +101,11 @@ export function NoteThread( {
 			return;
 		}
 
+		// Drop the highlight, unless another note (possibly on the same block) now owns it.
+		if ( ! isNoteFocused ) {
+			toggleBlockHighlight( note.blockClientId, false );
+		}
+
 		/*
 		 * Selection may have moved on before this deferred callback runs; only
 		 * clear it while this still owns the selection, or it would wipe out the

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -9,9 +9,12 @@ import clsx from 'clsx';
 import { useEffect, useRef } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { useDebounce } from '@wordpress/compose';
+import {
+	useDebounce,
+	__experimentalUseFocusOutside as useFocusOutside,
+} from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import {
 	store as blockEditorStore,
@@ -51,7 +54,7 @@ export function NoteThread( {
 		useDispatch( blockEditorStore )
 	);
 	const { selectNote } = unlock( useDispatch( editorStore ) );
-	const registry = useRegistry();
+	const { getSelectedNote } = unlock( useSelect( editorStore ) );
 	const relatedBlockElement = useBlockElement( note.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
 		toggleBlockHighlight,
@@ -59,9 +62,6 @@ export function NoteThread( {
 	);
 	const floatingRef = useRef( null );
 	const isKeyboardTabbingRef = useRef( false );
-	const blurDeselectTimeoutRef = useRef();
-
-	useEffect( () => () => clearTimeout( blurDeselectTimeoutRef.current ), [] );
 
 	const registerThread = floating?.registerThread;
 	const unregisterThread = floating?.unregisterThread;
@@ -85,80 +85,51 @@ export function NoteThread( {
 		scrollNoteThreadIntoView( note.id, sidebarRef.current );
 	}, [ isSelected, floating?.y, note.id, sidebarRef ] );
 
-	const onMouseEnter = () => {
-		debouncedToggleBlockHighlight( note.blockClientId, true );
-	};
-
-	const onMouseLeave = () => {
-		debouncedToggleBlockHighlight( note.blockClientId, false );
-	};
-
-	const onFocus = () => {
-		/*
-		 * Focus landing anywhere in UI owned by this thread cancels a pending
-		 * deselect from `onBlur`. This includes the delete confirmation
-		 * dialog, the note actions menu and format popovers (e.g. the Cmd+K
-		 * link UI): they portal out of the thread's DOM, but their focus
-		 * events still bubble here through the React tree.
-		 */
-		clearTimeout( blurDeselectTimeoutRef.current );
-		toggleBlockHighlight( note.blockClientId, true );
-	};
-
-	const onBlur = ( event ) => {
-		// Don't deselect notes when the browser window/tab loses focus.
-		if ( ! document.hasFocus() ) {
-			return;
-		}
-
+	/*
+	 * Deselect the thread once focus leaves it. `useFocusOutside` keeps the
+	 * thread selected while focus stays in UI it owns: the delete dialog, the
+	 * note actions menu and format popovers (e.g. the Cmd+K link UI) portal out
+	 * of the thread's DOM, but their focus events still bubble here through the
+	 * React tree. It also ignores window/tab blur.
+	 */
+	const focusOutside = useFocusOutside( ( event ) => {
+		// When another note is clicked, do nothing because the current note is automatically closed.
 		const isNoteFocused = event.relatedTarget?.closest(
 			'.editor-collab-sidebar-panel__thread'
 		);
-		const isTabbing = isKeyboardTabbingRef.current;
+		if ( isNoteFocused && ! isKeyboardTabbingRef.current ) {
+			return;
+		}
 
-		// When another note is clicked, do nothing because the current note is automatically closed.
-		if ( isNoteFocused && ! isTabbing ) {
-			return;
-		}
-		// When tabbing, do nothing if the focus is within the current note.
-		if (
-			isTabbing &&
-			event.currentTarget.contains( event.relatedTarget )
-		) {
-			return;
-		}
+		toggleBlockHighlight( note.blockClientId, false );
 
 		/*
-		 * Closes a note that has lost focus when any of the following
-		 * conditions are met:
-		 * - An element other than a note is clicked.
-		 * - Focus was lost by tabbing.
-		 * The deselect is deferred so that focus moving into a portaled
-		 * dialog, menu or popover belonging to this thread can cancel it via
-		 * `onFocus` above (their focus events reach it through React's
-		 * virtual bubbling, while `relatedTarget` reports them as outside).
+		 * Selection may have moved while the deselect was pending: clicking
+		 * a noted block in the canvas blurs this thread and then selects
+		 * the block's own thread (asynchronously, via focusNote()). Only
+		 * clear the selection if this thread still owns it, or the pending
+		 * deselect would wipe out the newly selected thread.
 		 */
-		clearTimeout( blurDeselectTimeoutRef.current );
-		blurDeselectTimeoutRef.current = setTimeout( () => {
-			toggleBlockHighlight( note.blockClientId, false );
+		if ( getSelectedNote() === note.id ) {
+			onDeselectNote();
+		}
+	} );
 
-			/*
-			 * Selection may have moved while the deselect was pending: clicking
-			 * a noted block in the canvas blurs this thread and then selects
-			 * the block's own thread (asynchronously, via focusNote()). Only
-			 * clear the selection if this thread still owns it, or the pending
-			 * deselect would wipe out the newly selected thread.
-			 */
-			const selectedNoteId = unlock(
-				registry.select( editorStore )
-			).getSelectedNote();
-			if ( selectedNoteId === note.id ) {
-				onDeselectNote();
-			}
-		}, 0 );
-	};
+	function onMouseEnter() {
+		debouncedToggleBlockHighlight( note.blockClientId, true );
+	}
 
-	const onSelectNote = () => {
+	function onMouseLeave() {
+		debouncedToggleBlockHighlight( note.blockClientId, false );
+	}
+
+	function onFocus( event ) {
+		// Cancel any pending deselect and highlight the related block.
+		focusOutside.onFocus( event );
+		toggleBlockHighlight( note.blockClientId, true );
+	}
+
+	function onSelectNote() {
 		if ( isSelected ) {
 			return;
 		}
@@ -170,14 +141,14 @@ export function NoteThread( {
 			// Pass `null` as the second parameter to prevent focusing the block.
 			selectBlock( note.blockClientId, null );
 		}
-	};
+	}
 
-	const onDeselectNote = () => {
+	function onDeselectNote() {
 		selectNote( undefined );
 		toggleBlockSpotlight( note.blockClientId, false );
-	};
+	}
 
-	const handleResolve = () => {
+	function handleResolve() {
 		onEditNote( { id: note.id, status: 'approved' } );
 		onDeselectNote();
 		if ( isFloating ) {
@@ -185,7 +156,7 @@ export function NoteThread( {
 		} else {
 			focusNoteThread( note.id, sidebarRef.current );
 		}
-	};
+	}
 
 	const allReplies = note?.reply || [];
 	const lastReply =
@@ -232,7 +203,7 @@ export function NoteThread( {
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onFocus }
-			onBlur={ onBlur }
+			onBlur={ focusOutside.onBlur }
 			onKeyUp={ ( event ) => {
 				if ( event.key === 'Tab' ) {
 					isKeyboardTabbingRef.current = false;

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -101,14 +101,10 @@ export function NoteThread( {
 			return;
 		}
 
-		toggleBlockHighlight( note.blockClientId, false );
-
 		/*
-		 * Selection may have moved while the deselect was pending: clicking
-		 * a noted block in the canvas blurs this thread and then selects
-		 * the block's own thread (asynchronously, via focusNote()). Only
-		 * clear the selection if this thread still owns it, or the pending
-		 * deselect would wipe out the newly selected thread.
+		 * Selection may have moved on before this deferred callback runs; only
+		 * clear it while this still owns the selection, or it would wipe out the
+		 * newly selected note.
 		 */
 		if ( getSelectedNote() === note.id ) {
 			onDeselectNote();

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -202,8 +202,8 @@ export function NoteThread( {
 			onClick={ onSelectNote }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
+			{ ...focusOutside }
 			onFocus={ onFocus }
-			onBlur={ focusOutside.onBlur }
 			onKeyUp={ ( event ) => {
 				if ( event.key === 'Tab' ) {
 					isKeyboardTabbingRef.current = false;

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -22,7 +22,8 @@
 	overflow: hidden;
 }
 
-.editor-collab-sidebar-panel__thread {
+.editor-collab-sidebar-panel__thread,
+.editor-collab-sidebar-panel__add-note {
 	position: relative;
 	padding: $grid-unit-20;
 	border-radius: $radius-large;

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -392,6 +392,49 @@ test.describe( 'Block Notes', () => {
 		await expect( replyTextbox ).toBeVisible();
 	} );
 
+	test( 'selecting note marks it as active and closes add new note form', async ( {
+		editor,
+		page,
+		blockNoteUtils,
+	} ) => {
+		// An existing thread to select later.
+		await blockNoteUtils.addBlockWithNote( {
+			type: 'core/paragraph',
+			attributes: { content: 'First block' },
+			comment: 'First block comment',
+		} );
+
+		// Open a new-note form on a second block and move focus into it.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second block' },
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		const newNoteForm = page.getByRole( 'textbox', {
+			name: 'New note',
+			exact: true,
+		} );
+		await newNoteForm.click();
+
+		const existingThread = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tree' )
+			.getByRole( 'treeitem', { name: 'Note: First block comment' } );
+
+		// Clicking the existing thread selects it and closes the new-note form.
+		await existingThread.click();
+		await expect( newNoteForm ).toBeHidden();
+
+		/*
+		 * The form unmounts on selection, but `useFocusOutside` still runs its
+		 * queued blur callback. It must not clear the newly selected thread.
+		 */
+		await expect( existingThread ).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	} );
+
 	test.describe( 'Keyboard', () => {
 		const KEY_COMBINATIONS = [
 			{

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -75,306 +75,6 @@ test.describe( 'Block Notes', () => {
 		await expect( thread ).toBeFocused();
 	} );
 
-	test.describe( 'Rich text formatting in the note form', () => {
-		test( 'Cmd+B toggles bold in the new note textbox', async ( {
-			editor,
-			page,
-			pageUtils,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Note rich text host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const textbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await textbox.click();
-			await page.keyboard.type( 'hello world' );
-			// Select all text and toggle bold.
-			await pageUtils.pressKeys( 'primary+a' );
-			await pageUtils.pressKeys( 'primary+b' );
-			await expect(
-				textbox.locator( 'strong' ),
-				'Selection should be wrapped in <strong> after primary+b'
-			).toHaveText( 'hello world' );
-		} );
-
-		test( 'Cmd+K opens the inline link popover for the selected text', async ( {
-			editor,
-			page,
-			pageUtils,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Note rich text host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const textbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await textbox.click();
-			await page.keyboard.type( 'visit example' );
-			// Select all text in the note form.
-			await pageUtils.pressKeys( 'primary+a' );
-
-			/*
-			 * Cmd+K should open the inline link UI rather than the
-			 * WordPress command palette. The command palette has the
-			 * "Command palette" accessible name; the inline link UI
-			 * surfaces the LinkControl search combobox.
-			 */
-			await pageUtils.pressKeys( 'primary+k' );
-			await expect(
-				page.getByRole( 'combobox', {
-					name: 'Search or type URL',
-				} ),
-				'Inline link search input should be visible'
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'dialog', { name: 'Command palette' } ),
-				'Command palette should not have opened'
-			).toBeHidden();
-
-			// The popover moves focus to the search input asynchronously;
-			// Escape must reach the popover rather than the reply field.
-			await expect(
-				page.getByRole( 'combobox', { name: 'Search or type URL' } )
-			).toBeFocused();
-
-			/*
-			 * Pressing Escape closes the link popover and leaves the note
-			 * form intact — focus does not get yanked out of the editor.
-			 */
-			await page.keyboard.press( 'Escape' );
-			await expect(
-				page.getByRole( 'combobox', { name: 'Search or type URL' } )
-			).toBeHidden();
-			await expect( textbox ).toBeVisible();
-		} );
-
-		test( 'Cmd+K opens an unclipped link popover in the reply form', async ( {
-			page,
-			pageUtils,
-			blockNoteUtils,
-		} ) => {
-			await blockNoteUtils.addBlockWithNote( {
-				type: 'core/paragraph',
-				attributes: { content: 'Reply link host' },
-				comment: 'Reply link note',
-			} );
-			const replyTextbox = page.getByRole( 'textbox', {
-				name: 'Reply to',
-			} );
-			await replyTextbox.click();
-			await page.keyboard.type( 'visit example' );
-			await pageUtils.pressKeys( 'primary+a' );
-			await pageUtils.pressKeys( 'primary+k' );
-
-			/*
-			 * The link popover portals out of the note card. Focus moving
-			 * into it must not deselect the thread (which would unmount the
-			 * reply form and the popover with it), and the popover must not
-			 * be clipped by the note card's overflow: it has to lie fully
-			 * within the viewport.
-			 */
-			const linkInput = page.getByRole( 'combobox', {
-				name: 'Search or type URL',
-			} );
-			await expect(
-				linkInput,
-				'Inline link search input should be visible'
-			).toBeVisible();
-			await expect( replyTextbox ).toBeVisible();
-
-			const inputBox = await linkInput.boundingBox();
-			const viewport = page.viewportSize();
-			expect( inputBox.x ).toBeGreaterThanOrEqual( 0 );
-			expect( inputBox.x + inputBox.width ).toBeLessThanOrEqual(
-				viewport.width
-			);
-
-			// The popover moves focus to the search input asynchronously;
-			// Escape must reach the popover rather than the reply field.
-			await expect( linkInput ).toBeFocused();
-
-			// Escape closes the popover and keeps the reply form intact.
-			await page.keyboard.press( 'Escape' );
-			await expect( linkInput ).toBeHidden();
-			await expect( replyTextbox ).toBeVisible();
-		} );
-
-		test( 'does not render the hidden field label as a placeholder', async ( {
-			editor,
-			page,
-			blockNoteUtils,
-		} ) => {
-			/*
-			 * The note forms label their fields with a visually hidden
-			 * label ("New note" / "Reply to note N by author") and render
-			 * no placeholder; the rich text placeholder element only
-			 * mounts when a placeholder is passed, so its presence means
-			 * the hidden label leaked into the visible field.
-			 */
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Placeholder host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const newNoteTextbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await expect( newNoteTextbox ).toBeVisible();
-			await expect( newNoteTextbox ).not.toHaveAttribute(
-				'aria-placeholder',
-				/./
-			);
-			await expect(
-				newNoteTextbox.locator( '[data-rich-text-placeholder]' )
-			).toHaveCount( 0 );
-
-			await blockNoteUtils.addNote( 'Placeholder note' );
-			const replyTextbox = page.getByRole( 'textbox', {
-				name: 'Reply to',
-			} );
-			await expect( replyTextbox ).toBeVisible();
-			// The visually hidden label still provides the descriptive
-			// accessible name; only the visible placeholder is gone.
-			await expect( replyTextbox ).toHaveAccessibleName(
-				/^Reply to note \d+ by admin$/
-			);
-			await expect( replyTextbox ).not.toHaveAttribute(
-				'aria-placeholder',
-				/./
-			);
-			await expect(
-				replyTextbox.locator( '[data-rich-text-placeholder]' )
-			).toHaveCount( 0 );
-		} );
-
-		test( 'backtick wrapping applies core/code inline format', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Note rich text host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const textbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await textbox.click();
-			/*
-			 * Typing `code` (backtick-wrapped) should auto-apply
-			 * `core/code`'s inline format via its `__unstableInputRule`.
-			 */
-			await page.keyboard.type( '`code` after' );
-			await expect( textbox.locator( 'code' ) ).toHaveText( 'code' );
-		} );
-	} );
-
-	test.describe( 'Mentions in the note form', () => {
-		let mentionedUserId;
-
-		test.beforeAll( async ( { requestUtils } ) => {
-			const user = await requestUtils.createUser( {
-				username: 'notementions',
-				email: 'notementions@example.com',
-				firstName: 'Mentionable',
-				lastName: 'Teammate',
-				password: 'iLoVeE2EtEsTs',
-			} );
-			mentionedUserId = user.id;
-		} );
-
-		test.afterAll( async ( { requestUtils } ) => {
-			await requestUtils.deleteAllUsers();
-		} );
-
-		test( 'inserts a mention chip that survives saving the note', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Mention host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const textbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await textbox.click();
-			await page.keyboard.type( 'Ping @' );
-
-			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
-
-			// Narrow the suggestions and pick the teammate.
-			await page.keyboard.type( 'Menti' );
-			await expect(
-				page.getByRole( 'option', {
-					name: 'Mentionable Teammate',
-					selected: true,
-				} )
-			).toBeVisible();
-			await page.keyboard.press( 'Enter' );
-
-			/*
-			 * The completer inserts the mention as a chip: a link to the
-			 * user's author page whose `user-N` class carries the mentioned
-			 * user's ID.
-			 */
-			const mentionClasses = new RegExp(
-				`^wp-note-mention user-${ mentionedUserId }$`
-			);
-			const draftChip = textbox.locator( 'a.wp-note-mention' );
-			await expect( draftChip ).toHaveText( '@Mentionable Teammate' );
-			await expect( draftChip ).toHaveClass( mentionClasses );
-			await expect( draftChip ).toHaveAttribute( 'href', /author/ );
-
-			await page.keyboard.type( 'please review' );
-			await page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Add note', exact: true } )
-				.click();
-
-			/*
-			 * The saved thread renders the content returned by the REST API,
-			 * so an intact chip here proves the mention markup survived
-			 * server-side sanitization.
-			 */
-			const savedChip = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'treeitem' )
-				.locator( 'a.wp-note-mention' );
-			await expect( savedChip ).toHaveText( '@Mentionable Teammate' );
-			await expect( savedChip ).toHaveClass( mentionClasses );
-		} );
-
-		test( 'can cancel mentions popover', async ( { editor, page } ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Mention host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const textbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await textbox.pressSequentially( 'Ping @' );
-
-			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
-			await page.keyboard.press( 'Escape' );
-			await expect( page.getByRole( 'listbox' ) ).toBeHidden();
-			await expect( textbox ).toBeFocused();
-		} );
-	} );
-
 	test( 'can reply to a block note', async ( { page, blockNoteUtils } ) => {
 		await blockNoteUtils.addBlockWithNote( {
 			type: 'core/paragraph',
@@ -1900,6 +1600,306 @@ test.describe( 'Block Notes', () => {
 				.click();
 
 			await expect.poll( alphaOf ).toBeGreaterThan( 0.4 );
+		} );
+	} );
+
+	test.describe( 'Rich text formatting in the note form', () => {
+		test( 'Cmd+B toggles bold in the new note textbox', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note rich text host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.click();
+			await page.keyboard.type( 'hello world' );
+			// Select all text and toggle bold.
+			await pageUtils.pressKeys( 'primary+a' );
+			await pageUtils.pressKeys( 'primary+b' );
+			await expect(
+				textbox.locator( 'strong' ),
+				'Selection should be wrapped in <strong> after primary+b'
+			).toHaveText( 'hello world' );
+		} );
+
+		test( 'Cmd+K opens the inline link popover for the selected text', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note rich text host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.click();
+			await page.keyboard.type( 'visit example' );
+			// Select all text in the note form.
+			await pageUtils.pressKeys( 'primary+a' );
+
+			/*
+			 * Cmd+K should open the inline link UI rather than the
+			 * WordPress command palette. The command palette has the
+			 * "Command palette" accessible name; the inline link UI
+			 * surfaces the LinkControl search combobox.
+			 */
+			await pageUtils.pressKeys( 'primary+k' );
+			await expect(
+				page.getByRole( 'combobox', {
+					name: 'Search or type URL',
+				} ),
+				'Inline link search input should be visible'
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'dialog', { name: 'Command palette' } ),
+				'Command palette should not have opened'
+			).toBeHidden();
+
+			// The popover moves focus to the search input asynchronously;
+			// Escape must reach the popover rather than the reply field.
+			await expect(
+				page.getByRole( 'combobox', { name: 'Search or type URL' } )
+			).toBeFocused();
+
+			/*
+			 * Pressing Escape closes the link popover and leaves the note
+			 * form intact — focus does not get yanked out of the editor.
+			 */
+			await page.keyboard.press( 'Escape' );
+			await expect(
+				page.getByRole( 'combobox', { name: 'Search or type URL' } )
+			).toBeHidden();
+			await expect( textbox ).toBeVisible();
+		} );
+
+		test( 'Cmd+K opens an unclipped link popover in the reply form', async ( {
+			page,
+			pageUtils,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Reply link host' },
+				comment: 'Reply link note',
+			} );
+			const replyTextbox = page.getByRole( 'textbox', {
+				name: 'Reply to',
+			} );
+			await replyTextbox.click();
+			await page.keyboard.type( 'visit example' );
+			await pageUtils.pressKeys( 'primary+a' );
+			await pageUtils.pressKeys( 'primary+k' );
+
+			/*
+			 * The link popover portals out of the note card. Focus moving
+			 * into it must not deselect the thread (which would unmount the
+			 * reply form and the popover with it), and the popover must not
+			 * be clipped by the note card's overflow: it has to lie fully
+			 * within the viewport.
+			 */
+			const linkInput = page.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} );
+			await expect(
+				linkInput,
+				'Inline link search input should be visible'
+			).toBeVisible();
+			await expect( replyTextbox ).toBeVisible();
+
+			const inputBox = await linkInput.boundingBox();
+			const viewport = page.viewportSize();
+			expect( inputBox.x ).toBeGreaterThanOrEqual( 0 );
+			expect( inputBox.x + inputBox.width ).toBeLessThanOrEqual(
+				viewport.width
+			);
+
+			// The popover moves focus to the search input asynchronously;
+			// Escape must reach the popover rather than the reply field.
+			await expect( linkInput ).toBeFocused();
+
+			// Escape closes the popover and keeps the reply form intact.
+			await page.keyboard.press( 'Escape' );
+			await expect( linkInput ).toBeHidden();
+			await expect( replyTextbox ).toBeVisible();
+		} );
+
+		test( 'does not render the hidden field label as a placeholder', async ( {
+			editor,
+			page,
+			blockNoteUtils,
+		} ) => {
+			/*
+			 * The note forms label their fields with a visually hidden
+			 * label ("New note" / "Reply to note N by author") and render
+			 * no placeholder; the rich text placeholder element only
+			 * mounts when a placeholder is passed, so its presence means
+			 * the hidden label leaked into the visible field.
+			 */
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Placeholder host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const newNoteTextbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await expect( newNoteTextbox ).toBeVisible();
+			await expect( newNoteTextbox ).not.toHaveAttribute(
+				'aria-placeholder',
+				/./
+			);
+			await expect(
+				newNoteTextbox.locator( '[data-rich-text-placeholder]' )
+			).toHaveCount( 0 );
+
+			await blockNoteUtils.addNote( 'Placeholder note' );
+			const replyTextbox = page.getByRole( 'textbox', {
+				name: 'Reply to',
+			} );
+			await expect( replyTextbox ).toBeVisible();
+			// The visually hidden label still provides the descriptive
+			// accessible name; only the visible placeholder is gone.
+			await expect( replyTextbox ).toHaveAccessibleName(
+				/^Reply to note \d+ by admin$/
+			);
+			await expect( replyTextbox ).not.toHaveAttribute(
+				'aria-placeholder',
+				/./
+			);
+			await expect(
+				replyTextbox.locator( '[data-rich-text-placeholder]' )
+			).toHaveCount( 0 );
+		} );
+
+		test( 'backtick wrapping applies core/code inline format', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note rich text host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.click();
+			/*
+			 * Typing `code` (backtick-wrapped) should auto-apply
+			 * `core/code`'s inline format via its `__unstableInputRule`.
+			 */
+			await page.keyboard.type( '`code` after' );
+			await expect( textbox.locator( 'code' ) ).toHaveText( 'code' );
+		} );
+	} );
+
+	test.describe( 'Mentions in the note form', () => {
+		let mentionedUserId;
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			const user = await requestUtils.createUser( {
+				username: 'notementions',
+				email: 'notementions@example.com',
+				firstName: 'Mentionable',
+				lastName: 'Teammate',
+				password: 'iLoVeE2EtEsTs',
+			} );
+			mentionedUserId = user.id;
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllUsers();
+		} );
+
+		test( 'inserts a mention chip that survives saving the note', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Mention host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.click();
+			await page.keyboard.type( 'Ping @' );
+
+			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
+
+			// Narrow the suggestions and pick the teammate.
+			await page.keyboard.type( 'Menti' );
+			await expect(
+				page.getByRole( 'option', {
+					name: 'Mentionable Teammate',
+					selected: true,
+				} )
+			).toBeVisible();
+			await page.keyboard.press( 'Enter' );
+
+			/*
+			 * The completer inserts the mention as a chip: a link to the
+			 * user's author page whose `user-N` class carries the mentioned
+			 * user's ID.
+			 */
+			const mentionClasses = new RegExp(
+				`^wp-note-mention user-${ mentionedUserId }$`
+			);
+			const draftChip = textbox.locator( 'a.wp-note-mention' );
+			await expect( draftChip ).toHaveText( '@Mentionable Teammate' );
+			await expect( draftChip ).toHaveClass( mentionClasses );
+			await expect( draftChip ).toHaveAttribute( 'href', /author/ );
+
+			await page.keyboard.type( 'please review' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Add note', exact: true } )
+				.click();
+
+			/*
+			 * The saved thread renders the content returned by the REST API,
+			 * so an intact chip here proves the mention markup survived
+			 * server-side sanitization.
+			 */
+			const savedChip = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem' )
+				.locator( 'a.wp-note-mention' );
+			await expect( savedChip ).toHaveText( '@Mentionable Teammate' );
+			await expect( savedChip ).toHaveClass( mentionClasses );
+		} );
+
+		test( 'can cancel mentions popover', async ( { editor, page } ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Mention host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.pressSequentially( 'Ping @' );
+
+			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
+			await page.keyboard.press( 'Escape' );
+			await expect( page.getByRole( 'listbox' ) ).toBeHidden();
+			await expect( textbox ).toBeFocused();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -138,6 +138,12 @@ test.describe( 'Block Notes', () => {
 				'Command palette should not have opened'
 			).toBeHidden();
 
+			// The popover moves focus to the search input asynchronously;
+			// Escape must reach the popover rather than the reply field.
+			await expect(
+				page.getByRole( 'combobox', { name: 'Search or type URL' } )
+			).toBeFocused();
+
 			/*
 			 * Pressing Escape closes the link popover and leaves the note
 			 * form intact — focus does not get yanked out of the editor.
@@ -189,6 +195,10 @@ test.describe( 'Block Notes', () => {
 			expect( inputBox.x + inputBox.width ).toBeLessThanOrEqual(
 				viewport.width
 			);
+
+			// The popover moves focus to the search input asynchronously;
+			// Escape must reach the popover rather than the reply field.
+			await expect( linkInput ).toBeFocused();
 
 			// Escape closes the popover and keeps the reply form intact.
 			await page.keyboard.press( 'Escape' );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -659,6 +659,7 @@ test.describe( 'Block Notes', () => {
 		} );
 
 		test( 'should collapse a note when the focus moves outside the note', async ( {
+			editor,
 			page,
 			blockNoteUtils,
 		} ) => {
@@ -675,12 +676,17 @@ test.describe( 'Block Notes', () => {
 				.getByRole( 'treeitem', {
 					name: 'Note: Test comment',
 				} );
+			const block = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
 
 			await thread.click();
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+			await expect( block ).toHaveClass( /is-highlighted/ );
 			await page.keyboard.press( 'Shift+Tab' );
 			await expect( thread ).not.toBeFocused();
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
+			await expect( block ).not.toHaveClass( /is-highlighted/ );
 		} );
 
 		test( 'should have accessible name for the note threads', async ( {

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -302,14 +302,15 @@ test.describe( 'Block Notes', () => {
 			await textbox.click();
 			await page.keyboard.type( 'Ping @' );
 
-			await expect(
-				page.getByRole( 'option', { name: 'Mentionable Teammate' } )
-			).toBeVisible();
+			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
 
 			// Narrow the suggestions and pick the teammate.
 			await page.keyboard.type( 'Menti' );
 			await expect(
-				page.getByRole( 'option', { name: 'Mentionable Teammate' } )
+				page.getByRole( 'option', {
+					name: 'Mentionable Teammate',
+					selected: true,
+				} )
 			).toBeVisible();
 			await page.keyboard.press( 'Enter' );
 


### PR DESCRIPTION
## What?
Closes #80226.
A small follow-up to #79604.

Both note forms hand-rolled the "deselect when focus leaves" logic. A timeout/rAF ref, an unmount cleanup effect, manual `setTimeout`/`clearTimeout`/`cancelAnimationFrame`, and a `document.hasFocus()` guard.

The `useFocusOutside` already does this: defers the check, cancels it when focus returns to any React-subtree descendant (including portaled dialogs/menus/popovers), and ignores window/tab blur.

- Swap the manual blur bookkeeping in the note thread and the add-note form for `__experimentalUseFocusOutside`; the deselect logic moves into its callback.
- Drop the now-redundant `contains( relatedTarget )` tab checks. The hook keeps the note selected while focus stays inside it.
- Keep the add-note form open when focus returns to it (e.g., link popover Escape) via a `relatedTarget` guard.
- Read `getSelectedNote` via `useSelect` instead of `useRegistry`.
- Convert the named event handlers to `function` declarations.

## Testing Instructions
Covered by the existing e2e specs: block-notes.spec.js and collaboration-notes.spec.ts. The two Cmd+K popover tests now wait for the popover's search input to be focused before Escape, otherwise Escape can race the async autofocus, hit the note field, and cancel the form (a pre-existing flake surfaced under load).

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
