### PR TITLE
Navigation: align overlay close button with toggle button position

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -808,9 +808,25 @@ class WP_Navigation_Block_Renderer {
 				data-wp-bind--aria-label="state.ariaLabel"
 				data-wp-bind--role="state.roleAttribute"
 			';
-			$close_button_directives                 = '
+			/**
+			 * Filters whether the default overlay close button's position
+			 * should be synced at runtime to match the toggle button's
+			 * on-screen position.
+			 *
+			 * @since 6.9.0
+			 *
+			 * @param bool $sync_close_button_position Whether to sync the close button's position. Default true.
+			 */
+			$sync_close_button_position = apply_filters(
+				'block_core_navigation_sync_close_button_position',
+				true
+			);
+
+			$close_button_directives                 = $sync_close_button_position ? '
 				data-wp-on--click="actions.closeMenuOnClick"
 				data-wp-watch="callbacks.positionCloseButton"
+			' : '
+				data-wp-on--click="actions.closeMenuOnClick"
 			';
 			$responsive_container_content_directives = '
 				data-wp-watch="callbacks.focusFirstElement"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -810,6 +810,7 @@ class WP_Navigation_Block_Renderer {
 			';
 			$close_button_directives                 = '
 				data-wp-on--click="actions.closeMenuOnClick"
+				data-wp-watch="callbacks.positionCloseButton"
 			';
 			$responsive_container_content_directives = '
 				data-wp-watch="callbacks.focusFirstElement"

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -589,7 +589,7 @@ button.wp-block-navigation-item__content {
 		// Add padding above to accommodate close button.
 		// Don't apply default padding when custom overlay is present.
 		&:not(.disable-default-overlay) .wp-block-navigation__responsive-container-content {
-			padding-top: calc(2rem + #{ $navigation-icon-size });
+			padding-top: var(--wp-navigation-overlay-content-offset, calc(2rem + #{ $navigation-icon-size }));
 		}
 
 		&:where(:not(.disable-default-overlay)) {

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -116,6 +116,10 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				ctx.previousFocus = ref;
+				// Remember where the toggle button actually is on screen so the
+				// close button can be placed in the same spot instead of jumping
+				// to a hard-coded corner. See #49402.
+				ctx.toggleButtonRect = ref.getBoundingClientRect();
 				actions.openMenu( 'click' );
 			},
 			closeMenuOnClick() {
@@ -142,6 +146,8 @@ const { state, actions } = store(
 					actions.closeMenu( 'hover' );
 				} else {
 					ctx.previousFocus = ref;
+					// See comment in `openMenuOnClick` above.
+					ctx.toggleButtonRect = ref.getBoundingClientRect();
 					actions.openMenu( 'click' );
 				}
 			},
@@ -245,6 +251,73 @@ const { state, actions } = store(
 					const focusableElements = getFocusableElements( ref );
 					focusableElements?.[ 0 ]?.focus();
 				}
+			},
+			// Positions the default overlay close button so that it lands
+			// exactly where the toggle (burger) button was, instead of a
+			// fixed top-right corner that rarely matches the toggle's real
+			// position in the theme's layout. See #49402.
+			//
+			// Because the close button can now end up anywhere vertically
+			// (not just pinned to the top), it also pushes the menu content
+			// down far enough to always clear the button, via a CSS custom
+			// property the stylesheet falls back from.
+			positionCloseButton() {
+				const ctx = getContext();
+
+				// Only the top-level overlay uses this positioning strategy;
+				// submenus keep their own (unrelated) close behavior.
+				if ( ctx.type !== 'overlay' ) {
+					return;
+				}
+
+				const { ref } = getElement();
+				const dialog = ref.closest(
+					'.wp-block-navigation__responsive-dialog'
+				);
+
+				// Nothing to align to, or the overlay isn't open: reset to
+				// the CSS-defined defaults so we don't leave stale inline
+				// styles/vars lying around (e.g. after a viewport resize
+				// while the previous position no longer makes sense).
+				if ( ! state.isMenuOpen || ! ctx.toggleButtonRect ) {
+					ref.style.removeProperty( 'top' );
+					ref.style.removeProperty( 'right' );
+					ref.style.removeProperty( 'left' );
+					dialog?.style.removeProperty(
+						'--wp-navigation-overlay-content-offset'
+					);
+					return;
+				}
+
+				if ( ! dialog ) {
+					return;
+				}
+
+				const dialogRect = dialog.getBoundingClientRect();
+				const openRect = ctx.toggleButtonRect;
+
+				ref.style.top = `${ openRect.top - dialogRect.top }px`;
+				ref.style.right = `${ dialogRect.right - openRect.right }px`;
+				ref.style.left = 'auto';
+
+				// Re-measure the close button now that it's been moved, so
+				// the content offset matches its *actual* rendered bottom
+				// edge (accounts for the button's own height/padding).
+				const closeRect = ref.getBoundingClientRect();
+				const rootFontSize =
+					parseFloat(
+						window.getComputedStyle( document.documentElement )
+							.fontSize
+					) || 16;
+				// Keep the same breathing room the static default used
+				// (2rem) below whatever the close button's real bottom is.
+				const contentOffset =
+					closeRect.bottom - dialogRect.top + rootFontSize * 2;
+
+				dialog.style.setProperty(
+					'--wp-navigation-overlay-content-offset',
+					`${ contentOffset }px`
+				);
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -116,10 +116,15 @@ const { state, actions } = store(
 				const ctx = getContext();
 				const { ref } = getElement();
 				ctx.previousFocus = ref;
-				// Remember where the toggle button actually is on screen so the
-				// close button can be placed in the same spot instead of jumping
-				// to a hard-coded corner. See #49402.
-				ctx.toggleButtonRect = ref.getBoundingClientRect();
+				// Remember which element opened the overlay so the close
+				// button can be placed in the same spot instead of jumping
+				// to a hard-coded corner. See #49402. We store a reference
+				// rather than a computed rect so position is always
+				// re-measured fresh (e.g. after a resize), and so this
+				// never forces a synchronous layout on click.
+				if ( ctx.type === 'overlay' ) {
+					ctx.toggleButtonRef = ref;
+				}
 				actions.openMenu( 'click' );
 			},
 			closeMenuOnClick() {
@@ -146,8 +151,12 @@ const { state, actions } = store(
 					actions.closeMenu( 'hover' );
 				} else {
 					ctx.previousFocus = ref;
-					// See comment in `openMenuOnClick` above.
-					ctx.toggleButtonRect = ref.getBoundingClientRect();
+					// See comment in `openMenuOnClick` above. Gated to
+					// overlay-type toggles only, so submenu clicks (which
+					// also go through this action) don't do any extra work.
+					if ( ctx.type === 'overlay' ) {
+						ctx.toggleButtonRef = ref;
+					}
 					actions.openMenu( 'click' );
 				}
 			},
@@ -277,9 +286,16 @@ const { state, actions } = store(
 
 				// Nothing to align to, or the overlay isn't open: reset to
 				// the CSS-defined defaults so we don't leave stale inline
-				// styles/vars lying around (e.g. after a viewport resize
-				// while the previous position no longer makes sense).
-				if ( ! state.isMenuOpen || ! ctx.toggleButtonRect ) {
+				// styles/vars lying around, and tear down any resize
+				// listener left over from the previous open state.
+				if ( ! state.isMenuOpen || ! ctx.toggleButtonRef ) {
+					if ( ctx.closeButtonResizeHandler ) {
+						window.removeEventListener(
+							'resize',
+							ctx.closeButtonResizeHandler
+						);
+						ctx.closeButtonResizeHandler = null;
+					}
 					ref.style.removeProperty( 'top' );
 					ref.style.removeProperty( 'right' );
 					ref.style.removeProperty( 'left' );
@@ -293,31 +309,51 @@ const { state, actions } = store(
 					return;
 				}
 
-				const dialogRect = dialog.getBoundingClientRect();
-				const openRect = ctx.toggleButtonRect;
-
-				ref.style.top = `${ openRect.top - dialogRect.top }px`;
-				ref.style.right = `${ dialogRect.right - openRect.right }px`;
-				ref.style.left = 'auto';
-
-				// Re-measure the close button now that it's been moved, so
-				// the content offset matches its *actual* rendered bottom
-				// edge (accounts for the button's own height/padding).
-				const closeRect = ref.getBoundingClientRect();
+				// Measure the close button's own box *before* moving it —
+				// repositioning via top/right doesn't change its size, so
+				// this lets us compute the content offset without a second
+				// forced layout read after writing the new position.
+				const closeButtonHeight = ref.offsetHeight;
 				const rootFontSize =
 					parseFloat(
 						window.getComputedStyle( document.documentElement )
 							.fontSize
 					) || 16;
 				// Keep the same breathing room the static default used
-				// (2rem) below whatever the close button's real bottom is.
-				const contentOffset =
-					closeRect.bottom - dialogRect.top + rootFontSize * 2;
+				// (2rem) below the close button's bottom edge.
+				const gap = rootFontSize * 2;
 
-				dialog.style.setProperty(
-					'--wp-navigation-overlay-content-offset',
-					`${ contentOffset }px`
-				);
+				const applyPosition = () => {
+					const dialogRect = dialog.getBoundingClientRect();
+					const openRect =
+						ctx.toggleButtonRef.getBoundingClientRect();
+
+					ref.style.top = `${ openRect.top - dialogRect.top }px`;
+					ref.style.right = `${
+						dialogRect.right - openRect.right
+					}px`;
+					ref.style.left = 'auto';
+
+					const contentOffset =
+						openRect.top - dialogRect.top + closeButtonHeight + gap;
+
+					dialog.style.setProperty(
+						'--wp-navigation-overlay-content-offset',
+						`${ contentOffset }px`
+					);
+				};
+
+				applyPosition();
+
+				// `data-wp-watch` re-runs when reactive state/context it
+				// reads changes (e.g. isMenuOpen), but not on viewport
+				// resize. Track the position manually while the overlay
+				// stays open so it doesn't go stale; tear down above once
+				// the overlay closes.
+				if ( ! ctx.closeButtonResizeHandler ) {
+					ctx.closeButtonResizeHandler = applyPosition;
+					window.addEventListener( 'resize', applyPosition );
+				}
 			},
 		},
 	},


### PR DESCRIPTION
## What?
Closes #49402

Makes the navigation overlay's close ("X") button appear in the same on-screen position as the toggle ("burger") button that opened it, instead of always jumping to a hard-coded top-right corner. Also adjusts the overlay menu content's top spacing so items never end up overlapping the (now dynamically positioned) close button.

## Why?
The close button was hard-coded to `top: 0; right: 0` (or `clamp(1rem, var(--wp--style--root--padding-*), 20rem)`) inside the fixed, full-screen overlay container. The toggle button, meanwhile, just sits wherever the theme's header layout places it in normal document flow. These are two unrelated positioning systems, so unless a theme happens to match a specific "recipe" (root-padding-aware `theme.json` settings, nav aligned top-right, no extra margin/padding, see #43852), the close button visibly jumps to a different spot than the toggle when the menu opens. This is a jarring, layout-breaking UX regression for any header that isn't top-right aligned (centered logos, left-aligned toggles, etc.).

## Testing Instructions
1. Create/edit a page or template with a Navigation block.
2. Try a few different header layouts, logo + nav left-aligned, centered logo, logo left / toggle right, by adjusting block alignment/justification or wrapping the nav in a group with different `justify-content`.
3. Resize the viewport (or use device toolbar) to trigger the mobile/responsive toggle.
4. Click the toggle (burger) button to open the overlay. Confirm the close ("X") button appears in the same spot the toggle button was, not the top-right corner.
5. Confirm the first menu item is never hidden or overlapped by the close button, regardless of header layout.
6. Close the overlay and reopen it a few times, and after resizing the window, to confirm the position keeps recalculating correctly and no stale inline styles linger.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/30b777ac-24ef-4008-8ecb-fd3cf06a1c47

## Use of AI Tools
I used Claude as a pairing tool throughout this PR: to investigate the root cause by reading the navigation block's source.