### PR TITLE
Clarify parent root-level block restriction

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -162,8 +162,9 @@ An implementation should expect and tolerate unknown categories, providing some 
 
 ### Parent
 
--   Type: `string[]`
+-   Type: `string[]` or `undefined`
 -   Optional
+-   Default: `undefined`
 -   Localized: No
 -   Property: `parent`
 
@@ -172,6 +173,12 @@ An implementation should expect and tolerate unknown categories, providing some 
 ```
 
 Setting `parent` lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+
+When `parent` is `undefined`, the block is available at any level where insertion is otherwise allowed. When `parent` is an empty array (`[]`), the block is only available at the root level.
+
+```json
+{ "parent": [] }
+```
 
 ### Ancestor
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -275,15 +275,21 @@ Transforms provide rules for what a block can be transformed from and what it ca
 
 #### parent (optional)
 
--   **Type:** `Array`
+-   **Type:** `Array` or `undefined`
+-   **Default:** `undefined`
 
 Blocks are able to be inserted into blocks that use [`InnerBlocks`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
-Setting `parent` lets a block require that it is only available when nested within the specified blocks.
+Setting `parent` lets a block require that it is only available when nested within the specified blocks. When `parent` is `undefined`, the block is available at any level where insertion is otherwise allowed. When `parent` is an empty array (`[]`), the block is only available at the root level.
 
 ```js
 // Only allow this block when it is nested in a Columns block
 parent: [ 'core/columns' ],
+```
+
+```js
+// Only allow this block at the root level.
+parent: [],
 ```
 
 #### ancestor (optional)

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1846,10 +1846,11 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const blockAllowedParentBlocks = blockType.parent;
-	const hasBlockAllowedParent = checkAllowList(
-		blockAllowedParentBlocks,
-		parentName
-	);
+	const hasBlockAllowedParent =
+		Array.isArray( blockAllowedParentBlocks ) &&
+		blockAllowedParentBlocks.length === 0
+			? parentName === null
+			: checkAllowList( blockAllowedParentBlocks, parentName );
 
 	let hasBlockAllowedAncestor = true;
 	const blockAllowedAncestorBlocks = blockType.ancestor;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -155,6 +155,16 @@ describe( 'selectors', () => {
 			parent: [ 'core/post-content' ],
 		} );
 
+		registerBlockType( 'core/root-only-child', {
+			apiVersion: 3,
+			save: () => null,
+			category: 'text',
+			title: 'Test Block Root Only Child',
+			icon: 'test',
+			keywords: [ 'testing' ],
+			parent: [],
+		} );
+
 		registerBlockType( 'core/test-block-ancestor', {
 			apiVersion: 3,
 			save: ( props ) => props.attributes.text,
@@ -220,6 +230,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-c' );
 		unregisterBlockType( 'core/freeform' );
 		unregisterBlockType( 'core/post-content-child' );
+		unregisterBlockType( 'core/root-only-child' );
 		unregisterBlockType( 'core/test-block-ancestor' );
 		unregisterBlockType( 'core/test-block-parent' );
 		unregisterBlockType( 'core/test-block-requires-ancestor' );
@@ -3048,6 +3059,48 @@ describe( 'selectors', () => {
 			expect(
 				canInsertBlockType( state, 'core/post-content-child' )
 			).toBe( true );
+		} );
+
+		it( 'should deny blocks that restrict parent to the root when not in editor root', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							block1: { name: 'core/test-block-a' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							block1: {},
+						} )
+					),
+					parents: new Map(),
+					order: new Map(),
+					blockEditingModes: new Map(),
+				},
+				blockListSettings: new Map(),
+				settings: {},
+			};
+			expect(
+				canInsertBlockType( state, 'core/root-only-child', 'block1' )
+			).toBe( false );
+		} );
+
+		it( 'should allow blocks that restrict parent to the root when in editor root', () => {
+			const state = {
+				blocks: {
+					byClientId: new Map(),
+					attributes: new Map(),
+					parents: new Map(),
+					order: new Map(),
+					blockEditingModes: new Map(),
+				},
+				blockListSettings: new Map(),
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/root-only-child' ) ).toBe(
+				true
+			);
 		} );
 
 		it( 'should allow blocks to be inserted in a descendant of a required ancestor', () => {


### PR DESCRIPTION
## What?
Clarifies how the `parent` block setting behaves when it is omitted versus set to an empty array, and makes `parent: []` restrict insertion to the editor root.

Fixes #15731.

## Why?
The documentation noted `parent` only as an array and did not explain the default behavior or the empty-array behavior. While adding explicit test coverage, `parent: []` was not accepted at the root, so this updates the insertion check to match the documented root-only behavior.

## How?
- Documents `parent` as `Array`/`string[]` or `undefined`, with `undefined` as the default.
- Documents that `parent: []` limits insertion to the root level.
- Updates `canInsertBlockType` to treat an empty parent allow-list as root-only.
- Adds selector tests for root-only insertion.

## Testing Instructions
Run:

```sh
npm run test:unit -- packages/block-editor/src/store/test/selectors.js --runInBand
npx wp-scripts lint-js packages/block-editor/src/store/selectors.js packages/block-editor/src/store/test/selectors.js
git diff --check
```

All passed locally.

Note: `npm run lint:md:docs -- docs/reference-guides/block-api/block-registration.md docs/reference-guides/block-api/block-metadata.md` reports pre-existing markdown lint issues in these files unrelated to the touched lines.