### PR TITLE
WP Build: avoid infinite worker build loop

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fixes
 
--   Ignore generated `src/worker-code.ts` in watch mode to stop rebuild loops for worker packages like `@wordpress/vips`.
+-   Ignore generated `src/worker-code.ts` in watch mode to stop rebuild loops for worker packages like `@wordpress/vips` ([#80361](https://github.com/WordPress/gutenberg/pull/80361)).
 -   Pass the current `$hook_suffix` to the `admin_footer` action in the generated single-page admin template instead of an empty string ([#75985](https://github.com/WordPress/gutenberg/pull/75985)).
 
 ## 0.19.0 (2026-07-14)

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   Ignore generated `src/worker-code.ts` in watch mode to stop rebuild loops for worker packages like `@wordpress/vips`.
 -   Pass the current `$hook_suffix` to the `admin_footer` action in the generated single-page admin template instead of an empty string ([#75985](https://github.com/WordPress/gutenberg/pull/75985)).
 
 ## 0.19.0 (2026-07-14)

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -1671,6 +1671,11 @@ function isPackageSourceFile( filename ) {
 		return false;
 	}
 
+	// Skip build-generated worker bundles written back into src/.
+	if ( relativePath.endsWith( '/src/worker-code.ts' ) ) {
+		return false;
+	}
+
 	return PACKAGES.some( ( packageName ) => {
 		const packagePath = normalizePath(
 			path.join( 'packages', packageName )
@@ -2592,6 +2597,9 @@ async function watchMode() {
 		ignored: [
 			'**/{__mocks__,__tests__,test,storybook,stories}/**',
 			'**/*.{spec,test}.{js,ts,tsx}',
+			// Avoid rebuild loops: worker packages write bundled WASM/JS back
+			// into src/worker-code.ts during each build (e.g. @wordpress/vips).
+			'**/worker-code.ts',
 		],
 		persistent: true,
 		ignoreInitial: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Stop `wp-build --watch` from rebuild-looping on generated `src/worker-code.ts` for worker packages (`@wordpress/vips`, `@wordpress/video-conversion`).

## Why?

Those packages write bundled worker/WASM output back into `src/worker-code.ts` on every build. The watcher treated that as a source change and rebuilt again (~3–5s each), spamming `✅ vips` during `npm run dev` / `storybook:dev` / `npm run storybook:e2e:dev`.

<img width="668" height="554" alt="Screenshot 2026-07-16 at 18 20 26" src="https://github.com/user-attachments/assets/5c57797d-7d6e-4384-9862-277e617cd4ed" />


## How?

Ignore `**/worker-code.ts` in the package watcher, and skip it in `isPackageSourceFile` as a second guard.

Path is hardcoded and used in WP Build initially here:
https://github.com/WordPress/gutenberg/blob/5e5c9ea27334d4e803db5da78970eb6e51fc659d/packages/wp-build/lib/worker-build.mjs#L117

Path is also already ignored by ESLint and Gitignore files around repo:
https://github.com/WordPress/gutenberg/blob/5e5c9ea27334d4e803db5da78970eb6e51fc659d/tools/eslint/config.mjs#L252-L253
https://github.com/WordPress/gutenberg/blob/5e5c9ea27334d4e803db5da78970eb6e51fc659d/packages/video-conversion/.gitignore#L1-L3
https://github.com/WordPress/gutenberg/blob/5e5c9ea27334d4e803db5da78970eb6e51fc659d/packages/vips/.gitignore#L1-L3

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Not sure other than running `npm run storybook:dev` or `npm run storybook:e2e:dev` for a while. :-)


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes