### PR TITLE
DataViews: support React node labels in filterText

### DIFF
--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactElement, ComponentType } from 'react';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 
 /**
  * Utility type that makes all properties of T optional recursively.
@@ -19,6 +19,12 @@ export type SortDirection = 'asc' | 'desc';
 export interface Option< Value extends any = any > {
 	value: Value;
 	label: string;
+	/**
+	 * Optional React node to render in place of `label` for contexts that
+	 * accept a node (e.g. the DataViews filter summary). When set, consumers
+	 * should prefer this over `label` for display.
+	 */
+	labelElement?: ReactNode;
 	description?: string;
 }
 

--- a/packages/dataviews/src/utils/operators.tsx
+++ b/packages/dataviews/src/utils/operators.tsx
@@ -6,7 +6,7 @@ import { subDays, subWeeks, subMonths, subYears } from 'date-fns';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, type TransformedText } from '@wordpress/i18n';
 import { createInterpolateElement, Fragment } from '@wordpress/element';
 import { getDate } from '@wordpress/date';
 import type { ReactElement, ReactNode } from 'react';
@@ -50,6 +50,16 @@ const filterTextWrappers = {
 };
 
 /**
+ * Translation template for a filter-chip prefix. Must contain a `%1$s`
+ * placeholder so `sprintf` can substitute the filter name. Mirrors the
+ * connectors package's `ConnectorHelpMessage` pattern so that
+ * `DistributeSprintfArgs` resolves to `[string]` instead of `[]`.
+ */
+type FilterTextTemplate =
+	| `${ string }%1$s${ string }`
+	| TransformedText< `${ string }%1$s${ string }` >;
+
+/**
  * Picks the displayable label for an option, preferring a React node
  * (`labelElement`) when provided so fields like User/Term can render rich
  * markup, otherwise falling back to the plain string `label`.
@@ -89,7 +99,7 @@ function joinOptionLabels( options: Option[] ): ReactNode {
  */
 function renderFilterTextPrefix(
 	filterName: string,
-	template: string
+	template: FilterTextTemplate
 ): ReactElement {
 	return createInterpolateElement(
 		sprintf( template, filterName ),
@@ -109,7 +119,7 @@ function renderFilterTextPrefix(
  */
 function renderFilterText(
 	filterName: string,
-	template: string,
+	template: FilterTextTemplate,
 	value: ReactNode
 ): ReactElement {
 	return (

--- a/packages/dataviews/src/utils/operators.tsx
+++ b/packages/dataviews/src/utils/operators.tsx
@@ -7,9 +7,9 @@ import { subDays, subWeeks, subMonths, subYears } from 'date-fns';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, Fragment } from '@wordpress/element';
 import { getDate } from '@wordpress/date';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -47,8 +47,80 @@ import {
 
 const filterTextWrappers = {
 	Name: <span className="dataviews-filters__summary-filter-text-name" />,
-	Value: <span className="dataviews-filters__summary-filter-text-value" />,
 };
+
+/**
+ * Picks the displayable label for an option, preferring a React node
+ * (`labelElement`) when provided so fields like User/Term can render rich
+ * markup, otherwise falling back to the plain string `label`.
+ *
+ * @param option Option to render.
+ * @return       React node for display.
+ */
+function getOptionLabel( option: Option ): ReactNode {
+	return option.labelElement ?? option.label;
+}
+
+/**
+ * Joins multiple options for display. Each value is rendered via
+ * `getOptionLabel` so a single React node can be embedded among strings.
+ *
+ * @param options Options to render.
+ * @return        React node with a `,` between each option.
+ */
+function joinOptionLabels( options: Option[] ): ReactNode {
+	return options.map( ( option, index ) => (
+		<Fragment key={ index }>
+			{ index > 0 && ', ' }
+			{ getOptionLabel( option ) }
+		</Fragment>
+	) );
+}
+
+/**
+ * Builds the localized prefix portion of a filter chip, e.g. "Author is:".
+ * Wraps the filter name in the `<Name>` CSS class and leaves the value
+ * portion to the caller.
+ *
+ * @param filterName Localized filter name (e.g. "Author").
+ * @param template   Translation template; must end with a trailing space
+ *                   because the value is appended as a JSX child.
+ * @return           React element containing the `<Name>`-wrapped prefix.
+ */
+function renderFilterTextPrefix(
+	filterName: string,
+	template: string
+): ReactElement {
+	return createInterpolateElement(
+		sprintf( template, filterName ),
+		filterTextWrappers
+	) as ReactElement;
+}
+
+/**
+ * Composes the full filter chip element: a localized prefix followed by
+ * the value content inside the `Value` CSS-class wrapper.
+ *
+ * @param filterName Localized filter name.
+ * @param template   Translation template for the prefix (e.g.
+ *                   `<Name>%1$s is: </Name>`).
+ * @param value      Value portion rendered as JSX children.
+ * @return           React element for the full filter chip.
+ */
+function renderFilterText(
+	filterName: string,
+	template: string,
+	value: ReactNode
+): ReactElement {
+	return (
+		<>
+			{ renderFilterTextPrefix( filterName, template ) }
+			<span className="dataviews-filters__summary-filter-text-value">
+				{ value }
+			</span>
+		</>
+	);
+}
 
 /**
  * Calculates a date offset from now.
@@ -77,14 +149,11 @@ const isNoneOperatorDefinition = {
 	/* translators: DataViews operator name */
 	label: __( 'Is none of' ),
 	filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-		createInterpolateElement(
-			sprintf(
-				/* translators: 1: Filter name (e.g. "Author"). 2: Filter value (e.g. "Admin"): "Author is none of: Admin, Editor". */
-				__( '<Name>%1$s is none of: </Name><Value>%2$s</Value>' ),
-				filter.name,
-				activeElements.map( ( element ) => element.label ).join( ', ' )
-			),
-			filterTextWrappers
+		renderFilterText(
+			filter.name,
+			/* translators: 1: Filter name (e.g. "Author"): "Author is none of:". */
+			__( '<Name>%1$s is none of: </Name>' ),
+			joinOptionLabels( activeElements )
 		),
 	filter: ( ( item, field, filterValue ) => {
 		if ( ! filterValue?.length ) {
@@ -121,16 +190,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Includes' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Author"). 2: Filter value (e.g. "Admin"): "Author is any: Admin, Editor". */
-					__( '<Name>%1$s includes: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements
-						.map( ( element ) => element.label )
-						.join( ', ' )
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Author"): "Author includes:". */
+				__( '<Name>%1$s includes: </Name>' ),
+				joinOptionLabels( activeElements )
 			),
 		filter( item, field, filterValue ) {
 			if ( ! filterValue?.length ) {
@@ -159,16 +223,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Includes all' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Author"). 2: Filter value (e.g. "Admin"): "Author includes all: Admin, Editor". */
-					__( '<Name>%1$s includes all: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements
-						.map( ( element ) => element.label )
-						.join( ', ' )
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Author"): "Author includes all:". */
+				__( '<Name>%1$s includes all: </Name>' ),
+				joinOptionLabels( activeElements )
 			),
 		filter( item, field, filterValue ) {
 			if ( ! filterValue?.length ) {
@@ -190,17 +249,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Between (inc)' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Item count"). 2: Filter value min. 3: Filter value max. e.g.: "Item count between (inc): 10 and 180". */
-					__(
-						'<Name>%1$s between (inc): </Name><Value>%2$s and %3$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label[ 0 ],
-					activeElements[ 0 ].label[ 1 ]
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Item count"): "Item count between (inc):". */
+				__( '<Name>%1$s between (inc): </Name>' ),
+				`${ activeElements[ 0 ].label[ 0 ] } and ${ activeElements[ 0 ].label[ 1 ] }`
 			),
 		filter( item, field, filterValue ) {
 			if (
@@ -234,16 +287,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'In the past' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "7 days"): "Date is in the past: 7 days". */
-					__(
-						'<Name>%1$s is in the past: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					`${ activeElements[ 0 ].value.value } ${ activeElements[ 0 ].value.unit }`
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is in the past:". */
+				__( '<Name>%1$s is in the past: </Name>' ),
+				`${ activeElements[ 0 ].value.value } ${ activeElements[ 0 ].value.unit }`
 			),
 		filter( item, field, filterValue ) {
 			if (
@@ -268,14 +316,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Over' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "7 days"): "Date is over: 7 days". */
-					__( '<Name>%1$s is over: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					`${ activeElements[ 0 ].value.value } ${ activeElements[ 0 ].value.unit }`
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is over:". */
+				__( '<Name>%1$s is over: </Name>' ),
+				`${ activeElements[ 0 ].value.value } ${ activeElements[ 0 ].value.unit }`
 			),
 		filter( item, field, filterValue ) {
 			if (
@@ -300,14 +345,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Is' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Author"). 2: Filter value (e.g. "Admin"): "Author is: Admin". */
-					__( '<Name>%1$s is: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Author"): "Author is:". */
+				__( '<Name>%1$s is: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			return (
@@ -322,14 +364,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Is not' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Author"). 2: Filter value (e.g. "Admin"): "Author is not: Admin". */
-					__( '<Name>%1$s is not: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Author"): "Author is not:". */
+				__( '<Name>%1$s is not: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			return filterValue !== field.getValue( { item } );
@@ -341,14 +380,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Less than' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Count"). 2: Filter value (e.g. "10"): "Count is less than: 10". */
-					__( '<Name>%1$s is less than: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Count"): "Count is less than:". */
+				__( '<Name>%1$s is less than: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -366,16 +402,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Greater than' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Count"). 2: Filter value (e.g. "10"): "Count is greater than: 10". */
-					__(
-						'<Name>%1$s is greater than: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Count"): "Count is greater than:". */
+				__( '<Name>%1$s is greater than: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -393,16 +424,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Less than or equal' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Count"). 2: Filter value (e.g. "10"): "Count is less than or equal to: 10". */
-					__(
-						'<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Count"): "Count is less than or equal to:". */
+				__( '<Name>%1$s is less than or equal to: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -420,16 +446,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Greater than or equal' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Count"). 2: Filter value (e.g. "10"): "Count is greater than or equal to: 10". */
-					__(
-						'<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Count"): "Count is greater than or equal to:". */
+				__( '<Name>%1$s is greater than or equal to: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -447,14 +468,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Before' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is before: 2024-01-01". */
-					__( '<Name>%1$s is before: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is before:". */
+				__( '<Name>%1$s is before: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -473,14 +491,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'After' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is after: 2024-01-01". */
-					__( '<Name>%1$s is after: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is after:". */
+				__( '<Name>%1$s is after: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -499,16 +514,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Before (inc)' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is on or before: 2024-01-01". */
-					__(
-						'<Name>%1$s is on or before: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is on or before:". */
+				__( '<Name>%1$s is on or before: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -527,16 +537,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'After (inc)' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is on or after: 2024-01-01". */
-					__(
-						'<Name>%1$s is on or after: </Name><Value>%2$s</Value>'
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is on or after:". */
+				__( '<Name>%1$s is on or after: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -555,14 +560,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Contains' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Title"). 2: Filter value (e.g. "Hello"): "Title contains: Hello". */
-					__( '<Name>%1$s contains: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Title"): "Title contains:". */
+				__( '<Name>%1$s contains: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -586,16 +588,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( "Doesn't contain" ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Title"). 2: Filter value (e.g. "Hello"): "Title doesn't contain: Hello". */
-					__(
-						"<Name>%1$s doesn't contain: </Name><Value>%2$s</Value>"
-					),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Title"): "Title doesn't contain:". */
+				__( "<Name>%1$s doesn't contain: </Name>" ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -619,14 +616,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Starts with' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Title"). 2: Filter value (e.g. "Hello"): "Title starts with: Hello". */
-					__( '<Name>%1$s starts with: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Title"): "Title starts with:". */
+				__( '<Name>%1$s starts with: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -650,14 +644,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'On' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is: 2024-01-01". */
-					__( '<Name>%1$s is: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is:". */
+				__( '<Name>%1$s is: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {
@@ -676,14 +667,11 @@ const OPERATORS: {
 		/* translators: DataViews operator name */
 		label: __( 'Not on' ),
 		filterText: ( filter: NormalizedFilter, activeElements: Option[] ) =>
-			createInterpolateElement(
-				sprintf(
-					/* translators: 1: Filter name (e.g. "Date"). 2: Filter value (e.g. "2024-01-01"): "Date is not: 2024-01-01". */
-					__( '<Name>%1$s is not: </Name><Value>%2$s</Value>' ),
-					filter.name,
-					activeElements[ 0 ].label
-				),
-				filterTextWrappers
+			renderFilterText(
+				filter.name,
+				/* translators: 1: Filter name (e.g. "Date"): "Date is not:". */
+				__( '<Name>%1$s is not: </Name>' ),
+				getOptionLabel( activeElements[ 0 ] )
 			),
 		filter( item, field, filterValue ) {
 			if ( filterValue === undefined ) {

--- a/packages/dataviews/src/utils/test/operators.test.tsx
+++ b/packages/dataviews/src/utils/test/operators.test.tsx
@@ -8,8 +8,10 @@ import { render, screen, within } from '@testing-library/react';
  */
 import { getOperatorByName } from '../operators';
 import { OPERATOR_IS, OPERATOR_IS_ANY } from '../../constants';
+import type { NormalizedFilter } from '../../types';
 
-const sampleFilter = { name: 'Author' } as const;
+// filterText only reads `filter.name`; cast keeps the mock small.
+const sampleFilter = { name: 'Author' } as unknown as NormalizedFilter;
 
 const ROOT_TEST_ID = 'filter-chip';
 const NAME_CLASS = 'dataviews-filters__summary-filter-text-name';

--- a/packages/dataviews/src/utils/test/operators.test.tsx
+++ b/packages/dataviews/src/utils/test/operators.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { render, screen, within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { getOperatorByName } from '../operators';
+import { OPERATOR_IS, OPERATOR_IS_ANY } from '../../constants';
+
+const sampleFilter = { name: 'Author' } as const;
+
+const ROOT_TEST_ID = 'filter-chip';
+const NAME_CLASS = 'dataviews-filters__summary-filter-text-name';
+const VALUE_CLASS = 'dataviews-filters__summary-filter-text-value';
+
+function renderFilter( element: React.ReactNode ) {
+	return render( <div data-testid={ ROOT_TEST_ID }>{ element }</div> );
+}
+
+function getRoot() {
+	return screen.getByTestId( ROOT_TEST_ID );
+}
+
+describe( 'operators filterText', () => {
+	it( 'renders a string label inside the Value wrapper (legacy BC)', () => {
+		const operator = getOperatorByName( OPERATOR_IS );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{ value: 1, label: 'Admin' },
+			] )
+		);
+
+		const root = getRoot();
+		expect( within( root ).getByText( 'Admin' ) ).toBeInTheDocument();
+		expect(
+			within( root ).getByText( ( _, el ) =>
+				Boolean(
+					el?.classList.contains( NAME_CLASS ) &&
+						el.textContent?.startsWith( 'Author' )
+				)
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders a React labelElement in place of label', () => {
+		const operator = getOperatorByName( OPERATOR_IS );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{
+					value: 1,
+					label: 'Admin',
+					labelElement: <span data-testid="badge">Admin</span>,
+				},
+			] )
+		);
+
+		const badge = screen.getByTestId( 'badge' );
+		expect( badge ).toBeInTheDocument();
+		expect( getRoot() ).toContainElement( badge );
+	} );
+
+	it( 'joins multiple labelElements with a comma separator', () => {
+		const operator = getOperatorByName( OPERATOR_IS_ANY );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{
+					value: 1,
+					label: 'Admin',
+					labelElement: <span data-testid="el">Admin</span>,
+				},
+				{
+					value: 2,
+					label: 'Editor',
+					labelElement: <span data-testid="el">Editor</span>,
+				},
+			] )
+		);
+
+		expect( screen.getAllByTestId( 'el' ) ).toHaveLength( 2 );
+		expect( getRoot() ).toHaveTextContent( 'Admin, Editor' );
+	} );
+
+	it( 'joins mixed string and React labels in order', () => {
+		const operator = getOperatorByName( OPERATOR_IS_ANY );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{ value: 1, label: 'Admin' },
+				{
+					value: 2,
+					label: 'Editor',
+					labelElement: <span data-testid="el">Editor</span>,
+				},
+				{ value: 3, label: 'Author' },
+			] )
+		);
+
+		expect( screen.getByTestId( 'el' ) ).toBeInTheDocument();
+		expect( screen.getAllByTestId( 'el' ) ).toHaveLength( 1 );
+		expect( getRoot() ).toHaveTextContent( 'Admin, Editor, Author' );
+	} );
+
+	it( 'wraps the filter name in the Name CSS class', () => {
+		const operator = getOperatorByName( OPERATOR_IS );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{ value: 1, label: 'Admin' },
+			] )
+		);
+
+		const nameWrapper = within( getRoot() ).getByText( ( _, el ) =>
+			Boolean(
+				el?.classList.contains( NAME_CLASS ) &&
+					el.textContent?.startsWith( 'Author' )
+			)
+		);
+		expect( nameWrapper ).toHaveClass( NAME_CLASS );
+	} );
+
+	it( 'keeps CSS class hooks for the React labelElement path', () => {
+		const operator = getOperatorByName( OPERATOR_IS );
+		expect( operator ).toBeDefined();
+
+		renderFilter(
+			operator!.filterText( sampleFilter, [
+				{
+					value: 1,
+					label: 'Admin',
+					labelElement: <span data-testid="badge">Admin</span>,
+				},
+			] )
+		);
+
+		const root = getRoot();
+		expect(
+			within( root ).getByText( ( _, el ) =>
+				Boolean( el?.classList.contains( NAME_CLASS ) )
+			)
+		).toBeInTheDocument();
+		expect(
+			within( root ).getByText( ( _, el ) =>
+				Boolean( el?.classList.contains( VALUE_CLASS ) )
+			)
+		).toBeInTheDocument();
+		expect( screen.getByTestId( 'badge' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #79361

`Option` now carries an optional `labelElement?: ReactNode` and every `filterText` callback in `packages/dataviews/src/utils/operators.tsx` was refactored to render that React node as a JSX child inside the `Value` wrapper.

## Why?
`filterText` was building the value portion of a filter chip with `sprintf` + `Array<string>.join(', ')`. Number-typed fields with a server-side `Edit` component (User, Term) need to render a React node as the filter value label (e.g. an avatar), which the string-only path cannot do.

## How?
- Added `labelElement?: ReactNode` to the `Option<Value>` interface in `packages/dataviews/src/types/field-api.ts`. Purely additive, no BC break.
- Introduced a shared `renderFilterText` helper in `packages/dataviews/src/utils/operators.tsx` that:
  - renders `<span class="dataviews-filters__summary-filter-text-name">...</span>` for the localized prefix via `createInterpolateElement`,
  - renders `<span class="dataviews-filters__summary-filter-text-value">{value}</span>` for the value, where `value` is a JSX node (or string) from `getOptionLabel(option)`.
- Replaced every per-operator `filterText` body with a single call to `renderFilterText(...)`. The multi-value operators (IS_ANY, IS_ALL, IS_NONE, IS_NOT_ALL) join elements with a `,` separator via `joinOptionLabels`, which uses `Fragment` to interleave labels.
- Updated the i18n translator comments on every affected operator: the value is no longer a `sprintf` argument, so `%2$s` is gone and the comment now documents only the prefix.
- Removed the unused `Value` key from the `filterTextWrappers` object; `createInterpolateElement` only ever needed `Name`.
- Added `packages/dataviews/src/utils/test/operators.test.tsx` with six tests covering: legacy string label, single React `labelElement`, multiple React `labelElement`s joined with `,`, mixed string + React in order, the `Name` CSS class, and full CSS hooks for the React path.

`BETWEEN`, `IN_THE_PAST`, and `OVER` were intentionally left alone because they do not consume `Option.label` / `Option.labelElement` (they read other fields like `label[0]`/`label[1]` and `value.value`/`value.unit`).

## Testing Instructions
1. From the repo root run `npm install` and `npm run wp-env start` (or use your existing dev environment).
2. In the editor, open a view that uses `@wordpress/dataviews` with a `SelectControl`/`ComboboxControl` filter on a number-typed field (User, Term, or any custom field that supplies server-side `Edit`).
3. Pick one or more filter values, then close the filter popover. The active filter chip at the top of the view should now render the React node you supplied via `Option.labelElement` (avatar, badge, etc.) instead of `[object Object]`.
4. With no `labelElement` set, the chip still renders the plain string label as before.

### Unit tests
- `npm run test:unit -- packages/dataviews/src/utils/test/operators.test.tsx` runs the new tests; the existing `packages/dataviews` suite (339 tests) must stay green.

### Testing Instructions for Keyboard
Not applicable: this change does not alter keyboard handling or focusable UI. Filter chips remain keyboard-accessible as before.

## Use of AI Tools
This change was developed with assistance from an AI coding assistant. The assistant was used for code generation, refactoring, and test authoring. All output was reviewed, edited, and verified by the human author before submission.
