### PR TITLE
Block Supports: Guard against non-string attribute values to avoid fatal errors

### DIFF
--- a/backport-changelog/7.2/12674.md
+++ b/backport-changelog/7.2/12674.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12674
+
+* https://github.com/WordPress/gutenberg/pull/80501

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -391,8 +391,9 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 		);
 	}
 
-	$minimum_column_width = is_string( $parent_layout['minimumColumnWidth'] ?? null ) ? $parent_layout['minimumColumnWidth'] : null;
-	$column_count         = $parent_layout['columnCount'] ?? null;
+	$minimum_column_width_attr = $parent_layout['minimumColumnWidth'] ?? null;
+	$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
+	$column_count              = $parent_layout['columnCount'] ?? null;
 
 	/*
 	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
@@ -520,9 +521,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
-		$content_size    = is_string( $layout_for_styles['contentSize'] ?? null ) ? $layout_for_styles['contentSize'] : '';
-		$wide_size       = is_string( $layout_for_styles['wideSize'] ?? null ) ? $layout_for_styles['wideSize'] : '';
-		$justify_content = is_string( $layout_for_styles['justifyContent'] ?? null ) ? $layout_for_styles['justifyContent'] : 'center';
+		$content_size_attr    = $layout_for_styles['contentSize'] ?? null;
+		$content_size         = is_string( $content_size_attr ) ? $content_size_attr : '';
+		$wide_size_attr       = $layout_for_styles['wideSize'] ?? null;
+		$wide_size            = is_string( $wide_size_attr ) ? $wide_size_attr : '';
+		$justify_content_attr = $layout_for_styles['justifyContent'] ?? null;
+		$justify_content      = is_string( $justify_content_attr ) ? $justify_content_attr : 'center';
 
 		// Check if viewport-specific ("override") values exist. Null values are valid and mean the user cleared a value inherited from the default viewport.
 		$has_justify_content_override = null !== $viewport_overrides && $has_viewport_property_override( 'justifyContent' );
@@ -741,23 +745,26 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 
+		$flex_justify_content    = $layout_for_styles['justifyContent'] ?? null;
+		$flex_vertical_alignment = $layout_for_styles['verticalAlignment'] ?? null;
+
 		if ( 'horizontal' === $layout_orientation ) {
 			/*
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.
 			 */
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && is_string( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $flex_justify_content ) && is_string( $flex_justify_content ) && array_key_exists( $flex_justify_content, $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
+					'declarations' => array( 'justify-content' => $justify_content_options[ $flex_justify_content ] ),
 				);
 			}
 
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && is_string( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $flex_vertical_alignment ) && is_string( $flex_vertical_alignment ) && array_key_exists( $flex_vertical_alignment, $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
+					'declarations' => array( 'align-items' => $vertical_alignment_options[ $flex_vertical_alignment ] ),
 				);
 			}
 		} else {
@@ -767,10 +774,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'flex-direction' => 'column' ),
 				);
 			}
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && is_string( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $flex_justify_content ) && is_string( $flex_justify_content ) && array_key_exists( $flex_justify_content, $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
+					'declarations' => array( 'align-items' => $justify_content_options[ $flex_justify_content ] ),
 				);
 			} elseif ( $should_output_flex_justification ) {
 				$layout_styles[] = array(
@@ -778,10 +785,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'align-items' => 'flex-start' ),
 				);
 			}
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && is_string( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $flex_vertical_alignment ) && is_string( $flex_vertical_alignment ) && array_key_exists( $flex_vertical_alignment, $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
+					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $flex_vertical_alignment ] ),
 				);
 			}
 		}
@@ -1121,15 +1128,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * not intended to provide an extended set of classes to match all block layout attributes
 	 * here.
 	 */
