### PR TITLE
RTC: Use str_contains() in WP_Sync_Config

### DIFF
--- a/lib/experimental/collaboration/class-wp-sync-config.php
+++ b/lib/experimental/collaboration/class-wp-sync-config.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WP_Sync_Config' ) ) {
 				return null;
 			}
 
-			if ( false !== strpos( $type_parts[1], '/' ) ) {
+			if ( str_contains( $type_parts[1], '/' ) ) {
 				return null;
 			}
 


### PR DESCRIPTION
## What?

Replaces `false !== strpos( $type_parts[1], '/' )` with `str_contains( $type_parts[1], '/' )` in `WP_Sync_Config`.

## Why?

`str_contains()` expresses the intent directly and is more readable than the `false !== strpos()` idiom. This is a pure refactor with no behavioral change.

Although `str_contains()` is a PHP 8.0 function, this is safe on lower PHP versions: WordPress ships a polyfill for it in `wp-includes/compat.php`, and Gutenberg already relies on `str_contains()` throughout the codebase.