### PR TITLE
Notes: Allow canceling the autocompleter popover with Escape without dismissing the note form

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -101,7 +101,7 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 					return;
 				}
 
-				if ( event.key === 'Escape' ) {
+				if ( event.key === 'Escape' && ! event.defaultPrevented ) {
 					event.preventDefault();
 					// Passing event for reply forms.
 					onCancel( event );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -344,6 +344,24 @@ test.describe( 'Block Notes', () => {
 			await expect( savedChip ).toHaveText( '@Mentionable Teammate' );
 			await expect( savedChip ).toHaveClass( mentionClasses );
 		} );
+
+		test( 'can cancel mentions popover', async ( { editor, page } ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Mention host' },
+			} );
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			const textbox = page.getByRole( 'textbox', {
+				name: 'New note',
+				exact: true,
+			} );
+			await textbox.pressSequentially( 'Ping @' );
+
+			await expect( page.getByRole( 'listbox' ) ).toBeVisible();
+			await page.keyboard.press( 'Escape' );
+			await expect( page.getByRole( 'listbox' ) ).toBeHidden();
+			await expect( textbox ).toBeFocused();
+		} );
 	} );
 
 	test( 'can reply to a block note', async ( { page, blockNoteUtils } ) => {


### PR DESCRIPTION
## What?
PR fixes a bug when canceling the autocompleter popover with <kbd>Escape</kbd>, also dismisses the note form. I've also added an e2e test for this case.

## Testing Instructions
1. Open a post.
2. Start adding a new note to the block.
3. Type `@` to trigger the autocompleter.
4. Press <kbd>Escape</kbd> to cancel the popover.
5. Confirm that the new note form stays open.

## Use of AI Tools

None.
