### PR TITLE
Fix flaky test in `tabs.spec.js`

### DIFF
--- a/test/e2e/specs/editor/blocks/tabs.spec.js
+++ b/test/e2e/specs/editor/blocks/tabs.spec.js
@@ -166,6 +166,8 @@ test.describe( 'Tabs', () => {
 			// The new tab's panel is the active one and is visible.
 			const panels = editor.canvas.getByRole( 'document', {
 				name: 'Block: Tab Panel',
+				exact: true,
+				includeHidden: true,
 			} );
 			await expect( panels ).toHaveCount( 3 );
 			await expect( panels.nth( 2 ) ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/tabs.spec.js
+++ b/test/e2e/specs/editor/blocks/tabs.spec.js
@@ -164,6 +164,9 @@ test.describe( 'Tabs', () => {
 			).toBeFocused();
 
 			// The new tab's panel is the active one and is visible.
+			// Use `exact: true` to avoid matching the parent 'Block: Tab Panels' name.
+			// Use `includeHidden: true` to check the number of hidden panels. getByRole()
+			// only returns visible elements by default.
 			const panels = editor.canvas.getByRole( 'document', {
 				name: 'Block: Tab Panel',
 				exact: true,


### PR DESCRIPTION
## What?

Fixes the `adds and activates a new tab when pressing Enter at the end of a tab label` tabs test to pass reliably in CI.

## Why?

See https://github.com/WordPress/gutenberg/issues/80106. The test has been flaky including 10 `trunk` failures in the last week. I've personally also seeing very reliable failures in other PRs (https://github.com/WordPress/gutenberg/pull/79685), but because of the test flakiness it's hard to tell if it's a PR problem or not.

## How?

The test previously ran this code to check for tab panels:

```js
const panels = editor.canvas.getByRole( 'document', {
    name: 'Block: Tab Panel',
} );

await expect( panels ).toHaveCount( 3 );
await expect( panels.nth( 2 ) ).toBeVisible();
```

This was probably not working as expected. `getByRole()` by default [only returns visible elements](https://playwright.dev/docs/api/class-page#page-get-by-role):

>`includeHidden`
>
> Option that controls whether hidden elements are matched. By default, only non-hidden elements, as [defined by ARIA](https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion), are matched by role selector.

That means `toHaveCount( 3 )` was expecting 3 visible tab sections at the same time, which doesn't make sense for the test, given that only 1 should be visible. Instead, here's what I think was happening. Visually, after the 3rd tab is added in the test, a direct `Block: Tab Panel` document query actually results in 4 results (including non-visible items):

https://github.com/user-attachments/assets/6d79b4ef-412d-48a9-bffc-63bcb1b4dee4

This includes the `Block: Tab Panels` parent item and each of the three child tabs. In local testing with `getByRole()`, the test was actually returning 2 `panels`, the newly created tab panel and the parent panel, and none of the hidden panels. When the test was "failing", it was properly reporting the correct number (2) of matching `panels`. I think in CI, running slower, there's a brief window when both Tab 2 and the new third tab are both present in the DOM before Tab 2 is hidden. The briefly still-visible Tab 2, the new tab, plus the parent DOM item, were adding to 3 incidentally.

To fix it, first use `exact: true` to avoid matching the parent "Block: Tab Panels" DOM item, and then explicitly `includeHidden: true` so the test assertion makes sense. Otherwise, we're only querying visible panels. Now we can correctly assert the 3 final panels exist, excluding the parent item, and that the last is visible.

## Testing Instructions

See CI test passes.
