### PR TITLE
UI: improve component code readability in Storybook by using arrays for children

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internal
 
--   Use keyed children arrays instead of Fragments in Storybook stories so Show code examples omit `Fragment` wrappers.
+-   Use keyed children arrays instead of Fragments in Storybook stories so Show code examples omit `Fragment` wrappers ([#80352](https://github.com/WordPress/gutenberg/pull/80352)).
 
 ## 0.18.0 (2026-07-14)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   Remove unused CSS property from `Tabs` stylesheet ([#80269](https://github.com/WordPress/gutenberg/pull/80269)).
 
+### Internal
+
+-   Use keyed children arrays instead of Fragments in Storybook stories so Show code examples omit `Fragment` wrappers.
+
 ## 0.18.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/ui/src/alert-dialog/stories/index.story.tsx
+++ b/packages/ui/src/alert-dialog/stories/index.story.tsx
@@ -38,15 +38,16 @@ type Story = StoryObj< typeof AlertDialog.Root >;
  */
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Move to trash?"
-					description="This post will be moved to trash. You can restore it later."
-				/>
-			</>
-		),
+		children: [
+			<AlertDialog.Trigger key="trigger">
+				Move to trash
+			</AlertDialog.Trigger>,
+			<AlertDialog.Popup
+				title="Move to trash?"
+				description="This post will be moved to trash. You can restore it later."
+				key="popup"
+			/>,
+		],
 	},
 };
 
@@ -56,17 +57,18 @@ export const Default: Story = {
  */
 export const Irreversible: Story = {
 	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Delete permanently</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					intent="irreversible"
-					title="Delete permanently?"
-					description="This action cannot be undone. All data will be lost."
-					confirmButtonText="Delete permanently"
-				/>
-			</>
-		),
+		children: [
+			<AlertDialog.Trigger key="trigger">
+				Delete permanently
+			</AlertDialog.Trigger>,
+			<AlertDialog.Popup
+				intent="irreversible"
+				title="Delete permanently?"
+				description="This action cannot be undone. All data will be lost."
+				confirmButtonText="Delete permanently"
+				key="popup"
+			/>,
+		],
 	},
 };
 
@@ -75,17 +77,18 @@ export const Irreversible: Story = {
  */
 export const CustomLabels: Story = {
 	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Send feedback</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Send feedback?"
-					description="Your feedback helps us improve. Would you like to send it now?"
-					confirmButtonText="Send feedback"
-					cancelButtonText="Not now"
-				/>
-			</>
-		),
+		children: [
+			<AlertDialog.Trigger key="trigger">
+				Send feedback
+			</AlertDialog.Trigger>,
+			<AlertDialog.Popup
+				title="Send feedback?"
+				description="Your feedback helps us improve. Would you like to send it now?"
+				confirmButtonText="Send feedback"
+				cancelButtonText="Not now"
+				key="popup"
+			/>,
+		],
 	},
 };
 
@@ -96,27 +99,28 @@ export const CustomLabels: Story = {
  */
 export const WithCustomContent: Story = {
 	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Remove pages</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Remove 3 pages?"
-					description="These pages will be moved to trash."
-					confirmButtonText="Delete pages"
+		children: [
+			<AlertDialog.Trigger key="trigger">
+				Remove pages
+			</AlertDialog.Trigger>,
+			<AlertDialog.Popup
+				title="Remove 3 pages?"
+				description="These pages will be moved to trash."
+				confirmButtonText="Delete pages"
+				key="popup"
+			>
+				<ul
+					style={ {
+						margin: 'var(--wpds-dimension-gap-sm) 0 0',
+						paddingInlineStart: 'var(--wpds-dimension-gap-lg)',
+					} }
 				>
-					<ul
-						style={ {
-							margin: 'var(--wpds-dimension-gap-sm) 0 0',
-							paddingInlineStart: 'var(--wpds-dimension-gap-lg)',
-						} }
-					>
-						<Text render={ <li /> }>About us</Text>
-						<Text render={ <li /> }>Contact</Text>
-						<Text render={ <li /> }>Privacy policy</Text>
-					</ul>
-				</AlertDialog.Popup>
-			</>
-		),
+					<Text render={ <li /> }>About us</Text>
+					<Text render={ <li /> }>Contact</Text>
+					<Text render={ <li /> }>Privacy policy</Text>
+				</ul>
+			</AlertDialog.Popup>,
+		],
 	},
 };
 
@@ -140,20 +144,21 @@ export const WithCustomContent: Story = {
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
-		children: (
-			<>
-				<AlertDialog.Trigger>Move to trash</AlertDialog.Trigger>
-				<AlertDialog.Popup
-					title="Move to trash?"
-					description="This post will be moved to trash. You can restore it later."
-					portal={
-						<AlertDialog.Portal
-							style={ { '--wp-ui-dialog-z-index': '9999' } }
-						/>
-					}
-				/>
-			</>
-		),
+		children: [
+			<AlertDialog.Trigger key="trigger">
+				Move to trash
+			</AlertDialog.Trigger>,
+			<AlertDialog.Popup
+				title="Move to trash?"
+				description="This post will be moved to trash. You can restore it later."
+				portal={
+					<AlertDialog.Portal
+						style={ { '--wp-ui-dialog-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			/>,
+		],
 	},
 };
 
@@ -338,6 +343,7 @@ function StickyToggle( {
 				checked={ value }
 				onChange={ ( event ) => onChange( event.target.checked ) }
 			/>
+
 			<label htmlFor={ id }>{ label }</label>
 		</Stack>
 	);
@@ -355,6 +361,7 @@ function ScrollableContent() {
 						value={ stickyHeader }
 						onChange={ setStickyHeader }
 					/>
+
 					<StickyToggle
 						label="Sticky footer"
 						value={ stickyFooter }

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -156,12 +156,7 @@ export const WithIcon: Story = {
 	...Default,
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Button.Icon icon={ wordpress } />
-				Button
-			</>
-		),
+		children: [ <Button.Icon icon={ wordpress } key="icon" />, 'Button' ],
 	},
 };
 

--- a/packages/ui/src/card/stories/index.story.tsx
+++ b/packages/ui/src/card/stories/index.story.tsx
@@ -52,28 +52,24 @@ type Story = StoryObj< typeof Card.Root >;
 
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Card title</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						This is the main content area. It can contain any
-						elements. This is the main content area. It can contain
-						any elements. This is the main content area. It can
-						contain any elements. This is the main content area. It
-						can contain any elements. This is the main content area.
-						It can contain any elements. This is the main content
-						area. It can contain any elements.
-					</Text>
-					<Text>
-						This is the main content area. It can contain any
-						elements.
-					</Text>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header key="header">
+				<Card.Title>Card title</Card.Title>
+			</Card.Header>,
+			<Card.Content key="content">
+				<Text>
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+					This is the main content area. It can contain any elements.
+				</Text>
+				<Text>
+					This is the main content area. It can contain any elements.
+				</Text>
+			</Card.Content>,
+		],
 	},
 };
 
@@ -106,24 +102,22 @@ export const FullBleedCoverOnly: Story = {
  */
 export const FullBleedCoverWithHeader: Story = {
 	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Card title</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header key="header">
+				<Card.Title>Card title</Card.Title>
+			</Card.Header>,
+			<Card.Content key="content">
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</Card.Content>,
+		],
 	},
 };
 
@@ -133,25 +127,26 @@ export const FullBleedCoverWithHeader: Story = {
  */
 export const WithFullBleed: Story = {
 	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title>Featured image</Card.Title>
-				</Card.Header>
-				<Card.Content render={ <Stack direction="column" gap="lg" /> }>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 160,
-								background:
-									'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Text>Content below the full-bleed area.</Text>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header key="header">
+				<Card.Title>Featured image</Card.Title>
+			</Card.Header>,
+			<Card.Content
+				key="content"
+				render={ <Stack direction="column" gap="lg" /> }
+			>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 160,
+							background:
+								'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Text>Content below the full-bleed area.</Text>
+			</Card.Content>,
+		],
 	},
 };
 
