### PR TITLE
[7.1 Backport] -- Worker threads: reject pending RPC calls on worker failure or termination 

### DIFF
--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -201,14 +201,20 @@ export function cancelItem( id: QueueItemId, error: Error, silent = false ) {
 
 		item.abortController?.abort();
 
-		// Cancel any ongoing vips operations for this item.
-		await vipsCancelOperations( id );
+		/*
+		 * Cancel any ongoing vips operations for this item. This is
+		 * best-effort cleanup: when the worker has crashed, the cancel call
+		 * itself rejects, and that must not abort the cancellation flow —
+		 * onError, item removal, and worker teardown below still need to run.
+		 */
+		await vipsCancelOperations( id ).catch( () => {} );
 
 		/*
 		 * Cancel any ongoing GIF-to-video conversion for this item so a
 		 * cancelled upload does not leave the encoder running off-thread.
+		 * Best-effort for the same reason as above.
 		 */
-		await cancelGifToVideoOperations( id );
+		await cancelGifToVideoOperations( id ).catch( () => {} );
 
 		if ( ! silent ) {
 			const { onError } = item;

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -693,6 +693,64 @@ describe( 'actions', () => {
 			expect( onError ).not.toHaveBeenCalled();
 		} );
 
+		it( 'still calls onError and removes the item when vips cancellation rejects', async () => {
+			/*
+			 * When the vips worker has crashed, any call on its remote —
+			 * including the cancellation itself — rejects. That rejection
+			 * must not abort cancelItem, or the item would be stuck in the
+			 * queue forever with no error surfaced.
+			 */
+			( vipsCancelOperations as jest.Mock ).mockImplementationOnce( () =>
+				Promise.reject( new Error( 'Worker error: crashed' ) )
+			);
+
+			const onError = jest.fn();
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+				onError,
+			} );
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			await registry
+				.dispatch( uploadStore )
+				.cancelItem( item.id, new Error( 'Test error' ) );
+
+			expect( onError ).toHaveBeenCalledWith(
+				expect.objectContaining( { message: 'Test error' } )
+			);
+			expect(
+				unlock( registry.select( uploadStore ) ).getAllItems()
+			).toHaveLength( 0 );
+		} );
+
+		it( 'still calls onError and removes the item when GIF-to-video cancellation rejects', async () => {
+			( cancelGifToVideoOperations as jest.Mock ).mockImplementationOnce(
+				() => Promise.reject( new Error( 'Worker error: crashed' ) )
+			);
+
+			const onError = jest.fn();
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+				onError,
+			} );
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			await registry
+				.dispatch( uploadStore )
+				.cancelItem( item.id, new Error( 'Test error' ) );
+
+			expect( onError ).toHaveBeenCalledWith(
+				expect.objectContaining( { message: 'Test error' } )
+			);
+			expect(
+				unlock( registry.select( uploadStore ) ).getAllItems()
+			).toHaveLength( 0 );
+		} );
+
 		describe( 'parent cancellation when child sideload fails', () => {
 			// Helpers used by every scenario below. Set up a parent that
 			// has finished its primary upload (so it has an attachment.id),

--- a/packages/worker-threads/CHANGELOG.md
+++ b/packages/worker-threads/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `expose`: Normalize thrown values that are not `Error` instances (or have an empty message), such as `WebAssembly.Exception`, so they reach the main thread as promise rejections instead of being mistaken for a successful `undefined` result ([#80259](https://github.com/WordPress/gutenberg/issues/80259)).
+-   Reject pending RPC calls when the worker fails (`error` / `messageerror` events) or is terminated via `terminate()`, instead of leaving the promises pending forever ([#79955](https://github.com/WordPress/gutenberg/pull/79955)).
 
 ## 1.11.0 (2026-07-14)
 

--- a/packages/worker-threads/src/main-thread.ts
+++ b/packages/worker-threads/src/main-thread.ts
@@ -35,9 +35,43 @@ class WorkerInjectAdapter implements Adapter {
 }
 
 /**
- * WeakMap to store workers for each remote proxy.
+ * Internal state tracked for each wrapped worker.
+ *
+ * comctx only settles a call promise when a response message arrives from
+ * the worker, so a worker that crashes, fails to initialize, or is
+ * terminated mid-call would otherwise leave its call promises pending
+ * forever. Pending rejecters are tracked here so those promises can be
+ * rejected when the worker fails or is terminated.
  */
-const remoteWorkers = new WeakMap< object, Worker >();
+interface WorkerState {
+	worker: Worker;
+	/** Rejecters for calls that have not settled yet. */
+	pendingRejects: Set< ( reason: Error ) => void >;
+	/** Set once the worker has failed or been terminated. */
+	failure?: Error;
+	/** Removes the worker error event listeners. */
+	removeListeners: () => void;
+}
+
+/**
+ * WeakMap to store the state for each remote proxy.
+ */
+const remoteStates = new WeakMap< object, WorkerState >();
+
+/**
+ * Rejects all pending calls and marks the worker as failed so that
+ * subsequent calls reject immediately instead of hanging.
+ *
+ * @param state Worker state.
+ * @param error Rejection reason.
+ */
+function failWorker( state: WorkerState, error: Error ): void {
+	state.failure ??= error;
+	for ( const reject of state.pendingRejects ) {
+		reject( state.failure );
+	}
+	state.pendingRejects.clear();
+}
 
 /**
  * Wraps a Worker to provide a type-safe RPC interface.
@@ -45,6 +79,10 @@ const remoteWorkers = new WeakMap< object, Worker >();
  * The returned proxy object allows calling methods on the worker as if they
  * were local async functions. Each method call is automatically serialized,
  * sent to the worker, and the result is returned as a Promise.
+ *
+ * If the worker fails (its `error` or `messageerror` event fires) or is
+ * terminated via terminate(), all pending calls are rejected and any
+ * subsequent calls reject immediately.
  *
  * @example
  * ```typescript
@@ -70,10 +108,40 @@ export function wrap< T extends object >( worker: Worker ): Remote< T > {
 	// Create the proxy using the injector.
 	const comctxRemote = inject( new WorkerInjectAdapter( worker ) );
 
-	// Store the worker reference.
-	remoteWorkers.set( comctxRemote as object, worker );
+	const onError = ( event: Event ) => {
+		const message = ( event as ErrorEvent ).message;
+		failWorker(
+			state,
+			new Error(
+				message
+					? `Worker error: ${ message }`
+					: 'Worker error: the worker crashed or failed to load.'
+			)
+		);
+	};
+	const onMessageError = () => {
+		failWorker(
+			state,
+			new Error( 'Worker error: a message could not be deserialized.' )
+		);
+	};
 
-	// Create a wrapper proxy that adds WORKER_SYMBOL support.
+	// Detect worker failures (crash, failed script load/instantiation, or
+	// undeserializable messages) so pending calls do not hang forever.
+	worker.addEventListener( 'error', onError );
+	worker.addEventListener( 'messageerror', onMessageError );
+
+	const state: WorkerState = {
+		worker,
+		pendingRejects: new Set(),
+		removeListeners: () => {
+			worker.removeEventListener( 'error', onError );
+			worker.removeEventListener( 'messageerror', onMessageError );
+		},
+	};
+
+	// Create a wrapper proxy that adds WORKER_SYMBOL support and tracks
+	// pending calls so they can be rejected on worker failure/termination.
 	const proxy = new Proxy( comctxRemote as Remote< T > & WithWorker, {
 		get( target, prop: string | symbol ) {
 			// Return the worker for the WORKER_SYMBOL.
@@ -82,12 +150,40 @@ export function wrap< T extends object >( worker: Worker ): Remote< T > {
 			}
 
 			// Delegate all other property access to the comctx remote.
-			return Reflect.get( target, prop );
+			const value = Reflect.get( target, prop );
+
+			if ( typeof value !== 'function' ) {
+				return value;
+			}
+
+			return ( ...args: unknown[] ) => {
+				if ( state.failure ) {
+					return Promise.reject( state.failure );
+				}
+
+				return new Promise( ( resolve, reject ) => {
+					state.pendingRejects.add( reject );
+					// Wrap the call so a synchronous throw or a non-thenable
+					// return value still removes the rejecter from the set.
+					Promise.resolve()
+						.then( () => value( ...args ) )
+						.then(
+							( result ) => {
+								state.pendingRejects.delete( reject );
+								resolve( result );
+							},
+							( error ) => {
+								state.pendingRejects.delete( reject );
+								reject( error );
+							}
+						);
+				} );
+			};
 		},
 	} );
 
-	// Store the worker for the proxy as well.
-	remoteWorkers.set( proxy, worker );
+	// Store the state for the proxy.
+	remoteStates.set( proxy, state );
 
 	return proxy;
 }
@@ -108,16 +204,20 @@ export function wrap< T extends object >( worker: Worker ): Remote< T > {
  * @param remote - The wrapped worker proxy returned by wrap().
  */
 export function terminate( remote: Remote< unknown > ): void {
-	// Get the worker from the proxy.
-	const worker = ( remote as unknown as WithWorker )[ WORKER_SYMBOL ];
+	const state = remoteStates.get( remote as object );
 
-	if ( ! worker ) {
+	if ( ! state ) {
 		return;
 	}
 
-	// Clean up the worker reference.
-	remoteWorkers.delete( remote as object );
+	// Reject pending calls; they would otherwise never settle.
+	failWorker( state, new Error( 'Worker was terminated.' ) );
+
+	state.removeListeners();
+
+	// Clean up the state reference.
+	remoteStates.delete( remote as object );
 
 	// Terminate the worker.
-	worker.terminate();
+	state.worker.terminate();
 }

--- a/packages/worker-threads/src/test/main-thread.test.ts
+++ b/packages/worker-threads/src/test/main-thread.test.ts
@@ -6,40 +6,68 @@ import { WORKER_SYMBOL } from '../types';
 
 /**
  * Mock Worker class for testing.
- * Implements addEventListener pattern used by comctx.
+ * Implements the addEventListener pattern used by comctx and the
+ * error/messageerror events used for worker failure detection.
  */
 class MockWorker {
 	postMessage = jest.fn();
 	terminate = jest.fn();
 
-	private messageListeners: Array< ( event: MessageEvent ) => void > = [];
+	private listeners: Map< string, Array< ( event: Event ) => void > > =
+		new Map();
 
-	addEventListener( type: string, handler: ( event: MessageEvent ) => void ) {
-		if ( type === 'message' ) {
-			this.messageListeners.push( handler );
-		}
+	addEventListener( type: string, handler: ( event: Event ) => void ) {
+		const handlers = this.listeners.get( type ) || [];
+		handlers.push( handler );
+		this.listeners.set( type, handlers );
 	}
 
-	removeEventListener(
-		type: string,
-		handler: ( event: MessageEvent ) => void
-	) {
-		if ( type === 'message' ) {
-			this.messageListeners = this.messageListeners.filter(
-				( h ) => h !== handler
-			);
-		}
+	removeEventListener( type: string, handler: ( event: Event ) => void ) {
+		const handlers = this.listeners.get( type ) || [];
+		this.listeners.set(
+			type,
+			handlers.filter( ( h ) => h !== handler )
+		);
 	}
 
 	/**
 	 * Simulate receiving a message from the worker.
 	 *
-	 * @param data
+	 * @param data Message data.
 	 */
 	simulateMessage( data: unknown ) {
-		for ( const handler of this.messageListeners ) {
+		for ( const handler of this.listeners.get( 'message' ) || [] ) {
 			handler( { data } as MessageEvent );
 		}
+	}
+
+	/**
+	 * Simulate an event on the worker (e.g. error, messageerror).
+	 *
+	 * @param type  Event type.
+	 * @param event Event object.
+	 */
+	simulateEvent( type: string, event: Partial< Event > = {} ) {
+		for ( const handler of this.listeners.get( type ) || [] ) {
+			handler( event as Event );
+		}
+	}
+
+	/**
+	 * Returns the last message sent to the worker via postMessage.
+	 */
+	get lastSentMessage(): Record< string, unknown > {
+		const { calls } = this.postMessage.mock;
+		return calls[ calls.length - 1 ][ 0 ];
+	}
+}
+
+/**
+ * Flushes pending microtasks so comctx's async message dispatch settles.
+ */
+async function flushMicrotasks() {
+	for ( let i = 0; i < 10; i++ ) {
+		await Promise.resolve();
 	}
 }
 
@@ -98,6 +126,111 @@ describe( 'main-thread', () => {
 			expect( promise1 ).toBeInstanceOf( Promise );
 			expect( promise2 ).toBeInstanceOf( Promise );
 		} );
+
+		it( 'should resolve calls when the worker responds', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise = remote.method( 1 );
+			await flushMicrotasks();
+
+			// Echo the request back as a provider response with a result.
+			worker.simulateMessage( {
+				...worker.lastSentMessage,
+				sender: 'provider',
+				data: 42,
+			} );
+
+			await expect( promise ).resolves.toBe( 42 );
+		} );
+
+		it( 'should reject calls when the worker responds with an error', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise = remote.method( 1 );
+			await flushMicrotasks();
+
+			worker.simulateMessage( {
+				...worker.lastSentMessage,
+				sender: 'provider',
+				error: 'processing failed',
+			} );
+
+			await expect( promise ).rejects.toThrow( 'processing failed' );
+		} );
+
+		it( 'should reject pending calls when the worker emits an error event', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise1 = remote.method( 1 );
+			const promise2 = remote.method( 2 );
+			await flushMicrotasks();
+
+			worker.simulateEvent( 'error', { message: 'worker crashed' } );
+
+			await expect( promise1 ).rejects.toThrow( 'worker crashed' );
+			await expect( promise2 ).rejects.toThrow( 'worker crashed' );
+		} );
+
+		it( 'should reject pending calls when the worker emits a messageerror event', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise = remote.method( 1 );
+			await flushMicrotasks();
+
+			worker.simulateEvent( 'messageerror' );
+
+			await expect( promise ).rejects.toThrow(
+				'could not be deserialized'
+			);
+		} );
+
+		it( 'should reject calls made after the worker has errored', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			worker.simulateEvent( 'error', { message: 'worker crashed' } );
+
+			await expect( remote.method( 1 ) ).rejects.toThrow(
+				'worker crashed'
+			);
+		} );
+
+		it( 'should not reject calls that already settled when the worker errors', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise = remote.method( 1 );
+			await flushMicrotasks();
+
+			worker.simulateMessage( {
+				...worker.lastSentMessage,
+				sender: 'provider',
+				data: 42,
+			} );
+
+			await expect( promise ).resolves.toBe( 42 );
+
+			// A later worker failure must not affect the settled call.
+			worker.simulateEvent( 'error', { message: 'worker crashed' } );
+
+			await expect( promise ).resolves.toBe( 42 );
+		} );
 	} );
 
 	describe( 'terminate', () => {
@@ -108,6 +241,33 @@ describe( 'main-thread', () => {
 			terminate( remote );
 
 			expect( worker.terminate ).toHaveBeenCalled();
+		} );
+
+		it( 'should reject pending calls', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			const promise1 = remote.method( 1 );
+			const promise2 = remote.method( 2 );
+			await flushMicrotasks();
+
+			terminate( remote );
+
+			await expect( promise1 ).rejects.toThrow( 'terminated' );
+			await expect( promise2 ).rejects.toThrow( 'terminated' );
+		} );
+
+		it( 'should reject calls made after termination', async () => {
+			const worker = new MockWorker();
+			const remote = wrap< { method: ( n: number ) => number } >(
+				worker as unknown as Worker
+			);
+
+			terminate( remote );
+
+			await expect( remote.method( 1 ) ).rejects.toThrow( 'terminated' );
 		} );
 
 		it( 'should handle terminate called multiple times', () => {

--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -832,4 +832,105 @@ test.describe( 'Client-side media processing', () => {
 
 		await page.unroute( '**/wp/v2/media**' );
 	} );
+
+	test( 'recovers when the image processing worker crashes mid-upload', async ( {
+		page,
+		editor,
+		mediaProcessingUtils,
+		requestUtils,
+	} ) => {
+		/*
+		 * Capture workers created from this point on. The vips worker is
+		 * created lazily (from a Blob URL) when the first image operation
+		 * starts, so wrapping the constructor before uploading reliably
+		 * captures it.
+		 */
+		await page.evaluate( () => {
+			window.__capturedBlobWorkers = [];
+			const OriginalWorker = window.Worker;
+			window.Worker = class extends OriginalWorker {
+				constructor( scriptURL, options ) {
+					super( scriptURL, options );
+					if ( String( scriptURL ).startsWith( 'blob:' ) ) {
+						window.__capturedBlobWorkers.push( this );
+					}
+				}
+			};
+		} );
+
+		await editor.insertBlock( { name: 'core/image' } );
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlock ).toBeVisible();
+
+		// A large image keeps transcoding busy long enough for the
+		// simulated crash to land while vips work is still pending.
+		await mediaProcessingUtils.upload(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'5000x4000_e2e_test_image_oversized.jpeg'
+		);
+
+		// Wait for the vips worker to spin up, which means image
+		// processing has started.
+		await page.waitForFunction(
+			() => window.__capturedBlobWorkers.length > 0,
+			undefined,
+			{ timeout: 30_000 }
+		);
+
+		/*
+		 * Simulate a worker crash: stop the underlying thread, then fire the
+		 * error event a real crash would emit so the RPC layer marks the
+		 * worker as failed and rejects its pending calls.
+		 */
+		await page.evaluate( () => {
+			for ( const worker of window.__capturedBlobWorkers ) {
+				worker.terminate();
+				worker.dispatchEvent(
+					new ErrorEvent( 'error', {
+						message: 'Simulated worker crash',
+					} )
+				);
+			}
+		} );
+
+		// The failure must surface to the user rather than dying silently
+		// inside the queue.
+		const errorSnackbar = page
+			.locator( '.components-snackbar' )
+			.filter( { hasText: /cannot generate responsive image sizes/i } );
+		await expect( errorSnackbar ).toBeVisible( { timeout: 30_000 } );
+
+		// The failed item must leave the queue instead of hanging forever…
+		await mediaProcessingUtils.waitForUploadQueueEmpty( 30_000 );
+
+		// …which releases the save lock so the post is saveable again.
+		await expect
+			.poll(
+				() =>
+					page.evaluate( () =>
+						window.wp.data
+							.select( 'core/editor' )
+							.isPostSavingLocked()
+					),
+				{ timeout: 10_000 }
+			)
+			.toBe( false );
+
+		/*
+		 * Emptying the queue also terminates the dead worker, so the next
+		 * upload lazily creates a fresh one and completes normally. Clear
+		 * the canvas first so the failed upload's leftover image block
+		 * doesn't collide with the helper's block locator.
+		 */
+		await editor.setContent( '' );
+		const media = await mediaProcessingUtils.uploadImageAndGetMedia(
+			editor,
+			requestUtils,
+			'1024x768_e2e_test_image_size.jpeg'
+		);
+		expect( media.mime_type ).toBe( 'image/jpeg' );
+	} );
 } );


### PR DESCRIPTION
Backports #79955 (merged as 70f9a9594d6532301fa31c3313f38275c60d26b9) to the `wp/7.1` branch. The automated cherry-pick failed with a conflict; see https://github.com/WordPress/gutenberg/pull/79955#issuecomment-5008542244.

## Why

Fixes #79953 for WordPress 7.1: when a media worker (vips, video conversion) crashes or is terminated, all pending RPC promises currently stay pending forever, leaving uploads stuck in the queue with no error surfaced. This makes `worker-threads` reject those pending calls on `error` / `messageerror` / `terminate()`.

## Conflict resolution

Cherry-picked directly onto `wp/7.1`. The only conflict was `packages/worker-threads/CHANGELOG.md`: kept both the already-backported #80259 bullet and the new #79955 bullet, matching trunk.

## Verification

All source files touched by #79955 are byte-identical to trunk. All `worker-threads`, `upload-media`, and `video-conversion` unit tests pass (392 tests).

Note: #80420 (the #80379 backport) is now stacked on this PR, matching the order the originals merged in trunk. This PR should merge first; #80420's cherry-pick then applies cleanly.
