### PR TITLE
Remove playlist caption support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -636,7 +636,7 @@ Embed a simple playlist.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding), typography (fontSize)
--	**Attributes:** caption, order, showArtists, showImages, showNumbers, showPlayButtonArtwork, showTrackLength, showTracklist, type, waveformBackgroundColor, waveformBackgroundGradient, waveformColor, waveformGradient, waveformStyle
+-	**Attributes:** order, showArtists, showImages, showNumbers, showPlayButtonArtwork, showTrackLength, showTracklist, type, waveformBackgroundColor, waveformBackgroundGradient, waveformColor, waveformGradient, waveformStyle
 
 ## Playlist track
 

--- a/packages/block-library/src/playlist/README.md
+++ b/packages/block-library/src/playlist/README.md
@@ -33,7 +33,6 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `waveformGradient` | `string` | — | — |
 | `waveformBackgroundColor` | `string` | — | — |
 | `waveformBackgroundGradient` | `string` | — | — |
-| `caption` | `string` | — | — |
 
 ## Supports
 
@@ -65,12 +64,11 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 This is a [**hybrid block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). It saves static markup that the server may enhance during rendering.
 
 ```html
-<!-- wp:core/playlist {"caption":"Sample playlist"} -->
+<!-- wp:core/playlist -->
 <figure class="wp-block-playlist">
 	<ol class="wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers">
 		<!-- wp:core/playlist-track {"id":123,"src":"https://example.com/audio.mp3","album":"Example album","artist":"Example creator","image":"https://example.com/track-image.jpg","imageAlt":"Track image","length":"3:21","title":"Sample track"} /-->
 	</ol>
-	<figcaption class="wp-element-caption">Sample playlist</figcaption>
 </figure>
 <!-- /wp:core/playlist -->
 ```

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -57,9 +57,6 @@
 		},
 		"waveformBackgroundGradient": {
 			"type": "string"
-		},
-		"caption": {
-			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -36,7 +36,6 @@ import { createBlobURL } from '@wordpress/blob';
 /**
  * Internal dependencies
  */
-import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
 import { PlaylistContext } from './context';
@@ -77,7 +76,6 @@ const PlaylistEdit = ( {
 	attributes,
 	setAttributes,
 	isSelected,
-	insertBlocksAfter,
 	clientId,
 } ) => {
 	const {
@@ -719,15 +717,6 @@ const PlaylistEdit = ( {
 						{ innerBlocksProps.children }
 					</PlaylistContext.Provider>
 				</ol>
-				<Caption
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					label={ __( 'Playlist caption text' ) }
-					showToolbarButton={ isSelected }
-					style={ { marginTop: 16 } }
-				/>
 			</figure>
 		</>
 	);

--- a/packages/block-library/src/playlist/save.js
+++ b/packages/block-library/src/playlist/save.js
@@ -6,21 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	useBlockProps,
-	useInnerBlocksProps,
-	__experimentalGetElementClassName,
-} from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function saveWithInnerBlocks( { attributes } ) {
-	const {
-		caption,
-		showNumbers,
-		showTracklist,
-		showArtists,
-		showTrackLength,
-	} = attributes;
+	const { showNumbers, showTracklist, showArtists, showTrackLength } =
+		attributes;
 
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
@@ -38,13 +28,6 @@ export default function saveWithInnerBlocks( { attributes } ) {
 			>
 				{ innerBlocksProps.children }
 			</ol>
-			{ ! RichText.isEmpty( caption ) && (
-				<RichText.Content
-					tagName="figcaption"
-					className={ __experimentalGetElementClassName( 'caption' ) }
-					value={ caption }
-				/>
-			) }
 		</figure>
 	);
 }

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -72,10 +72,6 @@ jest.mock( '@wordpress/notices', () => ( {
 	store: {},
 } ) );
 
-jest.mock( '../../utils/caption', () => ( {
-	Caption: () => <figcaption />,
-} ) );
-
 jest.mock( '../../utils/hooks', () => ( {
 	useToolsPanelDropdownMenuProps: () => ( {} ),
 } ) );

--- a/test/integration/fixtures/blocks/core__playlist.html
+++ b/test/integration/fixtures/blocks/core__playlist.html
@@ -1,8 +1,7 @@
-<!-- wp:core/playlist {"caption":"Sample playlist"} -->
+<!-- wp:core/playlist -->
 <figure class="wp-block-playlist">
 	<ol class="wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers">
 		<!-- wp:core/playlist-track {"id":123,"src":"https://example.com/audio.mp3","album":"Example album","artist":"Example creator","image":"https://example.com/track-image.jpg","imageAlt":"Track image","length":"3:21","title":"Sample track"} /-->
 	</ol>
-	<figcaption class="wp-element-caption">Sample playlist</figcaption>
 </figure>
 <!-- /wp:core/playlist -->

--- a/test/integration/fixtures/blocks/core__playlist.json
+++ b/test/integration/fixtures/blocks/core__playlist.json
@@ -11,8 +11,7 @@
 			"showArtists": true,
 			"showNumbers": true,
 			"showTrackLength": true,
-			"waveformStyle": "bars",
-			"caption": "Sample playlist"
+			"waveformStyle": "bars"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__playlist.parsed.json
+++ b/test/integration/fixtures/blocks/core__playlist.parsed.json
@@ -1,9 +1,7 @@
 [
 	{
 		"blockName": "core/playlist",
-		"attrs": {
-			"caption": "Sample playlist"
-		},
+		"attrs": {},
 		"innerBlocks": [
 			{
 				"blockName": "core/playlist-track",
@@ -22,11 +20,11 @@
 				"innerContent": []
 			}
 		],
-		"innerHTML": "\n<figure class=\"wp-block-playlist\">\n\t<ol class=\"wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers\">\n\t\t\n\t</ol>\n\t<figcaption class=\"wp-element-caption\">Sample playlist</figcaption>\n</figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-playlist\">\n\t<ol class=\"wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers\">\n\t\t\n\t</ol>\n</figure>\n",
 		"innerContent": [
 			"\n<figure class=\"wp-block-playlist\">\n\t<ol class=\"wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers\">\n\t\t",
 			null,
-			"\n\t</ol>\n\t<figcaption class=\"wp-element-caption\">Sample playlist</figcaption>\n</figure>\n"
+			"\n\t</ol>\n</figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__playlist.serialized.html
+++ b/test/integration/fixtures/blocks/core__playlist.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:playlist {"caption":"Sample playlist"} -->
-<figure class="wp-block-playlist"><ol class="wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers"><!-- wp:playlist-track {"id":123,"src":"https://example.com/audio.mp3","album":"Example album","artist":"Example creator","image":"https://example.com/track-image.jpg","imageAlt":"Track image","length":"3:21","title":"Sample track"} /--></ol><figcaption class="wp-element-caption">Sample playlist</figcaption></figure>
+<!-- wp:playlist -->
+<figure class="wp-block-playlist"><ol class="wp-block-playlist__tracklist wp-block-playlist__tracklist-show-numbers"><!-- wp:playlist-track {"id":123,"src":"https://example.com/audio.mp3","album":"Example album","artist":"Example creator","image":"https://example.com/track-image.jpg","imageAlt":"Track image","length":"3:21","title":"Sample track"} /--></ol></figure>
 <!-- /wp:playlist -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
I'm not sure this is a needed feature for playlists. I'd rather remove it from 7.1 (if possible) than have to support it forever.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Why do we need captions support for a playlist block?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removed the Playlist caption attribute from block.json.
- Removed the Caption component from playlist/edit.js, including the toolbar button UI.
- Removed caption serialization from playlist/save.js, so saved Playlist markup no longer outputs a figcaption.
- Cleaned up the stale caption mock in the Playlist edit component test.
- Regenerated/updated Playlist docs and block fixtures to remove caption attributes and markup.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add playlist block and some tracks
- Verify there is no caption support
- Switch to Trunk
- Add a caption to the block
- Save
- Switch back to this branch and render the frontend page
- Ensure the caption does not render

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
