### PR TITLE
Image block: Validate URL before accepting as image and check upload permissions for external images

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -330,7 +330,13 @@ export function ImageEdit( {
 		const normalizedNewURL = getProtocol( newURL )
 			? newURL
 			: prependHTTPS( newURL );
-		if ( normalizedNewURL !== url ) {
+
+		if ( normalizedNewURL === url ) {
+			return;
+		}
+
+		const testImage = new window.Image();
+		testImage.onload = () => {
 			setAttributes( {
 				blob: undefined,
 				url: normalizedNewURL,
@@ -338,7 +344,14 @@ export function ImageEdit( {
 				sizeSlug: getSettings().imageDefaultSize,
 			} );
 			setTemporaryURL();
-		}
+		};
+		testImage.onerror = () => {
+			createErrorNotice(
+				__( 'The provided URL could not be loaded as an image.' ),
+				{ type: 'snackbar' }
+			);
+		};
+		testImage.src = normalizedNewURL;
 	}
 
 	useUploadMediaFromBlobURL( {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -461,6 +461,11 @@ export default function Image( {
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
+	const hasUploadPermissions = useSelect( ( select ) => {
+		const { canUser } = select( coreStore );
+		return canUser( 'create', 'media' ) ?? true;
+	}, [] );
+
 	/*
 	 * Externally hosted images can be uploaded to the media library. The
 	 * server sideloads the URL (see mediaSideloadFromUrl), so this works even
@@ -470,7 +475,8 @@ export default function Image( {
 	const canUploadExternalImage =
 		isSingleSelected &&
 		isExternalImage( id, url ) &&
-		!! getSettings()[ mediaSideloadFromUrlKey ];
+		!! getSettings()[ mediaSideloadFromUrlKey ] &&
+		hasUploadPermissions;
 
 	// Get naturalWidth and naturalHeight from image, and fall back to loaded natural
 	// width and height. This resolves an issue in Safari where the loaded natural


### PR DESCRIPTION
## What?
Closes #46326

Fixes two related bugs in the Image block's "Insert from URL" flow:
1. Typing plain text (not an actual image URL) into the "Insert from URL" dialog was accepted as-is and the block would switch into full "valid image" editing UI (resize handles, dimension controls, upload-to-media-library button) even though nothing had actually loaded.
2. The "Upload to media library" toolbar button was shown regardless of whether the current user actually has permission to upload media.

## Why?
The Image block should only present itself as having a valid image, and only offer to upload something to the media library, once there is actually a loadable image at the given URL and the user is permitted to upload it. Without these checks, submitting arbitrary text in the URL popover silently produced a broken block that still exposed image-editing controls, and clicking "Upload" on it surfaced a raw `Invalid parameter(s): url` server error instead of a helpful message. Separately, showing the upload button to users without upload capabilities is misleading, since attempting to use it would only fail.

## Testing Instructions
1. Add an Image block.
2. Click "Insert from URL".
3. Type a plain word like `hello` and submit.
4. **Before:** the block became a "valid" image block, you could change image settings, and the (visible-to-anyone) "Upload to media library" button was shown; clicking it produced `undefined: Invalid parameter(s): url`.
5. **After:** an error notice appears ("The provided URL could not be loaded as an image.") and the block stays in its placeholder/"Insert from URL" state, no image settings or upload button are shown.
6. Repeat with a real image URL (e.g. an actual `.jpg`/`.png` URL) and confirm the block still becomes a normal, fully editable image block as expected.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/7d36ab0d-4d85-47c5-9dcc-287ed9bc71c7

