### PR TITLE
Autocomplete: Reference the suggestions list with `aria-controls` and `aria-haspopup`

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -359,6 +359,8 @@ export function RichTextWrapper(
 	// to the focused element.
 	const {
 		'aria-autocomplete': ariaAutocomplete,
+		'aria-haspopup': ariaHasPopup,
+		'aria-controls': ariaControls,
 		'aria-owns': ariaOwns,
 		'aria-activedescendant': ariaActiveDescendant,
 	} = autocompleteProps;
@@ -377,6 +379,8 @@ export function RichTextWrapper(
 
 		const attributes = {
 			'aria-autocomplete': ariaAutocomplete,
+			'aria-haspopup': ariaHasPopup,
+			'aria-controls': ariaControls,
 			'aria-owns': ariaOwns,
 			'aria-activedescendant': ariaActiveDescendant,
 		};
@@ -398,6 +402,8 @@ export function RichTextWrapper(
 		hasEditableRoot,
 		isSelected,
 		ariaAutocomplete,
+		ariaHasPopup,
+		ariaControls,
 		ariaOwns,
 		ariaActiveDescendant,
 	] );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,8 +4,15 @@
 
 ### Bug Fixes
 
+-   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
+-   `Autocomplete`: Omit `aria-activedescendant` while no suggestion is highlighted, instead of returning `null` for it ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).
 -   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
