### PR TITLE
Improve pre-flight npm access checks

### DIFF
--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -678,6 +678,66 @@ function parseNpmJsonOutput( output, description ) {
 }
 
 /**
+ * Checks that the authenticated npm user has publishing (read-write) access to given a package,
+ *
+ * @param {string}   packageName                     Package name.
+ * @param {string}   currentUser                     Authenticated npm username.
+ * @param {Object}   options                         Options.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Function} deps.commandFn                  Command runner.
+ *
+ * @return {Promise<boolean>} Whether the package exists and access was checked.
+ *                            Returns false for packages that don't exist yet.
+ */
+async function hasNpmPublishAccess(
+	packageName,
+	currentUser,
+	{ gitWorkingDirectoryPath },
+	deps = {}
+) {
+	const { commandFn = command } = deps;
+	let stdout;
+	try {
+		( { stdout } = await commandFn(
+			`npm access list collaborators ${ packageName } --json`,
+			{ cwd: gitWorkingDirectoryPath, stdio: 'pipe' }
+		) );
+	} catch ( error ) {
+		if ( isNpmPackageVersionMissing( error ) ) {
+			// Package doesn't exist yet (first-ever publish); nothing to verify here.
+			return false;
+		}
+
+		/*
+		 * Surface the failure reason (stderr) to aid debugging.
+		 *
+		 * The stdout is intentionally never printed because it would expose the
+		 * collaborator list for a private package.
+		 */
+		throw new Error(
+			`Unable to verify publish access for ${ packageName }: ${
+				error.stderr || error.shortMessage || error.message
+			}`
+		);
+	}
+
+	const collaborators = parseNpmJsonOutput(
+		stdout,
+		`${ packageName } collaborators`
+	);
+	const accessLevel = collaborators[ currentUser ] || 'none';
+
+	if ( accessLevel !== 'read-write' ) {
+		throw new Error(
+			`The "${ currentUser }" user does not have publish access to ${ packageName } (current: ${ accessLevel }).`
+		);
+	}
+
+	return true;
+}
+
+/**
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
@@ -695,11 +755,22 @@ async function runNpmPublishPreflight(
 	deps = {}
 ) {
 	const { commandFn = command } = deps;
-	log( '>> Checking npm package access.' );
-	await commandFn( 'npm access list packages @wordpress --json', {
+	log( '>> Checking npm publish access.' );
+	const { stdout: whoamiOutput } = await commandFn( 'npm whoami', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'pipe',
 	} );
+	const currentUser = whoamiOutput.trim();
+
+	for ( const { name } of releasePackages ) {
+		await hasNpmPublishAccess(
+			name,
+			currentUser,
+			{ gitWorkingDirectoryPath },
+			deps
+		);
+	}
+	log( `>> Publish access confirmed for "${ currentUser }".` );
 
 	log( '>> Verifying target package versions and dist-tags.' );
 	const publishedPackageNames = [];

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -678,66 +678,6 @@ function parseNpmJsonOutput( output, description ) {
 }
 
 /**
- * Checks that the authenticated npm user has publishing (read-write) access to given a package,
- *
- * @param {string}   packageName                     Package name.
- * @param {string}   currentUser                     Authenticated npm username.
- * @param {Object}   options                         Options.
- * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
- * @param {Object}   deps                            Dependencies.
- * @param {Function} deps.commandFn                  Command runner.
- *
- * @return {Promise<boolean>} Whether the package exists and access was checked.
- *                            Returns false for packages that don't exist yet.
- */
-async function hasNpmPublishAccess(
-	packageName,
-	currentUser,
-	{ gitWorkingDirectoryPath },
-	deps = {}
-) {
-	const { commandFn = command } = deps;
-	let stdout;
-	try {
-		( { stdout } = await commandFn(
-			`npm access list collaborators ${ packageName } --json`,
-			{ cwd: gitWorkingDirectoryPath, stdio: 'pipe' }
-		) );
-	} catch ( error ) {
-		if ( isNpmPackageVersionMissing( error ) ) {
-			// Package doesn't exist yet (first-ever publish); nothing to verify here.
-			return false;
-		}
-
-		/*
-		 * Surface the failure reason (stderr) to aid debugging.
-		 *
-		 * The stdout is intentionally never printed because it would expose the
-		 * collaborator list for a private package.
-		 */
-		throw new Error(
-			`Unable to verify publish access for ${ packageName }: ${
-				error.stderr || error.shortMessage || error.message
-			}`
-		);
-	}
-
-	const collaborators = parseNpmJsonOutput(
-		stdout,
-		`${ packageName } collaborators`
-	);
-	const accessLevel = collaborators[ currentUser ] || 'none';
-
-	if ( accessLevel !== 'read-write' ) {
-		throw new Error(
-			`The "${ currentUser }" user does not have publish access to ${ packageName } (current: ${ accessLevel }).`
-		);
-	}
-
-	return true;
-}
-
-/**
  * Runs a pragmatic npm preflight before publishing.
  *
  * @param {Object}   options                         Options.
@@ -755,22 +695,16 @@ async function runNpmPublishPreflight(
 	deps = {}
 ) {
 	const { commandFn = command } = deps;
-	log( '>> Checking npm publish access.' );
+	/*
+	 * `npm whoami` fails for every credential problem that happens in practice:
+	 * a missing, expired, or revoked auth token, or an unreachable registry.
+	 */
+	log( '>> Checking npm authentication.' );
 	const { stdout: whoamiOutput } = await commandFn( 'npm whoami', {
 		cwd: gitWorkingDirectoryPath,
 		stdio: 'pipe',
 	} );
