### PR TITLE
Icons: Fix collection unregister not removing icons after core added its own registry

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -187,36 +187,33 @@ jobs:
                 php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
-                # TEMPORARY: full exclude matrix disabled to verify icon registry
-                # compatibility across all PHP and WordPress versions (incl. previous
-                # major WP, which lacks the core icon registry). Revert before merge.
-                # exclude:
-                #     # On PRs: Only test PHP 7.4 and 8.5, single-site, latest WP
-                #     - event: 'pull_request'
-                #       php: '8.0'
-                #     - event: 'pull_request'
-                #       php: '8.1'
-                #     - event: 'pull_request'
-                #       php: '8.2'
-                #     - event: 'pull_request'
-                #       php: '8.3'
-                #     - event: 'pull_request'
-                #       php: '8.4'
-                #     - event: 'pull_request'
-                #       multisite: true
-                #     - event: 'pull_request'
-                #       wordpress: 'previous major version'
-                #     # On trunk/releases: Only test previous WP version with specific PHP versions
-                #     - php: '8.0'
-                #       wordpress: 'previous major version'
-                #     - php: '8.1'
-                #       wordpress: 'previous major version'
-                #     - php: '8.2'
-                #       wordpress: 'previous major version'
-                #     - php: '8.3'
-                #       wordpress: 'previous major version'
-                #     - php: '8.4'
-                #       wordpress: 'previous major version'
+                exclude:
+                    # On PRs: Only test PHP 7.4 and 8.5, single-site, latest WP
+                    - event: 'pull_request'
+                      php: '8.0'
+                    - event: 'pull_request'
+                      php: '8.1'
+                    - event: 'pull_request'
+                      php: '8.2'
+                    - event: 'pull_request'
+                      php: '8.3'
+                    - event: 'pull_request'
+                      php: '8.4'
+                    - event: 'pull_request'
+                      multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
+                    # On trunk/releases: Only test previous WP version with specific PHP versions
+                    - php: '8.0'
+                      wordpress: 'previous major version'
+                    - php: '8.1'
+                      wordpress: 'previous major version'
+                    - php: '8.2'
+                      wordpress: 'previous major version'
+                    - php: '8.3'
+                      wordpress: 'previous major version'
+                    - php: '8.4'
+                      wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -187,33 +187,36 @@ jobs:
                 php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
                 multisite: [false, true]
                 wordpress: ['', 'previous major version']
-                exclude:
-                    # On PRs: Only test PHP 7.4 and 8.5, single-site, latest WP
-                    - event: 'pull_request'
-                      php: '8.0'
-                    - event: 'pull_request'
-                      php: '8.1'
-                    - event: 'pull_request'
-                      php: '8.2'
-                    - event: 'pull_request'
-                      php: '8.3'
-                    - event: 'pull_request'
-                      php: '8.4'
-                    - event: 'pull_request'
-                      multisite: true
-                    - event: 'pull_request'
-                      wordpress: 'previous major version'
-                    # On trunk/releases: Only test previous WP version with specific PHP versions
-                    - php: '8.0'
-                      wordpress: 'previous major version'
-                    - php: '8.1'
-                      wordpress: 'previous major version'
-                    - php: '8.2'
-                      wordpress: 'previous major version'
-                    - php: '8.3'
-                      wordpress: 'previous major version'
-                    - php: '8.4'
-                      wordpress: 'previous major version'
+                # TEMPORARY: full exclude matrix disabled to verify icon registry
+                # compatibility across all PHP and WordPress versions (incl. previous
+                # major WP, which lacks the core icon registry). Revert before merge.
+                # exclude:
+                #     # On PRs: Only test PHP 7.4 and 8.5, single-site, latest WP
+                #     - event: 'pull_request'
+                #       php: '8.0'
+                #     - event: 'pull_request'
+                #       php: '8.1'
+                #     - event: 'pull_request'
+                #       php: '8.2'
+                #     - event: 'pull_request'
+                #       php: '8.3'
+                #     - event: 'pull_request'
+                #       php: '8.4'
+                #     - event: 'pull_request'
+                #       multisite: true
+                #     - event: 'pull_request'
+                #       wordpress: 'previous major version'
+                #     # On trunk/releases: Only test previous WP version with specific PHP versions
+                #     - php: '8.0'
+                #       wordpress: 'previous major version'
+                #     - php: '8.1'
+                #       wordpress: 'previous major version'
+                #     - php: '8.2'
+                #       wordpress: 'previous major version'
+                #     - php: '8.3'
+                #       wordpress: 'previous major version'
+                #     - php: '8.4'
+                #       wordpress: 'previous major version'
 
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -249,16 +249,36 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 	}
 
 	/**
-	 * Redefined to break away from base class.
-	 */
-	protected static $instance = null;
-
-	/**
-	 * Redefined to access new `$instance`
+	 * Returns the shared registry instance.
+	 *
+	 * The base `$instance` slot is intentionally not redefined, so both
+	 * `WP_Icons_Registry::get_instance()` (used by core) and this method share
+	 * one instance. An existing base registry is upgraded, replaying any
+	 * non-`core/` icons so they are not lost.
 	 */
 	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
