### PR TITLE
Table of Contents: render front-end list from current post headings

### DIFF
--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -6,6 +6,11 @@
  */
 
 /**
+ * The Heading block's default level when no `level` attribute is saved.
+ */
+const BLOCK_CORE_TABLE_OF_CONTENTS_DEFAULT_HEADING_LEVEL = 2;
+
+/**
  * Adds an aria-label to the table of contents block content.
  *
  * @param array  $attributes Attributes of the block being rendered.
@@ -33,8 +38,13 @@ function block_core_table_of_contents_add_aria_label( $attributes, $content ) {
 /**
  * Gets the link for a heading.
  *
+ * Headings without an id cannot be linked. Non-paginated posts can use a local
+ * fragment link. Paginated posts need a full permalink so headings on later
+ * pages link to the correct page before applying the fragment.
+ *
  * @param string $id      Heading id.
- * @param array  $context Heading resolution context.
+ * @param array  $context Heading resolution context used while scanning the
+ *                        post content.
  *
  * @return string Heading link.
  */
@@ -50,6 +60,8 @@ function block_core_table_of_contents_get_heading_link( $id, $context = array() 
 	$page      = isset( $context['current_page'] ) ? max( 1, (int) $context['current_page'] ) : 1;
 	$permalink = remove_query_arg( 'page', $context['permalink'] );
 
+	// Page 1 uses the canonical permalink, e.g. `/post/#intro`. Later pages use
+	// the page query arg before the fragment, e.g. `/post/?page=2#details`.
 	if ( 1 < $page ) {
 		$permalink = add_query_arg( 'page', $page, $permalink );
 	}
@@ -60,11 +72,19 @@ function block_core_table_of_contents_get_heading_link( $id, $context = array() 
 /**
  * Normalizes raw page break comments so the block processor can see them.
  *
+ * Classic content can store page breaks as bare `<!--nextpage-->` markers, and
+ * the Page Break block also saves that marker as its inner content. Because
+ * `WP_Block_Processor` only advances through block comments, wrapping those
+ * markers as `core/nextpage` blocks lets the ToC count paginated post pages in
+ * the same pass that it scans headings.
+ *
  * @param string $content Serialized block content.
  *
  * @return string Content with page breaks wrapped as nextpage blocks.
  */
 function block_core_table_of_contents_normalize_nextpage_blocks( $content ) {
+	// Collapse already-wrapped nextpage blocks first so the replacement below
+	// never nests a page break inside another nextpage wrapper.
 	$content = preg_replace(
 		'/<!--\s+wp:(?:core\/)?nextpage\s+-->\s*<!--nextpage-->\s*<!--\s+\/wp:(?:core\/)?nextpage\s+-->/',
 		'<!--nextpage-->',
@@ -92,7 +112,9 @@ function block_core_table_of_contents_get_heading_from_block( $block, $max_level
 		return null;
 	}
 
-	$level = isset( $block['attrs']['level'] ) ? (int) $block['attrs']['level'] : 2;
+	$level = isset( $block['attrs']['level'] )
+		? (int) $block['attrs']['level']
+		: BLOCK_CORE_TABLE_OF_CONTENTS_DEFAULT_HEADING_LEVEL;
 
 	if ( $max_level && $level > $max_level ) {
 		return null;
@@ -115,6 +137,10 @@ function block_core_table_of_contents_get_heading_from_block( $block, $max_level
 	}
 
 	$content = preg_replace( '/<br\s*\/?>/i', ' ', $rendered_heading );
+	// Decode entities from rendered heading HTML before the ToC escapes them
+	// once. Use html_entity_decode() because wp_specialchars_decode() only
+	// handles special HTML characters, while headings can contain other named
+	// entities.
 	$content = html_entity_decode(
 		trim( wp_strip_all_tags( $content ) ),
 		ENT_QUOTES,
@@ -134,6 +160,12 @@ function block_core_table_of_contents_get_heading_from_block( $block, $max_level
 
 /**
  * Normalizes heading resolution context.
+ *
+ * The context is the shared state used while walking the current post content.
+ * It tracks whether the post is paginated, which page is being scanned, which
+ * page the rendered ToC should include, and which permalink should be used for
+ * page-aware heading links. Callers can pass partial context, so this helper
+ * fills defaults and normalizes booleans and page numbers before scanning.
  *
  * @param string $content Serialized block content.
  * @param array  $context Heading resolution context.
@@ -188,6 +220,9 @@ function block_core_table_of_contents_get_headings_from_content( $content, $max_
 			continue;
 		}
 
+		// `only_include_current_page` is the normalized form of the block's
+		// `onlyIncludeCurrentPage` attribute. When false, headings from every
+		// paginated page are included.
 		$include_current_page = (
 			empty( $context['only_include_current_page'] ) ||
 			$context['current_page'] === $context['target_page']
@@ -246,6 +281,9 @@ function block_core_table_of_contents_linear_to_nested_heading_list( $headings )
 			isset( $headings[ $index + 1 ] ) &&
 			$headings[ $index + 1 ]['level'] > $heading['level']
 		) {
+			// The following headings are children until another heading at
+			// the current level appears. Slice that child run for recursion
+			// so nested nodes are not duplicated as top-level siblings.
 			$end_of_slice = count( $headings );
 			for ( $i = $index + 1; $i < count( $headings ); $i++ ) {
 				if ( $headings[ $i ]['level'] === $heading['level'] ) {
@@ -254,15 +292,16 @@ function block_core_table_of_contents_linear_to_nested_heading_list( $headings )
 				}
 			}
 
+			// The child slice starts after the current heading, so each
+			// recursive call receives fewer headings than its caller.
+			$child_headings    = array_slice(
+				$headings,
+				$index + 1,
+				$end_of_slice - $index - 1
+			);
 			$nested_headings[] = array(
 				'heading'  => $heading,
-				'children' => block_core_table_of_contents_linear_to_nested_heading_list(
-					array_slice(
-						$headings,
-						$index + 1,
-						$end_of_slice - $index - 1
-					)
-				),
+				'children' => block_core_table_of_contents_linear_to_nested_heading_list( $child_headings ),
 			);
 		} else {
 			$nested_headings[] = array(
@@ -340,7 +379,9 @@ function block_core_table_of_contents_render( $attributes, $content ) {
 	}
 
 	$max_level = isset( $attributes['maxLevel'] ) ? (int) $attributes['maxLevel'] : 0;
-	$context   = block_core_table_of_contents_normalize_heading_context(
+	// Heading context records the current pagination state so collection can
+	// skip headings outside the rendered page and build page-aware links.
+	$context  = block_core_table_of_contents_normalize_heading_context(
 		$post->post_content,
 		array(
 			'only_include_current_page' => ! empty( $attributes['onlyIncludeCurrentPage'] ),
@@ -348,7 +389,7 @@ function block_core_table_of_contents_render( $attributes, $content ) {
 			'target_page'               => block_core_table_of_contents_get_current_page_number(),
 		)
 	);
-	$headings  = block_core_table_of_contents_get_headings_from_content( $post->post_content, $max_level, $context );
+	$headings = block_core_table_of_contents_get_headings_from_content( $post->post_content, $max_level, $context );
 
 	if ( empty( $headings ) ) {
 		return '';

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -115,7 +115,11 @@ function block_core_table_of_contents_get_heading_from_block( $block, $max_level
 	}
 
 	$content = preg_replace( '/<br\s*\/?>/i', ' ', $rendered_heading );
-	$content = trim( wp_strip_all_tags( $content ) );
+	$content = html_entity_decode(
+		trim( wp_strip_all_tags( $content ) ),
+		ENT_QUOTES,
+		get_option( 'blog_charset' )
+	);
 
 	if ( '' === $content ) {
 		return null;

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -13,7 +13,7 @@
  *
  * @return string The content of the block being rendered.
  */
-function block_core_table_of_contents_render( $attributes, $content ) {
+function block_core_table_of_contents_add_aria_label( $attributes, $content ) {
 	if ( ! $content ) {
 		return $content;
 	}
@@ -28,6 +28,344 @@ function block_core_table_of_contents_render( $attributes, $content ) {
 	}
 
 	return $p->get_updated_html();
+}
+
+/**
+ * Gets the link for a heading.
+ *
+ * @param string $id      Heading id.
+ * @param array  $context Heading resolution context.
+ *
+ * @return string Heading link.
+ */
+function block_core_table_of_contents_get_heading_link( $id, $context = array() ) {
+	if ( '' === $id ) {
+		return '';
+	}
+
+	if ( empty( $context['is_paginated'] ) || empty( $context['permalink'] ) ) {
+		return '#' . $id;
+	}
+
+	$page      = isset( $context['current_page'] ) ? max( 1, (int) $context['current_page'] ) : 1;
+	$permalink = remove_query_arg( 'page', $context['permalink'] );
+
+	if ( 1 < $page ) {
+		$permalink = add_query_arg( 'page', $page, $permalink );
+	}
+
+	return $permalink . '#' . $id;
+}
+
+/**
+ * Normalizes raw page break comments so the block processor can see them.
+ *
+ * @param string $content Serialized block content.
+ *
+ * @return string Content with page breaks wrapped as nextpage blocks.
+ */
+function block_core_table_of_contents_normalize_nextpage_blocks( $content ) {
+	$content = preg_replace(
+		'/<!--\s+wp:(?:core\/)?nextpage\s+-->\s*<!--nextpage-->\s*<!--\s+\/wp:(?:core\/)?nextpage\s+-->/',
+		'<!--nextpage-->',
+		$content
+	);
+
+	return str_replace(
+		'<!--nextpage-->',
+		'<!-- wp:nextpage --><!--nextpage--><!-- /wp:nextpage -->',
+		$content
+	);
+}
+
+/**
+ * Gets the heading data from a heading block.
+ *
+ * @param array $block     Parsed heading block.
+ * @param int   $max_level Maximum heading level to include.
+ * @param array $context   Heading resolution context.
+ *
+ * @return array|null Heading data, or null when the heading should be skipped.
+ */
+function block_core_table_of_contents_get_heading_from_block( $block, $max_level, $context = array() ) {
+	if ( ! is_array( $block ) ) {
+		return null;
+	}
+
+	$level = isset( $block['attrs']['level'] ) ? (int) $block['attrs']['level'] : 2;
+
+	if ( $max_level && $level > $max_level ) {
+		return null;
+	}
+
+	$rendered_heading = render_block( $block );
+	$processor        = new WP_HTML_Tag_Processor( $rendered_heading );
+	$heading_tags     = array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' );
+	$id               = '';
+
+	while ( $processor->next_tag() ) {
+		if ( in_array( $processor->get_tag(), $heading_tags, true ) ) {
+			$id = $processor->get_attribute( 'id' );
+			break;
+		}
+	}
+
+	if ( ! is_string( $id ) ) {
+		$id = '';
+	}
+
+	$content = preg_replace( '/<br\s*\/?>/i', ' ', $rendered_heading );
+	$content = trim( wp_strip_all_tags( $content ) );
+
+	if ( '' === $content ) {
+		return null;
+	}
+
+	return array(
+		'content' => $content,
+		'level'   => $level,
+		'link'    => block_core_table_of_contents_get_heading_link( $id, $context ),
+	);
+}
+
+/**
+ * Normalizes heading resolution context.
+ *
+ * @param string $content Serialized block content.
+ * @param array  $context Heading resolution context.
+ *
+ * @return array Normalized heading resolution context.
+ */
+function block_core_table_of_contents_normalize_heading_context( $content, $context = array() ) {
+	$context = wp_parse_args(
+		$context,
+		array(
+			'current_page'              => 1,
+			'is_paginated'              => false !== strpos( $content, '<!--nextpage-->' ),
+			'only_include_current_page' => false,
+			'permalink'                 => '',
+			'target_page'               => 1,
+		)
+	);
+
+	return array(
+		'current_page'              => max( 1, (int) $context['current_page'] ),
+		'is_paginated'              => ! empty( $context['is_paginated'] ),
+		'only_include_current_page' => ! empty( $context['only_include_current_page'] ),
+		'permalink'                 => $context['permalink'],
+		'target_page'               => max( 1, (int) $context['target_page'] ),
+	);
+}
+
+/**
+ * Collects heading data from block content.
+ *
+ * @param string $content   Block content to scan.
+ * @param int    $max_level Maximum heading level to include.
+ * @param array  $context   Heading resolution context.
+ *
+ * @return array Heading data.
+ */
+function block_core_table_of_contents_get_headings_from_content( $content, $max_level = 0, $context = array() ) {
+	if ( ! class_exists( 'WP_Block_Processor' ) || '' === trim( $content ) ) {
+		return array();
+	}
+
+	$content   = block_core_table_of_contents_normalize_nextpage_blocks( $content );
+	$context   = block_core_table_of_contents_normalize_heading_context( $content, $context );
+	$headings  = array();
+	$processor = new WP_Block_Processor( $content );
+
+	while ( $processor->next_block() ) {
+		$block_type = $processor->get_block_type();
+
+		if ( 'core/nextpage' === $block_type ) {
+			++$context['current_page'];
+			continue;
+		}
+
+		$include_current_page = (
+			empty( $context['only_include_current_page'] ) ||
+			$context['current_page'] === $context['target_page']
+		);
+
+		if ( 'core/heading' !== $block_type || ! $include_current_page ) {
+			continue;
+		}
+
+		$block   = $processor->extract_full_block_and_advance();
+		$heading = block_core_table_of_contents_get_heading_from_block( $block, $max_level, $context );
+
+		if ( $heading ) {
+			$headings[] = $heading;
+		}
+	}
+
+	return $headings;
+}
+
+/**
+ * Gets the current page number for paginated post content.
+ *
+ * @return int Current page number.
+ */
+function block_core_table_of_contents_get_current_page_number() {
+	global $page;
+
+	$current_page = (int) get_query_var( 'page' );
+	if ( ! $current_page && isset( $page ) ) {
+		$current_page = (int) $page;
+	}
+
+	return max( 1, $current_page );
+}
+
+/**
+ * Converts a flat list of headings to a nested list.
+ *
+ * @param array $headings Flat heading data.
+ *
+ * @return array Nested heading data.
+ */
+function block_core_table_of_contents_linear_to_nested_heading_list( $headings ) {
+	$nested_headings = array();
+
+	foreach ( $headings as $index => $heading ) {
+		if (
+			'' === $heading['content'] ||
+			$heading['level'] !== $headings[0]['level']
+		) {
+			continue;
+		}
+
+		if (
+			isset( $headings[ $index + 1 ] ) &&
+			$headings[ $index + 1 ]['level'] > $heading['level']
+		) {
+			$end_of_slice = count( $headings );
+			for ( $i = $index + 1; $i < count( $headings ); $i++ ) {
+				if ( $headings[ $i ]['level'] === $heading['level'] ) {
+					$end_of_slice = $i;
+					break;
+				}
+			}
+
+			$nested_headings[] = array(
+				'heading'  => $heading,
+				'children' => block_core_table_of_contents_linear_to_nested_heading_list(
+					array_slice(
+						$headings,
+						$index + 1,
+						$end_of_slice - $index - 1
+					)
+				),
+			);
+		} else {
+			$nested_headings[] = array(
+				'heading'  => $heading,
+				'children' => null,
+			);
+		}
+	}
+
+	return $nested_headings;
+}
+
+/**
+ * Builds the table of contents list items.
+ *
+ * @param array  $nested_headings Nested heading data.
+ * @param string $list_tag        List tag name.
+ *
+ * @return string List item markup.
+ */
+function block_core_table_of_contents_build_list_items( $nested_headings, $list_tag ) {
+	$list = '';
+
+	foreach ( $nested_headings as $node ) {
+		$heading = $node['heading'];
+		$content = esc_html( $heading['content'] );
+
+		if ( '' !== $heading['link'] ) {
+			$entry = sprintf(
+				'<a class="wp-block-table-of-contents__entry" href="%1$s">%2$s</a>',
+				esc_url( $heading['link'] ),
+				$content
+			);
+		} else {
+			$entry = sprintf(
+				'<span class="wp-block-table-of-contents__entry">%s</span>',
+				$content
+			);
+		}
+
+		$list .= '<li>' . $entry;
+
+		if ( ! empty( $node['children'] ) ) {
+			$list .= sprintf(
+				'<%1$s>%2$s</%1$s>',
+				$list_tag,
+				block_core_table_of_contents_build_list_items( $node['children'], $list_tag )
+			);
+		}
+
+		$list .= '</li>';
+	}
+
+	return $list;
+}
+
+/**
+ * Renders the table of contents block from current post headings.
+ *
+ * @param array  $attributes Attributes of the block being rendered.
+ * @param string $content Content of the block being rendered.
+ *
+ * @return string The content of the block being rendered.
+ */
+function block_core_table_of_contents_render( $attributes, $content ) {
+	global $wp_current_filter;
+
+	if ( ! is_array( $wp_current_filter ) || ! in_array( 'the_content', $wp_current_filter, true ) ) {
+		return block_core_table_of_contents_add_aria_label( $attributes, $content );
+	}
+
+	$post = get_post();
+	if ( ! $post ) {
+		return '';
+	}
+
+	$max_level = isset( $attributes['maxLevel'] ) ? (int) $attributes['maxLevel'] : 0;
+	$context   = block_core_table_of_contents_normalize_heading_context(
+		$post->post_content,
+		array(
+			'only_include_current_page' => ! empty( $attributes['onlyIncludeCurrentPage'] ),
+			'permalink'                 => get_permalink( $post ),
+			'target_page'               => block_core_table_of_contents_get_current_page_number(),
+		)
+	);
+	$headings  = block_core_table_of_contents_get_headings_from_content( $post->post_content, $max_level, $context );
+
+	if ( empty( $headings ) ) {
+		return '';
+	}
+
+	$ordered            = array_key_exists( 'ordered', $attributes )
+		? (bool) $attributes['ordered']
+		: true;
+	$list_tag           = $ordered ? 'ol' : 'ul';
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$content            = sprintf(
+		'<nav %1$s><%2$s>%3$s</%2$s></nav>',
+		$wrapper_attributes,
+		$list_tag,
+		block_core_table_of_contents_build_list_items(
+			block_core_table_of_contents_linear_to_nested_heading_list( $headings ),
+			$list_tag
+		)
+	);
+
+	return block_core_table_of_contents_add_aria_label( $attributes, $content );
 }
 
 /**

--- a/phpunit/blocks/render-block-table-of-contents-test.php
+++ b/phpunit/blocks/render-block-table-of-contents-test.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Tests for the Table of Contents block rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Table_Of_Contents_Test extends WP_UnitTestCase {
+
+	public function tear_down() {
+		unset( $GLOBALS['page'] );
+		wp_reset_postdata();
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_uses_current_post_headings_instead_of_saved_headings() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(
+							array(
+								'headings' => array(
+									array(
+										'content' => 'Stale section',
+										'level'   => 2,
+										'link'    => '#stale-section',
+									),
+								),
+							),
+							'<nav class="wp-block-table-of-contents"><ol><li><a class="wp-block-table-of-contents__entry" href="#stale-section">Stale section</a></li></ol></nav>'
+						),
+						$this->heading_block( 'Current section', 'current-section' ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id ) );
+
+		$this->assertStringContainsString( 'Current section', $nav );
+		$this->assertStringContainsString( '#current-section', $nav );
+		$this->assertStringNotContainsString( 'Stale section', $nav );
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_returns_empty_markup_when_the_current_post_has_no_headings() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(),
+						'<!-- wp:paragraph --><p>No headings here.</p><!-- /wp:paragraph -->',
+					)
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString(
+			'wp-block-table-of-contents',
+			$this->render_post_content( $post_id )
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_respects_ordering_and_max_heading_level() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(
+							array(
+								'maxLevel' => 3,
+								'ordered'  => false,
+							)
+						),
+						$this->heading_block( 'Section', 'section', 2 ),
+						$this->heading_block( 'Subsection', 'subsection', 3 ),
+						$this->heading_block( 'Detailed aside', 'detailed-aside', 4 ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id ) );
+
+		$this->assertStringContainsString( '<ul>', $nav );
+		$this->assertStringContainsString( 'Section', $nav );
+		$this->assertStringContainsString( 'Subsection', $nav );
+		$this->assertStringNotContainsString( 'Detailed aside', $nav );
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_nests_subheadings_under_their_parent_heading() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(),
+						$this->heading_block( 'Main Section', 'main-section', 2 ),
+						$this->heading_block( 'Subsection', 'subsection', 3 ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id ) );
+
+		$this->assertStringContainsString(
+			'<a class="wp-block-table-of-contents__entry" href="#main-section">Main Section</a><ol><li><a class="wp-block-table-of-contents__entry" href="#subsection">Subsection</a></li></ol>',
+			$nav
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_uses_a_span_for_unanchored_headings() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(),
+						$this->heading_block( 'Unlinked section', '' ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id ) );
+
+		$this->assertStringContainsString(
+			'<span class="wp-block-table-of-contents__entry">Unlinked section</span>',
+			$nav
+		);
+		$this->assertStringNotContainsString( '<a class="wp-block-table-of-contents__entry"', $nav );
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_only_include_current_page_uses_current_paginated_page() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(
+							array(
+								'onlyIncludeCurrentPage' => true,
+							)
+						),
+						$this->heading_block( 'Page one heading', 'page-one-heading' ),
+						$this->nextpage_block(),
+						$this->heading_block( 'Page two heading', 'page-two-heading' ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id, 2 ) );
+
+		$this->assertStringContainsString( 'Page two heading', $nav );
+		$this->assertStringNotContainsString( 'Page one heading', $nav );
+		$this->assertStringContainsString( 'page=2#page-two-heading', $nav );
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_all_paginated_headings_links_to_each_page_when_current_page_filtering_is_disabled() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(),
+						$this->heading_block( 'Page one heading', 'page-one-heading' ),
+						$this->nextpage_block(),
+						$this->heading_block( 'Page two heading', 'page-two-heading' ),
+					)
+				),
+			)
+		);
+
+		$nav       = $this->get_table_of_contents_html( $this->render_post_content( $post_id, 2 ) );
+		$permalink = get_permalink( $post_id );
+
+		$this->assertStringContainsString( 'Page one heading', $nav );
+		$this->assertStringContainsString( 'Page two heading', $nav );
+		$this->assertStringContainsString( 'href="' . esc_url( $permalink . '#page-one-heading' ) . '"', $nav );
+		$this->assertStringContainsString(
+			'href="' . esc_url( add_query_arg( 'page', 2, $permalink ) . '#page-two-heading' ) . '"',
+			$nav
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
+	public function test_render_preserves_saved_markup_outside_the_content_filter() {
+		$rendered = gutenberg_block_core_table_of_contents_render(
+			array(),
+			'<nav class="wp-block-table-of-contents"><ol><li><a class="wp-block-table-of-contents__entry" href="#saved-section">Saved section</a></li></ol></nav>'
+		);
+
+		$this->assertStringContainsString( 'Saved section', $rendered );
+		$this->assertStringContainsString( 'aria-label="Table of Contents"', $rendered );
+	}
+
+	private function render_post_content( $post_id, $page_number = 1 ) {
+		global $page;
+
+		$url = add_query_arg( 'p', $post_id, home_url( '/' ) );
+		if ( 1 < $page_number ) {
+			$url = add_query_arg( 'page', $page_number, $url );
+		}
+
+		$this->go_to( $url );
+		$GLOBALS['post'] = get_post( $post_id );
+		setup_postdata( $GLOBALS['post'] );
+		$page = $page_number;
+
+		return apply_filters( 'the_content', $GLOBALS['post']->post_content );
+	}
+
+	private function get_table_of_contents_html( $content ) {
+		$matched = preg_match(
+			'/<nav\b[^>]*class="[^"]*\bwp-block-table-of-contents\b[^"]*"[^>]*>.*?<\/nav>/s',
+			$content,
+			$matches
+		);
+
+		$this->assertSame( 1, $matched, 'Expected rendered table of contents markup.' );
+
+		return $matches[0];
+	}
+
+	private function table_of_contents_block( $attributes = array(), $content = '' ) {
+		$serialized_attributes = empty( $attributes ) ? '' : ' ' . wp_json_encode( $attributes );
+
+		if ( '' === $content ) {
+			return '<!-- wp:table-of-contents' . $serialized_attributes . ' /-->';
+		}
+
+		return '<!-- wp:table-of-contents' . $serialized_attributes . ' -->' . $content . '<!-- /wp:table-of-contents -->';
+	}
+
+	private function heading_block( $content, $anchor = '', $level = 2 ) {
+		$attributes = array(
+			'level' => $level,
+		);
+		if ( '' !== $anchor ) {
+			$attributes['anchor'] = $anchor;
+		}
+
+		$id = '' === $anchor ? '' : ' id="' . esc_attr( $anchor ) . '"';
+
+		return sprintf(
+			'<!-- wp:heading %1$s --><h%2$d%3$s class="wp-block-heading">%4$s</h%2$d><!-- /wp:heading -->',
+			wp_json_encode( $attributes ),
+			$level,
+			$id,
+			esc_html( $content )
+		);
+	}
+
+	private function nextpage_block() {
+		return '<!--nextpage-->';
+	}
+}

--- a/phpunit/blocks/render-block-table-of-contents-test.php
+++ b/phpunit/blocks/render-block-table-of-contents-test.php
@@ -160,6 +160,29 @@ class Tests_Blocks_Render_Table_Of_Contents_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::gutenberg_block_core_table_of_contents_render
 	 */
+	public function test_render_escapes_heading_entities_once() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => implode(
+					"\n",
+					array(
+						$this->table_of_contents_block(),
+						$this->heading_block( 'Research & Development', 'research-development' ),
+					)
+				),
+			)
+		);
+
+		$nav = $this->get_table_of_contents_html( $this->render_post_content( $post_id ) );
+
+		$this->assertStringContainsString( 'Research &amp; Development', $nav );
+		$this->assertStringNotContainsString( '&amp;amp;', $nav );
+	}
+
+	/**
+	 * @covers ::gutenberg_block_core_table_of_contents_render
+	 */
 	public function test_render_only_include_current_page_uses_current_paginated_page() {
 		$post_id = self::factory()->post->create(
 			array(

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -337,68 +337,67 @@ test.describe( 'Table of Contents', () => {
 	} );
 
 	test.describe( 'Reading and navigating', () => {
-		// Desired behavior: the front-of-site ToC should render from the current post headings even when content changes outside the editor; trunk only reflects headings captured when the block was last updated in the editor.
-		test.fixme(
-			'front-of-site table of contents reflects updated post headings',
-			async ( { admin, editor, page, requestUtils } ) => {
-				await admin.createNewPost();
-				await editor.setContent(
-					postContentWithTocAndHeadings( [
-						{
-							content: 'Original section',
-							anchor: 'original-section',
-						},
-					] )
-				);
+		test( 'front-of-site table of contents reflects updated post headings', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{
+						content: 'Original section',
+						anchor: 'original-section',
+					},
+				] )
+			);
 
-				const postId = await editor.publishPost();
-				await openPostOnFrontend( page, postId );
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
 
-				await expect(
-					page
-						.getByRole( 'navigation', {
-							name: 'Table of Contents',
-						} )
-						.getByRole( 'link', { name: 'Original section' } )
-				).toBeVisible();
-
-				// Update the post content without opening the editor so the reader view must reflect the current post headings.
-				await updatePostContent(
-					requestUtils,
-					postId,
-					postContentWithTocAndHeadings( [
-						{
-							content: 'Updated section',
-							anchor: 'updated-section',
-						},
-					] )
-				);
-
-				await openPostOnFrontend( page, postId );
-
-				const tableOfContents = page.getByRole( 'navigation', {
-					name: 'Table of Contents',
-				} );
-				await expect(
-					tableOfContents.getByRole( 'link', {
-						name: 'Updated section',
+			await expect(
+				page
+					.getByRole( 'navigation', {
+						name: 'Table of Contents',
 					} )
-				).toBeVisible();
-				await expect(
-					tableOfContents.getByRole( 'link', {
-						name: 'Original section',
-					} )
-				).toHaveCount( 0 );
+					.getByRole( 'link', { name: 'Original section' } )
+			).toBeVisible();
 
-				await tableOfContents
-					.getByRole( 'link', { name: 'Updated section' } )
-					.click();
-				await expect( page ).toHaveURL( /#updated-section$/ );
-				await expect(
-					page.locator( '#updated-section' )
-				).toBeInViewport();
-			}
-		);
+			// Update the post content without opening the editor so the reader view must reflect the current post headings.
+			await updatePostContent(
+				requestUtils,
+				postId,
+				postContentWithTocAndHeadings( [
+					{
+						content: 'Updated section',
+						anchor: 'updated-section',
+					},
+				] )
+			);
+
+			await openPostOnFrontend( page, postId );
+
+			const tableOfContents = page.getByRole( 'navigation', {
+				name: 'Table of Contents',
+			} );
+			await expect(
+				tableOfContents.getByRole( 'link', {
+					name: 'Updated section',
+				} )
+			).toBeVisible();
+			await expect(
+				tableOfContents.getByRole( 'link', {
+					name: 'Original section',
+				} )
+			).toHaveCount( 0 );
+
+			await tableOfContents
+				.getByRole( 'link', { name: 'Updated section' } )
+				.click();
+			await expect( page ).toHaveURL( /#updated-section$/ );
+			await expect( page.locator( '#updated-section' ) ).toBeInViewport();
+		} );
 
 		test( 'clicking a table of contents item on the front of site scrolls to the matching section', async ( {
 			page,
@@ -889,6 +888,81 @@ test.describe( 'Table of Contents', () => {
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
 		} );
+
+		// Desired behavior: ToC should use the visible customized heading text from synced pattern overrides; this PR only handles direct core Heading blocks.
+		test.fixme(
+			'shows the customized synced pattern heading in the front-of-site table of contents',
+			async ( { page, requestUtils } ) => {
+				const customizableHeadingName = 'Section title';
+				const syncedPattern = await requestUtils.createBlock( {
+					title: 'Reusable section',
+					status: 'publish',
+					content: `<!-- wp:heading {"anchor":"custom-section-title","metadata":{"name":"${ customizableHeadingName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+<h2 id="custom-section-title" class="wp-block-heading">Reusable section title</h2>
+<!-- /wp:heading -->`,
+				} );
+				const post = await createPostWithContent(
+					requestUtils,
+					'Customized synced pattern table of contents',
+					[
+						'<!-- wp:table-of-contents /-->',
+						`<!-- wp:block {"ref":${ syncedPattern.id },"content":{"${ customizableHeadingName }":{"content":"Custom section title"}}} /-->`,
+					].join( '\n\n' )
+				);
+
+				await openPostOnFrontend( page, post.id );
+
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'Custom section title',
+					} )
+				).toBeVisible();
+				const tableOfContents = page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} );
+				await expect(
+					tableOfContents.getByRole( 'link', {
+						name: 'Custom section title',
+					} )
+				).toHaveAttribute( 'href', /#custom-section-title$/ );
+				await expect(
+					tableOfContents.getByText( 'Reusable section title' )
+				).toHaveCount( 0 );
+			}
+		);
+
+		// Desired behavior: ToC should include registered pattern headings once server-side referenced-content traversal is implemented.
+		test.fixme(
+			'registered pattern block headings appear in the front-of-site table of contents',
+			async ( { page, requestUtils } ) => {
+				const post = await createPostWithContent(
+					requestUtils,
+					'Registered pattern heading table of contents',
+					[
+						'<!-- wp:table-of-contents /-->',
+						'<!-- wp:pattern {"slug":"gutenberg-test/table-of-contents-pattern-heading"} /-->',
+					].join( '\n\n' )
+				);
+
+				await openPostOnFrontend( page, post.id );
+
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'Registered pattern heading',
+						exact: true,
+					} )
+				).toBeVisible();
+				await expect(
+					page
+						.getByRole( 'navigation', {
+							name: 'Table of Contents',
+						} )
+						.getByRole( 'link', {
+							name: 'Registered pattern heading',
+						} )
+				).toHaveAttribute( 'href', /#registered-pattern-heading$/ );
+			}
+		);
 
 		// This covers the author story that headings should count no matter which block created them.
 		// Desired behavior: ToC should extract heading elements from non-Heading blocks; trunk only observes core Heading blocks.

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -223,6 +223,72 @@ test.describe( 'Table of Contents', () => {
 			).toBeVisible();
 		} );
 
+		test( 'uses the anchor chosen for a heading after publish', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			const headingText = 'Chosen section';
+			const chosenAnchor = 'reader-picked-section';
+			const post = await requestUtils.createPost( {
+				title: 'Chosen anchor table of contents',
+				content: postContentWithTocAndHeadings( [
+					{ content: headingText },
+				] ),
+				status: 'draft',
+			} );
+
+			await admin.editPost( post.id );
+
+			await editor.canvas
+				.getByText( headingText, { exact: true } )
+				.last()
+				.click();
+			await editor.openDocumentSettingsSidebar();
+			const editorSettings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			await editorSettings
+				.getByRole( 'button', { name: 'Advanced' } )
+				.click();
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'textbox', { name: /HTML anchor/i } )
+				.fill( chosenAnchor );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{ name: 'core/table-of-contents' },
+				{
+					name: 'core/heading',
+					attributes: {
+						content: headingText,
+						anchor: chosenAnchor,
+					},
+				},
+			] );
+
+			const postId = await editor.publishPost();
+			await openPostOnFrontend( page, postId );
+
+			const link = page
+				.getByRole( 'navigation', { name: 'Table of Contents' } )
+				.getByRole( 'link', { name: headingText } );
+
+			await expect( link ).toHaveAttribute(
+				'href',
+				new RegExp( `#${ chosenAnchor }$` )
+			);
+
+			await link.click();
+			await expect( page ).toHaveURL(
+				new RegExp( `#${ chosenAnchor }$` )
+			);
+			await expect(
+				page.locator( `#${ chosenAnchor }` )
+			).toBeInViewport();
+		} );
+
 		test( 'limits visible heading levels in the editor and after publish when the block setting changes', async ( {
 			editor,
 			page,

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -817,6 +817,53 @@ test.describe( 'Table of Contents', () => {
 			}
 		);
 
+		// Desired behavior: a template-level ToC should still create working
+		// links when headings were authored in the Post Editor without a ToC in
+		// post content. In that scenario, the Single template contains the ToC,
+		// `generateAnchors` keeps its default false value, and the template is
+		// never loaded while editing the post. That means the Heading block's
+		// ToC-triggered editor auto-anchor generation never runs for the post
+		// heading, so template ToC support needs a separate anchor strategy.
+		test.fixme(
+			'a table of contents in a shared template links to post headings created without a post-level table of contents',
+			async ( { page, requestUtils } ) => {
+				await requestUtils.createTemplate( 'wp_template', {
+					// The single template slug makes this template apply to posts viewed on the front of site.
+					slug: 'single',
+					title: 'Single',
+					content: [
+						'<!-- wp:table-of-contents /-->',
+						'<!-- wp:post-content {"layout":{"inherit":true}} /-->',
+					].join( '\n\n' ),
+				} );
+				const post = await createPostWithContent(
+					requestUtils,
+					'Unanchored templated post',
+					headingBlock( {
+						content: 'Post editor section',
+					} )
+				);
+
+				await openPostOnFrontend( page, post.id );
+
+				const tableOfContents = page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} );
+				const link = tableOfContents.getByRole( 'link', {
+					name: 'Post editor section',
+				} );
+				await expect( link ).toHaveAttribute(
+					'href',
+					/#post-editor-section$/
+				);
+				await link.click();
+				await expect( page ).toHaveURL( /#post-editor-section$/ );
+				await expect(
+					page.locator( '#post-editor-section' )
+				).toBeInViewport();
+			}
+		);
+
 		// Desired behavior: ToC in template editing should explain that it uses viewed post headings; trunk only shows the generic empty-heading placeholder.
 		test.fixme(
 			'template editing explains when a live example cannot be shown and the front of site uses the viewed post',


### PR DESCRIPTION
## What

This updates the Table of Contents block so the front of site renders its list from the headings in the current post content instead of relying on heading data saved to block markup during the last editor session.

Part of https://github.com/WordPress/gutenberg/issues/42229

Alternative to https://github.com/WordPress/gutenberg/pull/72110

## Why

Saved heading data can become stale when content changes outside the editor. Rendering from current post headings keeps the reader-facing ToC aligned with the displayed post.

## How

This PR intentionally handles only the minimal dynamic-rendering path: direct `core/heading` blocks in current post content. It preserves existing support for ordering, maximum heading depth, current-page filtering, pagination links, empty output, nested lists, escaping, wrapper attributes, and aria labels.

Skipped e2e `fixme` specs document follow-up behavior without expanding this review. Known follow-up edge cases include:

- ToC blocks placed in shared templates or template parts.
- Headings inside synced patterns, registered patterns, and template parts.
- Synced pattern overrides where visible heading text differs from source content.
- Draft, password-protected, cross-theme, or otherwise unrenderable referenced content.
- Recursive/cyclic references and repeated sibling references.
- Template part source precedence between database customizations and theme files.
- Heading elements produced by non-Heading blocks or future plugin heading-source contracts.

## Out of Scope

- Editor and saved block markup behavior are deliberately unchanged in this PR. The block still serializes its `headings` attribute and saved `<nav>` markup for compatibility, while front-of-site rendering during `the_content` ignores that saved heading list and rebuilds from the current post content.
- Generating missing heading anchors is deliberately out of scope. This PR consumes the rendered heading `id` when one exists and renders an unlinked entry when it does not. It does not add a shared server-side heading anchor algorithm or inject generated IDs into heading markup.
- Template-level ToCs remain a follow-up, including the anchor gap where a ToC lives in a Single template but headings are authored in the Post Editor with `generateAnchors` left false and no post-level ToC. In that scenario the Heading block's ToC-triggered editor auto-generation never runs for the post heading, so the future template path needs a separate anchor strategy. A skipped e2e spec now documents this expected behavior.
- A follow-up PR can evaluate whether to stop serializing heading data once the dynamic render path is established.
- A follow-up PR will refactor the Table of Contents rendering helpers into a utility class. That will make it clearer which behavior is intended as public API and which parts are private implementation details for the block render path.

## Testing Instructions

### Manual

1. Enable experimental blocks.
2. Create or edit a post with a Table of Contents block followed by a few Heading blocks that have anchors.
3. Publish and view the post on the front of site. Confirm the ToC lists the current headings and clicking an item scrolls to the matching heading.
4. Change, reorder, or remove a heading, then view the front of site again and confirm the ToC reflects the current post content.

### Automated

1. `GUTENBERG_CHECK_INSTALLED_DEPS=NEVER npm run build -- --skip-types`
2. `npm run test:unit:php:base -- --filter Tests_Blocks_Render_Table_Of_Contents_Test`
3. `npm run test:e2e -- test/e2e/specs/editor/blocks/table-of-contents.spec.js`
4. `vendor/bin/phpcs packages/block-library/src/table-of-contents/index.php phpunit/blocks/render-block-table-of-contents-test.php`
5. `npm run lint:js -- test/e2e/specs/editor/blocks/table-of-contents.spec.js`