-	if ( ! empty( $block['attrs']['layout']['orientation'] ) && is_string( $block['attrs']['layout']['orientation'] ) ) {
-		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
+	$orientation = $block['attrs']['layout']['orientation'] ?? null;
+	if ( ! empty( $orientation ) && is_string( $orientation ) ) {
+		$class_names[] = 'is-' . sanitize_title( $orientation );
 	}
 
-	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) && is_string( $block['attrs']['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . sanitize_title( $block['attrs']['layout']['justifyContent'] );
+	$justify_content = $block['attrs']['layout']['justifyContent'] ?? null;
+	if ( ! empty( $justify_content ) && is_string( $justify_content ) ) {
+		$class_names[] = 'is-content-justification-' . sanitize_title( $justify_content );
 	}
 
-	if ( ! empty( $block['attrs']['layout']['flexWrap'] ) && 'nowrap' === $block['attrs']['layout']['flexWrap'] ) {
+	$flex_wrap = $block['attrs']['layout']['flexWrap'] ?? null;
+	if ( ! empty( $flex_wrap ) && 'nowrap' === $flex_wrap ) {
 		$class_names[] = 'is-nowrap';
 	}
 
@@ -1459,7 +1469,8 @@ add_filter( 'render_block', 'gutenberg_render_layout_support_flag', 10, 2 );
  * @return string                Filtered block content.
  */
 function gutenberg_restore_group_inner_container( $block_content, $block ) {
-	$tag_name                         = is_string( $block['attrs']['tagName'] ?? null ) ? $block['attrs']['tagName'] : 'div';
+	$tag_name_attr                    = $block['attrs']['tagName'] ?? null;
+	$tag_name                         = is_string( $tag_name_attr ) ? $tag_name_attr : 'div';
 	$group_with_inner_container_regex = sprintf(
 		'/(^\s*<%1$s\b[^>]*wp-block-group(\s|")[^>]*>)(\s*<div\b[^>]*wp-block-group__inner-container(\s|")[^>]*>)((.|\S|\s)*)/U',
 		preg_quote( $tag_name, '/' )

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -521,6 +521,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
+		// The schemas and editor UI only produce strings here, so treat a non-string
+		// value as absent rather than casting it — it couldn't render as valid CSS anyway.
 		$content_size_attr    = $layout_for_styles['contentSize'] ?? null;
 		$content_size         = is_string( $content_size_attr ) ? $content_size_attr : '';
 		$wide_size_attr       = $layout_for_styles['wideSize'] ?? null;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -391,7 +391,7 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 		);
 	}
 
-	$minimum_column_width = $parent_layout['minimumColumnWidth'] ?? null;
+	$minimum_column_width = is_string( $parent_layout['minimumColumnWidth'] ?? null ) ? $parent_layout['minimumColumnWidth'] : null;
 	$column_count         = $parent_layout['columnCount'] ?? null;
 
 	/*
@@ -520,9 +520,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
-		$content_size    = $layout_for_styles['contentSize'] ?? '';
-		$wide_size       = $layout_for_styles['wideSize'] ?? '';
-		$justify_content = $layout_for_styles['justifyContent'] ?? 'center';
+		$content_size    = is_string( $layout_for_styles['contentSize'] ?? null ) ? $layout_for_styles['contentSize'] : '';
+		$wide_size       = is_string( $layout_for_styles['wideSize'] ?? null ) ? $layout_for_styles['wideSize'] : '';
+		$justify_content = is_string( $layout_for_styles['justifyContent'] ?? null ) ? $layout_for_styles['justifyContent'] : 'center';
 
 		// Check if viewport-specific ("override") values exist. Null values are valid and mean the user cleared a value inherited from the default viewport.
 		$has_justify_content_override = null !== $viewport_overrides && $has_viewport_property_override( 'justifyContent' );
@@ -747,14 +747,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.
 			 */
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && is_string( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'justify-content' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
 				);
 			}
 
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && is_string( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
@@ -767,7 +767,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'flex-direction' => 'column' ),
 				);
 			}
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && is_string( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'align-items' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
@@ -778,7 +778,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'declarations' => array( 'align-items' => 'flex-start' ),
 				);
 			}
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && is_string( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
@@ -1121,11 +1121,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	 * not intended to provide an extended set of classes to match all block layout attributes
 	 * here.
 	 */
-	if ( ! empty( $block['attrs']['layout']['orientation'] ) ) {
+	if ( ! empty( $block['attrs']['layout']['orientation'] ) && is_string( $block['attrs']['layout']['orientation'] ) ) {
 		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
 	}
 
-	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) ) {
+	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) && is_string( $block['attrs']['layout']['justifyContent'] ) ) {
 		$class_names[] = 'is-content-justification-' . sanitize_title( $block['attrs']['layout']['justifyContent'] );
 	}
 
