### PR TITLE
Theme: Widen peer dependency ranges to support new versions of Vite, ESBuild, and Stylelint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47979,11 +47979,11 @@
 			},
 			"peerDependencies": {
 				"@types/react": "^18 || ^19",
-				"esbuild": "^0.27.2",
+				"esbuild": ">=0.27.2 <1.0.0",
 				"postcss": "^8.0.0",
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19",
-				"stylelint": "^16.8.2",
+				"stylelint": "^16 || ^17",
 				"vite": "^7 || ^8"
 			},
 			"peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47984,7 +47984,7 @@
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19",
 				"stylelint": "^16.8.2",
-				"vite": "^7.3.2"
+				"vite": "^7 || ^8"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Widen the optional `vite` peer dependency range to accept Vite 8, so projects on Vite 8 can install the package without peer resolution conflicts ([#80267](https://github.com/WordPress/gutenberg/pull/80267)).
+-   Widen the optional `vite` and `stylelint` peer dependency ranges to accept Vite 8 and Stylelint 17 (and the full Stylelint 16 range), so projects on newer tooling can install the package without peer resolution conflicts ([#80267](https://github.com/WordPress/gutenberg/pull/80267)).
 
 ### Documentation
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Widen the optional `vite` and `stylelint` peer dependency ranges to accept Vite 8 and Stylelint 17 (and the full Stylelint 16 range), so projects on newer tooling can install the package without peer resolution conflicts ([#80267](https://github.com/WordPress/gutenberg/pull/80267)).
+-   Widen optional peer dependency ranges so projects on newer tooling can install without peer resolution conflicts: Vite `^7 || ^8`, Stylelint `^16 || ^17`, and esbuild `>=0.27.2 <1.0.0` ([#80267](https://github.com/WordPress/gutenberg/pull/80267)).
 
 ### Documentation
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Widen the optional `vite` peer dependency range to accept Vite 8, so projects on Vite 8 can install the package without peer resolution conflicts ([#80267](https://github.com/WordPress/gutenberg/pull/80267)).
+
 ### Documentation
 
 -   Add a Storybook typography showcase that renders the published CSS design tokens directly ([#80212](https://github.com/WordPress/gutenberg/pull/80212)).

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -111,7 +111,7 @@
 		"react": "^18 || ^19",
 		"react-dom": "^18 || ^19",
 		"stylelint": "^16.8.2",
-		"vite": "^7.3.2"
+		"vite": "^7 || ^8"
 	},
 	"peerDependenciesMeta": {
 		"@types/react": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -106,7 +106,7 @@
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",
-		"esbuild": "^0.27.2",
+		"esbuild": ">=0.27.2 <1.0.0",
 		"postcss": "^8.0.0",
 		"react": "^18 || ^19",
 		"react-dom": "^18 || ^19",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -110,7 +110,7 @@
 		"postcss": "^8.0.0",
 		"react": "^18 || ^19",
 		"react-dom": "^18 || ^19",
-		"stylelint": "^16.8.2",
+		"stylelint": "^16 || ^17",
 		"vite": "^7 || ^8"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
## What?

Updates `@wordpress/theme` Vite peer dependency to allow Vite 8, ESBuild 0.28, and Stylelint 17 to be used as a peer dependency.

**Edit:** The remainder of this pull request was written when this only covered Vite, but the same logic extends to the other peer dependencies as well. See more detail in https://github.com/WordPress/gutenberg/pull/80267#discussion_r3581891452 and https://github.com/WordPress/gutenberg/pull/80267#issuecomment-4995228531.

## Why?

In general, we should seek to support the latest versions of whatever peer dependencies we impose.

Vite is an optional peer dependency, since the theme package provides its [own Vite plugin](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#vite) that can be used to dynamically inject design token fallback values. However, even though it's optional, if a downstream consumer uses both Vite and `@wordpress/theme` in the same project, the peer dependency range is validated according to what's defined in the theme package, even if the downstream project has no intention of using the theme Vite plugin. Since Vite is such a common build library, this could be quite common to encounter. This was flagged in the real world by [Automattic/studio](https://github.com/Automattic/studio) trying to adopt the theme package.

## How?

Updates peer dependency range to include v8 (and the entirety of the v7 range) after confirming compatibility.

## Testing Instructions

This might be difficult to test, though you might be able to achieve it with [`npm link`](https://docs.npmjs.com/cli/v8/commands/npm-link)ing the package in this branch. 

The general procedure would look like:

- Create a new NPM project: `mkdir tmp-vite && cd tmp-vite && npm init -y`
- Add Vite 8 as a dependency: `npm install vite`
- Add `@wordpress/theme` as a dependency: `npm install @wordpress/theme`
- Verify there are no peer dependency errors

## Use of AI Tools

Used Claude Code + Fable model to investigate and implement. Verified compatibility findings manually.