### PR TITLE
fix(block-editor): justify text alignment persists on frontend

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Text alignment: allow `justify` in the typography `textAlign` support so justified alignment is serialized as `has-text-align-justify` and offered on the block toolbar ([#79775](https://github.com/WordPress/gutenberg/issues/79775)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).
 -   Inserter: Keep the hovered block preview inside the viewport, so a tall preview in a short window is no longer clipped ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).

--- a/packages/block-editor/src/hooks/test/text-align.jsdom.test.jsx
+++ b/packages/block-editor/src/hooks/test/text-align.jsdom.test.jsx
@@ -40,8 +40,13 @@ describe( 'textAlign', () => {
 
 		it( 'should return all text aligns sorted when provided in the random order', () => {
 			expect(
-				getValidTextAlignments( [ 'right', 'center', 'left' ] )
-			).toEqual( [ 'left', 'center', 'right' ] );
+				getValidTextAlignments( [
+					'right',
+					'justify',
+					'center',
+					'left',
+				] )
+			).toEqual( [ 'left', 'center', 'right', 'justify' ] );
 		} );
 
 		it( 'should return all text aligns if block defines text align support as true', () => {
@@ -49,12 +54,19 @@ describe( 'textAlign', () => {
 				'left',
 				'center',
 				'right',
+				'justify',
 			] );
+		} );
+
+		it( 'should keep justify when listed by the block', () => {
+			expect(
+				getValidTextAlignments( [ 'left', 'right', 'justify' ] )
+			).toEqual( [ 'left', 'right', 'justify' ] );
 		} );
 
 		it( 'should remove incorrect text aligns', () => {
 			expect(
-				getValidTextAlignments( [ 'left', 'right', 'justify' ] )
+				getValidTextAlignments( [ 'left', 'right', 'foo' ] )
 			).toEqual( [ 'left', 'right' ] );
 		} );
 	} );
@@ -135,6 +147,35 @@ describe( 'textAlign', () => {
 
 			expect( props ).toEqual( {
 				className: 'has-text-align-center foo',
+			} );
+		} );
+
+		it( 'should add the justify classname when text align is justify', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					typography: {
+						textAlign: true,
+					},
+				},
+			} );
+
+			const props = addAssignedTextAlign(
+				{
+					className: 'foo',
+				},
+				'core/foo',
+				{
+					style: {
+						typography: {
+							textAlign: 'justify',
+						},
+					},
+				}
+			);
+
+			expect( props ).toEqual( {
+				className: 'has-text-align-justify foo',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/hooks/text-align.jsx
+++ b/packages/block-editor/src/hooks/text-align.jsx
@@ -1,7 +1,12 @@
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
-import { alignLeft, alignRight, alignCenter } from '@wordpress/icons';
+import {
+	alignLeft,
+	alignRight,
+	alignCenter,
+	alignJustify,
+} from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { AlignmentControl, BlockControls } from '../components';
 import { useBlockEditingMode } from '../components/block-editing-mode';
@@ -33,9 +38,14 @@ const TEXT_ALIGNMENT_OPTIONS = [
 		title: __( 'Align text right' ),
 		align: 'right',
 	},
+	{
+		icon: alignJustify,
+		title: __( 'Justify text' ),
+		align: 'justify',
+	},
 ];
 
-const VALID_TEXT_ALIGNMENTS = [ 'left', 'center', 'right' ];
+const VALID_TEXT_ALIGNMENTS = [ 'left', 'center', 'right', 'justify' ];
 const NO_TEXT_ALIGNMENTS = [];
 
 /**

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -15,6 +15,8 @@
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
 -   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
+-   Common styles: add `.has-text-align-justify` so justified text alignment from block supports renders on the front end ([#79775](https://github.com/WordPress/gutenberg/issues/79775)).
+-   Paragraph and Heading: preserve `text-align: justify` when pasting HTML ([#79775](https://github.com/WordPress/gutenberg/issues/79775)).
 
 ### Internal
 

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -49,6 +49,9 @@
 	/*rtl:ignore*/
 	text-align: right;
 }
