### PR TITLE
Visual revisions: Add a code diff view inside the editor

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
 
+### Enhancements
+
+-   Add a read-only code diff to the revisions screen.
+
 ### Bug Fixes
 
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,14 +5,11 @@
 ### Enhancements
 
 -   Notes: Remove "Add note" from the rich-text formatting toolbar's "More" (inline styles) dropdown. Adding a note is not an inline style, the item duplicated the block options entry, and the dropdown's chevron rendered as pressed whenever the caret sat inside a note ([#80531](https://github.com/WordPress/gutenberg/pull/80531)).
+-   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
 
 ### New Features
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
-
-### Enhancements
-
--   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Enhancements
 
--   Add a read-only code diff to the revisions screen.
+-   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -30,7 +30,11 @@ import TemplateValidationNotice from '../template-validation-notice';
 import Header from '../header';
 import InserterSidebar from '../inserter-sidebar';
 import ListViewSidebar from '../list-view-sidebar';
-import { RevisionsHeader, RevisionsCanvas } from '../post-revisions-preview';
+import {
+	RevisionsHeader,
+	RevisionsCanvas,
+	RevisionsCodeDiff,
+} from '../post-revisions-preview';
 import { CollaboratorsOverlay } from '../collaborators-overlay';
 import { useCollaboratorNotifications } from '../collaborators-presence/use-collaborator-notifications';
 import SavePublishPanels from '../save-publish-panels';
@@ -174,7 +178,13 @@ export default function EditorInterface( {
 						onToggleDiff={ () => setShowRevisionDiff( ! showDiff ) }
 					/>
 				}
-				content={ <RevisionsCanvas /> }
+				content={
+					mode === 'text' ? (
+						<RevisionsCodeDiff />
+					) : (
+						<RevisionsCanvas />
+					)
+				}
 				sidebar={ <ComplementaryArea.Slot scope="core" /> }
 			/>
 		);

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -22,10 +22,7 @@ import ToolsMoreMenuGroup from './tools-more-menu-group';
 import ViewMoreMenuGroup from './view-more-menu-group';
 import { store as editorStore } from '../../store';
 
-export default function MoreMenu( {
-	disabled = false,
-	isRevisionMode = false,
-} ) {
+export default function MoreMenu( { isRevisionMode = false } ) {
 	const { openModal } = useDispatch( interfaceStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
 	const { toggleDistractionFree } = useDispatch( editorStore );
@@ -50,7 +47,6 @@ export default function MoreMenu( {
 			...( showIconLabels && { variant: 'tertiary' } ),
 			tooltipPosition: 'bottom',
 			size: 'compact',
-			disabled,
 		},
 	};
 

--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -22,7 +22,10 @@ import ToolsMoreMenuGroup from './tools-more-menu-group';
 import ViewMoreMenuGroup from './view-more-menu-group';
 import { store as editorStore } from '../../store';
 
-export default function MoreMenu( { disabled = false } ) {
+export default function MoreMenu( {
+	disabled = false,
+	isRevisionMode = false,
+} ) {
 	const { openModal } = useDispatch( interfaceStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
 	const { toggleDistractionFree } = useDispatch( editorStore );
@@ -35,24 +38,33 @@ export default function MoreMenu( { disabled = false } ) {
 	const turnOffDistractionFree = () => {
 		setPreference( 'core', 'distractionFree', false );
 	};
+	const dropdownProps = {
+		icon: moreVertical,
+		label: __( 'Options' ),
+		popoverProps: {
+			placement: 'bottom-end',
+			className: 'more-menu-dropdown__content',
+		},
+		toggleProps: {
+			showTooltip: ! showIconLabels,
+			...( showIconLabels && { variant: 'tertiary' } ),
+			tooltipPosition: 'bottom',
+			size: 'compact',
+			disabled,
+		},
+	};
+
+	if ( isRevisionMode ) {
+		return (
+			<DropdownMenu { ...dropdownProps }>
+				{ () => <ModeSwitcher /> }
+			</DropdownMenu>
+		);
+	}
 
 	return (
 		<>
-			<DropdownMenu
-				icon={ moreVertical }
-				label={ __( 'Options' ) }
-				popoverProps={ {
-					placement: 'bottom-end',
-					className: 'more-menu-dropdown__content',
-				} }
-				toggleProps={ {
-					showTooltip: ! showIconLabels,
-					...( showIconLabels && { variant: 'tertiary' } ),
-					tooltipPosition: 'bottom',
-					size: 'compact',
-					disabled,
-				} }
-			>
+			<DropdownMenu { ...dropdownProps }>
 				{ ( { onClose } ) => (
 					<>
 						<MenuGroup label={ _x( 'View', 'noun' ) }>

--- a/packages/editor/src/components/post-revisions-preview/index.js
+++ b/packages/editor/src/components/post-revisions-preview/index.js
@@ -1,2 +1,3 @@
 export { default as RevisionsHeader } from './revisions-header';
 export { default as RevisionsCanvas } from './revisions-canvas';
+export { default as RevisionsCodeDiff } from './revisions-code-diff';

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -94,40 +94,58 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
 }
 
 /**
+ * Connects the revision code diff to the editor store.
+ *
+ * @return {React.JSX.Element} The connected revision code diff.
+ */
+export default function ConnectedRevisionsCodeDiff() {
+	const revisionDiff = useSelect( ( select ) => {
+		const editorSelectors = select( editorStore );
+		const {
+			getCurrentRevision,
+			getPreviousRevision,
+			getRevisionPage,
+			getRevisionsPerPage,
+			isShowingRevisionDiff,
+		} = unlock( editorSelectors );
+		const _previousRevision = getPreviousRevision();
+		const _showDiff = isShowingRevisionDiff();
+		const totalPages =
+			Math.ceil(
+				editorSelectors.getCurrentPostRevisionsCount() /
+					getRevisionsPerPage()
+			) || 1;
+
+		return {
+			revision: getCurrentRevision(),
+			previousRevision: _previousRevision,
+			showDiff: _showDiff,
+			isPreviousRevisionLoading:
+				_showDiff &&
+				_previousRevision === null &&
+				getRevisionPage() < totalPages,
+		};
+	}, [] );
+
+	return <RevisionsCodeDiff { ...revisionDiff } />;
+}
+
+/**
  * Shows the selected revision's raw block markup as a read-only diff.
  *
+ * @param {Object}      props                           Component props.
+ * @param {Object}      props.revision                  Selected revision.
+ * @param {Object|null} props.previousRevision          Previous revision.
+ * @param {boolean}     props.showDiff                  Whether to show changes.
+ * @param {boolean}     props.isPreviousRevisionLoading Whether the previous revision is loading.
  * @return {React.JSX.Element} The revision code diff.
  */
-export default function RevisionsCodeDiff() {
-	const { revision, previousRevision, showDiff, isPreviousRevisionLoading } =
-		useSelect( ( select ) => {
-			const editorSelectors = select( editorStore );
-			const {
-				getCurrentRevision,
-				getPreviousRevision,
-				getRevisionPage,
-				getRevisionsPerPage,
-				isShowingRevisionDiff,
-			} = unlock( editorSelectors );
-			const _previousRevision = getPreviousRevision();
-			const _showDiff = isShowingRevisionDiff();
-			const totalPages =
-				Math.ceil(
-					editorSelectors.getCurrentPostRevisionsCount() /
-						getRevisionsPerPage()
-				) || 1;
-
-			return {
-				revision: getCurrentRevision(),
-				previousRevision: _previousRevision,
-				showDiff: _showDiff,
-				isPreviousRevisionLoading:
-					_showDiff &&
-					_previousRevision === null &&
-					getRevisionPage() < totalPages,
-			};
-		}, [] );
-
+export function RevisionsCodeDiff( {
+	revision,
+	previousRevision,
+	showDiff,
+	isPreviousRevisionLoading,
+} ) {
 	const rows = useMemo( () => {
 		if ( ! revision || isPreviousRevisionLoading ) {
 			return [];

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -188,11 +188,11 @@ export default function RevisionsCodeDiff() {
 									className={ `editor-revisions-code-diff__line is-${ row.status }` }
 								>
 									{ showDiff && (
-										<td className="editor-revisions-code-diff__line-number">
+										<td className="editor-revisions-code-diff__line-number is-previous">
 											{ row.previousLineNumber }
 										</td>
 									) }
-									<td className="editor-revisions-code-diff__line-number">
+									<td className="editor-revisions-code-diff__line-number is-current">
 										{ row.currentLineNumber }
 									</td>
 									{ showDiff && (

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -93,11 +93,6 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
 	} );
 }
 
-/**
- * Connects the revision code diff to the editor store.
- *
- * @return {React.JSX.Element} The connected revision code diff.
- */
 export default function ConnectedRevisionsCodeDiff() {
 	const revisionDiff = useSelect( ( select ) => {
 		const editorSelectors = select( editorStore );

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -7,6 +7,7 @@ import { diffLines } from 'diff';
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,6 +17,7 @@ import { VisuallyHidden } from '@wordpress/ui';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { buildRevisionsPageQuery } from '../../store/private-selectors';
 import { unlock } from '../../lock-unlock';
 
 const MAX_DIFF_EDIT_LENGTH = 1000;
@@ -93,9 +95,39 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
 	} );
 }
 
+/**
+ * Determines whether the code diff should wait for an older revision or fall
+ * back to showing the selected revision without a diff.
+ *
+ * @param {Object}      options                             Display options.
+ * @param {Object|null} options.previousRevision            Previous revision.
+ * @param {boolean}     options.showDiff                    Whether changes should be highlighted.
+ * @param {boolean}     options.hasOlderRevisionPage        Whether another revisions page exists.
+ * @param {boolean}     options.hasFinishedPreviousRevision Whether the previous revision request finished.
+ * @return {Object} Code-diff display state.
+ */
+export function getCodeDiffDisplayState( {
+	previousRevision,
+	showDiff,
+	hasOlderRevisionPage,
+	hasFinishedPreviousRevision,
+} ) {
+	const needsPreviousRevision =
+		showDiff && previousRevision === null && hasOlderRevisionPage;
+
+	return {
+		showDiff:
+			showDiff &&
+			! ( needsPreviousRevision && hasFinishedPreviousRevision ),
+		isPreviousRevisionLoading:
+			needsPreviousRevision && ! hasFinishedPreviousRevision,
+	};
+}
+
 export default function ConnectedRevisionsCodeDiff() {
 	const revisionDiff = useSelect( ( select ) => {
 		const editorSelectors = select( editorStore );
+		const coreSelectors = select( coreStore );
 		const {
 			getCurrentRevision,
 			getPreviousRevision,
@@ -105,20 +137,44 @@ export default function ConnectedRevisionsCodeDiff() {
 		} = unlock( editorSelectors );
 		const _previousRevision = getPreviousRevision();
 		const _showDiff = isShowingRevisionDiff();
+		const revisionPage = getRevisionPage();
 		const totalPages =
 			Math.ceil(
 				editorSelectors.getCurrentPostRevisionsCount() /
 					getRevisionsPerPage()
 			) || 1;
+		const hasOlderRevisionPage = revisionPage < totalPages;
+		let hasFinishedPreviousRevision = true;
+
+		if ( _showDiff && _previousRevision === null && hasOlderRevisionPage ) {
+			const postType = editorSelectors.getCurrentPostType();
+			const postId = editorSelectors.getCurrentPostId();
+			const entityConfig = coreSelectors.getEntityConfig(
+				'postType',
+				postType
+			);
+			const revisionKey = entityConfig?.revisionKey || 'id';
+
+			hasFinishedPreviousRevision = coreSelectors.hasFinishedResolution(
+				'getRevisions',
+				[
+					'postType',
+					postType,
+					postId,
+					buildRevisionsPageQuery( revisionKey, revisionPage + 1 ),
+				]
+			);
+		}
 
 		return {
 			revision: getCurrentRevision(),
 			previousRevision: _previousRevision,
-			showDiff: _showDiff,
-			isPreviousRevisionLoading:
-				_showDiff &&
-				_previousRevision === null &&
-				getRevisionPage() < totalPages,
+			...getCodeDiffDisplayState( {
+				previousRevision: _previousRevision,
+				showDiff: _showDiff,
+				hasOlderRevisionPage,
+				hasFinishedPreviousRevision,
+			} ),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import { diffLines } from 'diff';
+
+/**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Splits a diff part into display lines without creating an extra line for a
+ * trailing newline.
+ *
+ * @param {string} value Diff part value.
+ * @return {string[]} Lines in the diff part.
+ */
+function splitLines( value ) {
+	const lines = value.split( '\n' );
+	if ( lines[ lines.length - 1 ] === '' ) {
+		lines.pop();
+	}
+	return lines;
+}
+
+/**
+ * Creates the rows shown in the code diff and adds line numbers for both
+ * revisions.
+ *
+ * @param {string}  previousContent Previous revision content.
+ * @param {string}  currentContent  Selected revision content.
+ * @param {boolean} showDiff        Whether changes should be highlighted.
+ * @return {Array<Object>} Code-diff rows.
+ */
+export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
+	const parts = showDiff
+		? diffLines( previousContent, currentContent )
+		: [ { value: currentContent } ];
+	let previousLineNumber = 1;
+	let currentLineNumber = 1;
+
+	return parts.flatMap( ( part ) => {
+		let status = 'unchanged';
+		if ( part.added ) {
+			status = 'added';
+		} else if ( part.removed ) {
+			status = 'removed';
+		}
+
+		return splitLines( part.value ).map( ( value ) => {
+			const row = {
+				value,
+				status,
+				previousLineNumber: null,
+				currentLineNumber: null,
+			};
+
+			if ( status !== 'added' && showDiff ) {
+				row.previousLineNumber = previousLineNumber++;
+			}
+			if ( status !== 'removed' ) {
+				row.currentLineNumber = currentLineNumber++;
+			}
+
+			return row;
+		} );
+	} );
+}
+
+/**
+ * Shows the selected revision's raw block markup as a read-only diff.
+ *
+ * @return {React.JSX.Element} The revision code diff.
+ */
+export default function RevisionsCodeDiff() {
+	const { revision, previousRevision, showDiff } = useSelect( ( select ) => {
+		const {
+			getCurrentRevision,
+			getPreviousRevision,
+			isShowingRevisionDiff,
+		} = unlock( select( editorStore ) );
+
+		return {
+			revision: getCurrentRevision(),
+			previousRevision: getPreviousRevision(),
+			showDiff: isShowingRevisionDiff(),
+		};
+	}, [] );
+
+	const rows = useMemo( () => {
+		if ( ! revision ) {
+			return [];
+		}
+
+		return getCodeDiffRows(
+			previousRevision?.content?.raw ?? '',
+			revision.content?.raw ?? '',
+			showDiff
+		);
+	}, [ revision, previousRevision, showDiff ] );
+
+	if ( ! revision ) {
+		return (
+			<div className="editor-revisions-canvas__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const label = showDiff ? __( 'Code changes' ) : __( 'Revision code' );
+
+	return (
+		<div
+			className="editor-revisions-code-diff"
+			role="region"
+			aria-label={ label }
+			tabIndex={ 0 }
+		>
+			{ rows.length ? (
+				<table className="editor-revisions-code-diff__table">
+					<VisuallyHidden render={ <caption /> }>
+						{ label }
+					</VisuallyHidden>
+					<VisuallyHidden render={ <thead /> }>
+						<tr>
+							{ showDiff && <th>{ __( 'Previous line' ) }</th> }
+							<th>{ __( 'Current line' ) }</th>
+							<th>{ __( 'Change' ) }</th>
+							<th>{ __( 'Code' ) }</th>
+						</tr>
+					</VisuallyHidden>
+					<tbody>
+						{ rows.map( ( row, index ) => {
+							let marker = '';
+							let statusLabel = __( 'Unchanged' );
+							if ( row.status === 'added' ) {
+								marker = '+';
+								statusLabel = __( 'Added' );
+							} else if ( row.status === 'removed' ) {
+								marker = '−';
+								statusLabel = __( 'Removed' );
+							}
+
+							return (
+								<tr
+									key={ index }
+									className={ `editor-revisions-code-diff__line is-${ row.status }` }
+								>
+									{ showDiff && (
+										<td className="editor-revisions-code-diff__line-number">
+											{ row.previousLineNumber }
+										</td>
+									) }
+									<td className="editor-revisions-code-diff__line-number">
+										{ row.currentLineNumber }
+									</td>
+									<td className="editor-revisions-code-diff__marker">
+										<VisuallyHidden>
+											{ statusLabel }
+										</VisuallyHidden>
+										<span aria-hidden="true">
+											{ marker }
+										</span>
+									</td>
+									<td className="editor-revisions-code-diff__code">
+										<code>{ row.value || '\u00a0' }</code>
+									</td>
+								</tr>
+							);
+						} ) }
+					</tbody>
+				</table>
+			) : (
+				<p className="editor-revisions-code-diff__empty">
+					{ __( 'This revision is empty.' ) }
+				</p>
+			) }
+		</div>
+	);
+}

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -18,9 +18,12 @@ import { VisuallyHidden } from '@wordpress/ui';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const MAX_DIFF_EDIT_LENGTH = 1000;
+const DIFF_TIMEOUT = 100;
+
 /**
- * Splits a diff part into display lines without creating an extra line for a
- * trailing newline.
+ * Diff parts often end in a newline. Remove the trailing empty item so it is
+ * not rendered as another source line.
  *
  * @param {string} value Diff part value.
  * @return {string[]} Lines in the diff part.
@@ -43,9 +46,22 @@ function splitLines( value ) {
  * @return {Array<Object>} Code-diff rows.
  */
 export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
-	const parts = showDiff
-		? diffLines( previousContent, currentContent )
-		: [ { value: currentContent } ];
+	let parts = [ { value: currentContent } ];
+	if ( showDiff ) {
+		parts = diffLines( previousContent, currentContent, {
+			maxEditLength: MAX_DIFF_EDIT_LENGTH,
+			timeout: DIFF_TIMEOUT,
+		} );
+
+		// Line diffing can be quadratic for unrelated revisions. If it exceeds
+		// either limit, mark every old and new line instead.
+		if ( ! parts ) {
+			parts = [
+				{ value: previousContent, removed: true },
+				{ value: currentContent, added: true },
+			];
+		}
+	}
 	let previousLineNumber = 1;
 	let currentLineNumber = 1;
 
@@ -83,22 +99,37 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
  * @return {React.JSX.Element} The revision code diff.
  */
 export default function RevisionsCodeDiff() {
-	const { revision, previousRevision, showDiff } = useSelect( ( select ) => {
-		const {
-			getCurrentRevision,
-			getPreviousRevision,
-			isShowingRevisionDiff,
-		} = unlock( select( editorStore ) );
+	const { revision, previousRevision, showDiff, isPreviousRevisionLoading } =
+		useSelect( ( select ) => {
+			const editorSelectors = select( editorStore );
+			const {
+				getCurrentRevision,
+				getPreviousRevision,
+				getRevisionPage,
+				getRevisionsPerPage,
+				isShowingRevisionDiff,
+			} = unlock( editorSelectors );
+			const _previousRevision = getPreviousRevision();
+			const _showDiff = isShowingRevisionDiff();
+			const totalPages =
+				Math.ceil(
+					editorSelectors.getCurrentPostRevisionsCount() /
+						getRevisionsPerPage()
+				) || 1;
 
-		return {
-			revision: getCurrentRevision(),
-			previousRevision: getPreviousRevision(),
-			showDiff: isShowingRevisionDiff(),
-		};
-	}, [] );
+			return {
+				revision: getCurrentRevision(),
+				previousRevision: _previousRevision,
+				showDiff: _showDiff,
+				isPreviousRevisionLoading:
+					_showDiff &&
+					_previousRevision === null &&
+					getRevisionPage() < totalPages,
+			};
+		}, [] );
 
 	const rows = useMemo( () => {
-		if ( ! revision ) {
+		if ( ! revision || isPreviousRevisionLoading ) {
 			return [];
 		}
 
@@ -107,9 +138,9 @@ export default function RevisionsCodeDiff() {
 			revision.content?.raw ?? '',
 			showDiff
 		);
-	}, [ revision, previousRevision, showDiff ] );
+	}, [ revision, previousRevision, showDiff, isPreviousRevisionLoading ] );
 
-	if ( ! revision ) {
+	if ( ! revision || isPreviousRevisionLoading ) {
 		return (
 			<div className="editor-revisions-canvas__loading">
 				<Spinner />
@@ -135,7 +166,7 @@ export default function RevisionsCodeDiff() {
 						<tr>
 							{ showDiff && <th>{ __( 'Previous line' ) }</th> }
 							<th>{ __( 'Current line' ) }</th>
-							<th>{ __( 'Change' ) }</th>
+							{ showDiff && <th>{ __( 'Change' ) }</th> }
 							<th>{ __( 'Code' ) }</th>
 						</tr>
 					</VisuallyHidden>
@@ -164,16 +195,18 @@ export default function RevisionsCodeDiff() {
 									<td className="editor-revisions-code-diff__line-number">
 										{ row.currentLineNumber }
 									</td>
-									<td className="editor-revisions-code-diff__marker">
-										<VisuallyHidden>
-											{ statusLabel }
-										</VisuallyHidden>
-										<span aria-hidden="true">
-											{ marker }
-										</span>
-									</td>
+									{ showDiff && (
+										<td className="editor-revisions-code-diff__marker">
+											<VisuallyHidden>
+												{ statusLabel }
+											</VisuallyHidden>
+											<span aria-hidden="true">
+												{ marker }
+											</span>
+										</td>
+									) }
 									<td className="editor-revisions-code-diff__code">
-										<code>{ row.value || '\u00a0' }</code>
+										<code>{ row.value }</code>
 									</td>
 								</tr>
 							);

--- a/packages/editor/src/components/post-revisions-preview/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-header.js
@@ -110,7 +110,7 @@ function RevisionsHeader( { showDiff, onToggleDiff } ) {
 					>
 						{ __( 'Restore' ) }
 					</Button>
-					<MoreMenu disabled />
+					<MoreMenu isRevisionMode />
 				</>
 			}
 		/>

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -6,10 +6,10 @@ import { RangeControl, Spinner, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import { useFocusOnMount } from '@wordpress/compose';
+import { useFocusOnMount, useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -65,7 +65,62 @@ function RevisionsSlider() {
 		useDispatch( editorStore )
 	);
 
-	const focusOnMountRef = useFocusOnMount( true );
+	const setFocusOnMountRef = useFocusOnMount( true );
+	const initialActiveElementRef = useRef();
+	const didInteractWhileLoadingRef = useRef( false );
+	const loadingRef = useRefEffect( ( node ) => {
+		if ( initialActiveElementRef.current === undefined ) {
+			initialActiveElementRef.current = node.ownerDocument.activeElement;
+		}
+
+		const handleInteraction = () => {
+			didInteractWhileLoadingRef.current = true;
+		};
+		const { ownerDocument } = node;
+		ownerDocument.addEventListener(
+			'pointerdown',
+			handleInteraction,
+			true
+		);
+		ownerDocument.addEventListener( 'keydown', handleInteraction, true );
+
+		return () => {
+			ownerDocument.removeEventListener(
+				'pointerdown',
+				handleInteraction,
+				true
+			);
+			ownerDocument.removeEventListener(
+				'keydown',
+				handleInteraction,
+				true
+			);
+		};
+	}, [] );
+
+	const focusOnMountRef = useCallback(
+		( node ) => {
+			if ( ! node ) {
+				setFocusOnMountRef( null );
+				return;
+			}
+
+			const { activeElement, body, documentElement } = node.ownerDocument;
+			const initialActiveElement =
+				initialActiveElementRef.current ?? activeElement;
+			const focusHasNotMoved =
+				activeElement === initialActiveElement ||
+				activeElement === body ||
+				activeElement === documentElement;
+
+			// If the user moves focus while revisions load, keep it there when the
+			// slider mounts.
+			if ( ! didInteractWhileLoadingRef.current && focusHasNotMoved ) {
+				setFocusOnMountRef( node );
+			}
+		},
+		[ setFocusOnMountRef ]
+	);
 
 	const isLoading = ! rawRevisions;
 	const totalPages = Math.ceil( totalRevisions / perPage ) || 1;
@@ -87,7 +142,6 @@ function RevisionsSlider() {
 		}
 	};
 
-	// Format date for tooltip.
 	const dateSettings = getDateSettings();
 	const renderTooltipContent = ( index ) => {
 		const revision = revisions?.[ index ];
@@ -100,7 +154,7 @@ function RevisionsSlider() {
 	const showPagination = totalPages > 1;
 
 	if ( isLoading && ! showPagination ) {
-		return <Spinner />;
+		return <Spinner ref={ loadingRef } />;
 	}
 
 	if ( ! isLoading && ! revisions?.length ) {
@@ -132,7 +186,7 @@ function RevisionsSlider() {
 
 	const sliderOrSpinner =
 		isLoading || selectedIndex === -1 ? (
-			<Spinner />
+			<Spinner ref={ loadingRef } />
 		) : (
 			<RangeControl
 				ref={ focusOnMountRef }

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -17,11 +17,6 @@ import { useFocusOnMount, useRefEffect } from '@wordpress/compose';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-/**
- * Connects the revisions slider to the editor store.
- *
- * @return {React.JSX.Element} The connected revisions slider.
- */
 export default function ConnectedRevisionsSlider() {
 	const revisionData = useSelect( ( select ) => {
 		const {

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -9,7 +9,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import { useFocusOnMount, useRefEffect } from '@wordpress/compose';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -86,35 +86,10 @@ export function RevisionsSlider( {
 } ) {
 	const setFocusOnMountRef = useFocusOnMount( true );
 	const initialActiveElementRef = useRef();
-	const didInteractWhileLoadingRef = useRef( false );
-	const loadingRef = useRefEffect( ( node ) => {
-		if ( initialActiveElementRef.current === undefined ) {
+	const loadingRef = useCallback( ( node ) => {
+		if ( node && initialActiveElementRef.current === undefined ) {
 			initialActiveElementRef.current = node.ownerDocument.activeElement;
 		}
-
-		const handleInteraction = () => {
-			didInteractWhileLoadingRef.current = true;
-		};
-		const { ownerDocument } = node;
-		ownerDocument.addEventListener(
-			'pointerdown',
-			handleInteraction,
-			true
-		);
-		ownerDocument.addEventListener( 'keydown', handleInteraction, true );
-
-		return () => {
-			ownerDocument.removeEventListener(
-				'pointerdown',
-				handleInteraction,
-				true
-			);
-			ownerDocument.removeEventListener(
-				'keydown',
-				handleInteraction,
-				true
-			);
-		};
 	}, [] );
 
 	const focusOnMountRef = useCallback(
@@ -134,7 +109,7 @@ export function RevisionsSlider( {
 
 			// If the user moves focus while revisions load, keep it there when the
 			// slider mounts.
-			if ( ! didInteractWhileLoadingRef.current && focusHasNotMoved ) {
+			if ( focusHasNotMoved ) {
 				setFocusOnMountRef( node );
 			}
 		},

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -18,19 +18,12 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Slider component for navigating revisions with pagination.
+ * Connects the revisions slider to the editor store.
  *
- * @return {React.JSX.Element} The revisions slider component.
+ * @return {React.JSX.Element} The connected revisions slider.
  */
-function RevisionsSlider() {
-	const {
-		revisions: rawRevisions,
-		perPage,
-		currentRevisionId,
-		revisionKey,
-		revisionPage,
-		totalRevisions,
-	} = useSelect( ( select ) => {
+export default function ConnectedRevisionsSlider() {
+	const revisionData = useSelect( ( select ) => {
 		const {
 			getCurrentRevisionId,
 			getRevisionPage,
@@ -47,24 +40,55 @@ function RevisionsSlider() {
 			'postType',
 			postType
 		);
-		const _revisionKey = entityConfig?.revisionKey || 'id';
-		const _revisionPage = getRevisionPage();
+		const revisionKey = entityConfig?.revisionKey || 'id';
+		const revisionPage = getRevisionPage();
 
 		return {
-			revisions: getPageRevisions( _revisionPage ),
+			revisions: getPageRevisions( revisionPage ),
 			perPage: getRevisionsPerPage(),
 			currentRevisionId: getCurrentRevisionId(),
-			revisionKey: _revisionKey,
-			revisionPage: _revisionPage,
+			revisionKey,
+			revisionPage,
 			totalRevisions:
 				select( editorStore ).getCurrentPostRevisionsCount(),
 		};
 	}, [] );
 
-	const { setCurrentRevisionId, setRevisionPage } = unlock(
-		useDispatch( editorStore )
-	);
+	const revisionActions = unlock( useDispatch( editorStore ) );
 
+	return (
+		<RevisionsSlider
+			{ ...revisionData }
+			setCurrentRevisionId={ revisionActions.setCurrentRevisionId }
+			setRevisionPage={ revisionActions.setRevisionPage }
+		/>
+	);
+}
+
+/**
+ * Slider component for navigating revisions with pagination.
+ *
+ * @param {Object}          props                      Component props.
+ * @param {Array|undefined} props.revisions            Revisions on the current page.
+ * @param {number}          props.perPage              Revisions per page.
+ * @param {number|string}   props.currentRevisionId    Selected revision ID.
+ * @param {string}          props.revisionKey          Revision identifier key.
+ * @param {number}          props.revisionPage         Current page.
+ * @param {number}          props.totalRevisions       Total number of revisions.
+ * @param {Function}        props.setCurrentRevisionId Selects a revision.
+ * @param {Function}        props.setRevisionPage      Selects a page.
+ * @return {React.JSX.Element} The revisions slider component.
+ */
+export function RevisionsSlider( {
+	revisions: rawRevisions,
+	perPage,
+	currentRevisionId,
+	revisionKey,
+	revisionPage,
+	totalRevisions,
+	setCurrentRevisionId,
+	setRevisionPage,
+} ) {
 	const setFocusOnMountRef = useFocusOnMount( true );
 	const initialActiveElementRef = useRef();
 	const didInteractWhileLoadingRef = useRef( false );
@@ -247,5 +271,3 @@ function RevisionsSlider() {
 		</Stack>
 	);
 }
-
-export default RevisionsSlider;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -1,6 +1,16 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+// The visual canvas injects its styles into an iframe, so keep its added and
+// removed colors in sync here.
+$revision-diff-added-color: #00a32a;
+$revision-diff-removed-color: #d63638;
+
+$revision-diff-marker-added-color: #008a20;
+$revision-diff-marker-modified-color: #9a7000;
+$revision-code-diff-line-number-width: 6ch;
+$revision-code-diff-marker-width: 3ch;
+
 .editor-revisions-header__slider {
 	width: 100%;
 
@@ -49,7 +59,8 @@
 	width: 100%;
 	min-width: max-content;
 	border: 0;
-	border-collapse: collapse;
+	border-collapse: separate;
+	border-spacing: 0;
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	line-height: 1.6;
@@ -57,18 +68,31 @@
 
 .editor-revisions-code-diff__line {
 	&.is-added {
-		background: rgba(#00a32a, 0.12);
+		background: rgba($revision-diff-added-color, 0.12);
+
+		> .editor-revisions-code-diff__line-number,
+		> .editor-revisions-code-diff__marker {
+			background: color-mix(in srgb, $revision-diff-added-color 12%, $white);
+		}
 	}
 
 	&.is-removed {
-		background: rgba(#d63638, 0.12);
+		background: rgba($revision-diff-removed-color, 0.12);
+
+		> .editor-revisions-code-diff__line-number,
+		> .editor-revisions-code-diff__marker {
+			background: color-mix(in srgb, $revision-diff-removed-color 12%, $white);
+		}
 	}
 }
 
 .editor-revisions-code-diff__line-number,
 .editor-revisions-code-diff__marker {
-	width: 1%;
+	position: sticky;
+	z-index: 1;
+	box-sizing: border-box;
 	padding: 0 $grid-unit-10;
+	background: $white;
 	color: $gray-700;
 	text-align: right;
 	white-space: nowrap;
@@ -76,14 +100,28 @@
 }
 
 .editor-revisions-code-diff__line-number {
+	left: 0;
+	width: $revision-code-diff-line-number-width;
+	min-width: $revision-code-diff-line-number-width;
+	max-width: $revision-code-diff-line-number-width;
 	border-right: $border-width solid $gray-200;
-	background: rgba($gray-100, 0.75);
+	background: $gray-100;
 	font-variant-numeric: tabular-nums;
+
+	&.is-previous + &.is-current {
+		left: $revision-code-diff-line-number-width;
+	}
 }
 
 .editor-revisions-code-diff__marker {
-	padding-right: 0;
+	left: $revision-code-diff-line-number-width * 2;
+	width: $revision-code-diff-marker-width;
+	min-width: $revision-code-diff-marker-width;
+	max-width: $revision-code-diff-marker-width;
+	border-right: $border-width solid $gray-200;
+	padding: 0;
 	font-weight: 600;
+	text-align: center;
 }
 
 .editor-revisions-code-diff__code {
@@ -96,6 +134,10 @@
 	white-space: pre;
 
 	code {
+		margin: 0;
+		padding: 0;
+		background: none;
+		color: inherit;
 		font: inherit;
 	}
 }
@@ -123,15 +165,15 @@
 		transition: opacity 0.1s ease;
 
 		&.is-added {
-			background: #008a20;
+			background: $revision-diff-marker-added-color;
 		}
 
 		&.is-removed {
-			background: repeating-linear-gradient(45deg, #d63638, #d63638 6px, rgba(#d63638, 0.45) 6px, rgba(#d63638, 0.45) 8px);
+			background: repeating-linear-gradient(45deg, $revision-diff-removed-color, $revision-diff-removed-color 6px, rgba($revision-diff-removed-color, 0.45) 6px, rgba($revision-diff-removed-color, 0.45) 8px);
 		}
 
 		&.is-modified {
-			background: repeating-linear-gradient(-45deg, #9a7000, #9a7000 6px, rgba(#9a7000, 0.45) 6px, rgba(#9a7000, 0.45) 8px);
+			background: repeating-linear-gradient(-45deg, $revision-diff-marker-modified-color, $revision-diff-marker-modified-color 6px, rgba($revision-diff-marker-modified-color, 0.45) 6px, rgba($revision-diff-marker-modified-color, 0.45) 8px);
 		}
 
 		&:hover {

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -89,6 +89,10 @@
 .editor-revisions-code-diff__code {
 	width: 100%;
 	padding: 0 $grid-unit-20 0 $grid-unit-10;
+	// Keep raw markup LTR even when the editor UI is RTL.
+	/*rtl:ignore*/
+	direction: ltr;
+	unicode-bidi: isolate;
 	white-space: pre;
 
 	code {

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -31,6 +31,77 @@
 	}
 }
 
+.editor-revisions-code-diff {
+	height: 100%;
+	overflow: auto;
+	background: $white;
+	color: $gray-900;
+
+	&:focus-visible {
+		box-shadow:
+			inset 0 0 0 var(--wp-admin-border-width-focus)
+			var(--wp-admin-theme-color);
+		outline: none;
+	}
+}
+
+.editor-revisions-code-diff__table {
+	width: 100%;
+	min-width: max-content;
+	border: 0;
+	border-collapse: collapse;
+	font-family: $editor-html-font;
+	font-size: $text-editor-font-size;
+	line-height: 1.6;
+}
+
+.editor-revisions-code-diff__line {
+	&.is-added {
+		background: rgba(#00a32a, 0.12);
+	}
+
+	&.is-removed {
+		background: rgba(#d63638, 0.12);
+	}
+}
+
+.editor-revisions-code-diff__line-number,
+.editor-revisions-code-diff__marker {
+	width: 1%;
+	padding: 0 $grid-unit-10;
+	color: $gray-700;
+	text-align: right;
+	white-space: nowrap;
+	user-select: none;
+}
+
+.editor-revisions-code-diff__line-number {
+	border-right: $border-width solid $gray-200;
+	background: rgba($gray-100, 0.75);
+	font-variant-numeric: tabular-nums;
+}
+
+.editor-revisions-code-diff__marker {
+	padding-right: 0;
+	font-weight: 600;
+}
+
+.editor-revisions-code-diff__code {
+	width: 100%;
+	padding: 0 $grid-unit-20 0 $grid-unit-10;
+	white-space: pre;
+
+	code {
+		font: inherit;
+	}
+}
+
+.editor-revisions-code-diff__empty {
+	margin: 0;
+	padding: $grid-unit-30;
+	color: $gray-700;
+}
+
 // Diff markers minimap
 .revision-diff-markers {
 	position: relative;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -106,7 +106,6 @@ $revision-code-diff-marker-width: 3ch;
 	max-width: $revision-code-diff-line-number-width;
 	border-right: $border-width solid $gray-200;
 	background: $gray-100;
-	font-variant-numeric: tabular-nums;
 
 	&.is-previous + &.is-current {
 		left: $revision-code-diff-line-number-width;

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { diffLines } from 'diff';
 
 /**
  * WordPress dependencies
@@ -12,6 +13,14 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import RevisionsCodeDiff, { getCodeDiffRows } from '../revisions-code-diff';
+
+jest.mock( 'diff', () => {
+	const actual = jest.requireActual( 'diff' );
+	return {
+		...actual,
+		diffLines: jest.fn( actual.diffLines ),
+	};
+} );
 
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 
@@ -26,16 +35,26 @@ jest.mock( '../../../lock-unlock', () => ( {
 function mockRevisions( {
 	currentContent = '',
 	previousContent = '',
+	previousRevision,
 	showDiff = true,
+	revisionPage = 1,
+	totalRevisions = 2,
+	revisionsPerPage = 100,
 } = {} ) {
+	const resolvedPreviousRevision =
+		previousRevision === undefined
+			? { content: { raw: previousContent } }
+			: previousRevision;
+
 	useSelect.mockImplementation( ( mapSelect ) =>
 		mapSelect( () => ( {
 			getCurrentRevision: () => ( {
 				content: { raw: currentContent },
 			} ),
-			getPreviousRevision: () => ( {
-				content: { raw: previousContent },
-			} ),
+			getPreviousRevision: () => resolvedPreviousRevision,
+			getRevisionPage: () => revisionPage,
+			getRevisionsPerPage: () => revisionsPerPage,
+			getCurrentPostRevisionsCount: () => totalRevisions,
 			isShowingRevisionDiff: () => showDiff,
 		} ) )
 	);
@@ -99,6 +118,47 @@ describe( 'getCodeDiffRows', () => {
 			},
 		] );
 	} );
+
+	it( 'uses a coarse diff when line diffing exceeds its limits', () => {
+		diffLines.mockReturnValueOnce( undefined );
+
+		expect( getCodeDiffRows( 'Before\nOld', 'After\nNew', true ) ).toEqual(
+			[
+				{
+					value: 'Before',
+					status: 'removed',
+					previousLineNumber: 1,
+					currentLineNumber: null,
+				},
+				{
+					value: 'Old',
+					status: 'removed',
+					previousLineNumber: 2,
+					currentLineNumber: null,
+				},
+				{
+					value: 'After',
+					status: 'added',
+					previousLineNumber: null,
+					currentLineNumber: 1,
+				},
+				{
+					value: 'New',
+					status: 'added',
+					previousLineNumber: null,
+					currentLineNumber: 2,
+				},
+			]
+		);
+		expect( diffLines ).toHaveBeenLastCalledWith(
+			'Before\nOld',
+			'After\nNew',
+			{
+				maxEditLength: 1000,
+				timeout: 100,
+			}
+		);
+	} );
 } );
 
 describe( 'RevisionsCodeDiff', () => {
@@ -136,5 +196,61 @@ describe( 'RevisionsCodeDiff', () => {
 		expect( screen.queryByText( '<p>Before</p>' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Added' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Removed' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'columnheader', { name: 'Change' } )
+		).not.toBeInTheDocument();
+		expect(
+			within(
+				screen.getByRole( 'row', { name: /<p>After<\/p>/ } )
+			).getAllByRole( 'cell' )
+		).toHaveLength( 2 );
+		expect( screen.queryByText( 'Unchanged' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'waits for the previous revision at a page boundary', () => {
+		mockRevisions( {
+			currentContent: '<p>Current</p>',
+			previousRevision: null,
+			revisionPage: 1,
+			totalRevisions: 101,
+		} );
+
+		render( <RevisionsCodeDiff /> );
+
+		expect( screen.getByRole( 'presentation' ) ).toHaveClass(
+			'components-spinner'
+		);
+		expect( screen.queryByRole( 'region' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'compares the oldest revision against empty content', () => {
+		mockRevisions( {
+			currentContent: '<p>Oldest</p>',
+			previousRevision: null,
+			revisionPage: 2,
+			totalRevisions: 101,
+		} );
+
+		render( <RevisionsCodeDiff /> );
+
+		expect(
+			screen.getByRole( 'row', { name: /Added.*<p>Oldest<\/p>/ } )
+		).toHaveClass( 'is-added' );
+	} );
+
+	it( 'preserves blank source lines without inserting text', () => {
+		mockRevisions( {
+			currentContent: 'First\n\nLast',
+			showDiff: false,
+		} );
+
+		render( <RevisionsCodeDiff /> );
+
+		expect(
+			screen.getByText( '', {
+				selector: '.editor-revisions-code-diff__code code',
+				normalizer: ( content ) => content,
+			} )
+		).toBeEmptyDOMElement();
 	} );
 } );

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -2,61 +2,31 @@
  * External dependencies
  */
 import { render, screen, within } from '@testing-library/react';
-import { diffLines } from 'diff';
-
-/**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import RevisionsCodeDiff, { getCodeDiffRows } from '../revisions-code-diff';
+import { RevisionsCodeDiff, getCodeDiffRows } from '../revisions-code-diff';
 
-jest.mock( 'diff', () => {
-	const actual = jest.requireActual( 'diff' );
-	return {
-		...actual,
-		diffLines: jest.fn( actual.diffLines ),
-	};
-} );
-
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-
-jest.mock( '../../../lock-unlock', () => ( {
-	unlock: ( object ) => ( {
-		...object,
-		registerPrivateActions: jest.fn(),
-		registerPrivateSelectors: jest.fn(),
-	} ),
-} ) );
-
-function mockRevisions( {
+function renderCodeDiff( {
 	currentContent = '',
 	previousContent = '',
 	previousRevision,
 	showDiff = true,
-	revisionPage = 1,
-	totalRevisions = 2,
-	revisionsPerPage = 100,
+	isPreviousRevisionLoading = false,
 } = {} ) {
 	const resolvedPreviousRevision =
 		previousRevision === undefined
 			? { content: { raw: previousContent } }
 			: previousRevision;
 
-	useSelect.mockImplementation( ( mapSelect ) =>
-		mapSelect( () => ( {
-			getCurrentRevision: () => ( {
-				content: { raw: currentContent },
-			} ),
-			getPreviousRevision: () => resolvedPreviousRevision,
-			getRevisionPage: () => revisionPage,
-			getRevisionsPerPage: () => revisionsPerPage,
-			getCurrentPostRevisionsCount: () => totalRevisions,
-			isShowingRevisionDiff: () => showDiff,
-		} ) )
+	return render(
+		<RevisionsCodeDiff
+			revision={ { content: { raw: currentContent } } }
+			previousRevision={ resolvedPreviousRevision }
+			showDiff={ showDiff }
+			isPreviousRevisionLoading={ isPreviousRevisionLoading }
+		/>
 	);
 }
 
@@ -120,55 +90,54 @@ describe( 'getCodeDiffRows', () => {
 	} );
 
 	it( 'uses a coarse diff when line diffing exceeds its limits', () => {
-		diffLines.mockReturnValueOnce( undefined );
+		const previousLines = Array.from(
+			{ length: 501 },
+			( _, index ) => `Before ${ index }`
+		);
+		const currentLines = Array.from(
+			{ length: 501 },
+			( _, index ) => `After ${ index }`
+		);
+		const rows = getCodeDiffRows(
+			previousLines.join( '\n' ),
+			currentLines.join( '\n' ),
+			true
+		);
 
-		expect( getCodeDiffRows( 'Before\nOld', 'After\nNew', true ) ).toEqual(
-			[
-				{
-					value: 'Before',
-					status: 'removed',
-					previousLineNumber: 1,
-					currentLineNumber: null,
-				},
-				{
-					value: 'Old',
-					status: 'removed',
-					previousLineNumber: 2,
-					currentLineNumber: null,
-				},
-				{
-					value: 'After',
-					status: 'added',
-					previousLineNumber: null,
-					currentLineNumber: 1,
-				},
-				{
-					value: 'New',
-					status: 'added',
-					previousLineNumber: null,
-					currentLineNumber: 2,
-				},
-			]
-		);
-		expect( diffLines ).toHaveBeenLastCalledWith(
-			'Before\nOld',
-			'After\nNew',
-			{
-				maxEditLength: 1000,
-				timeout: 100,
-			}
-		);
+		expect( rows ).toHaveLength( 1002 );
+		expect( rows[ 0 ] ).toEqual( {
+			value: 'Before 0',
+			status: 'removed',
+			previousLineNumber: 1,
+			currentLineNumber: null,
+		} );
+		expect( rows[ 500 ] ).toEqual( {
+			value: 'Before 500',
+			status: 'removed',
+			previousLineNumber: 501,
+			currentLineNumber: null,
+		} );
+		expect( rows[ 501 ] ).toEqual( {
+			value: 'After 0',
+			status: 'added',
+			previousLineNumber: null,
+			currentLineNumber: 1,
+		} );
+		expect( rows[ 1001 ] ).toEqual( {
+			value: 'After 500',
+			status: 'added',
+			previousLineNumber: null,
+			currentLineNumber: 501,
+		} );
 	} );
 } );
 
 describe( 'RevisionsCodeDiff', () => {
 	it( 'shows added and removed markup in the code diff', () => {
-		mockRevisions( {
+		renderCodeDiff( {
 			previousContent: '<!-- wp:paragraph -->\n<p>Before</p>',
 			currentContent: '<!-- wp:paragraph -->\n<p>After</p>',
 		} );
-
-		render( <RevisionsCodeDiff /> );
 
 		expect(
 			screen.getByRole( 'region', { name: 'Code changes' } )
@@ -182,13 +151,11 @@ describe( 'RevisionsCodeDiff', () => {
 	} );
 
 	it( 'shows only the selected revision when changes are hidden', () => {
-		mockRevisions( {
+		renderCodeDiff( {
 			previousContent: '<p>Before</p>',
 			currentContent: '<p>After</p>',
 			showDiff: false,
 		} );
-
-		render( <RevisionsCodeDiff /> );
 
 		expect(
 			screen.getByRole( 'region', { name: 'Revision code' } )
@@ -207,15 +174,12 @@ describe( 'RevisionsCodeDiff', () => {
 		expect( screen.queryByText( 'Unchanged' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'waits for the previous revision at a page boundary', () => {
-		mockRevisions( {
+	it( 'waits while the previous revision is loading', () => {
+		renderCodeDiff( {
 			currentContent: '<p>Current</p>',
 			previousRevision: null,
-			revisionPage: 1,
-			totalRevisions: 101,
+			isPreviousRevisionLoading: true,
 		} );
-
-		render( <RevisionsCodeDiff /> );
 
 		expect( screen.getByRole( 'presentation' ) ).toHaveClass(
 			'components-spinner'
@@ -224,14 +188,10 @@ describe( 'RevisionsCodeDiff', () => {
 	} );
 
 	it( 'compares the oldest revision against empty content', () => {
-		mockRevisions( {
+		renderCodeDiff( {
 			currentContent: '<p>Oldest</p>',
 			previousRevision: null,
-			revisionPage: 2,
-			totalRevisions: 101,
 		} );
-
-		render( <RevisionsCodeDiff /> );
 
 		expect(
 			screen.getByRole( 'row', { name: /Added.*<p>Oldest<\/p>/ } )
@@ -239,12 +199,10 @@ describe( 'RevisionsCodeDiff', () => {
 	} );
 
 	it( 'preserves blank source lines without inserting text', () => {
-		mockRevisions( {
+		renderCodeDiff( {
 			currentContent: 'First\n\nLast',
 			showDiff: false,
 		} );
-
-		render( <RevisionsCodeDiff /> );
 
 		expect(
 			screen.getByText( '', {

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import RevisionsCodeDiff, { getCodeDiffRows } from '../revisions-code-diff';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( object ) => ( {
+		...object,
+		registerPrivateActions: jest.fn(),
+		registerPrivateSelectors: jest.fn(),
+	} ),
+} ) );
+
+function mockRevisions( {
+	currentContent = '',
+	previousContent = '',
+	showDiff = true,
+} = {} ) {
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( () => ( {
+			getCurrentRevision: () => ( {
+				content: { raw: currentContent },
+			} ),
+			getPreviousRevision: () => ( {
+				content: { raw: previousContent },
+			} ),
+			isShowingRevisionDiff: () => showDiff,
+		} ) )
+	);
+}
+
+describe( 'getCodeDiffRows', () => {
+	it( 'adds line numbers for both revisions', () => {
+		expect(
+			getCodeDiffRows(
+				'First\nBefore\nLast\n',
+				'First\nAfter\nLast\n',
+				true
+			)
+		).toEqual( [
+			{
+				value: 'First',
+				status: 'unchanged',
+				previousLineNumber: 1,
+				currentLineNumber: 1,
+			},
+			{
+				value: 'Before',
+				status: 'removed',
+				previousLineNumber: 2,
+				currentLineNumber: null,
+			},
+			{
+				value: 'After',
+				status: 'added',
+				previousLineNumber: null,
+				currentLineNumber: 2,
+			},
+			{
+				value: 'Last',
+				status: 'unchanged',
+				previousLineNumber: 3,
+				currentLineNumber: 3,
+			},
+		] );
+	} );
+
+	it( 'returns the selected revision without diff markers when changes are hidden', () => {
+		expect( getCodeDiffRows( 'Old', 'First\n\nLast', false ) ).toEqual( [
+			{
+				value: 'First',
+				status: 'unchanged',
+				previousLineNumber: null,
+				currentLineNumber: 1,
+			},
+			{
+				value: '',
+				status: 'unchanged',
+				previousLineNumber: null,
+				currentLineNumber: 2,
+			},
+			{
+				value: 'Last',
+				status: 'unchanged',
+				previousLineNumber: null,
+				currentLineNumber: 3,
+			},
+		] );
+	} );
+} );
+
+describe( 'RevisionsCodeDiff', () => {
+	it( 'shows added and removed markup in the code diff', () => {
+		mockRevisions( {
+			previousContent: '<!-- wp:paragraph -->\n<p>Before</p>',
+			currentContent: '<!-- wp:paragraph -->\n<p>After</p>',
+		} );
+
+		render( <RevisionsCodeDiff /> );
+
+		expect(
+			screen.getByRole( 'region', { name: 'Code changes' } )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'row', { name: /Removed.*<p>Before<\/p>/ } )
+		).toHaveClass( 'is-removed' );
+		expect(
+			screen.getByRole( 'row', { name: /Added.*<p>After<\/p>/ } )
+		).toHaveClass( 'is-added' );
+	} );
+
+	it( 'shows only the selected revision when changes are hidden', () => {
+		mockRevisions( {
+			previousContent: '<p>Before</p>',
+			currentContent: '<p>After</p>',
+			showDiff: false,
+		} );
+
+		render( <RevisionsCodeDiff /> );
+
+		expect(
+			screen.getByRole( 'region', { name: 'Revision code' } )
+		).toHaveTextContent( '<p>After</p>' );
+		expect( screen.queryByText( '<p>Before</p>' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Added' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Removed' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -6,7 +6,11 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { RevisionsCodeDiff, getCodeDiffRows } from '../revisions-code-diff';
+import {
+	RevisionsCodeDiff,
+	getCodeDiffDisplayState,
+	getCodeDiffRows,
+} from '../revisions-code-diff';
 
 function renderCodeDiff( {
 	currentContent = '',
@@ -128,6 +132,50 @@ describe( 'getCodeDiffRows', () => {
 			status: 'added',
 			previousLineNumber: null,
 			currentLineNumber: 501,
+		} );
+	} );
+} );
+
+describe( 'getCodeDiffDisplayState', () => {
+	it( 'waits for an older revision from the next page', () => {
+		expect(
+			getCodeDiffDisplayState( {
+				previousRevision: null,
+				showDiff: true,
+				hasOlderRevisionPage: true,
+				hasFinishedPreviousRevision: false,
+			} )
+		).toEqual( {
+			showDiff: true,
+			isPreviousRevisionLoading: true,
+		} );
+	} );
+
+	it( 'shows the selected revision without a diff when the older revision request finishes without data', () => {
+		expect(
+			getCodeDiffDisplayState( {
+				previousRevision: null,
+				showDiff: true,
+				hasOlderRevisionPage: true,
+				hasFinishedPreviousRevision: true,
+			} )
+		).toEqual( {
+			showDiff: false,
+			isPreviousRevisionLoading: false,
+		} );
+	} );
+
+	it( 'compares the oldest revision against empty content', () => {
+		expect(
+			getCodeDiffDisplayState( {
+				previousRevision: null,
+				showDiff: true,
+				hasOlderRevisionPage: false,
+				hasFinishedPreviousRevision: true,
+			} )
+		).toEqual( {
+			showDiff: true,
+			isPreviousRevisionLoading: false,
 		} );
 	} );
 } );

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -161,17 +161,6 @@ describe( 'RevisionsCodeDiff', () => {
 			screen.getByRole( 'region', { name: 'Revision code' } )
 		).toHaveTextContent( '<p>After</p>' );
 		expect( screen.queryByText( '<p>Before</p>' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Added' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Removed' ) ).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole( 'columnheader', { name: 'Change' } )
-		).not.toBeInTheDocument();
-		expect(
-			within(
-				screen.getByRole( 'row', { name: /<p>After<\/p>/ } )
-			).getAllByRole( 'cell' )
-		).toHaveLength( 2 );
-		expect( screen.queryByText( 'Unchanged' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'waits while the previous revision is loading', () => {

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
@@ -4,58 +4,37 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
- * WordPress dependencies
- */
-import { useSelect, useDispatch } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
-import RevisionsSlider from '../revisions-slider';
+import { RevisionsSlider } from '../revisions-slider';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
-	jest.fn()
-);
+const noop = () => {};
 
-jest.mock( '../../../lock-unlock', () => ( {
-	unlock: ( object ) => ( {
-		...object,
-		registerPrivateActions: jest.fn(),
-		registerPrivateSelectors: jest.fn(),
-	} ),
-} ) );
+function getRevisionsSlider( revisions ) {
+	return (
+		<RevisionsSlider
+			revisions={ revisions }
+			perPage={ 100 }
+			currentRevisionId={ 2 }
+			revisionKey="id"
+			revisionPage={ 1 }
+			totalRevisions={ 2 }
+			setCurrentRevisionId={ noop }
+			setRevisionPage={ noop }
+		/>
+	);
+}
 
 describe( 'RevisionsSlider', () => {
-	let revisions;
-
-	beforeEach( () => {
-		revisions = undefined;
-		useSelect.mockImplementation( ( mapSelect ) =>
-			mapSelect( () => ( {
-				getCurrentPostType: () => 'post',
-				getCurrentRevisionId: () => 2,
-				getRevisionPage: () => 1,
-				getPageRevisions: () => revisions,
-				getRevisionsPerPage: () => 100,
-				getCurrentPostRevisionsCount: () => 2,
-				getEntityConfig: () => ( { revisionKey: 'id' } ),
-			} ) )
-		);
-		useDispatch.mockReturnValue( {
-			setCurrentRevisionId: jest.fn(),
-			setRevisionPage: jest.fn(),
-		} );
-	} );
-
 	it( 'focuses the slider when revisions load without user interaction', () => {
-		const { rerender } = render( <RevisionsSlider /> );
+		const { rerender } = render( getRevisionsSlider() );
 
-		revisions = [
-			{ id: 2, date: '2026-07-14T12:00:00' },
-			{ id: 1, date: '2026-07-14T11:00:00' },
-		];
-		rerender( <RevisionsSlider /> );
+		rerender(
+			getRevisionsSlider( [
+				{ id: 2, date: '2026-07-14T12:00:00' },
+				{ id: 1, date: '2026-07-14T11:00:00' },
+			] )
+		);
 
 		expect(
 			screen.getByRole( 'slider', { name: 'Revision' } )
@@ -66,21 +45,20 @@ describe( 'RevisionsSlider', () => {
 		const { rerender } = render(
 			<>
 				<button>Options</button>
-				<RevisionsSlider />
+				{ getRevisionsSlider() }
 			</>
 		);
 		const optionsButton = screen.getByRole( 'button', { name: 'Options' } );
 
 		fireEvent.pointerDown( optionsButton );
 		expect( document.body ).toHaveFocus();
-		revisions = [
-			{ id: 2, date: '2026-07-14T12:00:00' },
-			{ id: 1, date: '2026-07-14T11:00:00' },
-		];
 		rerender(
 			<>
 				<button>Options</button>
-				<RevisionsSlider />
+				{ getRevisionsSlider( [
+					{ id: 2, date: '2026-07-14T12:00:00' },
+					{ id: 1, date: '2026-07-14T11:00:00' },
+				] ) }
 			</>
 		);
 

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import RevisionsSlider from '../revisions-slider';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
+	jest.fn()
+);
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( object ) => ( {
+		...object,
+		registerPrivateActions: jest.fn(),
+		registerPrivateSelectors: jest.fn(),
+	} ),
+} ) );
+
+describe( 'RevisionsSlider', () => {
+	let revisions;
+
+	beforeEach( () => {
+		revisions = undefined;
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getCurrentPostType: () => 'post',
+				getCurrentRevisionId: () => 2,
+				getRevisionPage: () => 1,
+				getPageRevisions: () => revisions,
+				getRevisionsPerPage: () => 100,
+				getCurrentPostRevisionsCount: () => 2,
+				getEntityConfig: () => ( { revisionKey: 'id' } ),
+			} ) )
+		);
+		useDispatch.mockReturnValue( {
+			setCurrentRevisionId: jest.fn(),
+			setRevisionPage: jest.fn(),
+		} );
+	} );
+
+	it( 'focuses the slider when revisions load without user interaction', () => {
+		const { rerender } = render( <RevisionsSlider /> );
+
+		revisions = [
+			{ id: 2, date: '2026-07-14T12:00:00' },
+			{ id: 1, date: '2026-07-14T11:00:00' },
+		];
+		rerender( <RevisionsSlider /> );
+
+		expect(
+			screen.getByRole( 'slider', { name: 'Revision' } )
+		).toHaveFocus();
+	} );
+
+	it( 'does not focus after pointer interaction while revisions load', () => {
+		const { rerender } = render(
+			<>
+				<button>Options</button>
+				<RevisionsSlider />
+			</>
+		);
+		const optionsButton = screen.getByRole( 'button', { name: 'Options' } );
+
+		fireEvent.pointerDown( optionsButton );
+		expect( document.body ).toHaveFocus();
+		revisions = [
+			{ id: 2, date: '2026-07-14T12:00:00' },
+			{ id: 1, date: '2026-07-14T11:00:00' },
+		];
+		rerender(
+			<>
+				<button>Options</button>
+				<RevisionsSlider />
+			</>
+		);
+
+		expect(
+			screen.getByRole( 'slider', { name: 'Revision' } )
+		).not.toHaveFocus();
+		expect( document.body ).toHaveFocus();
+	} );
+} );

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -9,6 +10,10 @@ import { render, screen } from '@testing-library/react';
 import { RevisionsSlider } from '../revisions-slider';
 
 const noop = () => {};
+const loadedRevisions = [
+	{ id: 2, date: '2026-07-14T12:00:00' },
+	{ id: 1, date: '2026-07-14T11:00:00' },
+];
 
 function getRevisionsSlider( revisions ) {
 	return (
@@ -29,15 +34,52 @@ describe( 'RevisionsSlider', () => {
 	it( 'focuses the slider when revisions load without user interaction', () => {
 		const { rerender } = render( getRevisionsSlider() );
 
-		rerender(
-			getRevisionsSlider( [
-				{ id: 2, date: '2026-07-14T12:00:00' },
-				{ id: 1, date: '2026-07-14T11:00:00' },
-			] )
-		);
+		rerender( getRevisionsSlider( loadedRevisions ) );
 
 		expect(
 			screen.getByRole( 'slider', { name: 'Revision' } )
 		).toHaveFocus();
+	} );
+
+	it( 'focuses the slider after a key press that does not move focus while revisions load', async () => {
+		const user = userEvent.setup();
+		const { rerender } = render( getRevisionsSlider() );
+
+		await user.keyboard( '{Escape}' );
+		expect( document.body ).toHaveFocus();
+
+		rerender( getRevisionsSlider( loadedRevisions ) );
+
+		expect(
+			screen.getByRole( 'slider', { name: 'Revision' } )
+		).toHaveFocus();
+	} );
+
+	it( 'keeps focus on another control when revisions load', async () => {
+		const user = userEvent.setup();
+		const { rerender } = render(
+			<>
+				<button>Options</button>
+				{ getRevisionsSlider() }
+			</>
+		);
+		const optionsButton = screen.getByRole( 'button', {
+			name: 'Options',
+		} );
+
+		await user.click( optionsButton );
+		expect( optionsButton ).toHaveFocus();
+
+		rerender(
+			<>
+				<button>Options</button>
+				{ getRevisionsSlider( loadedRevisions ) }
+			</>
+		);
+
+		expect( optionsButton ).toHaveFocus();
+		expect(
+			screen.getByRole( 'slider', { name: 'Revision' } )
+		).not.toHaveFocus();
 	} );
 } );

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-slider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -39,32 +39,5 @@ describe( 'RevisionsSlider', () => {
 		expect(
 			screen.getByRole( 'slider', { name: 'Revision' } )
 		).toHaveFocus();
-	} );
-
-	it( 'does not focus after pointer interaction while revisions load', () => {
-		const { rerender } = render(
-			<>
-				<button>Options</button>
-				{ getRevisionsSlider() }
-			</>
-		);
-		const optionsButton = screen.getByRole( 'button', { name: 'Options' } );
-
-		fireEvent.pointerDown( optionsButton );
-		expect( document.body ).toHaveFocus();
-		rerender(
-			<>
-				<button>Options</button>
-				{ getRevisionsSlider( [
-					{ id: 2, date: '2026-07-14T12:00:00' },
-					{ id: 1, date: '2026-07-14T11:00:00' },
-				] ) }
-			</>
-		);
-
-		expect(
-			screen.getByRole( 'slider', { name: 'Revision' } )
-		).not.toHaveFocus();
-		expect( document.body ).toHaveFocus();
 	} );
 } );

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -86,6 +86,90 @@ test.describe( 'Post revisions', () => {
 		] );
 	} );
 
+	test( 'should show revision changes in the code editor', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			'<!-- wp:paragraph -->\n<p>Original content</p>\n<!-- /wp:paragraph -->'
+		);
+		await editor.saveDraft();
+
+		await editor.setContent(
+			'<!-- wp:paragraph -->\n<p>Updated content</p>\n<!-- /wp:paragraph -->'
+		);
+		await editor.saveDraft();
+
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', {
+				name: 'Open revisions screen: 2 revisions',
+			} )
+			.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		const optionsButton = page.getByRole( 'button', { name: 'Options' } );
+		await expect( optionsButton ).toBeEnabled();
+		await optionsButton.click();
+		await page
+			.getByRole( 'menuitemradio', { name: 'Code editor' } )
+			.click();
+
+		const codeDiff = page.getByRole( 'region', { name: 'Code changes' } );
+		await expect( codeDiff ).toBeVisible();
+		await expect(
+			codeDiff.locator( 'tr.is-removed' ).filter( {
+				hasText: '<p>Original content</p>',
+			} )
+		).toBeVisible();
+		await expect(
+			codeDiff.locator( 'tr.is-added' ).filter( {
+				hasText: '<p>Updated content</p>',
+			} )
+		).toBeVisible();
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await expect( slider ).toBeVisible();
+		await slider.focus();
+		await page.keyboard.press( 'Home' );
+		await expect(
+			codeDiff.locator( 'tr.is-added' ).filter( {
+				hasText: '<p>Original content</p>',
+			} )
+		).toBeVisible();
+		await expect( codeDiff ).not.toContainText( '<p>Updated content</p>' );
+
+		await page.keyboard.press( 'End' );
+		await expect(
+			codeDiff.locator( 'tr.is-added' ).filter( {
+				hasText: '<p>Updated content</p>',
+			} )
+		).toBeVisible();
+
+		await page.getByRole( 'button', { name: 'Show changes' } ).click();
+		const revisionCode = page.getByRole( 'region', {
+			name: 'Revision code',
+		} );
+		await expect( revisionCode ).toContainText( '<p>Updated content</p>' );
+		await expect( revisionCode.locator( 'tr.is-removed' ) ).toHaveCount(
+			0
+		);
+
+		await optionsButton.click();
+		await page
+			.getByRole( 'menuitemradio', { name: 'Visual editor' } )
+			.click();
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toHaveText( 'Updated content' );
+	} );
+
 	test( 'should preserve block clientId when sliding between revisions', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -147,14 +147,10 @@ test.describe( 'Post revisions', () => {
 		).toBeVisible();
 
 		const optionsButton = page.getByRole( 'button', { name: 'Options' } );
-		await expect( optionsButton ).toBeEnabled();
 		const codeEditorMenuItem = page.getByRole( 'menuitemradio', {
 			name: 'Code editor',
 		} );
 		try {
-			await expect(
-				page.locator( '.editor-revisions-header .components-spinner' )
-			).toBeVisible();
 			await optionsButton.click();
 			await expect( codeEditorMenuItem ).toBeVisible();
 		} finally {
@@ -167,7 +163,6 @@ test.describe( 'Post revisions', () => {
 		await codeEditorMenuItem.click();
 
 		const codeDiff = page.getByRole( 'region', { name: 'Code changes' } );
-		await expect( codeDiff ).toBeVisible();
 		await expect(
 			codeDiff.locator( 'tr.is-removed' ).filter( {
 				hasText: '<p>Original content</p>',
@@ -187,18 +182,11 @@ test.describe( 'Post revisions', () => {
 		).toBeVisible();
 		await expect( codeDiff ).not.toContainText( '<p>Updated content</p>' );
 
-		await page.keyboard.press( 'End' );
-		await expect(
-			codeDiff.locator( 'tr.is-added' ).filter( {
-				hasText: '<p>Updated content</p>',
-			} )
-		).toBeVisible();
-
 		await page.getByRole( 'button', { name: 'Show changes' } ).click();
 		const revisionCode = page.getByRole( 'region', {
 			name: 'Revision code',
 		} );
-		await expect( revisionCode ).toContainText( '<p>Updated content</p>' );
+		await expect( revisionCode ).toContainText( '<p>Original content</p>' );
 		await expect( revisionCode.locator( 'tr.is-removed' ) ).toHaveCount(
 			0
 		);
@@ -209,7 +197,7 @@ test.describe( 'Post revisions', () => {
 			.click();
 		await expect(
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
-		).toHaveText( 'Updated content' );
+		).toHaveText( 'Original content' );
 	} );
 
 	test( 'should preserve block clientId when sliding between revisions', async ( {

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -3,6 +3,15 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+function defer() {
+	let resolve;
+	const deferred = new Promise( ( res ) => {
+		resolve = res;
+	} );
+	deferred.resolve = resolve;
+	return deferred;
+}
+
 test.describe( 'Post revisions', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -86,7 +95,7 @@ test.describe( 'Post revisions', () => {
 		] );
 	} );
 
-	test( 'should show revision changes in the code editor', async ( {
+	test( 'should show revision changes in the code editor (@webkit)', async ( {
 		editor,
 		page,
 	} ) => {
@@ -100,6 +109,27 @@ test.describe( 'Post revisions', () => {
 		);
 		await editor.saveDraft();
 
+		const revisionsRequestStarted = defer();
+		const releaseRevisionsRequest = defer();
+		let shouldDelayRevisionsRequest = true;
+		await page.route(
+			( url ) => {
+				const restRoute = url.searchParams.get( 'rest_route' );
+				return ( restRoute ?? url.pathname ).includes( '/revisions' );
+			},
+			async ( route, request ) => {
+				if (
+					shouldDelayRevisionsRequest &&
+					request.method() === 'GET'
+				) {
+					shouldDelayRevisionsRequest = false;
+					revisionsRequestStarted.resolve();
+					await releaseRevisionsRequest;
+				}
+				await route.continue();
+			}
+		);
+
 		await editor.openDocumentSettingsSidebar();
 		const settingsSidebar = page.getByRole( 'region', {
 			name: 'Editor settings',
@@ -111,16 +141,30 @@ test.describe( 'Post revisions', () => {
 			} )
 			.click();
 
+		await revisionsRequestStarted;
 		await expect(
 			page.getByRole( 'button', { name: 'Restore' } )
 		).toBeVisible();
 
 		const optionsButton = page.getByRole( 'button', { name: 'Options' } );
 		await expect( optionsButton ).toBeEnabled();
-		await optionsButton.click();
-		await page
-			.getByRole( 'menuitemradio', { name: 'Code editor' } )
-			.click();
+		const codeEditorMenuItem = page.getByRole( 'menuitemradio', {
+			name: 'Code editor',
+		} );
+		try {
+			await expect(
+				page.locator( '.editor-revisions-header .components-spinner' )
+			).toBeVisible();
+			await optionsButton.click();
+			await expect( codeEditorMenuItem ).toBeVisible();
+		} finally {
+			releaseRevisionsRequest.resolve();
+		}
+
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await expect( slider ).toBeVisible();
+		await expect( codeEditorMenuItem ).toBeVisible();
+		await codeEditorMenuItem.click();
 
 		const codeDiff = page.getByRole( 'region', { name: 'Code changes' } );
 		await expect( codeDiff ).toBeVisible();
@@ -134,8 +178,6 @@ test.describe( 'Post revisions', () => {
 				hasText: '<p>Updated content</p>',
 			} )
 		).toBeVisible();
-		const slider = page.getByRole( 'slider', { name: 'Revision' } );
-		await expect( slider ).toBeVisible();
 		await slider.focus();
 		await page.keyboard.press( 'Home' );
 		await expect(


### PR DESCRIPTION
## What

Closes #77841, part of #79120.

Adds a Code editor option to the block editor revisions screen, showing the selected revision's raw markup and highlighting the lines that were added or removed. The `Show changes` toggle on the top left switches between the diff and the plain markup.

## Why

A visual diff can miss changes to block attributes when the rendered post still looks the same. The code view makes those changes visible in the new revisions screen instead of sending users back to the classic one.

## Testing Instructions

1. Create a post and save two revisions with different paragraph content.
2. Open Revisions from the Post sidebar.
3. Open Options and choose Code editor.
4. Check that the old and new markup are highlighted, then move the slider and confirm the diff updates.
5. Turn off Show changes and confirm that only the selected revision's markup is shown.
6. Exit revisions while the Code editor is selected and confirm that the post editor remains in code mode.
7. Switch back to the Visual editor and confirm that revisions return to the visual view.
8. With network throttling enabled, reopen Revisions and open Options before the slider finishes loading. Confirm that the focus does not jump to the slider.

## Screen recording

https://github.com/user-attachments/assets/2a0b4123-fba1-4bbe-bd8f-80bac3b4e134


---

I used Codex to implement these changes. I guided the work, tested it, and reviewed the results.