### PR TITLE
DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set. [#80254](https://github.com/WordPress/gutenberg/pull/80254)
+
 ## 17.2.0 (2026-07-14)
 
 ### New Features
@@ -10,7 +14,6 @@
 
 ### Bug Fix
 
-- DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set. [#](https://github.com/WordPress/gutenberg/pull/)
 - DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer's visibility no longer depends on the loading state, so it no longer mounts mid-load (resizing the scroll container). [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
 ### Internal

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fix
 
+- DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set. [#](https://github.com/WordPress/gutenberg/pull/)
 - DataViews: Stop the infinite-scroll list from jumping while pages load asynchronously. The scroll-anchor restoration no longer discards scrolling the user did during the load, and the footer's visibility no longer depends on the loading state, so it no longer mounts mid-load (resizing the scroll container). [#79546](https://github.com/WordPress/gutenberg/pull/79546)
 
 ### Internal

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -572,11 +572,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				>
 					{ Array.from( dataByGroup.entries() ).map(
 						( [ groupName, groupItems ] ) => (
-							<Stack
-								direction="column"
-								key={ groupName }
-								gap="sm"
-							>
+							<Stack direction="column" key={ groupName }>
 								<h3 className="dataviews-view-list__group-header">
 									{ view.groupBy?.showLabel === false
 										? groupName

--- a/packages/dataviews/src/components/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/list/style.scss
@@ -283,6 +283,6 @@ div.dataviews-view-list {
 	font-size: var(--wpds-typography-font-size-lg);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 	color: var(--wpds-color-foreground-content-neutral);
-	margin: 0 0 var(--wpds-dimension-gap-sm) 0;
+	margin: 0 0 var(--wpds-dimension-gap-lg) 0;
 	padding: 0 var(--wpds-dimension-padding-2xl);
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the unintended gap between `list` layout items when `groupBy` is set. In trunk we added an extra gap between the list items when grouped. 

## Testing Instructions
1. In storybook (`npm run storybook:dev`) go to `?path=/story/dataviews-dataviews--layout-list&args=groupBy:!true`
2. Select an item and observe there is no extra gap. 
3. Additionally the existing header gap from list items remains the same

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="905" height="736" alt="Screenshot 2026-07-14 at 5 03 43 PM" src="https://github.com/user-attachments/assets/e9af79cf-6942-4ebb-b08d-d9915d1fde46" />|<img width="905" height="736" alt="Screenshot 2026-07-14 at 4 54 35 PM" src="https://github.com/user-attachments/assets/4c382e69-f3bb-4c5b-afc7-d104468e3095" />|





