### PR TITLE
RichTextControl: Replace DOM focus tracking with a single React-tree focus boundary

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Internal
 
-- DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of a per-field `SlotFillProvider`/`Popover.Slot`, letting format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
+- DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 
 ## 17.2.0 (2026-07-14)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fix Dataviews popover hover text color readability issue on WordPress 7.0. [#80105](https://github.com/WordPress/gutenberg/pull/80105)
 - DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set. [#80254](https://github.com/WordPress/gutenberg/pull/80254)
 
+### Internal
+
+- DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of a per-field `SlotFillProvider`/`Popover.Slot`, letting format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
+
 ## 17.2.0 (2026-07-14)
 
 ### New Features

--- a/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
@@ -2,21 +2,21 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { FocusEvent, MutableRefObject, ReactNode } from 'react';
+import type { MutableRefObject, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
  */
 import {
-	Popover,
-	SlotFillProvider,
 	privateApis as componentsPrivateApis,
 	__unstableUseAutocompleteProps as useAutocompleteProps,
 } from '@wordpress/components';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import {
-	createPortal,
-	useEffect,
+	useMergeRefs,
+	useRefEffect,
+	__experimentalUseFocusOutside as useFocusOutside,
+} from '@wordpress/compose';
+import {
 	useInsertionEffect,
 	useMemo,
 	useRef,
@@ -209,104 +209,11 @@ export default function RichTextControl( {
 		new Set< ( event: KeyboardEvent ) => void >()
 	);
 
-	/*
-	 * The assembly owns the selection ("active") lifetime, because only it
-	 * can prove that a popover receiving focus belongs to this field: format
-	 * popovers (e.g. the inline link UI opened via Cmd+K) portal into the
-	 * `Popover.Slot` this component renders below inside its own
-	 * `SlotFillProvider`, so "focus is in one of this field's popovers" is
-	 * simply containment in that slot.
-	 */
-	const popoverSlotRef = useRef< HTMLDivElement | null >( null );
-	/*
-	 * Where the `Popover.Slot` portals to: the editable's `ownerDocument`
-	 * body. The slot must not render inline where the field sits — form
-	 * fields routinely live inside scroll containers (`overflow` ancestors
-	 * clip the popovers) and transformed ancestors (which re-root the
-	 * popovers' positioning). Portaling to the body mirrors where popovers
-	 * land by default when no slot is present, while keeping the slot inside
-	 * this field's `SlotFillProvider` (React context crosses portals) so the
-	 * containment-based focus tracking above keeps working.
-	 */
-	const [ popoverContainer, setPopoverContainer ] =
-		useState< HTMLElement | null >( null );
-	const popoverContainerRef = useRefEffect< HTMLElement >( ( element ) => {
-		setPopoverContainer( element.ownerDocument.body );
-	}, [] );
-	// When the editable blurs, defer flipping the selection off so a
-	// portal-rendered popover can claim focus without `FormatEdit` — and
-	// therefore the popover itself — unmounting underneath it.
-	const blurDeselectTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
-	/*
-	 * Once focus moves into one of the field's popovers, the editable has
-	 * already blurred and its `onBlur` will not fire again when focus later
-	 * leaves that popover. Watch document-level `focusout` for the duration
-	 * of the popover excursion so the field still deselects (and tears down
-	 * its format UI) once focus settles outside both the editable and its
-	 * popovers.
-	 */
-	const stopPopoverFocusTrackingRef = useRef< ( () => void ) | undefined >(
-		undefined
-	);
-	useEffect(
-		() => () => {
-			clearTimeout( blurDeselectTimeoutRef.current );
-			stopPopoverFocusTrackingRef.current?.();
-		},
-		[]
-	);
-
-	function isFocusInField( ownerDocument: Document ) {
-		const active = ownerDocument.activeElement;
-		return !! (
-			active &&
-			( anchorRef.current?.contains( active ) ||
-				popoverSlotRef.current?.contains( active ) )
-		);
-	}
-
-	function trackPopoverFocusOut( ownerDocument: Document ) {
-		stopPopoverFocusTrackingRef.current?.();
-
-		function onDocumentFocusOut() {
-			clearTimeout( blurDeselectTimeoutRef.current );
-			blurDeselectTimeoutRef.current = setTimeout( () => {
-				if ( isFocusInField( ownerDocument ) ) {
-					return;
-				}
-				stopPopoverFocusTrackingRef.current?.();
-				setIsSelected( false );
-			}, 0 );
-		}
-
-		ownerDocument.addEventListener( 'focusout', onDocumentFocusOut );
-		stopPopoverFocusTrackingRef.current = () => {
-			ownerDocument.removeEventListener( 'focusout', onDocumentFocusOut );
-			stopPopoverFocusTrackingRef.current = undefined;
-		};
-	}
-
-	function onEditableFocus() {
-		clearTimeout( blurDeselectTimeoutRef.current );
-		// Focus is back in the editable, so its own blur handling takes over
-		// from the popover focus tracking again.
-		stopPopoverFocusTrackingRef.current?.();
-		setIsSelected( true );
-	}
-
-	function onEditableBlur( event: FocusEvent< HTMLElement > ) {
-		clearTimeout( blurDeselectTimeoutRef.current );
-		const { ownerDocument } = event.currentTarget;
-		blurDeselectTimeoutRef.current = setTimeout( () => {
-			// Stay selected while focus is inside one of the popovers this
-			// field's format UI opened.
-			if ( isFocusInField( ownerDocument ) ) {
-				trackPopoverFocusOut( ownerDocument );
-				return;
-			}
-			setIsSelected( false );
-		}, 0 );
-	}
+	// The focus boundary (below) wraps the editable and its format UI. Format
+	// popovers portal out of it in the DOM but still bubble focus events
+	// through the React tree, so `useFocusOutside` deselects only once focus
+	// leaves the field's own UI for good.
+	const focusOutside = useFocusOutside( () => setIsSelected( false ) );
 
 	const adjustedAllowedFormats = getAllowedFormats( {
 		allowedFormats,
@@ -543,21 +450,19 @@ export default function RichTextControl( {
 		eventListenersRef,
 		enterRef,
 		focusOnMountRef,
-		popoverContainerRef,
 		autocompleteRef,
 	] );
 
 	return (
-		/*
-		 * The provider scopes every slot/fill rendered by this field — most
-		 * importantly the format popovers, which land in the `Popover.Slot`
-		 * below. That containment is what the blur handling above checks to
-		 * decide whether focus is still within the field's own UI. A format
-		 * popover using a custom `__unstableSlotName` would portal to the
-		 * body-level fallback container instead and deselect the field;
-		 * `core/link` (and every other core format) uses the default slot.
-		 */
-		<SlotFillProvider>
+		// Focus boundary for the field's selection: `onFocus` selects on entry;
+		// the spread `useFocusOutside` handlers deselect once focus leaves.
+		<div
+			{ ...focusOutside }
+			onFocus={ ( event ) => {
+				setIsSelected( true );
+				focusOutside.onFocus( event );
+			} }
+		>
 			<RichTextControlShell
 				label={ label }
 				id={ id }
@@ -579,8 +484,6 @@ export default function RichTextControl( {
 				aria-multiline={ ! disableLineBreaks }
 				{ ...autocompleteProps }
 				ref={ editableRef }
-				onFocus={ onEditableFocus }
-				onBlur={ onEditableBlur }
 			/>
 			{ /*
 			 * The format assembly mounts only while the field is selected —
@@ -609,11 +512,6 @@ export default function RichTextControl( {
 					</InputEventContext.Provider>
 				</KeyboardShortcutContext.Provider>
 			) }
-			{ popoverContainer &&
-				createPortal(
-					<Popover.Slot ref={ popoverSlotRef } />,
-					popoverContainer
-				) }
-		</SlotFillProvider>
+		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
@@ -8,6 +8,7 @@ import type { MutableRefObject, ReactNode } from 'react';
  * WordPress dependencies
  */
 import {
+	SlotFillProvider,
 	privateApis as componentsPrivateApis,
 	__unstableUseAutocompleteProps as useAutocompleteProps,
 } from '@wordpress/components';
@@ -463,55 +464,59 @@ export default function RichTextControl( {
 				focusOutside.onFocus( event );
 			} }
 		>
-			<RichTextControlShell
-				label={ label }
-				id={ id }
-				className={ clsx( 'dataviews-controls__richtext', className ) }
-				// The shell draws this while the element is empty, and the
-				// rich-text hook below renders its own placeholder element
-				// once it takes over the contents; either way the attribute
-				// keeps `aria-placeholder` exposed to assistive technology.
-				placeholder={ placeholder }
-				hideLabelFromVision={ hideLabelFromVision }
-				help={ help }
-				disabled={ disabled }
-				required={ required }
-				markWhenOptional={ markWhenOptional }
-				customValidity={ customValidity }
-				// The shell manages the editable content through the ref; the
-				// plain text only drives its hidden validity delegate.
-				value={ value.text }
-				aria-multiline={ ! disableLineBreaks }
-				{ ...autocompleteProps }
-				ref={ editableRef }
-			/>
 			{ /*
-			 * The format assembly mounts only while the field is selected —
-			 * the shell is presentational and knows nothing about selection,
-			 * so this module owns both the state and the gating.
+			 * Scopes the format types' `RichText.ToolbarControls.*` fills so
+			 * they can't reach a surrounding block toolbar.
 			 */ }
-			{ isSelected && ! disabled && (
-				<KeyboardShortcutContext.Provider value={ keyboardShortcuts }>
-					<InputEventContext.Provider value={ inputEvents }>
-						{ /*
-						 * Format types gate both their toolbar buttons and
-						 * their inline UIs (e.g. the link popover opened via
-						 * Cmd+K) on `isVisible`. A standalone field renders no
-						 * `RichText.ToolbarControls` slot, so the
-						 * toolbar-button fills mount into nothing while the
-						 * inline UIs stay functional.
-						 */ }
-						<FormatEdit
-							value={ value }
-							onChange={ onRichTextChange }
-							onFocus={ onFocus }
-							formatTypes={ formatTypes }
-							forwardedRef={ anchorRef }
-							isVisible
-						/>
-					</InputEventContext.Provider>
-				</KeyboardShortcutContext.Provider>
-			) }
+			<SlotFillProvider>
+				<RichTextControlShell
+					label={ label }
+					id={ id }
+					className={ clsx(
+						'dataviews-controls__richtext',
+						className
+					) }
+					// The shell draws this while the element is empty, and the
+					// rich-text hook below renders its own placeholder element
+					// once it takes over the contents; either way the attribute
+					// keeps `aria-placeholder` exposed to assistive technology.
+					placeholder={ placeholder }
+					hideLabelFromVision={ hideLabelFromVision }
+					help={ help }
+					disabled={ disabled }
+					required={ required }
+					markWhenOptional={ markWhenOptional }
+					customValidity={ customValidity }
+					// The shell manages the editable content through the ref; the
+					// plain text only drives its hidden validity delegate.
+					value={ value.text }
+					aria-multiline={ ! disableLineBreaks }
+					{ ...autocompleteProps }
+					ref={ editableRef }
+				/>
+				{ /*
+				 * The format assembly mounts only while the field is selected —
+				 * the shell is presentational and knows nothing about selection,
+				 * so this module owns both the state and the gating.
+				 */ }
+				{ isSelected && ! disabled && (
+					<KeyboardShortcutContext.Provider
+						value={ keyboardShortcuts }
+					>
+						<InputEventContext.Provider value={ inputEvents }>
+							{ /* Format types gate their inline UIs on `isVisible`. */ }
+							<FormatEdit
+								value={ value }
+								onChange={ onRichTextChange }
+								onFocus={ onFocus }
+								formatTypes={ formatTypes }
+								forwardedRef={ anchorRef }
+								isVisible
+							/>
+						</InputEventContext.Provider>
+					</KeyboardShortcutContext.Provider>
+				) }
+			</SlotFillProvider>
 		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
@@ -7,8 +7,7 @@ import type { MutableRefObject } from 'react';
 /**
  * WordPress dependencies
  */
-import { Fill } from '@wordpress/components';
-import { useContext, useEffect } from '@wordpress/element';
+import { createPortal, useContext, useEffect } from '@wordpress/element';
 import {
 	unregisterFormatType,
 	registerFormatType,
@@ -50,8 +49,20 @@ const flushMicrotasks = () =>
 		await Promise.resolve();
 	} );
 
-async function focusTextbox( textbox: HTMLElement ) {
-	fireEvent.focus( textbox );
+// Flush a deferred (0ms `setTimeout`) update — e.g. `useFocusOutside`'s blur
+// check, or a validity message revealed after the field is touched.
+const flushTimeouts = () =>
+	act( async () => {
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	} );
+
+// Move real focus (and flush the selection microtask focusing the editable
+// schedules). `useFocusOutside` needs real focus order: `focusout` on the old
+// element before `focusin` on the new.
+async function moveFocusTo( element: HTMLElement ) {
+	act( () => {
+		element.focus();
+	} );
 	await flushMicrotasks();
 }
 
@@ -203,7 +214,7 @@ describe( 'RichTextControl', () => {
 				/>
 			);
 			const textbox = getTextbox( container );
-			await focusTextbox( textbox );
+			await moveFocusTo( textbox );
 
 			// `fireEvent` returns `false` when `preventDefault()` was called.
 			expect( fireEvent.keyDown( textbox, { key: 'Enter' } ) ).toBe(
@@ -227,7 +238,7 @@ describe( 'RichTextControl', () => {
 					/>
 				);
 				const textbox = getTextbox( container );
-				await focusTextbox( textbox );
+				await moveFocusTo( textbox );
 
 				/*
 				 * The control takes over Enter handling from the browser
@@ -263,7 +274,7 @@ describe( 'RichTextControl', () => {
 					/>
 				);
 				const textbox = getTextbox( container );
-				await focusTextbox( textbox );
+				await moveFocusTo( textbox );
 
 				/*
 				 * During IME composition (e.g. CJK input), Enter confirms
@@ -292,7 +303,7 @@ describe( 'RichTextControl', () => {
 				/>
 			);
 			const textbox = getTextbox( container );
-			await focusTextbox( textbox );
+			await moveFocusTo( textbox );
 
 			expect(
 				fireEvent.keyDown( textbox, { key: 'Enter', metaKey: true } )
@@ -389,20 +400,18 @@ describe( 'RichTextControl', () => {
 				className: null,
 				edit: () => <TestShortcut onUse={ () => currentOnUse() } />,
 			} );
-			// Stand-in for a format type that opens a popover (e.g. the
-			// inline link UI). `Popover` renders its content through a
-			// `Fill` for the ambient popover slot — here that is the slot
-			// the assembly owns, which is exactly what its blur handling
-			// checks to prove the popover belongs to this field.
+			// Stand-in for a format type that opens a popover (e.g. the inline
+			// link UI). Like a real `Popover`, it portals out of the field's
+			// DOM subtree, but its focus still bubbles through the React tree.
 			registerTestFormatType( 'core/test-popover-ui', {
 				title: 'Test Popover UI',
 				tagName: 'kbd',
 				className: null,
-				edit: () => (
-					<Fill name="Popover">
-						<button type="button">Inside popover</button>
-					</Fill>
-				),
+				edit: () =>
+					createPortal(
+						<button type="button">Inside popover</button>,
+						document.body
+					),
 			} );
 		} );
 
@@ -414,18 +423,6 @@ describe( 'RichTextControl', () => {
 		beforeEach( () => {
 			currentOnUse = jest.fn();
 		} );
-
-		async function blurTextbox( textbox: HTMLElement ) {
-			fireEvent.blur( textbox );
-			// `RichTextControl` defers deselection on blur via a 0ms
-			// `setTimeout` so a portal-rendered popover (e.g., the
-			// inline link UI) can claim focus before `FormatEdit`
-			// unmounts. Flush that timer so the test sees the
-			// deselected state.
-			await act( async () => {
-				await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-			} );
-		}
 
 		// Dispatch a `primary+b` keydown — on non-Apple platforms (jsdom's
 		// default), the `primary` modifier maps to Ctrl, not Meta.
@@ -447,7 +444,7 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			await focusTextbox( textbox );
+			await moveFocusTo( textbox );
 
 			// `fireEvent.keyDown` returns `false` when the dispatched event
 			// had `preventDefault()` called on it.
@@ -473,37 +470,26 @@ describe( 'RichTextControl', () => {
 
 		it( 'stops dispatching shortcuts after blur', async () => {
 			const { container } = render(
-				<RichTextControl
-					label="Shortcut blur"
-					value=""
-					onChange={ () => {} }
-				/>
+				<>
+					<RichTextControl
+						label="Shortcut blur"
+						value=""
+						onChange={ () => {} }
+					/>
+					<button type="button">Outside</button>
+				</>
 			);
 			const textbox = getTextbox( container );
 
-			await focusTextbox( textbox );
-			await blurTextbox( textbox );
+			await moveFocusTo( textbox );
+			await moveFocusTo(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			);
+			await flushTimeouts();
 
 			dispatchPrimaryB( textbox );
 			expect( currentOnUse ).not.toHaveBeenCalled();
 		} );
-
-		// Focus the textbox, move focus into the supplied element, then blur
-		// the textbox and flush the deferred deselection timer.
-		async function blurWithFocusIn(
-			textbox: HTMLElement,
-			target: HTMLElement
-		) {
-			await focusTextbox( textbox );
-			// Focus the target before firing the textbox blur so
-			// `document.activeElement` points at it by the time the deferred
-			// check runs.
-			target.focus();
-			fireEvent.blur( textbox );
-			await act( async () => {
-				await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-			} );
-		}
 
 		it( "keeps dispatching shortcuts while focus is in the field's own popover", async () => {
 			const { container } = render(
@@ -515,17 +501,15 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			// Selecting the field mounts the stub format's popover content,
-			// which portals into the `Popover.Slot` the field owns.
-			await focusTextbox( textbox );
-			const popoverButton = screen.getByRole( 'button', {
-				name: 'Inside popover',
-			} );
+			// Selecting the field mounts the stub format's portalled popover.
+			await moveFocusTo( textbox );
+			await moveFocusTo(
+				screen.getByRole( 'button', { name: 'Inside popover' } )
+			);
+			await flushTimeouts();
 
-			await blurWithFocusIn( textbox, popoverButton );
-
-			// `FormatEdit` should stay mounted, so the shortcut still
-			// fires on a subsequent keydown delivered to the textbox.
+			// Focus stayed in UI the field owns, so `FormatEdit` stays mounted
+			// and the shortcut still fires.
 			dispatchPrimaryB( textbox );
 			expect( currentOnUse ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -543,24 +527,17 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			await focusTextbox( textbox );
-			const popoverButton = screen.getByRole( 'button', {
-				name: 'Inside popover',
-			} );
+			await moveFocusTo( textbox );
+			await moveFocusTo(
+				screen.getByRole( 'button', { name: 'Inside popover' } )
+			);
 
-			await blurWithFocusIn( textbox, popoverButton );
-
-			/*
-			 * Focus now leaves the popover for an element that belongs to
-			 * neither the field nor its popovers. The field's own `onBlur`
-			 * already fired, so this exercises the document-level focus
-			 * tracking that takes over during the popover excursion.
-			 */
-			screen.getByRole( 'button', { name: 'Outside' } ).focus();
-			fireEvent.focusOut( popoverButton );
-			await act( async () => {
-				await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-			} );
+			// Focus leaves the popover for an unrelated element, so the field
+			// deselects.
+			await moveFocusTo(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			);
+			await flushTimeouts();
 
 			// The field deselected, so `FormatEdit` unmounted and the
 			// shortcut no longer fires.
@@ -576,9 +553,9 @@ describe( 'RichTextControl', () => {
 						value=""
 						onChange={ () => {} }
 					/>
-					{ /* Stand-in for a popover owned by unrelated UI (an
-					   ambient popover slot outside the field): it must not
-					   keep the field selected. */ }
+					{ /* Stand-in for a popover owned by unrelated UI (outside
+					   the field's React tree): it must not keep the field
+					   selected. */ }
 					<div className="popover-slot">
 						<button type="button">Unrelated popover</button>
 					</div>
@@ -586,10 +563,11 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			await blurWithFocusIn(
-				textbox,
+			await moveFocusTo( textbox );
+			await moveFocusTo(
 				screen.getByRole( 'button', { name: 'Unrelated popover' } )
 			);
+			await flushTimeouts();
 
 			// The field deselected, so `FormatEdit` unmounted and the
 			// shortcut no longer fires.
@@ -675,11 +653,9 @@ describe( 'RichTextControl', () => {
 				screen.queryByText( 'Enter a summary' )
 			).not.toBeInTheDocument();
 
-			await focusTextbox( textbox );
+			await moveFocusTo( textbox );
 			fireEvent.blur( textbox );
-			await act( async () => {
-				await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-			} );
+			await flushTimeouts();
 
 			expect( screen.getByText( 'Enter a summary' ) ).toBeVisible();
 		} );
@@ -738,7 +714,7 @@ describe( 'RichTextControl', () => {
 				screen.queryByTestId( 'format-edit-ui' )
 			).not.toBeInTheDocument();
 
-			await focusTextbox( textbox );
+			await moveFocusTo( textbox );
 
 			expect( screen.getByTestId( 'format-edit-ui' ) ).toHaveTextContent(
 				'true'
@@ -785,8 +761,7 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			fireEvent.focus( textbox );
-			await flushMicrotasks();
+			await moveFocusTo( textbox );
 
 			fireEvent.input( textbox, { inputType: 'insertText' } );
 
@@ -809,8 +784,7 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			fireEvent.focus( textbox );
-			await flushMicrotasks();
+			await moveFocusTo( textbox );
 
 			fireEvent.input( textbox, { inputType: 'deleteContentBackward' } );
 

--- a/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
@@ -7,7 +7,8 @@ import type { MutableRefObject } from 'react';
 /**
  * WordPress dependencies
  */
-import { createPortal, useContext, useEffect } from '@wordpress/element';
+import { useContext, useEffect } from '@wordpress/element';
+import { Fill, Popover, Slot, SlotFillProvider } from '@wordpress/components';
 import {
 	unregisterFormatType,
 	registerFormatType,
@@ -400,18 +401,18 @@ describe( 'RichTextControl', () => {
 				className: null,
 				edit: () => <TestShortcut onUse={ () => currentOnUse() } />,
 			} );
-			// Stand-in for a format type that opens a popover (e.g. the inline
-			// link UI). Like a real `Popover`, it portals out of the field's
-			// DOM subtree, but its focus still bubbles through the React tree.
+			// Stand-in for a format type that opens inline UI in a popover
+			// (e.g. the link UI behind Cmd+K). A real `Popover`, so the tests
+			// exercise the actual Slot/Fill decision rather than a portal stub.
 			registerTestFormatType( 'core/test-popover-ui', {
 				title: 'Test Popover UI',
 				tagName: 'kbd',
 				className: null,
-				edit: () =>
-					createPortal(
-						<button type="button">Inside popover</button>,
-						document.body
-					),
+				edit: () => (
+					<Popover>
+						<button type="button">Inside popover</button>
+					</Popover>
+				),
 			} );
 		} );
 
@@ -501,11 +502,23 @@ describe( 'RichTextControl', () => {
 			);
 			const textbox = getTextbox( container );
 
-			// Selecting the field mounts the stub format's portalled popover.
+			// Selecting the field mounts the stub format's popover.
 			await moveFocusTo( textbox );
-			await moveFocusTo(
-				screen.getByRole( 'button', { name: 'Inside popover' } )
-			);
+			const popoverButton = screen.getByRole( 'button', {
+				name: 'Inside popover',
+			} );
+
+			// No `Popover.Slot` in the field's registry, so the popover lands
+			// in the body-level fallback container, outside the field's DOM.
+			expect(
+				// eslint-disable-next-line testing-library/no-node-access
+				popoverButton.closest(
+					'.components-popover__fallback-container'
+				)
+			).toBeInTheDocument();
+			expect( container ).not.toContainElement( popoverButton );
+
+			await moveFocusTo( popoverButton );
 			await flushTimeouts();
 
 			// Focus stayed in UI the field owns, so `FormatEdit` stays mounted
@@ -680,8 +693,7 @@ describe( 'RichTextControl', () => {
 		// Format types receive `isVisible` and gate both their toolbar
 		// buttons and their inline UIs (e.g. the link popover opened via
 		// Cmd+K) on it. The assembly must pass `isVisible` so the inline
-		// UIs can open; the toolbar-button fills render into nothing since
-		// a standalone field mounts no `RichText.ToolbarControls` slot.
+		// UIs can open.
 		beforeAll( () => {
 			registerTestFormatType( 'core/test-edit-ui', {
 				title: 'Test Edit UI',
@@ -693,10 +705,24 @@ describe( 'RichTextControl', () => {
 					</div>
 				),
 			} );
+			// Re-implement `RichTextToolbarButton` locally
+			// (`@wordpress/block-editor` isn't a dependency here): format types
+			// contribute toolbar buttons as `RichText.ToolbarControls.*` fills.
+			registerTestFormatType( 'core/test-toolbar-button', {
+				title: 'Test Toolbar Button',
+				tagName: 'b',
+				className: null,
+				edit: () => (
+					<Fill name="RichText.ToolbarControls.test">
+						<button type="button">Format toolbar button</button>
+					</Fill>
+				),
+			} );
 		} );
 
 		afterAll( () => {
 			unregisterFormatType( 'core/test-edit-ui' );
+			unregisterFormatType( 'core/test-toolbar-button' );
 		} );
 
 		it( 'mounts format edit components with `isVisible` while the field is selected', async () => {
@@ -719,6 +745,33 @@ describe( 'RichTextControl', () => {
 			expect( screen.getByTestId( 'format-edit-ui' ) ).toHaveTextContent(
 				'true'
 			);
+		} );
+
+		it( 'keeps format toolbar fills out of a surrounding block toolbar', async () => {
+			const { container } = render(
+				<SlotFillProvider>
+					<RichTextControl
+						label="Toolbar isolation"
+						value=""
+						onChange={ () => {} }
+					/>
+					{ /* Stands in for the editor's block toolbar, which renders
+					   the matching slots through `FormatToolbar`. */ }
+					<div data-testid="block-toolbar">
+						<Slot name="RichText.ToolbarControls.test" />
+					</div>
+				</SlotFillProvider>
+			);
+
+			// Selecting the field mounts `FormatEdit` and its toolbar fill.
+			await moveFocusTo( getTextbox( container ) );
+			expect(
+				screen.getByTestId( 'format-edit-ui' )
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByTestId( 'block-toolbar' )
+			).toBeEmptyDOMElement();
 		} );
 	} );
 


### PR DESCRIPTION
## What?
Part of #80294.
Related #79604.

PR replaces the DataViews rich text control's body-portaled `Popover.Slot` and DOM-containment focus-tracking with a single focus boundary that wraps the editable and its format UI.

## Why

The old approach reified "focus is in my popover" as DOM containment inside a field-owned slot, which:

- gave every field its own overlay root, bypassing the shared/default Popover container (cuts against the central overlay-slot consolidation);
- required ~90 lines of bookkeeping: container state, containment checks, and a document-level `focusout` listener.

Props to @ciampo for the suggestion.

## How

Format popovers keep the default (portalled) Popover, unclipped in the notes sidebar, and their focus events bubble through the **React tree** to a wrapping `<div>`. `useFocusOutside` (same hook the notes sidebar uses for this exact problem) deselects only once focus leaves the field's own UI; the boundary's `onFocus` selects on entry. This removes the `Popover.Slot`, the body portal, the containment logic, and the document listener.

The local `SlotFillProvider` stays, with the focus boundary placed outside it. It's no longer load-bearing for focus tracking, but it still scopes the format types' `RichText.ToolbarControls.*` fills: without it, a field rendered inside the editor would leak its format buttons into the block toolbar, where they'd appear to belong to the block while mutating the field. Since it renders no `Popover.Slot`, format popovers find no matching slot in that registry and use their body-level fallback portal.

Removing the provider needs a targeted format-host capability (so `RichTextToolbarButton` can skip registering its `Fill` when the host has no toolbar) rather than generic SlotFill isolation. That's a backward-compatible follow-up, out of scope here — see @ciampo's [review](https://github.com/WordPress/gutenberg/pull/80324#pullrequestreview-4706177103) for the full rationale.

## Testing Instructions
1. Open a post or page.
2. Start adding a note to a block.
3. Smoke test Link and autocomplete popovers. They should work as before.

Unit tests cover the focus boundary (including a real `Popover` reaching its fallback portal) and the toolbar-fill scoping; the notes e2e tests cover the user-facing flows.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude
