### PR TITLE
Writing flow: fully select the items when a selection extends down into a nested item

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1442,24 +1442,19 @@ export function selection( state = {}, action ) {
 				selectionEnd,
 			};
 		case 'MULTI_SELECT':
-			const { start, end } = action;
+			const nextSelection = {
+				selectionStart: { clientId: action.start },
+				selectionEnd: { clientId: action.end },
+			};
 
-			if (
-				start === state.selectionStart?.clientId &&
-				end === state.selectionEnd?.clientId &&
-				// A text selection between the same blocks is not the
-				// same selection: it carries attribute keys and offsets,
-				// making it partial rather than a block multi-selection.
-				state.selectionStart?.attributeKey === undefined &&
-				state.selectionEnd?.attributeKey === undefined
-			) {
+			// A text selection between the same blocks is not the same
+			// selection: it carries attribute keys and offsets, making it
+			// partial rather than a block multi-selection.
+			if ( fastDeepEqual( state, nextSelection ) ) {
 				return state;
 			}
 
-			return {
-				selectionStart: { clientId: start },
-				selectionEnd: { clientId: end },
-			};
+			return nextSelection;
 		case 'RESET_BLOCKS':
 			const startClientId = state?.selectionStart?.clientId;
 			const endClientId = state?.selectionEnd?.clientId;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1446,7 +1446,12 @@ export function selection( state = {}, action ) {
 
 			if (
 				start === state.selectionStart?.clientId &&
-				end === state.selectionEnd?.clientId
+				end === state.selectionEnd?.clientId &&
+				// A text selection between the same blocks is not the
+				// same selection: it carries attribute keys and offsets,
+				// making it partial rather than a block multi-selection.
+				state.selectionStart?.attributeKey === undefined &&
+				state.selectionEnd?.attributeKey === undefined
 			) {
 				return state;
 			}

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1975,6 +1975,155 @@ test.describe( 'List (@firefox)', () => {
 		] );
 	} );
 
+	test( 'should select the outer item fully when extending a selection down into its nested item', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '* ab' );
+		await page.keyboard.press( 'Enter' );
+		// Leading space at the start of an empty item triggers indent.
+		await page.keyboard.type( ' cd' );
+		// Enter on an empty nested item outdents back to the top level.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'zz' );
+
+		// Move the caret to the middle of "ab" and verify the setup:
+		// "ab" with a nested "cd" item, then a top-level sibling "zz".
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 7 } );
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a‸b' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'cd' },
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'zz' },
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Extend the selection down into the nested "cd" line, then
+		// yield so the selection observer can process it.
+		await page.keyboard.press( 'Shift+ArrowDown' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		// The outer "ab" item is presented as fully selected, like a
+		// block multi-selection.
+		await expect(
+			editor.canvas.locator( '.is-multi-selected' )
+		).toHaveCount( 1 );
+		await expect(
+			editor.canvas.locator( '.is-multi-selected' )
+		).toHaveText( 'abcd' );
+
+		// The press removes the fully selected item as a whole, together
+		// with its nested list; the unrelated sibling remains.
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'zz' },
+						innerBlocks: [],
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'should multi-select the top level items when extending a selection down across an item with a nested item', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '* one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Enter' );
+		// Leading space at the start of an empty item triggers indent.
+		await page.keyboard.type( ' nested' );
+
+		// Move the caret to the end of "one" and verify the setup: "one"
+		// and "two" at the top level, "nested" indented under "two".
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 11 } );
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one‸' },
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'two' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'nested' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+		await page.keyboard.press( 'Backspace' );
+
+		// Extend the selection down across "two" into "nested".
+		await page.keyboard.press( 'Shift+ArrowDown' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Shift+ArrowDown' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		// The endpoints are promoted to the top level items, which are
+		// multi-selected as blocks.
+		await expect(
+			editor.canvas.locator( '.is-multi-selected' )
+		).toHaveCount( 2 );
+
+		// Both items, including the nested one, are removed.
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [],
+			},
+		] );
+	} );
+
 	test( 'should multi-select the top level items when extending a selection from a nested item to the previous top level item', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -2040,18 +2040,25 @@ test.describe( 'List (@firefox)', () => {
 
 		// The native selection is untouched (only hidden by the block
 		// overlay), so the gesture could still continue. It reaches from
-		// "ab" into the nested "cd" item. The selected text is not
-		// asserted because the line navigation lands at the start of the
-		// indented nested line, right before "cd".
+		// the middle of "ab" into the nested "cd" item. The selected
+		// text is not asserted because the line navigation lands at the
+		// start of the indented nested line, right before "cd".
 		expect(
 			await page.frame( { name: 'editor-canvas' } ).evaluate( () => {
 				const selection = document.getSelection();
 				return {
 					anchor: selection.anchorNode.textContent,
+					anchorOffset: selection.anchorOffset,
 					focus: selection.focusNode.textContent,
+					focusOffset: selection.focusOffset,
 				};
 			} )
-		).toMatchObject( { anchor: 'ab', focus: 'cd' } );
+		).toMatchObject( {
+			anchor: 'ab',
+			anchorOffset: 1,
+			focus: 'cd',
+			focusOffset: 0,
+		} );
 
 		// The press removes the fully selected item as a whole, together
 		// with its nested list; the unrelated sibling remains.

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -2038,6 +2038,21 @@ test.describe( 'List (@firefox)', () => {
 			editor.canvas.locator( '.is-multi-selected' )
 		).toHaveText( 'abcd' );
 
+		// The native selection is untouched (only hidden by the block
+		// overlay), so the gesture could still continue. It reaches from
+		// "ab" into the nested "cd" item. The selected text is not
+		// asserted because the line navigation lands at the start of the
+		// indented nested line, right before "cd".
+		expect(
+			await page.frame( { name: 'editor-canvas' } ).evaluate( () => {
+				const selection = document.getSelection();
+				return {
+					anchor: selection.anchorNode.textContent,
+					focus: selection.focusNode.textContent,
+				};
+			} )
+		).toMatchObject( { anchor: 'ab', focus: 'cd' } );
+
 		// The press removes the fully selected item as a whole, together
 		// with its nested list; the unrelated sibling remains.
 		await page.keyboard.press( 'Backspace' );


### PR DESCRIPTION
## What?
Extending a text selection from a top level list item down across a sibling item into that sibling's nested item now multi-selects the two top level items as blocks, matching the behavior when selecting upward. Follow up to #80462.

## Why?
The selection stayed partially selected: the blocks kept the partial styling, and Backspace merged text instead of removing the selected blocks.

## How?
The selection observer already promotes such a selection with `multiSelect`, but the reducer deduplicated `MULTI_SELECT` by client IDs alone, so the promotion was dropped whenever a text selection between the same blocks was already recorded. The dedupe now only keeps the current state when it is a block selection, without attribute keys and offsets.

## Testing Instructions
1. Insert a list with items "one" and "two", and a "nested" item indented under "two".
2. Place the caret in "one" and press Shift+ArrowDown twice.
3. Both top level items show the block multi-selection; Backspace removes both.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.