### PR TITLE
Notes: Add placeholders to the RichText fields

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -121,7 +121,7 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 					onCancel={ unselectNote }
 					labels={ {
 						input: __( 'New note' ),
-						placeholder: __( 'Write note or mention with @' ),
+						placeholder: __( 'Add a note or @ mention' ),
 					} }
 				/>
 			</NoteCard>

--- a/packages/editor/src/components/collab-sidebar/add-note.js
+++ b/packages/editor/src/components/collab-sidebar/add-note.js
@@ -119,7 +119,10 @@ export function AddNote( { onSubmit, sidebarRef, floating } ) {
 						}
 					} }
 					onCancel={ unselectNote }
-					labels={ { input: __( 'New note' ) } }
+					labels={ {
+						input: __( 'New note' ),
+						placeholder: __( 'Write note or mention with @' ),
+					} }
 				/>
 			</NoteCard>
 		</FloatingContainer>

--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -114,6 +114,7 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 				hideLabelFromVision
 				value={ inputComment }
 				onChange={ setInputComment }
+				placeholder={ labels?.placeholder }
 				allowedFormats={ ALLOWED_NOTE_FORMATS }
 				completers={ NOTE_COMPLETERS }
 			/>

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -331,7 +331,7 @@ export function NoteThread( {
 								note.id,
 								note.author_name
 							),
-							placeholder: __( 'Reply or mention with @' ),
+							placeholder: __( 'Reply or @ mention' ),
 						} }
 					/>
 				</NoteCard>

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -331,6 +331,7 @@ export function NoteThread( {
 								note.id,
 								note.author_name
 							),
+							placeholder: __( 'Reply or mention with @' ),
 						} }
 					/>
 				</NoteCard>

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1783,55 +1783,6 @@ test.describe( 'Block Notes', () => {
 			await expect( replyTextbox ).toBeVisible();
 		} );
 
-		test( 'does not render the hidden field label as a placeholder', async ( {
-			editor,
-			page,
-			blockNoteUtils,
-		} ) => {
-			/*
-			 * The note forms label their fields with a visually hidden
-			 * label ("New note" / "Reply to note N by author") and render
-			 * no placeholder; the rich text placeholder element only
-			 * mounts when a placeholder is passed, so its presence means
-			 * the hidden label leaked into the visible field.
-			 */
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: { content: 'Placeholder host' },
-			} );
-			await editor.clickBlockOptionsMenuItem( 'Add note' );
-			const newNoteTextbox = page.getByRole( 'textbox', {
-				name: 'New note',
-				exact: true,
-			} );
-			await expect( newNoteTextbox ).toBeVisible();
-			await expect( newNoteTextbox ).not.toHaveAttribute(
-				'aria-placeholder',
-				/./
-			);
-			await expect(
-				newNoteTextbox.locator( '[data-rich-text-placeholder]' )
-			).toHaveCount( 0 );
-
-			await blockNoteUtils.addNote( 'Placeholder note' );
-			const replyTextbox = page.getByRole( 'textbox', {
-				name: 'Reply to',
-			} );
-			await expect( replyTextbox ).toBeVisible();
-			// The visually hidden label still provides the descriptive
-			// accessible name; only the visible placeholder is gone.
-			await expect( replyTextbox ).toHaveAccessibleName(
-				/^Reply to note \d+ by admin$/
-			);
-			await expect( replyTextbox ).not.toHaveAttribute(
-				'aria-placeholder',
-				/./
-			);
-			await expect(
-				replyTextbox.locator( '[data-rich-text-placeholder]' )
-			).toHaveCount( 0 );
-		} );
-
 		test( 'backtick wrapping applies core/code inline format', async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?
Closes #80227.

PR adds the following placeholders for new note and reply RichText fields:

* New note - `Add a note or @ mention`.
* Reply - `Reply or @ mention`.

These are a combination of ideas discussed in the issue, and the wording also matches placeholder texts used in other apps.

## Testing Instructions
1. Open a post or page.
2. Add note.
3. Test new note and reply placeholders.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
|New Note|Reply|
|-|-|
|<img width="264" height="271" alt="CleanShot 2026-07-15 at 16 16 11" src="https://github.com/user-attachments/assets/c6924e95-d857-4397-9389-f0d881d7694b" />|<img width="273" height="296" alt="CleanShot 2026-07-15 at 16 15 55" src="https://github.com/user-attachments/assets/5487ec7b-5040-44e9-8501-decdd1608e0f" />|

## Use of AI Tools

None.
