### PR TITLE
Notes: Carry mention user IDs in a data attribute instead of classes

### DIFF
--- a/backport-changelog/7.1/12503.md
+++ b/backport-changelog/7.1/12503.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/12503
 
 * https://github.com/WordPress/gutenberg/pull/79604
 * https://github.com/WordPress/gutenberg/pull/80221
+* https://github.com/WordPress/gutenberg/pull/80496

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -94,24 +94,27 @@ function gutenberg_strip_inline_note_markers( $block_content ) {
 add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
 
 /**
- * Allows note mention markup in the content of `note` comments for users
- * without `unfiltered_html`.
+ * Allows the note mention attribute on links in comment content.
  *
  * The notes `@` mention completer stores a mention as a link to the mentioned
- * user's author page carrying the user's ID in a class:
- * `<a class="wp-note-mention user-N" href="…">@Name</a>`. The default comment
- * kses allowlist includes `a` but only its `href` and `title` attributes, so
- * for users without `unfiltered_html` the mention classes would be stripped
- * on save.
+ * user's author page carrying the user's ID in a data attribute:
+ * `<a data-wp-note-mention-user="N" href="…">@Name</a>`. The default comment
+ * kses allowlist (`$allowedtags` in `wp-includes/kses.php`) includes `a` but
+ * only its `href` and `title` attributes, so for users without
+ * `unfiltered_html` the mention attribute would be stripped on save. Data
+ * attributes are only allowed by default in the `post` kses context, not the
+ * `pre_comment_content` context notes are sanitized in, so a narrow allowance
+ * is still required.
  *
- * This callback is deliberately not attached globally: `class` attributes are
- * CSS and JavaScript selector hooks, so allowing them in every comment would
- * extend what regular (including anonymous) commenters can publish. Instead
- * gutenberg_notes_arm_mention_kses() attaches it only while
- * a `note` comment is being filtered and detaches it right after, so the
- * sanitization of other comment types is unchanged. Notes can only be written
- * by logged-in users who can edit the post, and are never rendered on the
- * front end.
+ * Unlike the previous `class` allowance, `data-wp-note-mention-user` is a
+ * single purpose-specific attribute that is not a CSS or JavaScript selector
+ * hook outside the notes sidebar, so it is safe to allow globally in
+ * `pre_comment_content` rather than arming it per note write. Only that exact
+ * attribute is added, matched by name in `wp_kses_attr_check()`, so no
+ * `data-*` wildcard is opened up. Regular (including anonymous) commenters can
+ * now persist this one inert attribute on links; notification parsing (see
+ * Gutenberg PR #79606 and its Core equivalent) only processes `note`-type
+ * comments, so the attribute is meaningless anywhere else.
  *
  * @param array|string $allowed The allowed tags structure for the context.
  * @param string       $context The kses context.
@@ -126,116 +129,15 @@ function gutenberg_notes_allow_mention_attributes( $allowed, $context ) {
 		$allowed['a'] = array();
 	}
 
-	$allowed['a']['class'] = true;
+	$allowed['a']['data-wp-note-mention-user'] = true;
 
 	return $allowed;
 }
 
-/**
- * Arms the mention markup allowance for a single note kses pass.
- *
- * @see gutenberg_notes_allow_mention_attributes()
- */
-function gutenberg_notes_arm_mention_kses() {
-	add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes', 10, 2 );
-
-	/*
-	 * Disarm once this one comment's content has been filtered, so the
-	 * allowance cannot apply to any later comment. PHP_INT_MAX runs after
-	 * every other 'pre_comment_content' callback (wp_filter_kses at 10,
-	 * wp_rel_ugc at 15, anything a plugin adds): when a callback empties its
-	 * own priority bucket mid-run, WP_Hook skips the bucket that follows, so
-	 * a self-removing disarm must be the final bucket or it would silently
-	 * swallow the next callback.
-	 */
-	add_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses', PHP_INT_MAX );
-
-	/*
-	 * Backstop: if the write aborts between arming and content filtering (for
-	 * example a failed capability or flood check in a batched REST request),
-	 * disarm at the end of the REST request so the allowance cannot leak into
-	 * a later write.
-	 */
-	add_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' );
-}
-
-/**
- * Disarms the mention markup allowance after a note kses pass.
- *
- * Attached by gutenberg_notes_arm_mention_kses(); self-removes from both of
- * its hooks so the extended allowlist never outlives the single note write
- * that armed it.
- *
- * @param mixed $value The filtered value, passed through untouched.
- * @return mixed The unchanged value.
- */
-function gutenberg_notes_disarm_mention_kses( $value = null ) {
-	remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' );
-	remove_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses', PHP_INT_MAX );
-	remove_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' );
-
-	return $value;
-}
-
-/**
- * Arms the mention markup allowance when a `note` comment is inserted.
- *
- * Covers every wp_new_comment() caller; runs before wp_filter_comment()
- * sanitizes the content.
- *
- * @param array $commentdata Comment data.
- * @return array Unchanged comment data.
- */
-function gutenberg_notes_scope_mention_kses( $commentdata ) {
-	if ( isset( $commentdata['comment_type'] ) && 'note' === $commentdata['comment_type'] ) {
-		gutenberg_notes_arm_mention_kses();
-	}
-
-	return $commentdata;
-}
-
-/**
- * Arms the mention markup allowance for REST note writes.
- *
- * Runs in WP_REST_Comments_Controller::prepare_item_for_database() for both
- * creates and updates, before the comment is sanitized. Neither carries the
- * comment type in the prepared data, so it is resolved from the comment being
- * updated or, on creation, from the request's `type` param.
- *
- * @param array           $prepared_comment Prepared comment data.
- * @param WP_REST_Request $request          The REST request.
- * @return array Unchanged prepared comment data.
- */
-function gutenberg_notes_scope_mention_kses_rest( $prepared_comment, $request ) {
-	$comment_type = isset( $prepared_comment['comment_type'] ) ? $prepared_comment['comment_type'] : '';
-
-	if ( '' === $comment_type && ! empty( $request['id'] ) ) {
-		$comment_type = get_comment_type( (int) $request['id'] );
-	}
-
-	/*
-	 * On creation the controller only copies the `type` param into the
-	 * prepared data after this filter has run, and it inserts through
-	 * wp_filter_comment() directly - never through wp_new_comment() and its
-	 * 'preprocess_comment' filter - so this is the only chance to arm and the
-	 * type must be resolved from the request.
-	 */
-	if ( '' === $comment_type && isset( $request['type'] ) ) {
-		$comment_type = $request['type'];
-	}
-
-	if ( 'note' === $comment_type ) {
-		gutenberg_notes_arm_mention_kses();
-	}
-
-	return $prepared_comment;
-}
-
 /*
- * When WordPress itself scopes the mention allowance inside
- * wp_filter_comment() (WordPress 7.1+), defer to it.
+ * When WordPress core ships an equivalent allowance (WordPress 7.1+), defer to
+ * it.
  */
 if ( ! function_exists( '_wp_kses_allow_note_mention_attributes' ) ) {
-	add_filter( 'preprocess_comment', 'gutenberg_notes_scope_mention_kses' );
-	add_filter( 'rest_preprocess_comment', 'gutenberg_notes_scope_mention_kses_rest', 10, 2 );
+	add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes', 10, 2 );
 }

--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -29,8 +29,8 @@ const { RichTextControl } = unlock( dataviewsPrivateApis );
 
 /*
  * `core/link` also carries `@` mentions: the completer inserts a mention as a
- * link to the user's author page with a `wp-note-mention user-N` class, which
- * rich text preserves as an unregistered attribute of the link format.
+ * link to the user's author page with a `data-wp-note-mention-user` attribute,
+ * which rich text preserves as an unregistered attribute of the link format.
  */
 const ALLOWED_NOTE_FORMATS = [
 	'core/bold',

--- a/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
+++ b/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
@@ -23,10 +23,13 @@ type MentionableUser = {
  * A user mention completer for notes.
  *
  * Mirrors the editor's `@` user completer but inserts the mention as a link
- * to the user's author page, carrying the mentioned user's ID in a `user-N`
- * class so the mention can be styled as a chip and, in a follow-up, resolved
- * to a notification recipient. A plain `core/link` format handles the anchor,
- * so no dedicated mention format is needed.
+ * to the user's author page, carrying the mentioned user's ID in a
+ * `data-wp-note-mention-user` attribute so the mention can be styled as a chip
+ * and, in a follow-up, resolved to a notification recipient. A purpose-specific
+ * data attribute (rather than a class) keeps the kses allowance inert - it is
+ * not a CSS or JavaScript selector hook outside the notes sidebar. A plain
+ * `core/link` format handles the anchor, so no dedicated mention format is
+ * needed.
  */
 const noteMentionCompleter = {
 	name: 'note-mentions',
@@ -66,7 +69,7 @@ const noteMentionCompleter = {
 			action: 'insert-at-caret' as const,
 			value: (
 				<a
-					className={ `wp-note-mention user-${ user.id }` }
+					data-wp-note-mention-user={ String( user.id ) }
 					href={ user.link }
 				>
 					{ '@' + user.name }

--- a/packages/editor/src/components/collab-sidebar/stories/note-mention.story.tsx
+++ b/packages/editor/src/components/collab-sidebar/stories/note-mention.story.tsx
@@ -8,12 +8,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
  * A note mention is rendered as a link to the mentioned user's author page,
  * styled as a chip rather than an underlined link. The `@` completer inserts
  * the mention carrying the user's ID in a `data-wp-note-mention-user`
- * attribute; notes saved before that switch carry a legacy `wp-note-mention`
- * class instead. The chip styles target both so existing notes keep their look.
+ * attribute.
  *
- * These stories render the note-content markup for each form inside the
- * collab-sidebar panel structure so the built editor styles apply. Both forms
- * should render as an identical chip.
+ * The story renders the note-content markup inside the collab-sidebar panel
+ * structure so the built editor styles apply.
  */
 const meta: Meta = {
 	title: 'Editor/CollabSidebar/NoteMention',
@@ -36,8 +34,7 @@ const MentionChip = ( { children }: { children: ReactNode } ) => (
 );
 
 /**
- * Current mention markup: the user ID rides on the
- * `data-wp-note-mention-user` attribute.
+ * The user ID rides on the `data-wp-note-mention-user` attribute.
  */
 export const DataAttribute: Story = {
 	render: () => (
@@ -51,53 +48,5 @@ export const DataAttribute: Story = {
 			</a>{ ' ' }
 			please review.
 		</MentionChip>
-	),
-};
-
-/**
- * Legacy mention markup from notes saved before the switch to the data
- * attribute: the `wp-note-mention` class keeps the chip styling.
- */
-export const LegacyClass: Story = {
-	render: () => (
-		<MentionChip>
-			Ping{ ' ' }
-			<a
-				className="wp-note-mention user-5"
-				href="https://example.com/author/teammate/"
-			>
-				@Mentionable Teammate
-			</a>{ ' ' }
-			please review.
-		</MentionChip>
-	),
-};
-
-/**
- * Both forms side by side to confirm they render as an identical chip.
- */
-export const BothForms: Story = {
-	render: () => (
-		<div
-			style={ {
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'flex-start',
-				gap: '12px',
-			} }
-		>
-			<a
-				data-wp-note-mention-user="5"
-				href="https://example.com/author/teammate/"
-			>
-				@Data attribute
-			</a>
-			<a
-				className="wp-note-mention user-5"
-				href="https://example.com/author/teammate/"
-			>
-				@Legacy class
-			</a>
-		</div>
 	),
 };

--- a/packages/editor/src/components/collab-sidebar/stories/note-mention.story.tsx
+++ b/packages/editor/src/components/collab-sidebar/stories/note-mention.story.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * A note mention is rendered as a link to the mentioned user's author page,
+ * styled as a chip rather than an underlined link. The `@` completer inserts
+ * the mention carrying the user's ID in a `data-wp-note-mention-user`
+ * attribute; notes saved before that switch carry a legacy `wp-note-mention`
+ * class instead. The chip styles target both so existing notes keep their look.
+ *
+ * These stories render the note-content markup for each form inside the
+ * collab-sidebar panel structure so the built editor styles apply. Both forms
+ * should render as an identical chip.
+ */
+const meta: Meta = {
+	title: 'Editor/CollabSidebar/NoteMention',
+	parameters: {
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+};
+export default meta;
+
+type Story = StoryObj;
+
+const MentionChip = ( { children }: { children: ReactNode } ) => (
+	<div className="editor-collab-sidebar-panel" style={ { maxWidth: 320 } }>
+		<div className="editor-collab-sidebar-panel__thread">
+			<p className="editor-collab-sidebar-panel__note-content">
+				{ children }
+			</p>
+		</div>
+	</div>
+);
+
+/**
+ * Current mention markup: the user ID rides on the
+ * `data-wp-note-mention-user` attribute.
+ */
+export const DataAttribute: Story = {
+	render: () => (
+		<MentionChip>
+			Ping{ ' ' }
+			<a
+				data-wp-note-mention-user="5"
+				href="https://example.com/author/teammate/"
+			>
+				@Mentionable Teammate
+			</a>{ ' ' }
+			please review.
+		</MentionChip>
+	),
+};
+
+/**
+ * Legacy mention markup from notes saved before the switch to the data
+ * attribute: the `wp-note-mention` class keeps the chip styling.
+ */
+export const LegacyClass: Story = {
+	render: () => (
+		<MentionChip>
+			Ping{ ' ' }
+			<a
+				className="wp-note-mention user-5"
+				href="https://example.com/author/teammate/"
+			>
+				@Mentionable Teammate
+			</a>{ ' ' }
+			please review.
+		</MentionChip>
+	),
+};
+
+/**
+ * Both forms side by side to confirm they render as an identical chip.
+ */
+export const BothForms: Story = {
+	render: () => (
+		<div
+			style={ {
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'flex-start',
+				gap: '12px',
+			} }
+		>
+			<a
+				data-wp-note-mention-user="5"
+				href="https://example.com/author/teammate/"
+			>
+				@Data attribute
+			</a>
+			<a
+				className="wp-note-mention user-5"
+				href="https://example.com/author/teammate/"
+			>
+				@Legacy class
+			</a>
+		</div>
+	),
+};

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -170,7 +170,7 @@
 		border-radius: 2px;
 	}
 
-	a:not(.wp-note-mention) {
+	a:not(.wp-note-mention):not([data-wp-note-mention-user]) {
 		color: var(--wp-admin-theme-color);
 		text-decoration: underline;
 	}
@@ -247,7 +247,10 @@ mark.wp-note {
 
 // Mention chips, both in the note input and the rendered note content. A
 // mention is a link to the mentioned user's author page, styled as a chip
-// rather than an underlined link.
+// rather than an underlined link. The `[data-wp-note-mention-user]` selector
+// matches current mentions; the legacy `.wp-note-mention` class keeps notes
+// saved before the switch to the data attribute styled the same way.
+a[data-wp-note-mention-user],
 .wp-note-mention {
 	display: inline;
 	padding: 0 var(--wpds-dimension-padding-xs);

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -170,7 +170,7 @@
 		border-radius: 2px;
 	}
 
-	a:not(.wp-note-mention):not([data-wp-note-mention-user]) {
+	a:not([data-wp-note-mention-user]) {
 		color: var(--wp-admin-theme-color);
 		text-decoration: underline;
 	}
@@ -247,11 +247,8 @@ mark.wp-note {
 
 // Mention chips, both in the note input and the rendered note content. A
 // mention is a link to the mentioned user's author page, styled as a chip
-// rather than an underlined link. The `[data-wp-note-mention-user]` selector
-// matches current mentions; the legacy `.wp-note-mention` class keeps notes
-// saved before the switch to the data attribute styled the same way.
-a[data-wp-note-mention-user],
-.wp-note-mention {
+// rather than an underlined link.
+a[data-wp-note-mention-user] {
 	display: inline;
 	padding: 0 var(--wpds-dimension-padding-xs);
 	border-radius: var(--wpds-border-radius-sm);

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * Tests that the note mention kses allowance is scoped to `note` comments.
+ * Tests the note mention kses allowance for comment content.
  *
- * The `<a class="wp-note-mention user-N" href="…">` markup must survive
- * sanitization when a note is written by a user without `unfiltered_html`,
- * while the sanitization of every other comment type - which reaches back to
- * anonymous front-end comments - stays byte-identical to core's defaults.
+ * The `<a data-wp-note-mention-user="N" href="…">` markup must survive
+ * sanitization when a note is written by a user without `unfiltered_html`. The
+ * mention attribute is a single inert, purpose-specific data attribute, so the
+ * allowance is registered globally for the `pre_comment_content` context rather
+ * than armed per note write. Every other link attribute (`class`, event
+ * handlers, styles, other data attributes) still stays stripped as in core's
+ * defaults.
  *
  * @group notes
  */
@@ -17,9 +20,32 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 	 * any other comment - deterministically appends `rel="nofollow ugc"`
 	 * regardless of the test environment's home URL.
 	 */
-	const MENTION_CONTENT  = 'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/">@admin</a>!';
-	const MENTION_FILTERED = 'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/" rel="nofollow ugc">@admin</a>!';
+	const MENTION_CONTENT  = 'Hi <a data-wp-note-mention-user="2" href="https://example.com/author/admin/">@admin</a>!';
+	const MENTION_FILTERED = 'Hi <a data-wp-note-mention-user="2" href="https://example.com/author/admin/" rel="nofollow ugc">@admin</a>!';
 	const STRIPPED_CONTENT = 'Hi <a href="https://example.com/author/admin/" rel="nofollow ugc">@admin</a>!';
+
+	/**
+	 * Baseline: without the notes allowance, the comment kses context strips the
+	 * mention data attribute.
+	 *
+	 * This documents the load-bearing fact the allowance exists for: unlike the
+	 * `post` context, the `pre_comment_content` context does not allow `data-*`
+	 * attributes by default, so a mention would lose its user ID on save for any
+	 * user without `unfiltered_html`.
+	 */
+	public function test_comment_kses_strips_data_attribute_by_default() {
+		remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' );
+
+		$filtered = wp_kses( self::MENTION_CONTENT, 'pre_comment_content' );
+
+		add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes', 10, 2 );
+
+		$this->assertSame(
+			'Hi <a href="https://example.com/author/admin/">@admin</a>!',
+			$filtered,
+			'The comment kses context should strip the mention data attribute without the notes allowance.'
+		);
+	}
 
 	public function test_mention_markup_survives_note_content_filtering() {
 		$filtered = $this->filter_comment_with_kses( 'note' );
@@ -27,113 +53,28 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		$this->assertSame( self::MENTION_FILTERED, wp_unslash( $filtered['comment_content'] ) );
 	}
 
-	public function test_mention_markup_stripped_from_regular_comment_content() {
+	/**
+	 * The mention attribute is inert and allowed globally in comment content, so
+	 * it also survives in a regular (non-note) comment. This documents the
+	 * intended behavior change from the previous per-note-armed `class`
+	 * allowance.
+	 */
+	public function test_mention_attribute_survives_regular_comment_content() {
 		$filtered = $this->filter_comment_with_kses( 'comment' );
 
-		$this->assertSame( self::STRIPPED_CONTENT, wp_unslash( $filtered['comment_content'] ) );
+		$this->assertSame( self::MENTION_FILTERED, wp_unslash( $filtered['comment_content'] ) );
 	}
 
-	public function test_only_default_link_attributes_and_class_are_allowed_on_note_links() {
+	public function test_only_the_mention_attribute_and_default_link_attributes_are_allowed() {
 		$filtered = $this->filter_comment_with_kses(
 			'note',
-			'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/" data-user-id="2" onclick="alert(1)" style="color:red">@admin</a>!'
+			'Hi <a data-wp-note-mention-user="2" href="https://example.com/author/admin/" class="danger" data-user-id="2" onclick="alert(1)" style="color:red">@admin</a>!'
 		);
 
 		$this->assertSame(
 			self::MENTION_FILTERED,
 			wp_unslash( $filtered['comment_content'] ),
-			'Attributes beyond `class` and the default link attributes should be stripped from note links.'
-		);
-	}
-
-	public function test_mention_allowance_does_not_leak_after_note_filtering() {
-		$this->filter_comment_with_kses( 'note' );
-
-		// A regular comment filtered after a note still gets the default rules.
-		$filtered = $this->filter_comment_with_kses( 'comment' );
-		$this->assertSame(
-			self::STRIPPED_CONTENT,
-			wp_unslash( $filtered['comment_content'] ),
-			'The mention markup should be stripped from a regular comment filtered after a note.'
-		);
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'The allowlist filter should not outlive the note write that armed it.'
-		);
-		$this->assertFalse(
-			has_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses' ),
-			'The disarm filter should remove itself.'
-		);
-		$this->assertFalse(
-			has_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' ),
-			'The disarm backstop should remove itself.'
-		);
-	}
-
-	public function test_rest_prepare_arms_for_note_update() {
-		$post_id = self::factory()->post->create();
-		$note_id = self::factory()->comment->create(
-			array(
-				'comment_post_ID' => $post_id,
-				'comment_type'    => 'note',
-			)
-		);
-
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $note_id );
-		$request->set_param( 'id', $note_id );
-
-		// Updates do not carry the comment type in the prepared data.
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertNotFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Updating a note should arm the mention allowance.'
-		);
-
-		gutenberg_notes_disarm_mention_kses();
-	}
-
-	public function test_rest_prepare_arms_for_note_creation() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->set_param( 'type', 'note' );
-
-		// On creation the prepared data does not carry the comment type either:
-		// the controller only copies the `type` param in after preparing.
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertNotFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Creating a note should arm the mention allowance.'
-		);
-
-		gutenberg_notes_disarm_mention_kses();
-	}
-
-	public function test_rest_prepare_does_not_arm_for_regular_comment_creation() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->set_param( 'type', 'comment' );
-
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Creating a regular comment should not arm the mention allowance.'
-		);
-	}
-
-	public function test_rest_prepare_does_not_arm_for_regular_comment_update() {
-		$post_id    = self::factory()->post->create();
-		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
-
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
-		$request->set_param( 'id', $comment_id );
-
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Updating a regular comment should not arm the mention allowance.'
+			'Attributes beyond `data-wp-note-mention-user` and the default link attributes should be stripped from note links.'
 		);
 	}
 
@@ -178,12 +119,6 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 201, $response->get_status() );
 
-		/*
-		 * REST creation reaches kses through wp_filter_comment() directly, not
-		 * through wp_new_comment() and its 'preprocess_comment' filter, so the
-		 * REST-specific arming must cover it or mentions written by users
-		 * without `unfiltered_html` are silently stripped on save.
-		 */
 		$data = $response->get_data();
 		$this->assertSame(
 			self::MENTION_FILTERED,
@@ -194,9 +129,9 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 	/**
 	 * Runs commentdata of the given type through the insert-path sanitization.
 	 *
-	 * Mirrors wp_new_comment(): the 'preprocess_comment' filter (which arms the
-	 * allowance for notes) followed by wp_filter_comment() with kses attached as
-	 * it is for users without `unfiltered_html`.
+	 * Mirrors wp_new_comment(): the 'preprocess_comment' filter followed by
+	 * wp_filter_comment() with kses attached as it is for users without
+	 * `unfiltered_html`.
 	 *
 	 * @param string $comment_type The comment type to filter.
 	 * @param string $content      Optional. The comment content to filter.

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1860,15 +1860,15 @@ test.describe( 'Block Notes', () => {
 
 			/*
 			 * The completer inserts the mention as a chip: a link to the
-			 * user's author page whose `user-N` class carries the mentioned
-			 * user's ID.
+			 * user's author page whose `data-wp-note-mention-user` attribute
+			 * carries the mentioned user's ID.
 			 */
-			const mentionClasses = new RegExp(
-				`^wp-note-mention user-${ mentionedUserId }$`
-			);
-			const draftChip = textbox.locator( 'a.wp-note-mention' );
+			const draftChip = textbox.locator( 'a[data-wp-note-mention-user]' );
 			await expect( draftChip ).toHaveText( '@Mentionable Teammate' );
-			await expect( draftChip ).toHaveClass( mentionClasses );
+			await expect( draftChip ).toHaveAttribute(
+				'data-wp-note-mention-user',
+				String( mentionedUserId )
+			);
 			await expect( draftChip ).toHaveAttribute( 'href', /author/ );
 
 			await page.keyboard.type( 'please review' );
@@ -1885,9 +1885,12 @@ test.describe( 'Block Notes', () => {
 			const savedChip = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'treeitem' )
-				.locator( 'a.wp-note-mention' );
+				.locator( 'a[data-wp-note-mention-user]' );
 			await expect( savedChip ).toHaveText( '@Mentionable Teammate' );
-			await expect( savedChip ).toHaveClass( mentionClasses );
+			await expect( savedChip ).toHaveAttribute(
+				'data-wp-note-mention-user',
+				String( mentionedUserId )
+			);
 		} );
 
 		test( 'can cancel mentions popover', async ( { editor, page } ) => {


### PR DESCRIPTION
Closes #80502.

## What

Switch the Notes `@` mention markup from a pair of classes to a single purpose-specific data attribute:

```diff
-<a class="wp-note-mention user-N" href="…">@Name</a>
+<a data-wp-note-mention-user="N" href="…">@Name</a>
```

and replace the elaborate per-note kses arm/disarm machinery in `lib/compat/wordpress-7.1/block-comments.php` with a single always-registered `wp_kses_allowed_html` filter that allows only that one attribute on `a` in the `pre_comment_content` context.

Since the `wp-note-mention` class has never shipped in a stable WordPress release, it is removed entirely - no legacy selector or fallback is kept ([per review](https://github.com/WordPress/gutenberg/pull/80496#discussion_r3619092494)).

## Why

On the Core backport of the notes mention kses handling ([wordpress-develop#12503](https://github.com/WordPress/wordpress-develop/pull/12503)), @westonruter [suggested](https://github.com/WordPress/wordpress-develop/pull/12503#issuecomment-5029034877) carrying the mentioned user ID in a data attribute instead of a class. A class allowance lets note authors persist arbitrary classes on links, widening the CSS and JavaScript selector blast radius in the admin. A purpose-specific `data-wp-note-mention-user` attribute is inert: it is not a styling or scripting hook anywhere outside the notes sidebar.

Because the payload is now a single inert attribute rather than an open `class`, the per-note-write arming and disarming (the `preprocess_comment` / `rest_preprocess_comment` arming hooks plus the self-removing `pre_comment_content` disarm at `PHP_INT_MAX` and the `rest_request_after_callbacks` backstop) is no longer needed. It collapses to one always-on filter.

## Correction to the original suggestion

The premise that data attributes "would be allowed by Kses by default" holds only for the **post** kses context. The **comment** context (`pre_comment_content`) uses the minimal `$allowedtags` in `wp-includes/kses.php`, where `a` allows only `href`/`title` and `data-*` is not permitted (the `data-*` wildcard path in `wp_kses_attr_check()` requires the allowlist to already contain `data-*`). So a narrow kses allowance is still required; it just shrinks from "any class" to one inert attribute, and the arm/disarm machinery goes away.

This is proven by a new baseline unit test, `test_comment_kses_strips_data_attribute_by_default`, which removes the notes filter and asserts `wp_kses( $mention_markup, 'pre_comment_content' )` strips `data-wp-note-mention-user`.

## Behavior change

Regular (including anonymous) commenters can now persist this one inert `data-wp-note-mention-user` attribute on links in any comment content, not just notes. This is acceptable because:

- the attribute has no styling or JavaScript hook outside the notes sidebar, and
- mention notification parsing (Gutenberg [#79606](https://github.com/WordPress/gutenberg/pull/79606) and its Core equivalent) only processes `note`-type comments, so the attribute is meaningless anywhere else.

Every other link attribute (`class`, event handlers, styles, other `data-*` attributes) is still stripped exactly as in core's defaults, covered by `test_only_the_mention_attribute_and_default_link_attributes_are_allowed`.

## Coordination follow-ups

- **Gutenberg [#79606](https://github.com/WordPress/gutenberg/pull/79606)** (mention notifications) parses the user ID out of the `user-N` class in PHP (`preg_match( '/^user-([1-9][0-9]*)$/' )`). It should switch to reading the `data-wp-note-mention-user` attribute; no legacy-class fallback is needed since the class never shipped in a stable release.
- **wordpress-develop [#12503](https://github.com/WordPress/wordpress-develop/pull/12503)** can then be reduced to the same narrow attribute allowance in core (a `pre_comment_content` `data-wp-note-mention-user` allowance), at which point the `function_exists( '_wp_kses_allow_note_mention_attributes' )` guard here disables this plugin copy.

## Testing instructions

[![Test with WordPress Playground](https://img.shields.io/badge/Test%20with-WordPress%20Playground-3858E9?logo=wordpress)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/gutenberg/update/note-mentions-data-attribute/.github/workflows/tryitout.blueprint.json)

1. As a user **without** `unfiltered_html` (e.g. an author), open a post, select some text or a block, and add a note.
2. Type `@` and pick a teammate. The mention renders as a chip.
3. Save the note. The chip survives the round-trip and its anchor carries `data-wp-note-mention-user="<user id>"` (inspect the element) and links to the author page. This is the case the kses allowance exists for.

Automated coverage:

- PHP: `phpunit/tests/notes-mention-kses-test.php`
- e2e: the `Mentions in the note form` describe in `test/e2e/specs/editor/various/block-notes.spec.js`
- Storybook: `Editor/CollabSidebar/NoteMention` renders the mention chip.

