### PR TITLE
Dashboard Widgets: declarative actions in the widget schema

### DIFF
--- a/docs/explanations/architecture/dashboard-widgets.md
+++ b/docs/explanations/architecture/dashboard-widgets.md
@@ -22,7 +22,7 @@ A widget is a directory under `widgets/`, discovered by convention; there is no 
 
 ```
 widgets/hello-world/
-├── widget.json        static metadata (name, title, description, help, keywords, category, presentation, textdomain)
+├── widget.json        static metadata (name, title, description, help, actions, keywords, category, presentation, textdomain)
 ├── widget.ts          metadata module: default-exports icon, attributes, example
 ├── render.tsx         render module: default-exports the React component
 └── style.module.css   optional, injected at runtime by the build
@@ -31,6 +31,8 @@ widgets/hello-world/
 The split between `widget.json` and `widget.ts` is deliberate. `widget.json` is build-time input: plain JSON the pipeline can read without executing code, including the translatable strings (`title`, `description`, `help`, `keywords`) the server localizes through `textdomain`.
 
 Unlike the other translatable strings, `help` is an object: `content` plus optional `links`, meant for compact surfaces such as tooltips.
+
+`actions` is a list of the declarative actions a widget exposes: each carries `id`, `label`, `href`, and optional `download` / `openInNewTab`, with the label translated. A host renders them as links and decides where; the dashboard surfaces them in a "More" menu. Because navigation and download are the browser's, the widget declares an intent and a target without knowing its surface.
 
 `widget.ts` is the live half of the metadata: values that only exist in JavaScript, such as the icon element or the `attributes` field schema (including optional `relevance` hints) that hosts feed into `DataForm`.
 
@@ -51,13 +53,13 @@ export default function HelloWorld( { attributes } ) { ... }
 
 ## The server registry
 
-`WP_Widget_Type_Registry` (`lib/experimental/dashboard-widgets/`) is a singleton, hydrated at `init` from the manifest. Each entry becomes a `WP_Widget_Type` with `name`, `render_module`, `widget_module`, `presentation`, `category`, and the translatable `title`, `description`, `help`, and `keywords` (localized at registration time using the widget's `textdomain`).
+`WP_Widget_Type_Registry` (`lib/experimental/dashboard-widgets/`) is a singleton, hydrated at `init` from the manifest. Each entry becomes a `WP_Widget_Type` with `name`, `render_module`, `widget_module`, `presentation`, `category`, and the translatable `title`, `description`, `help`, `actions`, and `keywords` (localized at registration time using the widget's `textdomain`).
 
 The hydration is a deterministic copy, with no filters in between. The `widgets/` folder is the single source of widget authorship in this codebase.
 
 The registry is the server's authoritative list of widget types for the site. Two consumers read it:
 
--   The REST controller (`WP_REST_Widget_Modules_Controller`) exposes it at `/wp/v2/widget-modules`, returning `{ name, render_module, widget_module, presentation, category, title, description, help, keywords }` per record.
+-   The REST controller (`WP_REST_Widget_Modules_Controller`) exposes it at `/wp/v2/widget-modules`, returning `{ name, render_module, widget_module, presentation, category, title, description, help, actions, keywords }` per record.
 -   The dashboard page hooks its `dashboard-wp-admin_boot_dependencies` filter, a per-page instance of the generic `{page-slug}-wp-admin_boot_dependencies`, and adds every registered module to its import map as a `dynamic` dependency. A dynamic dependency is reachable by `import()` but never executed eagerly.
 
 Registration only makes the modules known to WordPress; loading them is a separate, per-host decision. Dynamic `import()` against the import map is how the dashboard loads widgets today. A host can load them another way: enqueue a module eagerly (`wp_enqueue_script_module()`), declare it as a `static` dependency of its own module, or, outside WordPress, skip the import map and resolve modules through its own `ResolveWidgetModule`.
@@ -68,7 +70,7 @@ The registry exists as a class, rather than having REST read the manifest direct
 
 Everything after the REST record is the job of [`@wordpress/widget-primitives`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/widget-primitives), the contract both widget authors and hosts share. Its full surface (the contract types, the discovery hook, and the render component) is covered in the _Widget Primitives / Introduction_ story. In the pipeline it does two things.
 
-`useWidgetTypes( records )` takes the host-supplied records, imports each record's `widget_module` for the live metadata, and merges it with the record into `WidgetType[]`. The record's `presentation`, `category`, `title`, `description`, `help`, and `keywords`, all sourced from `widget.json` (with `title`, `description`, `help`, and `keywords` localized server-side), win over the module's value. The hook reaches for no store or endpoint; a host such as the dashboard reads its own `widgetModule` core-data entity (backed by `/wp/v2/widget-modules`) and passes the records in.
+`useWidgetTypes( records )` takes the host-supplied records, imports each record's `widget_module` for the live metadata, and merges it with the record into `WidgetType[]`. The record's `presentation`, `category`, `title`, `description`, `help`, `actions`, and `keywords`, all sourced from `widget.json` (with `title`, `description`, `help`, `actions`, and `keywords` localized server-side), win over the module's value. The hook reaches for no store or endpoint; a host such as the dashboard reads its own `widgetModule` core-data entity (backed by `/wp/v2/widget-modules`) and passes the records in.
 
 A module's `attributes` may also reference field types by name (`type: 'location'`). The application registers those definitions up front through `registerFieldType()` (the dashboard route registers its own on boot), and `useWidgetTypes` resolves every named reference through that registry while building each `WidgetType`: the registered definition supplies the field's behavior on top of its DataViews `baseType`, and hosts receive plain DataViews fields. The widget declaration stays serializable; resolution happens once, at this boundary.
 

--- a/lib/experimental/dashboard-widgets/class-wp-rest-widget-modules-controller.php
+++ b/lib/experimental/dashboard-widgets/class-wp-rest-widget-modules-controller.php
@@ -211,6 +211,10 @@ if ( ! class_exists( 'WP_REST_Widget_Modules_Controller' ) ) {
 				$data['help'] = $widget_type->help;
 			}
 
+			if ( rest_is_field_included( 'actions', $fields ) ) {
+				$data['actions'] = $widget_type->actions;
+			}
+
 			if ( rest_is_field_included( 'keywords', $fields ) ) {
 				$data['keywords'] = $widget_type->keywords;
 			}
@@ -305,6 +309,23 @@ if ( ! class_exists( 'WP_REST_Widget_Modules_Controller' ) ) {
 										'href'  => array( 'type' => 'string' ),
 									),
 								),
+							),
+						),
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'readonly'    => true,
+					),
+
+					'actions'       => array(
+						'description' => __( 'Declarative actions the widget type exposes. Labels are translatable.', 'gutenberg' ),
+						'type'        => array( 'array', 'null' ),
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'           => array( 'type' => 'string' ),
+								'label'        => array( 'type' => 'string' ),
+								'href'         => array( 'type' => 'string' ),
+								'download'     => array( 'type' => array( 'string', 'boolean' ) ),
+								'openInNewTab' => array( 'type' => 'boolean' ),
 							),
 						),
 						'context'     => array( 'view', 'edit', 'embed' ),

--- a/lib/experimental/dashboard-widgets/class-wp-widget-type.php
+++ b/lib/experimental/dashboard-widgets/class-wp-widget-type.php
@@ -108,6 +108,17 @@ if ( ! class_exists( 'WP_Widget_Type' ) ) {
 		public $help = null;
 
 		/**
+		 * Declarative actions the widget exposes. Each entry carries `id`,
+		 * `label`, `href`, and optional `download`/`openInNewTab`. Labels are
+		 * translated at registration time using the widget's text domain.
+		 *
+		 * Null when the widget did not declare the field.
+		 *
+		 * @var array|null
+		 */
+		public $actions = null;
+
+		/**
 		 * Alternative terms used to match the widget type when searching,
 		 * e.g. "calendar" for an events widget. Translated at registration
 		 * time using the widget's text domain.

--- a/lib/experimental/dashboard-widgets/widget-i18n.json
+++ b/lib/experimental/dashboard-widgets/widget-i18n.json
@@ -5,5 +5,6 @@
 		"content": "widget help content",
 		"links": [ { "label": "widget help link label" } ]
 	},
+	"actions": [ { "label": "widget action label" } ],
 	"keywords": [ "widget keyword" ]
 }

--- a/lib/experimental/dashboard-widgets/widget-types.php
+++ b/lib/experimental/dashboard-widgets/widget-types.php
@@ -40,8 +40,8 @@ function gutenberg_get_widget_metadata_i18n_schema() {
 /**
  * Translates a widget's user-facing metadata strings.
  *
- * Runs `title`, `description`, `help`, and `keywords` through the widget
- * i18n schema using the widget's `textdomain`, leaving every other key
+ * Runs `title`, `description`, `help`, `actions`, and `keywords` through the
+ * widget i18n schema using the widget's `textdomain`, leaving every other key
  * untouched. A no-op when the widget declares no `textdomain`.
  *
  * @param array $widget Widget data from the build manifest.
@@ -55,7 +55,7 @@ function gutenberg_translate_widget_metadata( $widget ) {
 
 	$i18n_schema = gutenberg_get_widget_metadata_i18n_schema();
 
-	foreach ( array( 'title', 'description', 'help', 'keywords' ) as $field ) {
+	foreach ( array( 'title', 'description', 'help', 'actions', 'keywords' ) as $field ) {
 		if ( isset( $widget[ $field ], $i18n_schema->$field ) ) {
 			$widget[ $field ] = translate_settings_using_i18n_schema( $i18n_schema->$field, $widget[ $field ], $textdomain );
 		}
@@ -107,6 +107,52 @@ function gutenberg_sanitize_widget_help( $help ) {
 }
 
 /**
+ * Constrains a widget's actions to their allowed shape: each entry keeps
+ * `id`, `label`, and `href`; entries missing any of those are dropped.
+ * Optional `download` and `openInNewTab` are copied when present.
+ *
+ * @param array|null $actions Actions from the build manifest.
+ * @return array|null Sanitized actions, or null when there are none.
+ */
+function gutenberg_sanitize_widget_actions( $actions ) {
+	if ( ! is_array( $actions ) ) {
+		return null;
+	}
+
+	$sanitized = array();
+	foreach ( $actions as $action ) {
+		if (
+			! is_array( $action ) ||
+			empty( $action['id'] ) ||
+			empty( $action['label'] ) ||
+			empty( $action['href'] )
+		) {
+			continue;
+		}
+
+		$entry = array(
+			'id'    => $action['id'],
+			'label' => $action['label'],
+			'href'  => $action['href'],
+		);
+
+		if ( isset( $action['download'] ) ) {
+			$entry['download'] = is_bool( $action['download'] )
+				? $action['download']
+				: (string) $action['download'];
+		}
+
+		if ( isset( $action['openInNewTab'] ) ) {
+			$entry['openInNewTab'] = (bool) $action['openInNewTab'];
+		}
+
+		$sanitized[] = $entry;
+	}
+
+	return $sanitized ? $sanitized : null;
+}
+
+/**
  * Hydrates the widget type registry from the build manifest.
  *
  * Iterates the widgets discovered by the build pipeline (via
@@ -139,6 +185,7 @@ function gutenberg_register_widget_types() {
 				'title'         => $widget['title'] ?? null,
 				'description'   => $widget['description'] ?? null,
 				'help'          => gutenberg_sanitize_widget_help( $widget['help'] ?? null ),
+				'actions'       => gutenberg_sanitize_widget_actions( $widget['actions'] ?? null ),
 				'keywords'      => $widget['keywords'] ?? null,
 			)
 		);

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Features
+
+-   Surface a widget's declared `actions` in the tile chrome as a "More"
+    menu of links ([#80363](https://github.com/WordPress/gutenberg/pull/80363)).
+
 ### Enhancements
 
 -   Widget settings: use the `drawerRight` icon for the per-tile settings

--- a/packages/widget-dashboard/src/components/widget-actions/index.ts
+++ b/packages/widget-dashboard/src/components/widget-actions/index.ts
@@ -1,0 +1,1 @@
+export { WidgetActions } from './widget-actions';

--- a/packages/widget-dashboard/src/components/widget-actions/widget-actions.module.css
+++ b/packages/widget-dashboard/src/components/widget-actions/widget-actions.module.css
@@ -1,0 +1,3 @@
+.widget-action-items .widget-action-link {
+	display: inline-flex !important;
+}

--- a/packages/widget-dashboard/src/components/widget-actions/widget-actions.module.css
+++ b/packages/widget-dashboard/src/components/widget-actions/widget-actions.module.css
@@ -1,3 +1,3 @@
 .widget-action-items .widget-action-link {
-	display: inline-flex !important;
+	display: inline-flex;
 }

--- a/packages/widget-dashboard/src/components/widget-actions/widget-actions.tsx
+++ b/packages/widget-dashboard/src/components/widget-actions/widget-actions.tsx
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { IconButton, Link } from '@wordpress/ui';
+import type { WidgetType } from '@wordpress/widget-primitives';
+
+/**
+ * Internal dependencies
+ */
+import styles from './widget-actions.module.css';
+
+import { unlock } from '../../lock-unlock';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+type WidgetActionsProps = {
+	/**
+	 * The widget type whose declared actions render here.
+	 */
+	widgetType: WidgetType;
+};
+
+/**
+ * Materializes a widget type's declared `actions` as a "more" menu in the
+ * chrome: a three-dots trigger surfacing each action as a link. Each action
+ * is a declarative link target; the host renders it as an anchor and owns
+ * placement.
+ *
+ * @param {WidgetActionsProps} props Component props.
+ */
+export function WidgetActions( {
+	widgetType,
+}: WidgetActionsProps ): React.ReactNode {
+	const actions = widgetType.actions ?? [];
+
+	if ( actions.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Menu>
+			<Menu.TriggerButton
+				render={
+					<IconButton
+						icon={ moreVertical }
+						label={ __( 'More' ) }
+						variant="minimal"
+						tone="neutral"
+						size="compact"
+					/>
+				}
+			/>
+
+			<Menu.Popover>
+				<Menu.Group className={ styles[ 'widget-action-items' ] }>
+					{ actions.map( ( action ) => (
+						<Menu.Item
+							key={ action.id }
+							render={
+								<Link
+									href={ action.href }
+									download={ action.download }
+									openInNewTab={ action.openInNewTab }
+									className={ styles[ 'widget-action-link' ] }
+								/>
+							}
+						>
+							{ action.label }
+						</Menu.Item>
+					) ) }
+				</Menu.Group>
+			</Menu.Popover>
+		</Menu>
+	);
+}

--- a/packages/widget-dashboard/src/components/widgets/widgets.tsx
+++ b/packages/widget-dashboard/src/components/widgets/widgets.tsx
@@ -21,6 +21,7 @@ import type { WidgetName } from '@wordpress/widget-primitives';
  */
 import { useDashboardInternalContext } from '../../context/dashboard-context';
 import { useDashboardContainerColumnCount } from '../../hooks/use-dashboard-container-column-count';
+import { WidgetActions } from '../widget-actions';
 import { WidgetAttributeControls } from '../widget-attribute-controls';
 import { WidgetChrome } from '../widget-chrome';
 import { WidgetHeader } from '../widget-header';
@@ -134,21 +135,31 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 				( type ) => type.name === widget.type
 			);
 			const hasSettings = !! widgetType?.attributes?.length;
+			const hasActions = !! widgetType?.actions?.length;
+
 			const isFullBleed = widgetType?.presentation === 'full-bleed';
 
 			// The active mode's controls: layout while customizing, the
 			// attribute controls (high-relevance fields on the prominent
-			// surface, plus a settings entry point when needed)
-			// otherwise.
+			// surface, plus a settings entry point when needed) and the
+			// declared actions otherwise.
 			let controls: React.ReactNode;
 			if ( editMode ) {
 				controls = <WidgetLayoutControls widget={ widget } />;
-			} else if ( hasSettings && widgetType ) {
+			} else if ( ( hasSettings || hasActions ) && widgetType ) {
 				controls = (
-					<WidgetAttributeControls
-						widget={ widget }
-						widgetType={ widgetType }
-					/>
+					<>
+						{ hasSettings && (
+							<WidgetAttributeControls
+								widget={ widget }
+								widgetType={ widgetType }
+							/>
+						) }
+
+						{ hasActions && (
+							<WidgetActions widgetType={ widgetType } />
+						) }
+					</>
 				);
 			}
 

--- a/packages/widget-dashboard/src/stories/index.story.tsx
+++ b/packages/widget-dashboard/src/stories/index.story.tsx
@@ -16,6 +16,7 @@ import { useState } from '@wordpress/element';
 import { chartBar, trendingUp } from '@wordpress/icons';
 import type {
 	ResolveWidgetModule,
+	WidgetAction,
 	WidgetAttributeField,
 	WidgetRenderProps,
 	WidgetType,
@@ -139,6 +140,10 @@ const trafficSnapshotWidgetType: WidgetType = {
 	title: 'Traffic Snapshot',
 	description:
 		'Sample metric widget used to exercise the inline attribute controls.',
+	help: {
+		content:
+			'Three attributes. <strong>Metric</strong> and <strong>Period</strong> are <strong>high</strong> relevance — two fields in the header. <strong>Label</strong> is <strong>low</strong>, behind the settings button.',
+	},
 	icon: chartBar,
 	renderModule: 'demo/widgets/traffic-snapshot/render',
 	attributes: SNAPSHOT_FIELDS as WidgetType[ 'attributes' ],
@@ -256,14 +261,35 @@ const GOAL_FIELDS: WidgetAttributeField< GoalAttributes >[] = [
 	},
 ];
 
+// Two declarative actions: an external link and a client-side download.
+const GOAL_ACTIONS: WidgetAction[] = [
+	{
+		id: 'view-goal',
+		label: 'View goal details',
+		href: 'https://wordpress.org/',
+		openInNewTab: true,
+	},
+	{
+		id: 'export-progress',
+		label: 'Export progress',
+		href: 'data:text/csv;charset=utf-8,metric,target,current,percent%0Arevenue,5000,3600,72',
+		download: 'goal-progress.csv',
+	},
+];
+
 const goalProgressWidgetType: WidgetType = {
 	apiVersion: 1,
 	name: 'demo/goal-progress',
 	title: 'Goal Progress',
 	description: 'Sample goal widget whose attributes are all promoted.',
+	help: {
+		content:
+			'Two attributes, <strong>Goal metric</strong> and <strong>Target</strong>, both <strong>high</strong> relevance — two fields in the header, no settings button. Two actions in the <strong>More</strong> menu: a link and a download.',
+	},
 	icon: trendingUp,
 	renderModule: 'demo/widgets/goal-progress/render',
 	attributes: GOAL_FIELDS as WidgetType[ 'attributes' ],
+	actions: GOAL_ACTIONS,
 	example: {
 		attributes: { metric: 'revenue', target: '5000' },
 	},
@@ -360,9 +386,13 @@ Two demo types exercise that policy:
 Their tiles compare the header presentations:
 
 - The two-column tile fits the identity and both inline controls, so they stay in the header.
-- The one-column tiles do not: the promoted fields collapse into a dropdown holding them as a form, while the settings trigger stays in the toolbar beside it. The goal tile, with every attribute promoted, shows only the dropdown.
+- The one-column tiles do not: the promoted fields collapse into a dropdown holding them as a form, while the settings trigger stays in the toolbar beside it. The goal tile, with every attribute promoted, shows the dropdown next to its actions menu.
 
 The widget only declares relevance; the fit is measured by the chrome, so the same declaration adapts to any tile width. Resize the canvas to watch the headers switch presentations.
+
+Beyond attributes, \`demo/goal-progress\` declares two \`actions\`: a "View goal details" link and an "Export progress" download. The host surfaces them in a "More" menu in the toolbar, so the widget declares each action as data and the host owns where it appears.
+
+Each type also carries a \`help\` note, opened from the info icon in the header, that describes its attributes and what they do.
 `,
 			},
 		},

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -7,10 +7,13 @@
 -   `WidgetTypeMetadata`: add optional `actions`, a declarative list of
     user-triggerable links a widget exposes. Each `WidgetAction` carries
     `id`, `label`, `href`, and optional `download` / `openInNewTab`, and is
