### PR TITLE
Add shell completion for wp-env

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add shell completion for `wp-env` (Bash, Zsh, and Fish). Run `wp-env completion` and source the output to complete commands, options, and run containers. ([#79941](https://github.com/WordPress/gutenberg/issues/79941))
+
 ## 11.11.0 (2026-07-14)
 
 ## 11.10.0 (2026-07-01)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -895,6 +895,35 @@ From the SPX interface, you can:
 
 SPX provides a more lightweight alternative to Xdebug for profiling, with minimal performance overhead and an intuitive web-based interface.
 
+## Shell completion
+
+`wp-env` ships completion scripts for Bash, Zsh, and Fish so you can press <kbd>Tab</kbd> to complete commands, options, and values such as run containers and environments.
+
+### Bash
+
+```sh
+wp-env completion >> ~/.bashrc
+# On macOS use ~/.bash_profile instead.
+```
+
+### Zsh
+
+```sh
+autoload -Uz compinit && compinit
+wp-env completion >> ~/.zshrc
+# On macOS use ~/.zprofile instead.
+```
+
+### Fish
+
+Copy the completion file into your Fish configuration directory:
+
+```sh
+cp "$( node -e "console.log( require.resolve( '@wordpress/env/lib/completion/fish/wp-env.fish' ) )" )" ~/.config/fish/completions/wp-env.fish
+```
+
+Once installed, `wp-env s` followed by <kbd>Tab</kbd> suggests `start`, `status`, and `stop`, and `wp-env run ` followed by <kbd>Tab</kbd> lists the available containers.
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -314,5 +314,19 @@ module.exports = function cli() {
 	// formatting is applied even when stdout is not a terminal.
 	yargs.wrap( Math.min( 100, yargs.terminalWidth() ?? 100 ) );
 
+	// Adds a `completion` subcommand and a `--get-yargs-completions`
+	// flag. The generated bash/zsh script auto-completes commands,
+	// options, and positional choices (containers, environments, runtimes).
+	// Declare the flag as a known option so the `unknown-options-as-args`
+	// parser config does not swallow it before the completion handler runs.
+	yargs.option( 'get-yargs-completions', {
+		type: 'string',
+		hidden: true,
+	} );
+	yargs.completion(
+		'completion',
+		'Generate a bash/zsh completion script. (Fish uses the shipped wp-env.fish file.)'
+	);
+
 	return yargs;
 };

--- a/packages/env/lib/completion/fish/wp-env.fish
+++ b/packages/env/lib/completion/fish/wp-env.fish
@@ -1,0 +1,9 @@
+# Fish completion for wp-env.
+#
+# Reuses yargs' `--get-yargs-completions` flag, which returns the
+# candidates for the current command line. yargs expects the tokens in
+# the same shape its bash/zsh templates use: the program name
+# followed by the command line tokens and a trailing empty token, so
+# positional choices (containers, environments, runtimes) are offered.
+# Fish filters the candidates by the current partial token automatically.
+complete -c wp-env -f -a '(wp-env --get-yargs-completions wp-env (commandline -op) "")'

--- a/packages/env/lib/test/cli.js
+++ b/packages/env/lib/test/cli.js
@@ -195,4 +195,32 @@ describe( 'env cli', () => {
 		process.exit = processExit;
 		process.stderr.write = stderr;
 	} );
+
+	it( 'prints a bash/zsh completion script.', () => {
+		const logSpy = jest.spyOn( console, 'log' );
+		cli().parse( [ 'completion' ] );
+		expect( console ).toHaveLogged();
+		expect(
+			logSpy.mock.calls.map( ( call ) => call[ 0 ] ).join( '\n' )
+		).toMatch( /yargs_completions/ );
+	} );
+
+	it( 'completes top-level commands.', () => {
+		const logSpy = jest.spyOn( console, 'log' );
+		cli().parse( [ '--get-yargs-completions', 'wp-env', '' ] );
+		expect( console ).toHaveLogged();
+		const out = logSpy.mock.calls.map( ( call ) => call[ 0 ] ).join( '\n' );
+		expect( out ).toMatch( /\bstart\b/ );
+		expect( out ).toMatch( /\bstatus\b/ );
+		expect( out ).toMatch( /\brun\b/ );
+	} );
+
+	it( 'completes run containers from positional choices.', () => {
+		const logSpy = jest.spyOn( console, 'log' );
+		cli().parse( [ '--get-yargs-completions', 'wp-env', 'run', '' ] );
+		expect( console ).toHaveLogged();
+		const out = logSpy.mock.calls.map( ( call ) => call[ 0 ] ).join( '\n' );
+		expect( out ).toMatch( /\bcli\b/ );
+		expect( out ).toMatch( /\bwordpress\b/ );
+	} );
 } );


### PR DESCRIPTION
## Summary
Add shell tab-completion for `wp-env` so users can press <kbd>Tab</kbd> to complete commands, options, and run containers in Bash, Zsh, and Fish.

Fixes #79941

## Changes

### `packages/env/lib/cli.js`
Register a yargs `completion` subcommand and declare `--get-yargs-completions` as a known option.

The CLI uses the `unknown-options-as-args` parser config, which was swallowing yargs' own `--get-yargs-completions` flag into positional args before the completion handler ran, so the generated scripts produced no completions. Declaring the flag as a known option fixes it.

**Before:**
```js
// No completion command; --get-yargs-completions never reached the handler.
```

**After:**
```js
yargs.option( 'get-yargs-completions', { type: 'string', hidden: true } );
yargs.completion(
	'completion',
	'Generate a bash/zsh completion script. (Fish uses the shipped wp-env.fish file.)'
);
```

**Why:** yargs already implements the full completion protocol and reads the existing `choices` declarations (run containers, reset/logs environments, start runtime), so this wires up subcommand, option, and positional completion at the root with no custom logic. No Docker is spawned at completion time.

### `packages/env/lib/completion/fish/wp-env.fish`
Fish is not supported by yargs, so ship a small completion file that calls the same `--get-yargs-completions` backend.

### `packages/env/README.md`
New "Shell completion" section documenting install for each shell.

### `packages/env/lib/test/cli.js`
Three unit tests covering the completion script output, top-level command completion, and run-container positional completion.

## Testing

**Test 1: unit tests**
1. `npx jest --config test/unit/jest.config.js packages/env/lib/test/cli.js`
Result: 22 passed, including the three new completion tests.

**Test 2: manual sanity (no Docker)**
1. `node packages/env/bin/wp-env --get-yargs-completions 'wp-env' ''`
2. `node packages/env/bin/wp-env --get-yargs-completions 'wp-env' 'run' ''`
Result: subcommands and `cli`/`wordpress` container names returned.

**Test 3: end-to-end (user confirmed in real shells)**
1. `wp-env completion >> ~/.bashrc`, open new shell, `wp-env s` + Tab shows `start`/`status`/`stop`.
2. `wp-env run ` + Tab lists container names.
3. Copy `wp-env.fish` to `~/.config/fish/completions/` and confirm completion in a fish shell.

## Screenshots
N/A (shell completion, no visible UI change).