### PR TITLE
Math: Use ValidatedTextareaControl for LaTeX input

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -26,6 +26,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 	const [ error, setError ] = useState( null );
 	const [ latexToMathML, setLatexToMathML ] = useState();
 	const initialLatex = useRef( latex );
+	const formRef = useRef();
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -71,9 +72,16 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					offset={ 8 }
 					anchor={ blockRef }
 					focusOnMount={ false }
+					// Surface any parsing error before focus leaves the block.
+					// An invalid field is refocused, keeping the popover open.
+					onFocusOutside={ () => formRef.current?.reportValidity() }
 					__unstableSlotName="__unstable-block-tools-after"
 				>
-					<div style={ { padding: '4px', minWidth: '300px' } }>
+					<form
+						ref={ formRef }
+						style={ { padding: '4px', minWidth: '300px' } }
+						onSubmit={ ( event ) => event.preventDefault() }
+					>
 						<ValidatedTextareaControl
 							label={ __( 'LaTeX math syntax' ) }
 							hideLabelFromVision
@@ -105,7 +113,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 							} }
 							placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
 						/>
-					</div>
+					</form>
 				</Popover>
 			) }
 		</div>

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -1,27 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	TextareaControl,
 	Popover,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
 
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
+const { ValidatedTextareaControl } = unlock( componentsPrivateApis );
 
 export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 	const { latex, mathML } = attributes;
@@ -77,58 +74,37 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					__unstableSlotName="__unstable-block-tools-after"
 				>
 					<div style={ { padding: '4px', minWidth: '300px' } }>
-						<Stack direction="column" gap="xs">
-							<TextareaControl
-								label={ __( 'LaTeX math syntax' ) }
-								hideLabelFromVision
-								value={ latex }
-								className="wp-block-math__textarea-control"
-								onChange={ ( newLatex ) => {
-									if ( ! latexToMathML ) {
-										setAttributes( { latex: newLatex } );
-										return;
-									}
-									let newMathML = '';
-									try {
-										newMathML = latexToMathML( newLatex, {
-											displayMode: true,
-										} );
-										setError( null );
-									} catch ( err ) {
-										setError( err.message );
-										speak(
-											sprintf(
-												/* translators: %s: error message returned when parsing LaTeX. */
-												__(
-													'Error parsing mathematical expression: %s'
-												),
-												err.message
-											)
-										);
-									}
-									setAttributes( {
-										mathML: newMathML,
-										latex: newLatex,
+						<ValidatedTextareaControl
+							label={ __( 'LaTeX math syntax' ) }
+							hideLabelFromVision
+							value={ latex }
+							className="wp-block-math__textarea-control"
+							customValidity={
+								error
+									? { type: 'invalid', message: error }
+									: undefined
+							}
+							onChange={ ( newLatex ) => {
+								if ( ! latexToMathML ) {
+									setAttributes( { latex: newLatex } );
+									return;
+								}
+								let newMathML = '';
+								try {
+									newMathML = latexToMathML( newLatex, {
+										displayMode: true,
 									} );
-								} }
-								placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
-							/>
-							{ error && (
-								<>
-									<WCBadge
-										intent="error"
-										className="wp-block-math__error"
-									>
-										{ sprintf(
-											/* translators: %s: error message returned when parsing LaTeX. */
-											__( 'Error: %s' ),
-											error
-										) }
-									</WCBadge>
-									<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
-								</>
-							) }
-						</Stack>
+									setError( null );
+								} catch ( err ) {
+									setError( err.message );
+								}
+								setAttributes( {
+									mathML: newMathML,
+									latex: newLatex,
+								} );
+							} }
+							placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
+						/>
 					</div>
 				</Popover>
 			) }

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -9,9 +9,9 @@ import {
 import {
 	TextareaControl,
 	Popover,
-	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { speak } from '@wordpress/a11y';
@@ -77,7 +77,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					__unstableSlotName="__unstable-block-tools-after"
 				>
 					<div style={ { padding: '4px', minWidth: '300px' } }>
-						<VStack spacing={ 1 }>
+						<Stack direction="column" gap="xs">
 							<TextareaControl
 								label={ __( 'LaTeX math syntax' ) }
 								hideLabelFromVision
@@ -128,7 +128,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 									<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
 								</>
 							) }
