### PR TITLE
SlotFill: Validate cross-document SCSS module styles

### DIFF
--- a/packages/components/src/slot-fill/fill.tsx
+++ b/packages/components/src/slot-fill/fill.tsx
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { useObservableValue } from '@wordpress/compose';
 import {
 	useContext,
@@ -9,9 +6,6 @@ import {
 	createPortal,
 } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
 import SlotFillContext from './context';
 import type { FillComponentProps } from './types';
 import StyleProvider from '../style-provider';

--- a/packages/components/src/slot-fill/fill.tsx
+++ b/packages/components/src/slot-fill/fill.tsx
@@ -62,9 +62,9 @@ export default function Fill( { name, children }: FillComponentProps ) {
 			: children;
 
 	// When using a `Fill`, the `children` will be rendered in the document of the
-	// `Slot`. This means that we need to wrap the `children` in a `StyleProvider`
-	// to make sure we're referencing the right document/iframe (instead of the
-	// context of the `Fill`'s parent).
+	// `Slot`. Wrap the children in a `StyleProvider` so CSS module styles and
+	// legacy Emotion styles target that document/iframe instead of the document
+	// containing the `Fill`.
 	return createPortal(
 		<StyleProvider document={ portalEl.ownerDocument }>
 			{ wrappedChildren }

--- a/packages/components/src/slot-fill/stories/index.story.tsx
+++ b/packages/components/src/slot-fill/stories/index.story.tsx
@@ -2,16 +2,42 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
 
 /**
  * WordPress dependencies
  */
-import { createContext, useContext } from '@wordpress/element';
+import {
+	createContext,
+	createPortal,
+	useContext,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { Slot, Fill, Provider as SlotFillProvider } from '../';
+import { Spacer } from '../../spacer';
+
+function IframePortal( { children }: { children: ReactNode } ) {
+	const [ bodyNode, setBodyNode ] = useState< HTMLElement | null >( null );
+
+	return (
+		<iframe
+			title="Cross-document SlotFill styles"
+			srcDoc="<!doctype html><html><body></body></html>"
+			onLoad={ ( event ) => {
+				setBodyNode(
+					event.currentTarget.contentDocument?.body ?? null
+				);
+			} }
+			style={ { border: 0, height: 160, width: '100%' } }
+		>
+			{ bodyNode && createPortal( children, bodyNode ) }
+		</iframe>
+	);
+}
 
 const meta: Meta< typeof Slot > = {
 	tags: [ 'manifest' ],
@@ -142,4 +168,29 @@ export const WithContext: StoryFn< typeof Slot > = ( props ) => {
 };
 WithContext.args = {
 	...Default.args,
+};
+
+export const CrossDocumentStyles: StoryFn< typeof Slot > = () => {
+	return (
+		<SlotFillProvider>
+			<p>
+				The content below should have 32px of padding inside its
+				outline.
+			</p>
+			<IframePortal>
+				<Slot name="cross-document-styles" bubblesVirtually />
+			</IframePortal>
+			<Fill name="cross-document-styles">
+				<Spacer
+					padding={ 8 }
+					style={ {
+						display: 'inline-block',
+						outline: '2px solid currentColor',
+					} }
+				>
+					SCSS module styles rendered in another document
+				</Spacer>
+			</Fill>
+		</SlotFillProvider>
+	);
 };

--- a/packages/components/src/slot-fill/stories/index.story.tsx
+++ b/packages/components/src/slot-fill/stories/index.story.tsx
@@ -1,12 +1,6 @@
-/**
- * External dependencies
- */
 import type { Meta, StoryFn } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
-/**
- * WordPress dependencies
- */
 import {
 	createContext,
 	createPortal,
@@ -14,9 +8,6 @@ import {
 	useState,
 } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
 import { Slot, Fill, Provider as SlotFillProvider } from '../';
 import { Spacer } from '../../spacer';
 

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -304,7 +304,7 @@ describe( 'Slot', () => {
 			// generated production call explicitly.
 			registerStyle( styleHash, css );
 
-			const { unmount } = render(
+			render(
 				<Provider>
 					<IframePortal>
 						<Slot name="cross-document" bubblesVirtually />
@@ -326,8 +326,6 @@ describe( 'Slot', () => {
 				iframeDocument.defaultView.getComputedStyle( styledElement )
 					.padding
 			).toBe( '32px' );
-
-			unmount();
 		} );
 	} );
 

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -290,37 +290,45 @@ describe( 'Slot', () => {
 		expect( console ).toHaveWarned();
 	} );
 
-	it( 'injects registered SCSS module styles into the Slot document', () => {
-		const styleHash = 'slot-fill-cross-document-style';
-		const css = '.slot-fill-cross-document{padding:32px;}';
+	describe( 'cross-document styles', () => {
+		afterEach( () => {
+			delete globalThis.__wpStyleRuntime;
+			document.head.innerHTML = '';
+		} );
 
-		const { unmount } = render(
-			<Provider>
-				<IframePortal>
-					<Slot name="cross-document" bubblesVirtually />
-				</IframePortal>
-				<Fill name="cross-document">
-					<div className="slot-fill-cross-document">
-						Styled content
-					</div>
-				</Fill>
-			</Provider>
-		);
-		const iframeDocument =
-			screen.getByTitle( 'Slot document' ).contentDocument;
+		it( 'injects registered SCSS module styles into the Slot document', () => {
+			const styleHash = 'slot-fill-cross-document-style';
+			const css = '.slot-fill-cross-document{padding:32px;}';
 
-		// CSS module registration is skipped by the Jest transform, so mirror the
-		// generated production call explicitly.
-		registerStyle( styleHash, css );
+			// CSS module registration is skipped by the Jest transform, so mirror the
+			// generated production call explicitly.
+			registerStyle( styleHash, css );
 
-		const styledElement = within( iframeDocument.body ).getByText(
-			'Styled content'
-		);
-		expect(
-			iframeDocument.defaultView.getComputedStyle( styledElement ).padding
-		).toBe( '32px' );
+			const { unmount } = render(
+				<Provider>
+					<IframePortal>
+						<Slot name="cross-document" bubblesVirtually />
+					</IframePortal>
+					<Fill name="cross-document">
+						<div className="slot-fill-cross-document">
+							Styled content
+						</div>
+					</Fill>
+				</Provider>
+			);
+			const iframeDocument =
+				screen.getByTitle( 'Slot document' ).contentDocument;
 
-		unmount();
+			const styledElement = within( iframeDocument.body ).getByText(
+				'Styled content'
+			);
+			expect(
+				iframeDocument.defaultView.getComputedStyle( styledElement )
+					.padding
+			).toBe( '32px' );
+
+			unmount();
+		} );
 	} );
 
 	describe.each( [ false, true ] )(

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -1,18 +1,9 @@
-/**
- * External dependencies
- */
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-/**
- * WordPress dependencies
- */
 import { Component, createPortal } from '@wordpress/element';
 import { registerStyle } from '@wordpress/style-runtime';
 
-/**
- * Internal dependencies
- */
 import { Slot, Fill, Provider, useSlotFills } from '../';
 
 class Filler extends Component {

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, createPortal } from '@wordpress/element';
+import { registerStyle } from '@wordpress/style-runtime';
 
 /**
  * Internal dependencies
  */
 import { Slot, Fill, Provider, useSlotFills } from '../';
-
-/**
- * WordPress dependencies
- */
-import { Component } from '@wordpress/element';
 
 class Filler extends Component {
 	constructor() {
@@ -285,6 +286,37 @@ describe( 'Slot', () => {
 
 		expect( container ).toMatchSnapshot();
 		expect( console ).toHaveWarned();
+	} );
+
+	it( 'injects registered SCSS module styles into the Slot document', () => {
+		const iframeDocument = document.implementation.createHTMLDocument();
+		const styleHash = 'slot-fill-cross-document-style';
+		const css = '.slot-fill-cross-document{padding:32px;}';
+
+		const { unmount } = render(
+			<Provider>
+				{ createPortal(
+					<Slot name="cross-document" bubblesVirtually />,
+					iframeDocument.body
+				) }
+				<Fill name="cross-document">
+					<div className="slot-fill-cross-document" />
+				</Fill>
+			</Provider>
+		);
+
+		// CSS module registration is skipped by the Jest transform, so mirror the
+		// generated production call explicitly.
+		registerStyle( styleHash, css );
+
+		expect(
+			within( iframeDocument.head ).queryAllByText( css, {
+				ignore: false,
+				selector: `style[data-wp-hash="${ styleHash }"]`,
+			} )
+		).toHaveLength( 1 );
+
+		unmount();
 	} );
 
 	describe.each( [ false, true ] )(

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -1,10 +1,21 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { Component, createPortal } from '@wordpress/element';
+import { Component, createPortal, useState } from '@wordpress/element';
 import { registerStyle } from '@wordpress/style-runtime';
 
 import { Slot, Fill, Provider, useSlotFills } from '../';
+
+function IframePortal( { children } ) {
+	const [ iframe, setIframe ] = useState( null );
+	const body = iframe?.contentDocument?.body;
+
+	return (
+		<iframe title="Slot document" ref={ setIframe }>
+			{ body && createPortal( children, body ) }
+		</iframe>
+	);
+}
 
 class Filler extends Component {
 	constructor() {
@@ -280,21 +291,21 @@ describe( 'Slot', () => {
 	} );
 
 	it( 'injects registered SCSS module styles into the Slot document', () => {
-		const iframeDocument = document.implementation.createHTMLDocument();
 		const styleHash = 'slot-fill-cross-document-style';
 		const css = '.slot-fill-cross-document{padding:32px;}';
 
 		const { unmount } = render(
 			<Provider>
-				{ createPortal(
-					<Slot name="cross-document" bubblesVirtually />,
-					iframeDocument.body
-				) }
+				<IframePortal>
+					<Slot name="cross-document" bubblesVirtually />
+				</IframePortal>
 				<Fill name="cross-document">
 					<div className="slot-fill-cross-document" />
 				</Fill>
 			</Provider>
 		);
+		const iframeDocument =
+			screen.getByTitle( 'Slot document' ).contentDocument;
 
 		// CSS module registration is skipped by the Jest transform, so mirror the
 		// generated production call explicitly.

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -300,7 +300,9 @@ describe( 'Slot', () => {
 					<Slot name="cross-document" bubblesVirtually />
 				</IframePortal>
 				<Fill name="cross-document">
-					<div className="slot-fill-cross-document" />
+					<div className="slot-fill-cross-document">
+						Styled content
+					</div>
 				</Fill>
 			</Provider>
 		);
@@ -311,12 +313,12 @@ describe( 'Slot', () => {
 		// generated production call explicitly.
 		registerStyle( styleHash, css );
 
+		const styledElement = within( iframeDocument.body ).getByText(
+			'Styled content'
+		);
 		expect(
-			within( iframeDocument.head ).queryAllByText( css, {
-				ignore: false,
-				selector: `style[data-wp-hash="${ styleHash }"]`,
-			} )
-		).toHaveLength( 1 );
+			iframeDocument.defaultView.getComputedStyle( styledElement ).padding
+		).toBe( '32px' );
 
 		unmount();
 	} );


### PR DESCRIPTION
## What?

Follow-up to #66806.

Validates that SlotFill delivers SCSS module styles to the document containing the `Slot`, including iframe and other cross-document placements.

SlotFill does not own any Emotion-authored style declarations to translate. Its virtually bubbling wrapper already uses the SCSS-module-backed `View` migrated in #79443. The remaining migration risk is the cross-document `StyleProvider`, which now registers the Slot document with `@wordpress/style-runtime` while still supporting Emotion styles from consumers that have not migrated yet.

This PR adds focused regression coverage and a Storybook example for that boundary, without changing SlotFill's runtime API, DOM, class names, selectors, specificity, or style output.

## Why?

Removing or bypassing `StyleProvider` would cause SCSS module styles to remain in the Fill's document instead of following portaled content into the Slot's document. Removing its Emotion cache behavior now would also be a breaking change for existing Fill consumers.

The migration tracker identifies SlotFill as a risk component because it exercises this portal and cross-document behavior. The explicit coverage makes that contract verifiable while the broader Emotion migration continues.

## How?

- Adds a SlotFill unit test that portals a `Slot` into another document, registers the same style-runtime payload emitted by an SCSS module build, and verifies that the style is injected into the Slot document.
- Adds a `CrossDocumentStyles` story using the migrated `Spacer` component inside a Fill rendered through a Slot in an iframe.
- Clarifies why the existing `StyleProvider` must currently support both SCSS modules and legacy Emotion consumers.

No new SCSS file is necessary because SlotFill has no component-owned styles. There are also no style fragments to compose, so the Emotion source-order regression addressed in #79443 does not apply here.

## Testing Instructions

1. Run `npm run test:unit -- packages/components/src/slot-fill/test/slot.js --runInBand` and confirm the unit tests pass.
2. Run `npm run storybook:dev` and open **Components / Utilities / SlotFill / Cross Document Styles**. Confirm that the content rendered inside the iframe has 32px of padding inside its outline, showing that the Spacer SCSS module styles reached the Slot document.
3. Run `npm run test:unit:update -- --runInBand` and confirm there are no snapshot changes.

### Testing Instructions for Keyboard

Not applicable. This PR does not change interactions or focus behavior.

## Screenshots or screencast

Not applicable. This PR does not change production visual output.

## Use of AI Tools

Codex was used to inspect the reference migrations, implement the regression coverage and story, run verification, and draft this description. The resulting code and conclusions were reviewed by the author.
