### PR TITLE
Revisions: Synthesize explicit text rendering for visual diff markers

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -68,4 +68,89 @@
 			outline-offset: -2px;
 		}
 	}
+
+	// Activated when the "Show button text labels" preference
+	// is enabled.
+	.show-icon-labels & {
+		width: auto;
+		background: none;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 4px;
+		overflow-y: auto;
+
+		.revision-diff-marker {
+			position: static !important;
+			width: 100%;
+			min-height: 24px;
+			height: auto !important;
+			border-radius: 2px;
+			padding: 4px 8px;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+			font-size: $helptext-font-size;
+			font-weight: 600;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+
+			// In text-labels mode, show a small color swatch before the label
+			// to retain color as a secondary cue alongside the text.
+			&::before {
+				content: "";
+				flex-shrink: 0;
+				display: inline-block;
+				width: 10px;
+				height: 10px;
+				border-radius: 2px;
+			}
+
+			// Add text label from aria-label
+			&::after {
+				content: attr(aria-label);
+				flex: 1;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
+			&.is-added {
+				background: rgba(#008a20, 0.12);
+				color: #006117;
+
+				&::before {
+					background: #008a20;
+				}
+			}
+
+			&.is-removed {
+				background: rgba(#d63638, 0.1);
+				color: #c12b2d;
+
+				&::before {
+					background: repeating-linear-gradient(45deg, #d63638, #d63638 3px, rgba(#d63638, 0.45) 3px, rgba(#d63638, 0.45) 4px);
+				}
+			}
+
+			&.is-modified {
+				background: rgba(#9a7000, 0.1);
+				color: #7d5c00;
+
+				&::before {
+					background: repeating-linear-gradient(-45deg, #9a7000, #9a7000 3px, rgba(#9a7000, 0.45) 3px, rgba(#9a7000, 0.45) 4px);
+				}
+			}
+
+			&:hover {
+				opacity: 1;
+				filter: brightness(0.9);
+			}
+
+			&:focus {
+				outline: 2px solid $gray-900;
+				outline-offset: 2px;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What?

Part of #77530

This PR resolves the accessibility sub-issue where diff markers in the Revisions view did not respect the "Show button text labels" (`showIconLabels`) preference, remaining solely as color/pattern indicators instead of explicitly rendering their text.

## Why?

When a user activates the "Show button text labels" accessibility preference, visual indicators that rely solely on icons, shapes, or color should present a textual label. The diff markers minimap was providing color and pattern indicators (and tooltips), breaking this expectation in text-only mode and falling short of WCAG compliance for users who depend on explicit text labels.


## How?


Following the established pattern in Gutenberg's toolbar styles, this PR leverages the existing `.show-icon-labels` class added globally to the `<body>` element. This adds CSS rules targeting `.show-icon-labels .revision-diff-markers` that:
- Reflows the minimap from an absolutely positioned narrow element to a broader flex list.
- Overrides the inline positioning of markers with `!important` to allow static layout (standardizing the `.has-icon` overrides seen elsewhere in the editor).
- Employs `::after { content: attr(aria-label); }` to display the textual representation natively via CSS, sidestepping the need to add React state dependencies.


## Testing Instructions
1. Open a post that has previous revisions.
2. Go to **Options (⋮)** > **Preferences** > **Accessibility**.
3. Toggle ON **"Show button text labels"**.
4. Navigate to the Visual Revisions screen (from the Post sidebar).
5. Verify that the diff markers panel on the right displays fully labeled text buttons (e.g., "Go to modified block") with a small color swatch, rather than a narrow color-only minimap.
7. Turn the preference OFF and verify the minimap cleanly reverts to the original proportional visual appearance.


## Screenshots or screencast 


### Before


https://github.com/user-attachments/assets/27b04726-055e-46aa-bfa0-3e91949d1a6a



### After

https://github.com/user-attachments/assets/eedea397-4766-43d4-947f-fd502267f4f7


