### PR TITLE
Simplify view config data updates

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -85,75 +85,56 @@ DataViews-powered screens (such as the Pages list and its Quick Edit form) build
 
 The configuration has four keys: `default_view`, `default_layouts`, `view_list` (the saved views shown in the list), and `form` (the DataForm used by consumers like Quick Edit).
 
-The filter receives an object holding the entity's view configuration. Change the configuration by calling its methods and return the object. Each method merges a partial change (a patch) into one part of the configuration, and patches follow three shared rules: an associative array merges key by key, a numerically indexed array replaces the current value wholesale, and `null` deletes what it names.
+The filter receives an object holding the entity's view configuration. Change the configuration by passing a versioned contribution to `update_with( $new_data )` and return the object. Contributions follow three shared rules: an associative array merges key by key, a numerically indexed array replaces the current value wholesale, and `null` deletes what it names. Passing `null` for a whole top-level key resets it to its default.
 
--   `update_properties( $patch, $version )` merges into `default_view`, `default_layouts`, and the `form` properties other than its `fields`. Passing `null` for a whole top-level key resets it to its default.
--   `update_view_list_items( $items, $version )` adds, updates, or removes views in the `view_list`, keyed by `slug`: a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view.
--   `update_form_fields( $fields, $version )` adds, updates, or removes `form` fields, keyed by `id`. A field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id: a matching field merges in place, an unknown id appends a new field, and `null` removes the field. Within a field patch, `children` follows the shared rules: an associative array merges into the group's children by `id` (unknown ids append to the group), a numerically indexed array replaces the children wholesale, and `null` deletes the key.
+The `view_list` and `form.fields` lists also support identity-aware patches. For `view_list`, pass an associative array keyed by view `slug` to add, update, or remove individual views: a matching view merges in place, an unknown slug appends a new view to the end, and `null` removes the view. For `form.fields`, pass an associative array keyed by field `id`; the field is found wherever it lives — at the top level or nested inside a group's `children` — so a patch only needs the id. Within a field patch, `children` follows the shared rules: an associative array merges into the group's children by `id` (unknown ids append to the group), a numerically indexed array replaces the children wholesale, and `null` deletes the key.
 
 For form fields, the id always lives in the patch key and the value only carries overrides, so a new field with no overrides is expressed as `'my_field' => array()` — not `array( 'my_field' )`, which is a numerically indexed array and would replace the group's children with just that field. Patch entries apply in order and `null` removes every occurrence of an id, so to move a field into a group, remove it first and append it to the group's `children` later in the same patch.
 
-The `$version` argument declares the configuration schema version the patch was written against (currently `1`), so that a future release that changes the configuration shape can migrate existing patches forward instead of breaking them.
+The `version` key declares the configuration schema version the contribution was written against (currently `1`), so that a future release that changes the configuration shape can migrate existing contributions forward instead of breaking them.
 
 In the following example, a custom saved view is added to the `page` list, the existing Drafts view is retitled, the Trash view is removed, the `grid` layout option is unset, and `slug` and `author` fields are removed from the form.
 
 ```php
 function example_filter_page_view_config( $data ) {
-    // Patch the view list by slug: add a saved view, retitle the existing
-    // Drafts view — only the given keys change — and remove the Trash view
-    // with null.
-    $data->update_view_list_items(
+    return $data->update_with(
         array(
-            'my-drafts' => array(
-                'title' => __( 'My drafts', 'example' ),
-                'view'  => array(
-                    'filters' => array(
-                        array(
-                            'field'    => 'status',
-                            'operator' => 'isAny',
-                            'value'    => 'draft',
-                            'isLocked' => true,
+            'version'         => 1,
+            'default_layouts' => array( 'grid' => null ),
+            'view_list'       => array(
+                'my-drafts' => array(
+                    'title' => __( 'My drafts', 'example' ),
+                    'view'  => array(
+                        'filters' => array(
+                            array(
+                                'field'    => 'status',
+                                'operator' => 'isAny',
+                                'value'    => 'draft',
+                                'isLocked' => true,
+                            ),
                         ),
                     ),
                 ),
+                'drafts'    => array(
+                    'title' => __( 'In progress', 'example' ),
+                ),
+                'trash'     => null,
             ),
-            'drafts'    => array(
-                'title' => __( 'In progress', 'example' ),
+            'form'            => array(
+                'layout' => array( 'type' => 'regular' ),
+                'fields' => array(
+                    'post-content-info' => array(
+                        'layout' => array( 'labelPosition' => 'side' ),
+                    ),
+                    'slug'              => null,
+                    'author'            => null,
+                    'discussion'        => array(
+                        'children' => array( 'my_field' => array() ),
+                    ),
+                ),
             ),
-            'trash'     => null,
-        ),
-        1
+        )
     );
-
-    // Patch form fields by id, wherever they live in the form: update the
-    // label position of the post content info field, remove the slug and
-    // author fields with null, and append a new field to the discussion
-    // group's children ( array() carries no overrides ).
-    $data->update_form_fields(
-        array(
-            'post-content-info' => array(
-                'layout' => array( 'labelPosition' => 'side' ),
-            ),
-            'slug'              => null,
-            'author'            => null,
-            'discussion'        => array(
-                'children' => array( 'my_field' => array() ),
-            ),
-        ),
-        1
-    );
-
-    // Unset a nested value with null: drop the grid layout option. Form
-    // properties other than `fields` also merge here.
-    $data->update_properties(
-        array(
-            'default_layouts' => array( 'grid' => null ),
-            'form'            => array( 'layout' => array( 'type' => 'regular' ) ),
-        ),
-        1
-    );
-
-    return $data;
 }
 add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
 ```

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -9,30 +9,21 @@
  * Holds an entity's view configuration while it is being built.
  *
  * An instance of this class is what `get_entity_view_config_{$kind}_{$name}`
- * filter callbacks receive: a callback changes the configuration by calling
- * methods on the instance and returning it. The configuration has four
- * top-level keys — `default_view`, `default_layouts`, `view_list`, and
- * `form` — and there are two ways to contribute:
+ * filter callbacks receive: a callback changes the configuration by passing a
+ * versioned contribution to `update_with()` and returning the instance. The
+ * contribution declares the configuration schema version it was written
+ * against (currently 1), so a future WordPress release that changes the
+ * configuration shape can migrate existing contributions forward instead of
+ * breaking them.
  *
- * - The `update_*()` methods merge partial changes (patches) into what is
- *   already there, each covering one part of the configuration:
- *   `update_properties()` for `default_view`, `default_layouts`, and the
- *   `form` settings other than its `fields`; `update_view_list_items()` for
- *   the `view_list` entries, keyed by view `slug`; and `update_form_fields()`
- *   for the `form` fields, keyed by field `id`. This is what plugins should
- *   use: patches compose with core's configuration and with other plugins'.
- * - `set()` replaces a whole top-level key. It shouldn't be the default
- *   choice — a callback using it stops inheriting core's future changes to
- *   that key — but it's useful for cases like a post type that doesn't
- *   want the default form at all.
- *
- * Patches follow three shared rules: an associative array merges key by
- * key, a numerically indexed array replaces the current value wholesale,
- * and `null` deletes what it names — deleting a whole top-level key resets
- * it to its default. Each patch and each `set()` value also declares the
- * configuration schema version it was written against (currently 1), so a
- * future WordPress release that changes the configuration shape can migrate
- * existing patches forward instead of breaking them.
+ * Contributions follow three shared rules: an associative array merges key by
+ * key, a numerically indexed array replaces the current value wholesale, and
+ * `null` deletes what it names. Deleting a whole top-level key resets it to its
+ * default when the configuration is returned. The `view_list` and
+ * `form.fields` lists additionally support identity-aware patches: pass an
+ * associative array keyed by view `slug` or field `id` to merge, append, or
+ * remove individual entries; pass a numerically indexed array to replace the
+ * entire list.
  *
  * @since 7.1.0
  */
