### PR TITLE
Icon block: Show text and background color controls by default.

### DIFF
--- a/packages/block-library/src/icon/README.md
+++ b/packages/block-library/src/icon/README.md
@@ -28,9 +28,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`ariaLabel`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#arialabel): `true`
 - [`align`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#align): `"left"`, `"center"`, `"right"`
 - [`html`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#html): `false`
-- [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
-  - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-background): `true`
-  - [`text`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-text): `true`
+- [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color): `true`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -35,7 +35,11 @@
 		"color": {
 			"background": true,
 			"text": true,
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
 		},
 		"interactivity": {
 			"clientNavigation": true

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -33,8 +33,6 @@
 		"align": [ "left", "center", "right" ],
 		"html": false,
 		"color": {
-			"background": true,
-			"text": true,
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"background": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Show the Icon block text and background color controls by default in the block inspector. 


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since we moved the color controls to the typography and background sections the controls are hidden by default and could make it difficult to discover.

Many blocks that expose color controls already opt into visible defaults via `color.__experimentalDefaultControls` (for example, `core/paragraph`

This change brings the icon block in line with that pattern and makes color styling discoverable without extra clicks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `color.__experimentalDefaultControls` to `packages/block-library/src/icon/block.json`. The typography and background panels already read these defaults.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a page.
2. Add an icon block.
3. Open the block inspector styles tab.
4. Confirm "Typography > Color" is visible by default (no need to use the "+" menu).
5. Confirm "Background > Color" is visible by default.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="3560" height="1962" alt="Screenshot 2026-07-14 at 14-37-28 Edit Page ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/10af7026-7457-4233-9a6b-8e292e4ffd05" /> | <img width="3560" height="1962" alt="Screenshot 2026-07-14 at 13-41-37 Edit Page ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/33ab0b84-35c2-4f75-a29f-d8c0a2bd0658" /> |




