### PR TITLE
Theme: Update colorjs.io dependency and drop bug workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47933,7 +47933,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
-				"colorjs.io": "^0.6.0",
+				"colorjs.io": "^0.7.0",
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
@@ -47986,9 +47986,9 @@
 			}
 		},
 		"packages/theme/node_modules/colorjs.io": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.0.tgz",
+			"integrity": "sha512-JfLy3aZW1Xp2iwSFzGlLn0XSMnIdItH3BmzsXtwHVFEWwVUJIwKBWNzjQq2Tgf3998OY7qW2R6klrlYo8vmEGg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Code Quality
 
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).
+-   Update `colorjs.io` dependency to remove need for colorspace registration workaround ([#80272](https://github.com/WordPress/gutenberg/pull/80272)).
 
 ## 1.0.0 (2026-07-14)
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -83,7 +83,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",
-		"colorjs.io": "^0.6.0",
+		"colorjs.io": "^0.7.0",
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -43,9 +43,7 @@ export function getContrast(
  * `rgb()`/`rgba()`, or a CSS named color), throwing otherwise.
  *
  * Rejection is deterministic regardless of which `ColorSpace`s are globally
- * registered: `clampToGamut` registers `OKLCH`, which would otherwise make
- * `oklch()` strings parse, but their space id is `oklch` (not `srgb`) so they
- * are still rejected.
+ * registered.
  *
  * @param seed The seed-color string to validate.
  * @throws If `seed` is not an sRGB-parseable, fully opaque string.
@@ -87,8 +85,5 @@ export function assertValidSeedColor( seed: string ): void {
  */
 export function clampToGamut( c: string | PlainColorObject ) {
 	ColorSpace.register( sRGB );
-	// Workaround for upstream toGamut(method:'css') bug.
-	// https://github.com/color-js/color.js/pull/734
-	ColorSpace.register( OKLCH );
 	return to( toGamut( c, { space: sRGB, method: 'css' } ), OKLCH );
 }

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -1,6 +1,6 @@
 import {
 	get,
-	toGamut,
+	toGamutCSS,
 	OKLCH,
 	sRGB,
 	type ColorSpace,
@@ -209,7 +209,7 @@ function maxInGamutChromaAtLH(
 	};
 
 	// Let `toGamut` reduce the chroma to the gamut maximum.
-	const clamped = toGamut( probe, { space: gamutSpace, method: 'css' } );
+	const clamped = toGamutCSS( probe, { space: gamutSpace } );
 
 	return get( clamped, [ OKLCH, 'c' ] );
 }

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -1,9 +1,9 @@
 import {
-	ColorSpace,
 	get,
 	toGamut,
 	OKLCH,
 	sRGB,
+	type ColorSpace,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 
@@ -36,10 +36,6 @@ export function taperChroma(
 	lTarget: number, // [0..1]
 	options: TaperChromaOptions = {}
 ): { l: number; c: number } | PlainColorObject {
-	// Workaround for upstream toGamut(method:'css') bug.
-	// https://github.com/color-js/color.js/pull/734
-	ColorSpace.register( OKLCH );
-
 	const gamut = options.gamut ?? sRGB;
 	const alpha = options.alpha ?? 0.65; // 0.7-0.8 works well for accent surface
 	const carry = options.carry ?? 0.5;

--- a/packages/theme/src/color-ramps/test/seed-input.test.ts
+++ b/packages/theme/src/color-ramps/test/seed-input.test.ts
@@ -37,7 +37,7 @@ function testSeedColorContract( build: ( seed: string ) => unknown ) {
 		expect( () => build( seed ) ).toThrow();
 	} );
 
-	it( 'rejects oklch() even when the OKLCH color space is registered', () => {
+	it( 'rejects non-sRGB color spaces even when the color space is registered', () => {
 		// Registering OKLCH would otherwise make `oklch(...)` strings parse.
 		ColorSpace.register( OKLCH );
 		expect( () => build( 'oklch(0.7 0.15 250)' ) ).toThrow();


### PR DESCRIPTION
## What?

Updates `@wordpress/theme`'s dependency on [`colorjs.io`](https://www.npmjs.com/package/colorjs.io), removing temporary workarounds that have since been resolved upstream.

Changelog: https://github.com/color-js/color.js/releases/tag/v0.7.0

## Why?

In general, we should always want to stay up-to-date on dependencies.

For this one in particular though, there are a few specific reasons for updating:

- We've had to work-around an issue where we want to only support sRGB strings for theme seed values (as documented in [the package README](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/README.md#theme-provider)), but there was an upstream bug that required us to register OKLCH colorspace, and colorjs.io color space registration is global such that OKLCH values were parseable despite us not wanting to support them. #79148 added validation to enforce this. But with this updated version, our upstream patch https://github.com/color-js/color.js/pull/734 is included and we no longer need to register the OKLCH colorspace.
- The updated version includes a lot of new capabilities with new colorspaces and gamut mapping methods that could be relevant to refine our theme color ramp implementation.

## Testing Instructions

Verify tests pass:

```
npm run test:unit packages/theme
```

Verify that build artifacts produce identical results:

```
npm run --workspace @wordpress/theme build
git diff # Should be no diff
```

Verify Storybook ThemeProvider color ramps match [what's in the live Storybook](https://wordpress.github.io/gutenberg/?path=/docs/design-system-theme-theme-provider--docs):

1. `npm run storybook:dev`
2. Go to http://localhost:50240/gutenberg/?path=/docs/design-system-theme-theme-provider--docs

## Use of AI Tools

Implementation was manual, but I used Cursor IDE + Auto (likely Composer) model to identify any lingering references to this workaround, which helped find additional references in JSDoc and unit test descriptions that were included in the updates.