### PR TITLE
Social Link: Fix stray closing tag in Tumblr icon markup

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -295,7 +295,7 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 		),
 		'tumblr'        => array(
 			'name' => _x( 'Tumblr', 'social link block variation name' ),
-			'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M17.04 21.28h-3.28c-2.84 0-4.94-1.37-4.94-5.02v-5.67H6.08V7.5c2.93-.73 4.11-3.3 4.3-5.48h3.01v4.93h3.47v3.65H13.4v4.93c0 1.47.73 2.01 1.92 2.01h1.73v3.75z" /></path></svg>',
+			'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M17.04 21.28h-3.28c-2.84 0-4.94-1.37-4.94-5.02v-5.67H6.08V7.5c2.93-.73 4.11-3.3 4.3-5.48h3.01v4.93h3.47v3.65H13.4v4.93c0 1.47.73 2.01 1.92 2.01h1.73v3.75z"></path></svg>',
 		),
 		'twitch'        => array(
 			'name' => _x( 'Twitch', 'social link block variation name' ),


### PR DESCRIPTION
## What?

The server-side Tumblr icon SVG in `block_core_social_link_services()` closes its `<path>` element twice — once with a self-closing `/>` and again with an explicit `</path>`:

```html
<path d="…v3.75z" /></path>
```

This removes the redundant self-closing slash so the element is closed exactly once.

## Why?

`<path … /></path>` produces a stray `</path>` end tag, which is invalid HTML and throws a W3C validation error ("Stray end tag `path`") on every front-end render of a Social Links block that includes the Tumblr service — for example, the global footer on make.wordpress.org.

Note the JSX icon (`icons/tumblr.js`) is already valid; only the hand-written PHP SVG string used for server rendering carries the typo, so the editor looks fine while the front end emits invalid markup.

Reported downstream at https://meta.trac.wordpress.org/ticket/8317.

## How?

Drops the ` /` from the Tumblr `<path>` so it closes only via `</path>`, matching the convention used by the other 39 icons in this file.

Before:
```html
<path d="…h1.73v3.75z" /></path></svg>
```
After:
```html
<path d="…h1.73v3.75z"></path></svg>
```

## Testing Instructions

1. Add a Social Links block and include the Tumblr service (or view any page rendering one, e.g. a site's footer).
2. View the rendered page source on the front end.
3. Confirm the Tumblr icon outputs `<path … ></path>` with no stray `</path>`.
4. Run the output through the [W3C validator](https://validator.w3.org/nu/) and confirm the "Stray end tag path" error for the Tumblr icon is gone.

## Screenshots or screencast

N/A — markup-only change; the rendered icon is visually identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4aw9XgpM7VnE6WQ7ci6ff