### PR TITLE
[WP7.1] Fix: Allow icon labels to wrap with word breaks and no ellipsis

### DIFF
--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -66,10 +66,7 @@
 .wp-block-icon__inserter-grid-icons-list-item-title {
 	font-size: $font-size-small;
 	padding: $grid-unit-05 $grid-unit-05 $grid-unit-10;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	width: 100%;
+	overflow-wrap: break-word;
 }
 
 .wp-block-icon__toolbar-content {


### PR DESCRIPTION

## What?

Manually cherry-pick #80256 to the `wp/7.1` branch.

## Why?

It seems that the CI is not working properly at the moment for pull requests submitted from forked repositories.

https://github.com/WordPress/gutenberg/actions/runs/29407490908/job/87326367404
