### PR TITLE
Dashboard Widgets: Sanitize help link hrefs

### DIFF
--- a/lib/experimental/dashboard-widgets/widget-types.php
+++ b/lib/experimental/dashboard-widgets/widget-types.php
@@ -66,8 +66,8 @@ function gutenberg_translate_widget_metadata( $widget ) {
 
 /**
  * Constrains a widget help note to its allowed shape: `content` keeps
- * only `em`/`strong` markup, and links missing a `label` or `href` are
- * dropped.
+ * only `em`/`strong` markup, and links are dropped unless they carry a
+ * `label` and an `href` that survives `esc_url_raw()`.
  *
  * @param array|null $help Help note from the build manifest.
  * @return array|null Sanitized help note, or null when there is no content.
@@ -91,10 +91,14 @@ function gutenberg_sanitize_widget_help( $help ) {
 		$links = array();
 		foreach ( $help['links'] as $link ) {
 			if ( is_array( $link ) && ! empty( $link['label'] ) && ! empty( $link['href'] ) ) {
-				$links[] = array(
-					'label' => $link['label'],
-					'href'  => $link['href'],
-				);
+				$href = esc_url_raw( $link['href'] );
+
+				if ( $href ) {
+					$links[] = array(
+						'label' => $link['label'],
+						'href'  => $href,
+					);
+				}
 			}
 		}
 

--- a/phpunit/experimental/widget-types-test.php
+++ b/phpunit/experimental/widget-types-test.php
@@ -69,7 +69,8 @@ class Gutenberg_Widget_Types_Test extends WP_UnitTestCase {
 
 	/**
 	 * The help content keeps minimal emphasis, everything else is stripped,
-	 * and malformed links are dropped.
+	 * and links are dropped when malformed or when their href does not
+	 * survive esc_url_raw().
 	 */
 	public function test_sanitize_widget_help_constrains_markup_and_links() {
 		$help = gutenberg_sanitize_widget_help(
@@ -81,6 +82,10 @@ class Gutenberg_Widget_Types_Test extends WP_UnitTestCase {
 						'href'  => 'site-health.php',
 					),
 					array( 'label' => 'Missing href' ),
+					array(
+						'label' => 'Unsafe protocol',
+						'href'  => 'javascript:alert(1)',
+					),
 				),
 			)
 		);


### PR DESCRIPTION
## What?

Hardens `gutenberg_sanitize_widget_help()` so each help link `href` is run through `esc_url_raw()`, and links whose href does not survive sanitization are dropped along with the malformed ones.

## Why?

Widget help notes carry optional links rendered as anchors on the dashboard.

The previous sanitizer only checked that `label` and `href` were non-empty, so an `href` with an unsafe scheme such as `javascript: alert(1)` passed through untouched and reached the rendered markup.

Passing the href through `esc_url_raw()` rejects unsafe protocols and normalizes the value before it is stored and rendered.

## How?

In `lib/experimental/dashboard-widgets/widget-types.php`, each link `href` is now filtered with `esc_url_raw()`.

The link is kept only when the filtered href is non-empty, so unsafe or unparseable URLs are dropped instead of forwarded.

## Testing

Automated coverage in `phpunit/experimental/widget-types-test.php` adds an `Unsafe protocol` link (`javascript:alert(1)`) to the sanitizer input and asserts that only the valid link survives.
