### PR TITLE
Distraction Free: raise top bar above notices when revealed by hover or keyboard focus

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -286,6 +286,11 @@
 		position: absolute;
 		z-index: 35;
 	}
+
+	.interface-interface-skeleton__header:hover,
+	.interface-interface-skeleton__header:focus-within {
+		z-index: 36;
+	}
 }
 
 .components-popover.more-menu-dropdown__content {


### PR DESCRIPTION
## What?
Closes #49485

Fixes an accessibility bug in Distraction free mode where admin/editor notices visually cover the top bar, while its buttons remain focusable and operable underneath, leaving keyboard users unable to see where focus currently is.

## Why?
In Distraction free mode, the top bar (`Header`) is faded out (`opacity: 0`) via a motion animation until it's hovered or contains focus. Admin notices are rendered in a sibling region that's deliberately kept visible (via `position: absolute; z-index: 35`) so they aren't hidden along with the top bar.

The top bar's own `:focus-within` rule already restores its `opacity` when a keyboard user tabs into one of its controls, but the top bar's `z-index` was never raised to match, so it stayed underneath the notice's `z-index: 35`. The practical effect: a sighted keyboard user tabbing through the interface lands on top bar controls that are fully operable but invisible, with no way to see where focus is. Tooltips for those controls then appeared to pop up out of nowhere, disconnected from any visible trigger.

This was raised and discussed in the original Distraction free mode PR (#41740), but keyboard accessibility wasn't addressed at the time.

## Testing Instructions
1. Edit a post.
2. Enable Distraction free mode (via the three-dot **Options** menu, or `View > Distraction free`).
3. Open your browser's dev tools console and run:
```js
   wp.data.dispatch( 'core/notices' ).createWarningNotice( 'My warning message.', { id: 'my-warning', actions: [ { label: 'My action' }, { label: 'Awesome action' } ] } )
```
4. Confirm the notice appears on top of the (now hidden) top bar, as before, this part is unchanged.
5. Hover over the area where the top bar would be. Confirm the top bar now appears **on top of** the notice instead of behind it.
6. Move the mouse away and confirm the top bar fades back out as before.

### Testing Instructions for Keyboard
1. Follow steps 1–3 above.
2. Click into the post title or content to place focus there, then press `Tab` repeatedly to move focus toward the top bar controls (or `Shift+Tab` back from the content into the top bar).
3. As focus reaches each top bar button, confirm:
   - The button becomes visible (top bar rises above the notice) instead of remaining hidden behind it.
   - A visible focus ring is shown on the focused button.
   - Any tooltip appears attached to its visible trigger button, not floating disconnected over the page.
4. Continue tabbing through all top bar controls and confirm none of them are ever invisible while focused.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/4d1d399f-dc58-4143-aea0-cce6b953ce9e
