### PR TITLE
DataViews: Fix the `list` layout ignoring some settings when `groupBy`  is set (#80255)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- DataViews: Fix the `list` layout ignoring the density setting, the refreshing state, and the loading state when `groupBy` is set. [#80255](https://github.com/WordPress/gutenberg/pull/80255)
+
 ## 17.2.0 (2026-07-14)
 
 ### New Features

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -541,6 +541,20 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		isInfiniteScroll &&
 		( view.startPosition ?? 1 ) + ( view.perPage ?? 0 ) <
 			paginationInfo.totalItems;
+	const listClassName = clsx( 'dataviews-view-list', className, {
+		[ `has-${ view.layout?.density }-density` ]:
+			view.layout?.density &&
+			[ 'compact', 'comfortable' ].includes( view.layout.density ),
+		'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
+	} );
+	const compositeProps = {
+		ref: compositeRef,
+		id: baseId,
+		render: <div />,
+		activeId: activeCompositeId,
+		setActiveId: setActiveCompositeId,
+		inert: ! isInfiniteScroll && !! isLoading ? 'true' : undefined,
+	};
 	if ( ! hasData ) {
 		return (
 			<div
@@ -557,19 +571,11 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	if ( hasData && groupField && dataByGroup ) {
 		return (
 			<Composite
-				ref={ compositeRef }
-				id={ `${ baseId }` }
-				render={ <div /> }
+				{ ...compositeProps }
 				className="dataviews-view-list__group"
 				role="grid"
-				activeId={ activeCompositeId }
-				setActiveId={ setActiveCompositeId }
 			>
-				<Stack
-					direction="column"
-					gap="lg"
-					className={ clsx( 'dataviews-view-list', className ) }
-				>
+				<Stack direction="column" gap="lg" className={ listClassName }>
 					{ Array.from( dataByGroup.entries() ).map(
 						( [ groupName, groupItems ] ) => (
 							<Stack
@@ -623,24 +629,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	return (
 		<>
 			<Composite
-				ref={ compositeRef }
-				id={ baseId }
-				render={ <div /> }
-				className={ clsx( 'dataviews-view-list', className, {
-					[ `has-${ view.layout?.density }-density` ]:
-						view.layout?.density &&
-						[ 'compact', 'comfortable' ].includes(
-							view.layout.density
-						),
-					'is-refreshing': ! isInfiniteScroll && isDelayedLoading,
-				} ) }
+				{ ...compositeProps }
+				className={ listClassName }
 				role={ view.infiniteScrollEnabled ? 'feed' : 'grid' }
-				activeId={ activeCompositeId }
-				setActiveId={ setActiveCompositeId }
-				// @ts-ignore
-				inert={
-					! isInfiniteScroll && !! isLoading ? 'true' : undefined
-				}
 			>
 				{ data.map( ( item, index ) => {
 					const id = generateCompositeItemIdPrefix( item );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -683,6 +683,49 @@ describe( 'DataViews component', () => {
 				screen.getAllByRole( 'button', { name: 'Actions' } ).length
 			).toEqual( 3 );
 		} );
+
+		describe.each( [
+			[ 'ungrouped', undefined ],
+			[ 'grouped', { field: 'author', direction: 'asc' as const } ],
+		] )( 'when %s', ( _name, groupBy ) => {
+			const view: View = {
+				type: 'list',
+				groupBy,
+				layout: { density: 'compact' },
+			};
+
+			it( 'should apply the configured density', () => {
+				const { container } = render(
+					<DataViewWrapper view={ view } />
+				);
+				expect(
+					// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+					container.querySelector( '.dataviews-view-list' )
+				).toHaveClass( 'has-compact-density' );
+			} );
+
+			it( 'should become inert while loading and refreshing once the delay elapses', async () => {
+				const { container, rerender } = render(
+					<DataViewWrapper view={ view } />
+				);
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				const list = container.querySelector( '.dataviews-view-list' );
+
+				expect( screen.getByRole( 'grid' ) ).not.toHaveAttribute(
+					'inert'
+				);
+
+				rerender( <DataViewWrapper view={ view } isLoading /> );
+
+				expect( screen.getByRole( 'grid' ) ).toHaveAttribute( 'inert' );
+				// The refreshing state is deliberately delayed, so it is not
+				// applied on the render that starts the load.
+				expect( list ).not.toHaveClass( 'is-refreshing' );
+				await waitFor( () =>
+					expect( list ).toHaveClass( 'is-refreshing' )
+				);
+			} );
+		} );
 	} );
 
 	describe( 'actions on mobile viewport', () => {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Manual backport of https://github.com/WordPress/gutenberg/pull/80255