### PR TITLE
Notes: highlight the whole text block for block-level notes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -31,11 +31,13 @@ import { createBoardStore } from './board-store';
 import { NOTE_FORMAT_NAME } from './format';
 import {
 	applyNoteFormat,
+	BLOCK_LEVEL_NOTE_START,
 	calculateNotePositions,
 	findNoteInBlock,
 	getInlineMarkerStart,
 	getNoteIdsFromMetadata,
 	addNoteIdToMetadata,
+	pickPrimaryNote,
 	removeNoteFormat,
 	removeNoteIdFromMetadata,
 } from './utils';
@@ -66,9 +68,9 @@ export function useNoteThreads( postId ) {
 	}, [] );
 
 	// Process notes to build the tree structure.
-	const { notes, unresolvedNotes } = useMemo( () => {
+	const { notes, unresolvedNotes, blockHighlights } = useMemo( () => {
 		if ( ! threads || threads.length === 0 ) {
-			return { notes: [], unresolvedNotes: [] };
+			return { notes: [], unresolvedNotes: [], blockHighlights: [] };
 		}
 
 		/*
@@ -116,7 +118,7 @@ export function useNoteThreads( postId ) {
 		}
 
 		if ( rootThreads.length === 0 ) {
-			return { notes: [], unresolvedNotes: [] };
+			return { notes: [], unresolvedNotes: [], blockHighlights: [] };
 		}
 
 		// Order within a block: block-level notes (no inline anchor) come
@@ -126,6 +128,7 @@ export function useNoteThreads( postId ) {
 		// already iterated in document order above.
 		const unresolved = [];
 		const resolved = [];
+		const highlights = [];
 		for ( const [ clientId, noteIds ] of Object.entries(
 			blocksWithNotes
 		) ) {
@@ -155,6 +158,28 @@ export function useNoteThreads( postId ) {
 					resolved.push( thread );
 				}
 			}
+
+			/*
+			 * Unresolved notes with no inline marker anchor the whole block, so
+			 * the block itself is tinted in the author's color. A block can
+			 * hold several; one color has to win, so the primary thread (the
+			 * same one the avatar indicator surfaces) decides.
+			 */
+			const blockLevelThreads = orderedThreads
+				.filter(
+					( { thread, start } ) =>
+						start === BLOCK_LEVEL_NOTE_START &&
+						thread.status === 'hold'
+				)
+				.map( ( { thread } ) => thread );
+			const primary = pickPrimaryNote( blockLevelThreads );
+			if ( primary ) {
+				highlights.push( {
+					clientId,
+					id: primary.id,
+					author: primary.author,
+				} );
+			}
 		}
 
 		// Orphans: root threads without a linked block. They stay with the
@@ -167,12 +192,14 @@ export function useNoteThreads( postId ) {
 		return {
 			notes: [ ...unresolved, ...orphans, ...resolved ],
 			unresolvedNotes: unresolved,
+			blockHighlights: highlights,
 		};
 	}, [ clientIds, threads, getBlockAttributes ] );
 
 	return {
 		notes,
 		unresolvedNotes,
+		blockHighlights,
 	};
 }
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -77,7 +77,8 @@ function NotesSidebar( { postId } ) {
 		[]
 	);
 
-	const { notes, unresolvedNotes } = useNoteThreads( postId );
+	const { notes, unresolvedNotes, blockHighlights } =
+		useNoteThreads( postId );
 
 	// Only enable the floating sidebar for large viewports.
 	const showFloatingSidebar = isLargeViewport;
@@ -171,6 +172,7 @@ function NotesSidebar( { postId } ) {
 		<>
 			<NoteHighlightStyles
 				threads={ unresolvedNotes }
+				blockHighlights={ blockHighlights }
 				selectedId={ selectedNoteId }
 			/>
 			{ !! currentThread && (

--- a/packages/editor/src/components/collab-sidebar/note-highlight-styles.js
+++ b/packages/editor/src/components/collab-sidebar/note-highlight-styles.js
@@ -57,10 +57,53 @@ export function buildHighlightCss( threads, selectedId = null ) {
 }
 
 /**
+ * Build the CSS rule set that tints a whole text block whose note is attached at
+ * the block level. Block-level notes carry no in-content `<mark>` to target, so
+ * the block is matched by its client id instead.
+ *
+ * The selector only matches when the block's own wrapper element *is* a
+ * rich-text editable, which is true for text-leaf blocks (paragraph, heading,
+ * list item) and false for containers and media. That keeps the treatment
+ * scoped to text without any block-type checks: non-text blocks get an overlay
+ * of their own in a separate iteration.
+ *
+ * @param {Array}       blockHighlights Block-level notes (each with `clientId`, `id` and `author`).
+ * @param {string|null} selectedId      ID of the currently selected note, if any.
+ * @return {string} A serialized CSS string targeting the blocks' editable elements.
+ */
+export function buildBlockHighlightCss( blockHighlights, selectedId = null ) {
+	const rules = [];
+	for ( const highlight of blockHighlights ?? [] ) {
+		if ( ! highlight?.clientId ) {
+			continue;
+		}
+		const color = getAvatarBorderColor( highlight.author ?? 0 );
+		// Client ids are generated UUIDs, but escape `"`/`\` defensively since
+		// this composes a quoted attribute value.
+		const escapedClientId = String( highlight.clientId ).replace(
+			/["\\]/g,
+			'\\$&'
+		);
+		const sel = `[data-block="${ escapedClientId }"].block-editor-rich-text__editable`;
+		rules.push( `${ sel }{background-color:${ color }${ REST_ALPHA };}` );
+		rules.push(
+			`${ sel }:hover{background-color:${ color }${ ACTIVE_ALPHA };}`
+		);
+		if ( selectedId && String( selectedId ) === String( highlight.id ) ) {
+			rules.push(
+				`${ sel }{background-color:${ color }${ ACTIVE_ALPHA };}`
+			);
+		}
+	}
+	return rules.join( '' );
+}
+
+/**
  * Injects per-note background rules into the editor canvas so inline-note
  * markers carry their author's avatar color. The `core/note` format serializes
  * each marker as `<mark class="wp-note" data-id="{noteId}">`, which we target
- * directly.
+ * directly. Notes attached at the block level have no marker, so the whole text
+ * block is tinted instead.
  *
  * Uses `useStyleOverride` so the styles reach the iframed canvas; a plain
  * `<style>` element rendered in the sidebar would only affect the parent doc.
@@ -69,14 +112,21 @@ export function buildHighlightCss( threads, selectedId = null ) {
  * the editor's selected note.
  *
  * @param {Object}      props
- * @param {Array}       props.threads      Unresolved note threads.
- * @param {string|null} [props.selectedId] ID of the currently selected note.
+ * @param {Array}       props.threads           Unresolved note threads.
+ * @param {Array}       [props.blockHighlights] Unresolved block-level notes to tint whole.
+ * @param {string|null} [props.selectedId]      ID of the currently selected note.
  * @return {null} Renders nothing; styles are applied via `useStyleOverride`.
  */
-export function NoteHighlightStyles( { threads, selectedId } ) {
+export function NoteHighlightStyles( {
+	threads,
+	blockHighlights,
+	selectedId,
+} ) {
 	const css = useMemo(
-		() => buildHighlightCss( threads, selectedId ),
-		[ threads, selectedId ]
+		() =>
+			buildHighlightCss( threads, selectedId ) +
+			buildBlockHighlightCss( blockHighlights, selectedId ),
+		[ threads, blockHighlights, selectedId ]
 	);
 	useStyleOverride( { id: 'core-note-highlights', css } );
 	return null;

--- a/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
+++ b/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { buildHighlightCss } from '../note-highlight-styles';
+import {
+	buildBlockHighlightCss,
+	buildHighlightCss,
+} from '../note-highlight-styles';
 import { getAvatarBorderColor } from '../utils';
 
 describe( 'buildHighlightCss', () => {
@@ -102,5 +105,108 @@ describe( 'buildHighlightCss', () => {
 		expect( buildHighlightCss( null ) ).toBe(
 			'mark.wp-note{background-color:transparent;color:inherit;}'
 		);
+	} );
+} );
+
+describe( 'buildBlockHighlightCss', () => {
+	// The selector only matches when the block's own wrapper element is itself
+	// a rich-text editable, which is what scopes the treatment to text blocks.
+	const selectorFor = ( clientId ) =>
+		`[data-block="${ clientId }"].block-editor-rich-text__editable`;
+
+	it( 'tints each block with its author color at the rest alpha (0x40)', () => {
+		const css = buildBlockHighlightCss( [
+			{ clientId: 'abc-1', id: 7, author: 1 },
+			{ clientId: 'abc-2', id: 12, author: 3 },
+		] );
+		expect( css ).toContain(
+			`${ selectorFor(
+				'abc-1'
+			) }{background-color:${ getAvatarBorderColor( 1 ) }40;}`
+		);
+		expect( css ).toContain(
+			`${ selectorFor(
+				'abc-2'
+			) }{background-color:${ getAvatarBorderColor( 3 ) }40;}`
+		);
+	} );
+
+	it( 'emits a higher-alpha (0x80) rule on hover for each block', () => {
+		const css = buildBlockHighlightCss( [
+			{ clientId: 'abc-1', id: 7, author: 1 },
+		] );
+		expect( css ).toContain(
+			`${ selectorFor(
+				'abc-1'
+			) }:hover{background-color:${ getAvatarBorderColor( 1 ) }80;}`
+		);
+	} );
+
+	it( 'boosts opacity for the selected note by appending a second rule', () => {
+		const color = getAvatarBorderColor( 1 );
+		const css = buildBlockHighlightCss(
+			[ { clientId: 'abc-1', id: 7, author: 1 } ],
+			'7' // selected
+		);
+		const restIndex = css.indexOf(
+			`${ selectorFor( 'abc-1' ) }{background-color:${ color }40;}`
+		);
+		const activeIndex = css.lastIndexOf(
+			`${ selectorFor( 'abc-1' ) }{background-color:${ color }80;}`
+		);
+		// Rest rule still present, active rule appended later so it wins.
+		expect( restIndex ).toBeGreaterThanOrEqual( 0 );
+		expect( activeIndex ).toBeGreaterThan( restIndex );
+	} );
+
+	it( 'leaves other blocks at the rest alpha when one note is selected', () => {
+		const css = buildBlockHighlightCss(
+			[
+				{ clientId: 'abc-1', id: 7, author: 1 },
+				{ clientId: 'abc-2', id: 12, author: 1 },
+			],
+			7
+		);
+		const color = getAvatarBorderColor( 1 );
+		expect( css ).not.toContain(
+			`${ selectorFor( 'abc-2' ) }{background-color:${ color }80;}`
+		);
+	} );
+
+	it( 'matches numeric and string selectedId variants', () => {
+		const entry = [ { clientId: 'abc-1', id: 7, author: 1 } ];
+		expect( buildBlockHighlightCss( entry, 7 ) ).toEqual(
+			buildBlockHighlightCss( entry, '7' )
+		);
+	} );
+
+	it( 'escapes quotes and backslashes in the client id', () => {
+		const css = buildBlockHighlightCss( [
+			{ clientId: 'a"b\\c', id: 7, author: 1 },
+		] );
+		expect( css ).toContain( '[data-block="a\\"b\\\\c"]' );
+	} );
+
+	it( 'skips entries without a client id', () => {
+		const css = buildBlockHighlightCss( [
+			{ clientId: null, id: 7, author: 1 },
+			{ id: 8, author: 1 },
+		] );
+		expect( css ).not.toMatch( /data-block="(null|undefined)"/ );
+	} );
+
+	it( 'falls back to author 0 when the field is missing', () => {
+		const css = buildBlockHighlightCss( [ { clientId: 'abc-1', id: 7 } ] );
+		expect( css ).toContain(
+			`${ selectorFor(
+				'abc-1'
+			) }{background-color:${ getAvatarBorderColor( 0 ) }40;}`
+		);
+	} );
+
+	it( 'returns an empty string when there are no block-level notes', () => {
+		expect( buildBlockHighlightCss() ).toBe( '' );
+		expect( buildBlockHighlightCss( null ) ).toBe( '' );
+		expect( buildBlockHighlightCss( [] ) ).toBe( '' );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -18,6 +18,64 @@ test.describe( 'Block Notes', () => {
 		await requestUtils.deleteAllComments( 'note' );
 	} );
 
+	// Mirrors AVATAR_BORDER_COLORS in packages/editor/src/components/
+	// collab-sidebar/utils.js. Duplicated so the test fails loudly if the
+	// palette is changed without updating the e2e expectation.
+	const AVATAR_BORDER_COLORS = [
+		'#6F42C1',
+		'#D94145',
+		'#FBBF24',
+		'#FF35EE',
+		'#879F11',
+		'#0F766E',
+		'#00CFFF',
+	];
+
+	function hexToRgb( hex ) {
+		return {
+			r: parseInt( hex.slice( 1, 3 ), 16 ),
+			g: parseInt( hex.slice( 3, 5 ), 16 ),
+			b: parseInt( hex.slice( 5, 7 ), 16 ),
+		};
+	}
+
+	/**
+	 * Classify an element's computed background against an expected author
+	 * color. Returns 'rest' (alpha ≈ 0x40), 'active' (alpha ≈ 0x80), or a
+	 * readable description of what was actually found so a failure reports the
+	 * real value rather than just `false`.
+	 *
+	 * @param {import('@playwright/test').Locator} locator Element to inspect.
+	 * @param {Object}                             rgb     Expected author color.
+	 * @param {number}                             rgb.r   Red channel.
+	 * @param {number}                             rgb.g   Green channel.
+	 * @param {number}                             rgb.b   Blue channel.
+	 * @return {Promise<string>} 'rest', 'active', or a description.
+	 */
+	async function readTint( locator, { r, g, b } ) {
+		const bg = await locator.evaluate(
+			( el ) => window.getComputedStyle( el ).backgroundColor
+		);
+		const m = bg.match(
+			/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/
+		);
+		if ( ! m ) {
+			return bg;
+		}
+		const alpha = m[ 4 ] ? Number( m[ 4 ] ) : 1;
+		const matchesColor =
+			Number( m[ 1 ] ) === r &&
+			Number( m[ 2 ] ) === g &&
+			Number( m[ 3 ] ) === b;
+		if ( matchesColor && alpha > 0.2 && alpha < 0.35 ) {
+			return 'rest';
+		}
+		if ( matchesColor && alpha > 0.45 && alpha < 0.55 ) {
+			return 'active';
+		}
+		return `${ m[ 1 ] },${ m[ 2 ] },${ m[ 3 ] } a=${ alpha }`;
+	}
+
 	test( 'should move focus to add a new note form', async ( {
 		editor,
 		page,
@@ -1260,27 +1318,6 @@ test.describe( 'Block Notes', () => {
 	} );
 
 	test.describe( 'Inline notes', () => {
-		// Mirrors AVATAR_BORDER_COLORS in packages/editor/src/components/
-		// collab-sidebar/utils.js. Duplicated so the test fails loudly if the
-		// palette is changed without updating the e2e expectation.
-		const AVATAR_BORDER_COLORS = [
-			'#6F42C1',
-			'#D94145',
-			'#FBBF24',
-			'#FF35EE',
-			'#879F11',
-			'#0F766E',
-			'#00CFFF',
-		];
-
-		function hexToRgb( hex ) {
-			return {
-				r: parseInt( hex.slice( 1, 3 ), 16 ),
-				g: parseInt( hex.slice( 3, 5 ), 16 ),
-				b: parseInt( hex.slice( 5, 7 ), 16 ),
-			};
-		}
-
 		test( 'highlights an inline marker with the author color at the rest opacity', async ( {
 			editor,
 			page,
@@ -1649,6 +1686,103 @@ test.describe( 'Block Notes', () => {
 				.click();
 
 			await expect.poll( alphaOf ).toBeGreaterThan( 0.4 );
+		} );
+	} );
+
+	test.describe( 'Block-level note highlight', () => {
+		test( 'tints the whole text block with the author color and strengthens when selected', async ( {
+			editor,
+			page,
+			requestUtils,
+			blockNoteUtils,
+		} ) => {
+			const me = await requestUtils.rest( { path: '/wp/v2/users/me' } );
+			const rgb = hexToRgb(
+				AVATAR_BORDER_COLORS[ me.id % AVATAR_BORDER_COLORS.length ]
+			);
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note the whole block.' },
+			} );
+
+			// No text selection, so this takes the block-level path: the note
+			// is anchored via `metadata.noteId` with no inline `<mark>`.
+			await blockNoteUtils.addNote( 'Whole block note' );
+
+			const paragraph = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			// The block-level note carries no inline marker to tint.
+			await expect( editor.canvas.locator( 'mark.wp-note' ) ).toHaveCount(
+				0
+			);
+
+			// Adding a note auto-selects it, so the block starts at the active
+			// alpha. Move focus to the title to settle it back to rest.
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.click();
+			await expect
+				.poll( () => readTint( paragraph, rgb ) )
+				.toBe( 'rest' );
+
+			// Selecting the note from the sidebar promotes the block to the
+			// stronger active alpha.
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', { name: 'Note: Whole block note' } )
+				.click();
+			await expect
+				.poll( () => readTint( paragraph, rgb ) )
+				.toBe( 'active' );
+		} );
+
+		test( 'clears the tint when the block-level note is deleted', async ( {
+			editor,
+			page,
+			blockNoteUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Tint goes away.' },
+			} );
+			await blockNoteUtils.addNote( 'Temporary note' );
+
+			const paragraph = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			const backgroundOf = () =>
+				paragraph.evaluate(
+					( el ) => window.getComputedStyle( el ).backgroundColor
+				);
+
+			// Tinted while the note exists.
+			await expect
+				.poll( backgroundOf )
+				.not.toMatch( /rgba\(0,\s*0,\s*0,\s*0\)|transparent/ );
+
+			const settings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			await settings
+				.getByRole( 'treeitem', { name: 'Note: Temporary note' } )
+				.click();
+			await settings
+				.getByRole( 'button', { name: 'Actions' } )
+				.first()
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+			// Confirm the destructive action in the dialog.
+			await page
+				.getByRole( 'dialog' )
+				.getByRole( 'button', { name: 'Delete' } )
+				.click();
+
+			// Back to no background once the anchoring metadata is gone.
+			await expect
+				.poll( backgroundOf )
+				.toMatch( /rgba\(0,\s*0,\s*0,\s*0\)|transparent/ );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

Tints the whole text of a block when a note is attached at the block level, using the author's avatar color, so a block-level note has a visible at-rest indicator in the canvas.

Part of https://github.com/WordPress/gutenberg/issues/72860.

## Why?

Inline notes already mark their anchor: the `core/note` format serializes as `<mark class="wp-note" data-id="N">` and `NoteHighlightStyles` tints each marker in the author's avatar color, soft at rest and stronger when hovered or selected.

Block-level notes carry no marker, so they got nothing. The only signals were the spotlight dimming and blue outline applied when the note is selected, which is what @desrosj and @joedolson raised in #72860: with no at-rest marking you cannot see which blocks carry notes while reading, and the dimming makes the surrounding context hard to read.

This implements the "text is marked, blocks have an overlay" direction @jasmussen described, applied to the text half - the [first iteration of block notes](https://github.com/WordPress/gutenberg/issues/72860#issuecomment-3475194292) suggested marking *all* the text of the paragraph when the note is at the block level.

## How?

Reuses the existing CSS injection seam. No content mutation and no data-model change: a block-level note stays a pure `metadata.noteId` anchor.

- `useNoteThreads` already walks each block's attributes and computes `getInlineMarkerStart()` per thread. It now also collects `blockHighlights`: for each unresolved thread with no inline marker (`BLOCK_LEVEL_NOTE_START`), an entry of `{ clientId, id, author }`. Where a block holds several block-level notes, `pickPrimaryNote` decides which color paints, so one wins deterministically.
- A new pure `buildBlockHighlightCss()` mirrors `buildHighlightCss()`, emitting the rest tint plus the stronger alpha on `:hover` and when the note is selected. `NoteHighlightStyles` concatenates both rule sets into its single `useStyleOverride`.

The selector is `[data-block="{clientId}"].block-editor-rich-text__editable`, which only matches when a block's own wrapper element *is* a rich-text editable. That is true for text-leaf blocks (paragraph, heading, list item) and false for containers and media, so the treatment is scoped to text with no block-type checks. Overlays for non-text blocks are a separate item from the same discussion and are deliberately out of scope here, as is any change to spotlight behavior (#80493 covers that).

## Testing Instructions

[![Try in WordPress Playground](https://img.shields.io/badge/Try%20in%20WordPress%20Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=80498)

1. Enable notes and open a post with a few paragraphs.
2. Select a paragraph and add a note from the block options menu (no text selection, so the note lands at the block level).
3. The paragraph's whole text is tinted in your avatar color. Click elsewhere to deselect: the tint stays, softer.
4. Select the note in the sidebar: the tint strengthens.
5. Confirm neighbouring blocks stay legible, and that adding an inline note (with a text selection) still marks only the selected text.
6. Delete or resolve the note: the tint clears.

### Automated

- `npm run test:unit packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js` - 9 new cases covering `buildBlockHighlightCss` (rest / hover / selected rules, client-id escaping, empty input).
- `npm run test:e2e -- test/e2e/specs/editor/various/block-notes.spec.js` - 2 new cases, written failing first (both reported `rgba(0, 0, 0, 0)` before the change). Full spec: 47 passing.

## Screenshots

Block-level note at rest - the noted paragraph is marked, surrounding blocks stay fully legible:

Selected - the tint strengthens and connects to the note's avatar ring:
