### PR TITLE
Build: add independent react-18 vendor package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15000,6 +15000,10 @@
 			"resolved": "widgets/quick-draft",
 			"link": true
 		},
+		"node_modules/@wordpress/react-18": {
+			"resolved": "tools/react-18",
+			"link": true
+		},
 		"node_modules/@wordpress/react-19": {
 			"resolved": "tools/react-19",
 			"link": true
@@ -49028,6 +49032,7 @@
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 				"@wordpress/build": "file:../../packages/wp-build",
+				"@wordpress/react-18": "file:../react-18",
 				"@wordpress/react-19": "file:../react-19",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"babel-plugin-inline-json-import": "^0.3.2",
@@ -49036,8 +49041,6 @@
 				"esbuild": "^0.27.2",
 				"fast-glob": "^3.2.7",
 				"magic-string": "^0.30.21",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1",
 				"rimraf": "^5.0.10",
 				"source-map": "^0.6.1"
 			}
@@ -49086,6 +49089,15 @@
 				"react": "^18.3.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"typescript-eslint": "^8.57.1"
+			}
+		},
+		"tools/react-18": {
+			"name": "@wordpress/react-18",
+			"version": "0.0.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			}
 		},
 		"tools/react-19": {

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -19,9 +19,9 @@ export default {
 			policy: 'sameRange',
 		},
 		{
-			label: '`@wordpress/react-19` is the experimental React 19 build; it intentionally declares React v19.',
+			label: '`@wordpress/react-18` and `@wordpress/react-19` are standalone React builds pinned to their respective major versions, independent of the repo-wide React version.',
 			dependencies: [ 'react', 'react-dom' ],
-			packages: [ '@wordpress/react-19' ],
+			packages: [ '@wordpress/react-18', '@wordpress/react-19' ],
 			isIgnored: true,
 		},
 		{

--- a/tools/build-scripts/package.json
+++ b/tools/build-scripts/package.json
@@ -27,6 +27,7 @@
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 		"@wordpress/build": "file:../../packages/wp-build",
+		"@wordpress/react-18": "file:../react-18",
 		"@wordpress/react-19": "file:../react-19",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"babel-plugin-inline-json-import": "^0.3.2",
@@ -35,8 +36,6 @@
 		"esbuild": "^0.27.2",
 		"fast-glob": "^3.2.7",
 		"magic-string": "^0.30.21",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
 		"rimraf": "^5.0.10",
 		"source-map": "^0.6.1"
 	},

--- a/tools/build-scripts/packages/build-vendors.mjs
+++ b/tools/build-scripts/packages/build-vendors.mjs
@@ -31,27 +31,21 @@ const patchReactDOM = createPatcher(
 
 const VENDOR_SCRIPTS = [
 	{
-		name: 'react',
+		name: '@wordpress/react-18/react',
 		global: 'React',
 		handle: 'react',
 		dependencies: [ 'wp-polyfill' ],
 		version: '18.3.1',
 	},
 	{
-		name: 'react-dom',
+		name: '@wordpress/react-18/react-dom',
 		global: 'ReactDOM',
 		handle: 'react-dom',
 		dependencies: [ 'react' ],
-		contents: [
-			'module.exports = {',
-			'  ...require("react-dom"),',
-			'  ...require("react-dom/client"),',
-			'};',
-		].join( '\n' ),
 		version: '18.3.1',
 	},
 	{
-		name: 'react/jsx-runtime',
+		name: '@wordpress/react-18/react-jsx-runtime',
 		global: 'ReactJSXRuntime',
 		handle: 'react-jsx-runtime',
 		dependencies: [ 'react' ],
@@ -128,7 +122,7 @@ async function patchVendorOutput( fileName, patch ) {
  * This is used to build packages like React that don't ship UMD builds.
  *
  * @param {Object}   config              Vendor script configuration.
- * @param {string}   config.name         Package name (e.g., 'react', 'react-dom', 'react/jsx-runtime').
+ * @param {string}   config.name         Entry point name (e.g., '@wordpress/react-18/react').
  * @param {string}   config.global       Global variable name (e.g., 'React', 'ReactDOM').
  * @param {string}   config.handle       WordPress script handle (e.g., 'react', 'react-dom').
  * @param {string[]} config.dependencies WordPress script dependencies.
@@ -136,7 +130,7 @@ async function patchVendorOutput( fileName, patch ) {
  * @return {Promise<void>} Promise that resolves when all builds are finished.
  */
 async function bundleVendorScript( config ) {
-	const { name, global, handle, contents, dependencies } = config;
+	const { name, global, handle, dependencies } = config;
 
 	// Plugin that externalizes the `react` package.
 	const reactExternalPlugin = {
@@ -168,22 +162,13 @@ async function bundleVendorScript( config ) {
 		globalName: global,
 		target: 'esnext',
 		platform: 'browser',
+		entryPoints: [ name ],
 		// Resolve imports from this workspace's dependencies.
 		absWorkingDir: WORKSPACE_DIR,
 		plugins: dependencies?.includes( 'react' )
 			? [ reactExternalPlugin ]
 			: [],
 	};
-
-	if ( contents ) {
-		esbuildOptions.stdin = {
-			contents,
-			resolveDir: WORKSPACE_DIR,
-			loader: 'js',
-		};
-	} else {
-		esbuildOptions.entryPoints = [ name ];
-	}
 
 	await Promise.all( [
 		esbuild.build( {

--- a/tools/react-18/package.json
+++ b/tools/react-18/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@wordpress/react-18",
+	"version": "0.0.0",
+	"description": "React 18 for Gutenberg.",
+	"private": true,
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"react"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/tools/react-18",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/WordPress/gutenberg.git",
+		"directory": "tools/react-18"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"exports": {
+		"./react": "./react.js",
+		"./react-dom": "./react-dom.js",
+		"./react-jsx-runtime": "./react-jsx-runtime.js"
+	},
+	"dependencies": {
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/tools/react-18/react-dom.js
+++ b/tools/react-18/react-dom.js
@@ -1,0 +1,4 @@
+module.exports = {
+	...require( 'react-dom' ),
+	...require( 'react-dom/client' ),
+};

--- a/tools/react-18/react-jsx-runtime.js
+++ b/tools/react-18/react-jsx-runtime.js
@@ -1,0 +1,1 @@
+module.exports = require( 'react/jsx-runtime' );

--- a/tools/react-18/react.js
+++ b/tools/react-18/react.js
@@ -1,0 +1,1 @@
+module.exports = require( 'react' );


### PR DESCRIPTION
We currently ship two versions of React scripts, one for v18 (default), another for v19 (enabled by experimental flag). The v19 scripts are built from the `tools/react-19` sub-package, the v18 scripts are build from the packages installed in the root of the repo.

I'd like to switch the Gutenberg repo to React 19, with new types et al. Like we did in #61521 but had to revert. Then the root React packages would be v19, and the v18 build no longer works.

This PR introduces a new `tools/react-18` package, conceptually the same thing as `tools/react-19`. React v18 build will work from there, independently from the rest of the repo.

## Testing instructions
Run `npm run build` and verify that `react.js` etc in `build/scripts/vendors` are the same as before. Or more precisely, there will be a few bytes difference because the esbuild entrypoint is a bit different. But the rest of the script is exactly the same.