@@ -85,73 +76,25 @@ class Gutenberg_View_Config_Data {
 	}
 
 	/**
-	 * Replaces a whole top-level key with a new value.
+	 * Updates the view configuration with the given versioned contribution.
 	 *
-	 * It shouldn't be the default choice — a callback using it stops
-	 * inheriting core's future changes to that key — but it's useful for
-	 * cases like a post type that doesn't want the default form at all.
-	 *
-	 * A value that declares an unsupported schema version is rejected and
-	 * does not replace anything.
+	 * The contribution must include a `version` key declaring the schema
+	 * version it was authored against. The documented configuration keys are
+	 * `default_view`, `default_layouts`, `view_list`, and `form`.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $key     The configuration key to replace.
-	 * @param mixed  $value   The new value.
-	 * @param int    $version The schema version the value was authored against.
+	 * @param array $new_data The versioned configuration contribution.
 	 * @return Gutenberg_View_Config_Data The instance, for chaining.
 	 */
-	public function set( $key, $value, int $version ) {
-		if ( ! $this->check_version( $version, __METHOD__ ) ) {
+	public function update_with( array $new_data ) {
+		if ( ! $this->check_version( $new_data, __METHOD__ ) ) {
 			return $this;
 		}
 
-		if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %s: the configuration key. */
-					esc_html__( '"%s" is not a documented view configuration key.', 'gutenberg' ),
-					esc_html( $key )
-				),
-				'7.1.0'
-			);
-			return $this;
-		}
+		unset( $new_data['version'] );
 
