### PR TITLE
Global Styles panels: fix wrong preset committed and shown when two color presets share a hex

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -400,11 +400,10 @@ export default function BackgroundImagePanel( {
 							key: 'background',
 							label: __( 'Color' ),
 							inheritedValue: backgroundColor,
-							// The picker matches selection by slug, following
-							// whichever value is displayed: `userSlug` once a
-							// value is set, `inheritedSlug` at rest. Without
-							// the slugs it falls back to hex matching, which
-							// marks two same-hex presets as both selected.
+							// The picker selects by slug: `userSlug` when the
+							// block has its own value, otherwise
+							// `inheritedSlug`. Hex matching would mark two
+							// same-hex presets as both selected.
 							inheritedSlug: extractPresetSlug(
 								inheritedValue?.color?.background,
 								'color'

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -401,7 +401,7 @@ export default function BackgroundImagePanel( {
 							label: __( 'Color' ),
 							inheritedValue: backgroundColor,
 							// The picker matches selection by slug, following
-							// whichever value is displayed: `localSlug` once a
+							// whichever value is displayed: `userSlug` once a
 							// value is set, `inheritedSlug` at rest. Without
 							// the slugs it falls back to hex matching, which
 							// marks two same-hex presets as both selected.
@@ -409,7 +409,7 @@ export default function BackgroundImagePanel( {
 								inheritedValue?.color?.background,
 								'color'
 							),
-							localSlug: extractPresetSlug(
+							userSlug: extractPresetSlug(
 								value?.color?.background,
 								'color'
 							),

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -400,22 +400,19 @@ export default function BackgroundImagePanel( {
 							key: 'background',
 							label: __( 'Color' ),
 							inheritedValue: backgroundColor,
-							// Resolve the slug from the same source as the
-							// displayed value (user value first, then the
-							// inherited fallback). For a block instance the
-							// selection lives in `value` while `inheritedValue`
-							// only holds the global styles fallback, so reading
-							// the slug from `inheritedValue` alone would miss it
-							// and two same-hex presets would both appear selected.
-							inheritedSlug:
-								extractPresetSlug(
-									value?.color?.background,
-									'color'
-								) ??
-								extractPresetSlug(
-									inheritedValue?.color?.background,
-									'color'
-								),
+							// The picker matches selection by slug, following
+							// whichever value is displayed: `localSlug` once a
+							// value is set, `inheritedSlug` at rest. Without
+							// the slugs it falls back to hex matching, which
+							// marks two same-hex presets as both selected.
+							inheritedSlug: extractPresetSlug(
+								inheritedValue?.color?.background,
+								'color'
+							),
+							localSlug: extractPresetSlug(
+								value?.color?.background,
+								'color'
+							),
 							setValue: setBackgroundColor,
 							userValue: userBackgroundColor,
 							isPlaceholder:

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -151,7 +151,7 @@ function ColorGradientTab( {
 	// set, the same click correctly clears local back to at rest.
 	const onChange = ( newValue, newSlug ) => {
 		if ( isPlaceholder && newValue === undefined ) {
-			setValue( inheritedValue );
+			setValue( inheritedValue, inheritedSlug );
 			return;
 		}
 		setValue( newValue, newSlug );

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -143,10 +143,9 @@ function ColorGradientTab( {
 	// back to the inherited value so the at-rest preselection is visible
 	// inside the picker.
 	const displayed = userValue ?? inheritedValue;
-	// Selection inside the picker follows the slug of whichever value is
-	// displayed: the user slug once a value is set, the inherited slug at
-	// rest. Matching by slug keeps two same-hex presets apart; a slug-less
-	// (custom) value falls back to the picker's own hex matching.
+	// Slug of the displayed value: the block's own when it has one, otherwise
+	// the inherited one. Slug matching keeps two same-hex presets apart; a
+	// slug-less (custom) value falls back to hex matching.
 	const displayedSlug = userValue !== undefined ? userSlug : inheritedSlug;
 	// Display-without-commit interceptor. `ColorPalette` and `GradientPicker`
 	// fire `onChange( undefined )` when the user clicks the currently-selected

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -132,6 +132,7 @@ function ColorGradientTab( {
 	isGradient,
 	inheritedValue,
 	inheritedSlug,
+	localSlug,
 	userValue,
 	setValue,
 	isPlaceholder,
@@ -142,6 +143,11 @@ function ColorGradientTab( {
 	// back to the inherited value so the at-rest preselection is visible
 	// inside the picker.
 	const displayed = userValue ?? inheritedValue;
+	// Selection inside the picker follows the slug of whichever value is
+	// displayed: the local slug once a value is set, the inherited slug at
+	// rest. Matching by slug keeps two same-hex presets apart; a slug-less
+	// (custom) value falls back to the picker's own hex matching.
+	const displayedSlug = userValue !== undefined ? localSlug : inheritedSlug;
 	// Display-without-commit interceptor. `ColorPalette` and `GradientPicker`
 	// fire `onChange( undefined )` when the user clicks the currently-selected
 	// option. At rest (placeholder mode), that click is the user's "accept
@@ -163,11 +169,7 @@ function ColorGradientTab( {
 			enableAlpha
 			__experimentalIsRenderedInSidebar
 			colorValue={ isGradient ? undefined : displayed }
-			colorSlug={
-				isGradient || userValue !== undefined
-					? undefined
-					: inheritedSlug
-			}
+			colorSlug={ isGradient ? undefined : displayedSlug }
 			gradientValue={ isGradient ? displayed : undefined }
 			onColorChange={ isGradient ? undefined : onChange }
 			onGradientChange={ isGradient ? onChange : undefined }

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -132,7 +132,7 @@ function ColorGradientTab( {
 	isGradient,
 	inheritedValue,
 	inheritedSlug,
-	localSlug,
+	userSlug,
 	userValue,
 	setValue,
 	isPlaceholder,
@@ -144,10 +144,10 @@ function ColorGradientTab( {
 	// inside the picker.
 	const displayed = userValue ?? inheritedValue;
 	// Selection inside the picker follows the slug of whichever value is
-	// displayed: the local slug once a value is set, the inherited slug at
+	// displayed: the user slug once a value is set, the inherited slug at
 	// rest. Matching by slug keeps two same-hex presets apart; a slug-less
 	// (custom) value falls back to the picker's own hex matching.
-	const displayedSlug = userValue !== undefined ? localSlug : inheritedSlug;
+	const displayedSlug = userValue !== undefined ? userSlug : inheritedSlug;
 	// Display-without-commit interceptor. `ColorPalette` and `GradientPicker`
 	// fire `onChange( undefined )` when the user clicks the currently-selected
 	// option. At rest (placeholder mode), that click is the user's "accept

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -324,6 +324,10 @@ export default function ColorPanel( {
 						inheritedValue?.elements?.link?.color?.text,
 						'color'
 					),
+					localSlug: extractPresetSlug(
+						value?.elements?.link?.color?.text,
+						'color'
+					),
 					setValue: setLinkColor,
 					userValue: userLinkColor,
 					isPlaceholder:
@@ -336,6 +340,10 @@ export default function ColorPanel( {
 					inheritedSlug: extractPresetSlug(
 						inheritedValue?.elements?.link?.[ ':hover' ]?.color
 							?.text,
+						'color'
+					),
+					localSlug: extractPresetSlug(
+						value?.elements?.link?.[ ':hover' ]?.color?.text,
 						'color'
 					),
 					setValue: setHoverLinkColor,
@@ -476,6 +484,10 @@ export default function ColorPanel( {
 						inheritedValue?.elements?.[ name ]?.color?.text,
 						'color'
 					),
+					localSlug: extractPresetSlug(
+						value?.elements?.[ name ]?.color?.text,
+						'color'
+					),
 					setValue: setElementTextColor,
 					userValue: elementTextUserColor,
 					isPlaceholder: isElementTextPlaceholder,
@@ -488,6 +500,10 @@ export default function ColorPanel( {
 						inheritedSlug: extractPresetSlug(
 							inheritedValue?.elements?.[ name ]?.color
 								?.background,
+							'color'
+						),
+						localSlug: extractPresetSlug(
+							value?.elements?.[ name ]?.color?.background,
 							'color'
 						),
 						setValue: setElementBackgroundColor,

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -324,7 +324,7 @@ export default function ColorPanel( {
 						inheritedValue?.elements?.link?.color?.text,
 						'color'
 					),
-					localSlug: extractPresetSlug(
+					userSlug: extractPresetSlug(
 						value?.elements?.link?.color?.text,
 						'color'
 					),
@@ -342,7 +342,7 @@ export default function ColorPanel( {
 							?.text,
 						'color'
 					),
-					localSlug: extractPresetSlug(
+					userSlug: extractPresetSlug(
 						value?.elements?.link?.[ ':hover' ]?.color?.text,
 						'color'
 					),
@@ -484,7 +484,7 @@ export default function ColorPanel( {
 						inheritedValue?.elements?.[ name ]?.color?.text,
 						'color'
 					),
-					localSlug: extractPresetSlug(
+					userSlug: extractPresetSlug(
 						value?.elements?.[ name ]?.color?.text,
 						'color'
 					),
@@ -502,7 +502,7 @@ export default function ColorPanel( {
 								?.background,
 							'color'
 						),
-						localSlug: extractPresetSlug(
+						userSlug: extractPresetSlug(
 							value?.elements?.[ name ]?.color?.background,
 							'color'
 						),

--- a/packages/block-editor/src/components/global-styles/test/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/color-panel.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, renderHook, screen } from '@testing-library/react';
+import { click, render as renderAriakit } from '@ariakit/test/react';
 
 /**
  * Internal dependencies
@@ -208,6 +209,50 @@ const baseSettings = {
 		},
 	},
 };
+
+describe( 'ColorPanel — duplicate-hex preset slug identity', () => {
+	const duplicateHexSettings = {
+		color: {
+			link: true,
+			defaultPalette: false,
+			palette: {
+				theme: [
+					{
+						slug: 'dark-background',
+						color: '#000000',
+						name: 'Dark background',
+					},
+					{ slug: 'dark-text', color: '#000000', name: 'Dark text' },
+				],
+			},
+		},
+	};
+
+	it( 'marks only the local link preset as selected when another preset shares its hex', async () => {
+		await renderAriakit(
+			<ColorPanel
+				value={ {
+					elements: {
+						link: {
+							color: { text: 'var:preset|color|dark-text' },
+						},
+					},
+				} }
+				settings={ duplicateHexSettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+
+		await click( screen.getByRole( 'button', { name: /^Link/ } ) );
+		const swatches = await screen.findAllByRole( 'option' );
+
+		// swatch[0] = 'Dark background', swatch[1] = 'Dark text'. Selection
+		// must follow the stored slug; matching by hex would mark both.
+		expect( swatches[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( swatches[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+	} );
+} );
 
 describe( 'ColorPanel — inherited Global Styles label treatment', () => {
 	describe( 'Link color', () => {

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.js
@@ -739,16 +739,44 @@ const DUPLICATE_PALETTE_SETTINGS = {
 	},
 };
 
-describe( 'TypographyPanel — setTextColor link sync', () => {
-	// Helper: open the text Color dropdown and return the rendered swatches.
-	async function openTextColorDropdown() {
-		await click(
-			screen.getByRole( 'button', { name: /Color/, expanded: false } )
-		);
-		// `findAllByRole` waits for the Popover/portal content to appear.
-		return screen.findAllByRole( 'option' );
-	}
+// Helper: open the text Color dropdown and return the rendered swatches.
+async function openTextColorDropdown() {
+	await click(
+		screen.getByRole( 'button', { name: /Color/, expanded: false } )
+	);
+	// `findAllByRole` waits for the Popover/portal content to appear.
+	return screen.findAllByRole( 'option' );
+}
 
+describe( 'TypographyPanel — duplicate-hex preset slug identity', () => {
+	it( 'commits the inherited preset slug when accepting the preselected inherited color', async () => {
+		const onChange = jest.fn();
+
+		await renderAriakit(
+			<TypographyPanel
+				value={ {} }
+				inheritedValue={ {
+					color: { text: 'var:preset|color|dark-text' },
+				} }
+				settings={ DUPLICATE_PALETTE_SETTINGS }
+				panelId="test"
+				onChange={ onChange }
+			/>
+		);
+
+		const swatches = await openTextColorDropdown();
+		// swatch[1] ('Dark Text') is the preselected inherited option;
+		// activating it is the "accept inherited value" gesture. The commit
+		// must carry the inherited slug, not re-encode the shared #000 hex
+		// to whichever duplicate appears first in the palette.
+		await click( swatches[ 1 ] );
+
+		const result = onChange.mock.calls[ 0 ][ 0 ];
+		expect( result?.color?.text ).toBe( 'var:preset|color|dark-text' );
+	} );
+} );
+
+describe( 'TypographyPanel — setTextColor link sync', () => {
 	it( 'syncs the link color when text and link share the same raw preset reference', async () => {
 		const onChange = jest.fn();
 		const sharedRef = 'var:preset|color|dark-background';

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.js
@@ -774,6 +774,23 @@ describe( 'TypographyPanel — duplicate-hex preset slug identity', () => {
 		const result = onChange.mock.calls[ 0 ][ 0 ];
 		expect( result?.color?.text ).toBe( 'var:preset|color|dark-text' );
 	} );
+
+	it( 'marks only the local preset as selected when another preset shares its hex', async () => {
+		await renderAriakit(
+			<TypographyPanel
+				value={ { color: { text: 'var:preset|color|dark-text' } } }
+				settings={ DUPLICATE_PALETTE_SETTINGS }
+				panelId="test"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		// swatch[0] = 'Dark Background', swatch[1] = 'Dark Text'. Selection
+		// must follow the stored slug; matching by hex would mark both.
+		const swatches = await openTextColorDropdown();
+		expect( swatches[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( swatches[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+	} );
 } );
 
 describe( 'TypographyPanel — setTextColor link sync', () => {

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -826,7 +826,7 @@ export default function TypographyPanel( {
 								inheritedValue?.color?.text,
 								'color'
 							),
-							localSlug: extractPresetSlug(
+							userSlug: extractPresetSlug(
 								value?.color?.text,
 								'color'
 							),

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -822,15 +822,14 @@ export default function TypographyPanel( {
 							key: 'text',
 							label: __( 'Color' ),
 							inheritedValue: textColor,
-							inheritedSlug:
-								extractPresetSlug(
-									value?.color?.text,
-									'color'
-								) ??
-								extractPresetSlug(
-									inheritedValue?.color?.text,
-									'color'
-								),
+							inheritedSlug: extractPresetSlug(
+								inheritedValue?.color?.text,
+								'color'
+							),
+							localSlug: extractPresetSlug(
+								value?.color?.text,
+								'color'
+							),
 							setValue: setTextColor,
 							userValue: userTextColor,
 							isPlaceholder:


### PR DESCRIPTION
## What?

Fixes two related bugs in the inspector color controls when a palette contains two presets with the same hex value:

1. Clicking the preselected swatch to accept an inherited color committed the wrong preset. The decoded hex was re-encoded by palette lookup, which returns the first entry with that hex.
2. Once any local preset was set, the picker matched selection by hex, so both same-hex swatches rendered as selected.

Follow-up to #77894, raised in https://github.com/WordPress/gutenberg/pull/77894#discussion_r3611642941.

## How?

- The accept-inherited interceptor now passes `inheritedSlug` to `setValue`, so the encoder keeps the reference the at-rest UI was showing.
- Each color tab now receives a `localSlug` extracted from the raw local value. The picker selects by `localSlug` once a value is set and by `inheritedSlug` at rest. A slug-less custom value keeps the existing hex fallback.

## Testing Instructions

Add to `test/emptytheme/theme.json` and activate emptytheme:

```json
{
	"settings": {
		"color": {
			"defaultPalette": false,
			"palette": [
				{
					"slug": "dark-background",
					"color": "#000000",
					"name": "Dark background"
				},
				{ "slug": "dark-text", "color": "#000000", "name": "Dark text" }
			]
		}
	},
	"styles": {
		"blocks": {
			"core/paragraph": {
				"color": { "text": "var:preset|color|dark-text" }
			}
		}
	}
}
```

### Accepting the inherited color commits the right preset

1. New post, add a Paragraph. Confirm in the Code editor it has no `textColor` or `style` attribute.
2. Open Typography > Color. The "Dark text" swatch is checked (hover to confirm the name). Click it.
3. Check the Code editor: the block must have `"textColor":"dark-text"`. On trunk it gets `"dark-background"`.

### Selection follows the stored preset

4. Reopen the color popover. Only "Dark text" is checked. On trunk both swatches render as selected.
5. In the Colors panel, set the Link color to "Dark text". Reopen: only "Dark text" is checked.

### Custom colors unchanged

6. Set a custom color of `#000000` via the custom picker. Reopen: selection falls back to hex matching, same as trunk.



https://github.com/user-attachments/assets/0ea1cb1b-8165-4900-8a5c-65f4cd846cd3