@@ -1134,7 +1134,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	// Get classname for layout type.
-	if ( isset( $used_layout['type'] ) ) {
+	if ( isset( $used_layout['type'] ) && is_string( $used_layout['type'] ) ) {
 		$layout_classname = $layout_definitions[ $used_layout['type'] ]['className'] ?? '';
 	} else {
 		$layout_classname = $layout_definitions['default']['className'] ?? '';
@@ -1459,7 +1459,7 @@ add_filter( 'render_block', 'gutenberg_render_layout_support_flag', 10, 2 );
  * @return string                Filtered block content.
  */
 function gutenberg_restore_group_inner_container( $block_content, $block ) {
-	$tag_name                         = $block['attrs']['tagName'] ?? 'div';
+	$tag_name                         = is_string( $block['attrs']['tagName'] ?? null ) ? $block['attrs']['tagName'] : 'div';
 	$group_with_inner_container_regex = sprintf(
 		'/(^\s*<%1$s\b[^>]*wp-block-group(\s|")[^>]*>)(\s*<div\b[^>]*wp-block-group__inner-container(\s|")[^>]*>)((.|\S|\s)*)/U',
 		preg_quote( $tag_name, '/' )

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1255,4 +1255,111 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			'Global settings should still be resolved for a block that supports layout.'
 		);
 	}
+
+	/**
+	 * Tests that a constrained layout with non-string contentSize/wideSize/justifyContent
+	 * values (e.g. from hand-edited, imported, or AI-generated content) does not cause a
+	 * fatal error in the explode() calls.
+	 *
+	 * @covers ::gutenberg_get_layout_style
+	 */
+	public function test_gutenberg_get_layout_style_with_non_string_constrained_sizes() {
+		$layout_styles = gutenberg_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'           => 'constrained',
+				'contentSize'    => array( '800px' ),
+				'wideSize'       => array( '1200px' ),
+				'justifyContent' => array( 'center' ),
+			)
+		);
+
+		$this->assertIsString( $layout_styles, 'Constrained layout should not fatal when sizes are not strings.' );
+		$this->assertStringNotContainsString( 'Array', $layout_styles, 'A non-string size value should not leak into the output.' );
+	}
+
+	/**
+	 * Tests that a flex layout with non-string justifyContent/verticalAlignment values
+	 * does not cause a fatal error in the array_key_exists() calls.
+	 *
+	 * @covers ::gutenberg_get_layout_style
+	 */
+	public function test_gutenberg_get_layout_style_with_non_string_flex_alignment() {
+		$layout_styles = gutenberg_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'              => 'flex',
+				'orientation'       => 'horizontal',
+				'justifyContent'    => array( 'right' ),
+				'verticalAlignment' => array( 'center' ),
+			)
+		);
+
+		$this->assertIsString( $layout_styles, 'Flex layout should not fatal when alignment values are not strings.' );
+	}
+
+	/**
+	 * Tests that a responsive grid child with a non-string parent minimumColumnWidth
+	 * does not cause a fatal error in the explode() call.
+	 *
+	 * @covers ::gutenberg_get_child_layout_style_rules
+	 */
+	public function test_gutenberg_get_child_layout_style_rules_with_non_string_minimum_column_width() {
+		$actual_output = gutenberg_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array( 'columnSpan' => '2' ),
+			array( 'minimumColumnWidth' => array( '12rem' ) ),
+			null
+		);
+
+		$this->assertIsArray( $actual_output, 'Child layout rules should not fatal when minimumColumnWidth is not a string.' );
+	}
+
+	/**
+	 * Tests that layout classname generation does not fatal when the layout type,
+	 * orientation, or justifyContent attributes are not strings.
+	 *
+	 * @covers ::gutenberg_render_layout_support_flag
+	 */
+	public function test_layout_support_flag_with_non_string_layout_values() {
+		$block_content = '<div class="wp-block-group"></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'layout' => array(
+					'type'           => array( 'constrained' ),
+					'orientation'    => array( 'horizontal' ),
+					'justifyContent' => array( 'center' ),
+				),
+			),
+		);
+
+		$this->assertIsString(
+			gutenberg_render_layout_support_flag( $block_content, $block ),
+			'Layout support should not fatal when layout values are not strings.'
+		);
+	}
+
+	/**
+	 * Tests that restoring the group inner container does not fatal when the tagName
+	 * attribute is not a string (which would break the preg_quote() calls).
+	 *
+	 * @covers ::gutenberg_restore_group_inner_container
+	 */
+	public function test_restore_group_inner_container_with_non_string_tag_name() {
+		// The "default" theme doesn't have theme.json support, so the preg_quote() path runs.
+		switch_theme( 'default' );
+		$block_content = '<div class="wp-block-group"><p>Test</p></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'tagName' => array( 'div' ),
+			),
+		);
+
+		$this->assertIsString(
+			gutenberg_restore_group_inner_container( $block_content, $block ),
+			'Group inner container restore should not fatal when tagName is not a string.'
+		);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #80494


Guards block supports callbacks against non-string (and other wrong-typed) attribute values so they no longer cause fatal`TypeError`s on the front end. (Block support is handled in a this PR.)

## Why?

`block.json` / `theme.json` types aren't enforced at render time, so wrong-typed values from hand-editing, imports, or AI-generated content reach strict PHP ops (`explode`, `preg_match`, `str_contains`, `addcslashes`, `parse_url`, `array_column`, `wp_strip_all_tags`, array offsets) and fatal in PHP 8+.

## How?
Following the existing idiom guard with `is_string()` / `is_array()` / `is_scalar()` before each strict op and treat a wrong-typed value as absent.

## Testing Instructions
Existing tests should pass

### Testing Instructions for Keyboard
N/A — no UI changes.


## Use of AI Tools

Authored with Claude Code (Anthropic). AI applied the guards following existing merged patterns and ran phpcs/PHPUnit; all changes were reviewed and verified by me.