### PR TITLE
RTC: Fix deleted-user test on multisite

### DIFF
--- a/phpunit/tests/collaboration/quickEditCollaborationLock.php
+++ b/phpunit/tests/collaboration/quickEditCollaborationLock.php
@@ -59,7 +59,7 @@ class Tests_Collaboration_QuickEditCollaborationLock extends WP_UnitTestCase {
 
 	public function test_deleted_user_lock_is_treated_as_inactive() {
 		$deleted_user_id = self::factory()->user->create();
-		wp_delete_user( $deleted_user_id );
+		self::delete_user( $deleted_user_id );
 		$this->set_edit_lock( $deleted_user_id );
 
 		$this->assertSame( 0, gutenberg_get_active_edit_lock_user( self::$post_id ), 'A lock from a deleted user should be inactive.' );


### PR DESCRIPTION
## What?

Follow-up to #80016.

Updates the deleted-user edit-lock test to use WordPress's multisite-aware user deletion helper.

## Why?

The test added in #80016 failed in multisite CI because `wp_delete_user()` removes the user only from the current site, leaving the network user available to `get_userdata()`.

## How?

Uses `WP_UnitTestCase::delete_user()`, which deletes the user correctly in both single-site and multisite tests. Runtime behavior is unchanged.

## Testing Instructions

```
npm run wp-env-test -- run --env-cwd='wp-content/plugins/gutenberg' wordpress vendor/bin/phpunit phpunit/tests/collaboration/quickEditCollaborationLock.php
npm run wp-env-test -- run --env-cwd='wp-content/plugins/gutenberg' wordpress vendor/bin/phpunit -c phpunit/multisite.xml phpunit/tests/collaboration/quickEditCollaborationLock.php
vendor/bin/phpcs phpunit/tests/collaboration/quickEditCollaborationLock.php
```

## Use of AI Tools

Implemented and tested with assistance from Claude Code and Codex.