-	const currentUser = whoamiOutput.trim();
-
-	for ( const { name } of releasePackages ) {
-		await hasNpmPublishAccess(
-			name,
-			currentUser,
-			{ gitWorkingDirectoryPath },
-			deps
-		);
-	}
-	log( `>> Publish access confirmed for "${ currentUser }".` );
+	log( `>> Authenticated as "${ whoamiOutput.trim() }".` );
 
 	log( '>> Verifying target package versions and dist-tags.' );
 	const publishedPackageNames = [];

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -215,10 +215,16 @@ describe( 'verifyRemotePackageTags', () => {
 } );
 
 describe( 'runNpmPublishPreflight', () => {
-	it( 'uses the npm access command supported by current npm versions', async () => {
+	// npm whoami output, intentionally padded to verify it is trimmed.
+	const WHOAMI = { stdout: 'wp-user\n' };
+	// Collaborators payload granting the authenticated user publish access.
+	const READ_WRITE = { stdout: '{"wp-user":"read-write"}' };
+
+	it( 'resolves the authenticated user and checks per-package access before registry state', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockRejectedValueOnce( {
 				stderr: 'npm ERR! code E404',
 			} );
@@ -237,15 +243,191 @@ describe( 'runNpmPublishPreflight', () => {
 			)
 		).resolves.toEqual( [] );
 
+		expect( commandFn ).toHaveBeenNthCalledWith( 1, 'npm whoami', {
+			cwd: '/repo',
+			stdio: 'pipe',
+		} );
 		expect( commandFn ).toHaveBeenNthCalledWith(
-			1,
-			'npm access list packages @wordpress --json',
+			2,
+			'npm access list collaborators @wordpress/a11y --json',
 			{ cwd: '/repo', stdio: 'pipe' }
 		);
 		expect( commandFn ).toHaveBeenNthCalledWith(
-			2,
+			3,
 			'npm view @wordpress/a11y@4.50.0 version gitHead dist-tags --json',
 			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'checks access for every release package with a single whoami lookup', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
+			.mockResolvedValueOnce( READ_WRITE )
+			.mockRejectedValue( { stderr: 'npm ERR! code E404' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+						{ name: '@wordpress/blocks', version: '14.20.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).resolves.toEqual( [] );
+
+		expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
+			cwd: '/repo',
+			stdio: 'pipe',
+		} );
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npm access list collaborators @wordpress/a11y --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( commandFn ).toHaveBeenCalledWith(
+			'npm access list collaborators @wordpress/blocks --json',
+			{ cwd: '/repo', stdio: 'pipe' }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when the authenticated user is absent from the collaborators list', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( {
+				stdout: '{"someone-else":"read-write"}',
+			} );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'The "wp-user" user does not have publish access to @wordpress/a11y (current: none).'
+		);
+		// Registry verification must not run once access fails.
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'fails when the authenticated user only has read-only access', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( {
+				stdout: '{"wp-user":"read-only"}',
+			} );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'The "wp-user" user does not have publish access to @wordpress/a11y (current: read-only).'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips the access check for a package that does not exist yet', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			// Access check: package has never been published.
+			.mockRejectedValueOnce( { stderr: 'npm ERR! code E404' } )
+			// Registry verification: still unpublished.
+			.mockRejectedValueOnce( { stderr: 'npm ERR! code E404' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).resolves.toEqual( [] );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'surfaces the failure reason without echoing stdout when the access check fails unexpectedly', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockRejectedValueOnce( {
+				stderr: '403 Forbidden - you do not have permission',
+				// For a private package, stdout could carry the collaborator list.
+				stdout: '{"secret-collaborator":"read-write"}',
+			} );
+
+		const promise = runNpmPublishPreflight(
+			{
+				distTag: 'latest',
+				gitWorkingDirectoryPath: '/repo',
+				publishCommit: 'publish-sha',
+				releasePackages: [
+					{ name: '@wordpress/a11y', version: '4.50.0' },
+				],
+			},
+			{ commandFn }
+		);
+
+		// The stderr reason is surfaced to aid debugging.
+		await expect( promise ).rejects.toThrow(
+			'Unable to verify publish access for @wordpress/a11y: 403 Forbidden - you do not have permission'
+		);
+		// Captured stdout (a potential private collaborator list) must not leak.
+		await expect( promise ).rejects.not.toThrow( 'secret-collaborator' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'throws when the collaborators output cannot be parsed', async () => {
+		const commandFn = jest
+			.fn()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( { stdout: 'not-json' } );
+
+		await expect(
+			runNpmPublishPreflight(
+				{
+					distTag: 'latest',
+					gitWorkingDirectoryPath: '/repo',
+					publishCommit: 'publish-sha',
+					releasePackages: [
+						{ name: '@wordpress/a11y', version: '4.50.0' },
+					],
+				},
+				{ commandFn }
+			)
+		).rejects.toThrow(
+			'Unable to parse npm registry @wordpress/a11y collaborators: not-json'
 		);
 		expect( console ).toHaveLogged();
 	} );
@@ -253,7 +435,8 @@ describe( 'runNpmPublishPreflight', () => {
 	it( 'accepts a published version from the prepared commit with the expected dist-tag', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -271,14 +454,15 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).resolves.toEqual( [ '@wordpress/a11y' ] );
-		expect( commandFn ).toHaveBeenCalledTimes( 2 );
+		expect( commandFn ).toHaveBeenCalledTimes( 3 );
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'fails when a published version came from another commit', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"other-sha","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -304,7 +488,8 @@ describe( 'runNpmPublishPreflight', () => {
 	it( 'fails with an actionable error when a published version has no gitHead', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -330,7 +515,8 @@ describe( 'runNpmPublishPreflight', () => {
 	it( 'fails when a published version has the wrong dist-tag', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
 			} );
@@ -356,7 +542,8 @@ describe( 'runNpmPublishPreflight', () => {
 	it( 'fails when the registry returns a different version', async () => {
 		const commandFn = jest
 			.fn()
-			.mockResolvedValueOnce()
+			.mockResolvedValueOnce( WHOAMI )
+			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.49.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
 			} );

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -217,14 +217,11 @@ describe( 'verifyRemotePackageTags', () => {
 describe( 'runNpmPublishPreflight', () => {
 	// npm whoami output, intentionally padded to verify it is trimmed.
 	const WHOAMI = { stdout: 'wp-user\n' };
-	// Collaborators payload granting the authenticated user publish access.
-	const READ_WRITE = { stdout: '{"wp-user":"read-write"}' };
 
-	it( 'resolves the authenticated user and checks per-package access before registry state', async () => {
+	it( 'verifies npm authentication before checking registry state', async () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockRejectedValueOnce( {
 				stderr: 'npm ERR! code E404',
 			} );
@@ -249,62 +246,18 @@ describe( 'runNpmPublishPreflight', () => {
 		} );
 		expect( commandFn ).toHaveBeenNthCalledWith(
 			2,
-			'npm access list collaborators @wordpress/a11y --json',
-			{ cwd: '/repo', stdio: 'pipe' }
-		);
-		expect( commandFn ).toHaveBeenNthCalledWith(
-			3,
 			'npm view @wordpress/a11y@4.50.0 version gitHead dist-tags --json',
 			{ cwd: '/repo', stdio: 'pipe' }
 		);
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'checks access for every release package with a single whoami lookup', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
-			.mockResolvedValueOnce( READ_WRITE )
-			.mockRejectedValue( { stderr: 'npm ERR! code E404' } );
-
-		await expect(
-			runNpmPublishPreflight(
-				{
-					distTag: 'latest',
-					gitWorkingDirectoryPath: '/repo',
-					publishCommit: 'publish-sha',
-					releasePackages: [
-						{ name: '@wordpress/a11y', version: '4.50.0' },
-						{ name: '@wordpress/blocks', version: '14.20.0' },
-					],
-				},
-				{ commandFn }
-			)
-		).resolves.toEqual( [] );
-
-		expect( commandFn ).toHaveBeenCalledWith( 'npm whoami', {
-			cwd: '/repo',
-			stdio: 'pipe',
-		} );
-		expect( commandFn ).toHaveBeenCalledWith(
-			'npm access list collaborators @wordpress/a11y --json',
-			{ cwd: '/repo', stdio: 'pipe' }
+	it( 'fails without checking registry state when npm authentication fails', async () => {
+		const commandFn = jest.fn().mockRejectedValueOnce(
+			Object.assign( new Error( 'Command failed: npm whoami' ), {
+				stderr: 'npm ERR! code ENEEDAUTH',
+			} )
 		);
-		expect( commandFn ).toHaveBeenCalledWith(
-			'npm access list collaborators @wordpress/blocks --json',
-			{ cwd: '/repo', stdio: 'pipe' }
-		);
-		expect( console ).toHaveLogged();
-	} );
-
-	it( 'fails when the authenticated user is absent from the collaborators list', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( {
-				stdout: '{"someone-else":"read-write"}',
-			} );
 
 		await expect(
 			runNpmPublishPreflight(
@@ -318,117 +271,8 @@ describe( 'runNpmPublishPreflight', () => {
 				},
 				{ commandFn }
 			)
-		).rejects.toThrow(
-			'The "wp-user" user does not have publish access to @wordpress/a11y (current: none).'
-		);
-		// Registry verification must not run once access fails.
-		expect( commandFn ).toHaveBeenCalledTimes( 2 );
-		expect( console ).toHaveLogged();
-	} );
-
-	it( 'fails when the authenticated user only has read-only access', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( {
-				stdout: '{"wp-user":"read-only"}',
-			} );
-
-		await expect(
-			runNpmPublishPreflight(
-				{
-					distTag: 'latest',
-					gitWorkingDirectoryPath: '/repo',
-					publishCommit: 'publish-sha',
-					releasePackages: [
-						{ name: '@wordpress/a11y', version: '4.50.0' },
-					],
-				},
-				{ commandFn }
-			)
-		).rejects.toThrow(
-			'The "wp-user" user does not have publish access to @wordpress/a11y (current: read-only).'
-		);
-		expect( console ).toHaveLogged();
-	} );
-
-	it( 'skips the access check for a package that does not exist yet', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			// Access check: package has never been published.
-			.mockRejectedValueOnce( { stderr: 'npm ERR! code E404' } )
-			// Registry verification: still unpublished.
-			.mockRejectedValueOnce( { stderr: 'npm ERR! code E404' } );
-
-		await expect(
-			runNpmPublishPreflight(
-				{
-					distTag: 'latest',
-					gitWorkingDirectoryPath: '/repo',
-					publishCommit: 'publish-sha',
-					releasePackages: [
-						{ name: '@wordpress/a11y', version: '4.50.0' },
-					],
-				},
-				{ commandFn }
-			)
-		).resolves.toEqual( [] );
-		expect( console ).toHaveLogged();
-	} );
-
-	it( 'surfaces the failure reason without echoing stdout when the access check fails unexpectedly', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			.mockRejectedValueOnce( {
-				stderr: '403 Forbidden - you do not have permission',
-				// For a private package, stdout could carry the collaborator list.
-				stdout: '{"secret-collaborator":"read-write"}',
-			} );
-
-		const promise = runNpmPublishPreflight(
-			{
-				distTag: 'latest',
-				gitWorkingDirectoryPath: '/repo',
-				publishCommit: 'publish-sha',
-				releasePackages: [
-					{ name: '@wordpress/a11y', version: '4.50.0' },
-				],
-			},
-			{ commandFn }
-		);
-
-		// The stderr reason is surfaced to aid debugging.
-		await expect( promise ).rejects.toThrow(
-			'Unable to verify publish access for @wordpress/a11y: 403 Forbidden - you do not have permission'
-		);
-		// Captured stdout (a potential private collaborator list) must not leak.
-		await expect( promise ).rejects.not.toThrow( 'secret-collaborator' );
-		expect( console ).toHaveLogged();
-	} );
-
-	it( 'throws when the collaborators output cannot be parsed', async () => {
-		const commandFn = jest
-			.fn()
-			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( { stdout: 'not-json' } );
-
-		await expect(
-			runNpmPublishPreflight(
-				{
-					distTag: 'latest',
-					gitWorkingDirectoryPath: '/repo',
-					publishCommit: 'publish-sha',
-					releasePackages: [
-						{ name: '@wordpress/a11y', version: '4.50.0' },
-					],
-				},
-				{ commandFn }
-			)
-		).rejects.toThrow(
-			'Unable to parse npm registry @wordpress/a11y collaborators: not-json'
-		);
+		).rejects.toThrow( 'Command failed: npm whoami' );
+		expect( commandFn ).toHaveBeenCalledTimes( 1 );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -436,7 +280,6 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -454,7 +297,7 @@ describe( 'runNpmPublishPreflight', () => {
 				{ commandFn }
 			)
 		).resolves.toEqual( [ '@wordpress/a11y' ] );
-		expect( commandFn ).toHaveBeenCalledTimes( 3 );
+		expect( commandFn ).toHaveBeenCalledTimes( 2 );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -462,7 +305,6 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"other-sha","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -489,7 +331,6 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","dist-tags":{"latest":"4.50.0"}}',
 			} );
@@ -516,7 +357,6 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.50.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
 			} );
@@ -543,7 +383,6 @@ describe( 'runNpmPublishPreflight', () => {
 		const commandFn = jest
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
-			.mockResolvedValueOnce( READ_WRITE )
 			.mockResolvedValueOnce( {
 				stdout: '{"version":"4.49.0","gitHead":"publish-sha","dist-tags":{"latest":"4.49.0"}}',
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the use of `npm access list packages @wordpress` call in favor of `npm access list collaborators <package-name>`.

Follow-up to #79904.

<!-- In a few words, what is the PR actually doing? -->

## Why?
`npm access list packages` requires the current user or token to possess organization-level read access, which cannot be assigned to organization members (only administrators). `npm access list collaborators <package-name>` does not require any org-level access and even works for unauthenticated users.

When combined with `npm whoami`, this effectively replaces the need for any organization privileges to be assigned to a token.

This also expands the pre-flight checks to confirm that the user has the required permissions to publish every dependency that will be published as a part of running the publish command.

## Use of AI Tools

Claude Code was used to create the initial PR.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
