### PR TITLE
Responsive styles: Use viewport dropdown to control states for in-editor global styles sidebar

### DIFF
--- a/packages/editor/src/components/global-styles-sidebar/index.js
+++ b/packages/editor/src/components/global-styles-sidebar/index.js
@@ -10,6 +10,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { useViewportMatch, usePrevious } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ export default function GlobalStylesSidebar() {
 		hasRevisions,
 		activeComplementaryArea,
 		editorSettings,
+		styleStateViewport,
 	} = useSelect( ( select ) => {
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getStylesPath, getShowStylebook } = unlock(
@@ -62,6 +64,9 @@ export default function GlobalStylesSidebar() {
 			activeComplementaryArea:
 				select( interfaceStore ).getActiveComplementaryArea( 'core' ),
 			editorSettings: select( editorStore ).getEditorSettings(),
+			styleStateViewport: unlock(
+				select( blockEditorStore )
+			).getStyleStateViewport(),
 		};
 	}, [] );
 	const { setStylesPath, setShowStylebook, resetStylesNavigation } = unlock(
@@ -172,6 +177,8 @@ export default function GlobalStylesSidebar() {
 					path={ stylesPath }
 					onPathChange={ setStylesPath }
 					settings={ editorSettings }
+					selectedViewport={ styleStateViewport }
+					showViewportStateControl={ false }
 				/>
 			</DefaultSidebar>
 			<WelcomeGuideStyles />

--- a/packages/editor/src/components/global-styles-sidebar/index.js
+++ b/packages/editor/src/components/global-styles-sidebar/index.js
@@ -178,7 +178,7 @@ export default function GlobalStylesSidebar() {
 					onPathChange={ setStylesPath }
 					settings={ editorSettings }
 					selectedViewport={ styleStateViewport }
-					showViewportStateControl={ false }
+					showResponsiveStateControls={ false }
 				/>
 			</DefaultSidebar>
 			<WelcomeGuideStyles />

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -79,6 +79,8 @@ export default function GlobalStylesUIWrapper( {
 	path,
 	onPathChange,
 	settings,
+	selectedViewport,
+	showViewportStateControl,
 } ) {
 	const {
 		user: userConfig,
@@ -105,6 +107,8 @@ export default function GlobalStylesUIWrapper( {
 				fontLibraryEnabled={ fontLibraryEnabled }
 				serverCSS={ serverCSS }
 				serverSettings={ serverSettings }
+				selectedViewport={ selectedViewport }
+				showViewportStateControl={ showViewportStateControl }
 			/>
 			<GlobalStylesBlockLink
 				path={ path }

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -80,7 +80,7 @@ export default function GlobalStylesUIWrapper( {
 	onPathChange,
 	settings,
 	selectedViewport,
-	showViewportStateControl,
+	showResponsiveStateControls,
 } ) {
 	const {
 		user: userConfig,
@@ -108,7 +108,7 @@ export default function GlobalStylesUIWrapper( {
 				serverCSS={ serverCSS }
 				serverSettings={ serverSettings }
 				selectedViewport={ selectedViewport }
-				showViewportStateControl={ showViewportStateControl }
+				showResponsiveStateControls={ showResponsiveStateControls }
 			/>
 			<GlobalStylesBlockLink
 				path={ path }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -47,6 +47,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		templateId,
 		isResponsiveEditing,
 		hasBlockSelection,
+		activeComplementaryArea,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
@@ -77,6 +78,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			templateId: getCurrentTemplateId(),
 			isResponsiveEditing: _isResponsiveEditing(),
 			hasBlockSelection: !! getBlockSelectionStart(),
+			activeComplementaryArea:
+				select( interfaceStore ).getActiveComplementaryArea( 'core' ),
 		};
 	}, [] );
 	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
@@ -99,7 +102,13 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 				? VIEWPORT_STATE_BY_DEVICE_TYPE[ deviceType ] ?? 'default'
 				: 'default'
 		);
-		if ( newIsResponsiveEditing && hasBlockSelection ) {
+		// Only auto-open the block inspector when enabling responsive styles
+		// for a selected block and no complementary area is already open.
+		if (
+			newIsResponsiveEditing &&
+			hasBlockSelection &&
+			! activeComplementaryArea
+		) {
 			enableComplementaryArea( 'core', sidebars.block );
 		}
 	};

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -37,12 +37,16 @@ interface BlockStylesNavigationScreensProps {
 	parentMenu: string;
 	blockStyles: any[];
 	blockName: string;
+	selectedViewport?: string;
+	showViewportStateControl?: boolean;
 }
 
 function BlockStylesNavigationScreens( {
 	parentMenu,
 	blockStyles,
 	blockName,
+	selectedViewport,
+	showViewportStateControl,
 }: BlockStylesNavigationScreensProps ) {
 	return (
 		<>
@@ -51,7 +55,12 @@ function BlockStylesNavigationScreens( {
 					key={ index }
 					path={ parentMenu + '/variations/' + style.name }
 				>
-					<ScreenBlock name={ blockName } variation={ style.name } />
+					<ScreenBlock
+						name={ blockName }
+						variation={ style.name }
+						selectedViewport={ selectedViewport }
+						showViewportStateControl={ showViewportStateControl }
+					/>
 				</Navigator.Screen>
 			) ) }
 		</>
@@ -61,6 +70,8 @@ function BlockStylesNavigationScreens( {
 interface ContextScreensProps {
 	name?: string;
 	parentMenu?: string;
+	selectedViewport?: string;
+	showViewportStateControl?: boolean;
 }
 
 interface GlobalStylesNavigationScreenProps {
@@ -68,7 +79,12 @@ interface GlobalStylesNavigationScreenProps {
 	children: React.ReactNode;
 }
 
-function ContextScreens( { name, parentMenu = '' }: ContextScreensProps ) {
+function ContextScreens( {
+	name,
+	parentMenu = '',
+	selectedViewport,
+	showViewportStateControl,
+}: ContextScreensProps ) {
 	const blockStyleVariations = useSelect(
 		( select ) => {
 			if ( ! name ) {
@@ -89,6 +105,8 @@ function ContextScreens( { name, parentMenu = '' }: ContextScreensProps ) {
 			parentMenu={ parentMenu }
 			blockStyles={ blockStyleVariations }
 			blockName={ name || '' }
+			selectedViewport={ selectedViewport }
+			showViewportStateControl={ showViewportStateControl }
 		/>
 	);
 }
@@ -110,6 +128,10 @@ interface GlobalStylesUIProps {
 	serverCSS?: { isGlobalStyles?: boolean }[];
 	/** Server settings for BlockEditorProvider (optional) */
 	serverSettings?: { __unstableResolvedAssets: Record< string, unknown > };
+	/** Selected viewport state (optional) */
+	selectedViewport?: string;
+	/** Whether to show viewport state controls (optional) */
+	showViewportStateControl?: boolean;
 }
 
 export function GlobalStylesUI( {
@@ -121,6 +143,8 @@ export function GlobalStylesUI( {
 	fontLibraryEnabled = false,
 	serverCSS,
 	serverSettings,
+	selectedViewport,
+	showViewportStateControl = true,
 }: GlobalStylesUIProps ) {
 	const blocks = getBlockTypes();
 
@@ -232,13 +256,23 @@ export function GlobalStylesUI( {
 									encodeURIComponent( block.name )
 								}
 							>
-								<ScreenBlock name={ block.name } />
+								<ScreenBlock
+									name={ block.name }
+									selectedViewport={ selectedViewport }
+									showViewportStateControl={
+										showViewportStateControl
+									}
+								/>
 							</GlobalStylesNavigationScreen>
 							<ContextScreens
 								name={ block.name }
 								parentMenu={
 									'/blocks/' +
 									encodeURIComponent( block.name )
+								}
+								selectedViewport={ selectedViewport }
+								showViewportStateControl={
+									showViewportStateControl
 								}
 							/>
 						</Fragment>

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -38,7 +38,7 @@ interface BlockStylesNavigationScreensProps {
 	blockStyles: any[];
 	blockName: string;
 	selectedViewport?: string;
-	showViewportStateControl?: boolean;
+	showResponsiveStateControls?: boolean;
 }
 
 function BlockStylesNavigationScreens( {
@@ -46,7 +46,7 @@ function BlockStylesNavigationScreens( {
 	blockStyles,
 	blockName,
 	selectedViewport,
-	showViewportStateControl,
+	showResponsiveStateControls,
 }: BlockStylesNavigationScreensProps ) {
 	return (
 		<>
@@ -59,7 +59,9 @@ function BlockStylesNavigationScreens( {
 						name={ blockName }
 						variation={ style.name }
 						selectedViewport={ selectedViewport }
-						showViewportStateControl={ showViewportStateControl }
+						showResponsiveStateControls={
+							showResponsiveStateControls
+						}
 					/>
 				</Navigator.Screen>
 			) ) }
@@ -71,7 +73,7 @@ interface ContextScreensProps {
 	name?: string;
 	parentMenu?: string;
 	selectedViewport?: string;
-	showViewportStateControl?: boolean;
+	showResponsiveStateControls?: boolean;
 }
 
 interface GlobalStylesNavigationScreenProps {
@@ -83,7 +85,7 @@ function ContextScreens( {
 	name,
 	parentMenu = '',
 	selectedViewport,
-	showViewportStateControl,
+	showResponsiveStateControls,
 }: ContextScreensProps ) {
 	const blockStyleVariations = useSelect(
 		( select ) => {
@@ -106,7 +108,7 @@ function ContextScreens( {
 			blockStyles={ blockStyleVariations }
 			blockName={ name || '' }
 			selectedViewport={ selectedViewport }
-			showViewportStateControl={ showViewportStateControl }
+			showResponsiveStateControls={ showResponsiveStateControls }
 		/>
 	);
 }
@@ -130,8 +132,8 @@ interface GlobalStylesUIProps {
 	serverSettings?: { __unstableResolvedAssets: Record< string, unknown > };
 	/** Selected viewport state (optional) */
 	selectedViewport?: string;
-	/** Whether to show viewport state controls (optional) */
-	showViewportStateControl?: boolean;
+	/** Whether to show responsive state controls (optional) */
+	showResponsiveStateControls?: boolean;
 }
 
 export function GlobalStylesUI( {
@@ -144,7 +146,7 @@ export function GlobalStylesUI( {
 	serverCSS,
 	serverSettings,
 	selectedViewport,
-	showViewportStateControl = true,
+	showResponsiveStateControls = true,
 }: GlobalStylesUIProps ) {
 	const blocks = getBlockTypes();
 
@@ -259,8 +261,8 @@ export function GlobalStylesUI( {
 								<ScreenBlock
 									name={ block.name }
 									selectedViewport={ selectedViewport }
-									showViewportStateControl={
-										showViewportStateControl
+									showResponsiveStateControls={
+										showResponsiveStateControls
 									}
 								/>
 							</GlobalStylesNavigationScreen>
@@ -271,8 +273,8 @@ export function GlobalStylesUI( {
 									encodeURIComponent( block.name )
 								}
 								selectedViewport={ selectedViewport }
-								showViewportStateControl={
-									showViewportStateControl
+								showResponsiveStateControls={
+									showResponsiveStateControls
 								}
 							/>
 						</Fragment>

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -97,9 +97,16 @@ const {
 interface ScreenBlockProps {
 	name: string;
 	variation?: string;
+	selectedViewport?: string;
+	showViewportStateControl?: boolean;
 }
 
-function ScreenBlock( { name, variation }: ScreenBlockProps ) {
+function ScreenBlock( {
+	name,
+	variation,
+	selectedViewport: controlledSelectedViewport,
+	showViewportStateControl = true,
+}: ScreenBlockProps ) {
 	const {
 		user: userConfig,
 		merged: mergedConfig,
@@ -113,10 +120,12 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 	const prefix = prefixParts.join( '.' );
 
 	// State selector state
-	const [ selectedViewport, setSelectedViewport ] =
+	const [ localSelectedViewport, setSelectedViewport ] =
 		useState< string >( 'default' );
 	const [ selectedPseudoState, setSelectedPseudoState ] =
 		useState< string >( 'default' );
+	const selectedViewport =
+		controlledSelectedViewport ?? localSelectedViewport;
 	const viewportSettings = mergedConfig.settings?.viewport;
 	const validViewportStates = useMemo(
 		() => getValidViewportStates( viewportSettings ),
@@ -361,8 +370,11 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 				pseudoStates={ validPseudoStates }
 				selectedViewport={ effectiveSelectedViewport }
 				selectedPseudoState={ selectedPseudoState }
-				onChangeViewport={ setSelectedViewport }
+				onChangeViewport={
+					showViewportStateControl ? setSelectedViewport : undefined
+				}
 				onChangePseudoState={ setSelectedPseudoState }
+				showViewportStateControl={ showViewportStateControl }
 			/>
 			<BlockPreviewPanel
 				name={ name }

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -98,14 +98,14 @@ interface ScreenBlockProps {
 	name: string;
 	variation?: string;
 	selectedViewport?: string;
-	showViewportStateControl?: boolean;
+	showResponsiveStateControls?: boolean;
 }
 
 function ScreenBlock( {
 	name,
 	variation,
 	selectedViewport: controlledSelectedViewport,
-	showViewportStateControl = true,
+	showResponsiveStateControls = true,
 }: ScreenBlockProps ) {
 	const {
 		user: userConfig,
@@ -371,10 +371,12 @@ function ScreenBlock( {
 				selectedViewport={ effectiveSelectedViewport }
 				selectedPseudoState={ selectedPseudoState }
 				onChangeViewport={
-					showViewportStateControl ? setSelectedViewport : undefined
+					showResponsiveStateControls
+						? setSelectedViewport
+						: undefined
 				}
 				onChangePseudoState={ setSelectedPseudoState }
-				showViewportStateControl={ showViewportStateControl }
+				showResponsiveStateControls={ showResponsiveStateControls }
 			/>
 			<BlockPreviewPanel
 				name={ name }

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -33,6 +33,7 @@ interface ScreenHeaderProps {
 	selectedPseudoState?: string;
 	onChangeViewport?: ( value: string ) => void;
 	onChangePseudoState?: ( value: string ) => void;
+	showViewportStateControl?: boolean;
 }
 
 export function ScreenHeader( {
@@ -45,6 +46,7 @@ export function ScreenHeader( {
 	selectedPseudoState = 'default',
 	onChangeViewport,
 	onChangePseudoState,
+	showViewportStateControl = true,
 }: ScreenHeaderProps ) {
 	return (
 		<VStack spacing={ 0 }>
@@ -69,7 +71,11 @@ export function ScreenHeader( {
 									</Heading>
 									<VStack spacing={ 2 } alignment="right">
 										<StateControl
-											viewportStates={ viewportStates }
+											viewportStates={
+												showViewportStateControl
+													? viewportStates
+													: []
+											}
 											pseudoStates={ pseudoStates }
 											viewportValue={ selectedViewport }
 											pseudoStateValue={

--- a/packages/global-styles-ui/src/screen-header.tsx
+++ b/packages/global-styles-ui/src/screen-header.tsx
@@ -33,7 +33,7 @@ interface ScreenHeaderProps {
 	selectedPseudoState?: string;
 	onChangeViewport?: ( value: string ) => void;
 	onChangePseudoState?: ( value: string ) => void;
-	showViewportStateControl?: boolean;
+	showResponsiveStateControls?: boolean;
 }
 
 export function ScreenHeader( {
@@ -46,7 +46,7 @@ export function ScreenHeader( {
 	selectedPseudoState = 'default',
 	onChangeViewport,
 	onChangePseudoState,
-	showViewportStateControl = true,
+	showResponsiveStateControls = true,
 }: ScreenHeaderProps ) {
 	return (
 		<VStack spacing={ 0 }>
@@ -72,7 +72,7 @@ export function ScreenHeader( {
 									<VStack spacing={ 2 } alignment="right">
 										<StateControl
 											viewportStates={
-												showViewportStateControl
+												showResponsiveStateControls
 													? viewportStates
 													: []
 											}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #80284

Makes the global styles sidebar (the one on the right that's built in to the editor) work the same way as the block inspector in terms of responsive editing. Users control the states using the editor's viewport dropdown rather than a dropdown in the sidebar itself.

## Why?
The previous experience with two different dropdowns with the same kind of options could be confusing to users.

See #80284 for a broader explanation.

## How?
- Adds a prop that avoids showing the responsive controls in the sidebar itself
- Adds another prop that allows the sidebar to receive the current selected viewport style state

## Testing Instructions
1. Open the site editor and edit a template
2. Open the 'Styles' (global styles) sidebar using the button in the top bar
3. Select a block like paragraph (Blocks > Paragraph)
4. Observe there's no dropdown in the sidebar itself
5. Use the viewport dropdown to select 'Tablet' or 'Mobile' and enable 'Responsive styles'
6. Observe the sidebar now shows the 'Tablet' or 'Mobile' badge
7. Click the back button in the global styles sidebar and select the Button block
8. Observe the button block shows a state dropdown for pseudo states
9. Try selecting combining both pseudo and viewport states, confirm that works

## Screenshots or screencast <!-- if applicable -->
<img width="500" height="515" alt="Screenshot 2026-07-16 at 11 39 44 am" src="https://github.com/user-attachments/assets/b26828cd-ad90-4800-b258-8d43b47d2b83" />

## Use of AI Tools
OpenCode / Codex for the code