### PR TITLE
Block Supports: Handle nested array block gap values properly

### DIFF
--- a/backport-changelog/7.1/12604.md
+++ b/backport-changelog/7.1/12604.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12604
+
+* https://github.com/WordPress/gutenberg/pull/80464

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -290,7 +290,7 @@ function gutenberg_get_layout_container_values( $layout ) {
 function gutenberg_sanitize_block_gap_value( $gap_value ) {
 	if ( is_array( $gap_value ) ) {
 		foreach ( $gap_value as $key => $value ) {
-			$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$gap_value[ $key ] = ! is_scalar( $value ) || ( $value && preg_match( '%[\\\(&=}]|/\*%', (string) $value ) ) ? null : $value;
 		}
 		return $gap_value;
 	}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -72,6 +72,24 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		return $this->theme_root;
 	}
 
+	/**
+	 * @covers ::gutenberg_sanitize_block_gap_value
+	 */
+	public function test_sanitize_block_gap_value_rejects_nested_array_values() {
+		$this->assertSame(
+			array(
+				'top'  => null,
+				'left' => '2rem',
+			),
+			gutenberg_sanitize_block_gap_value(
+				array(
+					'top'  => array( '1rem' ),
+					'left' => '2rem',
+				)
+			)
+		);
+	}
+
 	public function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
@@ -625,6 +643,32 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 						'attrs'        => array(
 							'layout' => array(
 								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group"></div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow"></div>',
+			),
+			'single wrapper block layout with malformed axial block gap' => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+							'style'  => array(
+								'spacing' => array(
+									'blockGap' => array(
+										'top' => array( '1rem' ),
+									),
+								),
 							),
 						),
 						'innerBlocks'  => array(),


### PR DESCRIPTION
## What?

Fixes this fatal error when `blockGap` contains a nested array:

```text
Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in lib/block-supports/layout.php:293
```

## Why?

Malformed block spacing can break page rendering and REST API responses.

## How?

Non-scalar gap values are changed to `null` before calling `preg_match()`.

## Testing Instructions

### Automated

```bash
npm run wp-env-test start
npm run test:unit:php:base -- --filter WP_Block_Supports_Layout_Test
```

### Manual

1. Create and publish a page.
2. Open the code editor.
3. Replace the content with:

```html
<!-- wp:group {"style":{"spacing":{"blockGap":{"top":["1rem"],"left":"2rem"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group">
	<!-- wp:paragraph -->
	<p>Malformed block gap reproduction</p>
	<!-- /wp:paragraph -->
</div>
<!-- /wp:group -->
```

4. Update and view the page.
5. Open `/wp-json/wp/v2/pages/<PAGE_ID>`.
6. Confirm the page and REST response load without the fatal error.

Before this fix, updating or rendering the page triggers the fatal error.

### Testing Instructions for Keyboard

Same

## Screenshots or screencast

None