### PR TITLE
Hide block style variations when state is enabled in global styles

### DIFF
--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -214,7 +214,8 @@ function ScreenBlock( { name, variation }: ScreenBlockProps ) {
 		userSettings,
 		settings
 	);
-	const hasVariationsPanel = !! blockVariations?.length && ! variation;
+	const hasVariationsPanel =
+		!! blockVariations?.length && ! variation && ! hasSelectedState;
 	const { canEditCSS } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
 			select( coreStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Quick fix for something I noticed while testing #80339

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In global styles, select a block with style variations and pseudo states (e.g. Button)
2. Enable different states (viewport and pseudo) and check that the style variations don't display when those states are enabled:

Default state:


<img width="362" height="543" alt="Screenshot 2026-07-16 at 3 00 58 pm" src="https://github.com/user-attachments/assets/06c72309-1c63-44b3-a88d-62f669482028" />

Non-default state:

<img width="352" height="371" alt="Screenshot 2026-07-16 at 3 01 08 pm" src="https://github.com/user-attachments/assets/ba0c2a25-f930-4c93-910b-7b65c4c0a62e" />