+		if ( ! self::$instance instanceof self ) {
+			$original_registry  = self::$instance;
+			$gutenberg_registry = new self();
+
+			if ( null !== $original_registry ) {
+				foreach ( $original_registry->get_registered_icons() as $icon ) {
+					if ( str_starts_with( $icon['name'], 'core/' ) ) {
+						continue;
+					}
+					$icon_properties = array( 'label' => $icon['label'] );
+					if ( ! empty( $icon['content'] ) ) {
+						$icon_properties['content'] = $icon['content'];
+					} elseif ( ! empty( $icon['file_path'] ) ) {
+						$icon_properties['file_path'] = $icon['file_path'];
+					} else {
+						continue;
+					}
+					$gutenberg_registry->register( $icon['name'], $icon_properties );
+				}
+			}
+
+			self::$instance = $gutenberg_registry;
 		}
 
 		return self::$instance;
@@ -266,43 +286,10 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 }
 
 /**
- * Forces WP_Icons_Registry_Gutenberg instantiation and overrides WP_Icons_Registry
- * so that all code using WP_Icons_Registry::{method_name}() receives the Gutenberg
- * registry.
+ * Overrides the base `WP_Icons_Registry` singleton with the Gutenberg registry so
+ * that all code using `WP_Icons_Registry::{method_name}()` receives it.
  */
 function gutenberg_override_wp_icons_registry() {
-	$reflection = new ReflectionClass( WP_Icons_Registry::class );
-	$property   = $reflection->getProperty( 'instance' );
-	/*
-		* ReflectionProperty::setAccessible is:
-		* - redundant as of 8.1.0, which made all properties accessible
-		* - deprecated as of 8.5.0
-		* - needed until 8.1.0, as property `instance` is private
-		*/
-	if ( PHP_VERSION_ID < 80100 ) {
-		$property->setAccessible( true );
-	}
-	$original_registry  = $property->getValue( null );
-	$gutenberg_registry = WP_Icons_Registry_Gutenberg::get_instance();
-
-	// If the original registry was already instantiated, replay any icons outside
-	// the `core/` namespace onto the Gutenberg registry so they are not lost.
-	if ( null !== $original_registry ) {
-		foreach ( $original_registry->get_registered_icons() as $icon ) {
-			if ( str_starts_with( $icon['name'], 'core/' ) ) {
-				continue;
-			}
-			$icon_properties = array( 'label' => $icon['label'] );
-			if ( ! empty( $icon['content'] ) ) {
-				$icon_properties['content'] = $icon['content'];
-			} elseif ( ! empty( $icon['file_path'] ) ) {
-				$icon_properties['file_path'] = $icon['file_path'];
-			} else {
-				continue;
-			}
-			$gutenberg_registry->register( $icon['name'], $icon_properties );
-		}
-	}
-	$property->setValue( null, $gutenberg_registry );
+	WP_Icons_Registry_Gutenberg::get_instance();
 }
 add_action( 'init', 'gutenberg_override_wp_icons_registry', 1 );

