### PR TITLE
Editor: Disable canvas resizing while zoomed out

### DIFF
--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -359,9 +359,15 @@ export function getShowStylebook( state ) {
  * @param {Object} state Global application state.
  * @return {number} The canvas width in pixels.
  */
-export function getCanvasWidth( state ) {
-	return state.canvasWidth;
-}
+export const getCanvasWidth = createRegistrySelector(
+	( select ) => ( state ) => {
+		// Return undefined while zoomed out to disable canvas resizing.
+		if ( unlock( select( blockEditorStore ) ).isZoomOut() ) {
+			return undefined;
+		}
+		return state.canvasWidth;
+	}
+);
 
 /**
  * Returns the current revisions page number.


### PR DESCRIPTION
## What?

Follow up to #75121

Enabling Zoom Out mode while the Mobile or Tablet device preview is active leaves the canvas at the device width and keeps it resizable, which shows an unnatural scrollbar.

## Why?

This doesn't reproduce in 7.0, so it's most likely a regression from #75121, which unified the device preview and the resizable canvas.

`enableResizing` in the visual editor already checks `! isZoomedOut`, but the check is scoped to the left operand only:

https://github.com/WordPress/gutenberg/blob/14c541065009c24ad18a33d37fd4135223c635c0/packages/editor/src/components/visual-editor/index.js#L319-L332

The trailing `|| hasCanvasWidth` overrides the zoom out check whenever a device preview has set an explicit canvas width.

## How?

`getCanvasWidth` now returns `undefined` while zoomed out, meaning a Desktop canvas that hasn't been resized yet. The check lives inside `getCanvasWidth` for consistency with [`getDeviceType`, which already reports `Desktop` while zoomed out](https://github.com/WordPress/gutenberg/blob/14c541065009c24ad18a33d37fd4135223c635c0/packages/editor/src/store/selectors.js#L1353-L1356).  Handling it outside would leave the two selectors disagreeing during zoom out, with `getDeviceType()` returning `Desktop` while `getCanvasWidth()` still returns `480`.

Since `getCanvasWidth` is a private API, internal changes should be permissible.

## Testing Instructions

1. Switch the device preview to Mobile. The canvas should be resizable.
2. Enable Zoom Out mode. The device preview button should change to Desktop, and the canvas should switch to Desktop and no longer be resizable.
3. Disable Zoom Out mode. The device preview button should change back to Mobile, and the canvas should return to Mobile and be resizable again.

## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/0154706f-fe0f-4da5-a3f0-1237c58aab5d

### After

The exaggerated animation when switching to zoom-out mode is a bit distracting. It would be great if this could be made smoother...

https://github.com/user-attachments/assets/c2b95142-5583-4264-bad9-d96f7582493e

## Use of AI Tools

The investigation and the patch were produced with Claude Code (Claude Opus 4.8), which located the cause and drafted the change. I reviewed the diff and directed the final approach, and I take responsibility for the contents of this PR.