-		$this->config[ $key ] = $value;
-		return $this;
-	}
-
-	/**
-	 * Merges a partial configuration into `default_view`, `default_layouts`,
-	 * and the `form` settings other than its `fields`.
-	 *
-	 * An associative array merges key by key, a numerically indexed array
-	 * replaces the current value wholesale, and `null` deletes the key it
-	 * names; deleting a whole top-level key (any documented key, including
-	 * `view_list`) resets it to its default.
-	 *
-	 * The keyed collections have dedicated methods and are rejected here: a
-	 * non-null `view_list` value must go through `update_view_list_items()`,
-	 * and a `fields` key inside a `form` value must go through
-	 * `update_form_fields()`.
-	 *
-	 * A patch that declares an unsupported schema version is rejected and
-	 * does not merge.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param array $patch   The partial configuration to merge.
-	 * @param int   $version The schema version the patch was authored against.
-	 * @return Gutenberg_View_Config_Data The instance, for chaining.
-	 */
-	public function update_properties( array $patch, int $version ) {
-		if ( ! $this->check_version( $version, __METHOD__ ) ) {
-			return $this;
-		}
-
-		foreach ( $patch as $key => $value ) {
+		foreach ( $new_data as $key => $value ) {
 			if ( ! in_array( $key, self::CONFIG_KEYS, true ) ) {
 				_doing_it_wrong(
 					__METHOD__,
@@ -164,74 +107,85 @@ class Gutenberg_View_Config_Data {
 				);
 				continue;
 			}
+
 			// A null patch value drops the whole key from the container rather
 			// than assigning null.
 			if ( null === $value ) {
 				unset( $this->config[ $key ] );
 				continue;
 			}
-			if ( 'view_list' === $key ) {
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html__( 'The "view_list" entries are patched by identity. Use update_view_list_items() instead.', 'gutenberg' ),
-					'7.1.0'
-				);
-				continue;
-			}
-			if ( 'form' === $key ) {
-				$value = $this->extract_form_properties( $value );
-				// Nothing left to merge: the value was off-shape, or held only
-				// the rejected `fields` key.
-				if ( null === $value || array() === $value ) {
-					continue;
-				}
-			}
-			$this->config[ $key ] = $this->deep_merge( $this->config[ $key ] ?? array(), $value );
+
+			$this->merge_config_key( $key, $value );
 		}
 
 		return $this;
 	}
 
 	/**
-	 * Adds, updates, or removes `view_list` entries, keyed by view `slug`.
-	 *
-	 * Each patch key names the `slug` of the view it targets: a matching view
-	 * merges in place and keeps its position (following the shared rules —
-	 * e.g. the view's `filters`, being numerically indexed, replace
-	 * wholesale), an unknown slug appends a new view to the end, and `null`
-	 * removes the view. The patch key is the identity: a `slug` property
-	 * inside the value is ignored. A `null` for a slug that is not found is a
-	 * silent no-op — the view may have been removed by another callback or
-	 * simply not apply to this entity.
-	 *
-	 * A patch that declares an unsupported schema version is rejected and
-	 * does not merge.
+	 * Merges a documented top-level configuration key.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array $items   The view patches, keyed by slug.
-	 * @param int   $version The schema version the patch was authored against.
-	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 * @param string $key   The configuration key.
+	 * @param mixed  $value The incoming value.
 	 */
-	public function update_view_list_items( array $items, int $version ) {
-		if ( ! $this->check_version( $version, __METHOD__ ) ) {
-			return $this;
+	private function merge_config_key( $key, $value ) {
+		if ( 'view_list' === $key ) {
+			$this->merge_view_list( $value );
+			return;
 		}
 
-		if ( empty( $items ) ) {
-			return $this;
+		if ( 'form' === $key ) {
+			$this->merge_form( $value );
+			return;
 		}
-		if ( array_is_list( $items ) ) {
+
+		$this->config[ $key ] = $this->deep_merge( $this->config[ $key ] ?? array(), $value );
+	}
+
+	/**
+	 * Merges or replaces the `view_list` configuration.
+	 *
+	 * A numerically indexed array replaces the full list. An associative array
+	 * patches entries by view `slug`.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $value The incoming view list value.
+	 */
+	private function merge_view_list( $value ) {
+		if ( ! is_array( $value ) ) {
 			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'A view list patch must be keyed by view "slug".', 'gutenberg' ),
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'The "view_list" value must be an array.', 'gutenberg' ),
 				'7.1.0'
 			);
-			return $this;
+			return;
 		}
 
-		$view_list = isset( $this->config['view_list'] ) && is_array( $this->config['view_list'] ) ? $this->config['view_list'] : array();
+		if ( array_is_list( $value ) ) {
+			$this->config['view_list'] = $value;
+			return;
+		}
 
+		$view_list                  = isset( $this->config['view_list'] ) && is_array( $this->config['view_list'] ) ? $this->config['view_list'] : array();
+		$this->config['view_list'] = $this->merge_view_list_items( $view_list, $value );
+	}
+
+	/**
+	 * Adds, updates, or removes `view_list` entries, keyed by view `slug`.
+	 *
+	 * Each patch key names the `slug` of the view it targets: a matching view
+	 * merges in place and keeps its position, an unknown slug appends a new
+	 * view to the end, and `null` removes the view.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $view_list The current view list.
+	 * @param array $items     The view patches, keyed by slug.
+	 * @return array The merged view list.
+	 */
+	private function merge_view_list_items( array $view_list, array $items ) {
 		foreach ( $items as $slug => $value ) {
 			// PHP casts numeric-string array keys to integers; identities are strings.
 			$slug = (string) $slug;
@@ -248,7 +202,7 @@ class Gutenberg_View_Config_Data {
 
 			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 				_doing_it_wrong(
-					__METHOD__,
+					'Gutenberg_View_Config_Data::update_with',
 					esc_html__( 'Each view patch must be an associative array of view properties, or null to remove the view.', 'gutenberg' ),
 					'7.1.0'
 				);
@@ -277,77 +231,106 @@ class Gutenberg_View_Config_Data {
 			}
 		}
 
-		$this->config['view_list'] = array_values( $view_list );
-
-		return $this;
+		return array_values( $view_list );
 	}
 
 	/**
-	 * Adds, updates, or removes `form` fields, keyed by field `id`.
+	 * Merges the `form` configuration.
 	 *
-	 * Each patch key names the `id` of the field it targets, and the field is
-	 * found wherever it lives — at the top level or nested inside a group's
-	 * `children`. Fields are visited in document order and a group is checked
-	 * before its own children, so when an id appears at both levels the group
-	 * wins. A matching field merges in place, an unknown id appends a new field
-	 * to the end of the top-level fields, and `null` removes the field. The
-	 * patch key is the identity: an `id` property inside the value is ignored.
-	 * A `null` for an id that is not found is a silent no-op — the field may
-	 * have been removed by another callback or simply not apply to this
-	 * entity.
-	 *
-	 * Inside a field patch, `children` follows the shared rules: an associative
-	 * array merges into the group's children by id (appending unknown ones), a
-	 * numerically indexed array replaces the children wholesale, and `null`
-	 * deletes the key.
-	 *
-	 * A patch that declares an unsupported schema version is rejected and
-	 * does not merge.
+	 * Form properties merge normally. The `fields` property may be a list,
+	 * replacing all fields, or an associative array that patches fields by `id`.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array $fields  The field patches, keyed by field id.
-	 * @param int   $version The schema version the patch was authored against.
-	 * @return Gutenberg_View_Config_Data The instance, for chaining.
+	 * @param mixed $value The incoming form value.
 	 */
-	public function update_form_fields( array $fields, int $version ) {
-		if ( ! $this->check_version( $version, __METHOD__ ) ) {
-			return $this;
-		}
-
-		if ( empty( $fields ) ) {
-			return $this;
-		}
-		if ( array_is_list( $fields ) ) {
+	private function merge_form( $value ) {
+		if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'A fields patch must be keyed by field "id".', 'gutenberg' ),
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'The "form" value must be an associative array of form properties.', 'gutenberg' ),
 				'7.1.0'
 			);
-			return $this;
+			return;
+		}
+
+		if ( array() === $value ) {
+			$this->config['form'] = array();
+			return;
 		}
 
 		if ( ! isset( $this->config['form'] ) || ! is_array( $this->config['form'] ) ) {
 			$this->config['form'] = array();
 		}
-		$current = isset( $this->config['form']['fields'] ) && is_array( $this->config['form']['fields'] ) ? $this->config['form']['fields'] : array();
 
-		$this->config['form']['fields'] = $this->merge_fields_by_identity( $current, $fields );
-
-		return $this;
+		foreach ( $value as $key => $item ) {
+			if ( 'fields' === $key ) {
+				$this->merge_form_fields( $item );
+				continue;
+			}
+			if ( null === $item ) {
+				unset( $this->config['form'][ $key ] );
+				continue;
+			}
+			$this->config['form'][ $key ] = $this->deep_merge(
+				array_key_exists( $key, $this->config['form'] ) ? $this->config['form'][ $key ] : array(),
+				$item
+			);
+		}
 	}
 
 	/**
-	 * Validates a declared patch version, reporting misuse against the given
+	 * Merges or replaces the `form.fields` list.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $fields The incoming fields value.
+	 */
+	private function merge_form_fields( $fields ) {
+		if ( null === $fields ) {
+			unset( $this->config['form']['fields'] );
+			return;
+		}
+		if ( ! is_array( $fields ) ) {
+			_doing_it_wrong(
+				'Gutenberg_View_Config_Data::update_with',
+				esc_html__( 'The form "fields" value must be an array or null.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return;
+		}
+
+		if ( array_is_list( $fields ) ) {
+			$this->config['form']['fields'] = $fields;
+			return;
+		}
+
+		$current                        = isset( $this->config['form']['fields'] ) && is_array( $this->config['form']['fields'] ) ? $this->config['form']['fields'] : array();
+		$this->config['form']['fields'] = $this->merge_fields_by_identity( $current, $fields );
+	}
+
+	/**
+	 * Validates a declared contribution version, reporting misuse against the given
 	 * public method.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param int    $version The declared version.
-	 * @param string $method  The public method the patch was passed to.
+	 * @param array  $new_data The incoming contribution.
+	 * @param string $method   The public method the contribution was passed to.
 	 * @return bool Whether the declared version is a supported schema version.
 	 */
-	private function check_version( int $version, $method ) {
+	private function check_version( array $new_data, $method ) {
+		if ( ! array_key_exists( 'version', $new_data ) || ! is_int( $new_data['version'] ) ) {
+			_doing_it_wrong(
+				esc_html( $method ),
+				esc_html__( 'A view configuration contribution must declare a supported schema version.', 'gutenberg' ),
+				'7.1.0'
+			);
+
+			return false;
+		}
+
+		$version = $new_data['version'];
 		if ( $version >= 1 && $version <= self::LATEST_VERSION ) {
 			return true;
 		}
@@ -359,37 +342,6 @@ class Gutenberg_View_Config_Data {
 		);
 
 		return false;
-	}
-
-	/**
-	 * Validates a `form` patch value for update_properties() and strips the
-	 * `fields` key, which is managed by update_form_fields().
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param mixed $value The incoming `form` patch value.
-	 * @return array|null The form properties to merge, or null when the value
-	 *                    is off-shape.
-	 */
-	private function extract_form_properties( $value ) {
-		if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
-			_doing_it_wrong(
-				'Gutenberg_View_Config_Data::update_properties',
-				esc_html__( 'A "form" patch must be an associative array of form properties.', 'gutenberg' ),
-				'7.1.0'
-			);
-			return null;
-		}
-		if ( array_key_exists( 'fields', $value ) ) {
-			_doing_it_wrong(
-				'Gutenberg_View_Config_Data::update_properties',
-				esc_html__( 'The form "fields" are patched by identity. Use update_form_fields() instead.', 'gutenberg' ),
-				'7.1.0'
-			);
-			unset( $value['fields'] );
-		}
-
-		return $value;
 	}
 
 	/**
@@ -459,7 +411,7 @@ class Gutenberg_View_Config_Data {
 			}
 			if ( ! is_array( $value ) || ( array() !== $value && array_is_list( $value ) ) ) {
 				_doing_it_wrong(
-					'Gutenberg_View_Config_Data::update_form_fields',
+					'Gutenberg_View_Config_Data::update_with',
 					esc_html__( 'Each field patch must be an associative array of field properties, or null to remove the field.', 'gutenberg' ),
 					'7.1.0'
 				);
@@ -547,7 +499,7 @@ class Gutenberg_View_Config_Data {
 				}
 				if ( ! is_array( $item ) ) {
 					_doing_it_wrong(
-						'Gutenberg_View_Config_Data::update_form_fields',
+						'Gutenberg_View_Config_Data::update_with',
 						esc_html__( 'A "children" patch must be an associative array keyed by field id to merge, a numerically indexed array to replace the children wholesale, or null to delete the key.', 'gutenberg' ),
 						'7.1.0'
 					);

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -155,10 +155,8 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 	 * entity kind (e.g. `postType`) and the entity name (e.g. `page`).
 	 *
 	 * Callbacks receive a Gutenberg_View_Config_Data object and change the
-	 * configuration through its methods: the `update_*()` methods merge
-	 * partial changes into the current configuration, while `set()` replaces
-	 * a whole top-level key. Callbacks must return the object they were
-	 * given.
+	 * configuration by passing a versioned contribution to its `update_with()`
+	 * method. Callbacks must return the object they were given.
 	 *
 	 * @param Gutenberg_View_Config_Data $data   The view configuration container
 	 *                                           for the entity, exposing the
@@ -324,11 +322,16 @@ function _gutenberg_get_entity_view_config_post_type_page( $data ) {
 		),
 	);
 
-	$data->set( 'default_layouts', $default_layouts, 1 );
-	$data->set( 'default_view', $default_view, 1 );
 	// Append the status views, thereby preserving the base "all items" view,
 	// so its post-type-specific title is kept.
-	$data->update_view_list_items( array_column( $view_list, null, 'slug' ), 1 );
+	$data->update_with(
+		array(
+			'version'         => 1,
+			'default_layouts' => $default_layouts,
+			'default_view'    => $default_view,
+			'view_list'       => array_column( $view_list, null, 'slug' ),
+		)
+	);
 
 	return $data;
 }
@@ -366,9 +369,6 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
 		'filters'    => array(),
 		'layout'     => $default_layouts['grid']['layout'],
 	);
-
-	$data->set( 'default_layouts', $default_layouts, 1 );
-	$data->set( 'default_view', $default_view, 1 );
 
 	$view_list = array(
 		array(
@@ -417,32 +417,40 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
 		);
 	}
 
-	$data->set( 'view_list', $view_list, 1 );
-
-	$data->set(
-		'form',
+	$data->update_with(
 		array(
-			'layout' => array( 'type' => 'panel' ),
-			'fields' => array(
-				array(
-					'id'     => 'excerpt',
-					'layout' => array(
-						'type'          => 'panel',
-						'labelPosition' => 'top',
-					),
-				),
-				array(
-					'id'     => 'post-content-info',
-					'layout' => array(
-						'type'          => 'regular',
-						'labelPosition' => 'none',
-					),
-				),
-				'sync-status',
-				'revisions',
+			'version'         => 1,
+			'default_layouts' => array_merge(
+				$default_layouts,
+				array( 'list' => null )
 			),
-		),
-		1
+			'default_view'    => array_merge(
+				$default_view,
+				array( 'sort' => null )
+			),
+			'view_list'       => $view_list,
+			'form'            => array(
+				'layout' => array( 'type' => 'panel' ),
+				'fields' => array(
+					array(
+						'id'     => 'excerpt',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'top',
+						),
+					),
+					array(
+						'id'     => 'post-content-info',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					'sync-status',
+					'revisions',
+				),
+			),
+		)
 	);
 
 	return $data;
@@ -479,9 +487,6 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
 		'filters'    => array(),
 		'layout'     => $default_layouts['grid']['layout'],
 	);
-
-	$data->set( 'default_layouts', $default_layouts, 1 );
-	$data->set( 'default_view', $default_view, 1 );
 
 	$view_list = array(
 		array(
@@ -524,24 +529,32 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
 		);
 	}
 
-	$data->set( 'view_list', $view_list, 1 );
-
-	$data->set(
-		'form',
+	$data->update_with(
 		array(
-			'layout' => array( 'type' => 'panel' ),
-			'fields' => array(
-				array(
-					'id'     => 'last_edited_date',
-					'layout' => array(
-						'type'          => 'panel',
-						'labelPosition' => 'none',
-					),
-				),
-				'revisions',
+			'version'         => 1,
+			'default_layouts' => array_merge(
+				$default_layouts,
+				array( 'list' => null )
 			),
-		),
-		1
+			'default_view'    => array_merge(
+				$default_view,
+				array( 'sort' => null )
+			),
+			'view_list'       => $view_list,
+			'form'            => array(
+				'layout' => array( 'type' => 'panel' ),
+				'fields' => array(
+					array(
+						'id'     => 'last_edited_date',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'none',
+						),
+					),
+					'revisions',
+				),
+			),
+		)
 	);
 
 	return $data;
@@ -574,9 +587,6 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
 		'grid'  => array( 'showMedia' => true ),
 		'list'  => array( 'showMedia' => false ),
 	);
-
-	$data->set( 'default_view', $default_view, 1 );
-	$data->set( 'default_layouts', $default_layouts, 1 );
 
 	$view_list = array(
 		array(
@@ -716,45 +726,47 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
 		}
 	}
 
-	$data->set( 'view_list', array_merge( $view_list, $registered_authors, $user_authors ), 1 );
-
-	$data->set(
-		'form',
+	$data->update_with(
 		array(
-			'layout' => array( 'type' => 'panel' ),
-			'fields' => array(
-				array(
-					'id'     => 'description',
-					'layout' => array(
-						'type'          => 'panel',
-						'labelPosition' => 'top',
+			'version'         => 1,
+			'default_view'    => $default_view,
+			'default_layouts' => $default_layouts,
+			'view_list'       => array_merge( $view_list, $registered_authors, $user_authors ),
+			'form'            => array(
+				'layout' => array( 'type' => 'panel' ),
+				'fields' => array(
+					array(
+						'id'     => 'description',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'top',
+						),
 					),
-				),
-				array(
-					'id'     => 'description_readonly',
-					'layout' => array(
-						'type'          => 'regular',
-						'labelPosition' => 'none',
+					array(
+						'id'     => 'description_readonly',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
 					),
-				),
-				array(
-					'id'     => 'last_edited_date',
-					'layout' => array(
-						'type'          => 'panel',
-						'labelPosition' => 'none',
+					array(
+						'id'     => 'last_edited_date',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'none',
+						),
 					),
+					'revisions',
+					// The following fields are only meaningful in the `home`/`index`
+					// template summary. They edit other entities (`root/site` and the
+					// posts page); the editor merges those records into the form data
+					// under a namespace and controls when the fields are shown.
+					'posts_page_title',
+					'posts_per_page',
+					'default_comment_status',
 				),
-				'revisions',
-				// The following fields are only meaningful in the `home`/`index`
-				// template summary. They edit other entities (`root/site` and the
-				// posts page); the editor merges those records into the form data
-				// under a namespace and controls when the fields are shown.
-				'posts_page_title',
-				'posts_per_page',
-				'default_comment_status',
 			),
-		),
-		1
+		)
 	);
 
 	return $data;

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -319,7 +319,9 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 		$decoded = json_decode( wp_json_encode( $this->dispatch_request( 'postType', 'wp_template_part' )->get_data() ) );
 
 		$this->assertIsObject( $decoded->default_view->layout );
+		$this->assertFalse( property_exists( $decoded->default_view, 'sort' ) );
 		$this->assertIsObject( $decoded->default_layouts->grid->layout );
+		$this->assertFalse( property_exists( $decoded->default_layouts, 'list' ) );
 	}
 
 	/**
@@ -337,19 +339,21 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 		wp_set_current_user( self::$editor_id );
 
 		$filter = static function ( $data ) {
-			return $data->update_view_list_items(
+			return $data->update_with(
 				array(
-					'custom' => array(
-						'title' => 'Custom',
-						'view'  => array(
-							'type'   => 'table',
-							'layout' => array(
-								'styles' => array(),
+					'version'   => 1,
+					'view_list' => array(
+						'custom' => array(
+							'title' => 'Custom',
+							'view'  => array(
+								'type'   => 'table',
+								'layout' => array(
+									'styles' => array(),
+								),
 							),
 						),
 					),
-				),
-				1
+				)
 			);
 		};
 		add_filter( 'get_entity_view_config_custom_kind_custom_name', $filter );

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -9,45 +9,61 @@
 class Tests_View_Config_Data extends WP_UnitTestCase {
 
 	/**
-	 * set() replaces a whole documented key.
+	 * Wraps a contribution in the current schema version.
 	 *
-	 * @covers ::set
+	 * @param array $data The contribution.
+	 * @return array The versioned contribution.
 	 */
-	public function test_set_replaces_key() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'default_view' => array(
-					'type'    => 'table',
-					'perPage' => 20,
-				),
-			)
-		);
-		$data->set( 'default_view', array( 'type' => 'grid' ), 1 );
-
-		$this->assertSame( array( 'type' => 'grid' ), $data->get_config()['default_view'] );
+	private function versioned( array $data ) {
+		return array_merge( array( 'version' => 1 ), $data );
 	}
 
 	/**
-	 * set() rejects an undocumented key.
+	 * update_with() requires a supported contribution version.
 	 *
-	 * @covers ::set
+	 * @covers ::update_with
 	 */
-	public function test_set_unknown_key_triggers_doing_it_wrong() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::set' );
+	public function test_update_with_requires_supported_version() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
 
 		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
 		$before = $data->get_config();
-		$data->set( 'not_a_real_key', 'nope', 1 );
+
+		$data->update_with( array( 'default_view' => array( 'type' => 'grid' ) ) );
+		$data->update_with(
+			array(
+				'version'      => Gutenberg_View_Config_Data::LATEST_VERSION + 1,
+				'default_view' => array( 'type' => 'grid' ),
+			)
+		);
 
 		$this->assertSame( $before, $data->get_config() );
 	}
 
 	/**
-	 * update_properties() merges object-shaped keys recursively.
+	 * update_with() rejects undocumented top-level keys.
 	 *
-	 * @covers ::update_properties
+	 * Nested properties are not validated: their vocabulary is owned by the
+	 * client-side consumers.
+	 *
+	 * @covers ::update_with
 	 */
