### PR TITLE
Backport ColorPicker cursor shaking fix to WordPress 7.1

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
+
 ## 37.0.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -98,42 +98,40 @@ const UnconnectedColorPicker = (
 	// distinguish our own updates from external prop changes.
 	const lastProducedHexRef = useRef( safeColordColor.toHex() );
 
+	// While the user is dragging the visual picker, ignore color-prop sync
+	// so delayed/stale controlled echoes cannot overwrite internalHSLA mid-drag.
+	const isPickerInteractingRef = useRef( false );
+
 	// Sync internalHSLA when the color prop changes externally (e.g.
 	// parent passes a new color that wasn't produced by our onChange).
 	useEffect( () => {
-		const incomingHex = safeColordColor.toHex();
+		if ( isPickerInteractingRef.current ) {
+			return;
+		}
 
-		// If this hex matches what we last produced, it's our own
-		// update arriving back — skip the sync to avoid overwriting
-		// internalHSLA with lossy round-tripped values.
-		if ( incomingHex === lastProducedHexRef.current ) {
+		// Compare by color equality, not hex string — rgb()/rgba()
+		// round-trips can differ in string form for the same color.
+		if ( safeColordColor.isEqual( lastProducedHexRef.current ) ) {
 			return;
 		}
 
 		// Genuinely external change — sync internalHSLA.
-		lastProducedHexRef.current = incomingHex;
+		lastProducedHexRef.current = safeColordColor.toHex();
 		const externalHSLA = safeColordColor.toHsl();
 		setInternalHSLA( ( prev ) => mergeHSLA( externalHSLA, prev ) );
 	}, [ safeColordColor ] );
 
-	// Handler for HSL-aware components (Picker, HSL inputs) that
-	// provide raw HSLA values without information loss.
-	// Uses direct setColor (not debounced) to prevent race conditions
-	// where a stale debounced hex would overwrite newer internalHSLA.
-	// This is safe performance-wise because react-colorful internally
-	// throttles its onChange callbacks using requestAnimationFrame.
-
+	// Handler for HSL inputs (and the HSVA picker after it converts to HSLA).
+	// Apply the user's HSLA, then notify the parent only when the color
+	// actually changes. setColor must not run inside setInternalHSLA
+	// (state updaters must be pure). Uses direct setColor (not debounced)
+	// to avoid races with hex/RGB's debouncedSetColor.
 	const handleHSLAChange = useCallback(
 		( nextHSLA: HslaColor ) => {
-			// No mergeHSLA here — this handler receives the user's explicit
-			// choice from the picker or HSL inputs, with no lossy conversion.
 			setInternalHSLA( nextHSLA );
 			const previousHex = lastProducedHexRef.current;
 			const nextHex = colord( nextHSLA ).toHex();
-			// Only notify parent when the hex actually changes. This
-			// avoids firing onChange for H/S changes on achromatic
-			// colors (e.g. adjusting hue on pure white).
-			if ( nextHex !== previousHex ) {
+			if ( ! colord( nextHex ).isEqual( previousHex ) ) {
 				lastProducedHexRef.current = nextHex;
 				setColor( nextHex );
 			}
@@ -213,6 +211,12 @@ const UnconnectedColorPicker = (
 				onChange={ handleHSLAChange }
 				hsla={ internalHSLA }
 				enableAlpha={ enableAlpha }
+				onInteractionStart={ () => {
+					isPickerInteractingRef.current = true;
+				} }
+				onInteractionEnd={ () => {
+					isPickerInteractingRef.current = false;
+				} }
 			/>
 			<AuxiliaryColorArtefactWrapper>
 				<AuxiliaryColorArtefactHStackHeader justify="space-between">

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -1,42 +1,165 @@
 /**
  * External dependencies
  */
-import { HslColorPicker, HslaColorPicker } from 'react-colorful';
+import type { PointerEvent } from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { HsvColorPicker, HsvaColorPicker } from 'react-colorful';
+import { colord } from 'colord';
+import type { HslaColor, HsvaColor } from 'react-colorful';
 
 /**
  * Internal dependencies
  */
 import type { PickerProps } from './types';
 
-// Pointer capture fortifies drag gestures so that they continue to work
-// while dragging outside the component over objects like iframes. If a
-// newer version of react-colorful begins to employ pointer capture this
-// will be redundant and should be removed.
-const pointerCaptureProps = {
-	onPointerDown( { currentTarget, pointerId }: React.PointerEvent ) {
-		currentTarget.setPointerCapture( pointerId );
-	},
-	onPointerUp( { currentTarget, pointerId }: React.PointerEvent ) {
-		currentTarget.releasePointerCapture( pointerId );
-	},
-};
+function toHsva( hsla: PickerProps[ 'hsla' ] ): HsvaColor {
+	return {
+		...colord( hsla ).toHsv(),
+		// HSL and HSV share the hue angle. Color conversion collapses achromatic
+		// hue to 0, but HSLA retains the user's latent hue.
+		h: hsla.h,
+		a: hsla.a,
+	};
+}
 
-export const Picker = ( { hsla, enableAlpha, onChange }: PickerProps ) => {
+function isSameHsla( a: HslaColor, b: HslaColor ): boolean {
+	return a.h === b.h && a.s === b.s && a.l === b.l && a.a === b.a;
+}
+
+/**
+ * Convert parent HSLA into HSVA for prop sync.
+ *
+ * At black, RGB round-trips collapse saturation to 0. Preserve the native
+ * HSVA saturation coordinate unless the HSL saturation channel itself
+ * changed (sibling hue/alpha edits must not snap the pointer).
+ *
+ * At white, only `v: 100, s: 0` is visually white — preserving a prior
+ * chromatic saturation would leave the pointer at the top-right and make
+ * the first keyboard step jump from white to a saturated color.
+ */
+function toHsvaFromHsla(
+	hsla: HslaColor,
+	prevHsva: HsvaColor,
+	prevHsla: HslaColor | null
+): HsvaColor {
+	const converted = toHsva( hsla );
+
+	// White and chromatic colors use the converted value as-is.
+	if ( hsla.l !== 0 ) {
+		return converted;
+	}
+
+	const saturationChanged = prevHsla !== null && prevHsla.s !== hsla.s;
+
+	return {
+		h: hsla.h,
+		s: saturationChanged ? hsla.s : prevHsva.s,
+		v: 0,
+		a: hsla.a,
+	};
+}
+
+/**
+ * Visual color surface.
+ *
+ * Uses HSVA (react-colorful's native model) and keeps that value in local
+ * state so HSLA↔hex round-trips cannot move the pointer
+ * Parent ColorPicker still speaks HSLA for
+ * inputs and controlled value sync; conversion happens only at the boundary.
+ *
+ * Prop sync from parent HSLA is suppressed for:
+ * - pointer/touch drags (interaction flag), and
+ * - any picker-originated update including keyboard (HSLA origin token).
+ *
+ * Achromatic HSL sibling edits (hue/alpha while at black) preserve native
+ * HSVA saturation unless saturation itself changed. White always syncs to
+ * the converted `s: 0` visual coordinate.
+ */
+export const Picker = ( {
+	hsla,
+	enableAlpha,
+	onChange,
+	onInteractionStart,
+	onInteractionEnd,
+}: PickerProps ) => {
+	const [ hsva, setHsva ] = useState< HsvaColor >( () => toHsva( hsla ) );
+	// Last HSLA emitted by this picker — skip echoing it back into HSVA.
+	const pickerOriginHslaRef = useRef< HslaColor | null >( null );
+	// Previous parent HSLA — detect which channel changed on achromatic sync.
+	const prevHslaRef = useRef< HslaColor >( hsla );
+	// Pointer/touch drag: never sync from HSLA mid-gesture (origin match alone
+	// can fail across rapid frames when parent gradient state re-renders).
+	const isPointerInteractingRef = useRef( false );
+
+	useEffect( () => {
+		if ( isPointerInteractingRef.current ) {
+			// Keep prevHsla in lockstep with parent updates during the gesture
+			// so a post-drag HSL sibling edit is not compared against pre-drag
+			// HSLA and mistaken for a saturation change.
+			prevHslaRef.current = hsla;
+			return;
+		}
+		if (
+			pickerOriginHslaRef.current &&
+			isSameHsla( pickerOriginHslaRef.current, hsla )
+		) {
+			prevHslaRef.current = hsla;
+			return;
+		}
+		pickerOriginHslaRef.current = null;
+		setHsva( ( prev ) =>
+			toHsvaFromHsla( hsla, prev, prevHslaRef.current )
+		);
+		prevHslaRef.current = hsla;
+	}, [ hsla ] );
+
+	// Inline handlers so refs are not passed into a helper during render
+	// (react-hooks/refs). Pointer capture also keeps drag working over iframes.
+	const pointerCaptureProps = {
+		onPointerDown( { currentTarget, pointerId }: PointerEvent ) {
+			isPointerInteractingRef.current = true;
+			onInteractionStart?.();
+			currentTarget.setPointerCapture( pointerId );
+		},
+		onPointerUp( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			isPointerInteractingRef.current = false;
+			onInteractionEnd?.();
+		},
+		onPointerCancel( { currentTarget, pointerId }: PointerEvent ) {
+			currentTarget.releasePointerCapture( pointerId );
+			isPointerInteractingRef.current = false;
+			onInteractionEnd?.();
+		},
+	};
+
+	const handleChange = ( next: HsvaColor ) => {
+		setHsva( next );
+		const nextHsla: HslaColor = { ...colord( next ).toHsl(), a: next.a };
+		pickerOriginHslaRef.current = nextHsla;
+		onChange( nextHsla );
+	};
+
 	if ( enableAlpha ) {
 		return (
-			<HslaColorPicker
-				color={ hsla }
-				onChange={ onChange }
+			<HsvaColorPicker
+				color={ hsva }
+				onChange={ handleChange }
 				{ ...pointerCaptureProps }
 			/>
 		);
 	}
 
+	// HsvColorPicker's equality checks enumerate own keys — never pass `a`,
+	// or every parent re-render looks like an external color change and the
+	// pointer jitters while dragging.
+	const hsv = { h: hsva.h, s: hsva.s, v: hsva.v };
+
 	return (
-		<HslColorPicker
-			color={ hsla }
-			onChange={ ( nextColor ) => {
-				onChange( { ...nextColor, a: hsla.a } );
+		<HsvColorPicker
+			color={ hsv }
+			onChange={ ( next ) => {
+				handleChange( { ...next, a: hsva.a } );
 			} }
 			{ ...pointerCaptureProps }
 		/>

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -378,6 +378,102 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
 		} );
 
+		it.each( [
+			[ 'black', 0 ],
+			[ 'white', 100 ],
+		] )(
+			'should allow saturation 50→0 at %s without firing onChange',
+			async ( _label, lightness ) => {
+				const onChange = jest.fn();
+
+				render(
+					<ControlledColorPicker
+						onChange={ onChange }
+						enableAlpha={ false }
+						initialColor="#000000"
+					/>
+				);
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				await userEvent.setup().selectOptions( formatSelector, 'hsl' );
+
+				const hueSlider = screen
+					.getAllByRole( 'slider', { name: 'Hue' } )
+					.at( -1 )!;
+				const saturationSlider = screen.getByRole( 'slider', {
+					name: 'Saturation',
+				} );
+				const lightnessSlider = screen.getByRole( 'slider', {
+					name: 'Lightness',
+				} );
+				const saturationNumberInput = screen.getByRole( 'spinbutton', {
+					name: 'Saturation',
+				} );
+
+				// Build hsl(200, 50%, lightness%) via HSL controls.
+				fireEvent.change( hueSlider, { target: { value: 200 } } );
+				fireEvent.change( saturationSlider, { target: { value: 50 } } );
+				fireEvent.change( lightnessSlider, {
+					target: { value: lightness },
+				} );
+				await waitFor( () =>
+					expect( lightnessSlider ).toHaveValue( String( lightness ) )
+				);
+
+				expect( saturationSlider ).toHaveValue( '50' );
+				expect( saturationNumberInput ).toHaveValue( 50 );
+				onChange.mockClear();
+
+				fireEvent.change( saturationSlider, { target: { value: 0 } } );
+
+				expect( saturationSlider ).toHaveValue( '0' );
+				expect( saturationNumberInput ).toHaveValue( 0 );
+				expect( onChange ).not.toHaveBeenCalled();
+			}
+		);
+
+		it( 'should fire onChange once per real color change in controlled mode', async () => {
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#2ad5d5" // hsl(180, 67%, 50%)
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await userEvent.setup().selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+
+			fireEvent.change( lightnessSlider, { target: { value: 40 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '40' )
+			);
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+			fireEvent.change( lightnessSlider, { target: { value: 30 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '30' )
+			);
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			onChange.mockClear();
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 90 } } );
+			expect( onChange ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should reset saturation to 0 when a mid-gray is entered via hex input', async () => {
 			const user = userEvent.setup();
 
@@ -497,6 +593,412 @@ describe( 'ColorPicker', () => {
 
 				expect( onChange ).toHaveBeenCalledTimes( 3 );
 				expect( onChange ).toHaveBeenLastCalledWith( expected );
+			} );
+		} );
+	} );
+
+	describe( 'visual picker', () => {
+		const mockInteractiveBounds = ( interactive: HTMLElement ) => {
+			interactive.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100,
+					right: 100,
+					bottom: 100,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+		};
+
+		it( 'preserves saturation when keyboard-navigating to black in controlled mode', () => {
+			const onChange = jest.fn();
+
+			// Saturated red with mid brightness — HSVA s stays high at black.
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			// Pointer is a presentational sibling; no accessible role.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toBeTruthy();
+
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+
+			// react-colorful reads which/keyCode (37–40), not event.key.
+			// From v≈80, 5% steps need at least 16 ArrowDown presses to reach black.
+			colorSlider.focus();
+			for ( let i = 0; i < 20; i++ ) {
+				fireEvent.keyDown( colorSlider, {
+					key: 'ArrowDown',
+					keyCode: 40,
+					which: 40,
+				} );
+			}
+
+			expect( pointer ).toHaveStyle( { top: '100%', left: leftBefore } );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+		} );
+
+		it( 'preserves saturation when pointer selects black in controlled mode', () => {
+			const onChange = jest.fn();
+
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const interactive = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( interactive );
+
+			// Pointer is a presentational sibling; no accessible role.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+
+			// Click the bottom of the saturation surface (v = 0) at ~80% saturation.
+			fireEvent.mouseDown( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			// Lossy HSVA→HSLA→HSVA sync would snap left to 0%.
+			expect( pointer ).not.toHaveStyle( { left: '0%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+		} );
+
+		it( 'preserves saturation after a full pointer drag to black then HSL hue edit', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const interactive = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( interactive );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+
+			// Full pointer lifecycle so isPointerInteractingRef is exercised
+			// and prevHslaRef stays in sync across mid-gesture parent updates.
+			fireEvent.pointerDown( interactive, {
+				pointerId: 1,
+				buttons: 1,
+				pageX: 80,
+				pageY: 50,
+				clientX: 80,
+				clientY: 50,
+			} );
+			fireEvent.mouseDown( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 50,
+				clientX: 80,
+				clientY: 50,
+			} );
+			fireEvent.mouseMove( interactive, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+			fireEvent.pointerUp( interactive, {
+				pointerId: 1,
+				buttons: 0,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+			fireEvent.mouseUp( interactive, {
+				buttons: 0,
+				pageX: 80,
+				pageY: 100,
+				clientX: 80,
+				clientY: 100,
+			} );
+
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+			expect( onChange ).toHaveBeenLastCalledWith( '#000000' );
+			const leftAfterDrag = pointer.style.left;
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			// Stale prevHslaRef would mistake the hue edit for a saturation
+			// change and snap the pointer to left: 0%.
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftAfterDrag,
+			} );
+		} );
+
+		it( 'places the pointer at s:0 when HSL lightness is set to white', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			const { container } = render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '100' )
+			);
+			expect( onChange ).toHaveBeenLastCalledWith( '#ffffff' );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			// Only v:100,s:0 is white; a preserved chromatic s leaves the
+			// pointer at top-right and makes the next key step jump to red.
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			colorSlider.focus();
+			fireEvent.keyDown( colorSlider, {
+				key: 'ArrowDown',
+				keyCode: 40,
+				which: 40,
+			} );
+
+			expect( onChange ).not.toHaveBeenLastCalledWith( '#f50000' );
+			expect( onChange ).not.toHaveBeenLastCalledWith( '#cc0000' );
+		} );
+
+		it( 'preserves visual saturation when HSL hue is edited at black', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftBefore,
+			} );
+		} );
+
+		it( 'keeps the white visual coordinate at s:0 when HSL hue is edited', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+			await waitFor( () =>
+				expect( lightnessSlider ).toHaveValue( '100' )
+			);
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			expect( pointer ).toHaveStyle( { top: '0%', left: '0%' } );
+		} );
+
+		it( 'uses the HSL hue when leaving white through the visual surface', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			await user.selectOptions( screen.getByRole( 'combobox' ), 'hsl' );
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 100 } } );
+
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( colorSlider );
+			onChange.mockClear();
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 50,
+				pageY: 0,
+				clientX: 50,
+				clientY: 0,
+			} );
+
+			expect( onChange ).toHaveBeenLastCalledWith( '#80d4ff' );
+		} );
+
+		it( 'uses the HSL hue when leaving a mid-gray through the visual surface', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha={ false }
+					initialColor="#808080"
+				/>
+			);
+
+			await user.selectOptions( screen.getByRole( 'combobox' ), 'hsl' );
+			const hueSlider = screen
+				.getAllByRole( 'slider', { name: 'Hue' } )
+				.at( -1 )!;
+			fireEvent.change( hueSlider, { target: { value: 200 } } );
+			await waitFor( () => expect( hueSlider ).toHaveValue( '200' ) );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			mockInteractiveBounds( colorSlider );
+			onChange.mockClear();
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 50,
+				pageY: 50,
+				clientX: 50,
+				clientY: 50,
+			} );
+
+			expect( onChange ).toHaveBeenLastCalledWith( '#416c81' );
+		} );
+
+		it( 'updates visual saturation when HSL saturation is edited at black', async () => {
+			const user = userEvent.setup();
+
+			const { container } = render(
+				<ControlledColorPicker
+					enableAlpha={ false }
+					initialColor="#cc0000"
+				/>
+			);
+
+			const formatSelector = screen.getByRole( 'combobox' );
+			await user.selectOptions( formatSelector, 'hsl' );
+
+			const lightnessSlider = screen.getByRole( 'slider', {
+				name: 'Lightness',
+			} );
+			fireEvent.change( lightnessSlider, { target: { value: 0 } } );
+			await waitFor( () => expect( lightnessSlider ).toHaveValue( '0' ) );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const pointer = container.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toHaveStyle( { top: '100%' } );
+			expect( parseFloat( pointer.style.left ) ).toBeGreaterThan( 50 );
+
+			const saturationSlider = screen.getByRole( 'slider', {
+				name: 'Saturation',
+			} );
+			fireEvent.change( saturationSlider, {
+				target: { value: 25 },
+			} );
+			await waitFor( () =>
+				expect( saturationSlider ).toHaveValue( '25' )
+			);
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: '25%',
 			} );
 		} );
 	} );