+
+### TypeScript
+
+-   `Autocomplete`: `__unstableUseAutocompleteProps` now narrows its returned ARIA props and no longer asks for a `contentRef` it never used, so callers can spread its return value onto an element without a placeholder ref, normalizing, or casting ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
+-   Improved performance of TypeScript types for internal polymorphic `WordPressComponent` component type ([#80364](https://github.com/WordPress/gutenberg/pull/80364)).
 
 ## 37.0.0 (2026-07-14)
 

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -379,7 +379,11 @@ export function useLastDifferentValue(
 	return history.current[ 0 ];
 }
 
-export function useAutocompleteProps( options: UseAutocompleteProps ) {
+// The popover is anchored to the element this hook's own `ref` lands on, so it
+// owns `contentRef` and callers don't provide one.
+export function useAutocompleteProps(
+	options: Omit< UseAutocompleteProps, 'contentRef' >
+) {
 	const ref = useRef< HTMLElement >( null );
 	const onKeyDownRef =
 		useRef< ( event: KeyboardEvent ) => void >( undefined );
@@ -421,12 +425,21 @@ export function useAutocompleteProps( options: UseAutocompleteProps ) {
 		return { ref: mergedRefs };
 	}
 
+	// `aria-owns` and `aria-controls` point at the same list: either one lets
+	// `aria-activedescendant` resolve to an option rendered outside this
+	// element, and assistive technology support differs between them.
+	//
+	// No `aria-expanded`: consumers are `textbox` elements, which don't
+	// support it; that would mean `role="combobox"`, which in turn doesn't
+	// support the `aria-multiline` these fields set.
 	return {
 		ref: mergedRefs,
 		children: popover,
-		'aria-autocomplete': listBoxId ? 'list' : undefined,
+		'aria-autocomplete': listBoxId ? ( 'list' as const ) : undefined,
+		'aria-haspopup': listBoxId ? ( 'listbox' as const ) : undefined,
+		'aria-controls': listBoxId,
 		'aria-owns': listBoxId,
-		'aria-activedescendant': activeId,
+		'aria-activedescendant': activeId ?? undefined,
 	};
 }
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+-   DataForms: Complete the `richtext` control's autocomplete semantics by associating the textbox with its suggestions list for assistive technology. [#80403](https://github.com/WordPress/gutenberg/pull/80403)
 - DataViews: Fix the `list` layout ignoring the density setting, the refreshing state, and the loading state when `groupBy` is set. [#80255](https://github.com/WordPress/gutenberg/pull/80255)
 - Fix Dataviews popover hover text color readability issue on WordPress 7.0. [#80105](https://github.com/WordPress/gutenberg/pull/80105)
 - DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set. [#80254](https://github.com/WordPress/gutenberg/pull/80254)

--- a/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/control.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { MutableRefObject, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -405,33 +405,18 @@ export default function RichTextControl( {
 	 * returned props (including the rendered popover as `children`). With no
 	 * `completers` it does no work and renders nothing, keeping the control
 	 * zero-cost for consumers that don't opt in.
-	 * The hook anchors its popover to its own internal ref and overrides
-	 * whatever `contentRef` is passed, but the parameter type requires one.
 	 */
-	const unusedContentRef = useRef< HTMLElement >( null );
-	const {
-		ref: autocompleteRef,
-		'aria-activedescendant': autocompleteActiveDescendant,
-		'aria-autocomplete': autocompleteAriaAutocomplete,
-		...autocompleteRest
-	} = useAutocompleteProps( {
-		completers,
-		record: value,
-		onChange: onRichTextChange,
-		// This control's completers insert their completion into the value;
-		// none replace the whole value, so the required `onReplace` is a
-		// no-op here.
-		onReplace: () => {},
-		contentRef: unusedContentRef,
-	} );
-	// Normalize the hook's loosely-typed aria values for the DOM element:
-	// `aria-activedescendant` may be `null` (React wants `undefined`) and
-	// `aria-autocomplete` is only ever `'list'` or `undefined` at runtime.
-	const autocompleteProps = {
-		...autocompleteRest,
-		'aria-activedescendant': autocompleteActiveDescendant ?? undefined,
-		'aria-autocomplete': autocompleteAriaAutocomplete as 'list' | undefined,
-	};
+	const { ref: autocompleteRef, ...autocompleteProps } = useAutocompleteProps(
+		{
+			completers,
+			record: value,
+			onChange: onRichTextChange,
+			// This control's completers insert their completion into the value;
+			// none replace the whole value, so the required `onReplace` is a
+			// no-op here.
+			onReplace: () => {},
+		}
+	);
 
 	// The shell exposes no focus management of its own (form controls leave
 	// that to the surrounding region); focus the field on mount here when the
@@ -447,7 +432,7 @@ export default function RichTextControl( {
 
 	const editableRef = useMergeRefs( [
 		richTextRef,
-		anchorRef as MutableRefObject< HTMLElement | undefined >,
+		anchorRef,
 		eventListenersRef,
 		enterRef,
 		focusOnMountRef,

--- a/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
@@ -7,7 +7,7 @@ import type { MutableRefObject } from 'react';
 /**
  * WordPress dependencies
  */
-import { useContext, useEffect } from '@wordpress/element';
+import { useContext, useEffect, useState } from '@wordpress/element';
 import { Fill, Popover, Slot, SlotFillProvider } from '@wordpress/components';
 import {
 	unregisterFormatType,
@@ -67,6 +67,22 @@ async function moveFocusTo( element: HTMLElement ) {
 	await flushMicrotasks();
 }
 
+// Type the way a browser would — `useRichText` builds its value by reading the
+// DOM and selection back from its own `input` handler.
+async function typeIntoTextbox( textbox: HTMLElement, text: string ) {
+	act( () => {
+		textbox.textContent = text;
+		const range = document.createRange();
+		range.selectNodeContents( textbox );
+		range.collapse( false );
+		const selection = document.getSelection();
+		selection?.removeAllRanges();
+		selection?.addRange( range );
+	} );
+	fireEvent.input( textbox, { inputType: 'insertText' } );
+	await flushMicrotasks();
+}
+
 describe( 'RichTextControl', () => {
 	beforeAll( () => {
 		// Register a minimal stub for `core/bold` so the optional
@@ -77,10 +93,17 @@ describe( 'RichTextControl', () => {
 			className: null,
 			edit: () => null,
 		} );
+
+		// The autocomplete popover measures the caret range to anchor itself,
+		// which jsdom leaves unimplemented. Any non-empty rect lets it mount.
+		Range.prototype.getClientRects = () =>
+			[ new DOMRect( 0, 0, 1, 1 ) ] as unknown as DOMRectList;
 	} );
 
 	afterAll( () => {
 		unregisterFormatType( 'core/bold' );
+		// @ts-expect-error -- Restore jsdom's own (absent) implementation.
+		delete Range.prototype.getClientRects;
 	} );
 
 	it( 'renders a labeled contenteditable textbox', () => {
@@ -138,6 +161,48 @@ describe( 'RichTextControl', () => {
 		);
 
 		expect( getTextbox( container ) ).toBeInTheDocument();
+	} );
+
+	it( 'points the textbox at the suggestions listbox once a completer matches', async () => {
+		// Held outside the completer: the options are reported back through an
+		// effect keyed on their identity, so rebuilding them per render loops.
+		const items = [ { key: 'alice', value: 'Alice', label: 'Alice' } ];
+		const completer = {
+			name: 'test/mentions',
+			triggerPrefix: '@',
+			useItems: () => [ items ],
+			getOptionCompletion: () => '@Alice',
+		};
+
+		function ControlledRichText() {
+			const [ value, setValue ] = useState( '' );
+			return (
+				<RichTextControl
+					label="Note"
+					value={ value }
+					onChange={ setValue }
+					completers={
+						[ completer ] as unknown as React.ComponentProps<
+							typeof RichTextControl
+						>[ 'completers' ]
+					}
+				/>
+			);
+		}
+
+		const { container } = render( <ControlledRichText /> );
+		const textbox = getTextbox( container );
+
+		await moveFocusTo( textbox );
+		await typeIntoTextbox( textbox, '@' );
+
+		const listbox = screen.getByRole( 'listbox' );
+		const option = screen.getByRole( 'option', { name: 'Alice' } );
+
+		expect( textbox ).toHaveAttribute( 'aria-autocomplete', 'list' );
+		expect( textbox ).toHaveAttribute( 'aria-haspopup', 'listbox' );
+		expect( textbox ).toHaveAttribute( 'aria-controls', listbox.id );
+		expect( textbox ).toHaveAttribute( 'aria-activedescendant', option.id );
 	} );
 
 	it( 'visually hides the label when `hideLabelFromVision` is set', () => {

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -116,6 +116,13 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 				.evaluate( () => {
 					return document.activeElement.getAttribute( 'aria-owns' );
 				} );
+			const ariaControls = await editor.canvas
+				.locator( ':root' )
+				.evaluate( () => {
+					return document.activeElement.getAttribute(
+						'aria-controls'
+					);
+				} );
 			const ariaActiveDescendant = await editor.canvas
 				.locator( ':root' )
 				.evaluate( () => {
@@ -123,10 +130,16 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 						'aria-activedescendant'
 					);
 				} );
-			// Ensure `aria-owns` is part of the same document and ensure the
-			// selected option is equal to the active descendant.
+			// Ensure `aria-owns` and `aria-controls` are part of the same
+			// document and ensure the selected option is equal to the active
+			// descendant.
 			await expect(
 				editor.canvas.locator( `#${ ariaOwns } [aria-selected="true"]` )
+			).toHaveAttribute( 'id', ariaActiveDescendant );
+			await expect(
+				editor.canvas.locator(
+					`#${ ariaControls } [aria-selected="true"]`
+				)
 			).toHaveAttribute( 'id', ariaActiveDescendant );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( '.' );
@@ -721,6 +734,69 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 		await page.waitForTimeout( 100 );
 		await expect( page.getByRole( 'listbox' ) ).toBeHidden();
+	} );
+
+	test( 'should mirror the suggestions list reference onto the editing host', async ( {
+		editor,
+		page,
+	} ) => {
+		// The editing host, which `RichText` mirrors these attributes onto by
+		// hand, only takes over once the block has a sibling.
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'A first paragraph.' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'hello @fr' );
+
+		await expect(
+			page.getByRole( 'option', {
+				name: 'Frodo Baggins',
+				selected: true,
+			} )
+		).toBeVisible();
+
+		const editingHost = editor.canvas.getByRole( 'textbox', {
+			name: 'Editor canvas',
+		} );
+
+		// The popover renders outside the canvas, so the list is mirrored back
+		// into it — these IDs have to resolve in the host's own document.
+		const listBoxId = await editor.canvas
+			.getByRole( 'listbox' )
+			.getAttribute( 'id' );
+		const optionId = await editor.canvas
+			.getByRole( 'option', { name: 'Frodo Baggins' } )
+			.getAttribute( 'id' );
+
+		await expect( editingHost ).toHaveAttribute(
+			'aria-autocomplete',
+			'list'
+		);
+		await expect( editingHost ).toHaveAttribute(
+			'aria-haspopup',
+			'listbox'
+		);
+		await expect( editingHost ).toHaveAttribute(
+			'aria-controls',
+			listBoxId
+		);
+		await expect( editingHost ).toHaveAttribute( 'aria-owns', listBoxId );
+		await expect( editingHost ).toHaveAttribute(
+			'aria-activedescendant',
+			optionId
+		);
+
+		await page.keyboard.press( 'Escape' );
+		await expect( page.getByRole( 'listbox' ) ).toBeHidden();
+
+		// Only an omitted value clears an attribute here: a `null` would land
+		// on the host as the string "null".
+		await expect( editingHost ).not.toHaveAttribute( 'aria-controls' );
+		await expect( editingHost ).not.toHaveAttribute( 'aria-owns' );
+		await expect( editingHost ).not.toHaveAttribute(
+			'aria-activedescendant'
+		);
 	} );
 
 	test( 'should re-trigger autocomplete when backspacing into a completed mention', async ( {


### PR DESCRIPTION
## What?
Backports changes from https://github.com/WordPress/gutenberg/pull/80403.

## Testing Instructions
CI checks are green.