### PR TITLE
Blocks: Rename _wp_apply_content_filters() to _wp_apply_block_content_filters()

### DIFF
--- a/backport-changelog/7.1/12421.md
+++ b/backport-changelog/7.1/12421.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/12421
 
 * https://github.com/WordPress/gutenberg/pull/74866
 * https://github.com/WordPress/gutenberg/pull/80191
+* https://github.com/WordPress/gutenberg/pull/80191

--- a/lib/compat/wordpress-7.1/blocks.php
+++ b/lib/compat/wordpress-7.1/blocks.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( '_wp_apply_content_filters' ) ) {
+if ( ! function_exists( '_wp_apply_block_content_filters' ) ) {
 	/**
 	 * Applies standard content filters similar to 'the_content' filter.
 	 *
@@ -35,7 +35,7 @@ if ( ! function_exists( '_wp_apply_content_filters' ) ) {
 	 * @param string|null $id       Optional. Unique identifier for this content, used with $seen_ids. Default null.
 	 * @return string The processed content.
 	 */
-	function _wp_apply_content_filters( $content, $context = '', &$seen_ids = null, $id = null ) {
+	function _wp_apply_block_content_filters( $content, $context = '', &$seen_ids = null, $id = null ) {
 		$content = shortcode_unautop( $content );
 		$content = do_shortcode( $content );
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -202,7 +202,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 					try {
 						// Run through the actions that are typically taken on the_content.
-						$post_content = _wp_apply_content_filters( $post_content, 'latest-posts' );
+						$post_content = _wp_apply_block_content_filters( $post_content, 'latest-posts' );
 					} finally {
 						array_pop( $rendering_stack );
 					}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -150,7 +150,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	// Run through the actions that are typically taken on the_content.
-	$content = _wp_apply_content_filters( $content, "template_part_{$area}", $seen_ids, $template_part_id );
+	$content = _wp_apply_block_content_filters( $content, "template_part_{$area}", $seen_ids, $template_part_id );
 
 	if ( empty( $attributes['tagName'] ) || tag_escape( $attributes['tagName'] ) !== $attributes['tagName'] ) {
 		$area_tag = 'div';

--- a/phpunit/blocks/render-latest-posts-test.php
+++ b/phpunit/blocks/render-latest-posts-test.php
@@ -78,17 +78,17 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that _wp_apply_content_filters() works.
+	 * Test that _wp_apply_block_content_filters() works.
 	 *
-	 * @covers ::_wp_apply_content_filters
+	 * @covers ::_wp_apply_block_content_filters
 	 */
-	public function test_wp_apply_content_filters_works() {
+	public function test_wp_apply_block_content_filters_works() {
 		// Check if the function exists.
-		$this->assertTrue( function_exists( '_wp_apply_content_filters' ), '_wp_apply_content_filters function should exist' );
+		$this->assertTrue( function_exists( '_wp_apply_block_content_filters' ), '_wp_apply_block_content_filters function should exist' );
 
 		// Test with paragraph block.
 		$content = '<!-- wp:paragraph --><p>Test paragraph</p><!-- /wp:paragraph -->';
-		$output  = _wp_apply_content_filters( $content, 'test-context' );
+		$output  = _wp_apply_block_content_filters( $content, 'test-context' );
 
 		// Block comments should be removed.
 		$this->assertStringNotContainsString( '<!-- wp:paragraph -->', $output, 'Block comments should be removed' );
@@ -127,7 +127,7 @@ class Tests_Blocks_RenderLatestPosts extends WP_UnitTestCase {
 			$attachment_id_2
 		);
 
-		// Apply the same filters that _wp_apply_content_filters does.
+		// Apply the same filters that _wp_apply_block_content_filters does.
 		$processed_content = shortcode_unautop( $gallery_content );
 		$processed_content = do_shortcode( $processed_content );
 		$gallery_output    = do_blocks( $processed_content );


### PR DESCRIPTION
## What?
Follow up to #80191

Renames `_wp_apply_content_filters()` to `_wp_apply_block_content_filters()`.

## Why?

#80191 renamed the helper to the name it was expected to have in Core, but the name was wrong: the Core backport is landing it as `_wp_apply_block_content_filters()`, with the `block` part included.

## Testing Instructions

This is a rename with no behavior change. Confirm that all CI checks are green.

## Use of AI Tools

This PR was authored with the assistance of Claude Code. The change was reviewed by me.
