### PR TITLE
Notes: Finish WPDS treatment for mention chips

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -257,21 +257,25 @@ mark.wp-note {
 	white-space: nowrap;
 	text-decoration: none;
 
-	// Interactive states, since the chip look drops the link underline.
-	&:hover,
-	&:active {
-		background: var(--wpds-color-background-interactive-brand-weak-active);
-		color: var(--wpds-color-foreground-interactive-brand-active);
-	}
-
 	// Focus ring matching `ExternalLink`/`Link`; 0-width at rest avoids a stray forced-colors outline.
 	outline: 0 solid transparent;
 	outline-offset: 1px;
 
+	// Also clears the wp-admin common.css `a:focus` shadow/color/radius, which outrank the base rule.
 	&:focus {
 		outline:
 			var(--wpds-border-width-focus) solid
 			var(--wpds-color-stroke-focus);
+		box-shadow: none;
+		border-radius: var(--wpds-border-radius-sm);
+		color: var(--wpds-color-foreground-interactive-brand);
+	}
+
+	// Interactive states, since the chip look drops the link underline. After `:focus` so hover wins when both apply.
+	&:hover,
+	&:active {
+		background: var(--wpds-color-background-interactive-brand-weak-active);
+		color: var(--wpds-color-foreground-interactive-brand-active);
 	}
 
 	// Restore the underline when forced-colors drops the background tint.

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -249,13 +249,35 @@ mark.wp-note {
 // rather than an underlined link.
 .wp-note-mention {
 	display: inline;
-	padding: 0 $grid-unit-05;
-	border-radius: $radius-small;
-	background: color-mix(in srgb, var(--wp-admin-theme-color) 12%, transparent);
-	color: var(--wp-admin-theme-color);
+	padding: 0 var(--wpds-dimension-padding-xs);
+	border-radius: var(--wpds-border-radius-sm);
+	background: var(--wpds-color-background-surface-brand);
+	color: var(--wpds-color-foreground-interactive-brand);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 	white-space: nowrap;
 	text-decoration: none;
+
+	// Interactive states, since the chip look drops the link underline.
+	&:hover,
+	&:active {
+		background: var(--wpds-color-background-interactive-brand-weak-active);
+		color: var(--wpds-color-foreground-interactive-brand-active);
+	}
+
+	// Focus ring matching `ExternalLink`/`Link`; 0-width at rest avoids a stray forced-colors outline.
+	outline: 0 solid transparent;
+	outline-offset: 1px;
+
+	&:focus {
+		outline:
+			var(--wpds-border-width-focus) solid
+			var(--wpds-color-stroke-focus);
+	}
+
+	// Restore the underline when forced-colors drops the background tint.
+	@media (forced-colors: active) {
+		text-decoration: underline;
+	}
 }
 
 // Match the rounded avatars used for note bylines and the block toolbar


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/79604#issuecomment-4968932329.

PR replaces the legacy/Sass/custom values on the `.wp-note-mention` chip with semantic WPDS tokens and adds the interaction states a link needs.

- Swaps `$grid-unit-05` / `$radius-small` for `--wpds-dimension-padding-xs` / `--wpds-border-radius-sm` (same 4px/2px), and the `color-mix` + `--wp-admin-theme-color` fills for `--wpds-color-background-surface-brand` / `--wpds-color-foreground-interactive-brand`.
- Adds hover/active states (deeper tint + `-interactive-brand-active` foreground) so the underline-less chip no longer reads as a static highlight.
- Adds an `ExternalLink`/`Link`-style focus ring and a `forced-colors` fallback that restores the underline when the tint is dropped.

Kept the resting fill on the `surface-brand` token rather than `interactive-brand-weak`, since the latter is transparent at rest and would drop the chip's tint. No visual regression in legacy admin — the tokens track `--wp-admin-theme-color` through the fallback chain.

## Testing Instructions
1. Create a post.
2. Add a note with a mention.
3. Smoke test mentions chip styling.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/634d18d7-53e0-4a73-a9b1-89332d9c5156

## Use of AI Tools

Assisted by Claude.
