### PR TITLE
@wordpress/ui: Add Button Storybook example for keyboard shortcut composition

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
+-   `Button`: Add Storybook example demonstrating manual keyboard shortcut composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description ([#80353](https://github.com/WordPress/gutenberg/pull/80353)).
 
 ### Bug Fixes
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,4 +1,3 @@
-import type { ComponentProps } from 'react';
 import { Fragment, useId } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wordpress } from '@wordpress/icons';
@@ -195,38 +194,46 @@ export const Pressed: Story = {
 /**
  * `Button` has no dedicated `shortcut` prop, so keyboard shortcuts must be
  * composed manually: a visual hint in the tooltip, `aria-keyshortcuts` for
- * assistive technology, and a visually hidden description.
+ * assistive technology, and a visually hidden description. Consumers remain
+ * responsible for registering the shortcut and handling the corresponding
+ * keyboard event.
  */
 export const WithKeyboardShortcut: Story = {
 	args: {
 		children: 'Save',
 		'aria-keyshortcuts': ariaKeyShortcut.primary( 's' ),
 	},
-	render: ( { 'aria-describedby': consumerDescribedBy, ...args } ) => {
+	render: ( {
+		children,
+		'aria-describedby': consumerDescribedBy,
+		...args
+	} ) => {
 		const descriptionId = useId();
 
 		return (
-			<>
-				<Tooltip.Root>
-					<Tooltip.Trigger
-						{ ...( {
-							render: <Button { ...args } />,
-						} as ComponentProps< typeof Tooltip.Trigger > ) }
-						aria-describedby={ [
-							consumerDescribedBy,
-							descriptionId,
-						]
-							.filter( Boolean )
-							.join( ' ' ) }
-					/>
-					<Tooltip.Popup>
-						{ args.children } { displayShortcut.primary( 's' ) }
-					</Tooltip.Popup>
-				</Tooltip.Root>
-				<VisuallyHidden id={ descriptionId }>
-					Keyboard shortcut: { shortcutAriaLabel.primary( 's' ) }
-				</VisuallyHidden>
-			</>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					render={ <Button { ...args } /> }
+					aria-describedby={ [ consumerDescribedBy, descriptionId ]
+						.filter( Boolean )
+						.join( ' ' ) }
+				>
+					{ children }
+					<VisuallyHidden
+						id={ descriptionId }
+						aria-hidden="true"
+						render={ <span /> }
+					>
+						Keyboard shortcut: { shortcutAriaLabel.primary( 's' ) }
+					</VisuallyHidden>
+				</Tooltip.Trigger>
+				<Tooltip.Popup>
+					{ children }{ ' ' }
+					<span aria-hidden="true" dir="ltr">
+						{ displayShortcut.primary( 's' ) }
+					</span>
+				</Tooltip.Popup>
+			</Tooltip.Root>
 		);
 	},
 };

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,7 +1,10 @@
-import { Fragment } from '@wordpress/element';
+import { Fragment, useId } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wordpress } from '@wordpress/icons';
+import { displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
+
 import { Button } from '../index';
+import * as Tooltip from '../../tooltip';
 
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
@@ -180,5 +183,53 @@ export const Pressed: Story = {
 		tone: 'neutral',
 		variant: 'minimal',
 		'aria-pressed': true,
+	},
+};
+
+/**
+ * `Button` has no dedicated `shortcut` prop, so keyboard shortcuts must be
+ * composed manually: a visual hint in the tooltip, `aria-keyshortcuts` for
+ * assistive technology, and a visually hidden description.
+ */
+export const WithKeyboardShortcut: Story = {
+	render: () => {
+		const descriptionId = useId();
+
+		return (
+			<>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						{ ...( {
+							render: (
+								<Button
+									aria-keyshortcuts="Meta+S"
+									aria-describedby={ descriptionId }
+								>
+									Save
+								</Button>
+							),
+						} as React.ComponentProps< typeof Tooltip.Trigger > ) }
+					/>
+					<Tooltip.Popup>
+						{ displayShortcut.primary( 's' ) }
+					</Tooltip.Popup>
+				</Tooltip.Root>
+				<span
+					id={ descriptionId }
+					style={ {
+						position: 'absolute',
+						width: 1,
+						height: 1,
+						overflow: 'hidden',
+						clip: 'rect(0 0 0 0)',
+						whiteSpace: 'nowrap',
+					} }
+				>
+					{ `Keyboard shortcut: ${ shortcutAriaLabel.primary(
+						's'
+					) }` }
+				</span>
+			</>
+		);
 	},
 };

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,10 +1,16 @@
+import type { ComponentProps } from 'react';
 import { Fragment, useId } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wordpress } from '@wordpress/icons';
-import { displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
+import {
+	displayShortcut,
+	shortcutAriaLabel,
+	ariaKeyShortcut,
+} from '@wordpress/keycodes';
 
 import { Button } from '../index';
 import * as Tooltip from '../../tooltip';
+import { VisuallyHidden } from '../../visually-hidden';
 
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
@@ -192,7 +198,11 @@ export const Pressed: Story = {
  * assistive technology, and a visually hidden description.
  */
 export const WithKeyboardShortcut: Story = {
-	render: () => {
+	args: {
+		children: 'Save',
+		'aria-keyshortcuts': ariaKeyShortcut.primary( 's' ),
+	},
+	render: ( { 'aria-describedby': consumerDescribedBy, ...args } ) => {
 		const descriptionId = useId();
 
 		return (
@@ -200,35 +210,22 @@ export const WithKeyboardShortcut: Story = {
 				<Tooltip.Root>
 					<Tooltip.Trigger
 						{ ...( {
-							render: (
-								<Button
-									aria-keyshortcuts="Meta+S"
-									aria-describedby={ descriptionId }
-								>
-									Save
-								</Button>
-							),
-						} as React.ComponentProps< typeof Tooltip.Trigger > ) }
+							render: <Button { ...args } />,
+						} as ComponentProps< typeof Tooltip.Trigger > ) }
+						aria-describedby={ [
+							consumerDescribedBy,
+							descriptionId,
+						]
+							.filter( Boolean )
+							.join( ' ' ) }
 					/>
 					<Tooltip.Popup>
-						{ displayShortcut.primary( 's' ) }
+						{ args.children } { displayShortcut.primary( 's' ) }
 					</Tooltip.Popup>
 				</Tooltip.Root>
-				<span
-					id={ descriptionId }
-					style={ {
-						position: 'absolute',
-						width: 1,
-						height: 1,
-						overflow: 'hidden',
-						clip: 'rect(0 0 0 0)',
-						whiteSpace: 'nowrap',
-					} }
-				>
-					{ `Keyboard shortcut: ${ shortcutAriaLabel.primary(
-						's'
-					) }` }
-				</span>
+				<VisuallyHidden id={ descriptionId }>
+					Keyboard shortcut: { shortcutAriaLabel.primary( 's' ) }
+				</VisuallyHidden>
 			</>
 		);
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adds a `WithKeyboardShortcut` story to `@wordpress/ui`'s `Button` component, demonstrating the complete manual composition of `Tooltip`, `aria-keyshortcuts`, and a visually hidden accessible description for a keyboard shortcut.

Addresses one task from #80321 :
- [x] Add a `Button` Storybook example showing the complete manual composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As outlined in #80321, `Button` intentionally has no shortcut-specific API — adding one would either couple this low-level component to `Tooltip` or force a particular visual placement on consumers. Until a dedicated `ShortcutButton`-style component (also proposed in #80321) exists, consumers need a documented reference for wiring up shortcuts by hand.

A single logical shortcut needs three related representations, each covered by a separate `@wordpress/keycodes` helper:
- A visual representation (e.g. `⌘S`) — via `displayShortcut`
- An ARIA-compatible value (e.g. `Meta+S`) — applied via `aria-keyshortcuts`
- A localized, human-readable description for assistive technology (e.g. "Command S") — via `shortcutAriaLabel`

This story shows all three wired together correctly, following the same contract `IconButton` and the new `Menu` component are converging on elsewhere in #80321.

## How?
- Adds `WithKeyboardShortcut` to `packages/ui/src/button/stories/index.story.tsx`
- Composes `Tooltip.Root` / `Tooltip.Trigger` / `Tooltip.Popup` around `Button`, using `Tooltip.Trigger`'s `render` prop so the actual `Button` component (not a substitute element) is the interactive trigger
- Sets `aria-keyshortcuts` directly on `Button`
- Renders a visually hidden `<span>` with the human-readable description, referenced via `aria-describedby`

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open **Design System / Components / Button**
3. Select the **With Keyboard Shortcut** story
4. Inspect the rendered `<button>` and confirm it has `aria-keyshortcuts="Meta+S"` and an `aria-describedby` pointing to a visually hidden element containing "Keyboard shortcut: Command S"

### Testing Instructions for Keyboard
1. In the **With Keyboard Shortcut** story, focus the button with Tab
2. Confirm the tooltip appears, showing the platform-appropriate shortcut (`⌘S` on Mac, `Ctrl+S` on Windows/Linux)
3. With a screen reader (VoiceOver/NVDA), confirm the button announces its name, description, and role — e.g. "Save, Keyboard shortcut: Command S, button"

## Screenshots
<img width="1338" height="640" alt="Screenshot 2026-07-16 at 4 23 42 PM" src="https://github.com/user-attachments/assets/e4f2aec2-b216-4ab3-b5f9-bcb129f85cfb" />

## Use of AI Tools
Implemented with AI assistance (Claude); reviewed and manually verified in Storybook (DOM inspection of aria-keyshortcuts/aria-describedby).
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
