### PR TITLE
Autop: Preserve anchors around block elements

### DIFF
--- a/packages/autop/src/index.ts
+++ b/packages/autop/src/index.ts
@@ -138,6 +138,8 @@ function replaceInHtmlTags(
  */
 export function autop( text: string, br: boolean = true ): string {
 	const preTags: Array< [ string, string ] > = [];
+	let hasBlockAnchor = false;
+	let blockAnchorPlaceholder = '';
 
 	if ( text.trim() === '' ) {
 		return '';
@@ -176,8 +178,40 @@ export function autop( text: string, br: boolean = true ): string {
 	// Change multiple <br>s into two line breaks, which will turn into paragraphs.
 	text = text.replace( /<br\s*\/?>\s*<br\s*\/?>/g, '\n\n' );
 
-	const allBlocks =
+	let allBlocks =
 		'(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+
+	/*
+	 * Anchors can contain block-level elements. Replace their tags with temporary
+	 * block-level placeholders so the paragraph cleanup does not split the anchor.
+	 */
+	if ( text.indexOf( '<a' ) !== -1 ) {
+		blockAnchorPlaceholder = 'wp-autop-block-anchor';
+
+		while ( text.indexOf( '<' + blockAnchorPlaceholder ) !== -1 ) {
+			blockAnchorPlaceholder += '-';
+		}
+
+		text = text.replace(
+			new RegExp(
+				'<a(\\b[^>]*)>(?=\\s*<' +
+					allBlocks +
+					'[\\s/>])([\\s\\S]*?)(</a>)',
+				'g'
+			),
+			'<' +
+				blockAnchorPlaceholder +
+				'$1>$2</' +
+				blockAnchorPlaceholder +
+				'>'
+		);
+		hasBlockAnchor = text.indexOf( '<' + blockAnchorPlaceholder ) !== -1;
+
+		if ( hasBlockAnchor ) {
+			allBlocks =
+				allBlocks.slice( 0, -1 ) + '|' + blockAnchorPlaceholder + ')';
+		}
+	}
 
 	// Add a double line break above block-level opening tags.
 	text = text.replace(
@@ -265,6 +299,19 @@ export function autop( text: string, br: boolean = true ): string {
 	text = text.replace( /<p><blockquote([^>]*)>/gi, '<blockquote$1><p>' );
 	text = text.replace( /<\/blockquote><\/p>/g, '</p></blockquote>' );
 
+	// Move paragraphs inside anchors that contain block-level elements.
+	if ( hasBlockAnchor ) {
+		text = text.replace(
+			new RegExp( '<p>(<' + blockAnchorPlaceholder + '[^>]*>)', 'g' ),
+			'$1<p>'
+		);
+		text = text.replace(
+			new RegExp( '(</' + blockAnchorPlaceholder + '>)</p>', 'g' ),
+			'</p>$1'
+		);
+		text = text.replace( /<p>\s*<\/p>/g, '' );
+	}
+
 	// If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
 	text = text.replace(
 		new RegExp( '<p>\\s*(</?' + allBlocks + '[^>]*>)', 'g' ),
@@ -319,6 +366,18 @@ export function autop( text: string, br: boolean = true ): string {
 	// Restore newlines in all elements.
 	if ( -1 !== text.indexOf( '<!-- wpnl -->' ) ) {
 		text = text.replace( /\s?<!-- wpnl -->\s?/g, '\n' );
+	}
+
+	// Restore anchors that contain block-level elements.
+	if ( hasBlockAnchor ) {
+		text = text.replace(
+			new RegExp( '<' + blockAnchorPlaceholder, 'g' ),
+			'<a'
+		);
+		text = text.replace(
+			new RegExp( '</' + blockAnchorPlaceholder + '>', 'g' ),
+			'</a>'
+		);
 	}
 
 	return text;

--- a/packages/autop/src/test/index.test.ts
+++ b/packages/autop/src/test/index.test.ts
@@ -437,6 +437,20 @@ test( 'that autop treats inline elements as inline', () => {
 	expect( autop( contentString ).trim() ).toBe( expectedString );
 } );
 
+test( 'that autop does not split anchors containing block elements', () => {
+	let content = '<a href="document.htm"><div>Text</div></a>';
+	let expected = '<a href="document.htm">\n<div>Text</div>\n</a>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+
+	content =
+		'<a href="document.htm"><div>First</div><section>Second</section></a>';
+	expected =
+		'<a href="document.htm">\n<div>First</div>\n<section>Second</section>\n</a>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
 test( 'element sanity', () => {
 	[
 		[ 'Hello <a\nhref="world">', '<p>Hello <a\nhref="world"></p>\n' ],


### PR DESCRIPTION
## What?

Updates `@wordpress/autop` to preserve an anchor that wraps one or more block-level elements.

See https://core.trac.wordpress.org/ticket/40202
Companion to https://github.com/WordPress/wordpress-develop/pull/12512

## Why?

The JavaScript implementation currently splits the anchor into separate invalid paragraphs, matching the PHP regression reported in Trac #40202.

## How?

Block-wrapping anchors are temporarily represented as collision-safe block placeholders during paragraph cleanup, then restored. Regression coverage includes anchors containing one and multiple block elements.

## Testing Instructions

1. Run `npm run test:unit -- packages/autop/src/test/index.test.ts --runInBand`.
2. Confirm all 19 tests pass.
3. Run `npm run lint:js -- packages/autop/src/index.ts packages/autop/src/test/index.test.ts`.
4. Run `npm exec tsc -- --noEmit --project packages/autop/tsconfig.json`.

### Testing Instructions for Keyboard

Not applicable; this does not change UI interactions.

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Synchronizing the PHP fix with the TypeScript implementation, adding regression coverage, validation, and pull request drafting; the final changes were reviewed and validated by the contributor.