-	public function test_update_properties_merges_default_view_recursively() {
+	public function test_update_with_rejects_unknown_top_level_key() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
+		$data->update_with( $this->versioned( array( 'not_a_real_key' => 'nope' ) ) );
+
+		$this->assertSame( array( 'default_view' => array( 'type' => 'table' ) ), $data->get_config() );
+	}
+
+	/**
+	 * update_with() merges object-shaped keys recursively.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_merges_properties_recursively() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'default_view' => array(
@@ -60,14 +76,16 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_properties(
-			array(
-				'default_view' => array(
-					'perPage' => 50,
-					'sort'    => array( 'direction' => 'desc' ),
-				),
-			),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'default_view' => array(
+						'perPage' => 50,
+						'sort'    => array( 'direction' => 'desc' ),
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -84,111 +102,11 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_properties() merges default_layouts by map key and adds unknown ones.
+	 * update_with() unsets nested properties when the patch value is null.
 	 *
-	 * @covers ::update_properties
+	 * @covers ::update_with
 	 */
-	public function test_update_properties_merges_default_layouts_by_key() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'default_layouts' => array(
-					'table' => array(),
-					'grid'  => array(),
-				),
-			)
-		);
-		$data->update_properties(
-			array(
-				'default_layouts' => array(
-					'table'    => array( 'density' => 'compact' ),
-					'activity' => array(),
-				),
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				'table'    => array( 'density' => 'compact' ),
-				'grid'     => array(),
-				'activity' => array(),
-			),
-			$data->get_config()['default_layouts']
-		);
-	}
-
-	/**
-	 * update_properties() merges the form's plain properties and leaves its
-	 * fields untouched.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_merges_form_layout() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'layout' => array( 'type' => 'panel' ),
-					'fields' => array( 'date', 'slug' ),
-				),
-			)
-		);
-		$data->update_properties(
-			array( 'form' => array( 'layout' => array( 'type' => 'card' ) ) ),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				'layout' => array( 'type' => 'card' ),
-				'fields' => array( 'date', 'slug' ),
-			),
-			$data->get_config()['form']
-		);
-	}
-
-	/**
-	 * update_properties() merges a documented key that is absent from the config.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_merges_a_documented_key_absent_from_config() {
-		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array() ) );
-		$data->update_properties(
-			array( 'default_layouts' => array( 'table' => array( 'density' => 'compact' ) ) ),
-			1
-		);
-
-		$this->assertSame(
-			array( 'table' => array( 'density' => 'compact' ) ),
-			$data->get_config()['default_layouts']
-		);
-	}
-
-	/**
-	 * update_properties() unsets a property when the patch value is null.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_null_unsets_property() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'default_view' => array(
-					'type'    => 'table',
-					'perPage' => 20,
-				),
-			)
-		);
-		$data->update_properties( array( 'default_view' => array( 'perPage' => null ) ), 1 );
-
-		$this->assertSame( array( 'type' => 'table' ), $data->get_config()['default_view'] );
-	}
-
-	/**
-	 * update_properties() unsets a deeply nested layout property when the value is null.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_null_unsets_nested_layout_prop() {
+	public function test_update_with_null_unsets_nested_property() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'default_layouts' => array(
@@ -201,9 +119,17 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_properties(
-			array( 'default_layouts' => array( 'table' => array( 'layout' => array( 'styles' => null ) ) ) ),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'default_layouts' => array(
+						'table' => array(
+							'layout' => array( 'styles' => null ),
+						),
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -213,15 +139,14 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_properties() drops a whole top-level key when the patch value is
-	 * null — any documented key, including the identity-keyed view_list —
-	 * rather than storing a literal null. gutenberg_get_entity_view_config()
-	 * backfills a dropped documented key from the defaults, so that reads as
-	 * a reset.
+	 * update_with() drops a whole top-level key when the contribution value is null.
 	 *
-	 * @covers ::update_properties
+	 * gutenberg_get_entity_view_config() backfills a dropped documented key
+	 * from the defaults, so that reads as a reset.
+	 *
+	 * @covers ::update_with
 	 */
