### PR TITLE
Global Styles: Reject non-string custom CSS in the REST controller

### DIFF
--- a/backport-changelog/7.1/12549.md
+++ b/backport-changelog/7.1/12549.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12549
+
+* https://github.com/WordPress/gutenberg/pull/80338

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -698,10 +698,18 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 	 *              either through a STYLE end tag or a prefix of one which might become a
 	 *              full end tag when combined with the contents of other styles.
 	 *
-	 * @param string $css CSS to validate.
+	 * @param mixed $css CSS to validate.
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
 	protected function validate_custom_css( $css ) {
+		if ( ! is_string( $css ) ) {
+			return new WP_Error(
+				'rest_custom_css_invalid_type',
+				__( 'CSS must be a string.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$length = strlen( $css );
 		for (
 			$at = strcspn( $css, '<' );

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -581,6 +581,24 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 	}
 
 	/**
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
+	 */
+	public function test_update_item_non_string_styles_css() {
+		wp_set_current_user( self::$admin_id );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$request->set_body_params(
+			array(
+				'styles' => array( 'css' => array( 'body { color: red; }' ) ),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_custom_css_invalid_type', $response, 400 );
+	}
+
+	/**
 	 * Tests the submission of a custom block style variation that was defined
 	 * within a theme style variation and wouldn't be registered at the time
 	 * of saving via the API.
@@ -806,6 +824,43 @@ CSS;
 			'truncated "</sty"'          => array( '</sty', 'The CSS must not end in "&lt;/sty".' ),
 			'truncated "</STYL"'         => array( '</STYL', 'The CSS must not end in "&lt;/STYL".' ),
 			'truncated "</stYle"'        => array( '</stYle', 'The CSS must not end in "&lt;/stYle".' ),
+		);
+	}
+
+	/**
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::validate_custom_css
+	 *
+	 * @dataProvider data_custom_css_non_string
+	 *
+	 * @param mixed $custom_css Non-string value to validate.
+	 */
+	public function test_validate_custom_css_non_string( $custom_css ) {
+		$controller = new WP_REST_Global_Styles_Controller_Gutenberg();
+		$validate   = Closure::bind(
+			function ( $css ) {
+				return $this->validate_custom_css( $css );
+			},
+			$controller,
+			$controller
+		);
+
+		$result = $validate( $custom_css );
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_custom_css_invalid_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, mixed[]>
+	 */
+	public static function data_custom_css_non_string(): array {
+		return array(
+			'array'   => array( array( 'body { color: red; }' ) ),
+			'integer' => array( 123 ),
+			'boolean' => array( true ),
+			'null'    => array( null ),
+			'object'  => array( new stdClass() ),
 		);
 	}
 }


### PR DESCRIPTION




## What

Guards `validate_custom_css()` in the global styles REST controller against non-string values, returning a 400 error instead of a fatal.




## Why

`styles.css` has no type constraint in the request schema, so a consumer can PUT an array (or any other type). That value can reach `strlen()` and throw an uncaught `TypeError` on PHP 8+. 

Seen in the wild from third-party REST consumers; neither the editor UI nor Core sends non-strings.

## What changed

- `validate_custom_css()` returns a `rest_custom_css_invalid_type` `WP_Error` (status 400) when the value is not a string.
- Added a controller test that PUTs `styles.css` as an array and asserts the 400 response, plus unit tests covering array, integer, boolean, null, and object values.

### Risks

No change for well-formed requests. On PHP 8+ non-string senders currently get a 500 fatal and nothing is saved; they now get a 400 with a clear error code. On PHP 7.4, `strlen( array )` only raised a warning, so validation silently passed and the broken value was stored in the global styles post; those requests are now rejected with a 400 instead of storing data that can never render.

## Manual testing

1. Open the site editor, then open the browser console
2. Run: `wp.apiFetch( { path: '/wp/v2/global-styles/<id>', method: 'PUT', data: { styles: { css: [ 'body { color: red; }' ] } } } )`. See commands below for how to get the global styles ID.
3. On trunk this 500s with a `TypeError`; with this PR it rejects with `rest_custom_css_invalid_type` and a 400 status.
4. Confirm valid CSS still saves: repeat with `css: 'body { color: red; }'` and check the Site Editor's Additional CSS reflects it.

### Trunk

```
wp.apiFetch( { path: '/wp/v2/global-styles/' + wp.data.select('core').__experimentalGetCurrentGlobalStylesId(), method: 'PUT', data: { styles: { css: [ 'body { color: red; }' ] } } } )
```

<img width="1392" height="409" alt="Screenshot 2026-07-16 at 11 25 07 am" src="https://github.com/user-attachments/assets/86ea6827-f3c1-4ffb-865c-b12c5f3c4e4c" />

### This branch

```
wp.apiFetch( { path: '/wp/v2/global-styles/' + wp.data.select('core').__experimentalGetCurrentGlobalStylesId(), method: 'PUT', data: { styles: { css: [ 'body { color: red; }' ] } } } )
```

<img width="1385" height="300" alt="Screenshot 2026-07-16 at 11 21 32 am" src="https://github.com/user-attachments/assets/5e9c328b-be15-4fee-a237-aacf1d55d162" />


```
wp.apiFetch( { path: '/wp/v2/global-styles/' + wp.data.select('core').__experimentalGetCurrentGlobalStylesId(), method: 'PUT', data: { styles: { css: 'body { color: red; }' } } } )
```

<img width="1361" height="382" alt="Screenshot 2026-07-16 at 11 22 48 am" src="https://github.com/user-attachments/assets/a0e3cb2b-b1d4-4688-aaa2-3edddb472b8d" />
