### PR TITLE
React 19: add e2e compat test for boolean inert attribute

### DIFF
--- a/packages/e2e-tests/plugins/react-18-compat-block/editor.js
+++ b/packages/e2e-tests/plugins/react-18-compat-block/editor.js
@@ -99,17 +99,25 @@
 			return jsx( 'div', {
 				...blockProps,
 				children: [
-					// An element that relies on the `inert` attribute, created with
-					// the bundled React 18 runtime (legacy `react.element` symbol).
 					jsxDEV(
 						'div',
 						{
-							className: 'react-18-compat-block__inert',
+							className: 'react-18-compat-block__inert-string',
 							inert: '',
 							children:
-								'This subtree is inert and built with the React 18 runtime.',
+								'This subtree is inert and uses a React 18 style string attribute.',
 						},
 						'inert'
+					),
+					jsx(
+						'div',
+						{
+							className: 'react-18-compat-block__inert-boolean',
+							inert: true,
+							children:
+								'This subtree is inert and uses a React 19 style boolean attribute.',
+						},
+						'inert-boolean'
 					),
 					// The `defaultProps` component, created with the
 					// externalized React runtime.

--- a/test/e2e/specs/editor/plugins/react-18-compat-block.spec.js
+++ b/test/e2e/specs/editor/plugins/react-18-compat-block.spec.js
@@ -49,12 +49,55 @@ test.describe( 'React 18 compatibility block (React 19 runtime)', () => {
 			block.locator( '.react-18-compat-block__greeting' )
 		).toHaveText( 'Hello from defaultProps' );
 
-		// The subtree built with the bundled React 18 runtime renders, keeping
-		// the `inert` attribute on the important element.
-		const inert = block.locator( '.react-18-compat-block__inert' );
-		await expect( inert ).toHaveAttribute( 'inert' );
-		await expect( inert ).toContainText(
-			'This subtree is inert and built with the React 18 runtime.'
+		// `inert=''` attribute specified as string is rendered as `true` by a patched React 19 runtime.
+		const inertString = block.locator(
+			'.react-18-compat-block__inert-string'
 		);
+		await expect( inertString ).toHaveAttribute( 'inert' );
+
+		// `inert=true` attribute specified as boolean is rendered as `true`.
+		const inertBoolean = block.locator(
+			'.react-18-compat-block__inert-boolean'
+		);
+		await expect( inertBoolean ).toHaveAttribute( 'inert' );
+	} );
+} );
+
+test.describe( 'React 18 compatibility block (React 18 runtime)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+		await requestUtils.activatePlugin(
+			'gutenberg-test-react-18-compat-block'
+		);
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-react-18-compat-block'
+		);
+	} );
+
+	test( 'renders a React 19 boolean inert attribute with React 18 runtime', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( { name: 'test/react-18-compat-block' } );
+
+		const block = editor.canvas.locator(
+			'role=document[name="Block: React 18 Compat Block"i]'
+		);
+		await expect( block ).toBeVisible();
+
+		const inertBoolean = block.locator(
+			'.react-18-compat-block__inert-boolean'
+		);
+
+		// This result is bad and should be fixed. The `inert=true` boolean
+		// attribute should be rendered as `true`, but only the React 19 runtime
+		// will do it (see the v19 test above). The React 18 runtime will ignore it.
+		await expect( inertBoolean ).not.toHaveAttribute( 'inert' );
 	} );
 } );


### PR DESCRIPTION
Adds an explicit e2e test for a compat issue between React 18 and React 19. When we pass a boolean, v19-style `inert={true}` attribute, React 19 runtime will render it as true, but React 18 will render it as false, i.e., will not add the `inert` attribute at all. Because React 18 has an internal `shouldRemoveAttribute` which removes/ignores the attribute when the value is boolean AND it's not on its list of supported boolean attributes.

This will be a compat issue when a plugin author:
- uses React 19 for development, with React 19 types, and specifies `inert={true}` seeing no evil.
- doesn't use a special `inertValue` helper that e.g. BaseUI has and uses internally.
- runs the plugin on WordPress with the React 18 runtime.

I don't have a good solution for this at the moment. We're doing compat patches for React 19, but are leaving React 18 as-is, and there are of cource many WordPresses deployed that have the plain version of React 18.