-	public function test_update_properties_null_drops_whole_top_level_key() {
+	public function test_update_with_null_drops_whole_top_level_key() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'default_view' => array( 'type' => 'table' ),
@@ -234,12 +159,14 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				'form'         => array( 'layout' => array( 'type' => 'panel' ) ),
 			)
 		);
-		$data->update_properties(
-			array(
-				'default_view' => null,
-				'view_list'    => null,
-			),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'default_view' => null,
+					'view_list'    => null,
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -249,160 +176,50 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_properties() consumes a null delete-marker merged into an empty
-	 * base instead of storing it as a literal value.
+	 * Inherited map keys are removed explicitly with nested null patches.
 	 *
-	 * @covers ::update_properties
+	 * @covers ::update_with
 	 */
-	public function test_update_properties_null_into_empty_base_is_consumed() {
-		$data = new Gutenberg_View_Config_Data( array( 'default_layouts' => array( 'table' => array() ) ) );
-		$data->update_properties(
-			array( 'default_layouts' => array( 'table' => array( 'layout' => null ) ) ),
-			1
-		);
-
-		$this->assertSame( array(), $data->get_config()['default_layouts']['table'] );
-	}
-
-	/**
-	 * update_properties() strips nulls from a subtree assigned to a key absent
-	 * from the base instead of storing them as literal values.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_null_stripped_from_absent_key_subtree() {
-		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
-		// The base default_view has no `layout` key.
-		$data->update_properties(
-			array(
-				'default_view' => array(
-					'layout' => array(
-						'type'        => 'flex',
-						'badgeFields' => null,
-					),
-				),
-			),
-			1
-		);
-
-		$this->assertSame( array( 'type' => 'flex' ), $data->get_config()['default_view']['layout'] );
-	}
-
-	/**
-	 * update_properties() rejects the identity-keyed branches: a non-null
-	 * view_list value and form fields belong to their dedicated functions. A
-	 * valid sibling form property still merges.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_rejects_identity_keyed_branches() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
-
+	public function test_update_with_removes_inherited_map_keys_explicitly() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
-				'form' => array(
-					'layout' => array( 'type' => 'panel' ),
-					'fields' => array( 'date' ),
+				'default_view' => array(
+					'type'    => 'table',
+					'perPage' => 20,
+					'sort'    => array(
+						'field'     => 'title',
+						'direction' => 'asc',
+					),
 				),
 			)
 		);
 
-		$data->update_properties(
-			array(
-				'view_list' => array(
-					array(
-						'slug'  => 'mine',
-						'title' => 'Mine',
+		$data->update_with(
+			$this->versioned(
+				array(
+					'default_view' => array(
+						'type' => 'grid',
+						'sort' => null,
 					),
-				),
-			),
-			1
+				)
+			)
 		);
-		$this->assertArrayNotHasKey( 'view_list', $data->get_config() );
 
-		$data->update_properties(
-			array(
-				'form' => array(
-					'layout' => array( 'type' => 'card' ),
-					'fields' => array( 'my_field' ),
-				),
-			),
-			1
-		);
 		$this->assertSame(
 			array(
-				'layout' => array( 'type' => 'card' ),
-				'fields' => array( 'date' ),
+				'type'    => 'grid',
+				'perPage' => 20,
 			),
-			$data->get_config()['form']
+			$data->get_config()['default_view']
 		);
 	}
 
 	/**
-	 * update_properties() rejects an undocumented top-level key. Nested
-	 * properties are not validated: their vocabulary is owned by the
-	 * client-side consumers.
+	 * An associative view_list contribution patches views by slug.
 	 *
-	 * @covers ::update_properties
+	 * @covers ::update_with
 	 */
-	public function test_update_properties_warns_on_unknown_top_level_key() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
-
-		$data = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
-		$data->update_properties( array( 'not_a_real_key' => 'nope' ), 1 );
-
-		$this->assertSame( array( 'default_view' => array( 'type' => 'table' ) ), $data->get_config() );
-	}
-
-	/**
-	 * update_properties() rejects a list where the form map is expected.
-	 *
-	 * @covers ::update_properties
-	 */
-	public function test_update_properties_rejects_list_shaped_form_patch() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
-
-		$data   = new Gutenberg_View_Config_Data( array( 'form' => array( 'layout' => array( 'type' => 'panel' ) ) ) );
-		$before = $data->get_config();
-		$data->update_properties( array( 'form' => array( array( 'id' => 'my_field' ) ) ), 1 );
-
-		$this->assertSame( $before, $data->get_config() );
-	}
-
-	/**
-	 * Every update function and set() reject a patch whose version cannot be
-	 * migrated — newer than the latest supported version.
-	 *
-	 * @covers ::update_properties
-	 * @covers ::update_view_list_items
-	 * @covers ::update_form_fields
-	 * @covers ::set
-	 */
-	public function test_update_functions_reject_unmigratable_version() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_properties' );
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_view_list_items' );
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_form_fields' );
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::set' );
-
-		$data   = new Gutenberg_View_Config_Data( array( 'default_view' => array( 'type' => 'table' ) ) );
-		$before = $data->get_config();
-
-		$version = Gutenberg_View_Config_Data::LATEST_VERSION + 1;
-		$data->update_properties( array( 'default_view' => array( 'type' => 'grid' ) ), $version );
-		$data->update_view_list_items( array( 'mine' => array( 'title' => 'Mine' ) ), $version );
-		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), $version );
-		$data->set( 'default_view', array( 'type' => 'grid' ), $version );
-
-		$this->assertSame( $before, $data->get_config() );
-	}
-
-	/**
-	 * update_view_list_items() merges a matching slug in place and appends an
-	 * unknown one, injecting the slug from the patch key.
-	 *
-	 * @covers ::update_view_list_items
-	 */
-	public function test_update_view_list_items_merges_by_slug_and_appends_unknown() {
+	public function test_update_with_view_list_map_merges_by_slug_appends_and_removes() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'view_list' => array(
@@ -414,15 +231,27 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 						'title' => 'Published',
 						'slug'  => 'published',
 					),
+					array(
+						'title' => 'Trash',
+						'slug'  => 'trash',
+					),
 				),
 			)
 		);
