### PR TITLE
Scripts: Recognize GPLv3 as compatible in check-licenses

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `check-licenses`: Recognize GPLv3 licenses (`GPL-3.0`, `GPL-3.0-only`, `GPL-3.0-or-later`) as compatible when the `--gpl2` flag is not passed ([#20701](https://github.com/WordPress/gutenberg/issues/20701)).
+
 ## 33.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -177,6 +177,8 @@ It uses [check-node-version](https://www.npmjs.com/package/check-node-version) b
 
 Validates that all dependencies of a project are compatible with the project’s own license.
 
+Note that this is a WordPress-specific tool: it assumes that the project is distributed under the terms of the GPL version 2 (or later). GPLv3-licensed dependencies are considered compatible by default, since a "GPLv2 or later" project can be combined with GPLv3 code and distributed under GPLv3. Passing the `--gpl2` flag restricts the check to strict GPLv2 compatibility, which excludes GPLv3 (and other GPLv2-incompatible licenses such as Apache-2.0). This tool performs a best-effort check of `license` metadata and license files; it isn't guaranteed to produce legally accurate results.
+
 _Example:_
 
 ```json

--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -93,6 +93,9 @@ const otherOssLicenses = [
 	'Apache License, Version 2.0',
 	'CC-BY-3.0',
 	'CC-BY-SA-2.0',
+	'GPL-3.0',
+	'GPL-3.0-only',
+	'GPL-3.0-or-later',
 	'LGPL',
 	'Python-2.0',
 ];

--- a/packages/scripts/utils/test/license.js
+++ b/packages/scripts/utils/test/license.js
@@ -7,7 +7,11 @@ const path = require( 'path' );
 /**
  * Internal dependencies
  */
-import { detectTypeFromLicenseText, checkAllCompatible } from '../license';
+const {
+	detectTypeFromLicenseText,
+	checkAllCompatible,
+	getLicenses,
+} = require( '../license' );
 
 describe( 'detectTypeFromLicenseText', () => {
 	let licenseText;
@@ -82,5 +86,28 @@ describe( 'checkAllCompatible', () => {
 		expect( checkAllCompatible( [ 'A', 'D' ], [ 'A', 'B', 'C' ] ) ).toBe(
 			false
 		);
+	} );
+} );
+
+describe( 'getLicenses', () => {
+	it( 'should include GPLv3 licenses by default', () => {
+		const licenses = getLicenses( false );
+
+		expect( licenses ).toContain( 'GPL-3.0' );
+		expect( licenses ).toContain( 'GPL-3.0-only' );
+		expect( licenses ).toContain( 'GPL-3.0-or-later' );
+	} );
+
+	it( 'should exclude GPLv3 licenses when gpl2 is true', () => {
+		const licenses = getLicenses( true );
+
+		expect( licenses ).not.toContain( 'GPL-3.0' );
+		expect( licenses ).not.toContain( 'GPL-3.0-only' );
+		expect( licenses ).not.toContain( 'GPL-3.0-or-later' );
+	} );
+
+	it( 'should always include GPLv2 compatible licenses', () => {
+		expect( getLicenses( true ) ).toContain( 'GPL-2.0-or-later' );
+		expect( getLicenses( false ) ).toContain( 'GPL-2.0-or-later' );
 	} );
 } );


### PR DESCRIPTION
Fixes #20701

## What?

Adds the GPLv3 license identifiers (`GPL-3.0`, `GPL-3.0-only`, `GPL-3.0-or-later`) to the `otherOssLicenses` list in `check-licenses`, so dependencies under those licenses are accepted when the `--gpl2` flag is **not** passed. Strict GPLv2 mode (`--gpl2`) continues to reject them.

## Why?

As reported in #20701, `wp-scripts check-licenses` currently errors on `GPL-3.0-or-later` dependencies even in default mode. Since WordPress is distributed under "GPLv2 **or later**", GPLv3-licensed code can be combined with it. This implements the approach proposed by @pento in https://github.com/WordPress/gutenberg/issues/20701#issuecomment-761961307: add GPLv3 to `otherOssLicenses`, and be more explicit in the readme that `check-licenses` is a WordPress-specific tool.

Note: I'm aware of the warning comment in `license.js` that changes to the license lists need explicit review — flagging that this PR is exactly such a change. The deprecated SPDX identifier `GPL-3.0` is included alongside the two modern ones because older packages still declare it; happy to drop it if preferred.

## How?

- `packages/scripts/utils/license.js`: three GPLv3 identifiers added to `otherOssLicenses` (kept alphabetical).
- `packages/scripts/README.md`: the `check-licenses` section now explains the tool is WordPress-specific, why GPLv3 is accepted by default, and that `--gpl2` restricts to strict GPLv2 compatibility.
- `packages/scripts/utils/test/license.js`: new `getLicenses()` tests covering both modes (also converted the internal import to `require` to satisfy the strict `import/order` pre-commit lint).
- `packages/scripts/CHANGELOG.md`: entry under Unreleased.

## Testing Instructions

1. `npx jest packages/scripts/utils/test/license.js --config=test/unit/jest.config.js` — 12 tests pass.
2. Functional check: in a temp project with a dependency whose `package.json` declares `"license": "GPL-3.0-or-later"`:
   - `wp-scripts check-licenses` → passes (exit 0). Before this change it errored with `Module <dep> has an incompatible license 'GPL-3.0-or-later'.`
   - `wp-scripts check-licenses --gpl2` → still fails as expected.