@@ -175,28 +170,29 @@ export const HeaderOnly: Story = {
  */
 export const FullBleedHeroWithTitle: Story = {
 	args: {
-		children: (
-			<>
-				<Card.Header render={ <Stack direction="column" gap="lg" /> }>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Card.Title>Hero image card</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						The image above bleeds to the card&apos;s top and side
-						edges.
-					</Text>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header
+				key="header"
+				render={ <Stack direction="column" gap="lg" /> }
+			>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Card.Title>Hero image card</Card.Title>
+			</Card.Header>,
+			<Card.Content key="content">
+				<Text>
+					The image above bleeds to the card&apos;s top and side
+					edges.
+				</Text>
+			</Card.Content>,
+		],
 	},
 };
 
@@ -207,27 +203,25 @@ export const FullBleedHeroWithTitle: Story = {
  */
 export const FullBleedHeroOnly: Story = {
 	args: {
-		children: (
-			<>
-				<Card.Header>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</Card.Header>
-				<Card.Content>
-					<Text>
-						The image above bleeds to the card&apos;s top and side
-						edges.
-					</Text>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header key="header">
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</Card.Header>,
+			<Card.Content key="content">
+				<Text>
+					The image above bleeds to the card&apos;s top and side
+					edges.
+				</Text>
+			</Card.Content>,
+		],
 	},
 };
 
@@ -239,15 +233,13 @@ export const FullBleedHeroOnly: Story = {
 export const CustomSemantics: Story = {
 	args: {
 		render: <section />,
-		children: (
-			<>
-				<Card.Header>
-					<Card.Title render={ <h2 /> }>Section heading</Card.Title>
-				</Card.Header>
-				<Card.Content>
-					<Text>Semantically meaningful card content.</Text>
-				</Card.Content>
-			</>
-		),
+		children: [
+			<Card.Header key="header">
+				<Card.Title render={ <h2 /> }>Section heading</Card.Title>
+			</Card.Header>,
+			<Card.Content key="content">
+				<Text>Semantically meaningful card content.</Text>
+			</Card.Content>,
+		],
 	},
 };

--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -51,24 +51,20 @@ type Story = StoryObj< typeof CollapsibleCard.Root >;
  */
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>
-						Collapsible card (closed by default)
-					</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>
-						This is the collapsible content area. It can contain any
-						elements, just like a regular Card.Content.
-					</Text>
-					<Text>
-						When collapsed, only the header and chevron are visible.
-					</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
+		children: [
+			<CollapsibleCard.Header key="header">
+				<Card.Title>Collapsible card (closed by default)</Card.Title>
+			</CollapsibleCard.Header>,
+			<CollapsibleCard.Content key="content">
+				<Text>
+					This is the collapsible content area. It can contain any
+					elements, just like a regular Card.Content.
+				</Text>
+				<Text>
+					When collapsed, only the header and chevron are visible.
+				</Text>
+			</CollapsibleCard.Content>,
+		],
 	},
 };
 
@@ -82,16 +78,14 @@ export const InitiallyOpened: Story = {
 	args: {
 		...Default.args,
 		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Collapsed by default</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>This content was hidden until you expanded it.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
+		children: [
+			<CollapsibleCard.Header key="header">
+				<Card.Title>Collapsed by default</Card.Title>
+			</CollapsibleCard.Header>,
+			<CollapsibleCard.Content key="content">
+				<Text>This content was hidden until you expanded it.</Text>
+			</CollapsibleCard.Content>,
+		],
 	},
 };
 
@@ -102,16 +96,14 @@ export const Disabled: Story = {
 	args: {
 		...Default.args,
 		disabled: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Disabled card</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Text>The header is not interactive when disabled.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
+		children: [
+			<CollapsibleCard.Header key="header">
+				<Card.Title>Disabled card</Card.Title>
+			</CollapsibleCard.Header>,
+			<CollapsibleCard.Content key="content">
+				<Text>The header is not interactive when disabled.</Text>
+			</CollapsibleCard.Content>,
+		],
 	},
 };
 
@@ -327,24 +319,22 @@ export const FullBleedCoverWithHeader: Story = {
 	argTypes: { open: { control: false } },
 	args: {
 		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Card title</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 180,
-								background:
-									'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-				</CollapsibleCard.Content>
-			</>
-		),
+		children: [
+			<CollapsibleCard.Header key="header">
+				<Card.Title>Card title</Card.Title>
+			</CollapsibleCard.Header>,
+			<CollapsibleCard.Content key="content">
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 180,
+							background:
+								'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+			</CollapsibleCard.Content>,
+		],
 	},
 };
 
@@ -357,26 +347,25 @@ export const WithFullBleed: Story = {
 	argTypes: { open: { control: false } },
 	args: {
 		defaultOpen: true,
-		children: (
-			<>
-				<CollapsibleCard.Header>
-					<Card.Title>Featured image</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content
-					render={ <Stack direction="column" gap="lg" /> }
-				>
-					<Card.FullBleed>
-						<div
-							style={ {
-								height: 160,
-								background:
-									'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-							} }
-						/>
-					</Card.FullBleed>
-					<Text>Content below the full-bleed area.</Text>
-				</CollapsibleCard.Content>
-			</>
-		),
+		children: [
+			<CollapsibleCard.Header key="header">
+				<Card.Title>Featured image</Card.Title>
+			</CollapsibleCard.Header>,
+			<CollapsibleCard.Content
+				render={ <Stack direction="column" gap="lg" /> }
+				key="content"
+			>
+				<Card.FullBleed>
+					<div
+						style={ {
+							height: 160,
+							background:
+								'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+						} }
+					/>
+				</Card.FullBleed>
+				<Text>Content below the full-bleed area.</Text>
+			</CollapsibleCard.Content>,
+		],
 	},
 };

--- a/packages/ui/src/collapsible/stories/index.story.tsx
+++ b/packages/ui/src/collapsible/stories/index.story.tsx
@@ -23,14 +23,12 @@ type Story = StoryObj< typeof Collapsible.Root >;
 
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>Collapsible content here.</p>
-				</Collapsible.Panel>
-			</>
-		),
+		children: [
+			<Collapsible.Trigger key="trigger">Toggle</Collapsible.Trigger>,
+			<Collapsible.Panel key="panel">
+				<p>Collapsible content here.</p>
+			</Collapsible.Panel>,
+		],
 	},
 };
 
@@ -38,28 +36,26 @@ export const DefaultOpen: Story = {
 	argTypes: { open: { control: false } },
 	args: {
 		defaultOpen: true,
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>This panel is open by default.</p>
-				</Collapsible.Panel>
-			</>
-		),
+		children: [
+			<Collapsible.Trigger key="trigger">Toggle</Collapsible.Trigger>,
+			<Collapsible.Panel key="panel">
+				<p>This panel is open by default.</p>
+			</Collapsible.Panel>,
+		],
 	},
 };
 
 export const Disabled: Story = {
 	args: {
 		disabled: true,
-		children: (
-			<>
-				<Collapsible.Trigger>Toggle (disabled)</Collapsible.Trigger>
-				<Collapsible.Panel>
-					<p>This content cannot be toggled.</p>
-				</Collapsible.Panel>
-			</>
-		),
+		children: [
+			<Collapsible.Trigger key="trigger">
+				Toggle (disabled)
+			</Collapsible.Trigger>,
+			<Collapsible.Panel key="panel">
+				<p>This content cannot be toggled.</p>
+			</Collapsible.Panel>,
+		],
 	},
 };
 

--- a/packages/ui/src/dialog/stories/index.story.tsx
+++ b/packages/ui/src/dialog/stories/index.story.tsx
@@ -44,27 +44,25 @@ type Story = StoryObj< typeof Dialog.Root >;
  */
 export const _Default: Story = {
 	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup>
-					<Dialog.Header>
-						<Dialog.Title>Welcome</Dialog.Title>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<Dialog.Description>
-							This dialog demonstrates best practices for
-							informational dialogs. It includes a close icon
-							because dismissing it is safe and expected.
-						</Dialog.Description>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
+		children: [
+			<Dialog.Trigger key="trigger">Open Dialog</Dialog.Trigger>,
+			<Dialog.Popup key="popup">
+				<Dialog.Header>
+					<Dialog.Title>Welcome</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description>
+						This dialog demonstrates best practices for
+						informational dialogs. It includes a close icon because
+						dismissing it is safe and expected.
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>,
+		],
 	},
 };
 
