### PR TITLE
UI: Keep the compat overlay slot accessible inside Modal

### DIFF
--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -8,6 +8,10 @@ import userEvent from '@testing-library/user-event';
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import {
+	getWpCompatOverlaySlot,
+	useEnableWpCompatOverlaySlot,
+} from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -252,6 +256,44 @@ describe( 'Modal', () => {
 		// Closes outer modal > Unhides container.
 		await user.keyboard( '[Escape]' );
 		expect( container ).not.toHaveAttribute( 'aria-hidden' );
+	} );
+
+	it( 'keeps the @wordpress/ui compat overlay slot exposed while open', async () => {
+		const user = userEvent.setup();
+
+		const CompatOverlayDemo = () => {
+			useEnableWpCompatOverlaySlot();
+			useEffect( () => {
+				const slot = getWpCompatOverlaySlot();
+				return () => slot?.remove();
+			}, [] );
+
+			const [ isShown, setIsShown ] = useState( false );
+			return (
+				<>
+					<button onClick={ () => setIsShown( true ) }>
+						Open Modal
+					</button>
+					{ isShown && (
+						<Modal onRequestClose={ () => setIsShown( false ) }>
+							<p>Modal content</p>
+						</Modal>
+					) }
+				</>
+			);
+		};
+
+		const { container } = render( <CompatOverlayDemo /> );
+		// Disable reason: The infrastructure slot has no semantic role.
+		// eslint-disable-next-line testing-library/no-node-access
+		const slot = document.querySelector( '[data-wp-compat-overlay-slot]' );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Modal' } )
+		);
+
+		expect( container ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
 	} );
 
 	it( 'should render `headerActions` React nodes', async () => {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   Keep overlays in the compat overlay slot available to assistive technologies inside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
+-   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 
 ### Code Quality
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 
+### Bug Fixes
+
+-   Keep overlays in the compat overlay slot available to assistive technologies inside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
+
 ### Code Quality
 
 -   Remove unused CSS property from `Tabs` stylesheet ([#80269](https://github.com/WordPress/gutenberg/pull/80269)).

--- a/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
+++ b/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
@@ -203,6 +203,39 @@ describe( 'getWpCompatOverlaySlot', () => {
 		} );
 	} );
 
+	describe( 'modal accessibility isolation', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'exempts a newly created slot from modal accessibility isolation', () => {
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+			expect( slot ).not.toHaveAttribute( 'aria-live' );
+		} );
+
+		it( 'restores a cached slot hidden by modal accessibility isolation', () => {
+			const slot = getWpCompatOverlaySlot();
+			slot?.setAttribute( 'aria-hidden', 'true' );
+
+			expect( getWpCompatOverlaySlot() ).toBe( slot );
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+		} );
+
+		it( 'restores an adopted slot hidden by modal accessibility isolation', () => {
+			const preExisting = document.createElement( 'div' );
+			preExisting.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
+			preExisting.setAttribute( 'aria-hidden', 'true' );
+			document.body.appendChild( preExisting );
+
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).toBe( preExisting );
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+		} );
+	} );
+
 	describe( 'DOM-level singleton (cross-instance coordination)', () => {
 		beforeEach( () => {
 			internalWindow.__wpUiCompatOverlaySlotEnabled = true;

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -44,6 +44,14 @@ function isInWordPressEnvironment(): boolean {
 // slot's connection state.
 let cachedSlot: HTMLDivElement | null = null;
 
+function ensureSlotIsAccessible( element: HTMLDivElement ): HTMLDivElement {
+	// `@wordpress/components` Modal preserves body children that already
+	// declare their `aria-hidden` state. Explicitly keep the slot exposed and
+	// reset stale isolation left on a persistent slot.
+	element.setAttribute( 'aria-hidden', 'false' );
+	return element;
+}
+
 function createSlot( ownerDocument: Document ): HTMLDivElement {
 	const element = ownerDocument.createElement( 'div' );
 	element.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
@@ -99,7 +107,7 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		cachedSlot.ownerDocument === ownerDocument &&
 		cachedSlot.isConnected
 	) {
-		return cachedSlot;
+		return ensureSlotIsAccessible( cachedSlot );
 	}
 
 	// Prefer an existing slot in the document over creating a duplicate —
@@ -108,8 +116,8 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
 	);
 	if ( existing instanceof HTMLDivElement ) {
-		cachedSlot = existing;
-		return existing;
+		cachedSlot = ensureSlotIsAccessible( existing );
+		return cachedSlot;
 	}
 
 	// Don't orphan a cached slot still attached to a foreign document.
@@ -117,7 +125,7 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		cachedSlot.remove();
 	}
 
-	cachedSlot = createSlot( ownerDocument );
+	cachedSlot = ensureSlotIsAccessible( createSlot( ownerDocument ) );
 	return cachedSlot;
 }
 


### PR DESCRIPTION
Closes #80304.

## What?

Keeps overlays rendered into the `@wordpress/ui` compat overlay slot available to assistive technologies while an `@wordpress/components` Modal is open.

## Why?

If the persistent slot exists before a Modal opens, the Modal can set `aria-hidden="true"` on it. A later UI overlay remains visible but is hidden from assistive technologies.

## How?

- Normalizes created, cached, and adopted slots to `aria-hidden="false"`, which the Modal preserves.
- Avoids using `aria-live` as the exemption so descendant live-region behavior is unchanged.
- Covers all three slot paths with unit tests and the real `@wordpress/components` Modal interaction with an integration test.
- Documents the fix in the `@wordpress/ui` changelog.

## Testing Instructions

1. Run `npm run test:unit packages/components/src/modal/test/index.tsx packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts -- --runInBand`.
2. Run `npm run lint:js -- packages/components/src/modal/test/index.tsx packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts packages/ui/src/utils/wp-compat-overlay-slot.ts`.
3. Run `node_modules/.bin/tsc --build packages/components/tsconfig.json packages/ui/tsconfig.json`.
4. Run `npm run build -- --skip-types`.
5. Open and close a UI overlay to create the compat slot.
6. Open an `@wordpress/components` Modal, then open a UI overlay inside it.
7. Confirm `[data-wp-compat-overlay-slot]` has `aria-hidden="false"` and the overlay remains exposed to assistive technologies.

### Testing Instructions for Keyboard

1. Repeat the manual steps using the keyboard to open each overlay.
2. Confirm focus remains within the Modal flow, the nested overlay is operable, and Escape closes the active overlay as expected.

## Screenshots or screencast

Not applicable; there is no intended visual change.

## Use of AI Tools

Authored with Codex assistance.