--- a/packages/components/src/color-picker/types.ts
+++ b/packages/components/src/color-picker/types.ts
@@ -59,6 +59,8 @@ export interface PickerProps {
 	hsla: HslaColor;
 	enableAlpha: boolean;
 	onChange: ( nextHsla: HslaColor ) => void;
+	onInteractionStart?: () => void;
+	onInteractionEnd?: () => void;
 }
 
 export interface ColorInputProps {

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -1,15 +1,125 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import CustomGradientPicker from '../';
 
+function ControlledCustomGradientPicker( {
+	initialValue = 'linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)',
+}: {
+	initialValue?: string;
+} ) {
+	const [ value, setValue ] = useState( initialValue );
+	return <CustomGradientPicker value={ value } onChange={ setValue } />;
+}
+
 describe( 'CustomGradientPicker', () => {
+	describe( 'new gradient stop color picker', () => {
+		it( 'preserves visual saturation when setting a new stop color through black', async () => {
+			const { container } = render( <ControlledCustomGradientPicker /> );
+
+			// Presentational gradient bar markup; no accessible roles.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const markers = container.querySelector(
+				'.components-custom-gradient-picker__markers-container'
+			) as HTMLElement;
+			markers.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					x: 0,
+					width: 200,
+					top: 0,
+					height: 20,
+					right: 200,
+					bottom: 20,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const bar = container.querySelector(
+				'.components-custom-gradient-picker__gradient-bar'
+			) as HTMLElement;
+			// Hover mid-bar so the insert-point control appears (away from 0%/100%).
+			fireEvent.mouseMove( bar, { clientX: 100 } );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const insertButton = container.querySelector(
+				'.components-custom-gradient-picker__insert-point-dropdown'
+			) as HTMLElement;
+			expect( insertButton ).toBeTruthy();
+			fireEvent.click( insertButton );
+
+			const colorSlider = screen.getByRole( 'slider', { name: 'Color' } );
+			colorSlider.getBoundingClientRect = () =>
+				( {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100,
+					right: 100,
+					bottom: 100,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect;
+
+			// Choose a saturated mid-brightness color — creates the new stop and
+			// exercises parent gradient updates while picking.
+			fireEvent.mouseDown( colorSlider, {
+				buttons: 1,
+				pageX: 80,
+				pageY: 20,
+				clientX: 80,
+				clientY: 20,
+			} );
+
+			// ColorPicker content is portaled; pointer has no accessible role.
+			// eslint-disable-next-line testing-library/no-node-access
+			const pointer = document.querySelector(
+				'.react-colorful__saturation-pointer'
+			) as HTMLElement;
+			expect( pointer ).toBeTruthy();
+			const leftBefore = pointer.style.left;
+			expect( parseFloat( leftBefore ) ).toBeGreaterThan( 50 );
+
+			// Keyboard to black — must not reset saturation via HSVA↔HSLA echo
+			// while the gradient parent keeps updating (#80110 / #80205).
+			colorSlider.focus();
+			for ( let i = 0; i < 20; i++ ) {
+				fireEvent.keyDown( colorSlider, {
+					key: 'ArrowDown',
+					keyCode: 40,
+					which: 40,
+				} );
+			}
+
+			expect( pointer ).toHaveStyle( {
+				top: '100%',
+				left: leftBefore,
+			} );
+
+			// Close the portaled popover so later tests are not affected by
+			// asynchronous Popover position updates.
+			fireEvent.click( insertButton );
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'slider', { name: 'Color' } )
+				).not.toBeInTheDocument();
+			} );
+		} );
+	} );
+
 	describe( 'GradientTypePicker angle persistence', () => {
 		it( 'should restore the previous linear angle when switching from radial back to linear', async () => {
 			const user = userEvent.setup();


### PR DESCRIPTION
Backport of #80205 to WordPress 7.1.

## What?

Cherry-picks the ColorPicker cursor-shaking fix from #80205 onto `wp/7.1`.

## Why?

The automatic cherry-pick failed because the Components changelog conflicted with the release branch.

## How?

Applies the merged source commit unchanged and places its changelog entry in the `wp/7.1` `Unreleased` section.

## Testing Instructions

1. Create or edit a post.
2. Add a block and apply a gradient background.
3. Add a color stop.
4. Drag the color cursor around the visual picker.
5. Confirm that the cursor moves smoothly without shaking.
6. Change the picker to HSL, select an achromatic color, change its hue, then move through the visual surface.
7. Confirm that the selected hue is preserved.

Automated checks:

- `npm run test:unit -- packages/components/src/color-picker/test/index.tsx packages/components/src/custom-gradient-picker/test/index.tsx --runInBand`
- `npm run lint:js -- packages/components/src/color-picker/component.tsx packages/components/src/color-picker/picker.tsx packages/components/src/color-picker/test/index.tsx packages/components/src/color-picker/types.ts packages/components/src/custom-gradient-picker/test/index.tsx`
- `node_modules/.bin/tsc --build packages/components/tsconfig.json`
- `npm run test:unit:update`
- `npm run build -- --skip-types`
- `npm run other:check-local-changes`

### Testing Instructions for Keyboard

Repeat the HSL/visual-surface checks using Tab to reach the controls and arrow keys to adjust the sliders. Confirm that focus remains visible and the Color slider keeps the expected hue and position.

## Use of AI Tools

Codex was used to perform and verify the cherry-pick, resolve the changelog conflict, and draft this PR description.