### PR TITLE
Fix: Critical error websocket-driver fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42759,9 +42759,10 @@
 			}
 		},
 		"node_modules/websocket-driver": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-			"integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+			"integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"http-parser-js": ">=0.5.1",
 				"safe-buffer": ">=5.1.0",


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/security/dependabot/702

## Why?
Fixes a critical dependabot alert

## How?
Ran a simple command `npm audit fix`, this fixed the critical error. 

<img width="423" height="112" alt="image" src="https://github.com/user-attachments/assets/babe72ca-d35e-457d-8804-2bc286c1de3f" />

### Before 

<img width="423" height="112" alt="image" src="https://github.com/user-attachments/assets/071f124c-d611-4814-a94c-813bcfe3aec3" />

### After 
<img width="423" height="113" alt="image" src="https://github.com/user-attachments/assets/889d9890-06a9-4129-803a-5c3feb246c14" />
