### PR TITLE
UI: Provide text direction at Gutenberg app roots

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Provide RTL direction context to `@wordpress/ui` components in boot-powered admin pages. ([#80400](https://github.com/WordPress/gutenberg/pull/80400))
+
 ## 0.18.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/boot/src/components/app/index.tsx
+++ b/packages/boot/src/components/app/index.tsx
@@ -3,6 +3,8 @@
  */
 import { createRoot, StrictMode, type ComponentType } from '@wordpress/element';
 import { dispatch, useSelect } from '@wordpress/data';
+import { isRTL } from '@wordpress/i18n';
+import { DirectionProvider } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -69,7 +71,9 @@ export async function init( {
 		const root = createRoot( rootElement );
 		root.render(
 			<StrictMode>
-				<App />
+				<DirectionProvider direction={ isRTL() ? 'rtl' : 'ltr' }>
+					<App />
+				</DirectionProvider>
 			</StrictMode>
 		);
 	}
@@ -98,7 +102,9 @@ export async function initSinglePage( {
 		const root = createRoot( rootElement );
 		root.render(
 			<StrictMode>
-				<App rootComponent={ RootSinglePage } />
+				<DirectionProvider direction={ isRTL() ? 'rtl' : 'ltr' }>
+					<App rootComponent={ RootSinglePage } />
+				</DirectionProvider>
 			</StrictMode>
 		);
 	}

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Provide RTL direction context to `@wordpress/ui` components in the Post Editor. ([#80400](https://github.com/WordPress/gutenberg/pull/80400))
+
 ## 8.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -20,6 +20,8 @@ import {
 } from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
+import { isRTL } from '@wordpress/i18n';
+import { DirectionProvider } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -188,12 +190,14 @@ export function initializeEditor(
 		}
 		root.render(
 			<StrictMode>
-				<Layout
-					settings={ settings }
-					postId={ postId }
-					postType={ postType }
-					initialEdits={ initialEdits }
-				/>
+				<DirectionProvider direction={ isRTL() ? 'rtl' : 'ltr' }>
+					<Layout
+						settings={ settings }
+						postId={ postId }
+						postType={ postType }
+						initialEdits={ initialEdits }
+					/>
+				</DirectionProvider>
 			</StrictMode>
 		);
 	} );

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Provide RTL direction context to `@wordpress/ui` components in the Site Editor. ([#80400](https://github.com/WordPress/gutenberg/pull/80400))
+
 ## 7.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -16,6 +16,8 @@ import {
 	registerLegacyWidgetBlock,
 	registerWidgetGroupBlock,
 } from '@wordpress/widgets';
+import { isRTL } from '@wordpress/i18n';
+import { DirectionProvider } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -94,7 +96,9 @@ export function initializeEditor( id, settings ) {
 
 	root.render(
 		<StrictMode>
-			<App />
+			<DirectionProvider direction={ isRTL() ? 'rtl' : 'ltr' }>
+				<App />
+			</DirectionProvider>
 		</StrictMode>
 	);
 

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -20,6 +20,7 @@ ruleTester.run( 'use-recommended-components', rule, {
 
 		// Allowed @wordpress/ui components.
 		"import { Badge } from '@wordpress/ui';",
+		"import { DirectionProvider } from '@wordpress/ui';",
 		"import { Icon } from '@wordpress/ui';",
 		"import { Link } from '@wordpress/ui';",
 		"import { Stack } from '@wordpress/ui';",

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -20,6 +20,7 @@ const ALLOWLIST = {
 			'Card',
 			'Collapsible',
 			'CollapsibleCard',
+			'DirectionProvider',
 			'EmptyState',
 			'Icon',
 			'Link',

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `DirectionProvider` component. ([#80399](https://github.com/WordPress/gutenberg/pull/80399))
+
 ### Enhancements
 
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).

--- a/packages/ui/src/direction-provider/direction-provider.tsx
+++ b/packages/ui/src/direction-provider/direction-provider.tsx
@@ -1,0 +1,17 @@
+import { DirectionProvider as _DirectionProvider } from '@base-ui/react/direction-provider';
+import type { ComponentProps } from 'react';
+
+type DirectionProviderProps = ComponentProps< typeof _DirectionProvider >;
+
+/**
+ * Provides text direction context for `@wordpress/ui` components.
+ *
+ * Use `DirectionProvider` when rendering a subtree in a direction that differs
+ * from the document direction, such as previewing components in right-to-left
+ * mode inside Storybook.
+ */
+function DirectionProvider( props: DirectionProviderProps ) {
+	return <_DirectionProvider { ...props } />;
+}
+
+export { DirectionProvider };

--- a/packages/ui/src/direction-provider/index.ts
+++ b/packages/ui/src/direction-provider/index.ts
@@ -1,0 +1,1 @@
+export { DirectionProvider } from './direction-provider';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './button';
 export * as Card from './card';
 export * as Collapsible from './collapsible';
 export * as CollapsibleCard from './collapsible-card';
+export * from './direction-provider';
 export * as AlertDialog from './alert-dialog';
 export * as Dialog from './dialog';
 export * as Drawer from './drawer';

--- a/storybook/decorators/with-rtl.jsx
+++ b/storybook/decorators/with-rtl.jsx
@@ -1,12 +1,6 @@
-/**
- * WordPress dependencies
- */
+import { DirectionProvider } from '@wordpress/ui';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { useEffect, useRef, useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import CONFIG from '../package-styles/config';
 import { useSharedStyle } from './utils/use-shared-style';
 
@@ -49,7 +43,9 @@ export const WithRTL = ( Story, context ) => {
 
 	return (
 		<div ref={ ref } key={ rerenderKey }>
-			<Story { ...context } />
+			<DirectionProvider direction={ context.globals.direction }>
+				<Story { ...context } />
+			</DirectionProvider>
 		</div>
 	);
 };


### PR DESCRIPTION
Depends on #80399.

## What?

Provides the current WordPress text direction to `@wordpress/ui` across the boot, post editor, and site editor application roots.

## Why?

Base UI components default their React direction context to left-to-right. The document's `dir` attribute does not populate that context, so direction-aware positioning and keyboard behavior can remain left-to-right on RTL sites.

## How?

Wraps each application render root in `DirectionProvider`, deriving its value from `@wordpress/i18n`'s `isRTL()`. Both full and single-page boot modes are covered by the shared boot entrypoint.

## Testing Instructions

1. Run `npm run lint:js -- packages/boot/src/components/app/index.tsx packages/edit-post/src/index.js packages/edit-site/src/index.js`.
2. Run `npm run build`.
3. Configure WordPress to use an RTL locale.
4. Open the post editor, site editor, and a boot-powered admin page.
5. Confirm `@wordpress/ui` components follow RTL direction for directional positioning and keyboard navigation.

### Testing Instructions for Keyboard

In an RTL locale, use Tab to reach a direction-aware `@wordpress/ui` component and verify its arrow-key behavior follows RTL direction.

## Use of AI Tools

This PR was prepared with AI assistance in Codex and reviewed locally.
