### PR TITLE
Post Excerpt: Add preserve formatting toggle

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -734,7 +734,7 @@ Display the excerpt.
 -	**Name:** [core/post-excerpt](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-post-excerpt/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign, textColumns), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine
+-	**Attributes:** excerptLength, moreText, preserveFormatting, showMoreOnNewLine
 
 ## Featured Image
 

--- a/packages/block-library/src/post-excerpt/README.md
+++ b/packages/block-library/src/post-excerpt/README.md
@@ -17,6 +17,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `moreText` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `showMoreOnNewLine` | `boolean` | `true` | — |
 | `excerptLength` | `number` | `55` | — |
+| `preserveFormatting` | `boolean` | `false` | — |
 
 ## Supports
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -18,6 +18,10 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"preserveFormatting": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -36,7 +36,12 @@ const ELLIPSIS = '…';
 
 export default function PostExcerptEditor( props ) {
 	const {
-		attributes: { moreText, showMoreOnNewLine, excerptLength },
+		attributes: {
+			moreText,
+			showMoreOnNewLine,
+			excerptLength,
+			preserveFormatting,
+		},
 		setAttributes,
 		isSelected,
 		context: { postId, postType, queryId },
@@ -184,30 +189,43 @@ export default function PostExcerptEditor( props ) {
 
 	const isTrimmed = trimmedExcerpt !== rawOrRenderedExcerpt;
 
-	const excerptContent = isEditable ? (
-		<RichText
-			className={ excerptClassName }
-			aria-label={ __( 'Excerpt text' ) }
-			value={
-				isSelected
-					? rawOrRenderedExcerpt
-					: ( ! isTrimmed
-							? rawOrRenderedExcerpt
-							: trimmedExcerpt + ELLIPSIS ) ||
-					  __( 'No excerpt found' )
-			}
-			onChange={ setExcerpt }
-			tagName="p"
-			allowedFormats={ [] }
-			preserveWhiteSpace
-		/>
-	) : (
-		<p className={ excerptClassName }>
-			{ ! isTrimmed
-				? rawOrRenderedExcerpt || __( 'No excerpt found' )
-				: trimmedExcerpt + ELLIPSIS }
-		</p>
-	);
+	let excerptContent;
+	if ( isEditable ) {
+		excerptContent = (
+			<RichText
+				className={ excerptClassName }
+				aria-label={ __( 'Excerpt text' ) }
+				value={
+					isSelected
+						? rawOrRenderedExcerpt
+						: ( ! isTrimmed
+								? rawOrRenderedExcerpt
+								: trimmedExcerpt + ELLIPSIS ) ||
+						  __( 'No excerpt found' )
+				}
+				onChange={ setExcerpt }
+				tagName={ preserveFormatting ? 'div' : 'p' }
+				allowedFormats={ [] }
+				preserveWhiteSpace
+			/>
+		);
+	} else if ( preserveFormatting ) {
+		excerptContent = (
+			<div className={ excerptClassName }>
+				{ ! isTrimmed
+					? rawOrRenderedExcerpt || __( 'No excerpt found' )
+					: trimmedExcerpt + ELLIPSIS }
+			</div>
+		);
+	} else {
+		excerptContent = (
+			<p className={ excerptClassName }>
+				{ ! isTrimmed
+					? rawOrRenderedExcerpt || __( 'No excerpt found' )
+					: trimmedExcerpt + ELLIPSIS }
+			</p>
+		);
+	}
 	return (
 		<>
 			<InspectorControls>
@@ -217,10 +235,29 @@ export default function PostExcerptEditor( props ) {
 						setAttributes( {
 							showMoreOnNewLine: true,
 							excerptLength: 55,
+							preserveFormatting: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
+					<ToolsPanelItem
+						hasValue={ () => preserveFormatting !== false }
+						label={ __( 'Preserve formatting' ) }
+						onDeselect={ () =>
+							setAttributes( { preserveFormatting: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							label={ __( 'Preserve formatting' ) }
+							checked={ preserveFormatting }
+							onChange={ ( newPreserveFormatting ) =>
+								setAttributes( {
+									preserveFormatting: newPreserveFormatting,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
 					<ToolsPanelItem
 						hasValue={ () => showMoreOnNewLine !== true }
 						label={ __( 'Show link on new line' ) }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -14,7 +14,7 @@
  * All other blocks (lists, headings, tables, images, embeds, etc.) are skipped,
  * matching the default excerpt which discards non-prose formatting.
  *
- * @since x.x.x
+ * @since 7.0.2
  *
  * @see excerpt_remove_blocks()
  *
@@ -140,7 +140,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 				 * rendered paragraph <p> tags inside are never nested within another <p>,
 				 * which would produce invalid HTML.
 				 */
-				$inner  = '<div class="wp-block-post-excerpt__excerpt">' . $excerpt_html . '</div>';
+				$inner = '<div class="wp-block-post-excerpt__excerpt">' . $excerpt_html . '</div>';
 				if ( ! empty( $more_text ) ) {
 					$inner .= $show_more_on_new_line
 						? '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>'

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -6,6 +6,85 @@
  */
 
 /**
+ * Collects rendered paragraph HTML from a parsed block tree, up to a word limit.
+ *
+ * Only `core/paragraph` blocks are rendered, preserving their `<p>` tags.
+ * Layout container blocks (Group, Columns, Column, Cover, Media & Text) are
+ * recursed into so paragraphs nested inside them are still found.
+ * All other blocks (lists, headings, tables, images, embeds, etc.) are skipped,
+ * matching the default excerpt which discards non-prose formatting.
+ *
+ * @since x.x.x
+ *
+ * @see excerpt_remove_blocks()
+ *
+ * @param array $blocks     Parsed block array from parse_blocks().
+ * @param int   $max_words  Maximum number of words to include.
+ * @param int   $word_count Running word count, passed by reference.
+ * @return string Rendered HTML containing one or more `<p>` tags, safely truncated.
+ */
+function block_core_post_excerpt_render_paragraphs( $blocks, $max_words, &$word_count ) {
+	$output = '';
+
+	/*
+	 * Use the same wrapper-block allowlist that WordPress core uses in
+	 * excerpt_remove_blocks() (wp-includes/blocks.php). Recursing into only
+	 * these blocks ensures our preserve-formatting path is consistent with
+	 * what core considers "excerpt-worthy" container blocks, and the same
+	 * `excerpt_allowed_wrapper_blocks` filter is applied so any site-level
+	 * customisation is automatically inherited here too.
+	 */
+	$allowed_wrapper_blocks = array(
+		'core/columns',
+		'core/column',
+		'core/group',
+	);
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$allowed_wrapper_blocks = apply_filters( 'excerpt_allowed_wrapper_blocks', $allowed_wrapper_blocks );
+
+	foreach ( $blocks as $block ) {
+		if ( $word_count >= $max_words ) {
+			break;
+		}
+
+		// Recurse into wrapper blocks whose inner content counts toward excerpts.
+		if ( in_array( $block['blockName'], $allowed_wrapper_blocks, true ) && ! empty( $block['innerBlocks'] ) ) {
+			$output .= block_core_post_excerpt_render_paragraphs( $block['innerBlocks'], $max_words, $word_count );
+			continue;
+		}
+
+		// Only render core/paragraph blocks — everything else is skipped.
+		if ( 'core/paragraph' !== $block['blockName'] ) {
+			continue;
+		}
+
+		$block_html       = render_block( $block );
+		$block_text       = wp_strip_all_tags( $block_html );
+		$words            = preg_split( '/\s+/u', trim( $block_text ), -1, PREG_SPLIT_NO_EMPTY );
+		$block_word_count = count( $words );
+
+		if ( 0 === $block_word_count ) {
+			continue;
+		}
+
+		if ( $word_count + $block_word_count <= $max_words ) {
+			// Entire paragraph fits within the word limit — render it as-is.
+			$output     .= $block_html;
+			$word_count += $block_word_count;
+		} else {
+			// Paragraph exceeds the remaining budget — trim and append ellipsis.
+			$remaining     = $max_words - $word_count;
+			$trimmed_words = array_slice( $words, 0, $remaining );
+			$output       .= '<p>' . esc_html( implode( ' ', $trimmed_words ) ) . '&hellip;</p>';
+			$word_count    = $max_words;
+		}
+	}
+
+	return $output;
+}
+
+/**
  * Renders the `core/post-excerpt` block on the server.
  *
  * @since 5.8.0
@@ -18,6 +97,60 @@
 function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
+	}
+
+	/*
+	 * Preserve Formatting path: when the toggle is on, bypass get_the_excerpt()
+	 * and render individual paragraph blocks so that paragraph breaks are kept.
+	 * Falls back to the standard flat-text path when:
+	 *   - the toggle is off (default),
+	 *   - the post has a manually written excerpt, or
+	 *   - no paragraph blocks are found in the content.
+	 */
+	if ( ! empty( $attributes['preserveFormatting'] ) ) {
+		$post_id        = (int) $block->context['postId'];
+		$manual_excerpt = get_post_field( 'post_excerpt', $post_id );
+
+		if ( empty( trim( (string) $manual_excerpt ) ) ) {
+			$post_content  = get_post_field( 'post_content', $post_id, 'raw' );
+			$parsed_blocks = parse_blocks( (string) $post_content );
+			$word_count    = 0;
+			$max_words     = isset( $attributes['excerptLength'] ) ? (int) $attributes['excerptLength'] : 55;
+
+			$excerpt_html = block_core_post_excerpt_render_paragraphs( $parsed_blocks, $max_words, $word_count );
+
+			if ( ! empty( $excerpt_html ) ) {
+				$more_text = ! empty( $attributes['moreText'] )
+					? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_id ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>'
+					: '';
+
+				$show_more_on_new_line = ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'];
+
+				$classes = array();
+				if ( isset( $attributes['textAlign'] ) ) {
+					$classes[] = 'has-text-align-' . $attributes['textAlign'];
+				}
+				if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
+					$classes[] = 'has-link-color';
+				}
+				$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+				/*
+				 * Use a <div> wrapper (not <p>) for the excerpt container so that the
+				 * rendered paragraph <p> tags inside are never nested within another <p>,
+				 * which would produce invalid HTML.
+				 */
+				$inner  = '<div class="wp-block-post-excerpt__excerpt">' . $excerpt_html . '</div>';
+				if ( ! empty( $more_text ) ) {
+					$inner .= $show_more_on_new_line
+						? '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>'
+						: $more_text;
+				}
+
+				return sprintf( '<div %s>%s</div>', $wrapper_attributes, $inner );
+			}
+		}
+		// Falls through to the default path below.
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';

--- a/test/integration/fixtures/blocks/core__post-excerpt.json
+++ b/test/integration/fixtures/blocks/core__post-excerpt.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"showMoreOnNewLine": true,
-			"excerptLength": 55
+			"excerptLength": 55,
+			"preserveFormatting": false
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -86,7 +86,8 @@
 								"isValid": true,
 								"attributes": {
 									"showMoreOnNewLine": true,
-									"excerptLength": 55
+									"excerptLength": 55,
+									"preserveFormatting": false
 								},
 								"innerBlocks": []
 							}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #80380 

<!-- In a few words, what is the PR actually doing? -->
Adds a "Preserve formatting" toggle to the Post Excerpt block to allow users to retain paragraph blocks (`<p>`) and valid wrapper blocks instead of stripping the excerpt down to raw text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the standard Post Excerpt block completely strips all paragraph formatting and renders the resulting raw text inside a single `<p>` tag (or nothing, if there's no manual excerpt). This forces multi-paragraph content to run together into a single wall of text, making it impossible to render excerpts with their intended paragraph breaks and spacing.
Users need a way to opt-in to preserving their line breaks and paragraph formatting when displaying post excerpts, especially in Query Loops.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- `packages/block-library/src/post-excerpt/block.json`: Added a new `preserveFormatting` boolean attribute.
- `packages/block-library/src/post-excerpt/edit.js`: Added a new toggle in the `InspectorControls`. When active, it changes the excerpt wrapper from a `<p>` to a `<div>` to allow nested paragraphs in the editor.
- `packages/block-library/src/post-excerpt/index.php`: Updated `render_block_core_post_excerpt` to intercept the standard text-stripping logic when the toggle is on. It uses a new `block_core_post_excerpt_render_paragraphs` helper to safely traverse the post content and perfectly reconstruct the original `core/paragraph` blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new post and add multiple distinct Paragraph blocks with text.
2. Save the post (do not set a manual excerpt in the post settings).
3. Create a second post/page and insert a Query Loop block, or manually insert a Post Excerpt block and assign it to the post you just created.
4. Note that by default, the Post Excerpt strips all formatting and joins the paragraphs together into a single block of text.
5. Select the Post Excerpt block, open the Block Settings sidebar, and toggle on "Preserve formatting".
6. Verify that the excerpt now immediately updates to retain the paragraph spacing.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/7a46e425-ce5b-4e59-b07e-6d2300f3e477

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini, Claude
Used for: Used for diagnosing the issue and assistance with implementation.