### PR TITLE
DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
--   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#](https://github.com/WordPress/gutenberg/pull/)
+-   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 
 ### Bug Fix
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
+-   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#](https://github.com/WordPress/gutenberg/pull/)
 
 ### Bug Fix
 

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -19,13 +19,14 @@ import { Stack, VisuallyHidden } from '@wordpress/ui';
 import DataViewsContext from '../../dataviews-context';
 import { useIsMultiselectPicker } from '../../dataviews-picker-footer';
 import getDataByGroup from '../utils/get-data-by-group';
+import useSelectionProps from '../utils/use-selection-props';
+import type { SelectionProps } from '../utils/use-selection-props';
 import { useIntersectionObserver } from '../utils/use-infinite-scroll';
 import type {
 	NormalizedField,
 	ViewPickerActivity as ViewPickerActivityType,
 	ViewPickerActivityProps,
 } from '../../../types';
-import type { SetSelection } from '../../../types/private';
 
 function isDefined< T >( item: T | undefined ): item is T {
 	return !! item;
@@ -33,9 +34,8 @@ function isDefined< T >( item: T | undefined ): item is T {
 
 interface PickerActivityItemProps< Item > {
 	view: ViewPickerActivityType;
-	multiselect?: boolean;
 	selection: string[];
-	onChangeSelection: SetSelection;
+	selectionProps: SelectionProps;
 	getItemId: ( item: Item ) => string;
 	item: Item;
 	titleField?: NormalizedField< Item >;
@@ -48,9 +48,8 @@ interface PickerActivityItemProps< Item > {
 
 function PickerActivityItem< Item >( {
 	view,
-	multiselect,
 	selection,
-	onChangeSelection,
+	selectionProps,
 	getItemId,
 	item,
 	titleField,
@@ -127,18 +126,7 @@ function PickerActivityItem< Item >( {
 				density === 'comfortable' && 'is-comfortable',
 				isSelected && 'is-selected'
 			) }
-			onClick={ () => {
-				if ( isSelected ) {
-					onChangeSelection(
-						selection.filter( ( itemId ) => id !== itemId )
-					);
-				} else {
-					const newSelection = multiselect
-						? [ ...selection, id ]
-						: [ id ];
-					onChangeSelection( newSelection );
-				}
-			} }
+			{ ...selectionProps }
 			render={ <div /> }
 		>
 			<Stack direction="row" gap="lg" justify="start" align="flex-start">
@@ -273,13 +261,24 @@ export default function ViewPickerActivity< Item >( {
 	const hasData = !! data?.length;
 	const isGrouped = !! ( groupField && dataByGroup );
 
+	const orderedData = dataByGroup
+		? Array.from( dataByGroup.values() ).flat()
+		: data;
+	const { getSelectionProps } = useSelectionProps( {
+		data: orderedData,
+		actions,
+		getItemId,
+		selection,
+		onChangeSelection,
+		pickerMultiselect: isMultiselect,
+	} );
+
 	const renderItem = ( item: Item ) => (
 		<PickerActivityItem
 			key={ getItemId( item ) }
 			view={ view }
-			multiselect={ isMultiselect }
 			selection={ selection }
-			onChangeSelection={ onChangeSelection }
+			selectionProps={ getSelectionProps( getItemId( item ) ) }
 			getItemId={ getItemId }
 			item={ item }
 			titleField={ titleField }

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -35,6 +35,8 @@ import type { SetSelection } from '../../../types/private';
 import { GridItems } from '../utils/grid-items';
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 import getDataByGroup from '../utils/get-data-by-group';
+import useSelectionProps from '../utils/use-selection-props';
+import type { SelectionProps } from '../utils/use-selection-props';
 import { useGridColumns } from '../grid/preview-size-picker';
 import {
 	useIntersectionObserver,
@@ -43,9 +45,9 @@ import {
 
 interface GridItemProps< Item > {
 	view: ViewPickerGridType;
-	multiselect?: boolean;
 	selection: string[];
 	onChangeSelection: SetSelection;
+	selectionProps: SelectionProps;
 	getItemId: ( item: Item ) => string;
 	item: Item;
 	titleField?: NormalizedField< Item >;
@@ -62,9 +64,9 @@ interface GridItemProps< Item > {
 
 function GridItem< Item >( {
 	view,
-	multiselect,
 	selection,
 	onChangeSelection,
+	selectionProps,
 	getItemId,
 	item,
 	mediaField,
@@ -115,19 +117,7 @@ function GridItem< Item >( {
 				'is-selected': isSelected,
 			} ) }
 			aria-selected={ isSelected }
-			onClick={ () => {
-				// Toggle in/out of selection array
-				if ( isSelected ) {
-					onChangeSelection(
-						selection.filter( ( itemId ) => id !== itemId )
-					);
-				} else {
-					const newSelection = multiselect
-						? [ ...selection, id ]
-						: [ id ];
-					onChangeSelection( newSelection );
-				}
-			} }
+			{ ...selectionProps }
 		>
 			{ showMedia && renderedMediaField && (
 				<div className="dataviews-view-picker-grid__media">
@@ -333,6 +323,18 @@ function ViewPickerGrid< Item >( {
 	const isInfiniteScroll =
 		( view.infiniteScrollEnabled && ! dataByGroup ) ?? false;
 
+	const orderedData = dataByGroup
+		? Array.from( dataByGroup.values() ).flat()
+		: data;
+	const { getSelectionProps } = useSelectionProps( {
+		data: orderedData,
+		actions,
+		getItemId,
+		selection,
+		onChangeSelection,
+		pickerMultiselect: isMultiselect,
+	} );
+
 	const currentPage = view?.page ?? 1;
 	const perPage = view?.perPage ?? 0;
 	const setSize = isInfiniteScroll ? paginationInfo?.totalItems : undefined;
@@ -409,13 +411,13 @@ function ViewPickerGrid< Item >( {
 												<GridItem
 													key={ getItemId( item ) }
 													view={ view }
-													multiselect={
-														isMultiselect
-													}
 													selection={ selection }
 													onChangeSelection={
 														onChangeSelection
 													}
+													selectionProps={ getSelectionProps(
+														getItemId( item )
+													) }
 													getItemId={ getItemId }
 													item={ item }
 													mediaField={ mediaField }
@@ -501,9 +503,11 @@ function ViewPickerGrid< Item >( {
 								<GridItem
 									key={ getItemId( item ) }
 									view={ view }
-									multiselect={ isMultiselect }
 									selection={ selection }
 									onChangeSelection={ onChangeSelection }
+									selectionProps={ getSelectionProps(
+										getItemId( item )
+									) }
 									getItemId={ getItemId }
 									item={ item }
 									mediaField={ mediaField }

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -33,6 +33,8 @@ import type { SetSelection } from '../../../types/private';
 import ColumnHeaderMenu from '../table/column-header-menu';
 import ColumnPrimary from '../table/column-primary';
 import getDataByGroup from '../utils/get-data-by-group';
+import useSelectionProps from '../utils/use-selection-props';
+import type { SelectionProps } from '../utils/use-selection-props';
 import { useIntersectionObserver } from '../utils/use-infinite-scroll';
 
 interface TableColumnFieldProps< Item > {
@@ -53,7 +55,7 @@ interface TableRowProps< Item > {
 	selection: string[];
 	getItemId: ( item: Item ) => string;
 	onChangeSelection: SetSelection;
-	multiselect: boolean;
+	selectionProps: SelectionProps;
 	posinset?: number;
 }
 
@@ -92,7 +94,7 @@ function TableRow< Item >( {
 	selection,
 	getItemId,
 	onChangeSelection,
-	multiselect,
+	selectionProps,
 	posinset,
 }: TableRowProps< Item > ) {
 	const { paginationInfo } = useContext( DataViewsContext );
@@ -142,6 +144,8 @@ function TableRow< Item >( {
 			aria-setsize={ paginationInfo.totalItems || undefined }
 			aria-posinset={ posinset }
 			role={ infiniteScrollEnabled ? 'article' : 'option' }
+			onClickCapture={ selectionProps.onClickCapture }
+			onClick={ selectionProps.onClick }
 			onMouseDown={ ( event ) => {
 				if ( event.button !== 0 ) {
 					return;
@@ -156,19 +160,7 @@ function TableRow< Item >( {
 				event.currentTarget.parentElement?.focus( {
 					preventScroll: true,
 				} );
-			} }
-			onClick={ () => {
-				// Toggle in/out of selection array
-				if ( isSelected ) {
-					onChangeSelection(
-						selection.filter( ( itemId ) => id !== itemId )
-					);
-				} else {
-					const newSelection = multiselect
-						? [ ...selection, id ]
-						: [ id ];
-					onChangeSelection( newSelection );
-				}
+				selectionProps.onMouseDown( event );
 			} }
 		>
 			<td
@@ -269,6 +261,18 @@ function ViewPickerTable< Item >( {
 		: null;
 	const dataByGroup = groupField ? getDataByGroup( data, groupField ) : null;
 	const isInfiniteScroll = view.infiniteScrollEnabled && ! dataByGroup;
+
+	const orderedData = dataByGroup
+		? Array.from( dataByGroup.values() ).flat()
+		: data;
+	const { getSelectionProps } = useSelectionProps( {
+		data: orderedData,
+		actions,
+		getItemId,
+		selection,
+		onChangeSelection,
+		pickerMultiselect: isMultiselect,
+	} );
 
 	const tableNoticeId = useId();
 
@@ -443,25 +447,32 @@ function ViewPickerTable< Item >( {
 											  ) }
 									</td>
 								</tr>
-								{ groupItems.map( ( item, index ) => (
-									<TableRow
-										key={ getItemId( item ) }
-										item={ item }
-										fields={ fields }
-										id={
-											getItemId( item ) ||
-											index.toString()
-										}
-										view={ view }
-										titleField={ titleField }
-										mediaField={ mediaField }
-										descriptionField={ descriptionField }
-										selection={ selection }
-										getItemId={ getItemId }
-										onChangeSelection={ onChangeSelection }
-										multiselect={ isMultiselect }
-									/>
-								) ) }
+								{ groupItems.map( ( item, index ) => {
+									const id =
+										getItemId( item ) || index.toString();
+									return (
+										<TableRow
+											key={ getItemId( item ) }
+											item={ item }
+											fields={ fields }
+											id={ id }
+											view={ view }
+											titleField={ titleField }
+											mediaField={ mediaField }
+											descriptionField={
+												descriptionField
+											}
+											selection={ selection }
+											getItemId={ getItemId }
+											onChangeSelection={
+												onChangeSelection
+											}
+											selectionProps={ getSelectionProps(
+												id
+											) }
+										/>
+									);
+								} ) }
 							</Composite>
 						)
 					)
@@ -474,6 +485,7 @@ function ViewPickerTable< Item >( {
 						{ hasData &&
 							data.map( ( item, index ) => {
 								const itemId = getItemId( item );
+								const id = itemId || index.toString();
 								// Use position from item for accessibility in infinite scroll mode.
 								const posinset = ( item as any ).position;
 
@@ -482,7 +494,7 @@ function ViewPickerTable< Item >( {
 										key={ itemId }
 										item={ item }
 										fields={ fields }
-										id={ itemId || index.toString() }
+										id={ id }
 										view={ view }
 										titleField={ titleField }
 										mediaField={ mediaField }
@@ -490,7 +502,9 @@ function ViewPickerTable< Item >( {
 										selection={ selection }
 										getItemId={ getItemId }
 										onChangeSelection={ onChangeSelection }
-										multiselect={ isMultiselect }
+										selectionProps={ getSelectionProps(
+											id
+										) }
 										posinset={ posinset }
 									/>
 								);

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -136,6 +136,8 @@ export function getClosestSelectedId( {
 export interface SelectionProps {
 	onMouseDown: ( event: React.MouseEvent ) => void;
 	onClickCapture: ( event: React.MouseEvent ) => void;
+	// Only returned to the picker layouts, whose plain clicks select.
+	onClick?: () => void;
 }
 
 // Encapsulates the pointer gestures for multi-selection, shared by layouts:
@@ -147,6 +149,11 @@ export interface SelectionProps {
 // `getItemId`; the hook derives the selectable items itself (those with a
 // possible bulk action) so every layout doesn't repeat that logic. Spread
 // `getSelectionProps( id )` on each item's container element.
+//
+// The picker layouts select on a plain click instead, and set
+// `pickerMultiselect`; for them the hook also returns the `onClick` that
+// selects and anchors the range, and every rendered item is selectable rather
+// than only those with a bulk action.
 //
 // The selection model is one-dimensional: a range is the contiguous run of
 // selectable items between the anchor and the target. Two-dimensional layouts
@@ -165,12 +172,19 @@ export default function useSelectionProps< Item >( {
 	getItemId,
 	selection,
 	onChangeSelection,
+	pickerMultiselect,
 }: {
 	data: Item[];
 	actions: Action< Item >[];
 	getItemId: ( item: Item ) => string;
 	selection: string[];
 	onChangeSelection: SetSelection;
+	// Set by the picker layouts, where clicking an item is what selects it:
+	// `true` toggles the item into a multi-selection, `false` replaces the
+	// selection. Omitted by the other layouts, where a click opens the item and
+	// only the checkbox and modifier gestures select. `isEligible` is
+	// unsupported in a picker, so every rendered item is selectable there.
+	pickerMultiselect?: boolean;
 } ) {
 	// The Shift+Click range gesture in progress: the anchor ranges extend from
 	// — the last item whose selection was directly toggled — and the target of
@@ -182,6 +196,9 @@ export default function useSelectionProps< Item >( {
 		anchorId: string;
 		lastTargetId: string | null;
 	} | null >( null );
+	const anchorTo = ( id: string ) => {
+		gestureRef.current = { anchorId: id, lastTargetId: null };
+	};
 	// Set to true on the first `touchstart` anywhere in the document, and
 	// used to exclude touchscreen devices from the modifier-click gestures.
 	const isTouchDeviceRef = useRef( false );
@@ -196,30 +213,53 @@ export default function useSelectionProps< Item >( {
 			document.removeEventListener( 'touchstart', markTouchDevice );
 	}, [] );
 
-	// The ids of all selectable items — those with a possible bulk action —
-	// in the order the layout renders them; ranges follow this order.
-	const selectableIds = data
-		.filter( ( item ) => hasAPossibleBulkAction( actions, item ) )
-		.map( getItemId );
+	// The ids of all selectable items, in the order the layout renders them;
+	// ranges follow this order. A picker selects from every item it renders, so
+	// bulk actions don't gate it: `isEligible` is unsupported there, and reading
+	// `supportsBulk` with `some` would contradict the `every` that made the
+	// picker single-select in the first place.
+	const isPicker = pickerMultiselect !== undefined;
+	const selectableIds = (
+		isPicker
+			? data
+			: data.filter( ( item ) => hasAPossibleBulkAction( actions, item ) )
+	).map( getItemId );
 	const selectableIdSet = new Set( selectableIds );
 	const hasSelectableItems = selectableIds.length > 0;
+	// A single-select picker has no range to extend and no second item to add,
+	// so the modifier gestures have nothing to offer; its plain clicks are
+	// handled in `onClick` below.
+	const hasRangeGesture = hasSelectableItems && pickerMultiselect !== false;
 
 	const getSelectionProps = ( id: string ): SelectionProps => {
 		const isSelectable = selectableIdSet.has( id );
 		return {
+			// A picker selects on a plain click, so that click is also what
+			// anchors the range a following Shift+Click extends from. Modifier
+			// clicks never reach here: `onClickCapture` stops them.
+			...( isPicker && {
+				onClick: () => {
+					if ( selection.includes( id ) ) {
+						onChangeSelection(
+							selection.filter( ( itemId ) => id !== itemId )
+						);
+					} else {
+						onChangeSelection(
+							pickerMultiselect ? [ ...selection, id ] : [ id ]
+						);
+					}
+					anchorTo( id );
+				},
+			} ),
 			onMouseDown: ( event: React.MouseEvent ) => {
 				// Prevent native text selection from swallowing the
 				// Shift+Click range selection gesture.
-				if (
-					event.button === 0 &&
-					event.shiftKey &&
-					hasSelectableItems
-				) {
+				if ( event.button === 0 && event.shiftKey && hasRangeGesture ) {
 					event.preventDefault();
 				}
 			},
 			onClickCapture: ( event: React.MouseEvent ) => {
-				if ( ! hasSelectableItems ) {
+				if ( ! hasRangeGesture ) {
 					return;
 				}
 
@@ -235,10 +275,7 @@ export default function useSelectionProps< Item >( {
 					// it in the checkbox's own handler; it only anchors a new
 					// gesture here.
 					if ( isSelectable && isSelectionCheckboxClick ) {
-						gestureRef.current = {
-							anchorId: id,
-							lastTargetId: null,
-						};
+						anchorTo( id );
 					}
 					return;
 				}
@@ -310,7 +347,7 @@ export default function useSelectionProps< Item >( {
 							? selection.filter( ( itemId ) => id !== itemId )
 							: [ ...selection, id ]
 					);
-					gestureRef.current = { anchorId: id, lastTargetId: null };
+					anchorTo( id );
 				}
 			},
 		};

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -13,9 +13,14 @@ import { useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViewsPicker from '../index';
-import { LAYOUT_PICKER_GRID } from '../../constants';
+import {
+	LAYOUT_PICKER_ACTIVITY,
+	LAYOUT_PICKER_GRID,
+	LAYOUT_PICKER_TABLE,
+} from '../../constants';
 import type {
 	ActionButton,
+	Field,
 	SupportedLayouts,
 	View,
 	ViewPickerGrid,
@@ -75,20 +80,43 @@ const multiSelectActions: ActionButton< Data >[] = [
 	},
 ];
 
+// Groups ids 1 and 3 together and 2 on its own, so the rendered order
+// (1, 3, 2) differs from the order of `data`. `enableSorting: false` is what
+// makes that possible: it stops `filterSortAndPaginate` from sorting the data
+// into group order first, which would leave the two orders identical.
+const groupingFields: Field< Data >[] = [
+	{
+		id: 'parity',
+		label: 'Parity',
+		getValue: ( { item }: { item: Data } ) =>
+			item.id % 2 === 0 ? 'even' : 'odd',
+		enableSorting: false,
+	},
+];
+
+type PickerLayout =
+	| typeof LAYOUT_PICKER_GRID
+	| typeof LAYOUT_PICKER_TABLE
+	| typeof LAYOUT_PICKER_ACTIVITY;
+
 function Picker( {
 	view: additionalView,
 	actions,
 	label,
 	multiselect,
+	layout = LAYOUT_PICKER_GRID,
+	fields = [],
 	...props
 }: {
 	actions?: ActionButton< Data >[];
 	view?: Partial< View >;
 	label?: string;
 	multiselect?: boolean;
+	layout?: PickerLayout;
+	fields?: Field< Data >[];
 } ) {
 	const [ view, setView ] = useState< View >( {
-		type: LAYOUT_PICKER_GRID,
+		type: layout,
 		fields: [],
 		titleField: 'title',
 		mediaField: 'image',
@@ -97,13 +125,13 @@ function Picker( {
 		perPage: 10,
 		filters: [],
 		...additionalView,
-	} as ViewPickerGrid );
+	} as View );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( data, view, [] );
-	}, [ view ] );
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view, fields ] );
 
 	const dataViewProps = {
 		actions,
@@ -112,8 +140,8 @@ function Picker( {
 		paginationInfo,
 		data: shownData,
 		view,
-		defaultLayouts: { [ LAYOUT_PICKER_GRID ]: true } as SupportedLayouts,
-		fields: [],
+		defaultLayouts: { [ layout ]: true } as SupportedLayouts,
+		fields,
 		onChangeView: setView,
 		multiselect,
 		selection,
@@ -478,6 +506,116 @@ describe( 'DataViews Picker', () => {
 					'true'
 				);
 			} );
+		} );
+	} );
+
+	describe.each( [
+		[ 'picker grid', LAYOUT_PICKER_GRID ],
+		[ 'picker table', LAYOUT_PICKER_TABLE ],
+		[ 'picker activity', LAYOUT_PICKER_ACTIVITY ],
+	] as const )( 'Range selection (%s)', ( _layoutName, layout ) => {
+		it( 'selects the range between the clicked item and the Shift-clicked item', async () => {
+			render(
+				<Picker actions={ multiSelectActions } layout={ layout } />
+			);
+
+			const user = userEvent.setup();
+			const options = screen.getAllByRole( 'option' );
+
+			await user.click( options[ 0 ] );
+
+			await user.keyboard( '{Shift>}' );
+			await user.click( options[ 2 ] );
+			await user.keyboard( '{/Shift}' );
+
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 2 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( onChangeSelection ).toHaveBeenLastCalledWith( [
+				data[ 0 ].id.toString(),
+				data[ 1 ].id.toString(),
+				data[ 2 ].id.toString(),
+			] );
+		} );
+
+		it( 'redefines the range from the anchor when consecutive Shift+Clicks reverse direction', async () => {
+			render(
+				<Picker actions={ multiSelectActions } layout={ layout } />
+			);
+
+			const user = userEvent.setup();
+			const options = screen.getAllByRole( 'option' );
+
+			// The plain click anchors the range on the second item.
+			await user.click( options[ 1 ] );
+
+			await user.keyboard( '{Shift>}' );
+			await user.click( options[ 2 ] );
+			await user.click( options[ 0 ] );
+			await user.keyboard( '{/Shift}' );
+
+			// The anchor stayed on the second item, so reversing direction
+			// replaces the previous range rather than extending it.
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 2 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( onChangeSelection ).toHaveBeenLastCalledWith( [
+				data[ 0 ].id.toString(),
+				data[ 1 ].id.toString(),
+			] );
+		} );
+
+		it( 'selects only the Shift-clicked item when the picker is single-select', async () => {
+			render(
+				<Picker actions={ singleSelectActions } layout={ layout } />
+			);
+
+			const user = userEvent.setup();
+			const options = screen.getAllByRole( 'option' );
+
+			await user.click( options[ 0 ] );
+
+			await user.keyboard( '{Shift>}' );
+			await user.click( options[ 2 ] );
+			await user.keyboard( '{/Shift}' );
+
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( options[ 2 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( onChangeSelection ).toHaveBeenLastCalledWith( [
+				data[ 2 ].id.toString(),
+			] );
+		} );
+
+		it( 'extends the range in rendered order when grouping reorders the data', async () => {
+			render(
+				<Picker
+					actions={ multiSelectActions }
+					layout={ layout }
+					fields={ groupingFields }
+					view={ {
+						groupBy: { field: 'parity', direction: 'asc' },
+					} }
+				/>
+			);
+
+			const user = userEvent.setup();
+			const options = screen.getAllByRole( 'option' );
+
+			await user.click( options[ 0 ] );
+
+			await user.keyboard( '{Shift>}' );
+			await user.click( options[ 1 ] );
+			await user.keyboard( '{/Shift}' );
+
+			// The two clicked items are rendered neighbours but sit at either
+			// end of `data`, so a range following `data` order would have
+			// swept up the item in between.
+			expect( options[ 2 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( onChangeSelection ).toHaveBeenLastCalledWith( [
+				data[ 0 ].id.toString(),
+				data[ 2 ].id.toString(),
+			] );
 		} );
 	} );
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

https://github.com/WordPress/gutenberg/pull/80046 added Shift+Click range selection to the `table` and `grid` layouts. This adds it to the picker layouts: `pickerTable`, `pickerGrid` and `pickerActivity`.

<!-- In a few words, what is the PR actually doing? -->

## How?

The picker layouts reuse the existing `useSelectionProps` hook, with a picker-specific `pickerMultiselect` prop.

Per the [docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#actions-object-2), a picker's items are all selectable and a mixture of bulk and non-bulk actions falls back to single selection. 

Given that behavior, IMO the simplest approach is a prop (`pickerMultiselect`) that explicitly states whether the layout is a picker and whether it's single or multi selection. 

The rationale is that the hook still needs to know which mode a picker is in, but that rule — *every* action supports bulk — differs from the per-item check the other layouts rely on, which passes when *any* action does. The picker layouts already declare it, so passing it in avoids teaching the hook a second way to derive it.

 


## Testing Instructions
1. Open Storybook (`npm run storybook:dev`) to `?path=/story/dataviews-dataviewspicker--default`
3. Play around with `shift-click` with `isMultiselectable` and `isGrouped` on and off.
4. Test simple click and `Ctrl/Cmd+Click` interactions too to verify expected behavior.
5. Test all the three picker layouts (`table, grid, activity`).


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5e278acc-4590-4b00-af31-cdeab99207e7


https://github.com/user-attachments/assets/186e30dd-64d6-4eab-9456-e26a5028e1f7




## Use of AI Tools
Opus 4.8 with direction, changes and review