### PR TITLE
[7.1 Backport] -- Fix upload snackbar double-counting a single HEIC upload in Safari

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
 
+### Bug Fixes
+
+-   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
+
 ## 14.51.0 (2026-07-14)
 
 ### New Features

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -488,6 +488,7 @@ _Parameters_
 -   _$0.onFileChange_ `Function`: Function called each time a file or a temporary representation of the file is available.
 -   _$0.onSuccess_ `Function`: Function called after the final representation of the file is available.
 -   _$0.multiple_ `boolean`: Whether to allow multiple files to be uploaded.
+-   _$0.isTransportOnly_ `boolean`: Whether the caller owns the upload lifecycle UX (progress tracking and save locking) and uses this function only as its server transport. Set by the `@wordpress/upload-media` queue, which counts its own items for the progress snackbar and locks saving via `useUploadSaveLock`.
 
 ### MediaUploadCheck
 

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -9,7 +9,6 @@ import { v4 as uuid } from 'uuid';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { uploadMedia } from '@wordpress/media-utils';
-import { isClientSideMediaSupported } from '@wordpress/upload-media';
 
 /**
  * Internal dependencies
@@ -35,6 +34,10 @@ const noop = () => {};
  * @param {Function} $0.onFileChange      Function called each time a file or a temporary representation of the file is available.
  * @param {Function} $0.onSuccess         Function called after the final representation of the file is available.
  * @param {boolean}  $0.multiple          Whether to allow multiple files to be uploaded.
+ * @param {boolean}  $0.isTransportOnly   Whether the caller owns the upload lifecycle UX (progress tracking and
+ *                                        save locking) and uses this function only as its server transport. Set
+ *                                        by the `@wordpress/upload-media` queue, which counts its own items for
+ *                                        the progress snackbar and locks saving via `useUploadSaveLock`.
  */
 export default function mediaUpload( {
 	additionalData = {},
@@ -45,6 +48,7 @@ export default function mediaUpload( {
 	onFileChange,
 	onSuccess,
 	multiple = true,
+	isTransportOnly = false,
 } ) {
 	const { receiveEntityRecords } = dispatch( coreDataStore );
 	const { getCurrentPost, getEditorSettings } = select( editorStore );
@@ -56,8 +60,6 @@ export default function mediaUpload( {
 	} = dispatch( editorStore );
 
 	const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes;
-	const isClientSideMediaActive =
-		window.__clientSideMediaProcessing && isClientSideMediaSupported();
 	const lockKey = `image-upload-${ uuid() }`;
 	maxUploadFileSize =
 		maxUploadFileSize || getEditorSettings().maxUploadFileSize;
@@ -72,21 +74,21 @@ export default function mediaUpload( {
 		unlockPostAutosaving( lockKey );
 	};
 
-	// Lock saving immediately when the upload starts.
-	// When client-side media processing is enabled, save locking
-	// is handled by useUploadSaveLock in the editor provider.
-	if ( ! isClientSideMediaActive ) {
+	// Lock saving immediately when the upload starts. Skipped for transport
+	// calls from the `@wordpress/upload-media` queue, whose items already
+	// lock saving via useUploadSaveLock in the editor provider.
+	if ( ! isTransportOnly ) {
 		lockPostSaving( lockKey );
 		lockPostAutosaving( lockKey );
 	}
 
 	const postData = currentPostId ? { post: currentPostId } : {};
 
-	// Track this batch for the upload progress snackbar. Only applies to the
-	// non-CSM path — when CSM is enabled, the block-editor provider intercepts
-	// mediaUpload and dispatches to the upload-media store, so this wrapper is
-	// not called.
-	if ( ! isClientSideMediaActive ) {
+	// Track this batch for the upload progress snackbar. Skipped for
+	// transport calls from the `@wordpress/upload-media` queue — its items
+	// are already counted by the snackbar, so registering them here would
+	// double-count them (see gutenberg#80369).
+	if ( ! isTransportOnly ) {
 		const trackingFiles = Array.from( filesList ).map(
 			( f ) => f?.name || ''
 		);
@@ -116,15 +118,12 @@ export default function mediaUpload( {
 			}
 
 			// Unlock saving once all files have been uploaded (all have IDs).
-			if (
-				! isClientSideMediaActive &&
-				entityFiles.length === files.length
-			) {
+			if ( ! isTransportOnly && entityFiles.length === files.length ) {
 				clearSaveLock();
 			}
 
 			// Advance the snackbar tracker for newly-completed files.
-			if ( ! isClientSideMediaActive ) {
+			if ( ! isTransportOnly ) {
 				const completedCount = entityFiles.length;
 				if ( completedCount > lastCompletedCount ) {
 					trackAdvance( completedCount - lastCompletedCount );
@@ -139,7 +138,7 @@ export default function mediaUpload( {
 		},
 		maxUploadFileSize,
 		onError: ( { message } ) => {
-			if ( ! isClientSideMediaActive ) {
+			if ( ! isTransportOnly ) {
 				clearSaveLock();
 				// Failed files still count as "done" for the snackbar.
 				trackAdvance( 1 );

--- a/packages/editor/src/utils/test/media-upload.js
+++ b/packages/editor/src/utils/test/media-upload.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import mediaUpload from '../media-upload';
+import {
+	getState,
+	reset,
+} from '../../components/upload-progress-snackbar/tracker';
+
+jest.mock( '@wordpress/media-utils', () => ( {
+	uploadMedia: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+} ) );
+
+jest.mock( '../../store', () => ( {
+	store: { name: 'core/editor' },
+} ) );
+
+const mockLockPostSaving = jest.fn();
+const mockLockPostAutosaving = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	select: jest.fn( () => ( {
+		getCurrentPost: () => ( { id: 1 } ),
+		getEditorSettings: () => ( {
+			allowedMimeTypes: null,
+			maxUploadFileSize: 10 * 1024 * 1024,
+		} ),
+	} ) ),
+	dispatch: jest.fn( () => ( {
+		receiveEntityRecords: jest.fn(),
+		lockPostSaving: mockLockPostSaving,
+		unlockPostSaving: jest.fn(),
+		lockPostAutosaving: mockLockPostAutosaving,
+		unlockPostAutosaving: jest.fn(),
+	} ) ),
+} ) );
+
+describe( 'mediaUpload', () => {
+	beforeEach( () => {
+		reset();
+		jest.clearAllMocks();
+	} );
+
+	it( 'registers files with the upload progress tracker and locks saving', () => {
+		const file = new File( [ 'content' ], 'photo.jpg', {
+			type: 'image/jpeg',
+		} );
+
+		mediaUpload( { filesList: [ file ] } );
+
+		expect( getState() ).toEqual( {
+			total: 1,
+			completed: 0,
+			pending: [ 'photo.jpg' ],
+		} );
+		expect( mockLockPostSaving ).toHaveBeenCalled();
+		expect( mockLockPostAutosaving ).toHaveBeenCalled();
+	} );
+
+	it( 'skips tracking and save locking for transport-only calls', () => {
+		// The upload-media queue calls this wrapper as its server transport;
+		// it already counts its own queue items for the progress snackbar
+		// (registering the same file here would double-count it, see
+		// gutenberg#80369) and locks saving via useUploadSaveLock.
+		const file = new File( [ 'content' ], 'photo.jpg', {
+			type: 'image/jpeg',
+		} );
+
+		mediaUpload( { filesList: [ file ], isTransportOnly: true } );
+
+		expect( getState() ).toBeNull();
+		expect( mockLockPostSaving ).not.toHaveBeenCalled();
+		expect( mockLockPostAutosaving ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/upload-media/CHANGELOG.md
+++ b/packages/upload-media/CHANGELOG.md
@@ -4,17 +4,21 @@
 
 ### Breaking Changes
 
-- `vipsResizeImage`, `vipsCompressImage`, and `vipsConvertImageFormat` now accept their optional parameters (`smartCrop`, `addSuffix`, `signal`, `scaledSuffix`, `quality`, `interlaced`, `stripMeta`, `maxBitdepth`) as a single trailing `options` object instead of positional arguments ([#80328](https://github.com/WordPress/gutenberg/issues/80328)).
+-   `vipsResizeImage`, `vipsCompressImage`, and `vipsConvertImageFormat` now accept their optional parameters (`smartCrop`, `addSuffix`, `signal`, `scaledSuffix`, `quality`, `interlaced`, `stripMeta`, `maxBitdepth`) as a single trailing `options` object instead of positional arguments ([#80328](https://github.com/WordPress/gutenberg/issues/80328)).
 
 ### Enhancements
 
 - Honor the `image_strip_meta` and `image_max_bit_depth` filters for client-side processed images via the new `imageStripMeta` and `imageMaxBitDepth` settings, carried in the REST API root index ([#80216](https://github.com/WordPress/gutenberg/issues/80216)).
 
+### Bug Fixes
+
+-   Pass `isTransportOnly: true` to the `mediaUpload` setting when the queue uploads a file, so consumers that manage the upload lifecycle themselves (progress tracking, save locking) don't handle the same file twice ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
+
 ## 0.36.0 (2026-07-14)
 
 ### Enhancement
 
-- Honor the `wp_editor_set_quality` filter for client-side processed images. Sub-size resizing and transcoding now use the size-aware quality reported by the new `image_quality` field on the attachment upload response, instead of a hardcoded default.
+-   Honor the `wp_editor_set_quality` filter for client-side processed images. Sub-size resizing and transcoding now use the size-aware quality reported by the new `image_quality` field on the attachment upload response, instead of a hardcoded default.
 
 ### Enhancements
 

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1034,6 +1034,11 @@ export function uploadItem( id: QueueItemId ) {
 			filesList: [ item.file ],
 			additionalData: item.additionalData,
 			signal: item.abortController?.signal,
+			// The queue's own items drive upload progress UI and save
+			// locking; without this, consumers that track uploads themselves
+			// (e.g. the editor's progress snackbar) would count this file a
+			// second time.
+			isTransportOnly: true,
 			onFileChange: ( [ attachment ] ) => {
 				if ( attachment && ! isBlobURL( attachment.url ) ) {
 					finishUpload( attachment );

--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -20,6 +20,7 @@ import {
 	transcodeGifItem,
 	detectUltraHdr,
 	removeItem,
+	uploadItem,
 } from '../private-actions';
 import { OperationType, Type } from '../types';
 import {
@@ -1410,6 +1411,38 @@ describe( 'private actions', () => {
 			} finally {
 				warnSpy.mockRestore();
 			}
+		} );
+	} );
+
+	describe( 'uploadItem', () => {
+		it( 'flags the transport call so consumers skip their own lifecycle handling', async () => {
+			// The queue already counts its items for progress UI; the
+			// `mediaUpload` callback it delegates the server upload to must
+			// not count the same file again (see gutenberg#80369).
+			const mediaUpload = jest.fn();
+			const file = new File( [ 'content' ], 'photo.jpg', {
+				type: 'image/jpeg',
+			} );
+			const item = { id: 'item-1', file, additionalData: {} };
+
+			const dispatch = jest.fn();
+			dispatch.finishOperation = jest.fn();
+			dispatch.cancelItem = jest.fn();
+
+			await uploadItem( 'item-1' )( {
+				select: {
+					getItem: () => item,
+					getSettings: () => ( { mediaUpload } ),
+				},
+				dispatch,
+			} );
+
+			expect( mediaUpload ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					filesList: [ file ],
+					isTransportOnly: true,
+				} )
+			);
 		} );
 	} );
 

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -174,6 +174,9 @@ interface UploadMediaArgs {
 	wpAllowedMimeTypes?: Record< string, string > | null;
 	// Abort signal.
 	signal?: AbortSignal;
+	// Whether the caller owns the upload lifecycle UX (progress tracking,
+	// save locking) and uses the handler only as its server transport.
+	isTransportOnly?: boolean;
 }
 
 /**

--- a/test/e2e/specs/editor/various/heic-upload-progress-snackbar.spec.js
+++ b/test/e2e/specs/editor/various/heic-upload-progress-snackbar.spec.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Upload progress snackbar (HEIC-only canvas mode) (@webkit)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Disable full client-side media processing while leaving the
+		// HEIC canvas-conversion mode active (`window.__heicUploadSupport`
+		// is set regardless). This mirrors Safari, where full client-side
+		// processing is unsupported but HEIC files are still converted to
+		// JPEG via createImageBitmap + OffscreenCanvas before upload.
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test( 'counts a single HEIC upload as one file', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+
+		// A JPEG payload with an `image/heic` MIME type: the HEIC-only mode
+		// routes files by type, and `createImageBitmap()` decodes by content,
+		// so this exercises the exact HEIC conversion pipeline in Chromium,
+		// which cannot decode real HEIC data.
+		const buffer = fs.readFileSync(
+			path.join(
+				__dirname,
+				'..',
+				'..',
+				'..',
+				'assets',
+				'1024x768_e2e_test_image_size.jpeg'
+			)
+		);
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await imageBlock
+			.locator( 'data-testid=form-file-upload-input' )
+			.setInputFiles( {
+				name: 'IMG_1982.heic',
+				mimeType: 'image/heic',
+				buffer,
+			} );
+
+		const snackbarList = page.locator( '.components-snackbar-list' );
+
+		// A single file must use the single-file message throughout. The
+		// double-counted state ("Uploading 1 of 2 — …") appears mid-upload,
+		// so race it against the completion snackbar: completion has to win
+		// (regression: gutenberg#80369).
+		const multiFileText = snackbarList.getByText( /Uploading \d+ of \d+/ );
+		const completeText = snackbarList.getByText( 'Upload complete' );
+		const outcome = await Promise.race( [
+			multiFileText
+				.waitFor( { state: 'visible', timeout: 60_000 } )
+				.then( () => 'multi-file count shown' )
+				.catch( () => 'multi-file text never appeared' ),
+			completeText
+				.waitFor( { state: 'visible', timeout: 60_000 } )
+				.then( () => 'upload complete' )
+				.catch( () => 'completion snackbar never appeared' ),
+		] );
+		expect( outcome ).toBe( 'upload complete' );
+
+		// The HEIC file was converted client-side and uploaded as a JPEG.
+		const image = imageBlock.getByRole( 'img', {
+			name: 'This image has an empty alt attribute',
+		} );
+		await expect( image ).toHaveAttribute( 'src', /IMG_1982.*\.jpg/, {
+			timeout: 30_000,
+		} );
+	} );
+} );


### PR DESCRIPTION
Backports #80371 (merged as 88074b1575999a372f28f6c83c9d9d0144720751) to the `wp/7.1` branch. The automated cherry-pick failed with a conflict; see https://github.com/WordPress/gutenberg/pull/80371#issuecomment-5005710538.

## Why

Fixes #80369 for WordPress 7.1: in Safari, uploading a single HEIC image showed "Uploading 2 media items" and made the snackbar math wrong for the rest of the session. The upload queue passes the file to the `mediaUpload` setting for transport, and the editor's progress tracking counted that hand-off as a second, independent upload. The queue now passes `isTransportOnly: true` on that call so lifecycle-managing consumers (progress tracking, save locking) don't handle the same file twice.

## Conflict resolution

The only conflict was in `packages/upload-media/CHANGELOG.md`: trunk's `Unreleased` section contains the #80376 entries (GIF conversion guardrails and the `cancelItem` change), which are not on wp/7.1 - they belong to the separate open backport #80420. Resolved by keeping the wp/7.1 side and adding only this PR's Bug Fixes entry.

## Verification

Every source file in this PR is byte-identical to trunk's state after #80371 merged - `git diff 88074b15759 <backport-tip>` is empty for the `editor` package files and the e2e spec, and the remaining `upload-media` differences are exactly the #80376 pieces that wp/7.1 does not have yet. The new `editor` media-upload unit tests and the `upload-media` store tests pass (52 tests).

[<img src="https://img.shields.io/badge/▶-Test%20in%20WordPress%20Playground-blue?style=for-the-badge" alt="Test in WordPress Playground">](https://playground.wordpress.net/gutenberg.html?pr=80436)
