### PR TITLE
Tabs: Add horizontal scrolling for non-wrapping tab lists

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -1003,7 +1003,7 @@ Display the tab buttons for a tabbed interface.
 -	**Name:** [core/tab-list](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/core-block-tab-list/)
 -	**Category:** [design](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/)
 -	**Parent:** core/tabs
--	**Supports:** ariaLabel, color (background, text), layout (default, ~~allowOrientation~~, ~~allowVerticalAlignment~~, ~~allowWrap~~), spacing (blockGap, padding), typography (fontSize), ~~html~~, ~~lock~~, ~~visibility~~
+-	**Supports:** ariaLabel, color (background, text), layout (allowWrap, default, ~~allowOrientation~~, ~~allowVerticalAlignment~~), spacing (blockGap, padding), typography (fontSize), ~~html~~, ~~lock~~, ~~visibility~~
 -	**Attributes:** tabs
 
 ## Tab Panel

--- a/packages/block-library/src/tab-list/README.md
+++ b/packages/block-library/src/tab-list/README.md
@@ -38,7 +38,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
   - [`default`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-default): `{"type":"flex","flexWrap":"wrap"}`
   - [`allowVerticalAlignment`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowverticalalignment): `false`
   - [`allowOrientation`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-alloworientation): `false`
-  - [`allowWrap`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowwrap): `false`
+  - [`allowWrap`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowwrap): `true`
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):
   - `padding`: `true`
   - `blockGap`: `true`

--- a/packages/block-library/src/tab-list/block.json
+++ b/packages/block-library/src/tab-list/block.json
@@ -55,7 +55,7 @@
 			},
 			"allowVerticalAlignment": false,
 			"allowOrientation": false,
-			"allowWrap": false
+			"allowWrap": true
 		},
 		"spacing": {
 			"padding": true,

--- a/packages/block-library/src/tab-list/style.scss
+++ b/packages/block-library/src/tab-list/style.scss
@@ -37,3 +37,11 @@
 		bottom: 0;
 	}
 }
+
+.wp-block-tab-list.is-nowrap {
+	overflow-x: auto;
+
+	:where(button) {
+		flex-shrink: 0;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #80239.

Adds support for disabling wrapping in the Tab List block and enables horizontal scrolling when wrapping is turned off.

## Why?

The Tab List block now wraps onto multiple lines by default, which provides a better experience when many tabs are present.

However, the block did not expose the existing `allowWrap` layout support, so authors could not choose to keep the tab list on a single row.

Simply enabling that layout support is not sufficient. When wrapping is disabled, the tab list can overflow its container and individual tab buttons shrink, causing tab labels to wrap onto multiple lines.

This change completes the non-wrapping experience by allowing the tab list to scroll horizontally while preserving each tab's natural width.

## How?

This PR builds on Gutenberg's existing flex layout support.

- Enables the existing `allowWrap` layout support for the Tab List block.
- Uses the existing `.is-nowrap` class added by the layout system when wrapping is disabled.
- Adds horizontal scrolling for the non-wrapping layout.
- Prevents tab buttons from shrinking so their labels remain on a single line.
- Updates the generated block documentation to reflect the newly enabled layout support.

## Testing Instructions

1. Create a new post or page.
2. Insert a **Tabs** block.
3. Add enough tabs so they exceed the available width.
4. Select the **Tab List** block.
5. Open the **Layout** panel.
6. Verify the **Allow wrapping** option is now available.
7. Disable **Allow wrapping**.
8. Verify the tab list remains on a single row.
9. Verify the tab list becomes horizontally scrollable.
10. Verify tab labels remain on a single line and do not wrap.
11. Enable **Allow wrapping** again.
12. Verify the tabs wrap onto multiple rows.

## Screenshots or screencast

**Before**

- The Tab List block does not expose an **Allow wrapping** option.
- Tabs remain wrapped by default with no way to switch to a horizontally scrollable single-row layout.


https://github.com/user-attachments/assets/4931532b-76e3-43ff-82de-0ab9c12c4c0d



**After**

- The Tab List block exposes the **Allow wrapping** layout option.
- Disabling wrapping keeps the tabs on a single row with horizontal scrolling, while tab labels remain on a single line.


https://github.com/user-attachments/assets/22016656-06eb-4795-a2f4-8d892e773536

