### PR TITLE
Use Add track instead of only Add

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -164,7 +164,7 @@ const PlaylistTrackEdit = ( {
 			{ !! addTracks && (
 				<BlockControls group="block">
 					<MediaReplaceFlow
-						name={ __( 'Add' ) }
+						name={ __( 'Add track' ) }
 						onSelect={ addTracks }
 						accept="audio/*"
 						multiple

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -194,7 +194,7 @@ describe( 'PlaylistTrackEdit', () => {
 		const addTracks = jest.fn();
 		renderEdit( { addTracks } );
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add track' } ) );
 
 		expect( addTracks ).toHaveBeenCalledWith( {} );
 	} );
@@ -211,7 +211,7 @@ describe( 'PlaylistTrackEdit', () => {
 		expect(
 			within( screen.getByTestId( 'block-controls-block' ) ).getByRole(
 				'button',
-				{ name: 'Add' }
+				{ name: 'Add track' }
 			)
 		).toBeInTheDocument();
 	} );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -485,7 +485,7 @@ const PlaylistEdit = ( {
 		<>
 			<BlockControls group="other">
 				<MediaReplaceFlow
-					name={ __( 'Add' ) }
+					name={ __( 'Add track' ) }
 					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Should this be "Add tracks" instead of "Add track"?

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
"Add track" is clearer and lines up with similar explicit collection actions like "Add tab" in the Tabs block and "Add tracks" in the Video tracks editor.

"Replace" should stay generic because that matches media block convention once media already exists. Image and Cover use specific labels when adding empty media, like Add image or Add media, but switch to plain Replace for replacing the selected media. Since the selected playlist track already provides the context, Replace is enough there.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Clarity for what is being added and consistency with other blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
String replacement of Add to Add tracks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Select Playlist and check for Add track button. 
- Select Playlist track and check for Add track button.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
