### PR TITLE
Fix: Allow icon labels to wrap with word breaks and no ellipsis

### DIFF
--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -67,9 +67,10 @@
 	font-size: $font-size-small;
 	padding: $grid-unit-05 $grid-unit-05 $grid-unit-10;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	text-overflow: clip;
+	white-space: normal;
 	width: 100%;
+	overflow-wrap: break-word;
 }
 
 .wp-block-icon__toolbar-content {

--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -66,10 +66,6 @@
 .wp-block-icon__inserter-grid-icons-list-item-title {
 	font-size: $font-size-small;
 	padding: $grid-unit-05 $grid-unit-05 $grid-unit-10;
-	overflow: hidden;
-	text-overflow: clip;
-	white-space: normal;
-	width: 100%;
 	overflow-wrap: break-word;
 }
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This pull request updates the styling for icon editor text in the `editor.scss` file. The main change is to improve how long text is displayed, allowing it to wrap and preventing it from being cut off with an ellipsis.

Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
When adding custom Icons we noticed that icons with large lables were overlapping in core and in gutenberg
are not wrapped and there is ellipsis at end although making it difficult to read labels, it also doesn't have tooltip which confuses users 

## How?
**Text wrapping improvements:**

* Changed text overflow handling from `ellipsis` to `clip`, set `white-space` to `normal`, and added `overflow-wrap: break-word` to ensure long text wraps within the container instead of being truncated. (`packages/block-library/src/icon/editor.scss`)

## Testing Instructions
1. Install and activate the [custom-icons.zip](https://github.com/user-attachments/files/30013110/custom-icons.zip) attached with this PR
2. Goto -> Post -> insert Icon Block
3. Click change icons 
4. Toggle Custom Icons
5. Check if you can read the labels of custom icons eg: "Filled Arrow Bend Double Up Right", "Filled Arrow Elbow Left Down" etc.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1582" height="940" alt="Screenshot 2026-07-14 at 8 19 30 PM" src="https://github.com/user-attachments/assets/6c4b3d0c-9d6f-40ec-8cf8-eb977682e206" />|<img width="1582" height="940" alt="Screenshot 2026-07-14 at 8 22 38 PM" src="https://github.com/user-attachments/assets/66c83e21-abc9-4af4-8d9e-137b6ef25128" />|

## Use of AI Tools

Nope
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

