### PR TITLE
tools: Remove redundant parseArgs arguments

### DIFF
--- a/tools/validation/validate-package-contents.mjs
+++ b/tools/validation/validate-package-contents.mjs
@@ -13,7 +13,6 @@ let configuredDisallowedPath;
 
 try {
 	const { positionals, values } = parseArgs( {
-		args: process.argv.slice( 2 ),
 		allowPositionals: true,
 		options: {
 			'disallow-path': { type: 'string' },


### PR DESCRIPTION
Follow-up to #80213 and https://github.com/WordPress/gutenberg/pull/80213#discussion_r3584921849.

## What?

Removes the explicit `args: process.argv.slice( 2 )` configuration from the package-content validator.

## Why?

`parseArgs()` reads the current process arguments by default, so passing them explicitly is redundant and differs from the existing pattern used by other Gutenberg CLI scripts.

## How?

Relies on the built-in `parseArgs()` default while keeping the validator's positional and option configuration unchanged.

## Testing Instructions

1. Run `npm run test:unit -- tools/validation/validate-package-contents.test.js --runInBand`.
2. Run `npm run lint:js -- tools/validation/validate-package-contents.mjs`.
3. Run `npm run build`.

### Testing Instructions for Keyboard

Not applicable; no UI changes.

## Use of AI Tools

This PR was implemented with Codex. The change was reviewed against the installed Node implementation and verified with focused tests, lint, and the full build.