### PR TITLE
Suggest mode: Reject type-over overlapping a suggestion marker

### DIFF
--- a/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
@@ -5,6 +5,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,6 +31,32 @@ import {
 	readEventRange,
 } from './keyboard-target';
 import { isPartOfPendingInsertion } from './store-interceptor';
+
+/**
+ * Outcomes returned by the internal `insertText` router, telling the event
+ * handlers whether — and why — to cancel the browser's native edit:
+ *
+ * - `HANDLED`  we wrote the suggestion ourselves; cancel the native edit.
+ * - `REJECTED` we deliberately declined to write a suggestion (e.g. a type-over
+ *              whose selection overlaps an existing marker) but must still
+ *              cancel the native edit, because letting the browser edit a DOM
+ *              that contains `<mark>` markers corrupts them (dropped leading
+ *              space, fragmented marker, occasionally an emptied block — see
+ *              #79799). The keystroke is swallowed with no content change.
+ * - `DEFERRED` there is no valid inline anchor to own the edit (block-level
+ *              selection, a pending block insertion); let it fall through to
+ *              the native/overlay path *without* a `preventDefault`.
+ *
+ * Only `DEFERRED` falls through; `HANDLED` and `REJECTED` both cancel.
+ */
+const INSERT_HANDLED = 'handled';
+const INSERT_REJECTED = 'rejected';
+const INSERT_DEFERRED = 'deferred';
+
+// Stable id for the "can't type over a suggestion" snackbar. Reusing one id
+// means a burst of rejected keystrokes refreshes a single notice rather than
+// stacking one per character.
+const OVERLAP_REJECTED_NOTICE_ID = 'editor/suggestion-mode/type-over-rejected';
 
 /**
  * Turn typing (and simple paste) in Suggest mode into an inline addition
@@ -88,6 +116,26 @@ export default function SuggestionAdditionKeyboard() {
 	const { getBlockName } = useSelect( blockEditorStore );
 	const { requestInterceptorBypass, isDeferredInsertion } =
 		useSuggestionOverlay();
+	const { createNotice } = useDispatch( noticesStore );
+
+	// Tell the user why their keystroke did nothing when they type over a
+	// selection that overlaps an existing suggestion. Building a combined
+	// deletion+addition suggestion here is a later phase; until then the edit
+	// is rejected (see the overlap guard in `insertText`), and without this
+	// cue the swallowed keystroke reads as an unresponsive editor.
+	const notifyOverlapRejected = useCallback( () => {
+		createNotice(
+			'info',
+			__(
+				'You can’t type over an existing suggestion. Accept or reject it first.'
+			),
+			{
+				id: OVERLAP_REJECTED_NOTICE_ID,
+				type: 'snackbar',
+				isDismissible: true,
+			}
+		);
+	}, [ createNotice ] );
 
 	// The in-progress addition run. `id` is null while the suggestion note is
 	// being created; characters entered in that window queue in `pending` and
@@ -266,10 +314,10 @@ export default function SuggestionAdditionKeyboard() {
 	 * marker when the caret is still at its trailing edge, or start a new run.
 	 * `allowGrow` is false for paste so a pasted run is always its own marker.
 	 *
-	 * Returns whether the input was consumed. Callers must only cancel the
-	 * native edit when this returns true — when no valid single-attribute
-	 * anchor exists the input has to fall through to the native/overlay path
-	 * rather than being swallowed.
+	 * Returns one of `INSERT_HANDLED` / `INSERT_REJECTED` / `INSERT_DEFERRED`.
+	 * Callers cancel the native edit for the first two and let it fall through
+	 * for `INSERT_DEFERRED` — when no valid single-attribute anchor exists the
+	 * input has to reach the native/overlay path rather than being swallowed.
 	 *
 	 * `domRange` carries the DOM-derived offsets for the edit
 	 * (`readEventRange`); the store caret is only trusted for block/attribute
@@ -297,14 +345,14 @@ export default function SuggestionAdditionKeyboard() {
 					caret.attributeKey === inFlight.attributeKey
 				) {
 					inFlight.pending += text;
-					return true;
+					return INSERT_HANDLED;
 				}
 				resetRun();
 			}
 			if ( ! caret ) {
 				// Block-level / cross-attribute selection: nothing to anchor to.
 				resetRun();
-				return false;
+				return INSERT_DEFERRED;
 			}
 			const { clientId, attributeKey } = caret;
 			/*
@@ -324,7 +372,7 @@ export default function SuggestionAdditionKeyboard() {
 				)
 			) {
 				resetRun();
-				return false;
+				return INSERT_DEFERRED;
 			}
 			/*
 			 * Offsets come from the DOM truth at input time when available.
@@ -347,11 +395,15 @@ export default function SuggestionAdditionKeyboard() {
 				 * Type-over of a selection that overlaps an existing
 				 * suggestion marker: wrapping it in the `del` marker would
 				 * re-attribute part of that marker to the new id (see
-				 * `formatsRangeHasSuggestion`). Fall through to the
-				 * native/overlay path instead of intercepting.
+				 * `formatsRangeHasSuggestion`), so we decline to build a
+				 * combined suggestion here — that is left to a later phase.
+				 * Reject rather than fall through to native editing (which
+				 * corrupts the marker DOM — see `INSERT_REJECTED`), and tell
+				 * the user why nothing happened.
 				 */
 				resetRun();
