### PR TITLE
Responsive styles: Open inspector sidebar when toggling

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -18,7 +18,7 @@ import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { ActionItem } from '@wordpress/interface';
+import { ActionItem, store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
 import { VisuallyHidden } from '@wordpress/ui';
@@ -28,6 +28,7 @@ import { VisuallyHidden } from '@wordpress/ui';
  */
 import { store as editorStore } from '../../store';
 import { PostPreviewMenuItem } from '../post-preview-button';
+import { sidebars } from '../sidebar/constants';
 import { VIEWPORT_STATE_BY_DEVICE_TYPE } from '../../utils/device-type';
 import { unlock } from '../../lock-unlock';
 
@@ -45,6 +46,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		isTemplateHidden,
 		templateId,
 		isResponsiveEditing,
+		hasBlockSelection,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
@@ -52,15 +54,16 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			getRenderingMode,
 			getDeviceType,
 		} = unlock( select( editorStore ) );
-		const { isResponsiveEditing: _isResponsiveEditing } = unlock(
-			select( blockEditorStore )
-		);
-		const blockEditorSettings = select( blockEditorStore ).getSettings();
+		const {
+			isResponsiveEditing: _isResponsiveEditing,
+			getBlockSelectionStart,
+			getSettings,
+		} = unlock( select( blockEditorStore ) );
 		const { getEntityRecord, getPostType } = select( coreStore );
 		const { get } = select( preferencesStore );
 		const _currentPostType = getCurrentPostType();
 		const viewportBreakpoints = getViewportBreakpoints(
-			blockEditorSettings.__experimentalFeatures?.viewport
+			getSettings().__experimentalFeatures?.viewport
 		);
 		return {
 			deviceType: getDeviceType(),
@@ -73,6 +76,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			isTemplateHidden: getRenderingMode() === 'post-only',
 			templateId: getCurrentTemplateId(),
 			isResponsiveEditing: _isResponsiveEditing(),
+			hasBlockSelection: !! getBlockSelectionStart(),
 		};
 	}, [] );
 	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
@@ -80,6 +84,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	);
 	const { resetZoomLevel, setStyleStateViewport, setResponsiveEditing } =
 		unlock( useDispatch( blockEditorStore ) );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
 		setDeviceType( newDeviceType );
@@ -94,6 +99,9 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 				? VIEWPORT_STATE_BY_DEVICE_TYPE[ deviceType ] ?? 'default'
 				: 'default'
 		);
+		if ( newIsResponsiveEditing && hasBlockSelection ) {
+			enableComplementaryArea( 'core', sidebars.block );
+		}
 	};
 
 	const isMobile = useViewportMatch( 'medium', '<' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
This PR is really to try something out - in some situations users might toggle on 'Responsive styles' and not know what to do next. Most of the styling tools are in the block inspector sidebar, and if that's closed there's not much of a clue what to do next.

What if, the inspector sidebar opened when toggling on 'Responsive styles'?

This PR tries it out. I'm personally not sure about it, it feels a little weird that the sidebar opens underneath the dropdown. 🤔 

## Testing Instructions
1. Open the editor
2. Select a block
3. Close the block inspector sidebar if it's open
4. Pretend this is how it was when you opened the editor
5. Open the preview dropdown and toggle on 'Responsive editing', observe the block inspector opens.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2abb2c2d-3094-452d-b88a-0a1e31d6727d

## Use of AI Tools
OpenCode / Codex
