### PR TITLE
SearchControl: Remove redundant conditional and prop.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356)).
+-   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
 
 ### TypeScript
 

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -23,16 +23,7 @@ import type { WordPressComponentProps } from '../context/wordpress-component';
 import type { SearchControlProps, SuffixItemProps } from './types';
 import { StyledInputControl, StyledIcon } from './styles';
 
-function SuffixItem( {
-	searchRef,
-	value,
-	onChange,
-	onClose,
-}: SuffixItemProps ) {
-	if ( ! onClose && ! value ) {
-		return null;
-	}
-
+function SuffixItem( { searchRef, onChange, onClose }: SuffixItemProps ) {
 	if ( onClose ) {
 		deprecated( '`onClose` prop in wp.components.SearchControl', {
 			since: '6.8',
@@ -110,7 +101,6 @@ function UnforwardedSearchControl(
 				hasSuffix && (
 					<SuffixItem
 						searchRef={ searchRef }
-						value={ value }
 						onChange={ onChange }
 						onClose={ onClose }
 					/>

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -70,7 +70,7 @@ export type SearchControlProps = Pick< InputControlProps, 'help' | 'value' > & {
 
 export type SuffixItemProps = Pick<
 	SearchControlProps,
-	'value' | 'onChange' | 'onClose'
+	'onChange' | 'onClose'
 > & {
 	searchRef: React.RefObject< HTMLInputElement | null >;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/80356

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After https://github.com/WordPress/gutenberg/pull/80356, `SearchControl` only renders `<SuffixItem />` when there's actually a suffix to show. Which made the early bail inside SuffixItem unreachable. Removing that check also left `value` unused.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed early bail on `<SuffixItem />`, then the prop itself and the definition in the type.

## Testing Instructions

No behavior change, pure code removal. Confirm it builds and type checks cleanly, and that the existing `SearchControl` unit tests still pass.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
