### PR TITLE
Components: migrate Popover to SCSS module

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Internal
 
+-   `Popover`: Migrate styles from global SCSS to an SCSS Module while preserving legacy class names ([#80382](https://github.com/WordPress/gutenberg/pull/80382)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -51,6 +51,7 @@ import type {
 } from './types';
 import { overlayMiddlewares } from './overlay-middlewares';
 import { StyleProvider } from '../style-provider';
+import styles from './style.module.scss';
 
 /**
  * Name of slot in which popover should fill.
@@ -74,15 +75,21 @@ const ArrowTriangle = () => (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 100 100"
-		className="components-popover__triangle"
+		className={ clsx( styles.triangle, 'components-popover__triangle' ) }
 		role="presentation"
 	>
 		<Path
-			className="components-popover__triangle-bg"
+			className={ clsx(
+				styles[ 'triangle-bg' ],
+				'components-popover__triangle-bg'
+			) }
 			d="M 0 0 L 50 50 L 100 0"
 		/>
 		<Path
-			className="components-popover__triangle-border"
+			className={ clsx(
+				styles[ 'triangle-border' ],
+				'components-popover__triangle-border'
+			) }
 			d="M 0 0 L 50 50 L 100 0"
 			vectorEffect="non-scaling-stroke"
 		/>
@@ -452,16 +459,25 @@ const UnforwardedPopover = (
 
 	let content = (
 		<motion.div
-			className={ clsx( className, {
-				'is-expanded': isExpanded,
-				'is-positioned': isPositioned,
-				// Use the 'alternate' classname for 'toolbar' variant for back compat.
-				[ `is-${
-					computedVariant === 'toolbar'
-						? 'alternate'
-						: computedVariant
-				}` ]: computedVariant,
-			} ) }
+			className={ clsx(
+				styles.popover,
+				{
+					[ styles[ 'is-expanded' ] ]: isExpanded,
+					[ styles[ 'is-alternate' ] ]: computedVariant === 'toolbar',
+					[ styles[ 'is-unstyled' ] ]: computedVariant === 'unstyled',
+				},
+				className,
+				{
+					'is-expanded': isExpanded,
+					'is-positioned': isPositioned,
+					// Use the 'alternate' classname for 'toolbar' variant for back compat.
+					[ `is-${
+						computedVariant === 'toolbar'
+							? 'alternate'
+							: computedVariant
+					}` ]: computedVariant,
+				}
+			) }
 			{ ...animationProps }
 			{ ...contentProps }
 			ref={ mergedFloatingRef }
@@ -471,8 +487,18 @@ const UnforwardedPopover = (
 			{ /* Prevents scroll on the document */ }
 			{ isExpanded && <ScrollLock /> }
 			{ isExpanded && (
-				<div className="components-popover__header">
-					<span className="components-popover__header-title">
+				<div
+					className={ clsx(
+						styles.header,
+						'components-popover__header'
+					) }
+				>
+					<span
+						className={ clsx(
+							styles[ 'header-title' ],
+							'components-popover__header-title'
+						) }
+					>
 						{ headerTitle }
 					</span>
 					<Button
@@ -484,14 +510,23 @@ const UnforwardedPopover = (
 					/>
 				</div>
 			) }
-			<div className="components-popover__content">{ children }</div>
+			<div
+				className={ clsx(
+					styles.content,
+					'components-popover__content'
+				) }
+			>
+				{ children }
+			</div>
 			{ hasArrow && (
 				<div
 					ref={ arrowCallbackRef }
-					className={ [
+					className={ clsx(
+						styles.arrow,
+						styles[ `is-${ computedPlacement.split( '-' )[ 0 ] }` ],
 						'components-popover__arrow',
-						`is-${ computedPlacement.split( '-' )[ 0 ] }`,
-					].join( ' ' ) }
+						`is-${ computedPlacement.split( '-' )[ 0 ] }`
+					) }
 					style={ {
 						left:
 							typeof arrowData?.x !== 'undefined' &&

--- a/packages/components/src/popover/style.module.scss
+++ b/packages/components/src/popover/style.module.scss
@@ -10,7 +10,7 @@ $shadow-popover-border-default-alternate: 0 0 0 $border-width $gray-900;
 $shadow-popover-border-top-only: 0 #{-$border-width} 0 0 $gray-400;
 $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 
-.components-popover {
+.popover {
 	@include reset;
 	z-index: z-index(".components-popover");
 	will-change: transform;
@@ -18,24 +18,26 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 	&.is-expanded {
 		position: fixed;
 		top: 0;
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve Popover's physical viewport positioning. */
 		left: 0;
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve Popover's physical viewport positioning. */
 		right: 0;
 		bottom: 0;
 		z-index: z-index(".components-popover") !important;
 	}
 }
 
-.components-popover__content {
-	background: $white;
+.content {
+	background: var(--wpds-color-background-surface-neutral-strong);
 	box-shadow: $shadow-popover-border-default, $elevation-medium;
-	border-radius: $radius-medium;
+	border-radius: var(--wpds-border-radius-md);
 	box-sizing: border-box;
 	width: min-content;
 
 	// Alternate treatment for popovers that put them at elevation zero with high contrast and smaller radius.
 	.is-alternate & {
 		box-shadow: $shadow-popover-border-default-alternate;
-		border-radius: $radius-small;
+		border-radius: var(--wpds-border-radius-sm);
 	}
 
 	// A style that gives the popover no visible ui.
@@ -45,35 +47,37 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 		box-shadow: none;
 	}
 
-	.components-popover.is-expanded & {
+	.popover.is-expanded & {
 		position: static;
-		height: calc(100% - #{ $panel-header-height });
+		height: calc(100% - #{$panel-header-height});
 		overflow-y: visible;
 		width: auto;
 		box-shadow: $shadow-popover-border-top-only;
 	}
-	.components-popover.is-expanded.is-alternate & {
+
+	.popover.is-expanded.is-alternate & {
 		box-shadow: $shadow-popover-border-top-only-alternate;
 	}
 }
 
-.components-popover__header {
+.header {
 	align-items: center;
-	background: $white;
+	background: var(--wpds-color-background-surface-neutral-strong);
 	display: flex;
 	height: $panel-header-height;
 	justify-content: space-between;
-	padding: 0 8px 0 $grid-unit-20;
+	/* stylelint-disable-next-line declaration-property-max-values -- Preserve the existing physical header padding. */
+	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-lg);
 }
 
-.components-popover__header-title {
+.header-title {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
 }
 
-.components-popover__arrow {
+.arrow {
 	position: absolute;
 	width: $arrow-triangle-base-size;
 	height: $arrow-triangle-base-size;
@@ -87,10 +91,12 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 		content: "";
 		position: absolute;
 		top: -1px;
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the arrow's physical geometry. */
 		left: 1px;
 		height: 2px;
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the arrow's physical geometry. */
 		right: 1px;
-		background-color: $white;
+		background-color: var(--wpds-color-background-surface-neutral-strong);
 	}
 
 	// Position and rotate the arrow depending on the popover's placement.
@@ -99,35 +105,40 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 		bottom: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(0);
 	}
+
 	&.is-right {
 		/*rtl:begin:ignore*/
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- The physical side is part of the arrow rotation calculation. */
 		left: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(90deg);
 	}
+
 	&.is-bottom {
 		top: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(180deg);
 	}
+
 	&.is-left {
 		/*rtl:begin:ignore*/
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- The physical side is part of the arrow rotation calculation. */
 		right: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(-90deg);
 		/*rtl:end:ignore*/
 	}
 }
 
-.components-popover__triangle {
+.triangle {
 	display: block;
 	flex: 1;
 }
 
-.components-popover__triangle-bg {
-	// Fill color is the same as the .components-popover__content's background
-	fill: $white;
+.triangle-bg {
+	// Fill color is the same as the .content's background.
+	fill: var(--wpds-color-background-surface-neutral-strong);
 }
 
-.components-popover__triangle-border {
-	// Stroke colors are the same as the .components-popover__content's outline
+.triangle-border {
+	// Stroke colors are the same as the .content's outline.
 	fill: transparent;
 	stroke-width: $border-width;
 	stroke: $gray-400;

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -29,7 +29,6 @@
 @use "./notice/style.scss" as *;
 @use "./panel/style.scss" as *;
 @use "./placeholder/style.scss" as *;
-@use "./popover/style.scss" as *;
 @use "./radio-control/style.scss" as *;
 @use "./resizable-box/style.scss" as *;
 @use "./responsive-wrapper/style.scss" as *;


### PR DESCRIPTION
## What?

Follow up to #66806.

Migrates Popover's global SCSS to an SCSS Module while preserving its existing behavior and public class names.

## Why?

Popover renders through portals and can target a different document, making it an important component to validate as `@wordpress/components` moves away from Emotion.

## How?

- Composes internal module classes with the existing `components-popover*` and state classes.
- Preserves the existing selector specificity, physical positioning, RTL behavior, and visual values.
- Uses equivalent WPDS tokens where available.
- Keeps the existing `StyleProvider` integration so the style runtime registers the module in portal target documents.
- Removes Popover styles from the global Components stylesheet.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **Components / Overlays / Popover**.
3. Compare the **Default**, **Unstyled**, and **All Placements** stories with trunk. Exercise the toolbar variant, arrows, and expanded mobile treatment.
4. Open **With Slot Outside Iframe** and verify the Popover remains styled in the external document.

Automated checks:

- `npm run lint:js -- packages/components/src/popover/index.tsx`
- `./node_modules/.bin/wp-scripts lint-style packages/components/src/popover/style.module.scss`
- `./node_modules/.bin/tsc --build packages/components/tsconfig.json`
- `npm run test:unit -- packages/components/src/popover/test/index.tsx --runInBand`
- `npm run build -- --skip-types`
- `npm run other:check-local-changes`

<details>
<summary>Full repository snapshot run</summary>

`npm run test:unit:update` generated the full repository snapshot set. Three unrelated load-sensitive suites timed out in the parallel run; each passed in a focused serial rerun. No snapshot changes remain.

</details>

### Testing Instructions for Keyboard

1. Focus a Popover trigger and press Enter or Space to open it.
2. Use Tab and Shift+Tab to verify focus movement is unchanged.
3. Press Escape and verify the Popover closes and focus returns to its trigger.

## Screenshots or screencast

Not applicable: this refactor is intended to be visually unchanged.

## Use of AI Tools

Codex was used to research related migrations, implement and verify the refactor, and draft this PR description. The changes were reviewed by the contributor.
