### PR TITLE
Autocompleters: Don't pre-encode mention search terms

### DIFF
--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -52,7 +52,7 @@ export default {
 				const { getUsers } = select( coreStore );
 				return getUsers( {
 					context: 'view',
-					search: encodeURIComponent( filterValue ),
+					search: filterValue,
 				} );
 			},
 			[ filterValue ]

--- a/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
+++ b/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
@@ -40,7 +40,7 @@ const noteMentionCompleter = {
 				const { getUsers } = select( coreStore );
 				return getUsers( {
 					context: 'view',
-					search: encodeURIComponent( filterValue ),
+					search: filterValue,
 				} );
 			},
 			[ filterValue ]

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -46,6 +46,12 @@ const userList = [
 		lastName: 'Elf',
 		password: 'sm1lingsmyfavorite',
 	},
+	{
+		username: 'thescribe',
+		firstName: 'შოთა',
+		lastName: 'რუსთაველი',
+		password: 'n0nl@t1nName',
+	},
 ];
 
 test.describe( 'Autocomplete (@firefox, @webkit)', () => {
@@ -745,5 +751,24 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 				name: 'Frodo Baggins',
 			} )
 		).toBeVisible();
+	} );
+
+	// The search term must reach the REST API unencoded. Pre-encoding it means
+	// WordPress's `sanitize_text_field` strips every percent-encoded sequence,
+	// so a non-latin term is erased entirely and matches every user.
+	test( 'should filter mentions by non-latin search terms', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+
+		await page.keyboard.type( '@შოთა' );
+
+		await expect(
+			page.getByRole( 'option', { name: 'შოთა რუსთაველი' } )
+		).toBeVisible();
+		await expect( page.getByRole( 'option' ) ).toHaveCount( 1 );
 	} );
 } );


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/77185#issuecomment-4981544107.

PR fixes the user mention autocompleter (`@`) to return correct results for non-Latin search terms - Georgian, Japanese, Cyrillic and emoji.

## Why?

Both mentions of completers passed `search: encodeURIComponent( filterValue )` to `getUsers`. `addQueryArgs` already encodes query values, so the term was double-encoded and the server received the literal text `%E1%83%90%E1%83%91`.

WordPress runs the REST `search` arg through `sanitize_text_field()`, which strips every percent-encoded sequence. Latin letters aren't encoded, so they survive, and the bug stays hidden. Non-Latin characters are encoded in full and get erased:

| typed | server receives | after `sanitize_text_field` |
| --- | --- | --- |
| `abc` | `abc` | `abc` |
| `აბგ` | `%E1%83%90%E1%83%91%E1%83%92` | `""` |

An empty `search` matches everything, so `@აბგ` listed every user on the site.

The encoding was correct when the completer built its own query string (`'?search=' + encodeURIComponent( search )`), but became a double-encode when #33028 moved it to `getUsers`.

## How?

Pass `filterValue` through unencoded and let `addQueryArgs` encode it, matching the existing `links` completer. Same one-line fix in the post and Notes mentions completers.

## Testing Instructions

1. Create a user with a non-Latin display name, e.g. `გიორგი მამადაშვილი`.
2. In a paragraph, type `@გიორგი`.
3. Only that user is suggested. On the trunk, every user on the site is suggested.

Covered by a new e2e test in `autocomplete-and-mentions.spec.js`, which fails on trunk.

## Use of AI Tools

Assisted by Claude.