### PR TITLE
Post Excerpt: Remove unwanted leading space

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -74,7 +74,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
 		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
-		$content .= " $more_text</p>";
+		$separator = ( ! empty( $excerpt ) && ! empty( $more_text ) ) ? ' ' : '';
+		$content  .= $separator . $more_text . '</p>';
 	}
 	remove_filter( 'excerpt_more', $filter_excerpt_more );
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );


### PR DESCRIPTION
## What?

Closes #70216

Fixes unwanted leading/trailing whitespace in the Post Excerpt block when the excerpt or the "Read more" text is empty.

## Why?

In `packages/block-library/src/post-excerpt/index.php`, a space was always added before the "Read more" link, even when the excerpt was empty (leading space) or the "more text" was empty (trailing space). The space should only appear when both are present.

## How?

Replaced the hardcoded space with a conditional `$separator`:

```php
$separator = ( ! empty( $excerpt ) && ! empty( $more_text ) ) ? ' ' : '';
$content  .= $separator . $more_text . '</p>';
```

## Testing Instructions

1. Add a Post Excerpt block with "Show link on new line" off.
2. Leave the excerpt empty and set a "Read more" text — check there's no leading space in the markup.
3. Add excerpt content and clear the "Read more" text — check there's no trailing space.
4. Set both — check they're still separated by a single space.

### Testing Instructions for Keyboard

No UI changes — not applicable.

## Screenshots or screencast

Not applicable.
