### PR TITLE
Add contrast checking for viewport and pseudo states

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -234,13 +234,15 @@ export function BackgroundImagePanel( {
 			},
 		} ),
 	};
+	const value = isStateSelected
+		? getStyleForState( style, selectedState )
+		: styleValue;
 
 	// Skipped for gradients, which can't be reliably evaluated for contrast.
 	const enableContrastChecking =
-		! isStateSelected &&
-		! styleValue?.color?.gradient &&
-		! styleValue?.background?.gradient &&
-		!! styleValue?.color?.background &&
+		! value?.color?.gradient &&
+		! value?.background?.gradient &&
+		!! value?.color?.background &&
 		( settings?.color?.text || settings?.color?.link ) &&
 		false !== getBlockSupport( name, [ 'color', 'enableContrastChecker' ] );
 
@@ -386,11 +388,7 @@ export function BackgroundImagePanel( {
 			settings={ updatedSettings }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
-			value={
-				isStateSelected
-					? getStyleForState( style, selectedState )
-					: styleValue
-			}
+			value={ value }
 			contrastWarning={ contrastWarning }
 		/>
 	);

--- a/packages/block-editor/src/hooks/elements.js
+++ b/packages/block-editor/src/hooks/elements.js
@@ -93,7 +93,6 @@ export function ElementsEdit( {
 	// Text and background color failures are reported by the Typography and
 	// Background panels, which own those selections.
 	const enableContrastChecking =
-		! isStateSelected &&
 		!! value?.elements?.link?.color?.text &&
 		settings?.color?.link &&
 		false !==

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -214,7 +214,6 @@ export function TypographyPanel( {
 	// Link color failures are reported by the Elements panel, which owns the
 	// link color selection.
 	const enableContrastChecking =
-		! isStateSelected &&
 		! value?.color?.gradient &&
 		!! value?.color?.text &&
 		settings?.color?.text &&

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -98,6 +98,64 @@ test.describe( 'Contrast Checker', () => {
 		await textButton.click();
 	} );
 
+	test( 'should show warning in both the Typography and Background panels for viewport states', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Black text on Black background' },
+		} );
+
+		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
+		await page
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.click();
+		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
+		await page.keyboard.press( 'Escape' );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		const typographyPanel = editorSettings
+			.locator( '.components-tools-panel' )
+			.filter( {
+				has: page.getByRole( 'heading', { name: 'Typography' } ),
+			} );
+		const backgroundPanel = editorSettings
+			.locator( '.components-tools-panel' )
+			.filter( {
+				has: page.getByRole( 'heading', { name: 'Background' } ),
+			} );
+
+		const textButton = typographyPanel.getByRole( 'button', {
+			name: 'Color',
+			exact: true,
+		} );
+		const backgroundButton = backgroundPanel.getByRole( 'button', {
+			name: 'Color',
+			exact: true,
+		} );
+
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await textButton.click();
+
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await backgroundButton.click();
+
+		await expect(
+			typographyPanel.locator( WARNING_SELECTOR )
+		).toBeVisible();
+		await expect(
+			backgroundPanel.locator( WARNING_SELECTOR )
+		).toBeVisible();
+	} );
+
 	test( 'should not show warning for sufficient contrast', async ( {
 		editor,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #78305.

Mostly a matter of switching a few flags that were disabling the contrast check for style states.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add some Paragraphs and Buttons to a post
2. Enable responsive editing and change their color and background color to different combinations in default, mobile and tablet; observe contrast checker appearing when values are too close
3. Also check hover/focus etc and their combinations with mobile/tablet for the Button block

## Screenshots or screencast <!-- if applicable -->

<img width="988" height="654" alt="Screenshot 2026-07-14 at 3 33 35 pm" src="https://github.com/user-attachments/assets/f71c2bb1-2eb2-41ed-bf36-44b2bfa4f29c" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

codex/gpt 5.6