### PR TITLE
Release: Resolve commander from the test file in the release CLI test

### DIFF
--- a/tools/release/test/cli.js
+++ b/tools/release/test/cli.js
@@ -5,8 +5,13 @@ const path = require( 'path' );
 const { spawnSync } = require( 'child_process' );
 
 const cliPath = path.resolve( __dirname, '../cli.js' );
+/*
+ * Resolve from this file: an `-e` script resolves requires from the cwd,
+ * which is the repo root under Jest and has no `commander` installed.
+ */
+const commanderPath = require.resolve( 'commander' );
 const script = `
-	const { Command } = require( 'commander' );
+	const { Command } = require( ${ JSON.stringify( commanderPath ) } );
 	const { run } = require( ${ JSON.stringify( cliPath ) } );
 	const program = new Command();
 	program.command( 'reject' ).action( async () => {


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/80175#discussion_r3595252719

Resolves `commander` from the test file instead of relying on it being hoisted to the root `node_modules`.

## Why?

The test spawns `node -e "<script>"`, and that script does `require( 'commander' )`. An `-e` script has no file of its own, so Node resolves its requires from the cwd — the repo root under Jest. `commander` is a `tools/release` dependency, so this only works because npm's default hoisting happens to put a copy at the root. It fails with `Cannot find module 'commander'` under the `linked` install strategy, where `commander` stays in `tools/release/node_modules`.

## How?

Call `require.resolve( 'commander' )` in the test file, where resolution starts at `tools/release`, and pass the absolute path into the spawned script — the same way `cli.js` is already passed.

No production code changes; the assertions are unchanged.

## Testing Instructions

1. Run `npm run test:unit -- tools/release/test/cli.js --runInBand` and confirm both tests pass.
2. Run `npm run lint:js -- tools/release/test/cli.js`.

## Use of AI Tools

This PR was authored with Claude Code. I reviewed the change and the test results.
