### PR TITLE
Automated Testing: Restrict dirname globals in test files

### DIFF
--- a/packages/babel-preset-default/test/index.js
+++ b/packages/babel-preset-default/test/index.js
@@ -12,7 +12,7 @@ import babelPresetDefault from '../';
 
 describe( 'Babel preset default', () => {
 	test( 'transpilation works properly', () => {
-		const filename = path.join( __dirname, '/fixtures/input.js' );
+		const filename = path.join( import.meta.dirname, '/fixtures/input.js' );
 		const input = readFileSync( filename );
 
 		const output = transform( input, {
@@ -26,7 +26,10 @@ describe( 'Babel preset default', () => {
 	} );
 
 	test( 'transpilation includes magic comment when using the addPolyfillComments option', () => {
-		const filename = path.join( __dirname, '/fixtures/polyfill.js' );
+		const filename = path.join(
+			import.meta.dirname,
+			'/fixtures/polyfill.js'
+		);
 		const input = readFileSync( filename );
 
 		const output = transform( input, {

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -20,5 +20,5 @@ describe( 'block-serialization-default-parser-js', jsTester( parse ) ); // eslin
 
 phpTester(
 	'block-serialization-default-parser-php',
-	path.join( __dirname, 'test-parser.php' )
+	path.join( import.meta.dirname, 'test-parser.php' )
 );

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -13,5 +13,5 @@ describe( 'block-serialization-spec-parser-js', jsTester( parse ) ); // eslint-d
 
 phpTester(
 	'block-serialization-spec-parser-php',
-	path.join( __dirname, 'test-parser.php' )
+	path.join( import.meta.dirname, 'test-parser.php' )
 );

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -8,10 +8,10 @@ const path = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 
-const fixturesPath = path.join( __dirname, 'fixtures' );
+const fixturesPath = path.join( import.meta.dirname, 'fixtures' );
 const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
-afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
+afterAll( () => rimraf( path.join( import.meta.dirname, 'build' ) ) );
 
 describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 	'DependencyExtractionWebpackPlugin %s',
@@ -19,7 +19,7 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 		describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 			const testDirectory = path.join( fixturesPath, configCase );
 			const outputDirectory = path.join(
-				__dirname,
+				import.meta.dirname,
 				'build',
 				moduleMode,
 				configCase

--- a/packages/readable-js-assets-webpack-plugin/test/build.js
+++ b/packages/readable-js-assets-webpack-plugin/test/build.js
@@ -9,8 +9,8 @@ const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 
 describe( 'ReadableJsAssetsWebpackPlugin', () => {
-	const outputDirectory = path.join( __dirname, 'build' );
-	const testDirectory = path.join( __dirname, 'fixtures' );
+	const outputDirectory = path.join( import.meta.dirname, 'build' );
+	const testDirectory = path.join( import.meta.dirname, 'fixtures' );
 
 	beforeEach( () => {
 		rimraf( outputDirectory );

--- a/packages/scripts/scripts/test/build-blocks-manifest.js
+++ b/packages/scripts/scripts/test/build-blocks-manifest.js
@@ -7,11 +7,15 @@ const { execSync } = require( 'child_process' );
 const rimraf = require( 'rimraf' ).sync;
 
 const fixturesPath = path.join(
-	__dirname,
+	import.meta.dirname,
 	'fixtures',
 	'build-blocks-manifest'
 );
-const outputPath = path.join( __dirname, 'build', 'test-blocks-manifest' );
+const outputPath = path.join(
+	import.meta.dirname,
+	'build',
+	'test-blocks-manifest'
+);
 
 describe( 'build-blocks-manifest script', () => {
 	beforeAll( () => {
@@ -31,7 +35,7 @@ describe( 'build-blocks-manifest script', () => {
 
 		// Run the build-blocks-manifest script
 		const scriptPath = path.resolve(
-			__dirname,
+			import.meta.dirname,
 			'..',
 			'build-blocks-manifest.js'
 		);
@@ -48,7 +52,7 @@ describe( 'build-blocks-manifest script', () => {
 		const outputFile = path.join( outputPath, 'empty-blocks-manifest.php' );
 
 		const scriptPath = path.resolve(
-			__dirname,
+			import.meta.dirname,
 			'..',
 			'build-blocks-manifest.js'
 		);
@@ -77,7 +81,7 @@ describe( 'build-blocks-manifest script', () => {
 		const outputFile = path.join( outputPath, 'empty-blocks-manifest.php' );
 
 		const scriptPath = path.resolve(
-			__dirname,
+			import.meta.dirname,
 			'..',
 			'build-blocks-manifest.js'
 		);

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -87,13 +87,13 @@ describe( 'utils', () => {
 
 	describe( 'hasProjectFile', () => {
 		test( 'should return false for the current directory and unknown file', () => {
-			getPackagePathMock.mockReturnValueOnce( __dirname );
+			getPackagePathMock.mockReturnValueOnce( import.meta.dirname );
 
 			expect( hasProjectFile( 'unknown-file.name' ) ).toBe( false );
 		} );
 
 		test( 'should return true for the current directory and this file', () => {
-			getPackagePathMock.mockReturnValueOnce( __dirname );
+			getPackagePathMock.mockReturnValueOnce( import.meta.dirname );
 
 			expect( hasProjectFile( 'index.js' ) ).toBe( true );
 		} );

--- a/packages/scripts/utils/test/license.js
+++ b/packages/scripts/utils/test/license.js
@@ -14,7 +14,9 @@ describe( 'detectTypeFromLicenseText', () => {
 
 	it( "should return 'Apache 2.0' when the license text is the Apache 2.0 license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/apache2.txt' ) )
+			.readFileSync(
+				path.resolve( import.meta.dirname, 'licenses/apache2.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'Apache-2.0' );
@@ -23,7 +25,7 @@ describe( 'detectTypeFromLicenseText', () => {
 	it( "should return 'BSD' when the license text is the BSD 3-clause license", () => {
 		licenseText = fs
 			.readFileSync(
-				path.resolve( __dirname, 'licenses/bsd3clause.txt' )
+				path.resolve( import.meta.dirname, 'licenses/bsd3clause.txt' )
 			)
 			.toString();
 
@@ -32,7 +34,9 @@ describe( 'detectTypeFromLicenseText', () => {
 
 	it( "should return 'BSD-3-Clause-W3C' when the license text is the W3C variation of the BSD 3-clause license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/w3cbsd.txt' ) )
+			.readFileSync(
+				path.resolve( import.meta.dirname, 'licenses/w3cbsd.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe(
@@ -42,7 +46,9 @@ describe( 'detectTypeFromLicenseText', () => {
 
 	it( "should return 'MIT' when the license text is the MIT license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/mit.txt' ) )
+			.readFileSync(
+				path.resolve( import.meta.dirname, 'licenses/mit.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'MIT' );
@@ -51,7 +57,7 @@ describe( 'detectTypeFromLicenseText', () => {
 	it( "should return 'Apache2 AND MIT' when the license text is Apache2 followed by MIT license", () => {
 		licenseText = fs
 			.readFileSync(
-				path.resolve( __dirname, 'licenses/apache2-mit.txt' )
+				path.resolve( import.meta.dirname, 'licenses/apache2-mit.txt' )
 			)
 			.toString();
 

--- a/packages/stylelint-config/test/utils/index.js
+++ b/packages/stylelint-config/test/utils/index.js
@@ -21,12 +21,12 @@ const generateStylelintCommand = ( filename ) =>
 	'node ' +
 	stylelintBin +
 	' ' +
-	path.resolve( __dirname, '../', filename ) +
+	path.resolve( import.meta.dirname, '../', filename ) +
 	' -c' +
-	path.resolve( __dirname, '../', './.stylelintrc.tests.json' ) +
+	path.resolve( import.meta.dirname, '../', './.stylelintrc.tests.json' ) +
 	' --formatter json' +
 	' --ignore-path ' +
-	path.resolve( __dirname, '../', './.stylelintignore' );
+	path.resolve( import.meta.dirname, '../', './.stylelintignore' );
 
 module.exports = {
 	getStylelintResult: ( filename ) =>

--- a/packages/theme/src/stylelint-plugins/test/utils/index.ts
+++ b/packages/theme/src/stylelint-plugins/test/utils/index.ts
@@ -23,9 +23,13 @@ export const getStylelintResult = (
 ) =>
 	stylelint
 		.lint( {
-			files: path.resolve( __dirname, '../', filename ),
+			files: path.resolve( import.meta.dirname, '../', filename ),
 			config,
-			ignorePath: path.resolve( __dirname, '../', './.stylelintignore' ),
+			ignorePath: path.resolve(
+				import.meta.dirname,
+				'../',
+				'./.stylelintignore'
+			),
 			formatter: 'json',
 			quietDeprecationWarnings: true,
 		} )

--- a/packages/theme/src/test/build-plugin-parity.test.ts
+++ b/packages/theme/src/test/build-plugin-parity.test.ts
@@ -12,7 +12,7 @@ import esbuildPlugin from '../esbuild-plugins/esbuild-ds-token-fallbacks.mjs';
 import postcssPlugin from '../postcss-plugins/postcss-ds-token-fallbacks.mjs';
 import vitePlugin from '../vite-plugins/vite-ds-token-fallbacks.mjs';
 
-const fixturesDirectory = join( __dirname, 'fixtures/build-plugins' );
+const fixturesDirectory = join( import.meta.dirname, 'fixtures/build-plugins' );
 const validJsFixture = join( fixturesDirectory, 'source.ts' );
 const unknownJsFixture = join( fixturesDirectory, 'unknown-token.ts' );
 

--- a/packages/ui/src/test/index.test.ts
+++ b/packages/ui/src/test/index.test.ts
@@ -7,11 +7,11 @@ describe( 'index', () => {
 		// As described in the CONTRIBUTING.md file, each component should be
 		// exported from an index.ts in its implementation directory.
 		const components = await glob( '*/index.ts', {
-			cwd: join( __dirname, '..' ),
+			cwd: join( import.meta.dirname, '..' ),
 		} );
 		const directories = components.map( ( c ) => basename( dirname( c ) ) );
 		const index = await readFile(
-			join( __dirname, '../index.ts' ),
+			join( import.meta.dirname, '../index.ts' ),
 			'utf-8'
 		);
 

--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -1335,7 +1335,10 @@ describe( 'private actions', () => {
 			// native irot transform), so the server reports orientation 1 and
 			// the client parse is the source of truth.
 			const buffer = readFileSync(
-				join( __dirname, '../../test/fixtures/exif-rotated-90cw.avif' )
+				join(
+					import.meta.dirname,
+					'../../test/fixtures/exif-rotated-90cw.avif'
+				)
 			);
 			const rotatedFile = new File( [ 'rotated' ], 'photo-rotated.avif', {
 				type: 'image/avif',

--- a/packages/upload-media/src/test/heic-parser.ts
+++ b/packages/upload-media/src/test/heic-parser.ts
@@ -917,7 +917,7 @@ describe( 'parseExifOrientation / getUnappliedExifOrientation', () => {
 	describe( 'real encoder fixtures', () => {
 		const loadFixture = ( file: string ): ArrayBuffer => {
 			const contents = readFileSync(
-				join( __dirname, 'fixtures', file )
+				join( import.meta.dirname, 'fixtures', file )
 			);
 			return contents.buffer.slice(
 				contents.byteOffset,

--- a/packages/vips/src/test/highbitdepth-avif.ts
+++ b/packages/vips/src/test/highbitdepth-avif.ts
@@ -23,7 +23,7 @@ import { join } from 'node:path';
  */
 const Vips = require( 'wasm-vips' );
 
-const FIXTURES = join( __dirname, 'fixtures' );
+const FIXTURES = join( import.meta.dirname, 'fixtures' );
 
 describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 	let vips: Awaited< ReturnType< typeof Vips > >;

--- a/packages/vips/src/test/rotate-image-integration.ts
+++ b/packages/vips/src/test/rotate-image-integration.ts
@@ -46,7 +46,7 @@ jest.mock( 'wasm-vips', () => {
 	);
 } );
 
-const FIXTURES = join( __dirname, 'fixtures' );
+const FIXTURES = join( import.meta.dirname, 'fixtures' );
 
 const loadFixture = ( file: string ): ArrayBuffer => {
 	const contents = readFileSync( join( FIXTURES, file ) );

--- a/packages/wp-build/lib/test/package-utils.js
+++ b/packages/wp-build/lib/test/package-utils.js
@@ -6,24 +6,30 @@ import { getPackageInfo } from '../package-utils.mjs';
 describe( 'getPackageInfo() resolve-miss contract', () => {
 	it( 'returns null (does not throw) for an unresolvable scoped package', () => {
 		expect( () =>
-			getPackageInfo( '@does-not-exist/nope', __dirname )
+			getPackageInfo( '@does-not-exist/nope', import.meta.dirname )
 		).not.toThrow();
 
 		expect(
-			getPackageInfo( '@does-not-exist/nope', __dirname )
+			getPackageInfo( '@does-not-exist/nope', import.meta.dirname )
 		).toBeNull();
 	} );
 
 	it( 'returns the cached null on a repeated miss', () => {
-		const first = getPackageInfo( '@still-missing/pkg', __dirname );
-		const second = getPackageInfo( '@still-missing/pkg', __dirname );
+		const first = getPackageInfo(
+			'@still-missing/pkg',
+			import.meta.dirname
+		);
+		const second = getPackageInfo(
+			'@still-missing/pkg',
+			import.meta.dirname
+		);
 
 		expect( first ).toBeNull();
 		expect( second ).toBeNull();
 	} );
 
 	it( 'still resolves an installed package that exposes its package.json', () => {
-		const info = getPackageInfo( '@wordpress/build', __dirname );
+		const info = getPackageInfo( '@wordpress/build', import.meta.dirname );
 
 		expect( info ).toMatchObject( { name: '@wordpress/build' } );
 	} );

--- a/test/e2e/config/rtc-websocket-setup.ts
+++ b/test/e2e/config/rtc-websocket-setup.ts
@@ -23,7 +23,7 @@ const PROVIDER_PLUGIN = 'gutenberg-test-plugin-rtc-websocket-provider';
 
 function getProviderPluginDir() {
 	return path.resolve(
-		__dirname,
+		import.meta.dirname,
 		'../../../packages/e2e-tests/plugins/rtc-websocket-provider'
 	);
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -36,7 +36,7 @@ const config = defineConfig( {
 		: 'list',
 	workers: 1,
 	globalSetup: fileURLToPath(
-		new URL( './config/global-setup.ts', 'file:' + __filename ).href
+		new URL( './config/global-setup.ts', import.meta.url ).href
 	),
 	// The default suite runs RTC tests on the HTTP polling provider. Specs
 	// that rely on WebSocket-only semantics live under `websocket-only/` and

--- a/test/e2e/specs/editor/blocks/playlist.spec.js
+++ b/test/e2e/specs/editor/blocks/playlist.spec.js
@@ -9,11 +9,11 @@ const path = require( 'path' );
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const audioPath = path.join(
-	__dirname,
+	import.meta.dirname,
 	'../../../assets/playlist-e2e-test.wav'
 );
 const imagePath = path.join(
-	__dirname,
+	import.meta.dirname,
 	'../../../assets/10x10_e2e_test_image_green.png'
 );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-code-editor-performance.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-code-editor-performance.spec.ts
@@ -15,12 +15,12 @@ import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
 import { setCollaboration } from './fixtures/collaboration-utils';
 
 const STEP1_CONTENT = readFileSync(
-	join( __dirname, 'data', 'code-editor-perf-step1.md' ),
+	join( import.meta.dirname, 'data', 'code-editor-perf-step1.md' ),
 	'utf-8'
 );
 
 const STEP2_CONTENT = readFileSync(
-	join( __dirname, 'data', 'code-editor-perf-step2.md' ),
+	join( import.meta.dirname, 'data', 'code-editor-perf-step2.md' ),
 	'utf-8'
 );
 

--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -56,7 +56,7 @@ async function probeUltraHdrUrl( url ) {
  * @typedef {import('@playwright/test').Page} Page
  */
 
-const ASSETS_DIR = path.join( __dirname, '..', '..', '..', 'assets' );
+const ASSETS_DIR = path.join( import.meta.dirname, '..', '..', '..', 'assets' );
 
 test.use( {
 	mediaProcessingUtils: async ( { page }, use ) => {

--- a/test/e2e/specs/editor/various/gif-to-video.spec.js
+++ b/test/e2e/specs/editor/various/gif-to-video.spec.js
@@ -15,7 +15,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
  * @typedef {import('@playwright/test').Page} Page
  */
 
-const ASSETS_DIR = path.join( __dirname, '..', '..', '..', 'assets' );
+const ASSETS_DIR = path.join( import.meta.dirname, '..', '..', '..', 'assets' );
 
 /**
  * Animated GIF fixture used for conversion tests.

--- a/test/e2e/specs/editor/various/upload-save-lock.spec.js
+++ b/test/e2e/specs/editor/various/upload-save-lock.spec.js
@@ -12,7 +12,7 @@ const { randomUUID } = require( 'crypto' );
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const TEST_IMAGE_FILE_PATH = path.join(
-	__dirname,
+	import.meta.dirname,
 	'..',
 	'..',
 	'..',

--- a/test/e2e/specs/editor/various/wasm-inlining.spec.js
+++ b/test/e2e/specs/editor/various/wasm-inlining.spec.js
@@ -18,7 +18,7 @@ const path = require( 'path' );
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const buildModulePath = path.resolve(
-	__dirname,
+	import.meta.dirname,
 	'../../../../../packages/vips/build-module/index.mjs'
 );
 

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -436,19 +436,19 @@ describe( 'Blocks raw handling', () => {
 			it( type, () => {
 				const HTML = readFile(
 					path.join(
-						__dirname,
+						import.meta.dirname,
 						`fixtures/documents/${ type }-in.html`
 					)
 				);
 				const plainText = readFile(
 					path.join(
-						__dirname,
+						import.meta.dirname,
 						`fixtures/documents/${ type }-in.txt`
 					)
 				);
 				const output = readFile(
 					path.join(
-						__dirname,
+						import.meta.dirname,
 						`fixtures/documents/${ type }-out.html`
 					)
 				);
@@ -485,7 +485,7 @@ describe( 'Blocks raw handling', () => {
 		it( 'should remove extra blank lines', () => {
 			const HTML = readFile(
 				path.join(
-					__dirname,
+					import.meta.dirname,
 					'fixtures/documents/google-docs-blank-lines.html'
 				)
 			);
@@ -495,7 +495,10 @@ describe( 'Blocks raw handling', () => {
 
 		it( 'should strip windows data', () => {
 			const HTML = readFile(
-				path.join( __dirname, 'fixtures/documents/windows.html' )
+				path.join(
+					import.meta.dirname,
+					'fixtures/documents/windows.html'
+				)
 			);
 			expect( serialize( pasteHandler( { HTML } ) ) ).toMatchSnapshot();
 			expect( console ).toHaveLogged();
@@ -504,7 +507,7 @@ describe( 'Blocks raw handling', () => {
 		it( 'should strip HTML formatting space from inline text', () => {
 			const HTML = readFile(
 				path.join(
-					__dirname,
+					import.meta.dirname,
 					'fixtures/documents/inline-with-html-formatting-space.html'
 				)
 			);
@@ -517,14 +520,20 @@ describe( 'Blocks raw handling', () => {
 describe( 'rawHandler', () => {
 	it( 'should convert HTML post to blocks with minimal content changes', () => {
 		const HTML = readFile(
-			path.join( __dirname, 'fixtures/documents/wordpress-convert.html' )
+			path.join(
+				import.meta.dirname,
+				'fixtures/documents/wordpress-convert.html'
+			)
 		);
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
 
 	it( 'should convert a caption shortcode', () => {
 		const HTML = readFile(
-			path.join( __dirname, 'fixtures/documents/shortcode-caption.html' )
+			path.join(
+				import.meta.dirname,
+				'fixtures/documents/shortcode-caption.html'
+			)
 		);
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
@@ -532,7 +541,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a caption shortcode with link', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				import.meta.dirname,
 				'fixtures/documents/shortcode-caption-with-link.html'
 			)
 		);
@@ -542,7 +551,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a caption shortcode with caption', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				import.meta.dirname,
 				'fixtures/documents/shortcode-caption-with-caption-link.html'
 			)
 		);
@@ -552,7 +561,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a list with attributes', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				import.meta.dirname,
 				'fixtures/documents/list-with-attributes.html'
 			)
 		);

--- a/test/integration/fixtures/utils.js
+++ b/test/integration/fixtures/utils.js
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const FIXTURES_DIR = path.join( __dirname, 'blocks' );
+const FIXTURES_DIR = path.join( import.meta.dirname, 'blocks' );
 
 function readFixtureFile( fixturesDir, filename ) {
 	try {

--- a/test/performance/playwright.config.ts
+++ b/test/performance/playwright.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from '@playwright/test';
  */
 import baseConfig from '@wordpress/scripts/config/playwright.config.js';
 
-process.env.ASSETS_PATH = path.join( __dirname, 'assets' );
+process.env.ASSETS_PATH = path.join( import.meta.dirname, 'assets' );
 
 const config = defineConfig( {
 	...baseConfig,
@@ -25,7 +25,7 @@ const config = defineConfig( {
 	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 600_000, // Defaults to 10 minutes.
 	reportSlowTests: null,
 	globalSetup: fileURLToPath(
-		new URL( './config/global-setup.ts', 'file:' + __filename ).href
+		new URL( './config/global-setup.ts', import.meta.url ).href
 	),
 	use: {
 		...baseConfig.use,

--- a/test/performance/specs/media-processing.spec.js
+++ b/test/performance/specs/media-processing.spec.js
@@ -23,7 +23,7 @@ const IMAGE_SUB_SIZES = [
 ];
 
 const ASSETS_PATH =
-	process.env.ASSETS_PATH || path.join( __dirname, '..', 'assets' );
+	process.env.ASSETS_PATH || path.join( import.meta.dirname, '..', 'assets' );
 
 let vips;
 
@@ -36,7 +36,15 @@ async function getVips() {
 	}
 	// Resolve wasm-vips from the @wordpress/vips package where it's installed.
 	const require = createRequire(
-		path.join( __dirname, '..', '..', '..', 'packages', 'vips', 'index.js' )
+		path.join(
+			import.meta.dirname,
+			'..',
+			'..',
+			'..',
+			'packages',
+			'vips',
+			'index.js'
+		)
 	);
 	const Vips = require( 'wasm-vips' );
 	vips = await Vips( {

--- a/test/performance/specs/media-upload.spec.js
+++ b/test/performance/specs/media-upload.spec.js
@@ -23,7 +23,13 @@ const results = {
 	multipleImageUploadProcessing: [],
 };
 
-const E2E_ASSETS_PATH = path.join( __dirname, '..', '..', 'e2e', 'assets' );
+const E2E_ASSETS_PATH = path.join(
+	import.meta.dirname,
+	'..',
+	'..',
+	'e2e',
+	'assets'
+);
 
 /**
  * Creates a temporary copy of a test image with a unique filename.

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -584,6 +584,31 @@ export default dedupePlugins( [
 		},
 	},
 
+	// Override: Tests are written as ESM, and should avoid relying on globals
+	// that don't exist in the context of ES Modules. Ideally we'd avoid these
+	// ever being made available as globals. This can be achieved with ESLint
+	// globals configuration, but `no-undef` is disabled for TypeScript files,
+	// and TypeScript doesn't provide a way to disable the CommonJS globals.
+	{
+		files: [ '**/@(__tests__|test)/**/*.[tj]s?(x)' ],
+		// Jest harness under test/unit is plain CommonJS loaded by Node/Jest
+		// directly (not Babel-transformed), so import.meta.* is unavailable.
+		ignores: [ 'test/unit/**' ],
+		rules: {
+			'no-restricted-globals': [
+				'error',
+				{
+					name: '__dirname',
+					message: 'Use `import.meta.dirname` instead',
+				},
+				{
+					name: '__filename',
+					message: 'Use `import.meta.filename` instead',
+				},
+			],
+		},
+	},
+
 	// Override: CLI/bin/env files — allow console.
 	{
 		files: [ '**/{bin,scripts,tools}/**', 'packages/env/**' ],

--- a/tools/release/test/cli.js
+++ b/tools/release/test/cli.js
@@ -4,7 +4,7 @@
 const path = require( 'path' );
 const { spawnSync } = require( 'child_process' );
 
-const cliPath = path.resolve( __dirname, '../cli.js' );
+const cliPath = path.resolve( import.meta.dirname, '../cli.js' );
 const script = `
 	const { Command } = require( 'commander' );
 	const { run } = require( ${ JSON.stringify( cliPath ) } );


### PR DESCRIPTION
## What?

Updates ESLint rules to restrict the availability of `__dirname` and `__filename` globals in test files, and fixes existing issues.

This is a continuation from #79362. #79362 made `import.meta` values available in these files. This pull request enforces their usage.

## Why?

See rationale in #79362, specifically:

> We write our tests as if they're ESM, but we continue to use `__dirname` in tests despite the fact that [`__dirname` doesn't exist in true ESM](https://nodejs.org/api/esm.html#no-__filename-or-__dirname).

## How?

Uses [`no-restricted-globals` ESLint rule](https://eslint.org/docs/latest/rules/no-restricted-globals) to forbid use of these globals. As explained in the inline code comment, I'd rather have done this by preventing those globals from being available in the first place rather than after-the-fact, and we could do this [in ESLint through how globals are specified](https://eslint.org/docs/latest/use/configure/language-options#use-configuration-files), but globals enforcement through [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) is disabled through [use of recommended `typescript-eslint` configuration](https://github.com/WordPress/gutenberg/blob/363ec914f087263fd511e1711c4e9cc8d8ced2aa/packages/eslint-plugin/configs/recommended.js#L44) ([source](https://github.com/typescript-eslint/typescript-eslint/blob/42bb19a551d0bf4dd20507d3d7bc48c573983c8d/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts#L42)).

Updates are straightforward replacement of `__dirname` ➡️ `import.meta.dirname` and `__filename` ➡️ `import.meta.filename`.

## Testing Instructions

`npm run lint:js` should pass.

For bonus points, try adding `__dirname` or `__filename` to a test file and verify that `npm run lint:js` fails.

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to research and implement, though mostly on the side of updating files.