--- a/phpunit/class-wp-icon-test.php
+++ b/phpunit/class-wp-icon-test.php
@@ -7,6 +7,21 @@
 
 class Tests_Icons_WpGetIcon extends WP_UnitTestCase {
 
+	public function set_up() {
+		parent::set_up();
+
+		/*
+		 * Other suites reset the `WP_Icons_Registry` singleton, wiping the core icons that
+		 * `init` only registers once. Re-register them when empty so order-dependent tests pass.
+		 */
+		if ( ! WP_Icon_Collections_Registry::get_instance()->is_registered( 'core' ) ) {
+			gutenberg_register_default_icon_collections();
+		}
+		if ( empty( WP_Icons_Registry::get_instance()->get_registered_icons() ) ) {
+			gutenberg_register_default_icons();
+		}
+	}
+
 	public function test_wp_get_icon_returns_svg_for_known_icon() {
 		$output = wp_get_icon( 'core/plus' );
 		$this->assertStringStartsWith( '<svg ', $output );

--- a/phpunit/class-wp-rest-icon-controller-test.php
+++ b/phpunit/class-wp-rest-icon-controller-test.php
@@ -24,6 +24,21 @@ class WP_Test_REST_Icons_Controller extends WP_Test_REST_TestCase {
 		self::delete_user( self::$subscriber_id );
 	}
 
+	public function set_up() {
+		parent::set_up();
+
+		/*
+		 * Other suites reset the `WP_Icons_Registry` singleton, wiping the core icons that
+		 * `init` only registers once. Re-register them when empty so order-dependent tests pass.
+		 */
+		if ( ! WP_Icon_Collections_Registry::get_instance()->is_registered( 'core' ) ) {
+			gutenberg_register_default_icon_collections();
+		}
+		if ( empty( WP_Icons_Registry::get_instance()->get_registered_icons() ) ) {
+			gutenberg_register_default_icons();
+		}
+	}
+
 	/**
 	 * Test that GET /wp/v2/icons returns a list of icons for users with edit_posts capability.
 	 */


### PR DESCRIPTION
## What?

Fixes the icon registry so that unregistering an icon collection also removes its icons, which stopped working after [WordPress core added its own icon registry](https://github.com/WordPress/wordpress-develop/commit/571dcedcbc6549c294bf3be8e6657b3ec9c12b60).

## Why?

WordPress core now ships its own icon registry classes (`WP_Icons_Registry` and `WP_Icon_Collections_Registry`). When core has them, Gutenberg's compatibility copies are skipped, and core's versions are used.

Gutenberg uses a subclass, `WP_Icons_Registry_Gutenberg`, and it kept its own separate singleton instance. Core's `unregister a collection()` logic looks up icons through the base class instance, but the rest of the code held a different instance. So the two sides no longer pointed at the same registry, and icons were not removed when their collection was unregistered.

This broke a unit test (`WP_Test_Icon_Collections_Registry::test_unregister_collection_cascades_to_icons`).

## How?

Stop giving the subclass its own instance. By not redefining the `$instance` slot, the subclass and the base class share a single instance, so `WP_Icons_Registry::get_instance()` and `WP_Icons_Registry_Gutenberg::get_instance()` always return the same object.

`get_instance()` now upgrades an already-created base registry in place (keeping any non-`core/` icons). This also let us drop the old reflection-based override.

## Testing Instructions

To ensure this PR works on older WordPress versions, I have temporarily disabled the unit test exclusion rule. Once all CI checks pass, I will revert the matrix to its previous state before merging.

## Use of AI Tools

This PR was written with the help of Claude Code (Anthropic). The investigation, fix, and description were reviewed and verified by the author.