-				return false;
+				notifyOverlapRejected();
+				return INSERT_REJECTED;
 			}
 			const run = runRef.current;
 			const isContiguous =
@@ -377,11 +429,11 @@ export default function SuggestionAdditionKeyboard() {
 				} );
 				run.end += text.length;
 				commit( clientId, attributeKey, grown, run.end );
-				return true;
+				return INSERT_HANDLED;
 			}
 
 			beginInsertion( clientId, attributeKey, start, end, text );
-			return true;
+			return INSERT_HANDLED;
 		},
 		[
 			getSelectionStart,
@@ -392,6 +444,7 @@ export default function SuggestionAdditionKeyboard() {
 			beginInsertion,
 			commit,
 			resetRun,
+			notifyOverlapRejected,
 			authorId,
 		]
 	);
@@ -423,12 +476,17 @@ export default function SuggestionAdditionKeyboard() {
 				return;
 			}
 			/*
-			 * We own insertion in Suggest mode, but only cancel the native
-			 * edit once the caret resolved to a valid single-attribute anchor
-			 * — a preventDefault without a subsequent write would silently
-			 * drop the typed character.
+			 * We own insertion in Suggest mode. Cancel the native edit when
+			 * we either wrote the suggestion (`HANDLED`) or deliberately
+			 * declined but must not let the browser touch the marker DOM
+			 * (`REJECTED`). Only `DEFERRED` — no valid single-attribute anchor
+			 * — falls through, since a preventDefault without a subsequent
+			 * write would silently drop the typed character.
 			 */
-			if ( insertText( text, true, readEventRange( event ) ) ) {
+			if (
+				insertText( text, true, readEventRange( event ) ) !==
+				INSERT_DEFERRED
+			) {
 				event.preventDefault();
 			}
 		},
