### PR TITLE
Added Missing Global Documentation in `table-of-contents/index.php`

### DIFF
--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -246,6 +246,8 @@ function block_core_table_of_contents_get_headings_from_content( $content, $max_
 /**
  * Gets the current page number for paginated post content.
  *
+ * @global int $page Current page number of the content.
+ *
  * @return int Current page number.
  */
 function block_core_table_of_contents_get_current_page_number() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Added Global documentation in `table-of-contents/index.php` file

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Global Documentation missing in `table-of-contents/index.php` file

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added  Global documentation in `table-of-contents/index.php` file for `block_core_table_of_contents_get_current_page_number` function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Open `table-of-contents/index.php` file
- Go to `block_core_table_of_contents_get_current_page_number` function.

## Use of AI Tools
- None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
