### PR TITLE
Components: Skip polymorphism prop typings on intersection

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### TypeScript
+
+-   Improved performance of TypeScript types for internal polymorphic `WordPressComponent` component type ([#80364](https://github.com/WordPress/gutenberg/pull/80364)).
+
 ### Internal
 
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -30,8 +30,8 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 
 ### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | ... 516 more ... | ("view" & FunctionComponent<...>)`
- - Required: No
+ - Type: `ElementType<any, keyof IntrinsicElements>`
+ - Required: Yes
 
 The HTML element or React component to render the component as.
 

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -34,7 +34,7 @@ export type WordPressComponent<
 	IsPolymorphic extends boolean,
 > = {
 	< TT extends React.ElementType >(
-		props: WordPressComponentProps< O, TT, IsPolymorphic > &
+		props: WordPressComponentProps< O, TT, false > &
 			( IsPolymorphic extends true ? { as: TT } : {} )
 	): React.ReactNode;
 	( props: WordPressComponentProps< O, T, IsPolymorphic > ): React.ReactNode;

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -35,7 +35,12 @@ export type WordPressComponent<
 > = {
 	< TT extends React.ElementType >(
 		props: WordPressComponentProps< O, TT, false > &
-			( IsPolymorphic extends true ? { as: TT } : {} )
+			( IsPolymorphic extends true
+				? {
+						/** The HTML element or React component to render the component as. */
+						as: TT;
+				  }
+				: {} )
 	): React.ReactNode;
 	( props: WordPressComponentProps< O, T, IsPolymorphic > ): React.ReactNode;
 	displayName?: string;

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -19,8 +19,8 @@ component, and the `Menu.Popover` component.
 
 ### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | ... 517 more ...`
- - Required: No
+ - Type: `ElementType<any, keyof IntrinsicElements>`
+ - Required: Yes
 
 The HTML element or React component to render the component as.
 


### PR DESCRIPTION
## What?

Updates `@wordpress/components` shared components types to skip evaluating polymorphism when generating inner props types on `WordPressComponent` before defining its own intersecting `as` polymorphism.

## Why?

Reduces memory consumption in a case where we don't meaningfully need the base typing.

This is an outcome of some research based on failing CI builds that may be related to memory usage ([related Slack discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1784139282164719)), and so this could potentially improve reliability of tests.

## How?

Passing `false` instead of forwarding `IsPolymorphic` prevents [`as` type assignment](https://github.com/WordPress/gutenberg/blob/6441f384896c255b69ff6cff045dbebd4585bfd1/packages/components/src/context/wordpress-component.ts#L25-L28) in the base type. `keyof React.JSX.IntrinsicElements` creates a union of hundreds of element types that causes a non-insignificant amount of memory usage when resolving in the intersection type of `WordPressComponent`.

Very important to note that intersecting isn't the same as overriding, and it's not claimed that the typings behave in a way that `{ a: T } & { a: TT }` is equivalent to `{ a: TT }`. But in this case they provably reduce to the same result, and I don't believe it's the case that we intentionally want to inherit the base props at this typing layer. My understanding is that in `WordPressComponent`'s typings, it infers what element type will be assigned on `as`, so we can skip the guess-work of saying that `as` can be any valid element tag name.

Provability comes from [absorption law](https://en.wikipedia.org/wiki/Absorption_law):

```
A ∧ (A ∨ B) = A
```

So in terms of types:

```
{ as: TT } & { as?: TT | keyof React.JSX.IntrinsicElements; }
```

Is equivalent to (in how we enforce assignability):

```
{ as: TT }
```

(optional intersected with required becomes required)

**Impact:**

The net result here is **-6.6% memory used and -3.2% memory allocations when type-checking `@wordpress/components`**, with `@wordpress/components` accounting for 90%+ of memory usage of type-checking the entire project.

| Metric         | Baseline (`IsPolymorphic`) | Changed (`false`) | Δ         |
| -------------- | -------------------------- | ----------------- | --------- |
| Symbols        | 10,693,267                 | 10,645,697        | −0.4%     |
| Instantiations | 40,579,658                 | 40,561,637        | −0.04%    |
| Memory used    | 7.55 GB                    | 7.05 GB           | **−6.6%** |
| Memory allocs  | 58,828,467                 | 56,919,825        | **−3.2%** |


The reduction isn't huge, but with how much this polymorphism behavior contributes to overall memory usage across the entire project, it makes a meaningful dent. The polymorphism still remains a problematic source of significant memory consumption, but despite several attempts to explore broader improvements, I wasn't able to find a silver bullet solution, or at least one that doesn't involve losing benefits of the polymorphism (e.g. using `as="label"` on a polymorphic component makes TypeScript aware of additional label-specific props like `htmlFor`).

It also may carry over to build time; in a trial of 4-7 test runs compared between this branch and `trunk`, **a full TypeScript build (`tsc --build`) reduced from 33.4s on average to 30.8s (~ -8%)**.

It's not entirely clear this will benefit the original problem with builds terminating, as it does appear that the peak memory usage of the build remains stable at around ~10.7GB. 

## Testing Instructions

Verify TypeScript build is unaffected:

```
npm run build
```

If you want to validate performance yourself, you can compare the following set of commands on this branch and trunk:

```
rm -f packages/components/tsconfig.tsbuildinfo
/usr/bin/time -l npx tsc -p packages/components/tsconfig.json --extendedDiagnostics 2>&1 \
  | grep -E '^(Symbols|Instantiations|Memory used|Memory allocs):|maximum resident'
```

Or full project timings and memory usage:

```
npx tsc --build --clean >/dev/null 2>&1
rm -rf packages/*/build-types
/usr/bin/time -l npx tsc --build 2>&1 | grep -E 'maximum resident|real'
```

## Use of AI Tools

This was the result of a very long and involved conversation with Claude Code + Opus 4.8. So yes, a lot of the thinking and measuring here is AI-assisted, though with a lot of scrutiny, pushback, and idea exploration prompted by myself.