@@ -461,8 +519,13 @@ export default function SuggestionAdditionKeyboard() {
 			 * otherwise let the editor's paste pipeline have it.
 			 */
 			// A clipboard event exposes no target ranges; `readEventRange`
-			// falls back to the live DOM selection.
-			if ( insertText( plain, false, readEventRange( event ) ) ) {
+			// falls back to the live DOM selection. A paste over a selection
+			// that overlaps a marker is `REJECTED` — cancel it rather than let
+			// the native paste corrupt the marker DOM (see `onBeforeInput`).
+			if (
+				insertText( plain, false, readEventRange( event ) ) !==
+				INSERT_DEFERRED
+			) {
 				event.preventDefault();
 				event.stopImmediatePropagation();
 			}

--- a/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
@@ -222,6 +222,83 @@ test.describe( 'Suggest mode: overlay-retirement safety net (Phase 0)', () => {
 		await expect( formatMark ).toHaveText( 'world' );
 	} );
 
+	/*
+	 * Regression (#79799): typing over a selection that still overlaps an
+	 * existing marker. The addition keyboard declines to build a combined
+	 * deletion+addition suggestion here (that is a later phase — wrapping the
+	 * overlapping run in a `del` would re-attribute part of the existing
+	 * marker). The bug was that it declined by *falling through* to native
+	 * `contentEditable`, which edited a DOM that still contained the `<mark>`
+	 * and corrupted it: the leading space was dropped, the format marker was
+	 * fragmented into several `<mark>` segments, and the paragraph sometimes
+	 * emptied entirely. The fix rejects the keystroke instead — cancel the
+	 * native edit and make no change — so the marker and text are untouched.
+	 */
+	test( 'type-over of a selection overlapping a marker is rejected, not corrupted', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello world' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+
+		// Format marker: bold the trailing word "world".
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 5 } );
+		await pageUtils.pressKeys( 'primary+b' );
+		const formatMark = paragraph.locator(
+			`${ SUGGESTION_MARK }[data-suggestion-type="format"]`
+		);
+		await expect( formatMark ).toContainText( 'world' );
+
+		/*
+		 * The format-marker write re-renders RichText and restores the
+		 * selection over "world", so "world" is still selected. Type WITHOUT
+		 * collapsing the caret first: every keystroke is a type-over whose
+		 * selection overlaps the format marker — the exact #79799 trigger.
+		 */
+		await page.keyboard.type( ' more' );
+
+		// Rejected: no addition marker was created…
+		await expect(
+			paragraph.locator(
+				`${ SUGGESTION_MARK }[data-suggestion-type="add"]`
+			)
+		).toHaveCount( 0 );
+		// …the format marker was neither fragmented nor lost (still exactly one
+		// marker, still spanning "world" — a fragmented marker fails strict
+		// `toHaveText`)…
+		await expect( paragraph.locator( SUGGESTION_MARK ) ).toHaveCount( 1 );
+		await expect( formatMark ).toHaveText( 'world' );
+		// …and no marker ended up nested inside another.
+		await expect(
+			paragraph.locator( `${ SUGGESTION_MARK } ${ SUGGESTION_MARK }` )
+		).toHaveCount( 0 );
+		// The paragraph text is unchanged: nothing typed, nothing dropped, the
+		// block not emptied.
+		await expect
+			.poll( () => paragraph.textContent() )
+			.toBe( 'Hello world' );
+		// The user is told why the keystroke did nothing, so the rejection does
+		// not read as an unresponsive editor. Scope to the snackbar itself: the
+		// same copy is also mirrored into the `#a11y-speak-polite` live region,
+		// so a bare text match is ambiguous under Playwright strict mode.
+		await expect(
+			page
+				.getByTestId( 'snackbar' )
+				.filter( { hasText: /Accept or reject it first/i } )
+		).toBeVisible();
+	} );
+
 	// --- Seams (close in Phase 1) -----------------------------------------
 
 	test( 'seam: deleting a word backward becomes a deletion marker', async ( {


### PR DESCRIPTION
## What?

In Suggesting mode, typing over a selection that overlaps an existing inline suggestion marker now cleanly rejects the keystroke (with a snackbar explaining why) instead of falling through to native editing, which corrupted the content.

Part of #73411. Fixes #79799.

## Why?

The addition/deletion keyboards intentionally decline to build a suggestion when the current selection overlaps an existing marker (wrapping the range in a `del` would re-attribute part of that marker to a new id). The problem was *how* the addition keyboard declined: it returned without cancelling the event, so the browser edited a DOM that still contained the `<mark class="wp-suggestion">`. That native surgery corrupted the content:

- the typed leading space was dropped,
- the marker was fragmented into several `<mark>` segments, and
- the paragraph occasionally emptied entirely.

This is the pre-existing behaviour documented in #79799 (not a regression from the `readEventRange` DOM-caret work in #79714 / #79752).

## How?

- `suggestion-addition-keyboard.js`: `insertText` now returns a tri-state — `INSERT_HANDLED` (wrote a suggestion), `INSERT_REJECTED` (deliberately declined but must still cancel native editing), `INSERT_DEFERRED` (no valid inline anchor — let it fall through). The `onBeforeInput` / `onPaste` handlers `preventDefault` on `HANDLED` and `REJECTED`, and only fall through for `DEFERRED`. The type-over-overlap guard returns `REJECTED`, so the browser never touches the marker DOM.
- A snackbar ("You can't type over an existing suggestion. Accept or reject it first.") is shown on reject — with a stable notice id so a burst of keystrokes refreshes one notice instead of stacking — so the swallowed keystroke doesn't read as an unresponsive editor.
- Building a well-formed **combined** deletion+addition suggestion for this case is left to a follow-up phase; this PR guarantees the "cleanly rejected, no content change" outcome from the issue.

### Why the deletion/cut guards are left unchanged

They share the same structural shape, but their fall-through is already captured cleanly as a whole-attribute suggestion (the reconciler + store interceptor), pinned by the existing e2e test *"seam: a delete straddling an existing marker never corrupts it"*. Rejecting them would remove that working behaviour, so this PR scopes to the addition type-over that actually corrupts.

## Testing Instructions

1. Enable the **Suggestion Mode** experiment (Gutenberg → Experiments).
2. Add a paragraph `Hello world` and switch the editor mode to **Suggesting**.
3. Select `world` and press `Ctrl/Cmd+B` — `world` gets wrapped in a format suggestion marker.
4. With `world` still selected (do not collapse the caret), type ` more`.

**Expected:** nothing is inserted, the paragraph still reads `Hello world`, the `world` marker stays a single intact `<mark>` (no dropped space, no fragmented markers, block not emptied), and a snackbar explains why the keystroke did nothing.

**Automated:** `test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js` adds a regression test (*"type-over of a selection overlapping a marker is rejected, not corrupted"*). Whole spec passes locally (9/9), including the delete-straddle test that proves no regression.

## Screenshots or screencast

Before - 
<img width="1248" height="694" alt="Image" src="https://github.com/user-attachments/assets/6338ae39-5bff-4e87-a805-80b2f04b2939" />

After -
<img width="1470" height="801" alt="image" src="https://github.com/user-attachments/assets/6e624faa-372c-4c9a-88c8-ea3f045d3d4c" />

Usage of AI

Claude Code - Opus 4.8