### PR TITLE
Writing flow: mark shift+click as a multi-selection gesture

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -12,7 +12,6 @@ import {
  */
 import { isInsideRootBlock } from '../../../utils/dom';
 import { store as blockEditorStore } from '../../../store';
-import { isShiftClickInProgress } from '../../writing-flow/utils';
 import { unlock } from '../../../lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
@@ -23,7 +22,7 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
  * @param {string} clientId Block client ID.
  */
 export function useFocusHandler( clientId ) {
-	const { isBlockSelected, isBlockMultiSelected } =
+	const { isBlockSelected, isBlockMultiSelected, isMultiSelecting } =
 		useSelect( blockEditorStore );
 	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 
@@ -48,12 +47,14 @@ export function useFocusHandler( clientId ) {
 					return;
 				}
 
-				// Never select on the focus fired by a shift+click: the
-				// browser can focus the common editable ancestor of the
-				// range (e.g. a group block), and any selection re-render
-				// mid gesture destroys the native selection being made. The
-				// selection observer builds the multi-selection on mouseup.
-				if ( isShiftClickInProgress() ) {
+				// Never select on the focus fired during a selection
+				// gesture (a shift+click, marked by the selection observer
+				// with startMultiSelect). The browser can focus the common
+				// editable ancestor of the range (e.g. a group block), and
+				// any selection re-render mid gesture destroys the native
+				// selection being made. The observer builds the
+				// multi-selection on mouseup.
+				if ( isMultiSelecting() ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -15,7 +15,7 @@ import { isSelectionForward } from '@wordpress/dom';
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
 import { canHostEditableRoot } from './use-editable-root';
-import { setContentEditableWrapper, setShiftClickInProgress } from './utils';
+import { setContentEditableWrapper } from './utils';
 import { unlock } from '../../lock-unlock';
 
 const { ownsSelection } = unlock( richTextPrivateApis );
@@ -102,8 +102,13 @@ function getRichTextElement( node ) {
  * Sets a multi-selection based on the native selection across blocks.
  */
 export default function useSelectionObserver() {
-	const { multiSelect, selectBlock, selectionChange } =
-		useDispatch( blockEditorStore );
+	const {
+		multiSelect,
+		selectBlock,
+		selectionChange,
+		startMultiSelect,
+		stopMultiSelect,
+	} = useDispatch( blockEditorStore );
 	const blockEditorSelectors = useSelect( blockEditorStore );
 	const {
 		getBlockParents,
@@ -122,12 +127,18 @@ export default function useSelectionObserver() {
 
 			function onMouseDown( event ) {
 				isTripleClick = event.detail === 3;
-				setShiftClickInProgress( event.shiftKey );
+				// A shift+click makes a multi-selection: mark the gesture as
+				// in progress so the clicked block's focus handler does not
+				// select it (collapsing the native range being made), and so
+				// use-multi-selection does not clear the native selection.
+				// The selection is built on mouseup.
+				if ( event.shiftKey ) {
+					startMultiSelect();
+				}
 			}
 
 			function onKeyDown() {
 				isTripleClick = false;
-				setShiftClickInProgress( false );
 			}
 
 			function onSelectionChange( event ) {
@@ -444,7 +455,7 @@ export default function useSelectionObserver() {
 			);
 			function onMouseUp( event ) {
 				onSelectionChange( event );
-				setShiftClickInProgress( false );
+				stopMultiSelect();
 			}
 
 			defaultView.addEventListener( 'mouseup', onMouseUp );

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -118,29 +118,6 @@ function toPlainText( html ) {
 	return plainText.replace( /\n\n+/g, '\n\n' );
 }
 
-let shiftClickInProgress = false;
-
-/**
- * Tracks whether a shift+click gesture is in progress, from the shift held
- * mousedown until its mouseup. Maintained by the selection observer; read by
- * the block focus handler, since the focus event fired between the two
- * carries no modifier keys.
- *
- * @param {boolean} value Whether a shift+click gesture is in progress.
- */
-export function setShiftClickInProgress( value ) {
-	shiftClickInProgress = value;
-}
-
-/**
- * Returns whether a shift+click gesture is in progress.
- *
- * @return {boolean} Whether a shift+click gesture is in progress.
- */
-export function isShiftClickInProgress() {
-	return shiftClickInProgress;
-}
-
 /**
  * Makes the wrapper element an editing host, or stops it from being one. The
  * ARIA attributes travel with the editability: while the wrapper is the


### PR DESCRIPTION
## What?

Follow up to #79105.

Replaces the `shiftClickInProgress` module global with the store's `isMultiSelecting`.

## Why?

A shift+click is a multi-selection gesture, which is what `isMultiSelecting` means. `use-multi-selection` already leaves the native selection alone while it's true. The flag was only added because the selection observer and the block focus handler are separate hooks with no shared state, but the store already has the right state.

## How?

- The observer calls `startMultiSelect()` on a shift+mousedown and `stopMultiSelect()` on mouseup. The selection is still built from the native range on mouseup.
- The focus handler bails on `isMultiSelecting()` instead of the flag, so it no longer selects the clicked block mid-gesture and collapses the range.

## Testing Instructions

1. Select a paragraph, then shift+click another block. Both are selected.
2. Group a few blocks and shift+click across them. The selection spans them.
3. Shift+click a block with no text (image, spacer). It's included in the selection.

## Use of AI Tools

Written with the help of Claude Code.