-    also carried by `WidgetModuleRecord` with labels localized server-side.
+    also carried by `WidgetModuleRecord` with labels localized server-side
+    ([#80363](https://github.com/WordPress/gutenberg/pull/80363)).
 
 ### Documentation
 
+-   Add an Actions doc page and a `WithActions` story, and cover `actions`
+    in the widget anatomy doc ([#80363](https://github.com/WordPress/gutenberg/pull/80363)).
 -   Spell out the accepted field-type name syntax: lowercase kebab-case
     segments, with at most one namespace level ([#80208](https://github.com/WordPress/gutenberg/pull/80208)).
 

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### New Features
+
+-   `WidgetTypeMetadata`: add optional `actions`, a declarative list of
+    user-triggerable links a widget exposes. Each `WidgetAction` carries
+    `id`, `label`, `href`, and optional `download` / `openInNewTab`, and is
+    also carried by `WidgetModuleRecord` with labels localized server-side.
+
 ### Documentation
 
 -   Spell out the accepted field-type name syntax: lowercase kebab-case

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -75,8 +75,6 @@ The widget names the intent and a link target; the host renders it as an anchor 
 
 `useWidgetTypes` resolves those references into the plain per-field `Field` props DataViews understands, inheriting the rest from `baseType`.
 
-See the [Field Types story](https://wordpress.github.io/gutenberg/?path=/docs/widget-primitives-field-types--docs) for the pipeline diagram and a worked example.
-
 ## Architecture
 
 For how the full pipeline fits together (authoring, build, server registry, and

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -75,6 +75,8 @@ The widget names the intent and a link target; the host renders it as an anchor 
 
 `useWidgetTypes` resolves those references into the plain per-field `Field` props DataViews understands, inheriting the rest from `baseType`.
 
+See the [Field Types story](https://wordpress.github.io/gutenberg/?path=/docs/widget-primitives-field-types--docs) for the pipeline diagram and a worked example.
+
 ## Architecture
 
 For how the full pipeline fits together (authoring, build, server registry, and

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -43,37 +43,37 @@ the hook in its loading state: `widgetTypes` is empty and
 
 ## Public API
 
--   `<WidgetRender>`: entry point for any host that mounts a widget. It
-    resolves the widget's render module via a host-provided
-    `resolveWidgetModule` and mounts the resulting component with the
-    `attributes` / `setAttributes` render contract. Error handling and chrome
-    stay with the host, which wraps the lazy render in a `Suspense` boundary.
--   `useWidgetTypes( records )` → `[ widgetTypes, isResolvingWidgetTypes ]`:
-    takes host-supplied records (`WidgetModuleRecord[]`, or `null` while
-    loading) and imports each record's metadata module;
-    `isResolvingWidgetTypes` stays `true` until they resolve.
--   Contract types: `WidgetType`, `WidgetName`, `WidgetIcon`,
-    `WidgetRenderProps`, `ResolveWidgetModule`, `WidgetModuleRecord`.
-    `WidgetIcon` is a rendered SVG element; hosts pass it to their icon
-    primitive as is.
--   `WidgetAttributeField< Item >`: authoring helper. It is a DataViews
-    `Field` whose `id` is narrowed to the keys of the widget's attribute
-    object, with an optional `relevance` hint (`'high' | 'low'`) marking
-    attributes a host may promote to a prominent surface.
--   `WidgetAction`: a declarative action a widget type exposes, the
-    declarative sibling of a DataViews `Action`. Each carries `id`,
-    `label`, `href`, and optional `download` / `openInNewTab`. The widget
-    names the intent and a link target; the host renders it as an anchor and
-    owns placement (the dashboard surfaces them in a "More" menu). Only the
-    link target exists today; because navigation and download are the
-    browser's, the widget stays host-agnostic.
--   Field types: `registerFieldType( definition )` names a reusable
-    field type (`{ name: 'location', baseType: 'text', Edit, ... }`,
-    typed by `FieldTypeDefinition`) that attributes can reference via
-    `type`. `useWidgetTypes` resolves such references into the plain
-    per-field `Field` props DataViews understands, inheriting everything
-    else from `baseType`. Names that are not registered degrade exactly
-    as unknown types do in DataViews.
+### `<WidgetRender>`
+
+It's the entry point for any host that mounts a widget. It resolves the render module via a host-provided `resolveWidgetModule` and mounts the component using the `attributes` / `setAttributes` contract.
+
+Error handling and chrome stay with the host, which wraps the lazy render in a `Suspense` boundary.
+
+### `useWidgetTypes( records )`
+
+It takes host-supplied records (`WidgetModuleRecord[]`, or `null` while loading) and imports each one's metadata module. It returns `[ widgetTypes, isResolvingWidgetTypes ]`; the flag stays `true` until they resolve.
+
+### Contract types
+
+`WidgetType`, `WidgetName`, `WidgetIcon`, `WidgetRenderProps`, `ResolveWidgetModule`, and `WidgetModuleRecord`. `WidgetIcon` is a rendered SVG element that hosts the pass to its icon primitive as-is.
+
+### `WidgetAttributeField< Item >`
+
+It's an authoring helper: a DataViews `Field` whose `id` is narrowed to the widget's attribute keys.
+Its optional `relevance` hint (`'high' | 'low'`) marks attributes a host may promote to a prominent surface.
+
+### `WidgetAction`
+
+It's a declarative action a widget type exposes.
+Each carries `id`, `label`, `href`, and optional `download` / `openInNewTab`.
+
+The widget names the intent and a link target; the host renders it as an anchor and owns placement. Only the `link` target exists today, and navigation and downloads are handled by the browser.
+
+### Field types
+
+`registerFieldType( definition )` names a reusable field type — `{ name: 'location', baseType: 'text', Edit, ... }`, typed by `FieldTypeDefinition`. Those attributes reference via `type`.
+
+`useWidgetTypes` resolves those references into the plain per-field `Field` props DataViews understands, inheriting the rest from `baseType`.
 
 ## Architecture
 
@@ -83,15 +83,8 @@ hosts), see the
 
 ## Contributing to this package
 
-This is an individual package that's part of the Gutenberg project.
-The project is organized as a monorepo. It's made up of multiple
-self-contained software packages, each with a specific purpose. The
-packages in this monorepo are published to [npm](https://www.npmjs.com/)
-and used by [WordPress](https://make.wordpress.org/core/) as well as
-other software projects.
+This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.
 
-To find out more about contributing to this package or Gutenberg as a
-whole, please read the project's main
-[contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
+To find out more about contributing to this package or Gutenberg as a whole, please read the project's main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
 
 <br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/widget-primitives/README.md
+++ b/packages/widget-primitives/README.md
@@ -60,6 +60,13 @@ the hook in its loading state: `widgetTypes` is empty and
     `Field` whose `id` is narrowed to the keys of the widget's attribute
     object, with an optional `relevance` hint (`'high' | 'low'`) marking
     attributes a host may promote to a prominent surface.
+-   `WidgetAction`: a declarative action a widget type exposes, the
+    declarative sibling of a DataViews `Action`. Each carries `id`,
+    `label`, `href`, and optional `download` / `openInNewTab`. The widget
+    names the intent and a link target; the host renders it as an anchor and
+    owns placement (the dashboard surfaces them in a "More" menu). Only the
+    link target exists today; because navigation and download are the
+    browser's, the widget stays host-agnostic.
 -   Field types: `registerFieldType( definition )` names a reusable
     field type (`{ name: 'location', baseType: 'text', Edit, ... }`,
     typed by `FieldTypeDefinition`) that attributes can reference via

--- a/packages/widget-primitives/src/components/widget-render/stories/index.story.tsx
+++ b/packages/widget-primitives/src/components/widget-render/stories/index.story.tsx
@@ -18,7 +18,7 @@ import { Suspense, useId, useMemo, useState } from '@wordpress/element';
 import { globe, starFilled } from '@wordpress/icons';
 // `IconButton` is not on the recommended list yet.
 /* eslint-disable @wordpress/use-recommended-components */
-import { Card, Icon, IconButton, Stack } from '@wordpress/ui';
+import { Card, Icon, IconButton, Link, Stack } from '@wordpress/ui';
 /* eslint-enable @wordpress/use-recommended-components */
 
 /**
@@ -27,6 +27,7 @@ import { Card, Icon, IconButton, Stack } from '@wordpress/ui';
 import { WidgetRender } from '..';
 import { registerFieldType, resolveFields } from '../../../field-types';
 import type {
+	WidgetAction,
 	WidgetAttributeField,
 	WidgetRenderProps,
 	WidgetType,
@@ -742,6 +743,100 @@ The attribute references a **field type** by name instead of carrying a control:
 3. The host resolves the schema (hosts get this through \`useWidgetTypes\`; the story calls the resolver itself) and promotes the field to the prominent surface, where the registered control renders.
 
 An unregistered name would degrade silently, exactly like an unknown type in DataViews. See the **Field Types** doc for the full pipeline.
+`,
+			},
+		},
+	},
+};
+
+const actionsWidgetType: WidgetType< DemoAttributes > = {
+	...demoWidgetType,
+	actions: [
+		{
+			id: 'open-docs',
+			label: 'Open docs',
+			href: 'https://developer.wordpress.org/',
+			openInNewTab: true,
+		},
+		{
+			id: 'export-greeting',
+			label: 'Export greeting',
+			href: 'data:text/plain;charset=utf-8,Hello%20World',
+			download: 'greeting.txt',
+		},
+	] satisfies WidgetAction[],
+};
+
+function WidgetWithActions() {
+	const titleId = useId();
+	const actions = actionsWidgetType.actions ?? [];
+	const [ attributes ] = useState< DemoAttributes >( {
+		...actionsWidgetType.example?.attributes,
+	} );
+
+	return (
+		<div style={ { maxWidth: 560 } }>
+			<Card.Root render={ <section /> } aria-labelledby={ titleId }>
+				<Card.Header>
+					<Stack direction="row" align="center" gap="sm">
+						{ actionsWidgetType.icon && (
+							<span aria-hidden="true">
+								<Icon icon={ actionsWidgetType.icon } />
+							</span>
+						) }
+						<Card.Title
+							id={ titleId }
+							render={ <h3 /> }
+							style={ { flexGrow: 1 } }
+						>
+							{ actionsWidgetType.title }
+						</Card.Title>
+
+						{ /* The host materializes the declared actions; here, as links. */ }
+						<Stack direction="row" align="center" gap="md">
+							{ actions.map( ( action ) => (
+								<Link
+									key={ action.id }
+									href={ action.href }
+									download={ action.download }
+									openInNewTab={ action.openInNewTab }
+								>
+									{ action.label }
+								</Link>
+							) ) }
+						</Stack>
+					</Stack>
+				</Card.Header>
+				<Card.Content>
+					<Suspense fallback={ null }>
+						<WidgetRender< DemoAttributes >
+							widgetType={ actionsWidgetType }
+							attributes={ attributes }
+							resolveWidgetModule={ resolveDemoModule }
+						/>
+					</Suspense>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	);
+}
+
+export const WithActions: StoryObj = {
+	render: () => <WidgetWithActions />,
+	parameters: {
+		docs: {
+			description: {
+				story: `
+Beyond its data, a widget can declare \`actions\`: verbs a user can trigger, like opening docs or downloading a file. The widget names each action (\`id\`, \`label\`, and a link \`href\`); the host decides where to put it and materializes it.
+
+**In this demo**
+
+- The widget declares two actions: an external link (\`Open docs\`) and a download (\`Export greeting\`).
+- The host renders them as links beside the title. Another host could surface them in a menu, a footer, or a command palette.
+
+**Takeaway**
+
+The widget names the intent and a link target; navigation and download are the browser's, so the widget never knows its surface.
 `,
 			},
 		},

--- a/packages/widget-primitives/src/hooks/use-widget-types.ts
+++ b/packages/widget-primitives/src/hooks/use-widget-types.ts
@@ -94,6 +94,9 @@ export function useWidgetTypes(
 						...( record.keywords
 							? { keywords: record.keywords }
 							: {} ),
+						...( record.actions
+							? { actions: record.actions }
+							: {} ),
 					} as WidgetType;
 				} catch {
 					return null;

--- a/packages/widget-primitives/src/index.ts
+++ b/packages/widget-primitives/src/index.ts
@@ -20,6 +20,7 @@ export type {
 	WidgetName,
 	WidgetIcon,
 	WidgetType,
+	WidgetAction,
 	WidgetAttributeField,
 	WidgetRenderProps,
 	ResolveWidgetModule,

--- a/packages/widget-primitives/src/stories/actions.md
+++ b/packages/widget-primitives/src/stories/actions.md
@@ -4,13 +4,16 @@
 This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-A widget declares its data through `attributes`; it declares the verbs a user can trigger through `actions`. An action is something to _do_ — open a report, download a file — not something to configure. Like an attribute it is declarative and serializable, so it can ride in `widget.json`; unlike an attribute it names a verb, not a value.
+A widget declares its data through `attributes`; it declares the verbs a user can trigger through `actions`.
 
-The widget names the intent and a target; the host decides where the action appears and materializes it. The widget never knows its surface.
+An action is something to _do_: open a report, download a file, etc. Like other widgets' props, it's declarative and serializable, so it can ride in `widget.json`.
+
+The widget names the intent and a target; the host decides where the action appears and how it materializes.
 
 ## Envelope and fulfillment
 
-Every action carries an **envelope** — an `id` and a `label` — and one **fulfillment** that says what triggering it does. Today the only fulfillment is a `link`: a target the host renders as an anchor.
+Every action carries an **envelope**: an `id` and a `label`, and one **fulfillment** that says what it triggers.
+Today, the only fulfillment is a `link`: a target the host renders as an anchor.
 
 ```ts
 {
@@ -36,15 +39,6 @@ Every action carries an **envelope** — an `id` and a `label` — and one **ful
 
 ## Placement is the host's
 
-The widget lists its actions; it never says where they go. The host maps them to its own surfaces — a dashboard might gather them in a "More" menu, a footer, or a command palette. The same declaration surfaces differently in different hosts, and a host with no place for an action drops it. This is the contract attribute `relevance` already uses: the widget declares intent, the host owns the surface.
+The widget lists its actions; it never specifies where they go. The host maps them to its surfaces: a dashboard might gather them in a "More" menu, a footer, or a command palette. 
 
-## Why a link
-
-A link is data, so the action stays serializable and host-agnostic. Navigation and download are the browser's: the host renders the anchor and never interprets what the action means, and middle-click, copy-address, and the download attribute keep working. Building the URL — query strings, hashes — is the widget's job, with the standard `URL` / `URLSearchParams`.
-
-## Today and later
-
-The `link` fulfillment is the whole surface today. Two more are reserved, and both extend the same envelope, so an action's `id` and `label` do not change when its fulfillment does:
-
--   A `callback` fulfillment, for a verb that runs code the widget provides — a download whose bytes are generated in the browser, for instance.
--   A `steps` fulfillment, an ordered list of registered actions, backed by the connection language.
+This is the contract that the `relevance` attribute already uses: the widget declares intent, and the host owns the surface.

--- a/packages/widget-primitives/src/stories/actions.md
+++ b/packages/widget-primitives/src/stories/actions.md
@@ -1,0 +1,50 @@
+# Actions
+
+<div class="callout callout-alert">
+This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
+A widget declares its data through `attributes`; it declares the verbs a user can trigger through `actions`. An action is something to _do_ — open a report, download a file — not something to configure. Like an attribute it is declarative and serializable, so it can ride in `widget.json`; unlike an attribute it names a verb, not a value.
+
+The widget names the intent and a target; the host decides where the action appears and materializes it. The widget never knows its surface.
+
+## Envelope and fulfillment
+
+Every action carries an **envelope** — an `id` and a `label` — and one **fulfillment** that says what triggering it does. Today the only fulfillment is a `link`: a target the host renders as an anchor.
+
+```ts
+{
+	id: 'view-report',
+	label: __( 'View report' ),
+	href: 'admin.php?page=reports',
+}
+```
+
+`href` is a complete URL or path; external URLs and admin entry points load a full page. Two optional flags refine it:
+
+-   `download`: turns the target into a file download; a string names the file.
+-   `openInNewTab`: opens the target in a new browser tab.
+
+```ts
+{
+	id: 'export',
+	label: __( 'Export CSV' ),
+	href: reportCsvUrl,
+	download: 'report.csv',
+}
+```
+
+## Placement is the host's
+
+The widget lists its actions; it never says where they go. The host maps them to its own surfaces — a dashboard might gather them in a "More" menu, a footer, or a command palette. The same declaration surfaces differently in different hosts, and a host with no place for an action drops it. This is the contract attribute `relevance` already uses: the widget declares intent, the host owns the surface.
+
+## Why a link
+
+A link is data, so the action stays serializable and host-agnostic. Navigation and download are the browser's: the host renders the anchor and never interprets what the action means, and middle-click, copy-address, and the download attribute keep working. Building the URL — query strings, hashes — is the widget's job, with the standard `URL` / `URLSearchParams`.
+
+## Today and later
+
+The `link` fulfillment is the whole surface today. Two more are reserved, and both extend the same envelope, so an action's `id` and `label` do not change when its fulfillment does:
+
+-   A `callback` fulfillment, for a verb that runs code the widget provides — a download whose bytes are generated in the browser, for instance.
+-   A `steps` fulfillment, an ordered list of registered actions, backed by the connection language.

--- a/packages/widget-primitives/src/stories/actions.mdx
+++ b/packages/widget-primitives/src/stories/actions.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/addon-docs/blocks';
+import ActionsDoc from './actions.md?raw';
+
+<Meta title="Widget Primitives/Actions" />
+
+<Markdown>{ ActionsDoc }</Markdown>

--- a/packages/widget-primitives/src/stories/anatomy.md
+++ b/packages/widget-primitives/src/stories/anatomy.md
@@ -41,14 +41,14 @@ Framing is the layer the host translates, and the one place where the same decla
 
 ## Representation
 
-How the widget represents its data: `attributes`, `example`, and the render module.
+How the widget represents its data and the verbs it exposes: `attributes`, `actions`, `example`, and the render module.
 
 The `attributes` are the contract between host and widget. The widget owns their shape and meaning; the host owns their values.
 
 Each entry in `attributes` is a DataViews `Field` plus an optional `relevance` hint (`'high' | 'low'`). Its `type` may also reference a registered field type by name, resolved to plain `Field` props before any host reads the schema (see **Field Types**). The widget declares how important an attribute is; the host decides where, and whether, to expose it. When the hint is absent, treat it as `'low'`.
 
-- `'high'`: the host _may_ promote the field to a prominent surface near the instance, for quick in-context editing without opening a separate settings UI.
-- `'low'` (default): the field belongs in the host's settings surface, a form built from the full schema.
+-   `'high'`: the host _may_ promote the field to a prominent surface near the instance, for quick in-context editing without opening a separate settings UI.
+-   `'low'` (default): the field belongs in the host's settings surface, a form built from the full schema.
 
 The widget names importance, not a surface. One host might promote `'high'` fields inline; another might fold everything into a single panel. Both honor the same contract.
 
@@ -59,6 +59,10 @@ A value can change from either side. The widget can ask, when the host grants it
 Either way the host never interprets the values. It mounts the form from the declarative schema, stores and passes the values, and re-renders; the meaning stays the widget's.
 
 ![The attributes are a contract both sides write: the render module reads them to produce the output, the widget asks for changes through setAttributes, and the host edits them through a settings surface. The meaning stays the widget's.](./assets/representation.svg)
+
+Alongside its data, a widget can declare `actions`: the verbs a user triggers, such as opening a report or downloading a file. Each action names an `id`, a `label`, and a link target (`href`, with optional `download` / `openInNewTab`).
+
+The pattern matches attributes: the widget declares the intent, and the host decides the surface. It never says "put this in a toolbar"; it names the action, and the host materializes the affordance and places it. Today the only target is a link, so navigation and download are the browser's, and the host renders the anchor without interpreting what the action means.
 
 ## Why the split matters
 

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -71,6 +71,41 @@ export interface WidgetHelp {
 type WidgetAttributeRelevance = 'high' | 'low';
 
 /**
+ * A user-triggerable action a widget type declares. The declaration is
+ * serializable data; the host materializes it as an affordance and owns
+ * placement. The action points at a `link` target the host renders as an
+ * anchor; `download` turns it into a file download.
+ */
+export interface WidgetAction {
+	/**
+	 * Stable identifier, local to the widget type.
+	 */
+	id: string;
+
+	/**
+	 * Human-readable label naming the action. Translatable.
+	 */
+	label: string;
+
+	/**
+	 * Destination the action points at. External URLs and admin PHP entry
+	 * points load a full page.
+	 */
+	href: string;
+
+	/**
+	 * When set, the browser downloads the destination instead of navigating.
+	 * A string supplies the suggested filename.
+	 */
+	download?: string | boolean;
+
+	/**
+	 * Whether the destination opens in a new browser tab.
+	 */
+	openInNewTab?: boolean;
+}
+
+/**
  * A DataViews `Field` plus the widget-layer `relevance` hint; what hosts
  * read. Its `type` may also reference a registered field type by name
  * (see `registerFieldType`); `useWidgetTypes` resolves such references
@@ -178,6 +213,12 @@ export interface WidgetTypeMetadata< Item = unknown > {
 	attributes?: WidgetAttribute< Item >[];
 
 	/**
+	 * Declarative actions the widget type exposes. Hosts materialize each
+	 * one as an affordance and decide where to place it.
+	 */
+	actions?: WidgetAction[];
+
+	/**
 	 * Structured example data hosts use for previews, and the default
 	 * attributes applied when a new instance is created without initial
 	 * attributes.
@@ -253,6 +294,7 @@ type WidgetModuleRecordOverrides = {
 		| 'category'
 		| 'presentation'
 		| 'keywords'
+		| 'actions'
 	> ]?: WidgetTypeMetadata[ K ] | null;
 };
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Widgets: carry a widget's declarative `actions` from `widget.json` into
+    the generated PHP registry ([#80363](https://github.com/WordPress/gutenberg/pull/80363)).
+
 ## 0.19.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -2016,7 +2016,7 @@ async function buildAllWidgets() {
  * Discover all widgets and collect their registry-facing data.
  * Widgets without a valid widget.json are skipped.
  *
- * @return {Array<{ name: string, dirName: string, title: string | null, description: string | null, help: import('./widget-utils.mjs').WidgetHelpMetadata | null, hasRender: boolean, hasWidget: boolean, presentation: string | null, category: string | null, keywords: string[] | null, textdomain: string | null }>} Array of widget objects.
+ * @return {Array<{ name: string, dirName: string, title: string | null, description: string | null, help: import('./widget-utils.mjs').WidgetHelpMetadata | null, actions: import('./widget-utils.mjs').WidgetActionMetadata[] | null, hasRender: boolean, hasWidget: boolean, presentation: string | null, category: string | null, keywords: string[] | null, textdomain: string | null }>} Array of widget objects.
  */
 function collectWidgets() {
 	return getAllWidgets( ROOT_DIR ).flatMap( ( widgetName ) => {
@@ -2038,6 +2038,7 @@ function collectWidgets() {
 				title: metadata.title ?? null,
 				description: metadata.description ?? null,
 				help: metadata.help ?? null,
+				actions: metadata.actions ?? null,
 				hasRender: widgetFiles.hasRender,
 				hasWidget: widgetFiles.hasWidget,
 				presentation: metadata.presentation ?? null,
@@ -2115,6 +2116,60 @@ function toPhpHelpLiteral( help ) {
 }
 
 /**
+ * Format a widget's actions as a PHP array literal. Returns the PHP literal
+ * `null` when there are no valid actions; entries missing `id`, `label`, or
+ * `href` are dropped.
+ *
+ * @param {import('./widget-utils.mjs').WidgetActionMetadata[]|null|undefined} actions Source value.
+ * @return {string} PHP array literal, or `null`.
+ */
+function toPhpActionsLiteral( actions ) {
+	if ( ! Array.isArray( actions ) ) {
+		return 'null';
+	}
+
+	const entries = actions
+		.filter(
+			( action ) => action && action.id && action.label && action.href
+		)
+		.map( ( action ) => {
+			const parts = [
+				`'id' => ${ toPhpStringLiteral( action.id ) }`,
+				`'label' => ${ toPhpStringLiteral( action.label ) }`,
+				`'href' => ${ toPhpStringLiteral( action.href ) }`,
+			];
+
+			if ( action.download !== undefined ) {
+				parts.push(
+					typeof action.download === 'boolean'
+						? `'download' => ${
+								action.download ? 'true' : 'false'
+						  }`
+						: `'download' => ${ toPhpStringLiteral(
+								action.download
+						  ) }`
+				);
+			}
+
+			if ( action.openInNewTab !== undefined ) {
+				parts.push(
+					`'openInNewTab' => ${
+						action.openInNewTab ? 'true' : 'false'
+					}`
+				);
+			}
+
+			return `array( ${ parts.join( ', ' ) } )`;
+		} );
+
+	if ( entries.length === 0 ) {
+		return 'null';
+	}
+
+	return `array( ${ entries.join( ', ' ) } )`;
+}
+
+/**
  * Generate global widget registry file.
  * Creates a single registry with all widgets including file availability.
  *
@@ -2139,6 +2194,7 @@ async function generateWidgetRegistry( widgets, replacements ) {
 			const titleStr = toPhpStringLiteral( widget.title );
 			const descriptionStr = toPhpStringLiteral( widget.description );
 			const helpStr = toPhpHelpLiteral( widget.help );
+			const actionsStr = toPhpActionsLiteral( widget.actions );
 			const keywordsStr = toPhpStringArrayLiteral( widget.keywords );
 			const textdomainStr = toPhpStringLiteral( widget.textdomain );
 			return `\tarray(
@@ -2147,6 +2203,7 @@ async function generateWidgetRegistry( widgets, replacements ) {
 		'title'        => ${ titleStr },
 		'description'  => ${ descriptionStr },
 		'help'         => ${ helpStr },
+		'actions'      => ${ actionsStr },
 		'has_render'   => ${ hasRenderStr },
 		'has_widget'   => ${ hasWidgetStr },
 		'presentation' => ${ presentationStr },

--- a/packages/wp-build/lib/widget-utils.mjs
+++ b/packages/wp-build/lib/widget-utils.mjs
@@ -36,11 +36,21 @@ export function getAllWidgets( rootDir ) {
  */
 
 /**
+ * @typedef {Object} WidgetActionMetadata
+ * @property {string}         id             Stable identifier, local to the widget type.
+ * @property {string}         label          Human-readable label. Translatable.
+ * @property {string}         href           Destination the action points at.
+ * @property {string|boolean} [download]     Download the destination; a string sets the filename.
+ * @property {boolean}        [openInNewTab] Open the destination in a new browser tab.
+ */
+
+/**
  * @typedef {Object} WidgetMetadata
  * @property {string}                                    name           Widget namespaced identifier.
  * @property {string}                                    [title]        Human-readable title.
  * @property {string}                                    [description]  Short description.
  * @property {WidgetHelpMetadata}                        [help]         Contextual help note for compact surfaces.
+ * @property {WidgetActionMetadata[]}                    [actions]      Declarative actions the widget exposes.
  * @property {string}                                    [category]     Grouping category.
  * @property {'framed' | 'content-bleed' | 'full-bleed'} [presentation] Authoring intent about how the widget wants to render.
  * @property {string[]}                                  [keywords]     Search aliases used to match the widget.

--- a/phpunit/experimental/class-wp-rest-widget-modules-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-widget-modules-controller-test.php
@@ -71,6 +71,13 @@ class WP_REST_Widget_Modules_Controller_Test extends WP_UnitTestCase {
 						),
 					),
 				),
+				'actions'       => array(
+					array(
+						'id'    => 'open-settings',
+						'label' => 'Open settings',
+						'href'  => 'options-general.php',
+					),
+				),
 				'keywords'      => array( 'alpha', 'first' ),
 			)
 		);
@@ -152,6 +159,16 @@ class WP_REST_Widget_Modules_Controller_Test extends WP_UnitTestCase {
 			),
 			$data['help']
 		);
+		$this->assertSame(
+			array(
+				array(
+					'id'    => 'open-settings',
+					'label' => 'Open settings',
+					'href'  => 'options-general.php',
+				),
+			),
+			$data['actions']
+		);
 		$this->assertSame( array( 'alpha', 'first' ), $data['keywords'] );
 	}
 
@@ -202,6 +219,7 @@ class WP_REST_Widget_Modules_Controller_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'help', $properties );
+		$this->assertArrayHasKey( 'actions', $properties );
 		$this->assertArrayHasKey( 'keywords', $properties );
 		$this->assertSame( 'string', $properties['name']['type'] );
 		$this->assertSame( array( 'string', 'null' ), $properties['render_module']['type'] );
@@ -210,6 +228,7 @@ class WP_REST_Widget_Modules_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( array( 'string', 'null' ), $properties['title']['type'] );
 		$this->assertSame( array( 'string', 'null' ), $properties['description']['type'] );
 		$this->assertSame( array( 'object', 'null' ), $properties['help']['type'] );
+		$this->assertSame( array( 'array', 'null' ), $properties['actions']['type'] );
 		$this->assertSame( array( 'array', 'null' ), $properties['keywords']['type'] );
 	}
 }

--- a/widgets/hello-dolly/widget.json
+++ b/widgets/hello-dolly/widget.json
@@ -4,5 +4,19 @@
 	"description": "This is not just a widget, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from Hello, Dolly in the dashboard.",
 	"category": "dashboard",
 	"presentation": "full-bleed",
+	"actions": [
+		{
+			"id": "plugin-page",
+			"label": "Plugin page",
+			"href": "https://wordpress.org/plugins/hello-dolly/",
+			"openInNewTab": true
+		},
+		{
+			"id": "download-lyrics",
+			"label": "Download lyrics",
+			"href": "data:text/plain;charset=utf-8,Hello%2C%20Dolly%0AWell%2C%20hello%2C%20Dolly%0AIt's%20so%20nice%20to%20have%20you%20back%20where%20you%20belong%0AYou're%20lookin'%20swell%2C%20Dolly%0AI%20can%20tell%2C%20Dolly%0AYou're%20still%20glowin'%2C%20you're%20still%20crowin'%0AYou're%20still%20goin'%20strong%0AI%20feel%20the%20room%20swayin'%0AWhile%20the%20band's%20playin'%0AOne%20of%20our%20old%20favorite%20songs%20from%20way%20back%20when%0ASo%2C%20take%20her%20wrap%2C%20fellas%0ADolly%2C%20never%20go%20away%20again%0AHello%2C%20Dolly%0AWell%2C%20hello%2C%20Dolly%0AIt's%20so%20nice%20to%20have%20you%20back%20where%20you%20belong%0AYou're%20lookin'%20swell%2C%20Dolly%0AI%20can%20tell%2C%20Dolly%0AYou're%20still%20glowin'%2C%20you're%20still%20crowin'%0AYou're%20still%20goin'%20strong%0AI%20feel%20the%20room%20swayin'%0AWhile%20the%20band's%20playin'%0AOne%20of%20our%20old%20favorite%20songs%20from%20way%20back%20when%0ASo%2C%20golly%2C%20gee%2C%20fellas%0AHave%20a%20little%20faith%20in%20me%2C%20fellas%0ADolly%2C%20never%20go%20away%0APromise%2C%20you'll%20never%20go%20away%0ADolly'll%20never%20go%20away%20again",
+			"download": "hello-dolly-lyrics.txt"
+		}
+	],
 	"textdomain": "default"
 }

--- a/widgets/hello-dolly/widget.json
+++ b/widgets/hello-dolly/widget.json
@@ -7,7 +7,7 @@
 	"actions": [
 		{
 			"id": "plugin-page",
-			"label": "Plugin page",
+			"label": "WordPress.org plugin page",
 			"href": "https://wordpress.org/plugins/hello-dolly/",
 			"openInNewTab": true
 		},


### PR DESCRIPTION
## What

Adds an optional `actions` field to the widget schema: a declarative list of the verbs a widget type exposes, such as navigating to a report or downloading a file.

Each `WidgetAction` carries `id`, `label`, `href`, and optional `download` / `openInNewTab`.

**The only fulfillment today is a `link`**: the widget declares the intent and a target, and the host renders it as an anchor and owns placement.

The dashboard surfaces the actions in a "More" (three-dots) menu in the widget toolbar. Because navigation and downloads are handled by the browser, the widget stays host-agnostic.

The field travels from `widget.json` to the client through the full pipeline (build manifest → PHP registry → REST → TypeScript merge), mirroring `help`.

## Why

Widgets had no way to declare the verbs a user triggers.

## How

- **Contract** (`@wordpress/widget-primitives`)
A `WidgetAction` type (`{ id, label, href, download?, openInNewTab? }`), plus `actions?` on `WidgetTypeMetadata` and `WidgetModuleRecordOverrides`, merged in `useWidgetTypes`.

- **Server pipeline** (mirrors `help` at every layer)
The build manifest (`build.mjs` `toPhpActionsLiteral`), `WP_Widget_Type` (`$actions`), registration with sanitization and label i18n, and the REST controller (exposure plus item schema).
PHP coverage in the widget-modules controller test.

- **UI** (`@wordpress/widget-dashboard`):
A `WidgetActions` component rendering a three-dots `IconButton` that opens a `Menu` of `Link` items, mounted in the normal-mode toolbar.

- **Demo**
The `hello-dolly` widget declares two actions: a link to its plugin page and a lyrics download.

- **Docs**:
The widget-primitives README (`WidgetAction`), CHANGELOG, and the architecture doc (actions across the four pipeline stages).

The dashboard Storybook includes story exercises, actions, and help notes.

## Testing

1. Build the plugin so the widget manifest regenerates.
2. Enable the `gutenberg-dashboard-widgets` experiment.
3. Open the dashboard: the `hello-dolly` tile shows a three-dots menu in its toolbar.

<img width="729" height="590" alt="image" src="https://github.com/user-attachments/assets/d391a8cf-a9da-4b4d-86f4-d2f97250dd8a" />

<img width="758" height="667" alt="image" src="https://github.com/user-attachments/assets/7e7f4be3-20de-4cce-83f8-51f28df62536" />

4. Click "About Hello Dolly": it opens the plugin page in a new tab.
5. Click "Download lyrics": it downloads `hello-dolly-lyrics.txt`.

https://github.com/user-attachments/assets/cb46ee5d-9a7d-4d1a-80b9-cb199e32451b

6. Run the PHP test: `vendor/bin/phpunit phpunit/experimental/class-wp-rest-widget-modules-controller-test.php`.
7. In Storybook, open the Widget Dashboard story: the goal-progress tile surfaces its actions in a "More" menu, and each tile carries a help note.

https://github.com/user-attachments/assets/8fc52394-464e-42a0-96f9-b9c341857391

You can take a look at the widget-module endpoint to see the `actions` property:

<img width="839" height="691" alt="image" src="https://github.com/user-attachments/assets/68575c4f-275f-4e6e-99b3-8086969e253a" />

## Follow-ups

- [ ] Add a `scope: 'local' | 'global'` axis so a host can surface an action beyond the widget (for example, the dashboard command palette).
- [ ] Add a `callback` fulfillment for client-generated downloads (a handler that produces the file), beyond the declarative `link`.
- [ ] Add a `steps` fulfillment backed by the connection language.