### PR TITLE
Playlist: Update @since tags to 7.1.0

### DIFF
--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -8,7 +8,7 @@
 /**
  * Renders the `core/playlist-track` block on server.
  *
- * @since 6.9.0
+ * @since 7.1.0
  *
  * @param array         $attributes The block attributes.
  * @param string        $content    The block content.
@@ -68,7 +68,7 @@ function render_block_core_playlist_track( $attributes, $content = '', $block = 
 /**
  * Registers the `core/playlist-track` block on server.
  *
- * @since 6.9.0
+ * @since 7.1.0
  */
 function register_block_core_playlist_track() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -8,7 +8,7 @@
 /**
  * Renders the `core/playlist` block on server.
  *
- * @since 6.9.0
+ * @since 7.1.0
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
@@ -197,7 +197,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 /**
  * Registers the `core/playlist` block on server.
  *
- * @since 6.9.0
+ * @since 7.1.0
  */
 function register_block_core_playlist() {
 	register_block_type_from_metadata(


### PR DESCRIPTION
## What?

Update the `@since` tags of the Playlist and Playlist Track blocks from `6.9.0` to `7.1.0`.

## Why?

The `@since` version should be the WordPress core version in which the code first ships. These blocks will not ship in 6.9.0, so the tags need to reflect the actual release version, 7.1.0.

## Testing Instructions

No functional change;

## Use of AI Tools

Authored with the assistance of Claude Code.
