### PR TITLE
Theme: Correct documented default background seed

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -25,6 +25,7 @@ This package is now considered stable and production-ready. The API will follow 
 
 ### Documentation
 
+-   Correct the documented default `ThemeProvider` background seed to `#fcfcfc` ([#80237](https://github.com/WordPress/gutenberg/pull/80237)).
 -   Remove the experimental messaging from the package README and update the package keywords to reflect its stable design system purpose ([#80049](https://github.com/WordPress/gutenberg/pull/80049)).
 -   Clarify what `@wordpress/theme` provides, when consumers need to load `design-tokens.css`, the `ThemeProvider` contract including root provider usage, and the legacy compatibility boundary ([#79961](https://github.com/WordPress/gutenberg/pull/79961)).
 -   Document build plugin behavior and add parity coverage for PostCSS, esbuild, and Vite ([#80088](https://github.com/WordPress/gutenberg/pull/80088)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -102,7 +102,7 @@ function App() {
 The `color` prop accepts an object with the following optional properties:
 
 -   `primary`: The primary/accent seed color (default: `'#3858e9'`).
--   `background`: The background seed color (default: `'#f8f8f8'`).
+-   `background`: The background seed color (default: `'#fcfcfc'`).
 
 Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps and determines light/dark mode based on these seed colors.
 


### PR DESCRIPTION
Follow-up to #77462

## What?

Correct the documented default `ThemeProvider` background seed from `#f8f8f8` to `#fcfcfc` and record the documentation fix in the package changelog.

## Why?

The README did not match `DEFAULT_SEED_COLORS`, the generated design tokens, or the default ramp snapshots.

## How?

Align the README with the existing runtime default. No behavior changes.

## Testing Instructions

1. Confirm the README lists `#fcfcfc` as the default `color.background` seed.
2. Confirm it matches `DEFAULT_SEED_COLORS.background`.
3. Run `git diff --check`.

## Use of AI Tools

Codex was used to identify the documentation mismatch, make the scoped edit, verify it against the implementation, and prepare this draft PR.