### PR TITLE
Template Activation: fix array keys in get_block_templates() when merging registered templates

### DIFF
--- a/lib/compat/wordpress-7.0/template-activate.php
+++ b/lib/compat/wordpress-7.0/template-activate.php
@@ -818,7 +818,11 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 				$matching_registered_templates
 			);
 
-			$query_result = array_merge( $query_result, $matching_registered_templates );
+			// Re-index the array: `$matching_registered_templates` is keyed by the registered
+			// template name (e.g. `my-plugin//my-template`), so a plain `array_merge()` would
+			// leave the result with a mix of numeric and string keys whenever it is the only
+			// match for a query. Callers of `get_block_templates()` expect a zero-based list.
+			$query_result = array_values( array_merge( $query_result, $matching_registered_templates ) );
 		}
 	}
 

--- a/phpunit/class-gutenberg-get-block-templates-registered-template-test.php
+++ b/phpunit/class-gutenberg-get-block-templates-registered-template-test.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests that gutenberg_get_block_templates() returns a zero-indexed array
+ * when a plugin-registered template is the only match for a query.
+ *
+ * @package gutenberg
+ *
+ * @covers ::gutenberg_get_block_templates
+ */
+class Tests_Gutenberg_Get_Block_Templates_Registered_Template extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Enable the active_templates experiment so gutenberg_get_block_templates()
+		// short-circuits get_block_templates() via the pre_get_block_templates filter.
+		update_option( 'active_templates', array() );
+
+		switch_theme( 'emptytheme' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		delete_option( 'active_templates' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * When a plugin-registered template is the only result for a slug__in query,
+	 * the returned array must still be keyed from 0, not by the registered
+	 * template name (e.g. "test-plugin//test-template"). Consumers such as
+	 * wp_get_post_content_block_attributes() rely on $templates[0] to read the
+	 * match, and a string-keyed result causes an "Undefined array key 0" warning.
+	 */
+	public function test_returns_zero_indexed_array_for_single_registered_template() {
+		$template_name = 'test-plugin//test-template';
+
+		register_block_template(
+			$template_name,
+			array(
+				'title'   => 'Test Template',
+				'content' => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph -->',
+			)
+		);
+
+		$templates = get_block_templates( array( 'slug__in' => array( 'test-template' ) ) );
+
+		$this->assertCount( 1, $templates );
+		$this->assertArrayHasKey(
+			0,
+			$templates,
+			'get_block_templates() should return a zero-indexed array so callers can safely read $templates[0].'
+		);
+		$this->assertSame( 'test-template', $templates[0]->slug );
+
+		unregister_block_template( $template_name );
+	}
+
+	/**
+	 * A mix of a theme-provided/DB template and a registered template should
+	 * also come back zero-indexed and in a stable, iterable order.
+	 */
+	public function test_returns_zero_indexed_array_with_mixed_sources() {
+		$template_name = 'test-plugin//test-template-mixed';
+
+		register_block_template(
+			$template_name,
+			array(
+				'title'   => 'Test Template Mixed',
+				'content' => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph -->',
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'other-template',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph -->Other<!-- /wp:paragraph -->',
+			)
+		);
+		wp_set_post_terms( $post_id, array( get_stylesheet() ), 'wp_theme' );
+
+		$templates = get_block_templates(
+			array( 'slug__in' => array( 'test-template-mixed', 'other-template' ) )
+		);
+
+		$this->assertCount( 2, $templates );
+		$this->assertArrayHasKey( 0, $templates );
+		$this->assertArrayHasKey( 1, $templates );
+
+		$slugs = wp_list_pluck( $templates, 'slug' );
+		$this->assertContains( 'test-template-mixed', $slugs );
+		$this->assertContains( 'other-template', $slugs );
+
+		unregister_block_template( $template_name );
+		wp_delete_post( $post_id, true );
+	}
+}


### PR DESCRIPTION
## What?

Fixes the PHP warnings described in #80291, for the Template Activation experiment's copy of `get_block_templates()`.

## Why?

`gutenberg_get_block_templates()` (in `lib/compat/wordpress-7.0/template-activate.php`, hooked onto `pre_get_block_templates`) merges plugin-registered templates into the query result with `array_merge()`:

```php
$query_result = array_merge( $query_result, $matching_registered_templates );
```

`WP_Block_Templates_Registry::get_by_query()` returns its matches keyed by the full registered template name (e.g. `my-plugin//my-template`), not a numeric index. `array_merge()` preserves non-numeric string keys instead of renumbering them, so when a plugin-registered template is the *only* match for a `slug__in` query, `$query_result` ends up looking like:

```
[ 'my-plugin//my-template' => WP_Block_Template Object ]
```

instead of the expected:

```
[ 0 => WP_Block_Template Object ]
```

Every caller of `get_block_templates()` reads the first match as `$templates[0]` (for example core's `wp_get_post_content_block_attributes()`). With a string-keyed result, that produces `Undefined array key 0` / `Attempt to read property "content" on null`, and the resulting `null` flowing into `parse_blocks()` then trips the `preg_match()` / `strlen()` deprecation notices reported in the issue.

## How?

Wrap the merge in `array_values()` so the result is always re-indexed from `0`, regardless of whether the match came from the DB query, a theme file, or the plugin registry.

## Testing Instructions

1. Enable the `active_templates` experiment.
2. Register a template from a plugin using `register_block_template( 'my-plugin//my-template', [...] )`.
3. Call `get_block_templates( [ 'slug__in' => [ 'my-template' ] ] )` and confirm the single result is `$templates[0]`, not keyed by the registration name.
4. Run `phpunit/class-gutenberg-get-block-templates-registered-template-test.php` — it fails before this patch and passes after.

## Note on scope

This only fixes the Template Activation experiment's copy of the function. The bug reported in #80291 by default (without the experiment enabled) comes from core's own `get_block_templates()` in `wp-includes/block-template-utils.php`, which isn't duplicated in this plugin's `lib/` directory — that half needs a separate WordPress core Trac ticket and patch, tracked from the GitHub issue.