-		$data->update_view_list_items(
-			array(
-				'published' => array( 'title' => 'Live' ),
-				'mine'      => array( 'title' => 'Mine' ),
-			),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'view_list' => array(
+						'published' => array( 'title' => 'Live' ),
+						'mine'      => array(
+							'slug'  => 'other',
+							'title' => 'Mine',
+						),
+						'trash'     => null,
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -445,11 +274,11 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_view_list_items() removes a view when the patch value is null.
+	 * A list-shaped view_list contribution replaces the full view list.
 	 *
-	 * @covers ::update_view_list_items
+	 * @covers ::update_with
 	 */
-	public function test_update_view_list_items_null_removes_view() {
+	public function test_update_with_view_list_replaces_with_list() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'view_list' => array(
@@ -457,14 +286,56 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 						'title' => 'All',
 						'slug'  => 'all',
 					),
+				),
+			)
+		);
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'view_list' => array(
+						array(
+							'title' => 'Mine',
+							'slug'  => 'mine',
+						),
+					),
+				)
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'title' => 'Mine',
+					'slug'  => 'mine',
+				),
+			),
+			$data->get_config()['view_list']
+		);
+	}
+
+	/**
+	 * Invalid view list shapes are rejected.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_rejects_invalid_view_list_shapes() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
 					array(
-						'title' => 'Published',
-						'slug'  => 'published',
+						'title' => 'All',
+						'slug'  => 'all',
 					),
 				),
 			)
 		);
-		$data->update_view_list_items( array( 'published' => null ), 1 );
+
+		$data->update_with( $this->versioned( array( 'view_list' => 'nope' ) ) );
+		$data->update_with( $this->versioned( array( 'view_list' => array( 'all' => 'nope' ) ) ) );
 
 		$this->assertSame(
 			array(
@@ -478,81 +349,15 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The patch key is the identity: a conflicting `slug` property inside the
-	 * value is ignored.
+	 * Form properties merge normally, and associative fields patch by id.
 	 *
-	 * @covers ::update_view_list_items
+	 * @covers ::update_with
 	 */
-	public function test_update_view_list_items_patch_key_wins_over_slug_property() {
-		$data = new Gutenberg_View_Config_Data( array( 'view_list' => array() ) );
-		$data->update_view_list_items(
-			array(
-				'mine' => array(
-					'slug'  => 'other',
-					'title' => 'Mine',
-				),
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				array(
-					'slug'  => 'mine',
-					'title' => 'Mine',
-				),
-			),
-			$data->get_config()['view_list']
-		);
-	}
-
-	/**
-	 * update_view_list_items() rejects patches that are not keyed by slug and
-	 * members that are not view objects.
-	 *
-	 * @covers ::update_view_list_items
-	 */
-	public function test_update_view_list_items_rejects_off_shape_patches() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_view_list_items' );
-
-		$data   = new Gutenberg_View_Config_Data(
-			array(
-				'view_list' => array(
-					array(
-						'title' => 'All',
-						'slug'  => 'all',
-					),
-				),
-			)
-		);
-		$before = $data->get_config();
-
-		// A positional list where a map keyed by slug is expected.
-		$data->update_view_list_items(
-			array(
-				array(
-					'slug'  => 'mine',
-					'title' => 'Mine',
-				),
-			),
-			1
-		);
-		// A scalar where a view object (or null) is expected.
-		$data->update_view_list_items( array( 'all' => 'nope' ), 1 );
-
-		$this->assertSame( $before, $data->get_config() );
-	}
-
-	/**
-	 * update_form_fields() merges a top-level field by its id: in place, with
-	 * siblings untouched and nothing appended.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_merges_top_level_field_by_id() {
+	public function test_update_with_form_merges_properties_and_fields_by_id() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
+					'layout' => array( 'type' => 'panel' ),
 					'fields' => array(
 						array(
 							'id'     => 'excerpt',
@@ -561,39 +366,6 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 								'labelPosition' => 'top',
 							),
 						),
-						'date',
-					),
-				),
-			)
-		);
-		$data->update_form_fields( array( 'excerpt' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), 1 );
-
-		$this->assertSame(
-			array(
-				array(
-					'id'     => 'excerpt',
-					'layout' => array(
-						'type'          => 'panel',
-						'labelPosition' => 'side',
-					),
-				),
-				'date',
-			),
-			$data->get_config()['form']['fields']
-		);
-	}
-
-	/**
-	 * update_form_fields() finds a nested field by its bare id: the caller does
-	 * not need to know (or address) the group the field lives in.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_merges_nested_field_without_addressing_group() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
 						array(
 							'id'       => 'discussion',
 							'label'    => 'Discussion',
@@ -603,37 +375,55 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields( array( 'ping_status' => array( 'layout' => array( 'labelPosition' => 'side' ) ) ), 1 );
 
-		// comment_status stays a bare string; the matched ping_status child is
-		// promoted from a bare string and merged with the incoming overrides.
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'layout' => array( 'type' => 'card' ),
+						'fields' => array(
+							'excerpt'     => array( 'layout' => array( 'labelPosition' => 'side' ) ),
+							'ping_status' => array( 'layout' => array( 'labelPosition' => 'none' ) ),
+						),
+					),
+				)
+			)
+		);
+
 		$this->assertSame(
 			array(
-				array(
-					'id'       => 'discussion',
-					'label'    => 'Discussion',
-					'children' => array(
-						'comment_status',
-						array(
-							'id'     => 'ping_status',
-							'layout' => array( 'labelPosition' => 'side' ),
+				'layout' => array( 'type' => 'card' ),
+				'fields' => array(
+					array(
+						'id'     => 'excerpt',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'side',
+						),
+					),
+					array(
+						'id'       => 'discussion',
+						'label'    => 'Discussion',
+						'children' => array(
+							'comment_status',
+							array(
+								'id'     => 'ping_status',
+								'layout' => array( 'labelPosition' => 'none' ),
+							),
 						),
 					),
 				),
 			),
-			$data->get_config()['form']['fields']
+			$data->get_config()['form']
 		);
 	}
 
 	/**
-	 * Fields are visited in document order and a group matches before its own
-	 * children, so a group and a child sharing an id (as in core's default
-	 * `status` group) resolve to the group; the child is reached through a
-	 * `children` patch on the group.
+	 * Form fields are visited in document order, so a group matches before its children.
 	 *
-	 * @covers ::update_form_fields
+	 * @covers ::update_with
 	 */