+:root .has-text-align-justify {
+	text-align: justify;
+}
 
 // Fit Text
 .has-fit-text {

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -79,7 +79,8 @@ const transforms = {
 				if (
 					textAlign === 'left' ||
 					textAlign === 'center' ||
-					textAlign === 'right'
+					textAlign === 'right' ||
+					textAlign === 'justify'
 				) {
 					attributes.style = {
 						...attributes.style,

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -23,7 +23,8 @@ const transforms = {
 				if (
 					textAlign === 'left' ||
 					textAlign === 'center' ||
-					textAlign === 'right'
+					textAlign === 'right' ||
+					textAlign === 'justify'
 				) {
 					attributes.style = {
 						...attributes.style,

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   Types: allow `justify` in the `typography.textAlign` support array ([#79775](https://github.com/WordPress/gutenberg/issues/79775)).
 -   `getBlockAttributes` no longer breaks when a block has no content to parse, such as a self-closing shortcode: missing content is treated as empty markup instead of reaching the attribute matchers ([#81831](https://github.com/WordPress/gutenberg/pull/81831)).
 
 ## 15.27.0 (2026-08-26)

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -1089,7 +1089,7 @@ export interface TypographyProps {
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-textalign
 	 */
-	textAlign: boolean | Array< 'left' | 'center' | 'right' >;
+	textAlign: boolean | Array< 'left' | 'center' | 'right' | 'justify' >;
 }
 
 /**

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -660,7 +660,12 @@
 									"type": "array",
 									"items": {
 										"type": "string",
-										"enum": [ "left", "center", "right" ]
+										"enum": [
+											"left",
+											"center",
+											"right",
+											"justify"
+										]
 									}
 								}
 							],


### PR DESCRIPTION
## Summary

Fix justify text alignment not persisting on the frontend. When selecting Justify from the block toolbar, the `has-text-align-justify` class was not added to the saved HTML, causing the text to fall back to `text-align: start` on the front end.

Fixes #79775

## Changes

### packages/block-editor/src/hooks/text-align.js
**Before:** Justify was not included in the alignment options array
**After:** Added `justify` to the supported text alignments

### packages/block-library/src/paragraph/transforms.js
**Before:** Transform output did not include justify class
**After:** Added `has-text-align-justify` class mapping in block transforms

### packages/block-library/src/heading/transforms.js
**Before:** Transform output did not include justify class
**After:** Added `has-text-align-justify` class mapping in block transforms

### packages/block-library/src/common.scss
**Before:** No CSS rule for `has-text-align-justify`
**After:** Added `text-align: justify` rule for the justify class

### packages/block-editor/src/hooks/test/text-align.js
Added test coverage for justify alignment behavior.

## Testing

**Test 1: Toolbar justify persists on frontend**
1. Create a new post
2. Add a Paragraph block with 3-4 lines of text
3. Select Justify from the block toolbar
4. Publish and view on frontend
5. Inspect element: class list includes `has-text-align-justify`, computed `text-align` is `justify`

**Test 2: Left/center/right still work**
1. Set each alignment from toolbar
2. Publish and view frontend
3. Confirm matching class and computed text-align

**Test 3: Global Styles path**
1. Site Editor > Styles > Blocks > Paragraph > Typography > Text alignment > Justify
2. Confirm paragraphs render justified on frontend

## Screenshots

<img width="852" height="686" alt="SCR-20260715-bokt" src="https://github.com/user-attachments/assets/bdee0c8d-b9f6-4fbd-adce-a74f599f8912" />
<img width="1367" height="506" alt="SCR-20260715-bonz" src="https://github.com/user-attachments/assets/c940ad75-0a16-45fb-a11b-beb3762cb48c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Justify** as a text-alignment option in the block toolbar.
  * Justified text now displays correctly on the front end.
  * Paragraph and Heading blocks preserve justified alignment when pasting HTML.

* **Bug Fixes**
  * Improved handling and serialization of justified text alignment, including the appropriate alignment styling class.
  * Added support for justified alignment across typography settings and block configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->