### PR TITLE
Stylelint: no internal component classnames

### DIFF
--- a/packages/components/.stylelintrc.mjs
+++ b/packages/components/.stylelintrc.mjs
@@ -28,6 +28,7 @@ export default {
 				},
 			},
 		],
+		'plugin-wpds/no-internal-component-classnames': null,
 	},
 	overrides: [
 		{

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Added `no-internal-component-classnames` stylelint rule that disallows overriding internal `component-*` class names from `@wordpress/components`. Available as `@wordpress/theme/stylelint-plugins/no-internal-component-classnames`.
+-   Added `no-internal-component-classnames` stylelint rule that disallows overriding internal `component-*` and `components-*` class names from `@wordpress/components`. Available as `@wordpress/theme/stylelint-plugins/no-internal-component-classnames`.
 
 ### Code Quality
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added `no-internal-component-classnames` stylelint rule that disallows overriding internal `component-*` class names from `@wordpress/components`. Available as `@wordpress/theme/stylelint-plugins/no-internal-component-classnames`.
+
 ### Code Quality
 
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -216,12 +216,14 @@ These rules validate design token usage in CSS. Enable them in your Stylelint co
 	"plugins": [
 		"@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens",
 		"@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties",
-		"@wordpress/theme/stylelint-plugins/no-token-fallback-values"
+		"@wordpress/theme/stylelint-plugins/no-token-fallback-values",
+		"@wordpress/theme/stylelint-plugins/no-internal-component-classnames"
 	],
 	"rules": {
 		"plugin-wpds/no-unknown-ds-tokens": true,
 		"plugin-wpds/no-setting-wpds-custom-properties": true,
-		"plugin-wpds/no-token-fallback-values": true
+		"plugin-wpds/no-token-fallback-values": true,
+		"plugin-wpds/no-internal-component-classnames": true
 	}
 }
 ```
@@ -237,6 +239,10 @@ Reports definitions or overrides in the `--wpds-*` namespace.
 ### `plugin-wpds/no-token-fallback-values`
 
 Reports manual fallbacks that can drift from the generated values.
+
+### `plugin-wpds/no-internal-component-classnames`
+
+Reports CSS selectors that target internal `component-*` class names from `@wordpress/components`. These selectors are not a stable API and component style overrides are not advised. Prefer a custom selector on the component instead.
 
 ## Build Plugins
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -242,7 +242,7 @@ Reports manual fallbacks that can drift from the generated values.
 
 ### `plugin-wpds/no-internal-component-classnames`
 
-Reports CSS selectors that target internal `component-*` class names from `@wordpress/components`. These selectors are not a stable API and component style overrides are not advised. Prefer a custom selector on the component instead.
+Reports CSS selectors that target internal `component-*` or `components-*` class names from `@wordpress/components`. These selectors are not a stable API and component style overrides are not advised. Prefer a custom selector on the component instead.
 
 ## Build Plugins
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -71,6 +71,10 @@
 			"types": "./build-types/stylelint-plugins/no-token-fallback-values.d.mts",
 			"default": "./stylelint-plugins/no-token-fallback-values.mjs"
 		},
+		"./stylelint-plugins/no-internal-component-classnames": {
+			"types": "./build-types/stylelint-plugins/no-internal-component-classnames.d.mts",
+			"default": "./stylelint-plugins/no-internal-component-classnames.mjs"
+		},
 		"./package.json": "./package.json"
 	},
 	"wpScript": true,

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-internal-component-classnames.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-internal-component-classnames.test.ts.snap
@@ -9,7 +9,7 @@ exports[`flags warnings with invalid css snapshot matches warnings 1`] = `
     "line": 2,
     "rule": "plugin-wpds/no-internal-component-classnames",
     "severity": "error",
-    "text": "Avoid overriding internal "component-color-indicator" class names from @wordpress/components. These selectors are not a stable API. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
+    "text": "Avoid overriding internal "component-color-indicator" class names from @wordpress/components. These selectors are not a stable API and component style overrides are not advised. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
   },
   {
     "column": 1,
@@ -18,7 +18,16 @@ exports[`flags warnings with invalid css snapshot matches warnings 1`] = `
     "line": 7,
     "rule": "plugin-wpds/no-internal-component-classnames",
     "severity": "error",
-    "text": "Avoid overriding internal "component-box-control__reset-button" class names from @wordpress/components. These selectors are not a stable API. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
+    "text": "Avoid overriding internal "component-box-control__reset-button" class names from @wordpress/components. These selectors are not a stable API and component style overrides are not advised. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
+  },
+  {
+    "column": 1,
+    "endColumn": 2,
+    "endLine": 14,
+    "line": 12,
+    "rule": "plugin-wpds/no-internal-component-classnames",
+    "severity": "error",
+    "text": "Avoid overriding internal "components-button" class names from @wordpress/components. These selectors are not a stable API and component style overrides are not advised. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
   },
 ]
 `;

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-internal-component-classnames.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-internal-component-classnames.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flags warnings with invalid css snapshot matches warnings 1`] = `
+[
+  {
+    "column": 1,
+    "endColumn": 2,
+    "endLine": 4,
+    "line": 2,
+    "rule": "plugin-wpds/no-internal-component-classnames",
+    "severity": "error",
+    "text": "Avoid overriding internal "component-color-indicator" class names from @wordpress/components. These selectors are not a stable API. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
+  },
+  {
+    "column": 1,
+    "endColumn": 2,
+    "endLine": 9,
+    "line": 7,
+    "rule": "plugin-wpds/no-internal-component-classnames",
+    "severity": "error",
+    "text": "Avoid overriding internal "component-box-control__reset-button" class names from @wordpress/components. These selectors are not a stable API. Target the component with a custom CSS selector instead. (plugin-wpds/no-internal-component-classnames)",
+  },
+]
+`;

--- a/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.css
+++ b/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.css
@@ -7,3 +7,8 @@
 .component-box-control__reset-button {
 	margin: 0;
 }
+
+/* Invalid: legacy components-* class override */
+.my-panel .components-button {
+	margin: 0;
+}

--- a/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.css
+++ b/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.css
@@ -1,0 +1,9 @@
+/* Invalid: overriding an internal @wordpress/components class */
+.my-panel .component-color-indicator {
+	flex-shrink: 0;
+}
+
+/* Invalid: BEM element on an internal class */
+.component-box-control__reset-button {
+	margin: 0;
+}

--- a/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.scss
+++ b/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-invalid.scss
@@ -1,0 +1,6 @@
+.my-panel {
+	/* Invalid: nested internal class override */
+	.component-color-indicator {
+		float: right;
+	}
+}

--- a/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-valid.css
+++ b/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-valid.css
@@ -1,0 +1,19 @@
+/* Valid: custom selector on the consuming component */
+.my-panel__color-indicator {
+	flex-shrink: 0;
+}
+
+/* Valid: legacy public components-* class names are out of scope */
+.components-button {
+	margin: 0;
+}
+
+/* Valid: unrelated class names that happen to contain "component" */
+.my-component-wrapper {
+	padding: 8px;
+}
+
+/* Valid: admin-ui internal classes are out of scope for this rule */
+.admin-ui-navigable-region {
+	padding: 0;
+}

--- a/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-valid.css
+++ b/packages/theme/src/stylelint-plugins/test/fixtures/no-internal-component-classnames-valid.css
@@ -3,11 +3,6 @@
 	flex-shrink: 0;
 }
 
-/* Valid: legacy public components-* class names are out of scope */
-.components-button {
-	margin: 0;
-}
-
 /* Valid: unrelated class names that happen to contain "component" */
 .my-component-wrapper {
 	padding: 8px;

--- a/packages/theme/src/stylelint-plugins/test/no-internal-component-classnames.test.ts
+++ b/packages/theme/src/stylelint-plugins/test/no-internal-component-classnames.test.ts
@@ -46,7 +46,7 @@ describe( 'flags warnings with invalid css', () => {
 
 	it( 'flags correct number of warnings', () => {
 		return result.then( ( data ) =>
-			expect( data.results[ 0 ].warnings ).toHaveLength( 2 )
+			expect( data.results[ 0 ].warnings ).toHaveLength( 3 )
 		);
 	} );
 

--- a/packages/theme/src/stylelint-plugins/test/no-internal-component-classnames.test.ts
+++ b/packages/theme/src/stylelint-plugins/test/no-internal-component-classnames.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import plugin from '../../../stylelint-plugins/no-internal-component-classnames.mjs';
+import { getStylelintResult } from './utils';
+
+const CONFIG = {
+	plugins: [ plugin ],
+	rules: { 'plugin-wpds/no-internal-component-classnames': true },
+};
+
+describe( 'flags no warnings with valid css', () => {
+	let result: ReturnType< typeof getStylelintResult >;
+
+	beforeAll( () => {
+		result = getStylelintResult(
+			'./fixtures/no-internal-component-classnames-valid.css',
+			CONFIG
+		);
+	} );
+
+	it( 'did not error', () => {
+		return result.then( ( data ) => expect( data.errored ).toBeFalsy() );
+	} );
+
+	it( 'flags no warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toHaveLength( 0 )
+		);
+	} );
+} );
+
+describe( 'flags warnings with invalid css', () => {
+	let result: ReturnType< typeof getStylelintResult >;
+
+	beforeAll( () => {
+		result = getStylelintResult(
+			'./fixtures/no-internal-component-classnames-invalid.css',
+			CONFIG
+		);
+	} );
+
+	it( 'did error', () => {
+		return result.then( ( data ) => expect( data.errored ).toBeTruthy() );
+	} );
+
+	it( 'flags correct number of warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toHaveLength( 2 )
+		);
+	} );
+
+	it( 'snapshot matches warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toMatchSnapshot()
+		);
+	} );
+} );
+
+describe( 'flags warnings with invalid scss', () => {
+	let result: ReturnType< typeof getStylelintResult >;
+
+	beforeAll( () => {
+		result = getStylelintResult(
+			'./fixtures/no-internal-component-classnames-invalid.scss',
+			CONFIG
+		);
+	} );
+
+	it( 'did error', () => {
+		return result.then( ( data ) => expect( data.errored ).toBeTruthy() );
+	} );
+
+	it( 'flags correct number of warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toHaveLength( 1 )
+		);
+	} );
+} );

--- a/packages/theme/stylelint-plugins/no-internal-component-classnames.mjs
+++ b/packages/theme/stylelint-plugins/no-internal-component-classnames.mjs
@@ -1,0 +1,76 @@
+import stylelint from 'stylelint';
+import selectorParser from 'postcss-selector-parser';
+
+const INTERNAL_CLASS_PREFIX = 'component-';
+
+const {
+	createPlugin,
+	utils: { report, ruleMessages, validateOptions },
+} = stylelint;
+
+const ruleName = 'plugin-wpds/no-internal-component-classnames';
+
+const messages = ruleMessages( ruleName, {
+	rejected: ( className ) =>
+		`Avoid overriding internal "${ className }" class names from @wordpress/components. These selectors are not a stable API and component style overrides are not advised. Target the component with a custom CSS selector instead.`,
+} );
+
+/**
+ * @param {string} selector
+ * @return {Set<string>}
+ */
+function getInternalClassNames( selector ) {
+	/** @type {Set<string>} */
+	const classNames = new Set();
+
+	const processSelector = selectorParser( ( selectors ) => {
+		selectors.walkClasses( ( classNode ) => {
+			if ( classNode.value.startsWith( INTERNAL_CLASS_PREFIX ) ) {
+				classNames.add( classNode.value );
+			}
+		} );
+	} );
+
+	try {
+		processSelector.processSync( selector );
+	} catch {
+		// Ignore selectors that cannot be parsed (for example, SCSS placeholders).
+	}
+
+	return classNames;
+}
+
+/** @type {import('stylelint').Rule} */
+const ruleFunction = ( primary ) => {
+	return ( root, result ) => {
+		const validOptions = validateOptions( result, ruleName, {
+			actual: primary,
+			possible: [ true ],
+		} );
+
+		if ( ! validOptions ) {
+			return;
+		}
+
+		root.walkRules( ( ruleNode ) => {
+			const internalClassNames = getInternalClassNames(
+				ruleNode.selector
+			);
+
+			for ( const className of internalClassNames ) {
+				report( {
+					message: messages.rejected( className ),
+					node: ruleNode,
+					result,
+					ruleName,
+				} );
+			}
+		} );
+	};
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+
+/** @type {import('stylelint').Plugin} */
+export default createPlugin( ruleName, ruleFunction );

--- a/packages/theme/stylelint-plugins/no-internal-component-classnames.mjs
+++ b/packages/theme/stylelint-plugins/no-internal-component-classnames.mjs
@@ -1,7 +1,8 @@
 import stylelint from 'stylelint';
 import selectorParser from 'postcss-selector-parser';
 
-const INTERNAL_CLASS_PREFIX = 'component-';
+// Check `components-` before `component-` because `components-*` also starts with `component-`.
+const INTERNAL_CLASS_PREFIXES = [ 'components-', 'component-' ];
 
 const {
 	createPlugin,
@@ -25,7 +26,11 @@ function getInternalClassNames( selector ) {
 
 	const processSelector = selectorParser( ( selectors ) => {
 		selectors.walkClasses( ( classNode ) => {
-			if ( classNode.value.startsWith( INTERNAL_CLASS_PREFIX ) ) {
+			if (
+				INTERNAL_CLASS_PREFIXES.some( ( prefix ) =>
+					classNode.value.startsWith( prefix )
+				)
+			) {
 				classNames.add( classNode.value );
 			}
 		} );

--- a/tools/stylelint/config.js
+++ b/tools/stylelint/config.js
@@ -7,6 +7,7 @@ module.exports = {
 	plugins: [
 		'stylelint-plugin-logical-css',
 		'@wordpress/theme/stylelint-plugins/no-token-fallback-values',
+		'@wordpress/theme/stylelint-plugins/no-internal-component-classnames',
 	],
 	reportNeedlessDisables: true,
 	rules: {
@@ -82,6 +83,7 @@ module.exports = {
 		'scss/at-if-closing-brace-space-after': null,
 		'no-invalid-position-at-import-rule': null,
 		'plugin-wpds/no-token-fallback-values': true,
+		'plugin-wpds/no-internal-component-classnames': true,
 	},
 	overrides: [
 		{

--- a/tools/stylelint/stylelint-suppressions.json
+++ b/tools/stylelint/stylelint-suppressions.json
@@ -1,22 +1,28 @@
 {
 	"packages/block-editor/src/components/colors-gradients/style.scss": {
 		"plugin-wpds/no-internal-component-classnames": {
-			"count": 1
+			"count": 3
 		}
 	},
 	"packages/block-editor/src/components/link-control/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 20
 		}
 	},
 	"packages/block-library/src/image/editor.scss": {
 		"selector-class-pattern": {
 			"count": 2
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
 		}
 	},
 	"packages/block-library/src/navigation/editor.scss": {
 		"plugin-wpds/no-internal-component-classnames": {
-			"count": 1
+			"count": 19
 		}
 	},
 	"packages/block-library/src/navigation/style.scss": {
@@ -32,21 +38,33 @@
 	"packages/dataviews/src/components/dataviews-filters/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
 		}
 	},
 	"packages/edit-site/src/components/add-new-template/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
 		}
 	},
 	"packages/edit-site/src/components/sidebar-navigation-screen/style.scss": {
 		"selector-class-pattern": {
 			"count": 5
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 7
 		}
 	},
 	"packages/global-styles-ui/src/font-library/style.scss": {
 		"selector-class-pattern": {
 			"count": 2
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
 		}
 	},
 	"packages/global-styles-ui/src/variations/style.scss": {
@@ -67,6 +85,9 @@
 	"routes/template-list/add-new-template/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
+		},
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
 		}
 	},
 	"widgets/events/components/events-list/events-list.module.css": {
@@ -111,6 +132,711 @@
 	},
 	"widgets/welcome/components/feature-highlight/feature-highlight.module.css": {
 		"selector-class-pattern": {
+			"count": 1
+		}
+	},
+	"packages/base-styles/_mixins.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"routes/connectors-home/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
+		}
+	},
+	"routes/post-list/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"routes/styles/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/boot/src/view-transitions.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/content-types/src/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/customize-widgets/src/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-widgets/src/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/hooks/block-hooks.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-editor/src/hooks/layout.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/audio/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/avatar/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/comments/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/embed/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/cover/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/block-library/src/file/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/freeform/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/gallery/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
+		}
+	},
+	"packages/block-library/src/gallery/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/html/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/media-text/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-library/src/post-featured-image/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 10
+		}
+	},
+	"packages/block-library/src/search/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/site-logo/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 7
+		}
+	},
+	"packages/block-library/src/social-links/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/spacer/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-library/src/utils/media-control.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-library/src/utils/poster-image.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/block-library/src/video/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/commands/src/components/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/dataviews/src/dataviews/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/format-library/src/language/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/pagination/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/screen-revisions/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/patterns/src/components/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/workflow/src/components/workflow-menu.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"storybook/stories/playground/with-undo-redo/style.css": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"widgets/quick-draft/fields/quick-draft-content-field/quick-draft-content-field.module.css": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-directory/src/components/downloadable-blocks-panel/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/background-image-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 12
+		}
+	},
+	"packages/block-editor/src/components/block-alignment-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/block-draggable/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-editor/src/components/block-inspector/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 8
+		}
+	},
+	"packages/block-editor/src/components/block-lock/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-editor/src/components/block-list/content.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-editor/src/components/block-manager/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-editor/src/components/block-mover/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/block-popover/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/block-editor/src/components/block-preview/content.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-editor/src/components/block-styles/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/block-tools/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 8
+		}
+	},
+	"packages/block-editor/src/components/block-switcher/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-editor/src/components/block-toolbar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 21
+		}
+	},
+	"packages/block-editor/src/components/block-variation-picker/content.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-editor/src/components/border-radius-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/block-editor/src/components/default-block-appender/content.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/block-editor/src/components/duotone-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/block-editor/src/components/font-appearance-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/grid/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/block-editor/src/components/image-editor/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/inserter/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 16
+		}
+	},
+	"packages/block-editor/src/components/inserter-list-item/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/block-editor/src/components/link-picker/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/list-view/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/block-editor/src/components/rich-text/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 8
+		}
+	},
+	"packages/block-editor/src/components/responsive-block-control/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/url-input/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/block-editor/src/components/url-popover/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/block-editor/src/components/warning/content.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/customize-widgets/src/components/header/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/customize-widgets/src/components/more-menu/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/customize-widgets/src/components/sidebar-block-editor/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-item-actions/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-pagination/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-selection-checkbox/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-view-config/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/pagination/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/page-patterns/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/edit-site/src/components/post-list/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/edit-site/src/components/sidebar-global-styles/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/edit-site/src/components/sidebar-navigation-item/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/sidebar-navigation-screen-details-footer/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-site/src/components/welcome-guide/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-post/src/components/welcome-guide/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/edit-widgets/src/blocks/widget-area/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/edit-widgets/src/components/header/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
+		}
+	},
+	"packages/edit-widgets/src/components/more-menu/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-widgets/src/components/welcome-guide/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-widgets/src/components/sidebar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/hooks/push-changes-to-global-styles/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/blog-title/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/collapsible-block-toolbar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/editor/src/components/document-bar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/document-tools/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/global-styles-sidebar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/editor/src/components/header/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 8
+		}
+	},
+	"packages/editor/src/components/page-attributes/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-content-information/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-excerpt/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-discussion/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/post-featured-image/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/editor/src/components/post-last-revision/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/editor/src/components/post-panel-row/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/post-last-edited-panel/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-revisions-preview/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-publish-panel/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 14
+		}
+	},
+	"packages/editor/src/components/post-status/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/editor/src/components/post-schedule/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-template/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/post-trash/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/post-url/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/posts-per-page/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/sidebar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 3
+		}
+	},
+	"packages/editor/src/components/site-discussion/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/table-of-contents/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/editor/src/components/upload-progress-snackbar/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/visual-editor/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/fields/src/components/media-edit/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/fields/src/fields/slug/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/interface/src/components/complementary-area/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
+		}
+	},
+	"packages/interface/src/components/pinned-items/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/list-reusable-blocks/src/components/import-dropdown/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/media-utils/src/components/media-upload-modal/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 7
+		}
+	},
+	"packages/media-editor/src/components/media-editor/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/media-editor/src/components/media-editor-modal/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 6
+		}
+	},
+	"packages/preferences/src/components/preferences-modal/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/widgets/src/blocks/legacy-widget/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/boot/src/components/navigation/navigation-item/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/boot/src/components/navigation/navigation-screen/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataform-layouts/regular/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/dataviews/src/components/dataform-layouts/panel/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 5
+		}
+	},
+	"packages/dataviews/src/components/dataviews-layouts/activity/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-layouts/picker-table/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/dataviews/src/components/dataviews-layouts/table/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 4
+		}
+	},
+	"packages/dataviews/src/components/dataviews-layouts/list/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
+	"packages/editor/src/components/collaborators-presence/styles/collaborators-list.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 2
+		}
+	},
+	"packages/editor/src/components/collaborators-presence/styles/collaborators-presence.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
 			"count": 1
 		}
 	}

--- a/tools/stylelint/stylelint-suppressions.json
+++ b/tools/stylelint/stylelint-suppressions.json
@@ -1,60 +1,10 @@
 {
-	"widgets/events/style.module.css": {
-		"selector-class-pattern": {
-			"count": 3
-		}
-	},
-	"widgets/quick-draft/style.module.css": {
-		"selector-class-pattern": {
-			"count": 6
-		}
-	},
-	"widgets/site-preview/style.module.css": {
-		"selector-class-pattern": {
-			"count": 8
-		}
-	},
-	"packages/grid/src/dashboard-grid/grid.module.css": {
-		"selector-class-pattern": {
-			"count": 6
-		}
-	},
-	"packages/grid/src/dashboard-lanes/lanes.module.css": {
-		"selector-class-pattern": {
-			"count": 6
-		}
-	},
-	"widgets/news/components/news-list/news-list.module.css": {
-		"selector-class-pattern": {
-			"count": 2
-		}
-	},
-	"widgets/events/components/events-list/events-list.module.css": {
-		"selector-class-pattern": {
-			"count": 5
-		}
-	},
-	"widgets/quick-draft/components/drafts-list/drafts-list.module.css": {
-		"selector-class-pattern": {
-			"count": 5
-		}
-	},
-	"widgets/quick-draft/components/saved-post/saved-post.module.css": {
-		"selector-class-pattern": {
+	"packages/block-editor/src/components/colors-gradients/style.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
 			"count": 1
 		}
 	},
-	"widgets/welcome/components/banner/banner.module.css": {
-		"selector-class-pattern": {
-			"count": 2
-		}
-	},
-	"widgets/welcome/components/feature-highlight/feature-highlight.module.css": {
-		"selector-class-pattern": {
-			"count": 1
-		}
-	},
-	"routes/template-list/add-new-template/style.scss": {
+	"packages/block-editor/src/components/link-control/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
 		}
@@ -64,27 +14,17 @@
 			"count": 2
 		}
 	},
+	"packages/block-library/src/navigation/editor.scss": {
+		"plugin-wpds/no-internal-component-classnames": {
+			"count": 1
+		}
+	},
 	"packages/block-library/src/navigation/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
 		}
 	},
 	"packages/block-library/src/social-link/editor.scss": {
-		"selector-class-pattern": {
-			"count": 1
-		}
-	},
-	"packages/global-styles-ui/src/font-library/style.scss": {
-		"selector-class-pattern": {
-			"count": 2
-		}
-	},
-	"packages/global-styles-ui/src/variations/style.scss": {
-		"selector-class-pattern": {
-			"count": 6
-		}
-	},
-	"packages/block-editor/src/components/link-control/style.scss": {
 		"selector-class-pattern": {
 			"count": 1
 		}
@@ -102,6 +42,76 @@
 	"packages/edit-site/src/components/sidebar-navigation-screen/style.scss": {
 		"selector-class-pattern": {
 			"count": 5
+		}
+	},
+	"packages/global-styles-ui/src/font-library/style.scss": {
+		"selector-class-pattern": {
+			"count": 2
+		}
+	},
+	"packages/global-styles-ui/src/variations/style.scss": {
+		"selector-class-pattern": {
+			"count": 6
+		}
+	},
+	"packages/grid/src/dashboard-grid/grid.module.css": {
+		"selector-class-pattern": {
+			"count": 6
+		}
+	},
+	"packages/grid/src/dashboard-lanes/lanes.module.css": {
+		"selector-class-pattern": {
+			"count": 6
+		}
+	},
+	"routes/template-list/add-new-template/style.scss": {
+		"selector-class-pattern": {
+			"count": 1
+		}
+	},
+	"widgets/events/components/events-list/events-list.module.css": {
+		"selector-class-pattern": {
+			"count": 5
+		}
+	},
+	"widgets/events/style.module.css": {
+		"selector-class-pattern": {
+			"count": 3
+		}
+	},
+	"widgets/news/components/news-list/news-list.module.css": {
+		"selector-class-pattern": {
+			"count": 2
+		}
+	},
+	"widgets/quick-draft/components/drafts-list/drafts-list.module.css": {
+		"selector-class-pattern": {
+			"count": 5
+		}
+	},
+	"widgets/quick-draft/components/saved-post/saved-post.module.css": {
+		"selector-class-pattern": {
+			"count": 1
+		}
+	},
+	"widgets/quick-draft/style.module.css": {
+		"selector-class-pattern": {
+			"count": 6
+		}
+	},
+	"widgets/site-preview/style.module.css": {
+		"selector-class-pattern": {
+			"count": 8
+		}
+	},
+	"widgets/welcome/components/banner/banner.module.css": {
+		"selector-class-pattern": {
+			"count": 2
+		}
+	},
+	"widgets/welcome/components/feature-highlight/feature-highlight.module.css": {
+		"selector-class-pattern": {
+			"count": 1
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

(Prototype)

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Stylelint config for linting overrides for `@wordpress/components`.

Disallows attempts like:
```css
.my-panel .components-button {
	margin: 0;
}
```
Allows things like:
```jsx
<Button className="my-component-override">Example</Button>
```
```css
.my-panel .my-component-override {
	margin: 0;
}
```

Targeted more for 3rd-party consumers to avoid plugin developers targeting the component's internals. Linter guidance reasons both the "not stable API" argument as well as just discouraging component style overrides in general.

- Includes both `component-*` and `components-*` selectors; not sure yet what's the difference if any.
- Now in the theme package but could be in components, in shared wp stylelint config (likely best), or somewhere else. Doesn't matter much for a prototype now.
- Updates `tools/stylelint/stylelint-suppressions.json` with all local usage in Gutenberg. There could be argument about not needing this rule applied for Gutenberg repo since everything here is changed in lockstep; Gutenberg UIs and components themselves.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
