### PR TITLE
State control - avoid tertiary variant on toggle to match style of other dropdown toggles

### DIFF
--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -87,7 +87,7 @@ export default function StateControl( {
 	const icon = showText ? chevronDown : moreVertical;
 	const toggleProps = showText
 		? { size: 'compact', iconPosition: 'right' }
-		: { size: 'compact' };
+		: { size: 'small' };
 
 	return (
 		<Stack

--- a/packages/block-editor/src/components/global-styles/state-control.js
+++ b/packages/block-editor/src/components/global-styles/state-control.js
@@ -86,8 +86,8 @@ export default function StateControl( {
 		: __( 'Default' );
 	const icon = showText ? chevronDown : moreVertical;
 	const toggleProps = showText
-		? { size: 'compact', variant: 'tertiary', iconPosition: 'right' }
-		: { size: 'compact', variant: 'tertiary' };
+		? { size: 'compact', iconPosition: 'right' }
+		: { size: 'compact' };
 
 	return (
 		<Stack


### PR DESCRIPTION
## What?
Fixes a really small thing I noticed. The new style state dropdown toggle has a blue background hover color that comes from the button's tertiary style:
<img width="259" height="105" alt="Screenshot 2026-07-21 at 2 57 43 pm" src="https://github.com/user-attachments/assets/db002825-4bd1-4434-b70e-ae4859bf6469" />

This doesn't match the style of other similar dropdown toggles, like on the tools panel, which have no background, they simply have a very subtle blue foreground color:
<img width="255" height="93" alt="Screenshot 2026-07-21 at 3 05 21 pm" src="https://github.com/user-attachments/assets/7526504b-8534-44f8-906f-080c85f08951" />

The focus style is also different. The tools panel uses a 'small' size, while the state dropdown used 'compact' (slightly bigger). In this PR I've adjusted the style state dropdown to also use small, so they also match:
<img width="272" height="143" alt="Screenshot 2026-07-21 at 3 05 51 pm" src="https://github.com/user-attachments/assets/59424df2-0ecc-4218-98eb-8600c4acd8b5" />
<img width="271" height="171" alt="Screenshot 2026-07-21 at 3 06 03 pm" src="https://github.com/user-attachments/assets/4264c1e6-8095-4a40-849c-103f5606e440" />

## Why?
Looks like the cause of the discrepancy is the use of the `tertiary` variant. Tools panel dropdown toggles have no variant specified so they use some kind of default variant. It's very similar to the `tertiary` variant with a few minor differences like the background.

## How?
Remove usage of the tertiary variant. Switch from 'compact' to 'small'.

## Testing Instructions
1. Insert a buttons block
2. Select the button block
3. Open the block inspector and hover the dropdown

Expected: no background color
In trunk: a pale blue background color

## Use of AI Tools
None