### PR TITLE
Automated Testing: Skip type-checking in bundle size comparison build

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -68,3 +68,4 @@ jobs:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: '{build/scripts/**/*.min.js,build/styles/**/*.css,build/modules/**/*.min.js}'
                   clean-script: 'distclean'
+                  build-script: 'build -- --skip-types'


### PR DESCRIPTION
## What?

Updates the "Compressed Size" GitHub workflow to skip type-checking.

## Why?

Improve build speed for this workflow and reduce memory usage.

May also improve test stability overall. While it's likely coincidental, this specific workflow has suffered from some instability due to what is likely memory exhaustion in workers (see [example log](https://github.com/WordPress/gutenberg/actions/runs/29438586551/job/87431403247?pr=80272), [related Slack discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1784139282164719))

More generally, this is better because the point of the workflow is to compare bundle size difference, where the only relevance is the production runtime build. TypeScript type-checking happens separately in the "Static Checks" workflow. So this skips unnecessary work.

## How?

Configure's [the `build-script` option of the associated `preactjs/compressed-size-action` action](https://github.com/preactjs/compressed-size-action#customizing-the-build).

Note that this is documented as receiving an npm script. We don't currently have a dedicated npm script just for running build without types. We could do this, but the implementation of the action is such that it simply concatenates the `build-script` option to `npm run` ([source](https://github.com/preactjs/compressed-size-action/blob/f322c295dde06a1cb7ccaef105732dd8a726d1d9/src/index.js#L72)), becoming `npm run build -- -- skip-types` with the changes proposed here.

## Testing Instructions

Verify the "Compressed Size" GitHub workflow completes successfully and produces accurate output.

Compare against a baseline (e.g. another recent pull request) and hopefully observe speed improvements as well.

## Use of AI Tools

This finding came out of a very long and involved conversation with Claude Code + Opus 4.8, and the implementation was validated in a separate agent conversation with Cursor IDE + Auto (likely Composer) model. The code changes were applied myself.