@@ -159,33 +157,32 @@ export const AllSizes: Story = {
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup
-					portal={
-						<Dialog.Portal
-							style={ { '--wp-ui-dialog-z-index': '9999' } }
-						/>
-					}
-				>
-					<Dialog.Header>
-						<Dialog.Title>Custom z-index</Dialog.Title>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<Dialog.Description>
-							The backdrop and popup render at `z-index: 9999` via
-							the `--wp-ui-dialog-z-index` CSS custom property,
-							set on `Dialog.Portal` through the `portal` prop.
-						</Dialog.Description>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
+		children: [
+			<Dialog.Trigger key="trigger">Open Dialog</Dialog.Trigger>,
+			<Dialog.Popup
+				portal={
+					<Dialog.Portal
+						style={ { '--wp-ui-dialog-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				<Dialog.Header>
+					<Dialog.Title>Custom z-index</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<Dialog.Description>
+						The backdrop and popup render at `z-index: 9999` via the
+						`--wp-ui-dialog-z-index` CSS custom property, set on
+						`Dialog.Portal` through the `portal` prop.
+					</Dialog.Description>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>,
+		],
 	},
 };
 
@@ -213,6 +210,7 @@ function StickyToggle( {
 						onStickyHeaderChange( e.target.checked )
 					}
 				/>
+
 				<label htmlFor={ headerId }>Sticky header</label>
 			</Stack>
 			<Stack direction="row" gap="xs" align="center">
@@ -224,6 +222,7 @@ function StickyToggle( {
 						onStickyFooterChange( e.target.checked )
 					}
 				/>
+
 				<label htmlFor={ footerId }>Sticky footer</label>
 			</Stack>
 		</Stack>
@@ -242,12 +241,14 @@ function ScrollableContent() {
 			<Dialog.CloseIcon />
 		</Dialog.Header>
 	);
+
 	const footer = (
 		<Dialog.Footer>
 			<Dialog.Action variant="outline">Decline</Dialog.Action>
 			<Dialog.Action>Accept</Dialog.Action>
 		</Dialog.Footer>
 	);
+
 	const controls = (
 		<Stack direction="column" gap="sm" align="start">
 			<SizeSelector value={ size } onChange={ setSize } />
@@ -321,28 +322,25 @@ export const Scrollable: Story = {
  */
 export const WithVisuallyHiddenTitle: Story = {
 	args: {
-		children: (
-			<>
-				<Dialog.Trigger>Open Dialog</Dialog.Trigger>
-				<Dialog.Popup>
-					<Dialog.Header>
-						<VisuallyHidden render={ <Dialog.Title /> }>
-							Accessible dialog heading
-						</VisuallyHidden>
-						<Dialog.CloseIcon />
-					</Dialog.Header>
-					<Dialog.Content>
-						<p style={ { margin: 0 } }>
-							This dialog has a visually hidden title. Inspect the
-							DOM or use a screen reader to verify the heading is
-							present.
-						</p>
-					</Dialog.Content>
-					<Dialog.Footer>
-						<Dialog.Action>Got it</Dialog.Action>
-					</Dialog.Footer>
-				</Dialog.Popup>
-			</>
-		),
+		children: [
+			<Dialog.Trigger key="trigger">Open Dialog</Dialog.Trigger>,
+			<Dialog.Popup key="popup">
+				<Dialog.Header>
+					<VisuallyHidden render={ <Dialog.Title /> }>
+						Accessible dialog heading
+					</VisuallyHidden>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<p style={ { margin: 0 } }>
+						This dialog has a visually hidden title. Inspect the DOM
+						or use a screen reader to verify the heading is present.
+					</p>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action>Got it</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>,
+		],
 	},
 };

--- a/packages/ui/src/drawer/stories/index.story.tsx
+++ b/packages/ui/src/drawer/stories/index.story.tsx
@@ -43,25 +43,23 @@ type Story = StoryObj< typeof Drawer.Root >;
  */
 export const _Default: Story = {
 	args: {
-		children: (
-			<>
-				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-				<Drawer.Popup>
-					<Drawer.Header>
-						<Drawer.Title>Navigation</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							Browse through the available sections below.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Done</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
+		children: [
+			<Drawer.Trigger key="trigger">Open Drawer</Drawer.Trigger>,
+			<Drawer.Popup key="popup">
+				<Drawer.Header>
+					<Drawer.Title>Navigation</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						Browse through the available sections below.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Done</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>,
+		],
 	},
 };
 
@@ -133,26 +131,26 @@ export const Controlled: Story = {
 		);
 	},
 	args: {
-		children: (
-			<>
-				<Drawer.Trigger>Open Controlled Drawer</Drawer.Trigger>
-				<Drawer.Popup>
-					<Drawer.Header>
-						<Drawer.Title>Controlled Drawer</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							The open state is managed externally via{ ' ' }
-							<code>open</code> and <code>onOpenChange</code>.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Close</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
+		children: [
+			<Drawer.Trigger key="trigger">
+				Open Controlled Drawer
+			</Drawer.Trigger>,
+			<Drawer.Popup key="popup">
+				<Drawer.Header>
+					<Drawer.Title>Controlled Drawer</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						The open state is managed externally via{ ' ' }
+						<code>open</code> and <code>onOpenChange</code>.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>,
+		],
 	},
 	argTypes: {
 		open: { control: false },
@@ -170,26 +168,26 @@ export const NonModal: Story = {
 	args: {
 		swipeDirection: 'right',
 		modal: false,
-		children: (
-			<>
-				<Drawer.Trigger>Open Non-Modal Drawer</Drawer.Trigger>
-				<Drawer.Popup>
-					<Drawer.Header>
-						<Drawer.Title>Non-Modal</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							This drawer does not trap focus and allows
-							interaction with the rest of the page while open.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Close</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
+		children: [
+			<Drawer.Trigger key="trigger">
+				Open Non-Modal Drawer
+			</Drawer.Trigger>,
+			<Drawer.Popup key="popup">
+				<Drawer.Header>
+					<Drawer.Title>Non-Modal</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						This drawer does not trap focus and allows interaction
+						with the rest of the page while open.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Close</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>,
+		],
 	},
 	render: function NonModalRender( args ) {
 		return <Drawer.Root { ...args }>{ args.children }</Drawer.Root>;
@@ -286,34 +284,33 @@ function DirectionSelector( {
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
-		children: (
-			<>
-				<Drawer.Trigger>Open Drawer</Drawer.Trigger>
-				<Drawer.Popup
-					portal={
-						<Drawer.Portal
-							style={ { '--wp-ui-drawer-z-index': '9999' } }
-						/>
-					}
-				>
-					<Drawer.Header>
-						<Drawer.Title>Custom z-index</Drawer.Title>
-						<Drawer.CloseIcon />
-					</Drawer.Header>
-					<Drawer.Content>
-						<Drawer.Description>
-							The backdrop, viewport, and popup render at
-							`z-index: 9999` via the `--wp-ui-drawer-z-index` CSS
-							custom property, set on `Drawer.Portal` through the
-							`portal` prop.
-						</Drawer.Description>
-					</Drawer.Content>
-					<Drawer.Footer>
-						<Drawer.Action>Got it</Drawer.Action>
-					</Drawer.Footer>
-				</Drawer.Popup>
-			</>
-		),
+		children: [
+			<Drawer.Trigger key="trigger">Open Drawer</Drawer.Trigger>,
+			<Drawer.Popup
+				portal={
+					<Drawer.Portal
+						style={ { '--wp-ui-drawer-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				<Drawer.Header>
+					<Drawer.Title>Custom z-index</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Drawer.Description>
+						The backdrop, viewport, and popup render at `z-index:
+						9999` via the `--wp-ui-drawer-z-index` CSS custom
+						property, set on `Drawer.Portal` through the `portal`
+						prop.
+					</Drawer.Description>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action>Got it</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>,
+		],
 	},
 };
 
@@ -342,6 +339,7 @@ export const SizePlayground: Story = {
 						value={ direction }
 						onChange={ setDirection }
 					/>
+
 					<SizeSelector value={ size } onChange={ setSize } />
 					<Drawer.Trigger>Open Drawer</Drawer.Trigger>
 				</div>
@@ -362,6 +360,7 @@ export const SizePlayground: Story = {
 									value={ size }
 									onChange={ setSize }
 								/>
+
 								<DirectionSelector
 									value={ direction }
 									onChange={ setDirection }
@@ -419,6 +418,7 @@ function StickyToggle( {
 					checked={ stickyHeader }
 					onChange={ ( e ) => setStickyHeader( e.target.checked ) }
 				/>
+
 				<label htmlFor={ headerId }>Sticky header</label>
 			</Stack>
 			<Stack direction="row" gap="xs" align="center">
@@ -428,6 +428,7 @@ function StickyToggle( {
 					checked={ stickyFooter }
 					onChange={ ( e ) => setStickyFooter( e.target.checked ) }
 				/>
+
 				<label htmlFor={ footerId }>Sticky footer</label>
 			</Stack>
 		</Stack>
@@ -504,6 +505,7 @@ export const Scrollable: Story = {
 				<Drawer.CloseIcon />
 			</Drawer.Header>
 		);
+
 		const footer = (
 			<Drawer.Footer>
 				<Drawer.Action variant="outline">Decline</Drawer.Action>

--- a/packages/ui/src/empty-state/stories/index.story.tsx
+++ b/packages/ui/src/empty-state/stories/index.story.tsx
@@ -32,46 +32,42 @@ type Story = StoryObj< typeof EmptyState.Root >;
 
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<EmptyState.Icon icon={ search } />
-				<EmptyState.Title>No results found</EmptyState.Title>
-				<EmptyState.Description>
-					Try adjusting your search or filter to find what you&apos;re
-					looking for.
-				</EmptyState.Description>
-				<EmptyState.Actions>
-					<Button variant="outline">Clear filters</Button>
-					<Button>Add item</Button>
-				</EmptyState.Actions>
-			</>
-		),
+		children: [
+			<EmptyState.Icon icon={ search } key="icon" />,
+			<EmptyState.Title key="title">No results found</EmptyState.Title>,
+			<EmptyState.Description key="description">
+				Try adjusting your search or filter to find what you&apos;re
+				looking for.
+			</EmptyState.Description>,
+			<EmptyState.Actions key="actions">
+				<Button variant="outline">Clear filters</Button>
+				<Button>Add item</Button>
+			</EmptyState.Actions>,
+		],
 	},
 };
 
 export const WithCustomVisual: Story = {
 	args: {
-		children: (
-			<>
-				<EmptyState.Visual>
-					<svg
-						width="50"
-						height="50"
-						viewBox="0 0 50 50"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<circle cx="25" cy="25" r="25" fill="currentColor" />
-					</svg>
-				</EmptyState.Visual>
-				<EmptyState.Title>All caught up!</EmptyState.Title>
-				<EmptyState.Description>
-					You&apos;ve completed all your tasks. Great work!
-				</EmptyState.Description>
-				<EmptyState.Actions>
-					<Button>Create new task</Button>
-				</EmptyState.Actions>
-			</>
-		),
+		children: [
+			<EmptyState.Visual key="visual">
+				<svg
+					width="50"
+					height="50"
+					viewBox="0 0 50 50"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<circle cx="25" cy="25" r="25" fill="currentColor" />
+				</svg>
+			</EmptyState.Visual>,
+			<EmptyState.Title key="title">All caught up!</EmptyState.Title>,
+			<EmptyState.Description key="description">
+				You&apos;ve completed all your tasks. Great work!
+			</EmptyState.Description>,
+			<EmptyState.Actions key="actions">
+				<Button>Create new task</Button>
+			</EmptyState.Actions>,
+		],
 	},
 };

--- a/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/stories/index.story.tsx
@@ -52,28 +52,30 @@ type Story = StoryObj< typeof Autocomplete.Root >;
 export const Default: Story = {
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Enter a URL" type="url" />
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
+		children: [
+			<Autocomplete.Input
+				placeholder="Enter a URL"
+				type="url"
+				key="input"
+			/>,
+			<Autocomplete.Popup key="popup">
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>,
+		],
 	},
 };
 
@@ -226,47 +228,45 @@ export const Inline: Story = {
 export const WithSearchIconAndClearButton: Story = {
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.InputGroup>
-					<Autocomplete.Input
-						placeholder="Search URLs"
-						type="url"
-						render={
-							<Input
-								prefix={
-									<InputLayout.Slot padding="minimal">
-										<Icon icon={ search } />
-									</InputLayout.Slot>
-								}
-								suffix={
-									<InputLayout.Slot padding="minimal">
-										<Autocomplete.Clear />
-									</InputLayout.Slot>
-								}
-							/>
-						}
-					/>
-				</Autocomplete.InputGroup>
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
+		children: [
+			<Autocomplete.InputGroup key="inputGroup">
+				<Autocomplete.Input
+					placeholder="Search URLs"
+					type="url"
+					render={
+						<Input
+							prefix={
+								<InputLayout.Slot padding="minimal">
+									<Icon icon={ search } />
+								</InputLayout.Slot>
+							}
+							suffix={
+								<InputLayout.Slot padding="minimal">
+									<Autocomplete.Clear />
+								</InputLayout.Slot>
+							}
+						/>
+					}
+				/>
+			</Autocomplete.InputGroup>,
+			<Autocomplete.Popup key="popup">
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>,
+		],
 	},
 };
 
@@ -383,6 +383,7 @@ export const TextareaInlineAutocomplete: Story = {
 						/>
 					}
 				/>
+
 				<Autocomplete.Popup>
 					<Autocomplete.List>
 						<Autocomplete.ListBody>
@@ -424,33 +425,36 @@ export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
 		items: URLS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Enter a URL" type="url" />
-				<Autocomplete.Popup
-					portal={
-						<Autocomplete.Portal
-							style={ { '--wp-ui-autocomplete-z-index': '9999' } }
-						/>
-					}
-				>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( item: FixtureItem ) => (
-									<Autocomplete.Item
-										key={ item.id }
-										value={ item }
-									>
-										{ item.value }
-									</Autocomplete.Item>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
+		children: [
+			<Autocomplete.Input
+				placeholder="Enter a URL"
+				type="url"
+				key="input"
+			/>,
+			<Autocomplete.Popup
+				portal={
+					<Autocomplete.Portal
+						style={ { '--wp-ui-autocomplete-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( item: FixtureItem ) => (
+								<Autocomplete.Item
+									key={ item.id }
+									value={ item }
+								>
+									{ item.value }
+								</Autocomplete.Item>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>,
+		],
 	},
 };
 
@@ -461,39 +465,37 @@ export const WithCustomZIndex: Story = {
 export const Grouped: Story = {
 	args: {
 		items: GROUPED_COMMANDS,
-		children: (
-			<>
-				<Autocomplete.Input placeholder="Type a command" />
-				<Autocomplete.Popup>
-					<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
-					<Autocomplete.List>
-						<Autocomplete.ListBody>
-							<Autocomplete.Collection>
-								{ ( group: FixtureGroup ) => (
-									<Autocomplete.Group
-										key={ group.label }
-										items={ group.items }
-									>
-										<Autocomplete.GroupLabel>
-											{ group.label }
-										</Autocomplete.GroupLabel>
-										<Autocomplete.Collection>
-											{ ( item: FixtureItem ) => (
-												<Autocomplete.Item
-													key={ item.id }
-													value={ item }
-												>
-													{ item.value }
-												</Autocomplete.Item>
-											) }
-										</Autocomplete.Collection>
-									</Autocomplete.Group>
-								) }
-							</Autocomplete.Collection>
-						</Autocomplete.ListBody>
-					</Autocomplete.List>
-				</Autocomplete.Popup>
-			</>
-		),
+		children: [
+			<Autocomplete.Input placeholder="Type a command" key="input" />,
+			<Autocomplete.Popup key="popup">
+				<Autocomplete.Empty>No matching items.</Autocomplete.Empty>
+				<Autocomplete.List>
+					<Autocomplete.ListBody>
+						<Autocomplete.Collection>
+							{ ( group: FixtureGroup ) => (
+								<Autocomplete.Group
+									key={ group.label }
+									items={ group.items }
+								>
+									<Autocomplete.GroupLabel>
+										{ group.label }
+									</Autocomplete.GroupLabel>
+									<Autocomplete.Collection>
+										{ ( item: FixtureItem ) => (
+											<Autocomplete.Item
+												key={ item.id }
+												value={ item }
+											>
+												{ item.value }
+											</Autocomplete.Item>
+										) }
+									</Autocomplete.Collection>
+								</Autocomplete.Group>
+							) }
+						</Autocomplete.Collection>
+					</Autocomplete.ListBody>
+				</Autocomplete.List>
+			</Autocomplete.Popup>,
+		],
 	},
 };

--- a/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
@@ -43,31 +43,29 @@ const inputWrapperStyle = {
 export const Default: Story = {
 	args: {
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger />
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
+		children: [
+			<Combobox.Trigger key="trigger" />,
+			<Combobox.Popup key="popup">
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>,
+		],
 	},
 };
 
@@ -75,32 +73,30 @@ export const Compact: Story = {
 	args: {
 		defaultValue: ITEMS[ 0 ],
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger size="compact" />
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-										size="compact"
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
+		children: [
+			<Combobox.Trigger size="compact" key="trigger" />,
+			<Combobox.Popup key="popup">
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+									size="compact"
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>,
+		],
 	},
 };
 
@@ -116,33 +112,29 @@ export const DetachedInline: Story = {
 		items: ITEMS,
 		multiple: true,
 		inline: true,
-		children: (
-			<>
-				<Combobox.Input placeholder="Search" />
-				<div
-					style={ {
-						minHeight: '200px',
-						maxHeight: '200px',
-						marginTop: 8,
-						overflow: 'auto',
-					} }
-				>
-					<Combobox.Empty>No results found.</Combobox.Empty>
-					<Combobox.List>
-						<Combobox.Collection>
-							{ ( item: FixtureItem ) => (
-								<Combobox.Item
-									key={ item.value }
-									value={ item }
-								>
-									{ item.label }
-								</Combobox.Item>
-							) }
-						</Combobox.Collection>
-					</Combobox.List>
-				</div>
-			</>
-		),
+		children: [
+			<Combobox.Input placeholder="Search" key="input" />,
+			<div
+				style={ {
+					minHeight: '200px',
+					maxHeight: '200px',
+					marginTop: 8,
+					overflow: 'auto',
+				} }
+				key="div"
+			>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.Collection>
+						{ ( item: FixtureItem ) => (
+							<Combobox.Item key={ item.value } value={ item }>
+								{ item.label }
+							</Combobox.Item>
+						) }
+					</Combobox.Collection>
+				</Combobox.List>
+			</div>,
+		],
 	},
 };
 
@@ -280,66 +272,65 @@ export const WithCustomTriggerAndItem: Story = {
 	args: {
 		items: ITEMS,
 		defaultValue: ITEMS[ 0 ],
-		children: (
-			<>
-				<Combobox.Trigger>
-					{ ( item: FixtureItem ) => (
-						<span
+		children: [
+			<Combobox.Trigger key="trigger">
+				{ ( item: FixtureItem ) => (
+					<span
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+						} }
+					>
+						<img
+							src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
+							alt=""
+							width="20"
 							style={ {
-								display: 'flex',
-								alignItems: 'center',
-								gap: 8,
+								borderRadius: '50%',
 							} }
-						>
-							<img
-								src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
-								alt=""
-								width="20"
-								style={ {
-									borderRadius: '50%',
-								} }
-							/>
-							{ item.label }
-						</span>
-					) }
-				</Combobox.Trigger>
-				<Combobox.Popup>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-										aria-describedby={ `description-${ item.value }` }
+						/>
+
+						{ item.label }
+					</span>
+				) }
+			</Combobox.Trigger>,
+			<Combobox.Popup key="popup">
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+									aria-describedby={ `description-${ item.value }` }
+								>
+									<div
+										style={ {
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'space-between',
+											flexGrow: 1,
+										} }
 									>
-										<div
-											style={ {
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'space-between',
-												flexGrow: 1,
-											} }
+										<span>{ item.label }</span>
+										<span
+											id={ `description-${ item.value }` }
+											aria-hidden="true"
 										>
-											<span>{ item.label }</span>
-											<span
-												id={ `description-${ item.value }` }
-												aria-hidden="true"
-											>
-												99 in stock
-											</span>
-										</div>
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
+											99 in stock
+										</span>
+									</div>
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>,
+		],
 	},
 };
 
@@ -362,37 +353,36 @@ export const WithCustomZIndex: Story = {
 	args: {
 		defaultValue: ITEMS[ 0 ],
 		items: ITEMS,
-		children: (
-			<>
-				<Combobox.Trigger />
-				<Combobox.Popup
-					positioner={
-						<Combobox.Positioner
-							style={ {
-								'--wp-ui-combobox-z-index': '9999',
-							} }
-						/>
-					}
-				>
-					<div style={ inputWrapperStyle }>
-						<Combobox.Input placeholder="Search" />
-					</div>
-					<Combobox.List>
-						<Combobox.ListBody>
-							<Combobox.Collection>
-								{ ( item: FixtureItem ) => (
-									<Combobox.Item
-										key={ item.value }
-										value={ item }
-									>
-										{ item.label }
-									</Combobox.Item>
-								) }
-							</Combobox.Collection>
-						</Combobox.ListBody>
-					</Combobox.List>
-				</Combobox.Popup>
-			</>
-		),
+		children: [
+			<Combobox.Trigger key="trigger" />,
+			<Combobox.Popup
+				positioner={
+					<Combobox.Positioner
+						style={ {
+							'--wp-ui-combobox-z-index': '9999',
+						} }
+					/>
+				}
+				key="popup"
+			>
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( item: FixtureItem ) => (
+								<Combobox.Item
+									key={ item.value }
+									value={ item }
+								>
+									{ item.label }
+								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>,
+		],
 	},
 };

--- a/packages/ui/src/form/primitives/field/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/field/stories/index.story.tsx
@@ -30,17 +30,17 @@ export default meta;
  */
 export const Default: StoryObj< typeof Field.Root > = {
 	args: {
-		children: (
-			<>
-				<Field.Label>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-				<Field.Description>
-					The accessible description.
-				</Field.Description>
-			</>
-		),
+		children: [
+			<Field.Label key="label">Label</Field.Label>,
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+				key="control"
+			/>,
+
+			<Field.Description key="description">
+				The accessible description.
+			</Field.Description>,
+		],
 	},
 };
 
@@ -72,6 +72,7 @@ export const UsingHtmlFor: StoryObj< typeof Field.Root > = {
 					id={ controlId }
 					aria-describedby={ descriptionId }
 				/>
+
 				<Field.Description id={ descriptionId }>
 					The accessible description.
 				</Field.Description>
@@ -114,14 +115,15 @@ export const UsingAriaLabelledby: StoryObj< typeof Field.Root > = {
  */
 export const HiddenLabel: StoryObj< typeof Field.Root > = {
 	args: {
-		children: (
-			<>
-				<Field.Label hideFromVision>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-			</>
-		),
+		children: [
+			<Field.Label hideFromVision key="label">
+				Label
+			</Field.Label>,
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+				key="control"
+			/>,
+		],
 	},
 };
 
@@ -137,14 +139,14 @@ export const HiddenLabel: StoryObj< typeof Field.Root > = {
  */
 export const WithDetails: StoryObj< typeof Field.Root > = {
 	args: {
-		children: (
-			<>
-				<Field.Label>Label</Field.Label>
-				<Field.Control
-					render={ <input type="text" placeholder="Placeholder" /> }
-				/>
-				<Field.Details>{ DETAILS_EXAMPLE }</Field.Details>
-			</>
-		),
+		children: [
+			<Field.Label key="label">Label</Field.Label>,
+			<Field.Control
+				render={ <input type="text" placeholder="Placeholder" /> }
+				key="control"
+			/>,
+
+			<Field.Details key="details">{ DETAILS_EXAMPLE }</Field.Details>,
+		],
 	},
 };

--- a/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/fieldset/stories/index.story.tsx
@@ -24,20 +24,18 @@ type Story = StoryObj< typeof Fieldset.Root >;
 
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<Fieldset.Legend>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-				<Fieldset.Description>
-					This is a description for the entire fieldset.
-				</Fieldset.Description>
-			</>
-		),
+		children: [
+			<Fieldset.Legend key="legend">Legend</Fieldset.Legend>,
+			[ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ),
+			<Fieldset.Description key="description">
+				This is a description for the entire fieldset.
+			</Fieldset.Description>,
+		],
 	},
 };
 
@@ -47,17 +45,17 @@ export const Default: Story = {
  */
 export const HiddenLegend: Story = {
 	args: {
-		children: (
-			<>
-				<Fieldset.Legend hideFromVision>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-			</>
-		),
+		children: [
+			<Fieldset.Legend hideFromVision key="legend">
+				Legend
+			</Fieldset.Legend>,
+			[ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ),
+		],
 	},
 };
 
@@ -73,17 +71,17 @@ export const HiddenLegend: Story = {
  */
 export const WithDetails: Story = {
 	args: {
-		children: (
-			<>
-				<Fieldset.Legend>Legend</Fieldset.Legend>
-				{ [ 'Apples', 'Bananas' ].map( ( fruit ) => (
-					// eslint-disable-next-line jsx-a11y/label-has-associated-control
-					<label key={ fruit }>
-						<input type="checkbox" /> { fruit }
-					</label>
-				) ) }
-				<Fieldset.Details>{ DETAILS_EXAMPLE }</Fieldset.Details>
-			</>
-		),
+		children: [
+			<Fieldset.Legend key="legend">Legend</Fieldset.Legend>,
+			[ 'Apples', 'Bananas' ].map( ( fruit ) => (
+				// eslint-disable-next-line jsx-a11y/label-has-associated-control
+				<label key={ fruit }>
+					<input type="checkbox" /> { fruit }
+				</label>
+			) ),
+			<Fieldset.Details key="details">
+				{ DETAILS_EXAMPLE }
+			</Fieldset.Details>,
+		],
 	},
 };

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -31,40 +31,36 @@ const defaultItems = Array.from( { length: 6 }, ( _, index ) => ( {
 export const Default: Story = {
 	args: {
 		items: defaultItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ defaultItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 
 export const Compact: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger size="compact" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value }
-							value={ item }
-							size="compact"
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger size="compact" key="trigger" />,
+			<Select.Popup key="popup">
+				{ defaultItems.map( ( item ) => (
+					<Select.Item
+						key={ item.value }
+						value={ item }
+						size="compact"
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 
@@ -78,22 +74,21 @@ export const Compact: Story = {
  */
 export const Minimal: Story = {
 	args: {
-		children: (
-			<>
-				<Select.Trigger size="small" variant="minimal" />
-				<Select.Popup>
-					{ Array.from( { length: 6 }, ( _, index ) => (
-						<Select.Item
-							key={ index }
-							value={ `${ index + 1 }` }
-							size="small"
-						>
-							{ `${ index + 1 }` }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger size="small" variant="minimal" key="trigger" />,
+			<Select.Popup key="popup">
+				{ Array.from( { length: 6 }, ( _, index ) => (
+					<Select.Item
+						key={ index }
+						value={ `${ index + 1 }` }
+						size="small"
+					>
+						{ `${ index + 1 }` }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
+
 		defaultValue: '1',
 	},
 };
@@ -105,18 +100,16 @@ export const Minimal: Story = {
 export const WithCustomPlaceholder: Story = {
 	args: {
 		items: defaultItems,
-		children: (
-			<>
-				<Select.Trigger placeholder="Choose an item" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger placeholder="Choose an item" key="trigger" />,
+			<Select.Popup key="popup">
+				{ defaultItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 
@@ -135,21 +128,19 @@ const nullValueOptionItems = [
 export const WithNullValueOption: Story = {
 	args: {
 		items: nullValueOptionItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ nullValueOptionItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value ?? 'null' }
-							value={ item.value }
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ nullValueOptionItems.map( ( item ) => (
+					<Select.Item
+						key={ item.value ?? 'null' }
+						value={ item.value }
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 
@@ -162,18 +153,16 @@ export const WithNullValueOption: Story = {
 export const Labeling: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger aria-label="User role" />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger aria-label="User role" key="trigger" />,
+			<Select.Popup key="popup">
+				{ defaultItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 
@@ -194,18 +183,17 @@ const overflowItems = [
 export const WithOverflow: Story = {
 	args: {
 		items: overflowItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ overflowItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ overflowItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
+
 		defaultValue: overflowItems[ 0 ],
 	},
 };
@@ -213,18 +201,17 @@ export const WithOverflow: Story = {
 export const Disabled: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ defaultItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
+
 		defaultValue: defaultItems[ 0 ],
 		disabled: true,
 	},
@@ -245,22 +232,21 @@ const disabledItemItems = [
 export const WithDisabledItem: Story = {
 	args: {
 		items: disabledItemItems,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup>
-					{ disabledItemItems.map( ( item ) => (
-						<Select.Item
-							key={ item.value }
-							value={ item }
-							disabled={ item.disabled }
-						>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ disabledItemItems.map( ( item ) => (
+					<Select.Item
+						key={ item.value }
+						value={ item }
+						disabled={ item.disabled }
+					>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
+
 		defaultValue: disabledItemItems[ 0 ],
 	},
 };
@@ -283,38 +269,38 @@ const customOptions = [
 export const WithCustomTriggerAndItem: Story = {
 	args: {
 		items: customOptions,
-		children: (
-			<>
-				<Select.Trigger>
-					{ ( item ) => (
-						<span
+		children: [
+			<Select.Trigger key="trigger">
+				{ ( item ) => (
+					<span
+						style={ {
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+						} }
+					>
+						<img
+							src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
+							alt=""
+							width="20"
 							style={ {
-								display: 'flex',
-								alignItems: 'center',
-								gap: 8,
+								borderRadius: '50%',
 							} }
-						>
-							<img
-								src={ `https://gravatar.com/avatar/?d=initials&name=${ item.value }` }
-								alt=""
-								width="20"
-								style={ {
-									borderRadius: '50%',
-								} }
-							/>
-							{ item.label }
-						</span>
-					) }
-				</Select.Trigger>
-				<Select.Popup>
-					{ customOptions.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+						/>
+
+						{ item.label }
+					</span>
+				) }
+			</Select.Trigger>,
+			<Select.Popup key="popup">
+				{ customOptions.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
+
 		defaultValue: customOptions[ 0 ],
 	},
 };
@@ -339,23 +325,22 @@ export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Select.Trigger />
-				<Select.Popup
-					portal={
-						<Select.Portal
-							style={ { '--wp-ui-select-z-index': '9999' } }
-						/>
-					}
-				>
-					{ defaultItems.map( ( item ) => (
-						<Select.Item key={ item.value } value={ item }>
-							{ item.label }
-						</Select.Item>
-					) ) }
-				</Select.Popup>
-			</>
-		),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup
+				portal={
+					<Select.Portal
+						style={ { '--wp-ui-select-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				{ defaultItems.map( ( item ) => (
+					<Select.Item key={ item.value } value={ item }>
+						{ item.label }
+					</Select.Item>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };

--- a/packages/ui/src/form/select-control/stories/index.story.tsx
+++ b/packages/ui/src/form/select-control/stories/index.story.tsx
@@ -156,6 +156,7 @@ const User = ( { user }: { user: ( typeof userOptions )[ number ] } ) => (
 				borderRadius: '50%',
 			} }
 		/>
+
 		{ user.label }
 	</span>
 );
@@ -175,19 +176,18 @@ export const WithCustomTriggerAndItems: Story = {
 		label: 'Label',
 		description: 'This is the description.',
 		triggerContent: ( item ) => <User user={ item } />,
-		children: (
-			<>
-				{ userOptions.map( ( item ) => (
-					<SelectControl.Item
-						key={ item.value }
-						value={ item }
-						label={ item.label }
-					>
-						<User user={ item } />
-					</SelectControl.Item>
-				) ) }
-			</>
-		),
+		children: [
+			userOptions.map( ( item ) => (
+				<SelectControl.Item
+					key={ item.value }
+					value={ item }
+					label={ item.label }
+				>
+					<User user={ item } />
+				</SelectControl.Item>
+			) ),
+		],
+
 		defaultValue: userOptions[ 0 ],
 	},
 };
@@ -202,19 +202,17 @@ export const WithCustomTriggerAndItems: Story = {
 export const WithItemsArrayAndPartialCustomization: Story = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				{ Default.args?.items?.map( ( item ) => (
-					<SelectControl.Item
-						key={ item.value ?? 'null' }
-						value={ item }
-						label={ item.label }
-						disabled={ item.disabled }
-					>
-						✨ { item.label }
-					</SelectControl.Item>
-				) ) }
-			</>
-		),
+		children: [
+			Default.args?.items?.map( ( item ) => (
+				<SelectControl.Item
+					key={ item.value ?? 'null' }
+					value={ item }
+					label={ item.label }
+					disabled={ item.disabled }
+				>
+					✨ { item.label }
+				</SelectControl.Item>
+			) ),
+		],
 	},
 };

--- a/packages/ui/src/link-button/stories/index.story.tsx
+++ b/packages/ui/src/link-button/stories/index.story.tsx
@@ -137,12 +137,10 @@ export const WithIcon: Story = {
 	...Default,
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<LinkButton.Icon icon={ wordpress } />
-				Link button
-			</>
-		),
+		children: [
+			<LinkButton.Icon icon={ wordpress } key="icon" />,
+			'Link button',
+		],
 	},
 };
 

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -26,22 +26,20 @@ type Story = StoryObj< typeof Notice.Root >;
 
 export const Default: Story = {
 	args: {
-		children: (
-			<>
-				<Notice.Title>Notice Title</Notice.Title>
-				<Notice.Description>
-					Description text with details about this notification.
-				</Notice.Description>
-				<Notice.Actions>
-					<Notice.ActionButton>Primary button</Notice.ActionButton>
-					<Notice.ActionButton variant="outline">
-						Secondary button
-					</Notice.ActionButton>
-					<Notice.ActionLink href="#">Link</Notice.ActionLink>
-				</Notice.Actions>
-				<Notice.CloseIcon />
-			</>
-		),
+		children: [
+			<Notice.Title key="title">Notice Title</Notice.Title>,
+			<Notice.Description key="description">
+				Description text with details about this notification.
+			</Notice.Description>,
+			<Notice.Actions key="actions">
+				<Notice.ActionButton>Primary button</Notice.ActionButton>
+				<Notice.ActionButton variant="outline">
+					Secondary button
+				</Notice.ActionButton>
+				<Notice.ActionLink href="#">Link</Notice.ActionLink>
+			</Notice.Actions>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
 	},
 };
 
@@ -83,18 +81,16 @@ export const Error: Story = {
 export const NonDismissible: Story = {
 	args: {
 		intent: 'warning',
-		children: (
-			<>
-				<Notice.Title>Action Required</Notice.Title>
-				<Notice.Description>
-					This notice cannot be dismissed by the user.
-				</Notice.Description>
-				<Notice.Actions>
-					<Notice.ActionButton>Take Action</Notice.ActionButton>
-					<Notice.ActionLink href="#">Visit link</Notice.ActionLink>
-				</Notice.Actions>
-			</>
-		),
+		children: [
+			<Notice.Title key="title">Action Required</Notice.Title>,
+			<Notice.Description key="description">
+				This notice cannot be dismissed by the user.
+			</Notice.Description>,
+			<Notice.Actions key="actions">
+				<Notice.ActionButton>Take Action</Notice.ActionButton>
+				<Notice.ActionLink href="#">Visit link</Notice.ActionLink>
+			</Notice.Actions>,
+		],
 	},
 };
 
@@ -105,30 +101,26 @@ export const WithoutIcon: Story = {
 	args: {
 		intent: 'info',
 		icon: null,
-		children: (
-			<>
-				<Notice.Title>No Icon</Notice.Title>
-				<Notice.Description>
-					This notice has no decorative icon displayed.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
+		children: [
+			<Notice.Title key="title">No Icon</Notice.Title>,
+			<Notice.Description key="description">
+				This notice has no decorative icon displayed.
+			</Notice.Description>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
 	},
 };
 
 export const WithoutActions: Story = {
 	args: {
 		intent: 'info',
-		children: (
-			<>
-				<Notice.Title>Simple Notice</Notice.Title>
-				<Notice.Description>
-					A dismissable notice without any action buttons or links.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
+		children: [
+			<Notice.Title key="title">Simple Notice</Notice.Title>,
+			<Notice.Description key="description">
+				A dismissable notice without any action buttons or links.
+			</Notice.Description>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
 	},
 };
 
@@ -137,12 +129,10 @@ export const WithoutActions: Story = {
  */
 export const TitleOnly: Story = {
 	args: {
-		children: (
-			<>
-				<Notice.Title>Just a title</Notice.Title>
-				<Notice.CloseIcon />
-			</>
-		),
+		children: [
+			<Notice.Title key="title">Just a title</Notice.Title>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
 	},
 };
 
@@ -152,13 +142,11 @@ export const TitleOnly: Story = {
 export const DescriptionOnly: Story = {
 	args: {
 		intent: 'info',
-		children: (
-			<>
-				<Notice.Description>
-					Just a description without title or actions.
-				</Notice.Description>
-				<Notice.CloseIcon />
-			</>
-		),
+		children: [
+			<Notice.Description key="description">
+				Just a description without title or actions.
+			</Notice.Description>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
 	},
 };

--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -40,24 +40,20 @@ export const Default: Story = {
 		children: { control: { type: 'text' } },
 	},
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Popover title
-					</Popover.Title>
-					<Popover.Description>
-						Popover description
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Open Popover</Popover.Trigger>,
+			<Popover.Popup key="popup">
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Popover title
+				</Popover.Title>
+				<Popover.Description>Popover description</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -67,23 +63,19 @@ export const Default: Story = {
  */
 export const NoArrow: Story = {
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Popover title
-					</Popover.Title>
-					<Popover.Description>
-						Popover description
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Open Popover</Popover.Trigger>,
+			<Popover.Popup key="popup">
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Popover title
+				</Popover.Title>
+				<Popover.Description>Popover description</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -151,39 +143,37 @@ export const Positioning: Story = {
  */
 export const WithCloseButton: Story = {
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Settings</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<div
-						style={ {
-							display: 'flex',
-							justifyContent: 'space-between',
-							alignItems: 'center',
-							marginBottom: 'var(--wpds-dimension-gap-sm)',
-						} }
-					>
-						<Popover.Title>Settings</Popover.Title>
-						<Popover.Close
-							render={
-								<IconButton
-									variant="minimal"
-									size="compact"
-									tone="neutral"
-									icon={ close }
-									label="Close"
-								/>
-							}
-						/>
-					</div>
-					<Popover.Description>
-						Configure your notification preferences and display
-						settings.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Settings</Popover.Trigger>,
+			<Popover.Popup key="popup">
+				<Popover.Arrow />
+				<div
+					style={ {
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						marginBottom: 'var(--wpds-dimension-gap-sm)',
+					} }
+				>
+					<Popover.Title>Settings</Popover.Title>
+					<Popover.Close
+						render={
+							<IconButton
+								variant="minimal"
+								size="compact"
+								tone="neutral"
+								icon={ close }
+								label="Close"
+							/>
+						}
+					/>
+				</div>
+				<Popover.Description>
+					Configure your notification preferences and display
+					settings.
+				</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -202,24 +192,22 @@ export const Controlled: Story = {
 		defaultOpen: { control: false },
 	},
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Toggle Popover</Popover.Trigger>
-				<Popover.Popup>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Controlled Popover
-					</Popover.Title>
-					<Popover.Description>
-						This popover is controlled by external state.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Toggle Popover</Popover.Trigger>,
+			<Popover.Popup key="popup">
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Controlled Popover
+				</Popover.Title>
+				<Popover.Description>
+					This popover is controlled by external state.
+				</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 	render: function Render( args ) {
 		const [ isOpen, setIsOpen ] = useState( false );
@@ -290,83 +278,81 @@ export const Modal: Story = {
 	argTypes: { modal: { control: false } },
 	args: {
 		modal: true,
-		children: (
-			<>
-				<Popover.Trigger>Edit Settings</Popover.Trigger>
-				<Popover.Popup backdrop>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Settings
-					</Popover.Title>
-					<form
+		children: [
+			<Popover.Trigger key="trigger">Edit Settings</Popover.Trigger>,
+			<Popover.Popup backdrop key="popup">
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Settings
+				</Popover.Title>
+				<form
+					style={ {
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 'var(--wpds-dimension-gap-sm)',
+						marginTop: 'var(--wpds-dimension-gap-sm)',
+					} }
+					onSubmit={ ( e ) => e.preventDefault() }
+				>
+					<label
+						htmlFor="popover-test-name-id"
 						style={ {
 							display: 'flex',
 							flexDirection: 'column',
-							gap: 'var(--wpds-dimension-gap-sm)',
-							marginTop: 'var(--wpds-dimension-gap-sm)',
+							gap: 'var(--wpds-dimension-gap-xs)',
+							fontSize: 'inherit',
 						} }
-						onSubmit={ ( e ) => e.preventDefault() }
 					>
-						<label
-							htmlFor="popover-test-name-id"
+						Name
+						<input
+							// eslint-disable-next-line no-restricted-syntax
+							id="popover-test-name-id"
+							type="text"
+							placeholder="Enter your name"
+						/>
+					</label>
+					<label
+						htmlFor="popover-test-email-id"
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 'var(--wpds-dimension-gap-xs)',
+							fontSize: 'inherit',
+						} }
+					>
+						Email
+						<input
+							// eslint-disable-next-line no-restricted-syntax
+							id="popover-test-email-id"
+							type="email"
+							placeholder="Enter your email"
+						/>
+					</label>
+					<div
+						style={ {
+							display: 'flex',
+							justifyContent: 'flex-end',
+							gap: 'var(--wpds-dimension-gap-sm)',
+							marginTop: 'var(--wpds-dimension-gap-xs)',
+						} }
+					>
+						<Popover.Close
 							style={ {
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 'var(--wpds-dimension-gap-xs)',
-								fontSize: 'inherit',
+								all: 'unset',
+								cursor: 'pointer',
 							} }
 						>
-							Name
-							<input
-								// eslint-disable-next-line no-restricted-syntax
-								id="popover-test-name-id"
-								type="text"
-								placeholder="Enter your name"
-							/>
-						</label>
-						<label
-							htmlFor="popover-test-email-id"
-							style={ {
-								display: 'flex',
-								flexDirection: 'column',
-								gap: 'var(--wpds-dimension-gap-xs)',
-								fontSize: 'inherit',
-							} }
-						>
-							Email
-							<input
-								// eslint-disable-next-line no-restricted-syntax
-								id="popover-test-email-id"
-								type="email"
-								placeholder="Enter your email"
-							/>
-						</label>
-						<div
-							style={ {
-								display: 'flex',
-								justifyContent: 'flex-end',
-								gap: 'var(--wpds-dimension-gap-sm)',
-								marginTop: 'var(--wpds-dimension-gap-xs)',
-							} }
-						>
-							<Popover.Close
-								style={ {
-									all: 'unset',
-									cursor: 'pointer',
-								} }
-							>
-								Cancel
-							</Popover.Close>
-							<button type="submit">Save</button>
-						</div>
-					</form>
-				</Popover.Popup>
-			</>
-		),
+							Cancel
+						</Popover.Close>
+						<button type="submit">Save</button>
+					</div>
+				</form>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -376,24 +362,22 @@ export const Modal: Story = {
  */
 export const Unstyled: Story = {
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Unstyled</Popover.Trigger>
-				<Popover.Popup variant="unstyled">
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Custom Styled
-					</Popover.Title>
-					<Popover.Description>
-						This popup has no default styling — the consumer
-						controls all visual appearance.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Open Unstyled</Popover.Trigger>,
+			<Popover.Popup variant="unstyled" key="popup">
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
+				>
+					Custom Styled
+				</Popover.Title>
+				<Popover.Description>
+					This popup has no default styling — the consumer controls
+					all visual appearance.
+				</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -481,6 +465,7 @@ export const Inline: Story = {
 						ref={ inlineContainerRef }
 						style={ { display: 'contents' } }
 					/>
+
 					<Popover.Popup
 						portal={
 							<Popover.Portal container={ inlineContainerRef } />
@@ -715,32 +700,31 @@ export const CrossIframe: Story = {
 export const WithCustomZIndex: Story = {
 	name: 'With Custom z-index',
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Popover</Popover.Trigger>
-				<Popover.Popup
-					portal={
-						<Popover.Portal
-							style={ { '--wp-ui-popover-z-index': '9999' } }
-						/>
-					}
+		children: [
+			<Popover.Trigger key="trigger">Open Popover</Popover.Trigger>,
+			<Popover.Popup
+				portal={
+					<Popover.Portal
+						style={ { '--wp-ui-popover-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				<Popover.Arrow />
+				<Popover.Title
+					style={ {
+						marginBottom: 'var(--wpds-dimension-gap-xs)',
+					} }
 				>
-					<Popover.Arrow />
-					<Popover.Title
-						style={ {
-							marginBottom: 'var(--wpds-dimension-gap-xs)',
-						} }
-					>
-						Custom z-index
-					</Popover.Title>
-					<Popover.Description>
-						This popover renders at `z-index: 9999` via the
-						`--wp-ui-popover-z-index` CSS custom property, set on
-						`Popover.Portal` through the `portal` prop.
-					</Popover.Description>
-				</Popover.Popup>
-			</>
-		),
+					Custom z-index
+				</Popover.Title>
+				<Popover.Description>
+					This popover renders at `z-index: 9999` via the
+					`--wp-ui-popover-z-index` CSS custom property, set on
+					`Popover.Portal` through the `portal` prop.
+				</Popover.Description>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -910,31 +894,30 @@ export const Anchor: Story = {
  */
 export const ToolbarVariant: Story = {
 	args: {
-		children: (
-			<>
-				<Popover.Trigger>Open Toolbar</Popover.Trigger>
-				<Popover.Popup
-					variant="unstyled"
-					style={ {
-						display: 'flex',
-						gap: 'var(--wpds-dimension-gap-xs)',
-						padding: '4px 8px',
-						border: '1px solid #1e1e1e',
-						borderRadius: 2,
-						background: '#fff',
-						fontSize: 13,
-					} }
-				>
-					<VisuallyHidden render={ <Popover.Title /> }>
-						Formatting
-					</VisuallyHidden>
-					<button type="button">B</button>
-					<button type="button">I</button>
-					<button type="button">U</button>
-					<button type="button">Link</button>
-				</Popover.Popup>
-			</>
-		),
+		children: [
+			<Popover.Trigger key="trigger">Open Toolbar</Popover.Trigger>,
+			<Popover.Popup
+				variant="unstyled"
+				style={ {
+					display: 'flex',
+					gap: 'var(--wpds-dimension-gap-xs)',
+					padding: '4px 8px',
+					border: '1px solid #1e1e1e',
+					borderRadius: 2,
+					background: '#fff',
+					fontSize: 13,
+				} }
+				key="popup"
+			>
+				<VisuallyHidden render={ <Popover.Title /> }>
+					Formatting
+				</VisuallyHidden>
+				<button type="button">B</button>
+				<button type="button">I</button>
+				<button type="button">U</button>
+				<button type="button">Link</button>
+			</Popover.Popup>,
+		],
 	},
 };
 
@@ -1118,6 +1101,7 @@ export const InitialFocus: Story = {
 							type="text"
 							placeholder="Enter name"
 						/>
+
 						<label
 							htmlFor={ emailId }
 							style={ {

--- a/packages/ui/src/stack/stories/index.story.tsx
+++ b/packages/ui/src/stack/stories/index.story.tsx
@@ -29,16 +29,14 @@ type Story = StoryObj< typeof Stack >;
 export const Default: Story = {
 	args: {
 		gap: 'md',
-		children: (
-			<>
-				<DemoBox />
-				<DemoBox variant="lg" />
-				<DemoBox />
-				<DemoBox />
-				<DemoBox variant="lg" />
-				<DemoBox />
-			</>
-		),
+		children: [
+			<DemoBox key="demoBox" />,
+			<DemoBox variant="lg" key="demoBox-2" />,
+			<DemoBox key="demoBox-3" />,
+			<DemoBox key="demoBox-4" />,
+			<DemoBox variant="lg" key="demoBox-5" />,
+			<DemoBox key="demoBox-6" />,
+		],
 	},
 	argTypes: {
 		align: {
@@ -51,6 +49,7 @@ export const Default: Story = {
 				'baseline',
 				'stretch',
 			],
+
 			table: {
 				type: {
 					summary:
@@ -72,6 +71,7 @@ export const Default: Story = {
 				'left',
 				'right',
 			],
+
 			table: {
 				type: {
 					summary:
@@ -94,20 +94,18 @@ export const Nested: Story = {
 		...Default.args,
 		align: 'center',
 		justify: 'center',
-		children: (
-			<>
-				<DemoBox variant="lg" />
-				<Stack gap="lg">
-					<DemoBox />
-					<DemoBox />
-				</Stack>
-				<DemoBox variant="lg" />
-				<Stack direction="column">
-					<DemoBox />
-					<DemoBox />
-				</Stack>
-				<DemoBox variant="lg" />
-			</>
-		),
+		children: [
+			<DemoBox variant="lg" key="demoBox" />,
+			<Stack gap="lg" key="stack">
+				<DemoBox />
+				<DemoBox />
+			</Stack>,
+			<DemoBox variant="lg" key="demoBox-2" />,
+			<Stack direction="column" key="stack-2">
+				<DemoBox />
+				<DemoBox />
+			</Stack>,
+			<DemoBox variant="lg" key="demoBox-3" />,
+		],
 	},
 };

--- a/packages/ui/src/tabs/stories/index.story.tsx
+++ b/packages/ui/src/tabs/stories/index.story.tsx
@@ -37,48 +37,44 @@ const ThemedParagraph = ( { children }: { children: React.ReactNode } ) => {
 export const Default: StoryObj< typeof Tabs.Root > = {
 	args: {
 		defaultValue: 'tab1',
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
+		children: [
+			<Tabs.List key="list">
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>,
+			<Tabs.Panel value="tab1" key="panel-tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab2" key="panel-tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab3" key="panel-tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>,
+		],
 	},
 };
 
 export const Minimal: StoryObj< typeof Tabs.Root > = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Tabs.List variant="minimal">
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
+		children: [
+			<Tabs.List variant="minimal" key="list">
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>,
+			<Tabs.Panel value="tab1" key="panel-tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab2" key="panel-tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab3" key="panel-tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>,
+		],
 	},
 };
 
@@ -218,26 +214,24 @@ export const WithDisabledTab: StoryObj< typeof Tabs.Root > = {
 	args: {
 		...Default.args,
 		defaultValue: 'tab3',
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1" disabled>
-						Tab 1
-					</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1">
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2">
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3">
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
+		children: [
+			<Tabs.List key="list">
+				<Tabs.Tab value="tab1" disabled>
+					Tab 1
+				</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>,
+			<Tabs.Panel value="tab1" key="panel-tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab2" key="panel-tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab3" key="panel-tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>,
+		],
 	},
 };
 
@@ -274,109 +268,96 @@ const tabWithIconsData = [
 export const WithTabIconsAndTooltips: StoryObj< typeof Tabs.Root > = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					{ tabWithIconsData.map(
-						( { value, label, icon: Icon } ) => (
-							<Tooltip.Root key={ value }>
-								<Tooltip.Trigger
-									aria-label={ label }
-									render={ <Tabs.Tab value={ value } /> }
-								>
-									{ /* TODO: potentially refactor with new Icon component */ }
-									<Icon
-										style={ {
-											width: '20px',
-											height: '20px',
-										} }
-									/>
-								</Tooltip.Trigger>
-								<Tooltip.Popup
-									positioner={
-										<Tooltip.Positioner
-											align="center"
-											side="top"
-										/>
-									}
-								>
-									{ label }
-								</Tooltip.Popup>
-							</Tooltip.Root>
-						)
-					) }
-				</Tabs.List>
-				{ tabWithIconsData.map( ( { value, label } ) => (
-					<Tabs.Panel value={ value } key={ value }>
-						<ThemedParagraph>
-							Selected tab: { label }
-						</ThemedParagraph>
-					</Tabs.Panel>
+		children: [
+			<Tabs.List key="list">
+				{ tabWithIconsData.map( ( { value, label, icon: Icon } ) => (
+					<Tooltip.Root key={ value }>
+						<Tooltip.Trigger
+							aria-label={ label }
+							render={ <Tabs.Tab value={ value } /> }
+						>
+							{ /* TODO: potentially refactor with new Icon component */ }
+							<Icon
+								style={ {
+									width: '20px',
+									height: '20px',
+								} }
+							/>
+						</Tooltip.Trigger>
+						<Tooltip.Popup
+							positioner={
+								<Tooltip.Positioner align="center" side="top" />
+							}
+						>
+							{ label }
+						</Tooltip.Popup>
+					</Tooltip.Root>
 				) ) }
-			</>
-		),
+			</Tabs.List>,
+			tabWithIconsData.map( ( { value, label } ) => (
+				<Tabs.Panel value={ value } key={ value }>
+					<ThemedParagraph>Selected tab: { label }</ThemedParagraph>
+				</Tabs.Panel>
+			) ),
+		],
 	},
 };
 
 export const WithPanelsAlwaysMounted: StoryObj< typeof Tabs.Root > = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3" keepMounted>
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-				</Tabs.Panel>
-			</>
-		),
+		children: [
+			<Tabs.List key="list">
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>,
+			<Tabs.Panel value="tab1" keepMounted key="panel-tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab2" keepMounted key="panel-tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab3" keepMounted key="panel-tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+			</Tabs.Panel>,
+		],
 	},
 };
 
 export const WithNonFocusablePanels: StoryObj< typeof Tabs.Root > = {
 	args: {
 		...Default.args,
-		children: (
-			<>
-				<Tabs.List>
-					<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-					<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
-					<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
-				</Tabs.List>
-				<Tabs.Panel value="tab1" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab2" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-				<Tabs.Panel value="tab3" tabIndex={ -1 }>
-					<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
-					<ThemedParagraph>
-						This tabpanel is not focusable, therefore tabbing into
-						it will focus its first tabbable child.
-					</ThemedParagraph>
-					<button>Focus me</button>
-				</Tabs.Panel>
-			</>
-		),
+		children: [
+			<Tabs.List key="list">
+				<Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+				<Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+				<Tabs.Tab value="tab3">Tab 3</Tabs.Tab>
+			</Tabs.List>,
+			<Tabs.Panel value="tab1" tabIndex={ -1 } key="panel-tab1">
+				<ThemedParagraph>Selected tab: Tab 1</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab2" tabIndex={ -1 } key="panel-tab2">
+				<ThemedParagraph>Selected tab: Tab 2</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>,
+			<Tabs.Panel value="tab3" tabIndex={ -1 } key="panel-tab3">
+				<ThemedParagraph>Selected tab: Tab 3</ThemedParagraph>
+				<ThemedParagraph>
+					This tabpanel is not focusable, therefore tabbing into it
+					will focus its first tabbable child.
+				</ThemedParagraph>
+				<button>Focus me</button>
+			</Tabs.Panel>,
+		],
 	},
 };

--- a/packages/ui/src/tooltip/stories/index.story.tsx
+++ b/packages/ui/src/tooltip/stories/index.story.tsx
@@ -25,12 +25,12 @@ export default meta;
 
 export const Default: StoryObj< typeof Tooltip.Root > = {
 	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup>Save</Tooltip.Popup>
-			</>
-		),
+		children: [
+			<Tooltip.Trigger aria-label="Save" key="trigger">
+				💾
+			</Tooltip.Trigger>,
+			<Tooltip.Popup key="popup">Save</Tooltip.Popup>,
+		],
 	},
 };
 
@@ -108,22 +108,23 @@ export const Positioning: StoryObj< typeof Tooltip.Root > = {
  */
 export const WithCustomPositioner: StoryObj< typeof Tooltip.Root > = {
 	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup
-					positioner={
-						<Tooltip.Positioner
-							side="right"
-							align="start"
-							sideOffset={ 16 }
-						/>
-					}
-				>
-					Save
-				</Tooltip.Popup>
-			</>
-		),
+		children: [
+			<Tooltip.Trigger aria-label="Save" key="trigger">
+				💾
+			</Tooltip.Trigger>,
+			<Tooltip.Popup
+				positioner={
+					<Tooltip.Positioner
+						side="right"
+						align="start"
+						sideOffset={ 16 }
+					/>
+				}
+				key="popup"
+			>
+				Save
+			</Tooltip.Popup>,
+		],
 	},
 };
 
@@ -146,20 +147,21 @@ export const WithCustomPositioner: StoryObj< typeof Tooltip.Root > = {
 export const WithCustomZIndex: StoryObj< typeof Tooltip.Root > = {
 	name: 'With Custom z-index',
 	args: {
-		children: (
-			<>
-				<Tooltip.Trigger aria-label="Save">💾</Tooltip.Trigger>
-				<Tooltip.Popup
-					portal={
-						<Tooltip.Portal
-							style={ { '--wp-ui-tooltip-z-index': '9999' } }
-						/>
-					}
-				>
-					Save
-				</Tooltip.Popup>
-			</>
-		),
+		children: [
+			<Tooltip.Trigger aria-label="Save" key="trigger">
+				💾
+			</Tooltip.Trigger>,
+			<Tooltip.Popup
+				portal={
+					<Tooltip.Portal
+						style={ { '--wp-ui-tooltip-z-index': '9999' } }
+					/>
+				}
+				key="popup"
+			>
+				Save
+			</Tooltip.Popup>,
+		],
 	},
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Follow-up to https://github.com/WordPress/gutenberg/pull/77382#issuecomment-4731307918

Alternative to https://github.com/WordPress/gutenberg/pull/80129

Pairs with https://github.com/WordPress/gutenberg/pull/80132 which adds `displayName`s.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Avoid `<React.Fragment>`  appearing in code examples by using `[]` instead of `<>` in Storybook examples.

<!-- In a few words, what is the PR actually doing? -->

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Cleaner code previews and copy-paste for docs consumers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Run `npm run storybook:dev`
Smoke test different stories and code snippets.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="1047" height="718" alt="image" src="https://github.com/user-attachments/assets/61b39059-8f7e-4a4d-a609-56d2b4f25de4" />
<img width="1039" height="571" alt="image" src="https://github.com/user-attachments/assets/6e664ee6-d97c-406c-8747-0142983a6f2b" />


### After
<img width="467" height="342" alt="Screenshot 2026-07-16 at 12 50 46" src="https://github.com/user-attachments/assets/0a44982e-afbb-470f-b3c6-5151c66723fa" />
<img width="380"  alt="image" src="https://github.com/user-attachments/assets/8efc58df-626b-44ad-a01d-c92e4bd9fe8b" />

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
