### PR TITLE
Separator Block: prevent block from collapsing to zero size inside row/stack layouts

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -6,6 +6,15 @@
 	border-left: none;
 	border-right: none;
 	border-bottom: none;
+
+	// Prevent the separator from collapsing to zero size when it's a flex
+	// item inside a row/stack group variation. An empty <hr> has no
+	// natural content size, so flex layout can shrink it to 0 on either
+	// axis (height in a stack, width in a nowrap row) unless we set this
+	// explicitly. See https://github.com/WordPress/gutenberg/issues/47993.
+	flex-shrink: 0;
+	min-height: 1px;
+	min-width: 100%;
 }
 
 // Dots block style variation
@@ -13,6 +22,12 @@
 	text-align: center;
 	line-height: 1;
 	height: auto;
+
+	// The dots style has its own intrinsic width via the ::before content,
+	// so it doesn't need (and shouldn't get) the 100% min-width fallback
+	// above, which would otherwise stretch/center the dots incorrectly
+	// inside a flex row.
+	min-width: 0;
 
 	&::before {
 		content: "\00b7 \00b7 \00b7";


### PR DESCRIPTION
## What?
Closes #47993
Fixes the Separator block disappearing (rendering at zero size) when placed inside a row or stack Group block variation, in both the editor and the front end.

## Why?
The wp:separator block renders as an empty `<hr>` with no content. row/stack group variations use display: flex, and a flex item with no content has no natural size on the main axis unless one is explicitly set. As a result:
- Inside a stack (vertical main axis), the separator's height collapses to 0.
- Inside a row with flexWrap: nowrap (horizontal main axis), the separator's width collapses to 0.

This affects the default and wide separator styles. The dotted style (is-style-dots) was unaffected because it derives its width from generated pseudo-element content rather than layout, so it never collapsed. This same root cause was also reported affecting the Query Pagination block (#44587), which uses the same flex-based group layout internally.

## Testing Instructions
1. Insert a Group block and switch its variation to Row.
2. Insert a Separator block inside it (default style), followed by a paragraph.
3. Confirm the separator is visible in the editor and on the front end.
4. Repeat steps 1–3 with the Stack variation.
5. Repeat with the Wide separator style, in both Row and Stack.
6. Repeat with the Dots separator style, in both Row and Stack, confirm the dots render normally and are not stretched full-width.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/a646780f-9162-4551-841a-bf5785deeaf5

