### PR TITLE
IconButton: Improve keyboard shortcut accessibility

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `IconButton`: Require `shortcut.label` for a human-readable accessible shortcut description. Generate it with `shortcutAriaLabel` from `@wordpress/keycodes`. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
+
 ### Enhancements
 
--   `IconButton`: Add an accessible shortcut description with an optional human-readable label, falling back to the ARIA-compatible shortcut value. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
 -   Add `SearchableChipSelect` primitive ([#80779](https://github.com/WordPress/gutenberg/pull/80779)).
 -   Add `Combobox.InputGroup` primitive ([#80869](https://github.com/WordPress/gutenberg/pull/80869)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `IconButton`: Require shortcut metadata to include a human-readable description and render that description for assistive technologies. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
+
 ### Enhancements
 
 -   Add `SearchableChipSelect` primitive ([#80779](https://github.com/WordPress/gutenberg/pull/80779)).

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-### Breaking Changes
-
--   `IconButton`: Require shortcut metadata to include a human-readable label and render it as an accessible description. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
-
 ### Enhancements
 
+-   `IconButton`: Add an accessible shortcut description with an optional human-readable label, falling back to the ARIA-compatible shortcut value. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
 -   Add `SearchableChipSelect` primitive ([#80779](https://github.com/WordPress/gutenberg/pull/80779)).
 -   Add `Combobox.InputGroup` primitive ([#80869](https://github.com/WordPress/gutenberg/pull/80869)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   `IconButton`: Require shortcut metadata to include a human-readable description and render that description for assistive technologies. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
+-   `IconButton`: Require shortcut metadata to include a human-readable label and render it as an accessible description. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
 
 ### Enhancements
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-### Breaking Changes
-
--   `IconButton`: Require shortcut metadata to include a human-readable label and render it as an accessible description. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
-
 ### Enhancements
 
+-   `IconButton`: Add an accessible shortcut description with an optional human-readable label, falling back to the ARIA-compatible shortcut value. ([#80402](https://github.com/WordPress/gutenberg/pull/80402))
 -   Add `SearchableChipSelect` primitive ([#80779](https://github.com/WordPress/gutenberg/pull/80779)).
 -   Add `Combobox.InputGroup` primitive ([#80869](https://github.com/WordPress/gutenberg/pull/80869)).
 -   `Input`: Hide native browser spin controls for `type="number"` inputs by default ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -3,6 +3,10 @@ import { forwardRef } from '@wordpress/element';
 import { Button } from '../button';
 import { Icon } from '../icon';
 import * as Tooltip from '../tooltip';
+import {
+	KeyboardShortcutDescription,
+	useKeyboardShortcut,
+} from '../utils/keyboard-shortcut';
 import styles from './style.module.css';
 import { type IconButtonProps } from './types';
 
@@ -29,23 +33,30 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 			size,
 			shortcut,
 			positioner,
+			'aria-describedby': ariaDescribedBy,
+			'aria-keyshortcuts': ariaKeyShortcuts,
 			...restProps
 		}: IconButtonProps & { children?: unknown },
 		ref
 	) {
 		const classes = clsx( styles[ 'icon-button' ], className );
+		const { descriptionId, shortcutAriaProps } = useKeyboardShortcut( {
+			'aria-describedby': ariaDescribedBy,
+			'aria-keyshortcuts': ariaKeyShortcuts,
+			shortcut,
+		} );
 
 		return (
 			<Tooltip.Root>
 				<Tooltip.Trigger
 					ref={ ref }
+					{ ...shortcutAriaProps }
 					disabled={ disabled && ! focusableWhenDisabled }
 					render={
 						<Button
 							{ ...restProps }
 							size={ size }
 							aria-label={ label }
-							aria-keyshortcuts={ shortcut?.ariaKeyShortcut }
 							disabled={ disabled }
 							focusableWhenDisabled={ focusableWhenDisabled }
 						/>
@@ -53,13 +64,19 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 					className={ classes }
 				>
 					<Icon icon={ icon } size={ 24 } className={ styles.icon } />
+					{ shortcut && descriptionId && (
+						<KeyboardShortcutDescription
+							descriptionId={ descriptionId }
+							shortcut={ shortcut }
+						/>
+					) }
 				</Tooltip.Trigger>
 				<Tooltip.Popup positioner={ positioner }>
 					{ label }
 					{ shortcut && (
 						<>
 							{ ' ' }
-							<span aria-hidden="true">
+							<span aria-hidden="true" dir="ltr">
 								{ shortcut.displayShortcut }
 							</span>
 						</>

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -41,7 +41,7 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 		ref
 	) {
 		const classes = clsx( styles[ 'icon-button' ], className );
-		const { descriptionId, shortcutAriaProps } = useKeyboardShortcut( {
+		const { descriptionId, targetProps } = useKeyboardShortcut( {
 			'aria-describedby': ariaDescribedBy,
 			'aria-keyshortcuts': ariaKeyShortcuts,
 			shortcut,
@@ -51,7 +51,7 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 			<Tooltip.Root>
 				<Tooltip.Trigger
 					ref={ ref }
-					{ ...shortcutAriaProps }
+					{ ...targetProps }
 					disabled={ disabled && ! focusableWhenDisabled }
 					render={
 						<Button

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../icon';
 import * as Tooltip from '../tooltip';
 import {
 	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
 	useKeyboardShortcut,
 } from '../utils/keyboard-shortcut';
 import styles from './style.module.css';
@@ -76,9 +77,7 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 					{ shortcut && (
 						<>
 							{ ' ' }
-							<span aria-hidden="true" dir="ltr">
-								{ shortcut.displayShortcut }
-							</span>
+							<KeyboardShortcutDisplay shortcut={ shortcut } />
 						</>
 					) }
 				</Tooltip.Popup>

--- a/packages/ui/src/icon-button/icon-button.tsx
+++ b/packages/ui/src/icon-button/icon-button.tsx
@@ -6,7 +6,7 @@ import * as Tooltip from '../tooltip';
 import {
 	KeyboardShortcutDescription,
 	KeyboardShortcutDisplay,
-	useKeyboardShortcut,
+	useKeyboardShortcutProps,
 } from '../utils/keyboard-shortcut';
 import styles from './style.module.css';
 import { type IconButtonProps } from './types';
@@ -41,7 +41,7 @@ export const IconButton = forwardRef< HTMLButtonElement, IconButtonProps >(
 		ref
 	) {
 		const classes = clsx( styles[ 'icon-button' ], className );
-		const { descriptionId, targetProps } = useKeyboardShortcut( {
+		const { descriptionId, targetProps } = useKeyboardShortcutProps( {
 			'aria-describedby': ariaDescribedBy,
 			'aria-keyshortcuts': ariaKeyShortcuts,
 			shortcut,

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -133,8 +133,10 @@ const EXAMPLE_SHORTCUT_OBJECT = {
 };
 
 /**
- * Use the `displayShortcut`, `ariaKeyShortcut`, and `shortcutAriaLabel` helpers
- * from `@wordpress/keycodes` to create platform-appropriate shortcut metadata.
+ * Use the `displayShortcut` and `ariaKeyShortcut` helpers from
+ * `@wordpress/keycodes` to create shortcut metadata. Add `shortcutAriaLabel`
+ * for a platform-friendly accessible description. When omitted,
+ * `ariaKeyShortcut` is used instead.
  */
 export const WithShortcut: Story = {
 	...Default,

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -9,7 +9,11 @@ import {
 	upload,
 	wordpress,
 } from '@wordpress/icons';
-import { displayShortcut, ariaKeyShortcut } from '@wordpress/keycodes';
+import {
+	displayShortcut,
+	ariaKeyShortcut,
+	shortcutAriaLabel,
+} from '@wordpress/keycodes';
 import { IconButton } from '../index';
 import * as Tooltip from '../../tooltip';
 
@@ -125,6 +129,7 @@ export const Pressed: Story = {
 const EXAMPLE_SHORTCUT_OBJECT = {
 	displayShortcut: displayShortcut.primary( 'c' ),
 	ariaKeyShortcut: ariaKeyShortcut.primary( 'c' ),
+	description: shortcutAriaLabel.primary( 'c' ),
 };
 
 export const WithShortcut: Story = {

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -129,9 +129,13 @@ export const Pressed: Story = {
 const EXAMPLE_SHORTCUT_OBJECT = {
 	displayShortcut: displayShortcut.primary( 'c' ),
 	ariaKeyShortcut: ariaKeyShortcut.primary( 'c' ),
-	description: shortcutAriaLabel.primary( 'c' ),
+	label: shortcutAriaLabel.primary( 'c' ),
 };
 
+/**
+ * Use the `displayShortcut`, `ariaKeyShortcut`, and `shortcutAriaLabel` helpers
+ * from `@wordpress/keycodes` to create platform-appropriate shortcut metadata.
+ */
 export const WithShortcut: Story = {
 	...Default,
 	args: {

--- a/packages/ui/src/icon-button/stories/index.story.tsx
+++ b/packages/ui/src/icon-button/stories/index.story.tsx
@@ -133,10 +133,9 @@ const EXAMPLE_SHORTCUT_OBJECT = {
 };
 
 /**
- * Use the `displayShortcut` and `ariaKeyShortcut` helpers from
- * `@wordpress/keycodes` to create shortcut metadata. Add `shortcutAriaLabel`
- * for a platform-friendly accessible description. When omitted,
- * `ariaKeyShortcut` is used instead.
+ * Use the `displayShortcut`, `ariaKeyShortcut`, and `shortcutAriaLabel` helpers
+ * from `@wordpress/keycodes` to create the visual, ARIA-compatible, and
+ * human-readable representations of the shortcut.
  */
 export const WithShortcut: Story = {
 	...Default,

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef, useId } from '@wordpress/element';
+import { createRef } from '@wordpress/element';
 import { IconButton } from '../index';
 
 describe( 'IconButton', () => {
@@ -80,7 +80,7 @@ describe( 'IconButton', () => {
 						shortcut={ {
 							displayShortcut: '⌘S',
 							ariaKeyShortcut: 'Meta+S',
-							description: 'Command S',
+							label: 'Command S',
 						} }
 					/>
 				</>
@@ -91,20 +91,6 @@ describe( 'IconButton', () => {
 			expect( button ).toHaveAccessibleDescription(
 				'Available offline. Keyboard shortcut: Command S'
 			);
-
-			const shortcutDescription = screen.getByText(
-				'Keyboard shortcut: Command S'
-			);
-			expect( button ).toHaveAttribute(
-				'aria-describedby',
-				`${ externalDescriptionId } ${ shortcutDescription.id }`
-			);
-			expect( shortcutDescription ).toHaveAttribute(
-				'aria-hidden',
-				'true'
-			);
-			expect( shortcutDescription.tagName ).toBe( 'SPAN' );
-			expect( button ).toContainElement( shortcutDescription );
 
 			// The aria-keyshortcuts attribute is removed when there is no
 			// `shortcut` prop.
@@ -124,7 +110,7 @@ describe( 'IconButton', () => {
 					shortcut={ {
 						displayShortcut: '⌘S',
 						ariaKeyShortcut: 'Meta+S',
-						description: 'Command S',
+						label: 'Command S',
 					} }
 				/>
 			);
@@ -145,37 +131,25 @@ describe( 'IconButton', () => {
 		} );
 
 		it( 'preserves direct ARIA props when shortcut metadata is omitted', () => {
-			function IconButtonWithDirectAriaProps() {
-				const externalDescriptionId = useId();
+			const externalDescriptionId = 'external-description';
 
-				return (
-					<>
-						<span id={ externalDescriptionId }>
-							Available offline.
-						</span>
-						<IconButton
-							label="Save"
-							icon={ <svg /> }
-							aria-describedby={ externalDescriptionId }
-							aria-keyshortcuts="Meta+S"
-						/>
-					</>
-				);
-			}
-
-			render( <IconButtonWithDirectAriaProps /> );
-			const externalDescription =
-				screen.getByText( 'Available offline.' );
+			render(
+				<>
+					<span id={ externalDescriptionId }>Available offline.</span>
+					<IconButton
+						label="Save"
+						icon={ <svg /> }
+						aria-describedby={ externalDescriptionId }
+						aria-keyshortcuts="Meta+S"
+					/>
+				</>
+			);
 
 			const button = screen.getByRole( 'button', {
 				name: 'Save',
 				description: 'Available offline.',
 			} );
 			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
-			expect( button ).toHaveAttribute(
-				'aria-describedby',
-				externalDescription.id
-			);
 		} );
 
 		it( 'keeps shortcut metadata available when focusable while disabled', () => {
@@ -187,7 +161,7 @@ describe( 'IconButton', () => {
 					shortcut={ {
 						displayShortcut: '⌘S',
 						ariaKeyShortcut: 'Meta+S',
-						description: 'Command S',
+						label: 'Command S',
 					} }
 				/>
 			);

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createRef } from '@wordpress/element';
+import { createRef, useId } from '@wordpress/element';
 import { IconButton } from '../index';
 
 describe( 'IconButton', () => {
@@ -67,25 +67,51 @@ describe( 'IconButton', () => {
 	} );
 
 	describe( 'shortcut', () => {
-		it( 'sets aria-keyshortcuts attribute on the button', () => {
+		it( 'uses shortcut metadata for the button and its accessible description', () => {
+			const externalDescriptionId = 'external-description';
+
 			const { rerender } = render(
-				<IconButton
-					label="Save"
-					icon={ <svg /> }
-					shortcut={ {
-						displayShortcut: '⌘S',
-						ariaKeyShortcut: 'Meta+S',
-					} }
-				/>
+				<>
+					<span id={ externalDescriptionId }>Available offline.</span>
+					<IconButton
+						label="Save"
+						icon={ <svg /> }
+						aria-describedby={ externalDescriptionId }
+						shortcut={ {
+							displayShortcut: '⌘S',
+							ariaKeyShortcut: 'Meta+S',
+							description: 'Command S',
+						} }
+					/>
+				</>
 			);
 
 			const button = screen.getByRole( 'button', { name: 'Save' } );
 			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
+			expect( button ).toHaveAccessibleDescription(
+				'Available offline. Keyboard shortcut: Command S'
+			);
+
+			const shortcutDescription = screen.getByText(
+				'Keyboard shortcut: Command S'
+			);
+			expect( button ).toHaveAttribute(
+				'aria-describedby',
+				`${ externalDescriptionId } ${ shortcutDescription.id }`
+			);
+			expect( shortcutDescription ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			);
+			expect( shortcutDescription.tagName ).toBe( 'SPAN' );
+			expect( button ).toContainElement( shortcutDescription );
 
 			// The aria-keyshortcuts attribute is removed when there is no
 			// `shortcut` prop.
 			rerender( <IconButton label="Save" icon={ <svg /> } /> );
-			expect( button ).not.toHaveAttribute( 'aria-keyshortcuts' );
+			expect(
+				screen.getByRole( 'button', { name: 'Save' } )
+			).not.toHaveAttribute( 'aria-keyshortcuts' );
 		} );
 
 		it( 'displays the shortcut in the tooltip but hides it from assistive technology', async () => {
@@ -98,6 +124,7 @@ describe( 'IconButton', () => {
 					shortcut={ {
 						displayShortcut: '⌘S',
 						ariaKeyShortcut: 'Meta+S',
+						description: 'Command S',
 					} }
 				/>
 			);
@@ -114,6 +141,63 @@ describe( 'IconButton', () => {
 				'aria-hidden',
 				'true'
 			);
+			expect( screen.getByText( '⌘S' ) ).toHaveAttribute( 'dir', 'ltr' );
+		} );
+
+		it( 'preserves direct ARIA props when shortcut metadata is omitted', () => {
+			function IconButtonWithDirectAriaProps() {
+				const externalDescriptionId = useId();
+
+				return (
+					<>
+						<span id={ externalDescriptionId }>
+							Available offline.
+						</span>
+						<IconButton
+							label="Save"
+							icon={ <svg /> }
+							aria-describedby={ externalDescriptionId }
+							aria-keyshortcuts="Meta+S"
+						/>
+					</>
+				);
+			}
+
+			render( <IconButtonWithDirectAriaProps /> );
+			const externalDescription =
+				screen.getByText( 'Available offline.' );
+
+			const button = screen.getByRole( 'button', {
+				name: 'Save',
+				description: 'Available offline.',
+			} );
+			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
+			expect( button ).toHaveAttribute(
+				'aria-describedby',
+				externalDescription.id
+			);
+		} );
+
+		it( 'keeps shortcut metadata available when focusable while disabled', () => {
+			render(
+				<IconButton
+					label="Save"
+					icon={ <svg /> }
+					disabled
+					shortcut={ {
+						displayShortcut: '⌘S',
+						ariaKeyShortcut: 'Meta+S',
+						description: 'Command S',
+					} }
+				/>
+			);
+
+			const button = screen.getByRole( 'button', {
+				name: 'Save',
+				description: 'Keyboard shortcut: Command S',
+			} );
+			expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
 		} );
 	} );
 } );

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -67,10 +67,10 @@ describe( 'IconButton', () => {
 	} );
 
 	describe( 'shortcut', () => {
-		it( 'uses ariaKeyShortcut as the accessible-description fallback when label is omitted', () => {
+		it( 'uses the human-readable label in the accessible description', () => {
 			const externalDescriptionId = 'external-description';
 
-			const { rerender } = render(
+			render(
 				<>
 					<span id={ externalDescriptionId }>Available offline.</span>
 					<IconButton
@@ -80,6 +80,7 @@ describe( 'IconButton', () => {
 						shortcut={ {
 							displayShortcut: '⌘S',
 							ariaKeyShortcut: 'Meta+S',
+							label: 'Command S',
 						} }
 					/>
 				</>
@@ -88,35 +89,8 @@ describe( 'IconButton', () => {
 			const button = screen.getByRole( 'button', { name: 'Save' } );
 			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
 			expect( button ).toHaveAccessibleDescription(
-				'Available offline. Keyboard shortcut: Meta+S'
+				'Available offline. Keyboard shortcut: Command S'
 			);
-
-			// The aria-keyshortcuts attribute is removed when there is no
-			// `shortcut` prop.
-			rerender( <IconButton label="Save" icon={ <svg /> } /> );
-			expect(
-				screen.getByRole( 'button', { name: 'Save' } )
-			).not.toHaveAttribute( 'aria-keyshortcuts' );
-		} );
-
-		it( 'uses the explicit human-readable label when provided', () => {
-			render(
-				<IconButton
-					label="Save"
-					icon={ <svg /> }
-					shortcut={ {
-						displayShortcut: '⌘S',
-						ariaKeyShortcut: 'Meta+S',
-						label: 'Command S',
-					} }
-				/>
-			);
-
-			expect(
-				screen.getByRole( 'button', {
-					name: 'Save',
-				} )
-			).toHaveAccessibleDescription( 'Keyboard shortcut: Command S' );
 		} );
 
 		it( 'displays the shortcut in the tooltip but hides it from assistive technology', async () => {

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -67,7 +67,7 @@ describe( 'IconButton', () => {
 	} );
 
 	describe( 'shortcut', () => {
-		it( 'uses shortcut metadata for the button and its accessible description', () => {
+		it( 'uses ariaKeyShortcut as the accessible-description fallback when label is omitted', () => {
 			const externalDescriptionId = 'external-description';
 
 			const { rerender } = render(
@@ -80,7 +80,6 @@ describe( 'IconButton', () => {
 						shortcut={ {
 							displayShortcut: '⌘S',
 							ariaKeyShortcut: 'Meta+S',
-							label: 'Command S',
 						} }
 					/>
 				</>
@@ -89,7 +88,7 @@ describe( 'IconButton', () => {
 			const button = screen.getByRole( 'button', { name: 'Save' } );
 			expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
 			expect( button ).toHaveAccessibleDescription(
-				'Available offline. Keyboard shortcut: Command S'
+				'Available offline. Keyboard shortcut: Meta+S'
 			);
 
 			// The aria-keyshortcuts attribute is removed when there is no
@@ -98,6 +97,26 @@ describe( 'IconButton', () => {
 			expect(
 				screen.getByRole( 'button', { name: 'Save' } )
 			).not.toHaveAttribute( 'aria-keyshortcuts' );
+		} );
+
+		it( 'uses the explicit human-readable label when provided', () => {
+			render(
+				<IconButton
+					label="Save"
+					icon={ <svg /> }
+					shortcut={ {
+						displayShortcut: '⌘S',
+						ariaKeyShortcut: 'Meta+S',
+						label: 'Command S',
+					} }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Save',
+				} )
+			).toHaveAccessibleDescription( 'Keyboard shortcut: Command S' );
 		} );
 
 		it( 'displays the shortcut in the tooltip but hides it from assistive technology', async () => {

--- a/packages/ui/src/icon-button/types.ts
+++ b/packages/ui/src/icon-button/types.ts
@@ -1,6 +1,7 @@
 import { type ButtonProps } from '../button/types';
 import { type IconProps } from '../icon/types';
 import { type PopupProps as TooltipPopupProps } from '../tooltip/types';
+import type { KeyboardShortcut } from '../utils/keyboard-shortcut';
 
 export type IconButtonProps = Omit< ButtonProps, 'children' > & {
 	/**
@@ -19,23 +20,10 @@ export type IconButtonProps = Omit< ButtonProps, 'children' > & {
 	 * shortcut is displayed in the tooltip and announced to assistive technology.
 	 *
 	 * **Note**: This prop is for display and accessibility purposes only — the
-	 * consumer is responsible for implementing the actual keyboard event handler.
+	 * consumer is responsible for registering the keyboard shortcut and keeping
+	 * its handler synchronized with the button's disabled state.
 	 */
-	shortcut?: {
-		/**
-		 * The human-readable representation of the shortcut, displayed in the
-		 * tooltip. Use platform-appropriate symbols (e.g., "⌘S" on macOS,
-		 * "Ctrl+S" on Windows).
-		 */
-		displayShortcut: string;
-		/**
-		 * The shortcut in a format compatible with the
-		 * [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts)
-		 * attribute. Use "+" to separate keys and standard key names
-		 * (e.g., "Meta+S", "Control+Shift+P").
-		 */
-		ariaKeyShortcut: string;
-	};
+	shortcut?: KeyboardShortcut;
 
 	/**
 	 * Customize how the tooltip is positioned relative to the button. Accepts

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -3,11 +3,10 @@ import { useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { VisuallyHidden } from '../visually-hidden';
 
-export interface KeyboardShortcut {
+export type KeyboardShortcut = {
 	/**
-	 * The human-readable representation of the shortcut, displayed visually.
-	 * Use platform-appropriate symbols (e.g., "⌘S" on macOS, "Ctrl+S" on
-	 * Windows).
+	 * The visual representation of the shortcut (e.g., "⌘S" on macOS or
+	 * "Ctrl+S" on Windows).
 	 */
 	displayShortcut: string;
 
@@ -20,10 +19,11 @@ export interface KeyboardShortcut {
 	ariaKeyShortcut: string;
 
 	/**
-	 * A human-readable description of the shortcut for assistive technology.
+	 * The plain-text label for the shortcut, used in its accessible description
+	 * (e.g., "Command Shift S").
 	 */
-	description: string;
-}
+	label: string;
+};
 
 type ShortcutAriaProps = Pick<
 	AriaAttributes,
@@ -43,7 +43,7 @@ function useKeyboardShortcut( {
 
 	return {
 		descriptionId,
-		shortcutAriaProps: {
+		targetProps: {
 			'aria-describedby': describedBy || undefined,
 			'aria-keyshortcuts': shortcut?.ariaKeyShortcut ?? ariaKeyShortcuts,
 		},
@@ -66,7 +66,7 @@ function KeyboardShortcutDescription( {
 			{ sprintf(
 				/* translators: %s: human-readable keyboard shortcut. */
 				__( 'Keyboard shortcut: %s' ),
-				shortcut.description
+				shortcut.label
 			) }
 		</VisuallyHidden>
 	);

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -72,4 +72,22 @@ function KeyboardShortcutDescription( {
 	);
 }
 
-export { KeyboardShortcutDescription, useKeyboardShortcut };
+function KeyboardShortcutDisplay( {
+	className,
+	shortcut,
+}: {
+	className?: string;
+	shortcut: KeyboardShortcut;
+} ) {
+	return (
+		<span aria-hidden="true" className={ className } dir="ltr">
+			{ shortcut.displayShortcut }
+		</span>
+	);
+}
+
+export {
+	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
+	useKeyboardShortcut,
+};

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -1,0 +1,75 @@
+import type { AriaAttributes } from 'react';
+import { useId } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '../visually-hidden';
+
+export interface KeyboardShortcut {
+	/**
+	 * The human-readable representation of the shortcut, displayed visually.
+	 * Use platform-appropriate symbols (e.g., "⌘S" on macOS, "Ctrl+S" on
+	 * Windows).
+	 */
+	displayShortcut: string;
+
+	/**
+	 * The shortcut in a format compatible with the
+	 * [aria-keyshortcuts](https://www.w3.org/TR/wai-aria-1.3/#aria-keyshortcuts)
+	 * attribute. Use "+" to separate keys and standard key names
+	 * (e.g., "Meta+S", "Control+Shift+P").
+	 */
+	ariaKeyShortcut: string;
+
+	/**
+	 * A human-readable description of the shortcut for assistive technology.
+	 */
+	description: string;
+}
+
+type ShortcutAriaProps = Pick<
+	AriaAttributes,
+	'aria-describedby' | 'aria-keyshortcuts'
+>;
+
+function useKeyboardShortcut( {
+	'aria-describedby': ariaDescribedBy,
+	'aria-keyshortcuts': ariaKeyShortcuts,
+	shortcut,
+}: ShortcutAriaProps & { shortcut?: KeyboardShortcut } ) {
+	const generatedDescriptionId = useId();
+	const descriptionId = shortcut ? generatedDescriptionId : undefined;
+	const describedBy = [ ariaDescribedBy, descriptionId ]
+		.filter( Boolean )
+		.join( ' ' );
+
+	return {
+		descriptionId,
+		shortcutAriaProps: {
+			'aria-describedby': describedBy || undefined,
+			'aria-keyshortcuts': shortcut?.ariaKeyShortcut ?? ariaKeyShortcuts,
+		},
+	};
+}
+
+function KeyboardShortcutDescription( {
+	descriptionId,
+	shortcut,
+}: {
+	descriptionId: string;
+	shortcut: KeyboardShortcut;
+} ) {
+	return (
+		<VisuallyHidden
+			id={ descriptionId }
+			aria-hidden="true"
+			render={ <span /> }
+		>
+			{ sprintf(
+				/* translators: %s: human-readable keyboard shortcut. */
+				__( 'Keyboard shortcut: %s' ),
+				shortcut.description
+			) }
+		</VisuallyHidden>
+	);
+}
+
+export { KeyboardShortcutDescription, useKeyboardShortcut };

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -19,10 +19,11 @@ export type KeyboardShortcut = {
 	ariaKeyShortcut: string;
 
 	/**
-	 * The plain-text label for the shortcut, used in its accessible description
-	 * (e.g., "Command Shift S").
+	 * An optional plain-text label for the shortcut, used in its accessible
+	 * description (e.g., "Command Shift S"). When omitted, `ariaKeyShortcut`
+	 * is used instead.
 	 */
-	label: string;
+	label?: string;
 };
 
 type ShortcutAriaProps = Pick<
@@ -64,9 +65,9 @@ function KeyboardShortcutDescription( {
 			render={ <span /> }
 		>
 			{ sprintf(
-				/* translators: %s: human-readable keyboard shortcut. */
+				/* translators: %s: keyboard shortcut. */
 				__( 'Keyboard shortcut: %s' ),
-				shortcut.label
+				shortcut.label ?? shortcut.ariaKeyShortcut
 			) }
 		</VisuallyHidden>
 	);

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -19,11 +19,11 @@ export type KeyboardShortcut = {
 	ariaKeyShortcut: string;
 
 	/**
-	 * An optional plain-text label for the shortcut, used in its accessible
-	 * description (e.g., "Command Shift S"). When omitted, `ariaKeyShortcut`
-	 * is used instead.
+	 * A plain-text label for the shortcut, used in its accessible description
+	 * (e.g., "Command Shift S"). Generate this value with
+	 * `shortcutAriaLabel` from `@wordpress/keycodes`.
 	 */
-	label?: string;
+	label: string;
 };
 
 type ShortcutAriaProps = Pick<

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -31,7 +31,7 @@ type ShortcutAriaProps = Pick<
 	'aria-describedby' | 'aria-keyshortcuts'
 >;
 
-function useKeyboardShortcut( {
+function useKeyboardShortcutProps( {
 	'aria-describedby': ariaDescribedBy,
 	'aria-keyshortcuts': ariaKeyShortcuts,
 	shortcut,
@@ -90,5 +90,5 @@ function KeyboardShortcutDisplay( {
 export {
 	KeyboardShortcutDescription,
 	KeyboardShortcutDisplay,
-	useKeyboardShortcut,
+	useKeyboardShortcutProps,
 };


### PR DESCRIPTION
Follow-up to #80321.
See #80353.
Related: #79560.

## What?

Improves `IconButton` keyboard shortcut accessibility and extracts reusable internal shortcut helpers.

## Why?

`IconButton` displayed shortcuts and set `aria-keyshortcuts`, but did not provide an explicit accessible description.

## How?

- Requires a human-readable `shortcut.label` for the accessible description.
- Merges the description with existing `aria-describedby` and preserves direct ARIA props.
- Keeps the visual shortcut LTR and hidden from assistive technology.

Shortcut registration remains the consumer's responsibility.

## Testing Instructions

1. Open **Design System / Components / IconButton / With Shortcut** in Storybook.
2. Confirm the tooltip displays the platform shortcut.
3. Inspect the button and confirm it has `aria-keyshortcuts` and an accessible shortcut description.

### Testing Instructions for Keyboard

1. Press Tab until the icon button receives focus.
2. Confirm the tooltip opens and Enter and Space still activate the button.

## Use of AI Tools

This PR was implemented with AI assistance in Codex and reviewed locally.
