### PR TITLE
Components: Migrate Modal styles to SCSS module

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Internal
 
+-   `Modal`: Migrate component styles to an SCSS Module while preserving legacy class names and portal style routing ([#80393](https://github.com/WordPress/gutenberg/pull/80393)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Remove obsolete `__unstable-large` from the public `size` type. The value continues to work at runtime, and is equivalent to the `default` size. ([#80081](https://github.com/WordPress/gutenberg/pull/80081)).
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -27,6 +27,7 @@ import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { Spacer } from '../spacer';
 import { useModalExitAnimation } from './use-modal-exit-animation';
 import { ModalContext, type Dismissers } from './context';
+import styles from './style.module.scss';
 
 // Used to track body class names applied while modals are open.
 const bodyOpenClasses = new Map< string, number >();
@@ -245,7 +246,9 @@ function UnforwardedModal(
 			ref={ useMergeRefs( [ ref, forwardedRef ] ) }
 			className={ clsx(
 				'components-modal__screen-overlay',
+				styles[ 'screen-overlay' ],
 				overlayClassname,
+				overlayClassname && styles[ 'is-animating-out' ],
 				overlayClassnameProp
 			) }
 			onKeyDown={ withIgnoreIMEEvents( handleEscapeKeyDown ) }
@@ -255,7 +258,9 @@ function UnforwardedModal(
 				<div
 					className={ clsx(
 						'components-modal__frame',
+						styles.frame,
 						sizeClass,
+						sizeClass && styles[ sizeClass ],
 						className
 					) }
 					style={ style }
@@ -275,11 +280,17 @@ function UnforwardedModal(
 					onKeyDown={ onKeyDown }
 				>
 					<div
-						className={ clsx( 'components-modal__content', {
-							'hide-header': __experimentalHideHeader,
-							'is-scrollable': hasScrollableContent,
-							'has-scrolled-content': hasScrolledContent,
-						} ) }
+						className={ clsx(
+							'components-modal__content',
+							styles.content,
+							__experimentalHideHeader && 'hide-header',
+							__experimentalHideHeader && styles[ 'hide-header' ],
+							hasScrollableContent && 'is-scrollable',
+							hasScrollableContent && styles[ 'is-scrollable' ],
+							hasScrolledContent && 'has-scrolled-content',
+							hasScrolledContent &&
+								styles[ 'has-scrolled-content' ]
+						) }
 						role="document"
 						onScroll={ onContentContainerScroll }
 						ref={ contentRef }
@@ -291,8 +302,18 @@ function UnforwardedModal(
 						tabIndex={ hasScrollableContent ? 0 : undefined }
 					>
 						{ ! __experimentalHideHeader && (
-							<div className="components-modal__header">
-								<div className="components-modal__header-heading-container">
+							<div
+								className={ clsx(
+									'components-modal__header',
+									styles.header
+								) }
+							>
+								<div
+									className={ clsx(
+										'components-modal__header-heading-container',
+										styles[ 'header-heading-container' ]
+									) }
+								>
 									{ icon && (
 										<span
 											className="components-modal__icon-container"
@@ -304,7 +325,10 @@ function UnforwardedModal(
 									{ title && (
 										<h1
 											id={ headingId }
-											className="components-modal__header-heading"
+											className={ clsx(
+												'components-modal__header-heading',
+												styles[ 'header-heading' ]
+											) }
 										>
 											{ title }
 										</h1>

--- a/packages/components/src/modal/stories/e2e/index.story.tsx
+++ b/packages/components/src/modal/stories/e2e/index.story.tsx
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../../button';
+import Modal from '../..';
+
+export default {
+	title: 'Components/Modal',
+	component: Modal,
+};
+
+export const Default = () => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				variant="secondary"
+				onClick={ () => setIsOpen( true ) }
+			>
+				Open Modal
+			</Button>
+			{ isOpen && (
+				<Modal
+					title="Modal title"
+					onRequestClose={ () => setIsOpen( false ) }
+				>
+					Modal content
+				</Modal>
+			) }
+		</>
+	);
+};

--- a/packages/components/src/modal/style.module.scss
+++ b/packages/components/src/modal/style.module.scss
@@ -5,8 +5,13 @@
 @use "@wordpress/base-styles/z-index" as *;
 @use "../utils/theme-variables" as *;
 
+// CSS Module styles are injected after static consumer styles. Qualifying the
+// zero-specificity module class with the rendered element keeps these defaults
+// above element resets but below the public `className`, `overlayClassName`, and
+// legacy class selectors that previously followed the components stylesheet.
+
 // The scrim behind the modal window.
-.screen-overlay {
+div:where(.screen-overlay) {
 	position: fixed;
 	top: 0;
 	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the legacy viewport-relative positioning in every writing mode. */
@@ -29,7 +34,7 @@
 }
 
 // The modal window element.
-.frame {
+div:where(.frame) {
 	@include reset;
 	// On smaller screens, render as a bottom sheet: edge-to-edge, anchored
 	// to the bottom of the viewport. `align-self: flex-end` both anchors
@@ -195,7 +200,7 @@
 // Fix header to the top so it is always there to provide context to the modal
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
 // modal screen).
-.header {
+div:where(.header) {
 	box-sizing: border-box;
 	border-bottom: $border-width solid transparent;
 	padding: $grid-unit-30;
@@ -232,7 +237,7 @@
 	}
 }
 
-.header-heading-container {
+div:where(.header-heading-container) {
 	align-items: center;
 	flex-grow: 1;
 	display: flex;
@@ -251,7 +256,7 @@
 }
 
 // Modal contents.
-.content {
+div:where(.content) {
 	flex: 1;
 	margin-top: $header-height + $grid-unit-10;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.

--- a/packages/components/src/modal/style.module.scss
+++ b/packages/components/src/modal/style.module.scss
@@ -6,11 +6,13 @@
 @use "../utils/theme-variables" as *;
 
 // The scrim behind the modal window.
-.components-modal__screen-overlay {
+.screen-overlay {
 	position: fixed;
 	top: 0;
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the legacy viewport-relative positioning in every writing mode. */
 	right: 0;
 	bottom: 0;
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the legacy viewport-relative positioning in every writing mode. */
 	left: 0;
 	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
@@ -27,7 +29,7 @@
 }
 
 // The modal window element.
-.components-modal__frame {
+.frame {
 	@include reset;
 	// On smaller screens, render as a bottom sheet: edge-to-edge, anchored
 	// to the bottom of the viewport. `align-self: flex-end` both anchors
@@ -39,13 +41,16 @@
 	max-height: calc(100% - #{$grid-unit-50});
 	background: $white;
 	box-shadow: $elevation-large;
+	/* stylelint-disable-next-line declaration-property-max-values -- Preserve the legacy physical corner values. */
 	border-radius: $radius-large $radius-large 0 0;
 	overflow: hidden;
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
 	color: $gray-900;
 	// Animate the modal frame/contents appearing on the page.
-	animation-name: components-modal__appear-animation;
+	// The fallback prevents CSS Modules from scoping the global animation name
+	// that is also observed by the exit-animation hook.
+	animation-name: var(--_wp-components-modal-animation-name, components-modal__appear-animation);
 	animation-fill-mode: forwards;
 	animation-timing-function: var(--wpds-motion-easing-expressive);
 
@@ -60,8 +65,8 @@
 		animation-duration: var(--wpds-motion-duration-md);
 	}
 
-	.components-modal__screen-overlay.is-animating-out & {
-		animation-name: components-modal__disappear-animation;
+	.screen-overlay.is-animating-out & {
+		animation-name: var(--_wp-components-modal-animation-name, components-modal__disappear-animation);
 		animation-timing-function: var(--wpds-motion-easing-expressive);
 	}
 
@@ -107,7 +112,7 @@
 		border-radius: 0;
 
 		// When full screen, make sure the children container is full height.
-		:where(.components-modal__content) {
+		:where(.content) {
 			display: flex;
 			// If this container is scrollable, bottom padding won't apply so we use margin instead.
 			margin-bottom: $grid-unit-30;
@@ -135,8 +140,10 @@
 	}
 }
 
+// Keep the animation names global because the exit-animation hook listens for
+// the existing `components-modal__disappear-animation` name.
 // On mobile, the modal slides up from the bottom of the viewport.
-@keyframes components-modal__appear-animation {
+@keyframes :global(components-modal__appear-animation) {
 	from {
 		opacity: 0;
 		transform: translateY(100%);
@@ -147,9 +154,7 @@
 	}
 }
 
-// Note: this animation is also used in the animationend JS event listener.
-// Make sure that the animation name is kept in sync across the two files.
-@keyframes components-modal__disappear-animation {
+@keyframes :global(components-modal__disappear-animation) {
 	from {
 		opacity: 1;
 		transform: translateY(0);
@@ -164,7 +169,7 @@
 // names are intentionally reused so the JS animationend listener
 // (use-modal-exit-animation.ts) keeps working unchanged.
 @include break-small() {
-	@keyframes components-modal__appear-animation {
+	@keyframes :global(components-modal__appear-animation) {
 		from {
 			opacity: 0;
 			transform: scale(0.9);
@@ -175,7 +180,7 @@
 		}
 	}
 
-	@keyframes components-modal__disappear-animation {
+	@keyframes :global(components-modal__disappear-animation) {
 		from {
 			opacity: 1;
 			transform: scale(1);
@@ -190,7 +195,7 @@
 // Fix header to the top so it is always there to provide context to the modal
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
 // modal screen).
-.components-modal__header {
+.header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid transparent;
 	padding: $grid-unit-30;
@@ -204,9 +209,10 @@
 	z-index: 10;
 	position: absolute;
 	top: 0;
+	/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the legacy physical positioning. */
 	left: 0;
 
-	.components-modal__header-heading {
+	.header-heading {
 		font-size: $font-size-x-large;
 		font-weight: var(--wpds-typography-font-weight-emphasis);
 	}
@@ -216,7 +222,8 @@
 		margin: 0;
 	}
 
-	.components-modal__content.has-scrolled-content:not(.hide-header) & {
+	.content.has-scrolled-content:not(.hide-header) & {
+		/* stylelint-disable-next-line plugin/use-logical-properties-and-values -- Preserve the legacy physical border declaration. */
 		border-bottom-color: var(--wpds-color-stroke-surface-neutral);
 	}
 
@@ -225,7 +232,7 @@
 	}
 }
 
-.components-modal__header-heading-container {
+.header-heading-container {
 	align-items: center;
 	flex-grow: 1;
 	display: flex;
@@ -233,7 +240,7 @@
 	justify-content: flex-start;
 }
 
-.components-modal__header-icon-container {
+.header-icon-container {
 	display: inline-block;
 
 	svg {
@@ -244,7 +251,7 @@
 }
 
 // Modal contents.
-.components-modal__content {
+.content {
 	flex: 1;
 	margin-top: $header-height + $grid-unit-10;
 	// Small top padding required to avoid cutting off the visible outline when the first child element is focusable.

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -81,6 +81,37 @@ describe( 'Modal', () => {
 		expect( title ).not.toBeInTheDocument();
 	} );
 
+	it( 'preserves legacy public class names', () => {
+		render(
+			<Modal
+				className="custom-frame"
+				overlayClassName="custom-overlay"
+				size="small"
+				__experimentalHideHeader
+				onRequestClose={ noop }
+			>
+				<p>Modal content</p>
+			</Modal>
+		);
+
+		const dialog = screen.getByRole( 'dialog' );
+		expect( dialog ).toHaveClass(
+			'components-modal__frame',
+			'has-size-small',
+			'custom-frame'
+		);
+		// Disable reason: No semantic query can reach the overlay.
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( dialog.parentElement ).toHaveClass(
+			'components-modal__screen-overlay',
+			'custom-overlay'
+		);
+		expect( screen.getByRole( 'document' ) ).toHaveClass(
+			'components-modal__content',
+			'hide-header'
+		);
+	} );
+
 	it( 'should call onRequestClose when the escape key is pressed', async () => {
 		const user = userEvent.setup();
 		const onRequestClose = jest.fn();

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -14,8 +14,8 @@ import { CONFIG } from '../utils';
  * Milliseconds used as a fallback when racing `animationend` against a timeout.
  *
  * Sourced from `CONFIG.transitionDuration`. This value is implicitly coupled to
- * the modal frame’s CSS `animation-duration` in `style.scss`, which uses the
- * WPDS `motion-duration-md` token. If either the token, the SCSS, or
+ * the modal frame’s CSS `animation-duration` in `style.module.scss`, which uses
+ * the WPDS `motion-duration-md` token. If either the token, the SCSS, or
  * `CONFIG.transitionDuration` changes, keep them aligned so exit timing stays correct.
  */
 const FRAME_ANIMATION_DURATION_MS = Number.parseInt(

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -25,7 +25,6 @@
 @use "./menu-group/style.scss" as *;
 @use "./menu-item/style.scss" as *;
 @use "./menu-items-choice/style.scss" as *;
-@use "./modal/style.scss" as *;
 @use "./notice/style.scss" as *;
 @use "./panel/style.scss" as *;
 @use "./placeholder/style.scss" as *;

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -60,7 +60,7 @@ export default Object.assign( {}, CONTROL_PROPS, {
 	surfaceColor: COLORS.white,
 	// Modal exit animation: `use-modal-exit-animation` parses this for the
 	// `animationend` timeout race; keep the numeric duration equal to the WPDS
-	// `motion-duration-md` token on `.components-modal__frame` in modal/style.scss.
+	// `motion-duration-md` token on `.frame` in modal/style.module.scss.
 	transitionDuration: '200ms',
 	transitionDurationFast: '160ms',
 	transitionDurationFaster: '120ms',

--- a/test/storybook-playwright/specs/modal.spec.ts
+++ b/test/storybook-playwright/specs/modal.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { gotoStoryId } from '../utils';
+
+test.describe( 'Modal', () => {
+	test( 'preserves consumer overrides loaded before the component styles', async ( {
+		page,
+	} ) => {
+		await gotoStoryId( page, 'components-modal--default' );
+
+		await page.evaluate( () => {
+			const style = document.createElement( 'style' );
+			style.textContent = `
+				.components-modal__screen-overlay {
+					z-index: 999999;
+				}
+				.modal-consumer-overlay {
+					display: block;
+				}
+				.modal-consumer-frame {
+					width: 480px;
+				}
+			`;
+			document.head.prepend( style );
+		} );
+
+		await page.getByRole( 'button', { name: 'Open Modal' } ).click();
+
+		const overlay = page.locator( '.components-modal__screen-overlay' );
+		const frame = page.locator( '.components-modal__frame' );
+
+		await overlay.evaluate( ( element ) =>
+			element.classList.add( 'modal-consumer-overlay' )
+		);
+		await frame.evaluate( ( element ) =>
+			element.classList.add( 'modal-consumer-frame' )
+		);
+
+		await expect( overlay ).toHaveCSS( 'z-index', '999999' );
+		await expect( overlay ).toHaveCSS( 'display', 'block' );
+		await expect( frame ).toHaveCSS( 'width', '480px' );
+	} );
+} );


### PR DESCRIPTION
## What?

Follow up to #66806.

Migrates Modal's component styles from global SCSS to an SCSS Module.

## Why?

This continues the components styling migration while keeping Modal's portal, cross-document styling, and consumer overrides intact.

## How?

- Adds private, kebab-case module classes alongside the existing public class names.
- Uses `clsx` for size, scroll, hidden-header, full-screen, and exit-animation states.
- Preserves the existing declarations, physical properties, WPDS tokens, and global animation names.
- Uses type-qualified `:where()` roots so runtime-injected defaults remain below public `className`, `overlayClassName`, and legacy-class overrides, while state selectors retain their intended strength.
- Retains `StyleProvider` so Modal and nested Emotion components continue to receive styles in registered documents.
- Adds unit coverage for legacy class names and browser coverage for consumer overrides loaded before the component styles.

Modal does not compose multiple Emotion fragments, so the exact regression from #79443 does not apply. Its broader source-order risk does apply to Modal consumers; the selector strategy and browser test cover that case.

## Testing Instructions

1. Run `npm run test:unit -- packages/components/src/modal/test --runInBand`.
2. Run `npm run lint:js -- packages/components/src/modal test/storybook-playwright/specs/modal.spec.ts packages/components/src/utils/config-values.js`.
3. Run `npm run lint:css -- packages/components/src/modal/style.module.scss`.
4. Run `npm run storybook:e2e:dev`, then `npm exec --workspace @wordpress/storybook-playwright -- playwright test specs/modal.spec.ts --config playwright.config.ts`.
5. Run `npm run build`.
6. Run `npm run test:unit:update -- --runInBand` and inspect any snapshot changes. The migration should not update snapshots.
7. Run `npm run storybook:dev`, open **Components / Overlays / Modal**, and verify the default, small-size, and full-screen variants match trunk.

### Testing Instructions for Keyboard

1. Open the Modal story using only the keyboard.
2. Confirm focus moves into the modal and Tab/Shift+Tab remain constrained within it.
3. Press Escape and confirm the modal closes and focus returns to the trigger.

## Screenshots or screencast

No visual change is expected.

## Use of AI Tools

OpenAI Codex was used to implement the migration, analyze the related migrations, and run the verification steps. The resulting diff was reviewed for style equivalence, accessibility, source-order behavior, and regressions.