-	public function test_update_form_fields_matches_group_before_its_children() {
+	public function test_update_with_form_fields_match_group_before_children() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
@@ -647,14 +437,20 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields(
-			array(
-				'status' => array(
-					'label'    => 'Visibility',
-					'children' => array( 'status' => array( 'layout' => array( 'labelPosition' => 'none' ) ) ),
-				),
-			),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'status' => array(
+								'label'    => 'Visibility',
+								'children' => array( 'status' => array( 'layout' => array( 'labelPosition' => 'none' ) ) ),
+							),
+						),
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -676,88 +472,11 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_form_fields() appends an unknown id to the end of the top-level
-	 * list: as an object when the patch carries overrides, as a bare string
-	 * reference otherwise.
+	 * Field children maps merge by id and append unknown children.
 	 *
-	 * @covers ::update_form_fields
+	 * @covers ::update_with
 	 */
-	public function test_update_form_fields_appends_unknown_field() {
-		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
-		$data->update_form_fields(
-			array(
-				'my_field'    => array( 'layout' => array( 'labelPosition' => 'side' ) ),
-				'other_field' => array(),
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				'date',
-				array(
-					'id'     => 'my_field',
-					'layout' => array( 'labelPosition' => 'side' ),
-				),
-				'other_field',
-			),
-			$data->get_config()['form']['fields']
-		);
-	}
-
-	/**
-	 * A null patch value removes the field wherever it lives, including nested
-	 * inside a group's children.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_null_removes_field_wherever_it_lives() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'     => 'excerpt',
-							'layout' => array( 'type' => 'panel' ),
-						),
-						array(
-							'id'       => 'discussion',
-							'label'    => 'Discussion',
-							'children' => array( 'comment_status', 'ping_status' ),
-						),
-						'date',
-					),
-				),
-			)
-		);
-		$data->update_form_fields(
-			array(
-				'excerpt'     => null,
-				'ping_status' => null,
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				array(
-					'id'       => 'discussion',
-					'label'    => 'Discussion',
-					'children' => array( 'comment_status' ),
-				),
-				'date',
-			),
-			$data->get_config()['form']['fields']
-		);
-	}
-
-	/**
-	 * A `children` map merges into the group's children by id, appending
-	 * unknown ones.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_children_map_merges_by_id() {
+	public function test_update_with_form_field_children_map_merges_by_id() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
@@ -771,16 +490,22 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields(
-			array(
-				'discussion' => array(
-					'children' => array(
-						'comment_status' => array( 'layout' => array( 'labelPosition' => 'none' ) ),
-						'my_field'       => array(),
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'discussion' => array(
+								'children' => array(
+									'comment_status' => array( 'layout' => array( 'labelPosition' => 'none' ) ),
+									'my_field'       => array(),
+								),
+							),
+						),
 					),
-				),
-			),
-			1
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -803,12 +528,11 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A `children` list replaces the group's children wholesale while the group
-	 * keeps its position among the other top-level fields.
+	 * Field children lists replace wholesale, and null deletes the key.
 	 *
-	 * @covers ::update_form_fields
+	 * @covers ::update_with
 	 */
-	public function test_update_form_fields_children_list_replaces_wholesale() {
+	public function test_update_with_form_field_children_list_replaces_and_null_deletes() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
@@ -824,9 +548,17 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields(
-			array( 'discussion' => array( 'children' => array( 'ping_status', 'my_field' ) ) ),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'discussion' => array( 'children' => array( 'ping_status', 'my_field' ) ),
+						),
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -841,48 +573,96 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 			),
 			$data->get_config()['form']['fields']
 		);
-	}
 
-	/**
-	 * A null `children` value deletes the key, turning the group into a plain
-	 * field.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_children_null_drops_key() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'       => 'discussion',
-							'label'    => 'Discussion',
-							'children' => array( 'comment_status' ),
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'discussion' => array( 'children' => null ),
 						),
 					),
-				),
+				)
 			)
 		);
-		$data->update_form_fields( array( 'discussion' => array( 'children' => null ) ), 1 );
 
 		$this->assertSame(
 			array(
+				'excerpt',
 				array(
 					'id'    => 'discussion',
 					'label' => 'Discussion',
 				),
+				'date',
 			),
 			$data->get_config()['form']['fields']
 		);
 	}
 
 	/**
-	 * The patch key is the identity: a conflicting `id` property inside the
-	 * value is ignored.
+	 * Field patches append unknown ids and remove known ids wherever they live.
 	 *
-	 * @covers ::update_form_fields
+	 * @covers ::update_with
 	 */
-	public function test_update_form_fields_patch_key_wins_over_id_property() {
+	public function test_update_with_form_fields_appends_and_removes_by_id() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'form' => array(
+					'fields' => array(
+						array(
+							'id'     => 'excerpt',
+							'layout' => array( 'type' => 'panel' ),
+						),
+						array(
+							'id'       => 'discussion',
+							'label'    => 'Discussion',
+							'children' => array( 'comment_status', 'ping_status' ),
+						),
+						'date',
+					),
+				),
+			)
+		);
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'excerpt'     => null,
+							'ping_status' => null,
+							'my_field'    => array( 'layout' => array( 'labelPosition' => 'side' ) ),
+							'other_field' => array(),
+						),
+					),
+				)
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'id'       => 'discussion',
+					'label'    => 'Discussion',
+					'children' => array( 'comment_status' ),
+				),
+				'date',
+				array(
+					'id'     => 'my_field',
+					'layout' => array( 'labelPosition' => 'side' ),
+				),
+				'other_field',
+			),
+			$data->get_config()['form']['fields']
+		);
+	}
+
+	/**
+	 * The field patch key is the identity.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_form_field_patch_key_wins_over_id_property() {
 		$data = new Gutenberg_View_Config_Data(
 			array(
 				'form' => array(
@@ -895,14 +675,20 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_form_fields(
-			array(
-				'excerpt' => array(
-					'id'     => 'other',
-					'layout' => array( 'labelPosition' => 'side' ),
-				),
-			),
-			1
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array(
+							'excerpt' => array(
+								'id'     => 'other',
+								'layout' => array( 'labelPosition' => 'side' ),
+							),
+						),
+					),
+				)
+			)
 		);
 
 		$this->assertSame(
@@ -917,152 +703,68 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * update_form_fields() rejects patches that are not keyed by id and members
-	 * that are not field objects.
+	 * A list-shaped form fields contribution replaces the full fields list.
 	 *
-	 * @covers ::update_form_fields
+	 * @covers ::update_with
 	 */
