### PR TITLE
Hide color controls for Navigation and Social Icons when viewport sta…

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,22 +297,30 @@ function Navigation( {
 		onNavigateToEntityRecord,
 		currentTheme,
 		editorDisabledResponsive,
-	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
+		hasSelectedStyleState,
+	} = useSelect(
+		( select ) => {
+			const {
+				getSettings,
+				hasSelectedStyleState: hasSelectedBlockStyleState,
+			} = unlock( select( blockEditorStore ) );
+			const settings = getSettings();
 
-		return {
-			isPreviewMode: settings.isPreviewMode,
-			onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
-			// Needed to construct the template part ID for the overlay preview.
-			currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
-			// When editing a navigation post directly in an isolated editor,
-			// always show navigation expanded (no hamburger) so users can see
-			// and interact with all menu items.
-			editorDisabledResponsive:
-				!! settings?.[ isNavigationPostEditorKey ],
-		};
-	}, [] );
+			return {
+				isPreviewMode: settings.isPreviewMode,
+				onNavigateToEntityRecord: settings?.onNavigateToEntityRecord,
+				// Needed to construct the template part ID for the overlay preview.
+				currentTheme: select( coreStore ).getCurrentTheme()?.stylesheet,
+				// When editing a navigation post directly in an isolated editor,
+				// always show navigation expanded (no hamburger) so users can see
+				// and interact with all menu items.
+				editorDisabledResponsive:
+					!! settings?.[ isNavigationPostEditorKey ],
+				hasSelectedStyleState: hasSelectedBlockStyleState( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 	const hasAlreadyRendered = isPreviewMode ? false : recursionDetected;
 
 	const blockEditingMode = useBlockEditingMode();
@@ -924,26 +932,28 @@ function Navigation( {
 					/>
 				</InspectorControls>
 			) }
-			<InspectorControls group="color">
-				{ /*
-				 * Avoid useMultipleOriginColorsAndGradients and detectColors
-				 * on block mount. InspectorControls only mounts this component
-				 * when the block is selected.
-				 * */ }
-				<ColorTools
-					textColor={ textColor }
-					setTextColor={ setTextColor }
-					backgroundColor={ backgroundColor }
-					setBackgroundColor={ setBackgroundColor }
-					overlayTextColor={ overlayTextColor }
-					setOverlayTextColor={ setOverlayTextColor }
-					overlayBackgroundColor={ overlayBackgroundColor }
-					setOverlayBackgroundColor={ setOverlayBackgroundColor }
-					clientId={ clientId }
-					navRef={ navRef }
-					hasCustomOverlay={ !! overlay }
-				/>
-			</InspectorControls>
+			{ ! hasSelectedStyleState && (
+				<InspectorControls group="color">
+					{ /*
+					 * Avoid useMultipleOriginColorsAndGradients and detectColors
+					 * on block mount. InspectorControls only mounts this component
+					 * when the block is selected.
+					 * */ }
+					<ColorTools
+						textColor={ textColor }
+						setTextColor={ setTextColor }
+						backgroundColor={ backgroundColor }
+						setBackgroundColor={ setBackgroundColor }
+						overlayTextColor={ overlayTextColor }
+						setOverlayTextColor={ setOverlayTextColor }
+						overlayBackgroundColor={ overlayBackgroundColor }
+						setOverlayBackgroundColor={ setOverlayBackgroundColor }
+						clientId={ clientId }
+						navRef={ navRef }
+						hasCustomOverlay={ !! overlay }
+					/>
+				</InspectorControls>
+			) }
 		</>
 	);
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -30,6 +30,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { unlock } from '../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const sizeOptions = [
@@ -60,17 +61,23 @@ export function SocialLinksEdit( props ) {
 		size,
 	} = attributes;
 
-	const { hasSocialIcons, hasSelectedChild } = useSelect(
-		( select ) => {
-			const { getBlockCount, hasSelectedInnerBlock } =
-				select( blockEditorStore );
-			return {
-				hasSocialIcons: getBlockCount( clientId ) > 0,
-				hasSelectedChild: hasSelectedInnerBlock( clientId ),
-			};
-		},
-		[ clientId ]
-	);
+	const { hasSocialIcons, hasSelectedChild, hasSelectedStyleState } =
+		useSelect(
+			( select ) => {
+				const {
+					getBlockCount,
+					hasSelectedInnerBlock,
+					hasSelectedStyleState: hasSelectedBlockStyleState,
+				} = unlock( select( blockEditorStore ) );
+				return {
+					hasSocialIcons: getBlockCount( clientId ) > 0,
+					hasSelectedChild: hasSelectedInnerBlock( clientId ),
+					hasSelectedStyleState:
+						hasSelectedBlockStyleState( clientId ),
+				};
+			},
+			[ clientId ]
+		);
 
 	const hasAnySelected = isSelected || hasSelectedChild;
 
@@ -157,6 +164,8 @@ export function SocialLinksEdit( props ) {
 	}
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+	const showColorControls =
+		colorGradientSettings.hasColorsOrGradients && ! hasSelectedStyleState;
 
 	return (
 		<>
@@ -227,7 +236,7 @@ export function SocialLinksEdit( props ) {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			{ colorGradientSettings.hasColorsOrGradients && (
+			{ showColorControls && (
 				<InspectorControls group="color">
 					{ colorSettings.map(
 						( { onChange, label, value, resetAllFilter } ) => (


### PR DESCRIPTION
…tes are active

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of #77817. 

The Color panel controls for the Navigation and Social Icons blocks don't work with viewport states, because they are custom implementations, not using the default color block support. We can maybe migrate them at some point, or else enable the custom controls to output viewport-specific styles, but for now, given 7.1 is in Beta, it's best to hide them.

(i'm also considering color to be low priority for responsive styles because it's unusual to use different colors for different viewports)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Navigation and a Social Icons block to a post
2. Enable responsive styles in the preview dropdown and switch to Tablet or Mobile viewport
3. Select the blocks and check that color panels are hidden

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="902" height="829" alt="Screenshot 2026-07-15 at 3 20 46 pm" src="https://github.com/user-attachments/assets/6b714a58-f6be-42e8-9694-cc2885226644" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
used codex/gpt 5.6