### PR TITLE
Rich Text: Restore the selection when focus returns to the editable

### DIFF
--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -305,7 +305,9 @@ export default ( props ) => ( element ) => {
 			// snapshot must not skip synchronization.
 			selectionSnapshot = undefined;
 		} else {
-			applyRecord( record.current, { domOnly: true } );
+			// The document's selection may have moved elsewhere while the
+			// element was blurred, so restore it from the record.
+			applyRecord( record.current );
 		}
 
 		onSelectionChange( record.current.start, record.current.end );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1723,13 +1723,19 @@ test.describe( 'Block Notes', () => {
 
 			/*
 			 * Pressing Escape closes the link popover and leaves the note
-			 * form intact — focus does not get yanked out of the editor.
+			 * form intact; focus does not get yanked out of the editor, and
+			 * the selection is restored rather than left collapsed.
 			 */
 			await page.keyboard.press( 'Escape' );
 			await expect(
 				page.getByRole( 'combobox', { name: 'Search or type URL' } )
 			).toBeHidden();
-			await expect( textbox ).toBeVisible();
+			await expect( textbox ).toBeFocused();
+			await expect
+				.poll( () =>
+					page.evaluate( () => window.getSelection().toString() )
+				)
+				.toBe( 'visit example' );
 		} );
 
 		test( 'Cmd+K opens an unclipped link popover in the reply form', async ( {


### PR DESCRIPTION
## What?
Part of #80294.

PR removes `domOnly: true` from the rich text focus handler, so focus restores the record's selection again.

## Why?
Select text in a same-document rich text field, press <kbd>Cmd</kbd>+<kbd>K</kbd>, then press <kbd>Escape</kbd>. The caret returns to the start of the text instead of the selection.

The field and the link popover share one document, so focusing the popover's input takes the document's only selection. `domOnly: true` makes the focus handler skip `applySelection`, so nothing restores it. An iframed editor is unaffected; its canvas is a separate document with its own selection, which is why this only surfaces in same-document fields: the non-iframed block editor (widgets screen) and the dataviews `RichTextControl` (block notes).

`domOnly: true` came from #58745, fixing #58322 (clicking between two links in a paragraph opened the wrong preview). It has been vestigial since #59635 (March 2024) added `shouldAutoFocus`, which stops the Link UI from stealing focus on link-click. That removed the focus round-trip #58322 depended on, so the focus handler is no longer on that path: it receives zero `focusin` events in the #58322 scenario, and #58322's e2e guard passes with or without `domOnly`.

## Testing Instructions
1. Add a note to a block (or use the widgets screen).
2. Type some text and select it.
3. Press Cmd+K to open the link UI, then press Escape.
4. The text should still be selected, not collapsed to the start.

Automated: new e2e covering this in `block-notes.spec.js`. `links.spec.js` (incl. the #58322 guard), `rich-text.spec.js`, `writing-flow.spec.js` and `block-notes.spec.js` show no new failures.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1415423f-971c-4a16-9fa5-5ae0502cf027

https://github.com/user-attachments/assets/85e17fb1-51b2-4347-bd27-7ac00f52a26a

## Use of AI Tools

Assisted by Claude.
