### PR TITLE
Storybook: build the resolve specifier as a URL-style string

### DIFF
--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -16,9 +16,7 @@ import dsTokenFallbacksJs from '@wordpress/theme/vite-plugins/vite-ds-token-fall
  */
 function getAbsolutePath( packageName: string ) {
 	return path.dirname(
-		fileURLToPath(
-			import.meta.resolve( path.join( packageName, 'package.json' ) )
-		)
+		fileURLToPath( import.meta.resolve( `${ packageName }/package.json` ) )
 	);
 }
 


### PR DESCRIPTION
## What?

Follow up to #80414 ([review comment](https://github.com/WordPress/gutenberg/pull/80414#discussion_r3603780579)). Builds the specifier passed to `import.meta.resolve()` as a URL-style string instead of a filesystem path.

## Why?

`path.join()` uses the platform separator, so on Windows it produces `@storybook\addon-docs\package.json`. Module specifiers are always `/`-separated.

## How?

Template string, matching [Storybook's guidance](https://storybook.js.org/docs/faq#how-do-i-fix-module-resolution-in-special-environments): `import.meta.resolve( \`${ packageName }/package.json\` )`.

## Testing Instructions

`npm run storybook:dev` — Storybook starts and stories render as before.

## Use of AI Tools

Claude Code applied the change and drafted this description; both reviewed by me.
