### PR TITLE
Fix upload snackbar stuck in uploading state on server-side uploads

### DIFF
--- a/packages/editor/src/components/upload-progress-snackbar/index.js
+++ b/packages/editor/src/components/upload-progress-snackbar/index.js
@@ -102,7 +102,7 @@ export default function UploadProgressSnackbar() {
 	// Track peak total across sources during a session. The CSM queue removes
 	// items on completion, and the tracker tops out at its recorded total, so
 	// `total` has to be tracked as the high-water mark. Held in a ref (updated
-	// inside the effect below) because it never drives rendering — setting
+	// inside the effect below) because it never drives rendering - setting
 	// state during render here discarded the in-progress render pass, which
 	// corrupted `useSyncExternalStore`'s snapshot bookkeeping and made it drop
 	// the tracker's completion notification, leaving the snackbar stuck in its

--- a/packages/editor/src/components/upload-progress-snackbar/index.js
+++ b/packages/editor/src/components/upload-progress-snackbar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { store as uploadStore } from '@wordpress/upload-media';
@@ -101,12 +101,14 @@ export default function UploadProgressSnackbar() {
 
 	// Track peak total across sources during a session. The CSM queue removes
 	// items on completion, and the tracker tops out at its recorded total, so
-	// `total` has to be tracked as the high-water mark.
-	const [ peak, setPeak ] = useState( 0 );
+	// `total` has to be tracked as the high-water mark. Held in a ref (updated
+	// inside the effect below) because it never drives rendering — setting
+	// state during render here discarded the in-progress render pass, which
+	// corrupted `useSyncExternalStore`'s snapshot bookkeeping and made it drop
+	// the tracker's completion notification, leaving the snackbar stuck in its
+	// uploading state (see gutenberg#80343).
 	const sessionTotal = csmRemaining + ( tracker ? tracker.total : 0 );
-	if ( sessionTotal > peak ) {
-		setPeak( sessionTotal );
-	}
+	const peakRef = useRef( 0 );
 
 	const { createNotice, removeNotice } = useDispatch( noticesStore );
 
@@ -139,7 +141,7 @@ export default function UploadProgressSnackbar() {
 			if ( completionTimeoutRef.current ) {
 				clearTimeout( completionTimeoutRef.current );
 				completionTimeoutRef.current = null;
-				setPeak( 0 );
+				peakRef.current = 0;
 			}
 		} else if ( ! isUploading && wasUploadingRef.current ) {
 			speak( __( 'Media upload complete' ), 'polite' );
@@ -160,10 +162,10 @@ export default function UploadProgressSnackbar() {
 				completionTimeoutRef.current = setTimeout( () => {
 					removeNotice( NOTICE_ID );
 					completionTimeoutRef.current = null;
-					setPeak( 0 );
+					peakRef.current = 0;
 				}, COMPLETION_DISPLAY_MS );
 			} else {
-				setPeak( 0 );
+				peakRef.current = 0;
 			}
 		}
 
@@ -173,7 +175,11 @@ export default function UploadProgressSnackbar() {
 			return;
 		}
 
-		const total = peak;
+		if ( sessionTotal > peakRef.current ) {
+			peakRef.current = sessionTotal;
+		}
+
+		const total = peakRef.current;
 		const current = total - remaining + 1;
 
 		// Prefer the CSM queue's first original filename, then fall back to
@@ -210,7 +216,14 @@ export default function UploadProgressSnackbar() {
 				dismissedRef.current = true;
 			},
 		} );
-	}, [ remaining, peak, csmOriginals, tracker, createNotice, removeNotice ] );
+	}, [
+		remaining,
+		sessionTotal,
+		csmOriginals,
+		tracker,
+		createNotice,
+		removeNotice,
+	] );
 
 	return null;
 }

--- a/test/e2e/specs/editor/various/upload-progress-snackbar.spec.js
+++ b/test/e2e/specs/editor/various/upload-progress-snackbar.spec.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Upload progress snackbar (server-side uploads)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Force the traditional server-side upload path, mirroring a site
+		// where the `wp_client_side_media_processing_enabled` filter returns
+		// false or the browser lacks client-side processing support.
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test( 'completes and dismisses when uploading to an image block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await imageBlock
+			.locator( 'data-testid=form-file-upload-input' )
+			.setInputFiles( './assets/10x10_e2e_test_image_z9T8jK.png' );
+
+		// Wait for the upload to finish: the image src flips from a blob URL
+		// to the final uploaded URL.
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
+		await expect( image ).toHaveAttribute( 'src', /^https?:\/\//, {
+			timeout: 30_000,
+		} );
+
+		// The progress snackbar must transition to its completion state and
+		// not remain stuck at "Uploading" (regression: gutenberg#80343).
+		const snackbarList = page.locator( '.components-snackbar-list' );
+		await expect( snackbarList.getByText( 'Upload complete' ) ).toBeVisible(
+			{ timeout: 10_000 }
+		);
+		await expect( snackbarList.getByText( /^Uploading/ ) ).toBeHidden();
+
+		// The completion snackbar dismisses itself shortly after.
+		await expect( snackbarList.getByText( 'Upload complete' ) ).toBeHidden(
+			{ timeout: 10_000 }
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes #80343

## What?

Fixes the upload progress snackbar getting stuck in its "Uploading" state when media is uploaded via the traditional server-side path, i.e. when client-side media processing is disabled via the `wp_client_side_media_processing_enabled` filter or unavailable in the browser.

## Why?

With client-side media processing disabled, uploading to an image block left the "Uploading — filename" snackbar on screen indefinitely, even after the upload completed. See #80343.

## How?

Root cause: `UploadProgressSnackbar` called `setPeak()` during render to track the session's high-water upload count. When the non-CSM upload tracker notified its `useSyncExternalStore` subscription, the resulting re-render performed that render-phase state update, which discards the in-progress render pass and leaves the hook's internal snapshot bookkeeping stale. The tracker's next (and final) notification - the one that signals completion - then compared as "unchanged" and was silently dropped, so the component never re-rendered and the notice never transitioned to "Upload complete".

The client-side media processing path masked the bug because the upload-media store emits many notifications per upload, so a single dropped update self-heals. The server-side tracker emits exactly two (start and completion), so losing the completion one left the snackbar stuck.

The peak count is only read inside the effect that manages the notice - it never drives rendering - so this PR stores it in a ref updated within that effect, removing the render-phase state update entirely.

A new e2e test covers the server-side upload path end to end (it fails on trunk and passes with this fix). Existing unit tests and the client-side media processing e2e suite pass unchanged.

## Testing Instructions

1. Disable client-side media processing, e.g. in a plugin or mu-plugin:
   ```php
   add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
   ```
2. Open the post editor and add an Image block.
3. Upload an image file.
4. Observe the snackbar: it should show "Uploading — filename", then switch to "Upload complete" and dismiss itself a few seconds later. On trunk it stays stuck at "Uploading".

Or run the new e2e test:

```
npm run test:e2e -- upload-progress-snackbar.spec.js
```

Or test in Playground (add the filter via a snippet or just observe the default behavior in unsupported browsers):

[![Test in WP Playground](https://img.shields.io/badge/Test%20in-WP%20Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=80345)
