### PR TITLE
UI: Backport compat overlay fixes to WordPress 7.1

### DIFF
--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -8,6 +8,10 @@ import userEvent from '@testing-library/user-event';
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import {
+	getWpCompatOverlaySlot,
+	useEnableWpCompatOverlaySlot,
+} from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -252,6 +256,44 @@ describe( 'Modal', () => {
 		// Closes outer modal > Unhides container.
 		await user.keyboard( '[Escape]' );
 		expect( container ).not.toHaveAttribute( 'aria-hidden' );
+	} );
+
+	it( 'keeps the @wordpress/ui compat overlay slot exposed while open', async () => {
+		const user = userEvent.setup();
+
+		const CompatOverlayDemo = () => {
+			useEnableWpCompatOverlaySlot();
+			useEffect( () => {
+				const slot = getWpCompatOverlaySlot();
+				return () => slot?.remove();
+			}, [] );
+
+			const [ isShown, setIsShown ] = useState( false );
+			return (
+				<>
+					<button onClick={ () => setIsShown( true ) }>
+						Open Modal
+					</button>
+					{ isShown && (
+						<Modal onRequestClose={ () => setIsShown( false ) }>
+							<p>Modal content</p>
+						</Modal>
+					) }
+				</>
+			);
+		};
+
+		const { container } = render( <CompatOverlayDemo /> );
+		// Disable reason: The infrastructure slot has no semantic role.
+		// eslint-disable-next-line testing-library/no-node-access
+		const slot = document.querySelector( '[data-wp-compat-overlay-slot]' );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open Modal' } )
+		);
+
+		expect( container ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
 	} );
 
 	it( 'should render `headerActions` React nodes', async () => {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
+
 ## 0.18.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 
+### Bug Fixes
+
+-   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
+
 ## 0.18.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/ui/src/popover/portal.tsx
+++ b/packages/ui/src/popover/portal.tsx
@@ -1,13 +1,21 @@
 import { Popover as _Popover } from '@base-ui/react/popover';
 import { forwardRef } from '@wordpress/element';
 import type { PortalProps } from './types';
+import { getWpCompatOverlaySlot } from '../utils/wp-compat-overlay-slot';
 
 /**
  * Used to apply custom portal behavior to `Popover`'s floating content.
+ * `container` defaults to the `@wordpress/ui` compat overlay slot.
  */
 const Portal = forwardRef< HTMLDivElement, PortalProps >(
-	function PopoverPortal( props, ref ) {
-		return <_Popover.Portal ref={ ref } { ...props } />;
+	function PopoverPortal( { container, ...restProps }, ref ) {
+		return (
+			<_Popover.Portal
+				container={ container ?? getWpCompatOverlaySlot() }
+				{ ...restProps }
+				ref={ ref }
+			/>
+		);
 	}
 );
 

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -1,7 +1,9 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import * as Popover from '../index';
+import { useEnableWpCompatOverlaySlot } from '../../utils/use-enable-wp-compat-overlay-slot';
 
 function collectUncaughtErrors() {
 	const errors: Error[] = [];
@@ -529,6 +531,107 @@ describe( 'Popover', () => {
 			).not.toContainElement( content );
 		} );
 	} );
+
+	// Slot is identified by a data attribute, not a user-facing role/text.
+	/* eslint-disable testing-library/no-node-access */
+	describe( 'wp compat overlay slot', () => {
+		const SLOT_SELECTOR = '[data-wp-compat-overlay-slot]';
+
+		// Exercises the public opt-in path rather than poking the flag.
+		function WithSlotEnabled( { children }: { children: ReactNode } ) {
+			useEnableWpCompatOverlaySlot();
+			return <>{ children }</>;
+		}
+
+		afterEach( () => {
+			// The hook is one-way at runtime; reset explicitly between tests.
+			delete ( window as { __wpUiCompatOverlaySlotEnabled?: boolean } )
+				.__wpUiCompatOverlaySlotEnabled;
+			document
+				.querySelectorAll( SLOT_SELECTOR )
+				.forEach( ( element ) => element.remove() );
+		} );
+
+		it( 'portals the popup into the slot when the consumer opts in', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<WithSlotEnabled>
+					<Popover.Root>
+						<Popover.Trigger>Open</Popover.Trigger>
+						<Popover.Popup>
+							<Popover.Title>Title</Popover.Title>
+							Popover content
+						</Popover.Popup>
+					</Popover.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			const content = await screen.findByText( 'Popover content' );
+			expect( content ).toBeVisible();
+
+			const slot = document.querySelector( SLOT_SELECTOR );
+			expect( slot ).not.toBeNull();
+			expect( slot ).toContainElement( content );
+		} );
+
+		it( 'does not create a slot when the consumer has not opted in (dormant default)', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Title>Title</Popover.Title>
+						Popover content
+					</Popover.Popup>
+				</Popover.Root>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			expect(
+				await screen.findByText( 'Popover content' )
+			).toBeVisible();
+			expect( document.querySelector( SLOT_SELECTOR ) ).toBeNull();
+		} );
+
+		it( 'lets a caller-supplied portal container override the slot', async () => {
+			const user = userEvent.setup();
+			const containerRef = createRef< HTMLDivElement >();
+
+			render(
+				<WithSlotEnabled>
+					<Popover.Root>
+						<Popover.Trigger>Open</Popover.Trigger>
+						<div
+							ref={ containerRef }
+							data-testid="custom-container"
+						/>
+						<Popover.Popup
+							portal={
+								<Popover.Portal container={ containerRef } />
+							}
+						>
+							<Popover.Title>Title</Popover.Title>
+							Popover content
+						</Popover.Popup>
+					</Popover.Root>
+				</WithSlotEnabled>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Open' } ) );
+
+			const content = await screen.findByText( 'Popover content' );
+			expect( content ).toBeVisible();
+			expect( screen.getByTestId( 'custom-container' ) ).toContainElement(
+				content
+			);
+		} );
+	} );
+	/* eslint-enable testing-library/no-node-access */
 
 	describe( 'positioner', () => {
 		it( 'should render the custom positioner element wrapping the popup content', async () => {

--- a/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
+++ b/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
@@ -203,6 +203,39 @@ describe( 'getWpCompatOverlaySlot', () => {
 		} );
 	} );
 
+	describe( 'modal accessibility isolation', () => {
+		beforeEach( () => {
+			internalWindow.__wpUiCompatOverlaySlotEnabled = true;
+		} );
+
+		it( 'exempts a newly created slot from modal accessibility isolation', () => {
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+			expect( slot ).not.toHaveAttribute( 'aria-live' );
+		} );
+
+		it( 'restores a cached slot hidden by modal accessibility isolation', () => {
+			const slot = getWpCompatOverlaySlot();
+			slot?.setAttribute( 'aria-hidden', 'true' );
+
+			expect( getWpCompatOverlaySlot() ).toBe( slot );
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+		} );
+
+		it( 'restores an adopted slot hidden by modal accessibility isolation', () => {
+			const preExisting = document.createElement( 'div' );
+			preExisting.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
+			preExisting.setAttribute( 'aria-hidden', 'true' );
+			document.body.appendChild( preExisting );
+
+			const slot = getWpCompatOverlaySlot();
+
+			expect( slot ).toBe( preExisting );
+			expect( slot ).toHaveAttribute( 'aria-hidden', 'false' );
+		} );
+	} );
+
 	describe( 'DOM-level singleton (cross-instance coordination)', () => {
 		beforeEach( () => {
 			internalWindow.__wpUiCompatOverlaySlotEnabled = true;

--- a/packages/ui/src/utils/wp-compat-overlay-slot.ts
+++ b/packages/ui/src/utils/wp-compat-overlay-slot.ts
@@ -44,6 +44,14 @@ function isInWordPressEnvironment(): boolean {
 // slot's connection state.
 let cachedSlot: HTMLDivElement | null = null;
 
+function ensureSlotIsAccessible( element: HTMLDivElement ): HTMLDivElement {
+	// `@wordpress/components` Modal preserves body children that already
+	// declare their `aria-hidden` state. Explicitly keep the slot exposed and
+	// reset stale isolation left on a persistent slot.
+	element.setAttribute( 'aria-hidden', 'false' );
+	return element;
+}
+
 function createSlot( ownerDocument: Document ): HTMLDivElement {
 	const element = ownerDocument.createElement( 'div' );
 	element.setAttribute( WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE, '' );
@@ -99,7 +107,7 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		cachedSlot.ownerDocument === ownerDocument &&
 		cachedSlot.isConnected
 	) {
-		return cachedSlot;
+		return ensureSlotIsAccessible( cachedSlot );
 	}
 
 	// Prefer an existing slot in the document over creating a duplicate —
@@ -108,8 +116,8 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		`[${ WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE }]`
 	);
 	if ( existing instanceof HTMLDivElement ) {
-		cachedSlot = existing;
-		return existing;
+		cachedSlot = ensureSlotIsAccessible( existing );
+		return cachedSlot;
 	}
 
 	// Don't orphan a cached slot still attached to a foreign document.
@@ -117,7 +125,7 @@ export function getWpCompatOverlaySlot(): HTMLDivElement | undefined {
 		cachedSlot.remove();
 	}
 
-	cachedSlot = createSlot( ownerDocument );
+	cachedSlot = ensureSlotIsAccessible( createSlot( ownerDocument ) );
 	return cachedSlot;
 }
 

--- a/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
+++ b/storybook/stories/playground/wp-compat-overlay-slot.story.jsx
@@ -1,8 +1,9 @@
-import { Modal, Popover, Button } from '@wordpress/components';
+import { Modal, Popover as WCPopover, Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import {
 	Autocomplete,
 	Combobox,
+	Popover,
 	Select,
 	SelectControl,
 	Tooltip,
@@ -27,10 +28,54 @@ const inputWrapperStyle = {
 		'var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xs)',
 };
 
-// Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Select`,
-// `Combobox`, `SelectControl`, `Autocomplete`) inside a
+function UiPopoverFixture() {
+	return (
+		<div style={ { marginTop: '1rem' } }>
+			<Popover.Root>
+				<Popover.Trigger>Open `@wordpress/ui` Popover</Popover.Trigger>
+				<Popover.Popup>
+					<Popover.Title>Popover from `@wordpress/ui`</Popover.Title>
+					<p>
+						The popover and its nested autocomplete should appear
+						above the host overlay.
+					</p>
+					<Autocomplete.Root items={ autocompleteItems }>
+						<Autocomplete.Input
+							placeholder="Search nested items"
+							aria-label="Autocomplete inside @wordpress/ui Popover"
+						/>
+						<Autocomplete.Popup>
+							<Autocomplete.Empty>
+								No matching items.
+							</Autocomplete.Empty>
+							<Autocomplete.List>
+								<Autocomplete.ListBody>
+									<Autocomplete.Collection>
+										{ ( item ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.ListBody>
+							</Autocomplete.List>
+						</Autocomplete.Popup>
+					</Autocomplete.Root>
+				</Popover.Popup>
+			</Popover.Root>
+		</div>
+	);
+}
+
+// Cross-library stacking: `@wordpress/ui` overlays (`Tooltip`, `Popover`,
+// `Select`, `Combobox`, `SelectControl`, `Autocomplete`) inside a
 // `@wordpress/components` Modal / Popover should sit above the
-// components-side overlay via the compat overlay slot.
+// components-side overlay via the compat overlay slot. The Popover fixture uses
+// controlled `@wordpress/ui` content; arbitrary legacy descendants remain out
+// of scope.
 export default {
 	title: 'Playground/Debug fixtures/WP Compat Overlay Slot',
 	decorators: [ WithWpCompatOverlaySlot ],
@@ -68,6 +113,8 @@ export const InsideComponentsModal = {
 								</Tooltip.Popup>
 							</Tooltip.Root>
 						</Tooltip.Provider>
+
+						<UiPopoverFixture />
 
 						<div style={ { marginTop: '1rem' } }>
 							<Select.Root items={ selectItems }>
@@ -173,7 +220,7 @@ export const InsideComponentsPopover = {
 					Toggle `@wordpress/components` Popover
 				</Button>
 				{ isOpen && anchor && (
-					<Popover
+					<WCPopover
 						anchor={ anchor }
 						onClose={ () => setIsOpen( false ) }
 					>
@@ -191,6 +238,8 @@ export const InsideComponentsPopover = {
 									</Tooltip.Popup>
 								</Tooltip.Root>
 							</Tooltip.Provider>
+
+							<UiPopoverFixture />
 
 							<div style={ { marginTop: '1rem' } }>
 								<Select.Root items={ selectItems }>
@@ -274,7 +323,7 @@ export const InsideComponentsPopover = {
 								</Autocomplete.Root>
 							</div>
 						</div>
-					</Popover>
+					</WCPopover>
 				) }
 			</>
 		);


### PR DESCRIPTION
Backports #80278 and #80310 to `wp/7.1`.

## What?

Manually backports two `@wordpress/ui` compat overlay fixes:

- Default `Popover.Portal` to the compat overlay slot when the host opts in.
- Keep the compat overlay slot available to assistive technologies while an `@wordpress/components` Modal is open.

## Why?

Both fixes landed on `trunk` after the WordPress 7.1 branch split. Without them, a controlled UI Popover can stack below a host overlay, and a persistent compat slot can be hidden from assistive technologies by Modal isolation.

## How?

Cherry-picks the two merged changes as separate commits. The only manual conflict resolution keeps both changelog entries in the 7.1 branch's current Unreleased section.

## Testing Instructions

1. CI checks pass
2. Run `npm run storybook:dev` and open **Playground → Debug fixtures → WP Compat Overlay Slot**.
3. In both stories, open the UI Popover and its nested Autocomplete. Confirm they render above the host overlay.
4. While the Modal story is open, confirm `[data-wp-compat-overlay-slot]` has `aria-hidden="false"`.

### Testing Instructions for Keyboard

1. Open each host overlay with Enter or Space.
2. Tab to the UI Popover trigger and open it with Enter or Space.
3. Tab to the nested Autocomplete, type to filter, and use the arrow keys to navigate.
4. Press Escape to close the active overlay and confirm focus remains within the expected overlay flow.

## Use of AI Tools

Authored with Codex assistance.