### PR TITLE
Replaces the `title` attributes used by revision inline diff annotations with `aria-describedby`

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -29,6 +29,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { DIFF_DESCRIPTION_IDS } from './diff-format-types';
 
 const { parseRawBlock } = unlock( blocksPrivateApis );
 
@@ -562,7 +563,9 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 				removedSlice,
 				{
 					type: 'revision/diff-removed',
-					attributes: { title: __( 'Removed' ) },
+					attributes: {
+						'aria-describedby': DIFF_DESCRIPTION_IDS.removed,
+					},
 				},
 				0,
 				part.value.length
@@ -580,7 +583,9 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 				addedSlice,
 				{
 					type: 'revision/diff-added',
-					attributes: { title: __( 'Added' ) },
+					attributes: {
+						'aria-describedby': DIFF_DESCRIPTION_IDS.added,
+					},
 				},
 				0,
 				part.value.length
@@ -619,26 +624,40 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 					);
 
 					if ( rangeFormatChanged ) {
-						// Get type and description of what changed
-						const { type, description } = describeFormatChange(
+						// Get type of what changed. `description` (e.g. "2
+						// formats changed") is no longer used for the
+						// accessible name: aria-describedby must point to a
+						// static element already in the document, so we
+						// reference one of a fixed set of shared hidden
+						// descriptions instead of building one per instance.
+						const { type } = describeFormatChange(
 							currentFormats,
 							previousFormats,
 							currentIdx + rangeStart,
 							previousIdx + rangeStart
 						);
 
-						// Map change type to format type for styling
+						// Map change type to format type for styling, and
+						// the id of its shared hidden description element.
 						const formatType = {
 							added: 'revision/diff-format-added',
 							removed: 'revision/diff-format-removed',
 							changed: 'revision/diff-format-changed',
 						}[ type ];
 
+						const descriptionId = {
+							added: DIFF_DESCRIPTION_IDS.formatAdded,
+							removed: DIFF_DESCRIPTION_IDS.formatRemoved,
+							changed: DIFF_DESCRIPTION_IDS.formatChanged,
+						}[ type ];
+
 						const marked = applyFormat(
 							rangeSlice,
 							{
 								type: formatType,
-								attributes: { title: description },
+								attributes: {
+									'aria-describedby': descriptionId,
+								},
 							},
 							0,
 							i - rangeStart

--- a/packages/editor/src/components/post-revisions-preview/diff-format-types.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-format-types.js
@@ -4,6 +4,21 @@
 import { __ } from '@wordpress/i18n';
 import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 
+/**
+ * IDs of the visually-hidden description elements rendered into the
+ * revisions canvas (see revisions-canvas.js). Diff formats reference
+ * these via `aria-describedby` instead of a `title` attribute, since
+ * `title` is inconsistently announced by screen readers in
+ * low-verbosity modes.
+ */
+export const DIFF_DESCRIPTION_IDS = {
+	removed: 'revision-diff-removed-desc',
+	added: 'revision-diff-added-desc',
+	formatAdded: 'revision-diff-format-added-desc',
+	formatRemoved: 'revision-diff-format-removed-desc',
+	formatChanged: 'revision-diff-format-changed-desc',
+};
+
 const DIFF_FORMAT_TYPES = [
 	{
 		name: 'revision/diff-removed',
@@ -41,7 +56,7 @@ export function registerDiffFormatTypes() {
 	for ( const formatType of DIFF_FORMAT_TYPES ) {
 		registerFormatType( formatType.name, {
 			...formatType,
-			attributes: { title: 'title' },
+			attributes: { 'aria-describedby': 'aria-describedby' },
 			edit: () => null,
 		} );
 	}

--- a/packages/editor/src/components/post-revisions-preview/diff-format-types.js
+++ b/packages/editor/src/components/post-revisions-preview/diff-format-types.js
@@ -35,19 +35,19 @@ const DIFF_FORMAT_TYPES = [
 	{
 		name: 'revision/diff-format-added',
 		title: __( 'Format added' ),
-		tagName: 'span',
+		tagName: 'mark',
 		className: 'revision-diff-format-added',
 	},
 	{
 		name: 'revision/diff-format-removed',
 		title: __( 'Format removed' ),
-		tagName: 'span',
+		tagName: 'mark',
 		className: 'revision-diff-format-removed',
 	},
 	{
 		name: 'revision/diff-format-changed',
 		title: __( 'Format changed' ),
-		tagName: 'span',
+		tagName: 'mark',
 		className: 'revision-diff-format-changed',
 	},
 ];

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -11,6 +11,8 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -21,6 +23,7 @@ import VisualEditor from '../visual-editor';
 import {
 	registerDiffFormatTypes,
 	unregisterDiffFormatTypes,
+	DIFF_DESCRIPTION_IDS,
 } from './diff-format-types';
 import { useDiffMarkers } from './diff-markers';
 
@@ -136,10 +139,36 @@ function DiffStyleOverrides( { showDiff } ) {
 	return null;
 }
 
+/**
+ * Visually hidden descriptions that diff marks (<del>, <ins>, <span>)
+ * reference via `aria-describedby`. They must be rendered inside the
+ * canvas iframe because `aria-describedby` cannot reference an element
+ * across a document/iframe boundary. This is more reliable than `title`,
+ * which some screen readers ignore in low-verbosity modes.
+ */
+function DiffDescriptions() {
+	return (
+		<VisuallyHidden>
+			<span id={ DIFF_DESCRIPTION_IDS.removed }>{ __( 'Removed' ) }</span>
+			<span id={ DIFF_DESCRIPTION_IDS.added }>{ __( 'Added' ) }</span>
+			<span id={ DIFF_DESCRIPTION_IDS.formatAdded }>
+				{ __( 'Format added' ) }
+			</span>
+			<span id={ DIFF_DESCRIPTION_IDS.formatRemoved }>
+				{ __( 'Format removed' ) }
+			</span>
+			<span id={ DIFF_DESCRIPTION_IDS.formatChanged }>
+				{ __( 'Format changed' ) }
+			</span>
+		</VisuallyHidden>
+	);
+}
+
 function CanvasContent( { showDiff } ) {
 	const [ contentRef, diffMarkers ] = useDiffMarkers();
 	return (
 		<>
+			{ showDiff && <DiffDescriptions /> }
 			<VisualEditor contentRef={ contentRef } />
 			{ showDiff && diffMarkers }
 		</>

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.js
@@ -81,6 +81,14 @@ const REVISION_DIFF_STYLES = `
 		background-color: color-mix(in srgb, currentColor 5%, #00a32a 15%);
 		text-decoration: none;
 	}
+	/* Reset UA <mark> styles so format markers keep the same look as before. */
+	mark.revision-diff-format-added,
+	mark.revision-diff-format-removed,
+	mark.revision-diff-format-changed {
+		background: transparent;
+		color: inherit;
+		padding: 0;
+	}
 	.revision-diff-format-added {
 		text-decoration: underline wavy color-mix(in srgb, currentColor 30%, #00a32a 70%);
 		text-decoration-thickness: 2px;
@@ -140,7 +148,7 @@ function DiffStyleOverrides( { showDiff } ) {
 }
 
 /**
- * Visually hidden descriptions that diff marks (<del>, <ins>, <span>)
+ * Visually hidden descriptions that diff marks (<del>, <ins>, <mark>)
  * reference via `aria-describedby`. They must be rendered inside the
  * canvas iframe because `aria-describedby` cannot reference an element
  * across a document/iframe boundary. This is more reliable than `title`,

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -1056,7 +1056,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <strong><span aria-describedby="revision-diff-format-added-desc" class="revision-diff-format-added">world</span></strong>',
+							'Hello <strong><mark aria-describedby="revision-diff-format-added-desc" class="revision-diff-format-added">world</mark></strong>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1136,7 +1136,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://new-site.com"><span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">our site</span></a> today',
+							'Visit <a href="https://new-site.com"><mark aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">our site</mark></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1216,7 +1216,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<span aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">Bold</span> and <span aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">italic</span> text',
+							'<mark aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">Bold</mark> and <mark aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">italic</mark> text',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1244,7 +1244,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <em><span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">world</span></em>',
+							'Hello <em><mark aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">world</mark></em>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -859,7 +859,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								// jumps→leaps modification with inline diff
 								content:
-									'The quick brown fox <del title="Removed" class="revision-diff-removed">jumps</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">leaps</ins> over the lazy dog',
+									'The quick brown fox <del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">jumps</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">leaps</ins> over the lazy dog',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},
@@ -1166,7 +1166,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://example.com"><del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">our</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">the</ins> <del title="Removed" class="revision-diff-removed">site</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">website</ins></a> today',
+							'Visit <a href="https://example.com"><del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">our</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">the</ins> <del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">site</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">website</ins></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1216,7 +1216,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" class="revision-diff-format-removed">italic</span> text',
+							'<span aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">Bold</span> and <span aria-describedby="revision-diff-format-removed-desc" class="revision-diff-format-removed">italic</span> text',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -230,7 +230,7 @@ describe( 'diffRevisionContent', () => {
 				attributes: {
 					// Inline diff: "existing" → "modified"
 					content:
-						'This is some <del title="Removed" class="revision-diff-removed">existing</del><ins title="Added" class="revision-diff-added">modified</ins> content',
+						'This is some <del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">existing</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">modified</ins> content',
 					__revisionDiffStatus: {
 						status: 'modified',
 					},
@@ -427,7 +427,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'Second block content<ins title="Added" class="revision-diff-added"> modified</ins>',
+						'Second block content<ins aria-describedby="revision-diff-added-desc" class="revision-diff-added"> modified</ins>',
 					__revisionDiffStatus: {
 						status: 'modified',
 					},
@@ -523,7 +523,7 @@ describe( 'diffRevisionContent', () => {
 				name: 'core/paragraph',
 				attributes: {
 					content:
-						'Original tail content sentence<ins title="Added" class="revision-diff-added"> rewritten</ins>',
+						'Original tail content sentence<ins aria-describedby="revision-diff-added-desc" class="revision-diff-added"> rewritten</ins>',
 					__revisionDiffStatus: { status: 'modified' },
 				},
 			},
@@ -800,7 +800,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								// B→D modification with inline diff
 								content:
-									'<del title="Removed" class="revision-diff-removed">B</del><ins title="Added" class="revision-diff-added">D</ins>',
+									'<del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">B</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">D</ins>',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},
@@ -859,7 +859,7 @@ describe( 'diffRevisionContent', () => {
 							attributes: {
 								// jumps→leaps modification with inline diff
 								content:
-									'The quick brown fox <del title="Removed" class="revision-diff-removed">jumps</del><ins title="Added" class="revision-diff-added">leaps</ins> over the lazy dog',
+									'The quick brown fox <del title="Removed" class="revision-diff-removed">jumps</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">leaps</ins> over the lazy dog',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},
@@ -1056,7 +1056,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <strong><span title="1 format added" class="revision-diff-format-added">world</span></strong>',
+							'Hello <strong><span aria-describedby="revision-diff-format-added-desc" class="revision-diff-format-added">world</span></strong>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1084,7 +1084,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
+							'Hello <strong><del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">world</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">everyone</ins></strong>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1136,7 +1136,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://new-site.com"><span title="1 format changed" class="revision-diff-format-changed">our site</span></a> today',
+							'Visit <a href="https://new-site.com"><span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">our site</span></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1166,7 +1166,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Visit <a href="https://example.com"><del title="Removed" class="revision-diff-removed">our</del><ins title="Added" class="revision-diff-added">the</ins> <del title="Removed" class="revision-diff-removed">site</del><ins title="Added" class="revision-diff-added">website</ins></a> today',
+							'Visit <a href="https://example.com"><del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">our</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">the</ins> <del title="Removed" class="revision-diff-removed">site</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">website</ins></a> today',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1216,7 +1216,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<span title="1 format removed" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" class="revision-diff-format-removed">italic</span> text',
+							'<span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-removed">Bold</span> and <span title="1 format removed" class="revision-diff-format-removed">italic</span> text',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1244,7 +1244,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'Hello <em><span title="1 format added, 1 format removed" class="revision-diff-format-changed">world</span></em>',
+							'Hello <em><span aria-describedby="revision-diff-format-changed-desc" class="revision-diff-format-changed">world</span></em>',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1291,7 +1291,7 @@ describe( 'diffRevisionContent', () => {
 					name: 'core/paragraph',
 					attributes: {
 						content:
-							'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong>world</strong>!',
+							'<del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">Hello</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">Goodbye</ins> <strong>world</strong>!',
 						__revisionDiffStatus: {
 							status: 'modified',
 						},
@@ -1329,7 +1329,7 @@ describe( 'diffRevisionContent', () => {
 							name: 'core/paragraph',
 							attributes: {
 								content:
-									'<del title="Removed" class="revision-diff-removed">Hello</del><ins title="Added" class="revision-diff-added">Goodbye</ins> <strong><del title="Removed" class="revision-diff-removed">world</del><ins title="Added" class="revision-diff-added">everyone</ins></strong>',
+									'<del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">Hello</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">Goodbye</ins> <strong><del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">world</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">everyone</ins></strong>',
 								__revisionDiffStatus: {
 									status: 'modified',
 								},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/77530
This PR replaces the `title` attributes used by revision inline diff annotations with `aria-describedby`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The revision diff markers currently rely on the `title` attribute to provide additional context to assistive technologies. However, `title` is not announced consistently by screen readers, particularly when users enable low-verbosity or **text-only** reading modes. As a result, the descriptions for inline diff markers may not be conveyed reliably, reducing the accessibility of the revisions interface.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR introduces a small set of shared visually hidden description elements within the revisions canvas and updates inline diff annotations (`<ins>`, `<del>`, and formatting change markers) to reference them via `aria-describedby` instead of `title`.

## Testing Instructions
- Create a post, and iterate it several times to create revisions.
- Navigate through the cited features using keyboard and a screen reader.

## Use of AI Tools
- Yes (inline comments)

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
