### PR TITLE
Device preview dropdown: use active color for device icon when responsive styles are active

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -176,7 +176,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		<DropdownMenu
 			className={ clsx(
 				'editor-preview-dropdown',
-				`editor-preview-dropdown--${ deviceType.toLowerCase() }`
+				`editor-preview-dropdown--${ deviceType.toLowerCase() }`,
+				{ 'is-responsive-editing': isResponsiveEditing }
 			) }
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -2,3 +2,9 @@
 	padding-right: 4px;
 	padding-left: 6px;
 }
+
+// Tint the device icon to signal that responsive styling is active,
+// reusing the synced-pattern color for a consistent "special state" cue.
+.editor-preview-dropdown.is-responsive-editing .editor-preview-dropdown__toggle svg {
+	fill: var(--wp-block-synced-color);
+}

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -3,8 +3,10 @@
 	padding-left: 6px;
 }
 
-// Tint the device icon to signal that responsive styling is active,
-// reusing the synced-pattern color for a consistent "special state" cue.
-.editor-preview-dropdown.is-responsive-editing .editor-preview-dropdown__toggle svg {
-	fill: var(--wp-block-synced-color);
+// Tint the toggle to signal that responsive styling is active, reusing the
+// synced-pattern color for a consistent "special state" cue. Coloring the
+// button (rather than just the icon) also tints the "View" text label when the
+// "Show button text labels" preference is on; the icon follows via currentColor.
+.editor-preview-dropdown.is-responsive-editing .editor-preview-dropdown__toggle {
+	color: var(--wp-block-synced-color);
 }


### PR DESCRIPTION


## What

Colours the device icon on the editor's preview/view toggle when Responsive styles editing is on, reusing the synced-pattern purple.

## Why

Nothing in the header signals that you're in responsive editing mode. Tinting the icon gives a persistent cue, matching the synced-pattern colour already used in the settings sidebar.

## What changed

- Add an `is-responsive-editing` modifier to the preview dropdown, driven by the existing `isResponsiveEditing` flag.
- Tint the toggle with `var(--wp-block-synced-color)`. The icon follows via `currentColor`, and the "View" text label is also tinted when the "Show button text labels" preference is on.

## Manual testing

1. Open a template or post in the editor.
2. Open the View (preview) dropdown and enable Responsive styles.
3. Confirm the device icon in the header turns purple.
4. Switch device (Desktop / Tablet / Mobile) and confirm the tint persists.
5. Disable Responsive styles and confirm the icon returns to default.
6. Set "Show button text labels" to on in Preferences > Accessibility
7. Check that "View" also behaves the same way.


https://github.com/user-attachments/assets/cf0d8166-ac23-40fe-9784-aabebe8464ce



