### PR TITLE
docs(block-api): clarify no-selector attribute source behavior

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -112,7 +112,7 @@ The available `source` values are:
 - `query` - data is stored as an array of objects.
 - `meta` - data is stored in post meta (deprecated).
 
-The `source` field is usually combined with a `selector` field. If no selector argument is specified, the source definition runs against the block's root node. If a selector argument is specified, it will run against the matching element(s) within the block.
+The `source` field is usually combined with a `selector` field. If no selector argument is specified, the source definition runs against the body element that wraps the block's markup, not the block's root element itself. To read a value from the block's root element, use a selector that matches it, such as its tag or a class. If a selector argument is specified, the source definition runs against the matching element(s) within the block.
 
 The `selector` can be an HTML tag, or anything queryable with [querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), such as a class or id attribute. Examples are given below.
 

--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -118,6 +118,8 @@ The `selector` can be an HTML tag, or anything queryable with [querySelector](ht
 
 For example, a `selector` of `img` will match an `img` element, and `img.class` will match an `img` element that has a class of `class`.
 
+A selector can also match the block's root element itself. For example, if a block saves `<div class="wp-block-myplugin-section" data-section-name="…">`, an attribute sourced from `data-section-name` needs `"selector": "div.wp-block-myplugin-section"` (or simply `"div"`) — without a selector, the block's own attributes are not matched.
+
 Under the hood, attribute sources are a superset of the functionality provided by [hpq](https://github.com/aduth/hpq), a small library used to parse and query HTML markup into an object shape.
 
 To summarize, the `source` determines where data is stored in your content, and the `type` determines what that data is. To reduce the amount of data stored it is usually better to store as much data as possible within HTML rather than as attributes within the comment delimiter.


### PR DESCRIPTION
## Summary

Updates the block attribute reference so the no-selector behavior is described accurately. The current docs say a `source` with no `selector` runs against "the block's root node," which is not what happens and leads to an invalid content error when reading a `data-*` attribute off the block's own root element.

Fixes #80121

## Changes

### `docs/reference-guides/block-api/block-attributes.md`

**Before:**
```
The `source` field is usually combined with a `selector` field. If no selector argument is specified, the source definition runs against the block's root node. If a selector argument is specified, it will run against the matching element(s) within the block.
```

**After:**
```
The `source` field is usually combined with a `selector` field. If no selector argument is specified, the source definition runs against the body element that wraps the block's markup, not the block's root element itself. To read a value from the block's root element, use a selector that matches it, such as its tag or a class. If a selector argument is specified, the source definition runs against the matching element(s) within the block.
```

**Why:** When no selector is set, the block markup string is parsed into a synthetic `<body>` element and the source reads from that body, not from the block's root element. So a `data-*` attribute on the block's root element is not picked up and the block fails validation on reload. Telling the reader to add a selector (tag or class) to read from the block root avoids this.

The parser path confirms it: `getBlockAttributes` parses the markup via hpq, and hpq's `parse()` puts the string into a `body` node and returns it. Every `source: "attribute"` definition in core uses an explicit `selector`, so the no-selector case is never relied on to read the block root.

## Testing

Docs-only change, no runtime effect.

1. Open `docs/reference-guides/block-api/block-attributes.md` and read the "Value source" section.
2. Confirm the no-selector sentence now mentions the body element and says to use a selector to read from the block root.
3. Optional lint, no new warning expected on line 115:

   ```bash
   npm run lint:md:docs -- docs/reference-guides/block-api/block-attributes.md
   ```