### PR TITLE
Block Editor: Guard against non-string spacing preset values

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -82,6 +82,15 @@ describe( 'getSpacingPresetCssVar', () => {
 			'var(--wp--preset--spacing--20)'
 		);
 	} );
+	it( 'should return undefined for a malformed non-string value such as an array', () => {
+		// Malformed blockGap data, e.g. `{ top: [ '1rem' ] }`, would otherwise
+		// throw when `.match()` is called on the array.
+		expect( getSpacingPresetCssVar( [ '1rem' ] ) ).toBe( undefined );
+	} );
+	it( 'should return undefined for other non-string values', () => {
+		expect( getSpacingPresetCssVar( { top: '1rem' } ) ).toBe( undefined );
+		expect( getSpacingPresetCssVar( 20 ) ).toBe( undefined );
+	} );
 } );
 
 describe( 'getSpacingPresetSlug', () => {

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -126,7 +126,7 @@ export function getPresetValueFromCustomValue( value, spacingSizes ) {
  * @return {string | undefined} CSS var string for given spacing preset value.
  */
 export function getSpacingPresetCssVar( value ) {
-	if ( ! value ) {
+	if ( ! value || typeof value !== 'string' ) {
 		return;
 	}
 


### PR DESCRIPTION

## What

`getSpacingPresetCssVar` calls `.match()` on its argument, which throws when the value is not a string (for example a malformed `blockGap` like `{ top: [ '1rem' ] }`). This adds a type guard so non-string values return early instead of crashing the editor.

## Why

Malformed block spacing data can put an array (or other non-string) where a gap value should be. On the front end this surfaced as a PHP fatal, fixed separately in #80464. In the editor the same data throws `TypeError: value.match is not a function`, which the React error boundary turns into a white screen. This handles the editor side.

## What changed

- Return early from `getSpacingPresetCssVar` when the value is falsy or not a string.
- Add unit tests covering an array value (the malformed `blockGap` case), an object, and a number.

## Manual testing

1. Create a draft post and note its ID.
2. From the browser console, save malformed content into it:
   ```js
   wp.apiFetch( { path: '/wp/v2/posts/<ID>', method: 'PUT', data: { content: '<!-- wp:group {"style":{"spacing":{"blockGap":{"top":["1rem"],"left":"2rem"}}},"layout":{"type":"default"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Malformed block gap</p><!-- /wp:paragraph --></div><!-- /wp:group -->' } } )
