### PR TITLE
Fix default aspect ratio for lazy loaded Featured image

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -182,6 +182,7 @@ export default function PostFeaturedImageEdit( {
 	const borderProps = useBorderProps( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
 	const blockEditingMode = useBlockEditingMode();
+	const aspectRatioStyle = aspectRatio === 'auto' ? undefined : aspectRatio;
 
 	const placeholder = ( content ) => {
 		return (
@@ -192,7 +193,7 @@ export default function PostFeaturedImageEdit( {
 				) }
 				withIllustration
 				style={ {
-					aspectRatio,
+					aspectRatio: aspectRatioStyle,
 					height: hasDimensionValue( height )
 						? height
 						: hasDimensionValue( width ) && 'auto',
@@ -426,7 +427,7 @@ export default function PostFeaturedImageEdit( {
 	const imageStyles = {
 		...borderProps.style,
 		...shadowProps.style,
-		aspectRatio,
+		aspectRatio: aspectRatioStyle,
 		height: hasDimensionValue( height )
 			? height
 			: hasDimensionValue( width ) && 'auto',

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -44,7 +44,10 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$has_height   = array_key_exists( 'height', $attributes ) && null !== $attributes['height'] && '' !== $attributes['height'];
 
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
-		$extra_styles .= esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';';
+		// If there's no non-default value set, let the image's width and height attributes determine its intrinsic aspect ratio.
+		if ( 'auto' !== $attributes['aspectRatio'] ) {
+			$extra_styles .= esc_attr( safecss_filter_attr( 'aspect-ratio:' . $attributes['aspectRatio'] ) ) . ';';
+		}
 		$extra_styles .= 'width:100%;';
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #80378 by removing the explicit aspect ratio declaration when its value is `auto`.

Fwiw I was able to repro the bug in Chrome and Firefox, but not Safari.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Query to a post or template, and ensure the posts or pages in it have featured images set.
2. Save and check that the featured images are sized correctly in the front end.


## Screenshots or screencast <!-- if applicable -->


<img width="772" height="467" alt="Screenshot 2026-07-17 at 10 00 57 am" src="https://github.com/user-attachments/assets/f7f81c19-51c6-4152-8e78-4d5d2a674b8e" />
