### PR TITLE
Notes: increase contrast between avatar border colors

### DIFF
--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -23,13 +23,13 @@ const OVERLAP_MARGIN = 20;
  * the editor's semantic UI colors (Delta E > 10 between all pairs).
  */
 const AVATAR_BORDER_COLORS = [
-	'#C36EFF', // Purple
+	'#6F42C1', // Purple
 	'#D94145', // Red
-	'#E4780A', // Orange
+	'#FBBF24', // Orange
 	'#FF35EE', // Magenta
 	'#879F11', // Olive
-	'#46A494', // Teal
-	'#00A2C3', // Cyan
+	'#0F766E', // Teal
+	'#00CFFF', // Cyan
 ];
 
 /**

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1504,13 +1504,13 @@ test.describe( 'Block Notes', () => {
 		// collab-sidebar/utils.js. Duplicated so the test fails loudly if the
 		// palette is changed without updating the e2e expectation.
 		const AVATAR_BORDER_COLORS = [
-			'#C36EFF',
+			'#6F42C1',
 			'#D94145',
-			'#E4780A',
+			'#FBBF24',
 			'#FF35EE',
 			'#879F11',
-			'#46A494',
-			'#00A2C3',
+			'#0F766E',
+			'#00CFFF',
 		];
 
 		function hexToRgb( hex ) {


### PR DESCRIPTION
## What?

Adjusts four of the seven avatar border colors used for Notes (and inline note markers) to increase contrast between similar-looking pairs, as proposed by @adrianduffell in https://github.com/WordPress/gutenberg/issues/73144#issuecomment-4880380427 and endorsed for the 7.1 release in https://github.com/WordPress/gutenberg/issues/73144#issuecomment-4967002352.

Addresses https://github.com/WordPress/gutenberg/issues/73144.

## Why?

The palette introduced in #75652 and #78299 contains pairs that look too similar at small sizes: purple/magenta, red/orange, and teal/cyan. This makes it harder to tell authors apart, especially for users without profile pictures.

## How?

Updates the `AVATAR_BORDER_COLORS` palette in `packages/editor/src/components/collab-sidebar/utils.js` (and the mirrored list in the e2e test):

| Color | Current Value | Proposed Value |
| ------- | ------ | ----- |
| Purple | `#C36EFF` | `#6F42C1` |
| Red | `#D94145` | `#D94145` (no change) |
| Orange | `#E4780A` | `#FBBF24` |
| Magenta | `#FF35EE` | `#FF35EE` (no change) |
| Olive | `#879F11` | `#879F11` (no change) |
| Teal | `#46A494` | `#0F766E` |
| Cyan | `#00A2C3` | `#00CFFF` |

## Testing Instructions

[![Test in WordPress Playground](https://img.shields.io/badge/Test%20in-WordPress%20Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=80285)

1. Create a post with notes from several different users (each user ID maps to a palette color via `userId % 7`).
2. Open the Notes sidebar and verify avatar rings use the new colors and that purple/magenta, red/orange, and teal/cyan are clearly distinguishable at small sizes.
3. Add an inline note and confirm the marker highlight uses the author color.

cc @t-hamano @jasmussen @fcoveram @adrianduffell
