### PR TITLE
Rename 'Responsive editing' toggle to 'Responsive styles'

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -196,7 +196,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								'Style changes apply only to the selected viewport.'
 							) }
 						>
-							{ __( 'Responsive editing' ) }
+							{ __( 'Responsive styles' ) }
 						</MenuItem>
 					</MenuGroup>
 					{ isTemplate && (

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -594,7 +594,7 @@ test.describe( 'Cover', () => {
 
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive styles' } )
 			.click();
 		await page.getByRole( 'menuitemradio', { name: 'Tablet' } ).click();
 		await page.keyboard.press( 'Escape' );

--- a/test/e2e/specs/editor/various/block-style-state-colors.spec.js
+++ b/test/e2e/specs/editor/various/block-style-state-colors.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Relocated color controls with block style states', () => {
 
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive styles' } )
 			.click();
 		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
 		await page.keyboard.press( 'Escape' );
@@ -79,7 +79,7 @@ test.describe( 'Relocated color controls with block style states', () => {
 		// Switch the block's editing context to the Mobile viewport state.
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive styles' } )
 			.click();
 		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
 		await page.keyboard.press( 'Escape' );
@@ -147,7 +147,7 @@ test.describe( 'Relocated color controls with block style states', () => {
 
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive styles' } )
 			.click();
 		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
 		await page.keyboard.press( 'Escape' );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -111,7 +111,7 @@ test.describe( 'Contrast Checker', () => {
 
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Responsive editing' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Responsive styles' } )
 			.click();
 		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
 		await page.keyboard.press( 'Escape' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It occurred to me that in previous PRs #80146 and #79999, the preview dropdown copy was updated to remove 'edit' in favour of 'style', but the main button text still says 'Responsive editing'. It could still lead users to think any edits work responsively if they don't bother reading the small text.

In this PR I'm proposing to change it to 'Responsive styles'.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="259" height="382" alt="Screenshot 2026-07-14 at 5 20 10 pm" src="https://github.com/user-attachments/assets/3d7b872b-c327-4d46-b189-5e2825cb8fe7" /> | <img width="259" height="380" alt="Screenshot 2026-07-14 at 5 19 30 pm" src="https://github.com/user-attachments/assets/fbb9f068-585b-4941-a423-7aac3a74a805" /> |

## Use of AI Tools
None