### PR TITLE
Style Book: Restore live global styles updates on the styles route

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/styles.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles.js
@@ -16,10 +16,9 @@ import SidebarGlobalStyles from '../sidebar-global-styles';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { StyleBookPreview, useGlobalStyles } = unlock( editorPrivateApis );
 
-function StylesPreviewArea( { siteData } ) {
+function StylebookPreviewArea( { siteData } ) {
 	const { path, query } = useLocation();
 	const history = useHistory();
-	const isStylebook = query.preview === 'stylebook';
 	const { user: userConfig } = useGlobalStyles();
 
 	// Get section from URL query params
@@ -32,16 +31,22 @@ function StylesPreviewArea( { siteData } ) {
 		);
 	};
 
-	if ( isStylebook ) {
-		return (
-			<StyleBookPreview
-				path={ section }
-				onPathChange={ onChangeSection }
-				settings={ siteData.editorSettings }
-				// Without userConfig the preview falls back to the static `settings` styles and unsaved global styles edits are not shown.
-				userConfig={ userConfig }
-			/>
-		);
+	return (
+		<StyleBookPreview
+			path={ section }
+			onPathChange={ onChangeSection }
+			settings={ siteData.editorSettings }
+			// Without userConfig the preview falls back to the static `settings` styles and unsaved global styles edits are not shown.
+			userConfig={ userConfig }
+		/>
+	);
+}
+
+function StylesPreviewArea( { siteData } ) {
+	const { query } = useLocation();
+
+	if ( query.preview === 'stylebook' ) {
+		return <StylebookPreviewArea siteData={ siteData } />;
 	}
 
 	return <Editor />;

--- a/packages/edit-site/src/components/site-editor-routes/styles.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles.js
@@ -16,7 +16,7 @@ import SidebarGlobalStyles from '../sidebar-global-styles';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 const { StyleBookPreview, useGlobalStyles } = unlock( editorPrivateApis );
 
-function StylebookPreviewArea( { siteData } ) {
+function StyleBookPreviewArea( { siteData } ) {
 	const { path, query } = useLocation();
 	const history = useHistory();
 	const { user: userConfig } = useGlobalStyles();
@@ -46,7 +46,7 @@ function StylesPreviewArea( { siteData } ) {
 	const { query } = useLocation();
 
 	if ( query.preview === 'stylebook' ) {
-		return <StylebookPreviewArea siteData={ siteData } />;
+		return <StyleBookPreviewArea siteData={ siteData } />;
 	}
 
 	return <Editor />;

--- a/packages/edit-site/src/components/site-editor-routes/styles.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles.js
@@ -14,12 +14,13 @@ import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-gl
 import SidebarGlobalStyles from '../sidebar-global-styles';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
-const { StyleBookPreview } = unlock( editorPrivateApis );
+const { StyleBookPreview, useGlobalStyles } = unlock( editorPrivateApis );
 
 function StylesPreviewArea( { siteData } ) {
 	const { path, query } = useLocation();
 	const history = useHistory();
 	const isStylebook = query.preview === 'stylebook';
+	const { user: userConfig } = useGlobalStyles();
 
 	// Get section from URL query params
 	const section = query.section ?? '/';
@@ -37,6 +38,8 @@ function StylesPreviewArea( { siteData } ) {
 				path={ section }
 				onPathChange={ onChangeSection }
 				settings={ siteData.editorSettings }
+				// Without userConfig the preview falls back to the static `settings` styles and unsaved global styles edits are not shown.
+				userConfig={ userConfig }
 			/>
 		);
 	}

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -167,6 +167,33 @@ test.describe( 'Style Book', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should reflect unsaved global styles edits', async ( { page } ) => {
+		const styleBookIframe = page.frameLocator(
+			'[name="style-book-canvas"]'
+		);
+		await expect(
+			styleBookIframe.getByRole( 'grid', { name: 'Examples of blocks' } )
+		).toBeVisible();
+
+		// Edit the user global styles without saving.
+		await page.evaluate( async () => {
+			const globalStylesId = await window.wp.data
+				.resolveSelect( 'core' )
+				.__experimentalGetCurrentGlobalStylesId();
+			window.wp.data
+				.dispatch( 'core' )
+				.editEntityRecord( 'root', 'globalStyles', globalStylesId, {
+					styles: { color: { background: '#ff0000' } },
+				} );
+		} );
+
+		// The Style Book should pick up the edit without a save or reload.
+		await expect( styleBookIframe.locator( 'body' ) ).toHaveCSS(
+			'background-color',
+			'rgb(255, 0, 0)'
+		);
+	} );
+
 	test( 'should allow opening the command menu from the header when open', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION

## What

Passes the live user global styles config into `StyleBookPreview` on the `/styles` route, so the Style Book reflects unsaved global styles edits again.

## Why

Since #80035, the Style Book stopped live-updating while editing global styles. Changing a paragraph or body style in the sidebar had no effect on the Style Book preview until reload.

## What changed

- `packages/edit-site/src/components/site-editor-routes/styles.js`: unlock `useGlobalStyles` from the editor private APIs and pass its `user` config as the `userConfig` prop to `StyleBookPreview`.

## Manual testing

1. With a block theme active, open the Site Editor and go to Styles, then open the Style Book preview (`site-editor.php?p=%2Fstyles&preview=stylebook`).
2. In the sidebar, change a body style, for example the background or text colour. The Style Book examples should update immediately, without saving.
3. Change a block-level style, for example Typography for the Paragraph block. The paragraph examples should update immediately.
4. Reload without saving, then repeat an edit and save. Saved styles should persist and the preview should stay in sync throughout.
5. In DevTools, run `wp.data.select( 'core/block-editor' ).getSettings().__experimentalDiscussionSettings` and confirm it is still defined (the #80035 fix). Also visit `wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks&preview=stylebook` and make sure there are no console errors (see https://github.com/WordPress/gutenberg/issues/73869)


https://github.com/user-attachments/assets/43feb516-e05d-4b45-8bd3-ca3de269b188


