### PR TITLE
Interactivity Router: prototype persisted head elements for client-side navigation

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a `data-wp-router-persist` attribute and a `persistedHeadElements` `core/router` config option (set via `wp_interactivity_config()`) so `<style>`/`<link rel="stylesheet">` elements can opt out of the router's head merge on client-side navigation. This covers both markup you control directly and third-party CSS injected at runtime by scripts like consent managers (OneTrust, Complianz) or chat widgets (HubSpot), which won't add a WordPress-specific attribute themselves. Prototype for [#76031](https://github.com/WordPress/gutenberg/issues/76031).
+
 ## 2.51.0 (2026-07-14)
 
 ## 2.50.0 (2026-07-01)

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -106,6 +106,49 @@ Example with `attachTo`:
 </div>
 ```
 
+### Persisting head styles across navigation
+
+<div class="callout callout-info">
+This is an early, minimal prototype meant to make the discussion in <a href="https://github.com/WordPress/gutenberg/issues/76031">#76031</a> concrete for the WordPress 7.1 planning cycle. The API described here may still change.
+</div>
+
+When the router navigates to a new page, it merges the `<style>` and `<link rel="stylesheet">` elements of the fetched page into the current document, and disables any stylesheet that isn't part of that new page. This is normally what you want, but it breaks stylesheets that a script added to `<head>` at runtime and that aren't part of any server-rendered page, such as the CSS a consent-management banner (OneTrust, Complianz) or a chat widget (HubSpot) injects after the page loads. The router has no way of knowing those styles matter, so on the first client-side navigation it silently disables them, and the widget ends up unstyled.
+
+There are two ways to tell the router to leave a style or link element alone, no matter what the fetched page looks like:
+
+#### `data-wp-router-persist` attribute
+
+Add `data-wp-router-persist` to any `<style>` or `<link rel="stylesheet">` element that your own code controls. This works for stylesheets your theme or plugin enqueues and then mutates on the client (e.g. toggling a `media` attribute to implement a client-side theme switcher):
+
+```html
+<link
+	rel="stylesheet"
+	id="my-plugin-theme-light-css"
+	href="theme-light.css"
+	data-wp-router-persist
+/>
+```
+
+The router will never disable, remove, or reorder an element carrying this attribute, whether or not a matching element exists in the fetched page's HTML.
+
+#### `persistedHeadElements` config
+
+The attribute above only helps for markup you control. A vendor like OneTrust or HubSpot will never add a WordPress-specific attribute to their own snippet. For those cases, the site owner (who knows exactly which third-party tools are running on their site, even though the vendor has no idea WordPress or its router exists) can register a list of CSS selectors through the existing `core/router` config, using the same `wp_interactivity_config()` call other parts of the Interactivity API already use:
+
+```php
+wp_interactivity_config(
+	'core/router',
+	array(
+		'persistedHeadElements' => array(
+			'#onetrust-consent-sdk style',
+			'style[data-hubspot]',
+		),
+	)
+);
+```
+
+Any `<style>` or `<link rel="stylesheet">` element matching one of these selectors is treated exactly like an element carrying `data-wp-router-persist`: the router leaves it alone during the head merge, regardless of whether anything matching it is present in the fetched page.
+
 ### Actions
 
 #### `navigate`

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -6,6 +6,56 @@ import { shortestCommonSupersequence } from './scs';
 export type StyleElement = HTMLLinkElement | HTMLStyleElement;
 
 /**
+ * Attribute that can be added to a `<style>` or `<link rel="stylesheet">`
+ * element to tell the router to leave it alone during the head merge, no
+ * matter what the fetched page looks like.
+ *
+ * This only helps for elements the site owner (or the developer building
+ * for them) controls directly. Third-party scripts (consent managers, chat
+ * widgets, etc.) that inject their own `<style>` tags at runtime will never
+ * add this attribute to their own markup, which is why
+ * {@link isPersistedElement|`isPersistedElement`} also accepts a list of
+ * selectors registered by the site owner.
+ */
+export const PERSIST_ATTRIBUTE = 'data-wp-router-persist';
+
+/**
+ * Checks whether a style or link element should be left untouched by the
+ * router's head merge.
+ *
+ * An element is considered "persisted" when it either carries the
+ * {@link PERSIST_ATTRIBUTE|`data-wp-router-persist`} attribute or matches
+ * one of the selectors registered through the `persistedHeadElements` config
+ * of the `core/router` store (see `wp_interactivity_config()`). The latter
+ * exists for elements injected by third-party scripts that will never add a
+ * WordPress-specific attribute to their own markup.
+ *
+ * @param element            `<style>` or `<link>` element.
+ * @param persistedSelectors List of CSS selectors registered by the site
+ *                           owner for elements that aren't under their
+ *                           direct control (e.g. `#onetrust-consent-sdk
+ *                           style`).
+ * @return Whether the element should be excluded from the head merge.
+ */
+export const isPersistedElement = (
+	element: StyleElement,
+	persistedSelectors: string[] = []
+): boolean => {
+	if ( element.hasAttribute( PERSIST_ATTRIBUTE ) ) {
+		return true;
+	}
+
+	return persistedSelectors.some( ( selector ) => {
+		try {
+			return element.matches( selector );
+		} catch {
+			// Ignore invalid selectors instead of breaking navigation.
+			return false;
+		}
+	} );
+};
+
+/**
  * Compares the passed style or link elements to check if they can be
  * considered equal.
  *
@@ -210,18 +260,30 @@ const prepareStylePromise = (
  * Note that this function alters the passed document, as it can transfer
  * nodes from it to the global document.
  *
- * @param doc Document instance.
+ * Elements considered "persisted" (see {@link isPersistedElement|
+ * `isPersistedElement`}) are excluded on both sides of the comparison, so
+ * the head merge doesn't add, remove, or reorder them regardless of whether
+ * a matching element exists in the fetched page.
+ *
+ * @param doc                Document instance.
+ * @param persistedSelectors List of CSS selectors registered by the site
+ *                           owner for third-party elements that should be
+ *                           left alone (see `persistedHeadElements` in the
+ *                           `core/router` config).
  * @return A list of promises for each style element in the passed document.
  */
-export const preloadStyles = ( doc: Document ): Promise< StyleElement >[] => {
+export const preloadStyles = (
+	doc: Document,
+	persistedSelectors: string[] = []
+): Promise< StyleElement >[] => {
 	const currentStyleElements = Array.from(
 		window.document.querySelectorAll< StyleElement >(
 			'style,link[rel=stylesheet]'
 		)
-	);
+	).filter( ( el ) => ! isPersistedElement( el, persistedSelectors ) );
 	const newStyleElements = Array.from(
 		doc.querySelectorAll< StyleElement >( 'style,link[rel=stylesheet]' )
-	);
+	).filter( ( el ) => ! isPersistedElement( el, persistedSelectors ) );
 
 	// Set styles in order.
 	return updateStylesWithSCS( currentStyleElements, newStyleElements );
@@ -234,12 +296,29 @@ export const preloadStyles = ( doc: Document ): Promise< StyleElement >[] => {
  * If the style element has the `data-original-media` attribute, the
  * original `media` value is restored.
  *
- * @param styles List of style elements to apply.
+ * Elements considered "persisted" (see {@link isPersistedElement|
+ * `isPersistedElement`}) are skipped entirely: their `sheet.disabled` state
+ * is left exactly as-is, whether or not they're included in `styles`. This
+ * is what stops the router from silently disabling CSS injected at runtime
+ * by third-party scripts (e.g. a consent manager banner) on navigation.
+ *
+ * @param styles             List of style elements to apply.
+ * @param persistedSelectors List of CSS selectors registered by the site
+ *                           owner for third-party elements that should be
+ *                           left alone (see `persistedHeadElements` in the
+ *                           `core/router` config).
  */
-export const applyStyles = ( styles: StyleElement[] ) => {
+export const applyStyles = (
+	styles: StyleElement[],
+	persistedSelectors: string[] = []
+) => {
 	window.document
 		.querySelectorAll( 'style,link[rel=stylesheet]' )
 		.forEach( ( el: HTMLLinkElement | HTMLStyleElement ) => {
+			if ( isPersistedElement( el, persistedSelectors ) ) {
+				return;
+			}
+
 			if ( el.sheet ) {
 				if ( styles.includes( el ) ) {
 					// Only update mediaText when necessary.

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -6,6 +6,8 @@ import {
 	updateStylesWithSCS,
 	preloadStyles,
 	applyStyles,
+	isPersistedElement,
+	PERSIST_ATTRIBUTE,
 	type StyleElement,
 } from '../styles';
 
@@ -768,6 +770,147 @@ describe( 'Router styles management', () => {
 			expect( styles[ 0 ].isEqualNode( styles[ 1 ] ) ).toBe( true );
 			expect( styles[ 0 ].isEqualNode( styles[ 2 ] ) ).toBe( true );
 			expect( styles[ 0 ].isEqualNode( styles[ 3 ] ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isPersistedElement', () => {
+		it( 'should return true for elements with the persist attribute', () => {
+			const style = createStyleElement( 'onetrust-style' );
+			style.setAttribute( PERSIST_ATTRIBUTE, '' );
+
+			expect( isPersistedElement( style ) ).toBe( true );
+		} );
+
+		it( 'should return false for regular elements when no selectors are registered', () => {
+			const style = createStyleElement( 'regular-style' );
+
+			expect( isPersistedElement( style ) ).toBe( false );
+		} );
+
+		it( 'should return true for elements matching a registered selector', () => {
+			const style = createStyleElement( 'onetrust-consent-sdk-style' );
+			style.id = 'onetrust-consent-sdk-style';
+
+			expect(
+				isPersistedElement( style, [
+					'#onetrust-consent-sdk-style',
+					'style[data-hubspot]',
+				] )
+			).toBe( true );
+		} );
+
+		it( 'should return false for elements that match neither the attribute nor a registered selector', () => {
+			const style = createStyleElement( 'unrelated-style' );
+
+			expect(
+				isPersistedElement( style, [ 'style[data-hubspot]' ] )
+			).toBe( false );
+		} );
+
+		it( 'should ignore invalid selectors instead of throwing', () => {
+			const style = createStyleElement( 'some-style' );
+
+			expect( () =>
+				isPersistedElement( style, [ ':::not-a-selector' ] )
+			).not.toThrow();
+			expect( isPersistedElement( style, [ ':::not-a-selector' ] ) ).toBe(
+				false
+			);
+		} );
+	} );
+
+	describe( 'preloadStyles with persisted elements', () => {
+		it( 'should not include a live persisted element in the returned promises', async () => {
+			const persisted = createStyleElement( 'onetrust-style' );
+			persisted.setAttribute( PERSIST_ATTRIBUTE, '' );
+			parent.append( persisted );
+
+			const doc = document.implementation.createHTMLDocument();
+
+			const promises = preloadStyles( doc );
+
+			expect( promises.length ).toBe( 0 );
+			// The persisted element should still be in the document, untouched.
+			expect( parent.contains( persisted ) ).toBe( true );
+		} );
+
+		it( 'should not duplicate an element matching a registered selector from the fetched page', async () => {
+			const persisted = createStyleElement( 'hubspot-style' );
+			persisted.setAttribute( 'data-hubspot', '' );
+			parent.append( persisted );
+
+			const doc = document.implementation.createHTMLDocument();
+			const fetchedTwin = doc.createElement( 'style' );
+			fetchedTwin.setAttribute( 'data-hubspot', '' );
+			doc.head.appendChild( fetchedTwin );
+
+			const promises = preloadStyles( doc, [ 'style[data-hubspot]' ] );
+
+			expect( promises.length ).toBe( 0 );
+			expect(
+				parent.querySelectorAll( 'style[data-hubspot]' ).length
+			).toBe( 1 );
+		} );
+
+		it( 'should still reconcile non-persisted elements normally', () => {
+			const persisted = createStyleElement( 'onetrust-style' );
+			persisted.setAttribute( PERSIST_ATTRIBUTE, '' );
+			const regular = createStyleElement( 'regular-style' );
+			parent.append( persisted, regular );
+
+			const doc = document.implementation.createHTMLDocument();
+			const newStyle = doc.createElement( 'style' );
+			newStyle.id = 'new-style';
+			doc.head.appendChild( newStyle );
+
+			const promises = preloadStyles( doc );
+
+			// Only the new, non-persisted style should generate a promise.
+			expect( promises.length ).toBe( 1 );
+			expect( parent.contains( persisted ) ).toBe( true );
+			expect( parent.contains( regular ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'applyStyles with persisted elements', () => {
+		it( 'should never disable an element with the persist attribute', () => {
+			const persisted = createStyleElement( 'onetrust-style' );
+			persisted.setAttribute( PERSIST_ATTRIBUTE, '' );
+			document.head.appendChild( persisted );
+
+			mockSheet( persisted, { disabled: false, mediaText: 'all' } );
+
+			// Not included in `styles`, which would normally disable it.
+			applyStyles( [] );
+
+			expect( persisted.sheet!.disabled ).toBe( false );
+		} );
+
+		it( 'should never disable an element matching a registered selector', () => {
+			const vendor = createStyleElement( 'onetrust-consent-sdk' );
+			vendor.id = 'onetrust-consent-sdk';
+			document.head.appendChild( vendor );
+
+			mockSheet( vendor, { disabled: false, mediaText: 'all' } );
+
+			applyStyles( [], [ '#onetrust-consent-sdk' ] );
+
+			expect( vendor.sheet!.disabled ).toBe( false );
+		} );
+
+		it( 'should still disable regular elements not present in styles', () => {
+			const persisted = createStyleElement( 'onetrust-style' );
+			persisted.setAttribute( PERSIST_ATTRIBUTE, '' );
+			const regular = createStyleElement( 'regular-style' );
+			document.head.append( persisted, regular );
+
+			mockSheet( persisted, { disabled: false, mediaText: 'all' } );
+			mockSheet( regular, { disabled: false, mediaText: 'all' } );
+
+			applyStyles( [] );
+
+			expect( persisted.sheet!.disabled ).toBe( false );
+			expect( regular.sheet!.disabled ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -35,6 +35,19 @@ const regionAttr = `data-wp-router-region`;
 const interactiveAttr = `data-wp-interactive`;
 const regionsSelector = `[${ interactiveAttr }][${ regionAttr }], [${ interactiveAttr }] [${ interactiveAttr }][${ regionAttr }]`;
 
+/**
+ * Returns the list of CSS selectors that a site owner registered, via
+ * `wp_interactivity_config( 'core/router', [ 'persistedHeadElements' => [...] ] )`,
+ * for head elements the router's style merge should never touch (e.g. a
+ * `<style>` tag injected at runtime by a consent-management script). See
+ * `isPersistedElement()` in `./assets/styles`.
+ *
+ * @return List of registered selectors, or an empty array if none were
+ *         registered.
+ */
+const getPersistedHeadElements = (): string[] =>
+	getConfig( 'core/router' )?.persistedHeadElements ?? [];
+
 export interface NavigateOptions {
 	force?: boolean;
 	html?: string;
@@ -222,7 +235,7 @@ const preparePage: PreparePage = async ( url, dom, { vdom } = {} ) => {
 
 	// Wait for styles and modules to be ready.
 	const [ styles, scriptModules ] = await Promise.all( [
-		Promise.all( preloadStyles( dom ) ),
+		Promise.all( preloadStyles( dom, getPersistedHeadElements() ) ),
 		Promise.all( preloadScriptModules( dom ) ),
 	] );
 
@@ -244,7 +257,7 @@ const preparePage: PreparePage = async ( url, dom, { vdom } = {} ) => {
  * @param page The {@link Page} object to render.
  */
 const renderPage = ( page: Page ) => {
-	applyStyles( page.styles );
+	applyStyles( page.styles, getPersistedHeadElements() );
 
 	// Clone regionsToAttach.
 	const regionsToAttach = { ...page.regionsToAttach };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #76031.

This is a small prototype for the head styles part of #76031, where dynamically injected CSS (from things like consent managers or chat widgets) gets silently disabled by the router's head merge on client side navigation. It adds two mechanisms so a live head element can opt out of that merge entirely:

1. A `data-wp-router-persist` attribute for `<style>`/`<link rel="stylesheet">` elements the site owner controls directly.
2. A `persistedHeadElements` config option on the `core/router` store, set through the existing `wp_interactivity_config()` channel, so a site owner can register CSS selectors for elements they don't control (vendor snippets that will never add a WordPress attribute to their own markup).

This is deliberately independent of #76289, which I know is an existing, actively discussed PR for this same issue. I wanted to build a small, separate prototype that follows the direction I proposed in my comment on the issue, so it's something concrete we can point at during the WP 7.1 planning discussion, not a replacement for that other PR.

## Why?
We keep running into this on client sites. Consent managers like OneTrust inject styles and DOM at runtime, and on sites with client side navigation on, that CSS gets dropped on the first navigation with no error, just a banner that's suddenly unstyled. Complianz has the same problem, and HubSpot's chat widget was raised in the thread as another real example.

The attribute-only approach that was discussed earlier in the issue only helps for markup the site owner controls directly. Vendors like OneTrust and HubSpot are never going to add a `data-wp-*` attribute to their own snippets, so an attribute alone can't fully solve this. Pairing it with a site level registration API means the site owner, who knows exactly which third party tools are running, can tell the router to leave specific selectors alone without needing any cooperation from the vendor.

## How?
`packages/interactivity-router/src/assets/styles.ts`:

- Adds an `isPersistedElement()` helper that returns true if an element carries the `data-wp-router-persist` attribute, or matches one of a list of passed in CSS selectors (via `element.matches()`, wrapped in a try/catch so an invalid selector never breaks navigation).
- `preloadStyles()` now filters persisted elements out of both the current DOM elements and the elements found in the fetched page before running the shortest common supersequence reconciliation. This means the router's merge algorithm doesn't add, remove, or reorder them at all, regardless of whether a matching element happens to exist in the fetched page.
- `applyStyles()` now skips any element matching the persist criteria when enabling/disabling stylesheets after navigation, so its `sheet.disabled` state is left exactly as it was, whatever a vendor script last set it to.

`packages/interactivity-router/src/index.ts`:

- Adds a small `getPersistedHeadElements()` helper that reads `persistedHeadElements` off the `core/router` config via `getConfig()`, the same way `clientNavigationDisabled` is already read elsewhere in this file.
- Passes that list through to `preloadStyles()` (in `preparePage()`) and `applyStyles()` (in `renderPage()`).

No PHP changes were needed. `wp_interactivity_config( 'core/router', [ 'persistedHeadElements' => [ ... ] ] )` already works today the same way `clientNavigationDisabled` does in `packages/block-library/src/query/index.php`, since `wp_interactivity_config()` is a WordPress Core function.

Also added a README section (with a OneTrust flavored example) and a CHANGELOG entry for the package.

## Testing Instructions
Since `packages/interactivity-router/src/assets/styles.ts` already has a unit test suite, I added unit tests there rather than a new e2e fixture, to keep the diff small. To run them:

```
npm run test:unit -- packages/interactivity-router/src/assets/test/styles.test.ts
```

All 40 tests pass (5 new `isPersistedElement` tests, 3 new `preloadStyles`-with-persisted-elements tests, 3 new `applyStyles`-with-persisted-elements tests, plus the existing suite unchanged). `npm run lint:js` is clean on all changed files.

Manually, you could also:
1. Enqueue a stylesheet with `data-wp-router-persist` on a page using the router.
2. From the console, simulate a vendor injecting a `<style>` element into `<head>` after load (no attribute), and register its selector via `wp_interactivity_config( 'core/router', [ 'persistedHeadElements' => [ 'style#my-test-style' ] ] )`.
3. Trigger a client side navigation.
4. Confirm both stylesheets are still enabled and in the same position after navigating.

### Testing Instructions for Keyboard
No UI changes, this is a router/config level behavior change with no visible interface.

## Screenshots or screencast
Not applicable, no visual/UI changes.

## Use of AI Tools
This PR was written with Claude Code (Claude Fable 5) based on my own analysis of the issue thread and my comment there. I reviewed the diff, ran the tests and linter myself, and take responsibility for the change.

---

This is a prototype meant to make the discussion in #76031 concrete for the WordPress 7.1 iteration planning, not a finished, ready to merge solution. Happy to iterate based on feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
