### PR TITLE
 [7.1 Backport] --  ContentEditableControl: fix invalid label association with contenteditable div 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).
+
 ## 37.0.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/components/src/content-editable-control/index.tsx
+++ b/packages/components/src/content-editable-control/index.tsx
@@ -6,7 +6,8 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
+import { forwardRef, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import { forwardRef } from '@wordpress/element';
 import BaseControl from '../base-control';
 import { useBaseControlProps } from '../base-control/hooks';
 import type { WordPressComponentProps } from '../context';
+import { VisuallyHidden } from '../visually-hidden';
 import type { ContentEditableControlProps } from './types';
 import styles from './style.module.scss';
 
@@ -31,25 +33,42 @@ function UnforwardedContentEditableControl(
 	}: WordPressComponentProps< ContentEditableControlProps, 'div', false >,
 	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
+	// The label is not passed through to `BaseControl`: it would render a
+	// `<label for>` pointing at the `contentEditable` `div`, which is not a
+	// labelable element, making the association invalid. The label is instead
+	// rendered here without `for` and wired up via `aria-labelledby`.
 	const { baseControlProps, controlProps } = useBaseControlProps( {
 		id,
 		className,
 		help,
-		hideLabelFromVision,
-		label,
 	} );
+
+	const labelId = `${ controlProps.id }__label`;
+	const editableRef = useRef< HTMLDivElement >( null );
+	const mergedRefs = useMergeRefs( [ editableRef, forwardedRef ] );
 
 	return (
 		<BaseControl { ...baseControlProps }>
+			{ hideLabelFromVision ? (
+				<VisuallyHidden id={ labelId }>{ label }</VisuallyHidden>
+			) : (
+				<BaseControl.VisualLabel
+					id={ labelId }
+					// Focus the field on label click, like `<label for>` would.
+					onClick={ () => editableRef.current?.focus() }
+				>
+					{ label }
+				</BaseControl.VisualLabel>
+			) }
 			<div
 				className={ styles.editable }
 				role="textbox"
 				aria-multiline
-				aria-label={ label }
+				aria-labelledby={ labelId }
 				aria-placeholder={ placeholder || undefined }
 				aria-disabled={ disabled || undefined }
 				aria-required={ required || undefined }
-				ref={ forwardedRef }
+				ref={ mergedRefs }
 				// A disabled field is not `contentEditable`, which also
 				// removes it from the tab order.
 				contentEditable={ ! disabled }

--- a/packages/components/src/content-editable-control/test/index.tsx
+++ b/packages/components/src/content-editable-control/test/index.tsx
@@ -21,12 +21,20 @@ describe( 'ContentEditableControl', () => {
 		const label = screen.getByText( 'Description' );
 
 		expect( textbox ).toHaveAttribute( 'contenteditable', 'true' );
-		// `BaseControl` wires the label's `for` to the control's `id`.
-		expect( label ).toHaveAttribute( 'for', textbox.id );
-		// `<label for>` does not contribute an accessible name to a non-form
-		// element (a `<div role="textbox">`), so the label is also mirrored
-		// onto `aria-label` for assistive tech and test locators.
-		expect( textbox ).toHaveAttribute( 'aria-label', 'Description' );
+		// A `<div contenteditable>` is not a labelable element, so the label
+		// must not use `for` (Chrome logs a console error for the invalid
+		// association). The name is wired through `aria-labelledby` instead.
+		expect( label ).not.toHaveAttribute( 'for' );
+		expect( textbox ).toHaveAttribute( 'aria-labelledby', label.id );
+		expect( textbox ).toHaveAccessibleName( 'Description' );
+	} );
+
+	it( 'focuses the textbox when the label is clicked', () => {
+		render( <ContentEditableControl label="Description" /> );
+
+		fireEvent.click( screen.getByText( 'Description' ) );
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveFocus();
 	} );
 
 	it( 'visually hides the label when `hideLabelFromVision` is set', () => {
@@ -95,9 +103,13 @@ describe( 'ContentEditableControl', () => {
 			'id',
 			'my-custom-id'
 		);
+		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute(
+			'aria-labelledby',
+			'my-custom-id__label'
+		);
 		expect( screen.getByText( 'Custom id' ) ).toHaveAttribute(
-			'for',
-			'my-custom-id'
+			'id',
+			'my-custom-id__label'
 		);
 	} );
 

--- a/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
@@ -98,12 +98,11 @@ describe( 'RichTextControl', () => {
 		expect( textbox ).toBeInTheDocument();
 		expect( textbox ).toHaveAttribute( 'role', 'textbox' );
 		expect( textbox ).toHaveAttribute( 'contenteditable', 'true' );
-		// `BaseControl` wires the label's `for` to the control's `id`.
-		expect( label ).toHaveAttribute( 'for', textbox.id );
-		// `<label for>` does not contribute an accessible name to a non-form
-		// element (a `<div role="textbox">`), so the label is also mirrored
-		// onto `aria-label` for assistive tech and test locators.
-		expect( textbox ).toHaveAttribute( 'aria-label', 'Description' );
+		// A `<div contenteditable>` is not a labelable element, so the label
+		// must not use `for`; the name is wired through `aria-labelledby`.
+		expect( label ).not.toHaveAttribute( 'for' );
+		expect( textbox ).toHaveAttribute( 'aria-labelledby', label.id );
+		expect( textbox ).toHaveAccessibleName( 'Description' );
 	} );
 
 	it( 'renders without autocomplete when no `completers` are passed', () => {
@@ -197,9 +196,13 @@ describe( 'RichTextControl', () => {
 
 		const textbox = getTextbox( container );
 		expect( textbox ).toHaveAttribute( 'id', 'my-custom-id' );
+		expect( textbox ).toHaveAttribute(
+			'aria-labelledby',
+			'my-custom-id__label'
+		);
 		expect( screen.getByText( 'Custom id' ) ).toHaveAttribute(
-			'for',
-			'my-custom-id'
+			'id',
+			'my-custom-id__label'
 		);
 	} );
 


### PR DESCRIPTION
Backports #80344 (merged as d75dbfd2c82c457ef1dba1573a6424992da3af34) to the `wp/7.1` branch. The automated cherry-pick failed with a conflict; see https://github.com/WordPress/gutenberg/pull/80344#issuecomment-5008611455.

## Why

Fixes #80204 for WordPress 7.1: `ContentEditableControl` associated its label with the `contentEditable` div via `label[for]`, which is invalid for non-labelable elements and triggered Chrome console errors. The control now uses `aria-labelledby` on the editable div instead.

## Conflict resolution

The only conflict was in `packages/components/CHANGELOG.md`: trunk's `Unreleased` section contains entries for PRs that are not on wp/7.1 (#80356, #80205, #80364, #80381, #80394, #80323, #80081, #80270). Resolved by keeping the wp/7.1 side and adding only this PR's Bug Fixes entry.

## Verification

Every source file in this PR is byte-identical to trunk's state after #80344 merged - `git diff d75dbfd2c82 <backport-tip>` is empty for the `components` and `dataviews` source and test files; only the CHANGELOG differs, as described above. Unit tests for `ContentEditableControl` and the DataViews richtext control pass (42 tests).

[<img src="https://img.shields.io/badge/▶-Test%20in%20WordPress%20Playground-blue?style=for-the-badge" alt="Test in WordPress Playground">](https://playground.wordpress.net/gutenberg.html?pr=80441)
