### PR TITLE
Add wp-theme as a style dependency of wp-components

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -125,8 +125,10 @@ function gutenberg_register_packages_styles( $styles ) {
 	$version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
 	$suffix  = SCRIPT_DEBUG ? '' : '.min';
 
-	// wp-components: add dashicons (icon font dependency)
-	$styles->query( 'wp-components', 'registered' )->deps[] = 'dashicons';
+	// wp-components: add dashicons (icon font dependency) and design tokens.
+	$components_style         = $styles->query( 'wp-components', 'registered' );
+	$components_style->deps[] = 'dashicons';
+	$components_style->deps[] = 'wp-theme';
 
 	// wp-edit-post: add wp-edit-blocks (custom handle not auto-inferred)
 	$styles->query( 'wp-edit-post', 'registered' )->deps[] = 'wp-edit-blocks';
@@ -143,10 +145,10 @@ function gutenberg_register_packages_styles( $styles ) {
 	// wp-customize-widgets: add wp-edit-blocks (custom handle not auto-inferred)
 	$styles->query( 'wp-customize-widgets', 'registered' )->deps[] = 'wp-edit-blocks';
 
-	// Register wp-theme (Design System tokens from @wordpress/theme) as a
-	// dependency of wp-base-styles so its `:root` token block loads
-	// everywhere wp-base-styles does, including the editor iframe via
-	// $wp_edit_blocks_dependencies below.
+	// Register wp-theme (Design System tokens from @wordpress/theme).
+	// wp-base-styles also depends on wp-theme so tokens load on admin pages
+	// that enqueue wp-admin but not wp-components. admin-schemes.css itself
+	// does not consume --wpds-* tokens; wp-components is the primary consumer.
 	gutenberg_override_style(
 		$styles,
 		'wp-theme',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -145,9 +145,6 @@ function gutenberg_register_packages_styles( $styles ) {
 	// wp-customize-widgets: add wp-edit-blocks (custom handle not auto-inferred)
 	$styles->query( 'wp-customize-widgets', 'registered' )->deps[] = 'wp-edit-blocks';
 
-	// Register wp-theme (Design System tokens from @wordpress/theme).
-	// Entry points that consume --wpds-* tokens declare this dependency
-	// explicitly (for example wp-components and wp-edit-blocks).
 	gutenberg_override_style(
 		$styles,
 		'wp-theme',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -146,9 +146,8 @@ function gutenberg_register_packages_styles( $styles ) {
 	$styles->query( 'wp-customize-widgets', 'registered' )->deps[] = 'wp-edit-blocks';
 
 	// Register wp-theme (Design System tokens from @wordpress/theme).
-	// wp-base-styles also depends on wp-theme so tokens load on admin pages
-	// that enqueue wp-admin but not wp-components. admin-schemes.css itself
-	// does not consume --wpds-* tokens; wp-components is the primary consumer.
+	// Entry points that consume --wpds-* tokens declare this dependency
+	// explicitly (for example wp-components and wp-edit-blocks).
 	gutenberg_override_style(
 		$styles,
 		'wp-theme',
@@ -165,7 +164,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-base-styles',
 		gutenberg_url( 'build/styles/base-styles/admin-schemes' . $suffix . '.css' ),
-		array( 'wp-theme' ),
+		array(),
 		$version
 	);
 	$styles->add_data( 'wp-base-styles', 'rtl', 'replace' );


### PR DESCRIPTION
## What?

Adds `wp-theme` as a style dependency of `wp-components` in the Gutenberg plugin asset registration, and removes the `wp-theme` bootstrap from `wp-base-styles`.

## Why?

`@wordpress/components` styles consume `--wpds-*` design tokens defined by the `wp-theme` stylesheet. The JS packages already declare this dependency, but the style graph did not.

`admin-schemes.css` (which is essentially what the `wp-base-styles` stylesheet handle loads) does not consume tokens itself, so it is not quite logical that `wp-base-styles` declares `wp-theme` as a dependency. We were only hooking into `wp-base-styles` as a kind of convenience. Entry points that need tokens should declare the dependency explicitly.

I was rethinking this in the context of https://github.com/WordPress/wordpress-develop/pull/12560, and this PR basically matches the stylesheet dependency logic we're implementing upstream in Core.

## How?

- Add `wp-theme` to `wp-components` style dependencies in `lib/client-assets.php`.
- Remove `wp-theme` from `wp-base-styles` style dependencies.

## Testing Instructions

1. Run `npm run build` (Gutenberg plugin activated).
2. Make sure that the design-tokens stylesheet is still loaded in places where it should, like the editor iframe or the extensible site editor.