### PR TITLE
UI: Remove unused direction factor CSS property

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Remove unused CSS property from `Tabs` stylesheet ([#80269](https://github.com/WordPress/gutenberg/pull/80269)).
+
 ## 0.18.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/ui/src/tabs/style.module.css
+++ b/packages/ui/src/tabs/style.module.css
@@ -8,12 +8,10 @@
 			overflow-inline: auto;
 			overscroll-behavior-inline: none;
 
-			--direction-factor: 1;
 			--direction-start: left;
 			--direction-end: right;
 
 			&:dir(rtl) {
-				--direction-factor: -1;
 				--direction-start: right;
 				--direction-end: left;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes an unused CSS property `--direction-factor` from the implementation of `@wordpress/ui` Tabs component.

Follow-up to https://github.com/WordPress/gutenberg/pull/74652/files#r3508159487

## Why?

Unused code inflates downloaded stylesheet size and creates confusion for future maintenance.

## Testing Instructions

Verify no regressions in Tabs Storybook:

1. `npm run storybook:dev`
2. Go to http://localhost:50240/gutenberg/?path=/docs/design-system-components-tabs--docs
3. Observe that Tabs component looks and behaves as it does in `trunk`.

## Use of AI Tools

No AI was used in implementation. I don't recall if I had used AI assistance in research leading up to my comment https://github.com/WordPress/gutenberg/pull/74652/files#r3508159487 as to whether the CSS property was unused.