-	public function test_update_form_fields_rejects_off_shape_patches() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_form_fields' );
+	public function test_update_with_form_fields_replaces_with_list() {
+		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date', 'slug' ) ) ) );
+
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array( 'title' ),
+					),
+				)
+			)
+		);
+
+		$this->assertSame( array( 'title' ), $data->get_config()['form']['fields'] );
+	}
+
+	/**
+	 * Invalid form shapes are rejected without changing the config.
+	 *
+	 * @covers ::update_with
+	 */
+	public function test_update_with_rejects_invalid_form_shapes() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::update_with' );
 
 		$data   = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
 		$before = $data->get_config();
 
-		// A positional list where a map keyed by id is expected.
-		$data->update_form_fields( array( array( 'id' => 'my_field' ) ), 1 );
-		// A scalar where a field object (or null) is expected.
-		$data->update_form_fields( array( 'date' => 'nope' ), 1 );
+		$data->update_with( $this->versioned( array( 'form' => array( array( 'id' => 'my_field' ) ) ) ) );
+		$data->update_with( $this->versioned( array( 'form' => 'nope' ) ) );
+		$data->update_with( $this->versioned( array( 'form' => array( 'fields' => 'nope' ) ) ) );
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form' => array(
+						'fields' => array( 'date' => 'nope' ),
+					),
+				)
+			)
+		);
 
 		$this->assertSame( $before, $data->get_config() );
 	}
 
 	/**
-	 * Several null field patches drop several members in one patch: both nested
-	 * children are removed while the group itself remains.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_null_removes_multiple_nested_fields() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
-						'excerpt',
-						array(
-							'id'       => 'discussion',
-							'label'    => 'Discussion',
-							'children' => array( 'comment_status', 'ping_status' ),
-						),
-					),
-				),
-			)
-		);
-		$data->update_form_fields(
-			array(
-				'ping_status'    => null,
-				'comment_status' => null,
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				'excerpt',
-				array(
-					'id'       => 'discussion',
-					'label'    => 'Discussion',
-					'children' => array(),
-				),
-			),
-			$data->get_config()['form']['fields']
-		);
-	}
-
-	/**
-	 * Removing a group removes its children with it: they are not hoisted to
-	 * the top level.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_null_removes_group_with_its_children() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
-						array(
-							'id'       => 'discussion',
-							'label'    => 'Discussion',
-							'children' => array( 'comment_status', 'ping_status' ),
-						),
-						'date',
-					),
-				),
-			)
-		);
-		$data->update_form_fields( array( 'discussion' => null ), 1 );
-
-		$this->assertSame( array( 'date' ), $data->get_config()['form']['fields'] );
-	}
-
-	/**
-	 * Patch entries apply in order and a null removes every occurrence of the
-	 * id, so a field moves into a group by removing it first and appending it
-	 * to the group's children later in the same patch.
-	 *
-	 * @covers ::update_form_fields
-	 */
-	public function test_update_form_fields_moves_field_into_group_in_one_patch() {
-		$data = new Gutenberg_View_Config_Data(
-			array(
-				'form' => array(
-					'fields' => array(
-						'author',
-						array(
-							'id'       => 'discussion',
-							'label'    => 'Discussion',
-							'children' => array( 'comment_status' ),
-						),
-					),
-				),
-			)
-		);
-		$data->update_form_fields(
-			array(
-				'author'     => null,
-				'discussion' => array( 'children' => array( 'author' => array() ) ),
-			),
-			1
-		);
-
-		$this->assertSame(
-			array(
-				array(
-					'id'       => 'discussion',
-					'label'    => 'Discussion',
-					'children' => array( 'comment_status', 'author' ),
-				),
-			),
-			$data->get_config()['form']['fields']
-		);
-	}
-
-	/**
-	 * A null patch for an identity that is not found is a silent no-op.
+	 * A null patch for an unknown identity is a silent no-op.
 	 *
 	 * A member that is not present may have been removed by another filter or
 	 * simply not apply to this entity, so it is not treated as misuse.
 	 *
-	 * @covers ::update_form_fields
-	 * @covers ::update_view_list_items
+	 * @covers ::update_with
 	 */
 	public function test_null_patch_for_unknown_identity_is_silent_no_op() {
-		$data = new Gutenberg_View_Config_Data( array( 'form' => array( 'fields' => array( 'date' ) ) ) );
-		$data->update_form_fields( array( 'does_not_exist' => null ), 1 );
-
-		$this->assertSame( array( 'date' ), $data->get_config()['form']['fields'] );
-
 		$data = new Gutenberg_View_Config_Data(
 			array(
+				'form'      => array( 'fields' => array( 'date' ) ),
 				'view_list' => array(
 					array(
 						'title' => 'All',
@@ -1071,8 +773,17 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 				),
 			)
 		);
-		$data->update_view_list_items( array( 'does_not_exist' => null ), 1 );
 
+		$data->update_with(
+			$this->versioned(
+				array(
+					'form'      => array( 'fields' => array( 'does_not_exist' => null ) ),
+					'view_list' => array( 'also_missing' => null ),
+				)
+			)
+		);
+
+		$this->assertSame( array( 'date' ), $data->get_config()['form']['fields'] );
 		$this->assertSame(
 			array(
 				array(

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -146,15 +146,17 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A filter can override configuration values through update_properties().
+	 * A filter can override configuration values through update_with().
 	 */
-	public function test_filter_update_properties_overrides_config() {
+	public function test_filter_update_with_overrides_config() {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_properties(
-					array( 'default_view' => array( 'type' => 'grid' ) ),
-					1
+				return $data->update_with(
+					array(
+						'version'      => 1,
+						'default_view' => array( 'type' => 'grid' ),
+					)
 				);
 			}
 		);
@@ -173,17 +175,18 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->set(
-					'form',
+				return $data->update_with(
 					array(
-						'fields' => array(
-							array(
-								'id'       => 'discussion',
-								'children' => array( 'comment_status', 'ping_status' ),
+						'version' => 1,
+						'form'    => array(
+							'fields' => array(
+								array(
+									'id'       => 'discussion',
+									'children' => array( 'comment_status', 'ping_status' ),
+								),
 							),
 						),
-					),
-					1
+					)
 				);
 			},
 			9
@@ -191,7 +194,14 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_form_fields( array( 'ping_status' => null ), 1 );
+				return $data->update_with(
+					array(
+						'version' => 1,
+						'form'    => array(
+							'fields' => array( 'ping_status' => null ),
+						),
+					)
+				);
 			},
 			11
 		);
@@ -242,7 +252,12 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		add_filter(
 			'get_entity_view_config_custom_kind_custom_name',
 			function ( $data ) {
-				return $data->update_properties( array( 'default_view' => null ), 1 );
+				return $data->update_with(
+					array(
+						'version'      => 1,
+						'default_view' => null,
+					)
+				);
 			}
 		);
 


### PR DESCRIPTION
## What?
Simplifies the server-side view config data API to a single write method: `Gutenberg_View_Config_Data::update_with()`.

Before:
```php
$data->set( $key, $value, $version );
$data->update_properties( $patch, $version );
$data->update_view_list_items( $items, $version );
$data->update_form_fields( $fields, $version );
```

After:
```php
$data->update_with( $patch );
```

## Why?

The API should not be tied to particular keys that can change. Additionally, consumers should not need to choose between several public mutation methods.

## How?

`update_with()` now applies versioned patches.

## Testing Instructions

- Automated test should pass.
- Actual entity usage. Smoke test the site editor that uses the view config API: pages, templates, patterns, parts.

## Use of AI Tools

Used Codex for assistance.