### PR TITLE
UI: Hook Popover into the wp compat overlay slot

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
+
 ### Code Quality
 
 -   Remove unused CSS property from `Tabs` stylesheet ([#80269](https://github.com/WordPress/gutenberg/pull/80269)).

--- a/packages/ui/src/popover/portal.tsx
+++ b/packages/ui/src/popover/portal.tsx
@@ -1,13 +1,21 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import { forwardRef } from '@wordpress/element';
 import type { PortalProps } from './types';
+import { getWpCompatOverlaySlot } from '../utils/wp-compat-overlay-slot';
 
 /**
  * Used to apply custom portal behavior to `Popover`'s floating content.
+ * `container` defaults to the `@wordpress/ui` compat overlay slot.
  */
 const Portal = forwardRef< HTMLDivElement, PortalProps >(
-	function PopoverPortal( props, ref ) {
-		return <_Popover.Portal ref={ ref } { ...props } />;
+	function PopoverPortal( { container, ...restProps }, ref ) {
+		return (
+			<_Popover.Portal
+				container={ container ?? getWpCompatOverlaySlot() }
+				{ ...restProps }
+				ref={ ref }
+			/>
+		);
 	}
 );
 

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -1,7 +1,9 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import * as Popover from '../index';
+import { useEnableWpCompatOverlaySlot } from '../../utils/use-enable-wp-compat-overlay-slot';
 
 function collectUncaughtErrors() {
 	const errors: Error[] = [];
@@ -529,6 +531,107 @@ describe( 'Popover', () => {
 			).not.toContainElement( content );
 		} );
 	} );
+
+	// Slot is identified by a data attribute, not a user-facing role/text.
+	/* eslint-disable testing-library/no-node-access */
+	describe( 'wp compat overlay slot', () => {
+		const SLOT_SELECTOR = '[data-wp-compat-overlay-slot]';
+
+		// Exercises the public opt-in path rather than poking the flag.
+		function WithSlotEnabled( { children }: { children: ReactNode } ) {
+			useEnableWpCompatOverlaySlot();
+			return <>{ children }</>;
+		}
+
+		afterEach( () => {
+			// The hook is one-way at runtime; reset explicitly between tests.
+			delete ( window as { __wpUiCompatOverlaySlotEnabled?: boolean } )
+				.__wpUiCompatOverlaySlotEnabled;
+			document
+				.querySelectorAll( SLOT_SELECTOR )
+				.forEach( ( element ) => element.remove() );
+		} );
+
+		it( 'portals the popup into the slot when the consumer opts in', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<WithSlotEnabled>
+					<Popover.Root>
+						<Popover.Trigger>Open</Popover.Trigger>
+						<Popover.Popup>
+							<Popover.Title>Title</Popover.Title>
+							Popover content
+						</Popover.Popup>
+					</Popover.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			const content = await screen.findByText( 'Popover content' );
+			expect( content ).toBeVisible();
+
+			const slot = document.querySelector( SLOT_SELECTOR );
+			expect( slot ).not.toBeNull();
+			expect( slot ).toContainElement( content );
+		} );
+
+		it( 'does not create a slot when the consumer has not opted in (dormant default)', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Title>Title</Popover.Title>
+						Popover content
+					</Popover.Popup>
+				</Popover.Root>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			expect(
+				await screen.findByText( 'Popover content' )
+			).toBeVisible();
+			expect( document.querySelector( SLOT_SELECTOR ) ).toBeNull();
+		} );
+
+		it( 'lets a caller-supplied portal container override the slot', async () => {
+			const user = userEvent.setup();
+			const containerRef = createRef< HTMLDivElement >();
+
+			render(
+				<WithSlotEnabled>
+					<Popover.Root>
+						<Popover.Trigger>Open</Popover.Trigger>
+						<div
+							ref={ containerRef }
+							data-testid="custom-container"
+						/>
+						<Popover.Popup
+							portal={
+								<Popover.Portal container={ containerRef } />
+							}
+						>
+							<Popover.Title>Title</Popover.Title>
+							Popover content
+						</Popover.Popup>
+					</Popover.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			const content = await screen.findByText( 'Popover content' );
+			expect( content ).toBeVisible();
+			expect( screen.getByTestId( 'custom-container' ) ).toContainElement(
+				content
+			);
+		} );
+	} );
+	/* eslint-enable testing-library/no-node-access */
 
 	describe( 'positioner', () => {
 		it( 'should render the custom positioner element wrapping the popup content', async () => {

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -1,9 +1,9 @@
-import { Modal, Popover, Button } from '@wordpress/components';
+import { Modal, Popover as WCPopover, Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import {
 	Autocomplete,
 	Combobox,
-	Popover as UiPopover,
+	Popover,
 	Select,
 	SelectControl,
 	Tooltip,
@@ -31,14 +31,10 @@ const inputWrapperStyle = {
 function UiPopoverFixture() {
 	return (
 		<div style={ { marginTop: '1rem' } }>
-			<UiPopover.Root>
-				<UiPopover.Trigger>
-					Open `@wordpress/ui` Popover
-				</UiPopover.Trigger>
-				<UiPopover.Popup>
-					<UiPopover.Title>
-						Popover from `@wordpress/ui`
-					</UiPopover.Title>
+			<Popover.Root>
+				<Popover.Trigger>Open `@wordpress/ui` Popover</Popover.Trigger>
+				<Popover.Popup>
+					<Popover.Title>Popover from `@wordpress/ui`</Popover.Title>
 					<p>
 						The popover and its nested autocomplete should appear
 						above the host overlay.
@@ -68,8 +64,8 @@ function UiPopoverFixture() {
 							</Autocomplete.List>
 						</Autocomplete.Popup>
 					</Autocomplete.Root>
-				</UiPopover.Popup>
-			</UiPopover.Root>
+				</Popover.Popup>
+			</Popover.Root>
 		</div>
 	);
 }
@@ -224,7 +220,7 @@ export const InsideComponentsPopover = {
 					Toggle `@wordpress/components` Popover
 				</Button>
 				{ isOpen && anchor && (
-					<Popover
+					<WCPopover
 						anchor={ anchor }
 						onClose={ () => setIsOpen( false ) }
 					>
@@ -327,7 +323,7 @@ export const InsideComponentsPopover = {
 								</Autocomplete.Root>
 							</div>
 						</div>
-					</Popover>
+					</WCPopover>
 				) }
 			</>
 		);

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -3,6 +3,7 @@ import { useState } from '@wordpress/element';
 import {
 	Autocomplete,
 	Combobox,
+	Popover as UiPopover,
 	Select,
 	SelectControl,
 	Tooltip,
@@ -27,10 +28,58 @@ const inputWrapperStyle = {
 		'var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xs)',
 };
 
-// Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Select`,
-// `Combobox`, `SelectControl`, `Autocomplete`) inside a
+function UiPopoverFixture() {
+	return (
+		<div style={ { marginTop: '1rem' } }>
+			<UiPopover.Root>
+				<UiPopover.Trigger>
+					Open `@wordpress/ui` Popover
+				</UiPopover.Trigger>
+				<UiPopover.Popup>
+					<UiPopover.Title>
+						Popover from `@wordpress/ui`
+					</UiPopover.Title>
+					<p>
+						The popover and its nested autocomplete should appear
+						above the host overlay.
+					</p>
+					<Autocomplete.Root items={ autocompleteItems }>
+						<Autocomplete.Input
+							placeholder="Search nested items"
+							aria-label="Autocomplete inside @wordpress/ui Popover"
+						/>
+						<Autocomplete.Popup>
+							<Autocomplete.Empty>
+								No matching items.
+							</Autocomplete.Empty>
+							<Autocomplete.List>
+								<Autocomplete.ListBody>
+									<Autocomplete.Collection>
+										{ ( item ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.ListBody>
+							</Autocomplete.List>
+						</Autocomplete.Popup>
+					</Autocomplete.Root>
+				</UiPopover.Popup>
+			</UiPopover.Root>
+		</div>
+	);
+}
+
+// Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Popover`,
+// `Select`, `Combobox`, `SelectControl`, `Autocomplete`) inside a
 // `@wordpress/components` Modal / Popover should sit above the
-// components-side overlay via the compat overlay slot.
+// components-side overlay via the compat overlay slot. The Popover fixture uses
+// controlled `@wordpress/ui` content; arbitrary legacy descendants remain out
+// of scope.
 export default {
 	title: 'Playground/Debug fixtures/WP Compat Overlay Slot',
 	decorators: [ WithWpCompatOverlaySlot ],
@@ -68,6 +117,8 @@ export const InsideComponentsModal = {
 								</Tooltip.Popup>
 							</Tooltip.Root>
 						</Tooltip.Provider>
+
+						<UiPopoverFixture />
 
 						<div style={ { marginTop: '1rem' } }>
 							<Select.Root items={ selectItems }>
@@ -191,6 +242,8 @@ export const InsideComponentsPopover = {
 									</Tooltip.Popup>
 								</Tooltip.Root>
 							</Tooltip.Provider>
+
+							<UiPopoverFixture />
 
 							<div style={ { marginTop: '1rem' } }>
 								<Select.Root items={ selectItems }>


### PR DESCRIPTION
Follow-up to #77851.
Supports the controlled Popover use in #80208.

## What?

Defaults `@wordpress/ui` `Popover.Portal` to the wp compat overlay slot when the host opts in.

`Popover` remains marked `use-with-caution` and is not added to the recommended-components allowlist.

## Why?

A controlled UI Popover can appear inside an `@wordpress/components` Modal or Popover. Without the compat slot, its portal can stack below the host overlay.

This does not make arbitrary mixed overlay descendants compatible. Keeping Popover unrecommended preserves that caveat while allowing controlled uses to participate in the existing compatibility mechanism.

## How?

- Uses the compat overlay slot as Popover's default portal container.
- Preserves an explicitly supplied portal container.
- Covers the opted-in, dormant, and explicit-container cases with unit tests.
- Extends the compat-slot playground with a UI Popover containing a nested UI Autocomplete.

## Testing Instructions

1. Run `npm run test:unit -- packages/ui/src/popover/test/index.test.tsx --runInBand`.
2. Run `node_modules/.bin/tsc --build packages/ui/tsconfig.json`.
3. Run `npm run storybook:dev`.
4. Open **Playground → Debug fixtures → WP Compat Overlay Slot**.
5. In both stories, open the UI Popover, then open its nested Autocomplete.
6. Confirm both render above the host `@wordpress/components` overlay.

### Testing Instructions for Keyboard

1. Open each host overlay with Enter or Space.
2. Tab to the UI Popover trigger and open it with Enter or Space.
3. Tab to the nested Autocomplete, type to filter, and use the arrow keys to navigate.
4. Press Escape to close the active overlay and confirm focus remains within the expected overlay flow.

## Screenshots or screencast

Not applicable; this changes overlay placement without an intended visual change.

## AI Tools

Authored with Codex assistance.