### PR TITLE
Fix `useHomeEnd` on tabs in mac testing

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-home-end.js
+++ b/packages/block-editor/src/components/writing-flow/use-home-end.js
@@ -12,10 +12,16 @@ import { getSelectionEditableElement } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
- * While the wrapper is the contentEditable editing host (a selected block
- * supports `editableRoot`), browsers don't perform the default caret
- * movement for Home and End. Perform the equivalent movement with
- * `Selection.modify()`.
+ * Moves the caret to the start or end of the visual line for Home and End
+ * with `Selection.modify()`, because the browser's default caret movement
+ * cannot be relied on in two cases:
+ *
+ * - While the wrapper is the contentEditable editing host (a selected block
+ *   supports `editableRoot`), browsers don't perform the default caret
+ *   movement for Home and End.
+ * - Chromium on macOS maps Home and End to scroll commands, so it never
+ *   moves the caret in editable content on that platform, including nested
+ *   editable elements like the tab labels in the tab-list block.
  */
 export default function useHomeEnd() {
 	const { hasMultiSelection } = useSelect( blockEditorStore );
@@ -33,11 +39,13 @@ export default function useHomeEnd() {
 				return;
 			}
 
-			if (
-				node.contentEditable !== 'true' ||
-				node.ownerDocument.activeElement !== node ||
-				hasMultiSelection()
-			) {
+			// Only handle keys pressed in editable content, in both of the
+			// cases mentioned above: `event.target` is the focused element,
+			// and `isContentEditable` is true both for the wrapper as the
+			// editing host and for a nested editable element like a tab label.
+			// Anything else that takes focus like inputs and textareas keep
+			// default behavior.
+			if ( ! event.target.isContentEditable || hasMultiSelection() ) {
 				return;
 			}
 

--- a/test/e2e/specs/editor/blocks/tabs.spec.js
+++ b/test/e2e/specs/editor/blocks/tabs.spec.js
@@ -166,6 +166,8 @@ test.describe( 'Tabs', () => {
 			// The new tab's panel is the active one and is visible.
 			const panels = editor.canvas.getByRole( 'document', {
 				name: 'Block: Tab Panel',
+				exact: true,
+				includeHidden: true,
 			} );
 			await expect( panels ).toHaveCount( 3 );
 			await expect( panels.nth( 2 ) ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/tabs.spec.js
+++ b/test/e2e/specs/editor/blocks/tabs.spec.js
@@ -164,6 +164,9 @@ test.describe( 'Tabs', () => {
 			).toBeFocused();
 
 			// The new tab's panel is the active one and is visible.
+			// Use `exact: true` to avoid matching the parent 'Block: Tab Panels' name.
+			// Use `includeHidden: true` to check the number of hidden panels. getByRole()
+			// only returns visible elements by default.
 			const panels = editor.canvas.getByRole( 'document', {
 				name: 'Block: Tab Panel',
 				exact: true,


### PR DESCRIPTION
## What?

Follow-up to #80373 (otherwise independent, but the fixed test is included in this PR to demonstrate the local failure). That PR should get merged first.

 While working on that fix, I noticed that the fixed CI test still always failed locally (Mac + Chromium):

```bash
$ npm run test:e2e -- test/e2e/specs/editor/blocks/tabs.spec.js --repeat-each=5 -g "adds and activates a new tab"

  # ...
  ✘  1 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (7.0s)
  ✘  2 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (6.2s)
  ✘  3 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (6.2s)
  ✘  4 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (6.2s)
  ✘  5 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (6.1s)
```

Locally [the "End" key press](https://github.com/WordPress/gutenberg/blob/e2d18199d715cc6b45587e49d8dd7028fe40dd74/test/e2e/specs/editor/blocks/tabs.spec.js#L145) in the test was failing to fire, and a new tab was not being created.

## Why?

On `trunk`, try creating a `core/tabs` block, entering a tab title mid-line, and hitting the Home or End keys:

https://github.com/user-attachments/assets/1e675fa0-bdfb-4f2a-8306-186ffbe2ac7e

Above I'm hitting home/end inside of the tab title but nothing happens. In this PR branch, the same test:

https://github.com/user-attachments/assets/5eca3f32-038b-4277-9dc0-42d74016f699

Home and end work properly, and also the test above (which utilizes the End key) passes reliably:

```
$ npm run test:e2e -- test/e2e/specs/editor/blocks/tabs.spec.js --repeat-each=5 -g "adds and activates a new tab"

> gutenberg@23.6.0-rc.1 test:e2e
> npm exec --workspace @wordpress/e2e-tests-playwright -- wp-scripts test-e2e --config playwright.config.ts test/e2e/specs/editor/blocks/tabs.spec.js --repeat-each=5 -g adds and activates a new tab


Running 5 tests using 1 worker

  ✓  1 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (2.1s)
  ✓  2 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (1.2s)
  ✓  3 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (1.1s)
  ✓  4 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (1.1s)
  ✓  5 [chromium] › specs/editor/blocks/tabs.spec.js:136:3 › Tabs › Editor functionality › adds and activates a new tab when pressing Enter at the end of a tab label (1.1s)

  5 passed (9.0s)
```

## How?

macOS [maps Home and End to scroll commands](https://github.com/jakob/Postico/issues/659#issuecomment-498160902), so it never performs caret movement in editable content. Other platforms bind the keys to the proper home and end movements.

#79105 recently added `use-home-end.js`. When the writing flow wrapper is the `contentEditable` host (an `editableRoot` block is selected), no browser performs the "correct" movement for home and end. That's specifically addressed in the editing host case, on the assumption that the browser handles everything else. On macOS the browser doesn't handle home and end in the same way, so any editable that holds focus directly (like tab labels) gets no caret movement at all.

Replace the wrapper-specific guard with a slightly broader editable content check. `event.target.isContentEditable` is true both for the wrapper when it's the editing host and for a nested editable, and false for inputs, textareas, and other focusables, which keep the browser's default behavior.

## Testing Instructions

1. On macOS running on `trunk`, insert a `core/tabs` block.
2. Click in the middle of a tab title.
3. Press home/end.
4. See nothing happening.
5. Repeat the same steps in this PR branch (`fix/use-home-end-tabs`). See the caret move appropriately.

### Automated testing

Run the tab test and see it pass locally on macOS:

```
npm run test:e2e -- test/e2e/specs/editor/blocks/tabs.spec.js --repeat-each=5 -g "adds and activates a new tab"
```

## Use of AI Tools

Claude for the whole process.