### PR TITLE
Playlist: Add border radius support

### DIFF
--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -79,10 +79,12 @@
 		},
 		"__experimentalBorder": {
 			"color": true,
+			"radius": true,
 			"style": true,
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
+				"radius": true,
 				"style": true,
 				"width": true
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #80450

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Playlist block's `block.json` declares `color`, `style`, and `width` under `__experimentalBorder`, but omits `radius`. As a result, the Border section in the block settings sidebar is missing the radius control.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added `"radius": true` to both `__experimentalBorder` and `__experimentalDefaultControls` in block.json.

## Testing Instructions
1. Insert a Playlist block and add some audio tracks.
2. Select the Playlist block, open the block settings sidebar.
3. Go to the Border section under Styles.
4. Confirm a border radius control now appears alongside width, color, and style.
5. Set a radius value and confirm it applies to the playlist container in the editor and on the front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1470" height="880" alt="Screenshot 2026-07-20 at 4 35 41 PM" src="https://github.com/user-attachments/assets/d2a79de7-eaea-43e9-ac6d-bc3177a0fc25" />|<img width="1470" height="880" alt="Screenshot 2026-07-20 at 4 35 41 PM" src="https://github.com/user-attachments/assets/d0b81525-38e4-421e-963b-e3893943b790" />|

## Use of AI Tools
No