-						</VStack>
+						</Stack>
 					</div>
 				</Popover>
 			) }

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import {
 	insert,
 	insertObject,
@@ -13,19 +13,16 @@ import {
 import { RichTextToolbarButton } from '@wordpress/block-editor';
 import {
 	Popover,
-	TextControl,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
 import { math as icon } from '@wordpress/icons';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
 
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
+const { ValidatedTextControl } = unlock( componentsPrivateApis );
 
 const name = 'core/math';
 const title = __( 'Math' );
@@ -41,6 +38,7 @@ function InlineUI( {
 		activeAttributes?.[ 'data-latex' ] || ''
 	);
 	const [ error, setError ] = useState( null );
+	const formRef = useRef();
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
@@ -49,25 +47,18 @@ function InlineUI( {
 
 	// Update the math object in real-time as the user types
 	const handleLatexChange = ( newLatex ) => {
-		let mathML = '';
-
 		setLatex( newLatex );
 
-		if ( newLatex ) {
+		let mathML = '';
+		if ( newLatex && latexToMathML ) {
 			try {
 				mathML = latexToMathML( newLatex, { displayMode: false } );
 				setError( null );
 			} catch ( err ) {
 				setError( err.message );
-				speak(
-					sprintf(
-						/* translators: %s: error message returned when parsing LaTeX. */
-						__( 'Error parsing mathematical expression: %s' ),
-						err.message
-					)
-				);
-				return;
 			}
+		} else {
+			setError( null );
 		}
 
 		const newReplacements = value.replacements.slice();
@@ -91,36 +82,29 @@ function InlineUI( {
 			offset={ 8 }
 			focusOnMount={ false }
 			anchor={ popoverAnchor }
+			// Surface any parsing error before focus leaves the popover.
+			// An invalid field is refocused, keeping the popover open.
+			onFocusOutside={ () => formRef.current?.reportValidity() }
 			className="block-editor-format-toolbar__math-popover"
 		>
-			<div style={ { minWidth: '300px', padding: '4px' } }>
-				<Stack direction="column" gap="xs">
-					<TextControl
-						hideLabelFromVision
-						label={ __( 'LaTeX math syntax' ) }
-						value={ latex }
-						onChange={ handleLatexChange }
-						placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
-						autoComplete="off"
-						className="block-editor-format-toolbar__math-input"
-					/>
-					{ error && (
-						<>
-							<WCBadge
-								intent="error"
-								className="wp-block-math__error"
-							>
-								{ sprintf(
-									/* translators: %s: error message returned when parsing LaTeX. */
-									__( 'Error: %s' ),
-									error
-								) }
-							</WCBadge>
-							<style children=".wp-block-math__error .components-badge__content{white-space:normal}" />
-						</>
-					) }
-				</Stack>
-			</div>
+			<form
+				ref={ formRef }
+				style={ { minWidth: '300px', padding: '4px' } }
+				onSubmit={ ( event ) => event.preventDefault() }
+			>
+				<ValidatedTextControl
+					hideLabelFromVision
+					label={ __( 'LaTeX math syntax' ) }
+					value={ latex }
+					customValidity={
+						error ? { type: 'invalid', message: error } : undefined
+					}
+					onChange={ handleLatexChange }
+					placeholder={ __( 'e.g., x^2, \\frac{a}{b}' ) }
+					autoComplete="off"
+					className="block-editor-format-toolbar__math-input"
+				/>
+			</form>
 		</Popover>
 	);
 }

--- a/packages/format-library/src/math/style.scss
+++ b/packages/format-library/src/math/style.scss
@@ -1,4 +1,7 @@
-.block-editor-format-toolbar__math-input {
+@use "@wordpress/base-styles/variables" as *;
+
+.block-editor-format-toolbar__math-input input {
+	font-family: $font-family-mono;
 	/*rtl:ignore*/
 	direction: ltr;
 }

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -76,7 +76,10 @@ test.describe( 'Math Block', () => {
 			`Expected 'EOF', got '&' at position 1: &̲x^2`
 		);
 
+		// Fix syntax error.
+		await page.keyboard.press( 'Backspace' );
 		// Can delete the math block.
+		await pageUtils.pressKeys( 'shift+Tab' );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [

--- a/test/e2e/specs/editor/blocks/math.spec.js
+++ b/test/e2e/specs/editor/blocks/math.spec.js
@@ -68,12 +68,15 @@ test.describe( 'Math Block', () => {
 			},
 		] );
 
-		await expect( page.locator( '[aria-live="polite"]' ) ).toHaveText(
-			`Error parsing mathematical expression: Expected 'EOF', got '&' at position 1: &̲x^2`
+		// The parsing error is surfaced once the field is blurred.
+		await pageUtils.pressKeys( 'shift+Tab' );
+		await expect(
+			page.getByRole( 'textbox', { name: 'LaTeX math syntax' } )
+		).toHaveAccessibleDescription(
+			`Expected 'EOF', got '&' at position 1: &̲x^2`
 		);
 
 		// Can delete the math block.
-		await pageUtils.pressKeys( 'shift+Tab' );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await editor.getBlocks() ).toMatchObject( [

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -338,11 +338,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-library/src/math/edit.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/media-text/edit.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
PR started as a simple refactoring from `VStack` to `Stack` component (first commit), then realized that we could use relatively new `ValidatedTextareaControl` to handle validation and its display.

LaTeX errors now appear as standard validation messages rather than a custom badge, and the screen reader announcement on every keystroke is gone. Initial feedback is deferred until the field first loses focus; after that, the message updates live as you type.

### Notes

* Moving focus away is a bit odd at the moment. Should we add "Cancel/Save" actions to the popover?
* If we agree on design, I can also refactor the Math format to match the new design specs.

## Why?
Parse errors fired on every keystroke, both a visible badge and a screen reader announcement. Typing a formula means most intermediate states are invalid, so this interrupts people constantly mid-expression.

## Testing Instructions
1. Open a post or page.
2. Add a Math block.
3. Add an invalid formula.
4. Confirm that the error is displayed when focus moves away from the form.
5. Type the correct formula.
6. Confirm there's no validation error.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/01f9f340-49ce-486c-a4b8-44a8152d87a2

https://github.com/user-attachments/assets/77f12f1b-f475-4129-9a91-b765e56f578b

## Use of AI Tools

Assisted by Claude
