### PR TITLE
Post Excerpt: Add accessible name to 'Read more' link

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -20,7 +20,27 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
+	$more_text = '';
+	if ( ! empty( $attributes['moreText'] ) ) {
+		$post_id    = $block->context['postId'];
+		$post_title = get_the_title( $post_id );
+		if ( '' === $post_title ) {
+			$post_title = sprintf(
+				/* translators: %s is post ID to describe the link for screen readers. */
+				__( 'untitled post %s' ),
+				$post_id
+			);
+		}
+		$screen_reader_text = sprintf(
+			/* translators: %s is the post title. */
+			__( ': %s' ),
+			$post_title
+		);
+		$more_text = '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_id ) ) . '">'
+			. wp_kses_post( $attributes['moreText'] )
+			. '<span class="screen-reader-text">' . $screen_reader_text . '</span>'
+			. '</a>';
+	}
 	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -38,7 +38,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		);
 		$more_text = '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_id ) ) . '">'
 			. wp_kses_post( $attributes['moreText'] )
-			. '<span class="screen-reader-text">' . $screen_reader_text . '</span>'
+			. '<span class="screen-reader-text">' . esc_html( $screen_reader_text ) . '</span>'
 			. '</a>';
 	}
 	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -31,6 +31,21 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 				$post_id
 			);
 		}
+		$allowed_html       = array(
+			'abbr'    => array(),
+			'acronym' => array(),
+			'b'       => array(),
+			'br'      => array(),
+			'cite'    => array(),
+			'code'    => array(),
+			'em'      => array(),
+			'i'       => array(),
+			'span'    => array(),
+			'strong'  => array(),
+			'sub'     => array(),
+			'sup'     => array(),
+			'time'    => array(),
+		);
 		$screen_reader_text = sprintf(
 			/* translators: %s is the post title. */
 			__( ': %s' ),
@@ -38,7 +53,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		);
 		$more_text = '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_id ) ) . '">'
 			. wp_kses_post( $attributes['moreText'] )
-			. '<span class="screen-reader-text">' . esc_html( $screen_reader_text ) . '</span>'
+			. '<span class="screen-reader-text">' . wp_kses( $screen_reader_text, $allowed_html ) . '</span>'
 			. '</a>';
 	}
 	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {


### PR DESCRIPTION
## What?
Closes #45396

Adds a `<span class="screen-reader-text">` with the post title inside the "Read more" link rendered by the Post Excerpt block.

## Why
When a user sets a "Read more" text on the Post Excerpt block, the rendered link has no accessible name context — screen reader users hear "Read more, Read more, Read more" with no indication of which post each link points to.

## How
- Gets the post title (with a fallback for untitled posts)
- Appends it as a `.screen-reader-text` span inside the `<a>` tag
- Follows the same pattern already used by the Read More block (`core/read-more`)

## Testing Instructions
1. Insert a Post Excerpt block in a query loop
2. Set a "Read more" link text in the block inspector
3. View the front end
4. Inspect the HTML — the "Read more" link should contain:
   ```html
   <a class="wp-block-post-excerpt__more-link" href="...">
       Read more
       <span class="screen-reader-text">: Post Title</span>
   </a>
   ```