### PR TITLE
GitHub workflows: Fix changelog checks for forked PRs

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -71,8 +71,8 @@ jobs:
                   fetch-depth: ${{ env.PR_COMMIT_COUNT }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
-            - name: 'Fetch relevant history from origin'
-              run: git fetch origin "$GITHUB_BASE_REF"
+            - name: 'Fetch relevant history from base repository'
+              run: git fetch "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "$GITHUB_BASE_REF"
             - name: Determine if package has relevant changes
               id: filter
               env:

--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -71,8 +71,8 @@ jobs:
                   fetch-depth: ${{ env.PR_COMMIT_COUNT }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
-            - name: 'Fetch relevant history from base repository'
-              run: git fetch "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "$GITHUB_BASE_REF"
+            - name: 'Fetch relevant history from origin'
+              run: git fetch origin "$GITHUB_BASE_REF"
             - name: Determine if package has relevant changes
               id: filter
               env:

--- a/packages/components/changelog-workflow-test.txt
+++ b/packages/components/changelog-workflow-test.txt
@@ -1,1 +1,0 @@
-Temporary file used to exercise the package changelog workflow.

--- a/packages/components/changelog-workflow-test.txt
+++ b/packages/components/changelog-workflow-test.txt
@@ -1,0 +1,1 @@
+Temporary file used to exercise the package changelog workflow.


### PR DESCRIPTION
## What?

Fixes the optional package changelog workflow to fetch the base branch history from the base repository instead of the pull request author's fork.

## Why?

When a pull request comes from a fork whose `trunk` branch is behind upstream, the current fetch may not include the pull request's base SHA. The subsequent three-dot diff cannot resolve the merge base and may incorrectly skip the changelog check. This occurred in #80472.

## How?

Fetches the base branch from `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git`. These variables identify the repository running the workflow, so forked and same-repository pull requests use the upstream base history consistently.

## Testing Instructions

This was tested in the draft PR by adding and then removing a temporary file under `packages/components`. Both testing commits are retained in the PR history.

1. Open the [test workflow run](https://github.com/WordPress/gutenberg/actions/runs/29768229436).
2. Confirm the Components changelog check fetched `trunk` from `WordPress/gutenberg`.
3. Confirm it reached the changelog validation and failed with `Please add a CHANGELOG entry to packages/components/CHANGELOG.md` instead of skipping due to an invalid diff.
4. Confirm the other package matrix jobs passed.
