### PR TITLE
Fix crashes when manipulating locked blocks

### DIFF
--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -26,8 +26,13 @@ export default function CodeEdit( {
 				aria-label={ __( 'Code' ) }
 				preserveWhiteSpace
 				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				__unstableOnSplitAtDoubleLineEnd={
+					insertBlocksAfter
+						? () =>
+								insertBlocksAfter(
+									createBlock( getDefaultBlockName() )
+								)
+						: undefined
 				}
 				style={ { whiteSpace: 'break-spaces' } }
 			/>

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -239,7 +239,9 @@ const EmbedEdit = ( props ) => {
 					value={ url }
 					cannotEmbed={ cannotEmbed }
 					onChange={ ( value ) => setURL( value ) }
-					fallback={ () => fallback( url, onReplace ) }
+					fallback={
+						onReplace ? () => fallback( url, onReplace ) : undefined
+					}
 					tryAgain={ () => {
 						invalidateResolution( 'getEmbedPreview', [ url ] );
 					} }

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -70,13 +70,15 @@ export default function EmbedPlaceholder( {
 						>
 							{ _x( 'Try again', 'button label' ) }
 						</Button>
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							onClick={ fallback }
-						>
-							{ _x( 'Convert to link', 'button label' ) }
-						</Button>
+						{ fallback && (
+							<Button
+								__next40pxDefaultSize
+								variant="secondary"
+								onClick={ fallback }
+							>
+								{ _x( 'Convert to link', 'button label' ) }
+							</Button>
+						) }
 					</Stack>
 				</Stack>
 			) }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -94,7 +94,7 @@ function HeadingEdit( props ) {
 			onChange={ onContentChange }
 			onMerge={ mergeBlocks }
 			onReplace={ onReplace }
-			onRemove={ () => onReplace( [] ) }
+			onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 			placeholder={ placeholder || __( 'Heading' ) }
 			{ ...blockProps }
 		/>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -491,7 +491,7 @@ export default function Image( {
 		// Check if there's an embed block that handles this URL, e.g., instagram URL.
 		// See: https://github.com/WordPress/gutenberg/pull/11472
 		const embedBlock = createUpgradedEmbedBlock( { attributes: { url } } );
-		if ( undefined !== embedBlock ) {
+		if ( undefined !== embedBlock && onReplace ) {
 			onReplace( embedBlock );
 		}
 	}

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -76,10 +76,13 @@ export default function MoreEdit( {
 						setAttributes( { customText: value } )
 					}
 					disableLineBreaks
-					__unstableOnSplitAtEnd={ () =>
-						insertBlocksAfter(
-							createBlock( getDefaultBlockName() )
-						)
+					__unstableOnSplitAtEnd={
+						insertBlocksAfter
+							? () =>
+									insertBlocksAfter(
+										createBlock( getDefaultBlockName() )
+									)
+							: undefined
 					}
 				/>
 			</div>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -425,12 +425,15 @@ export default function NavigationLinkEdit( {
 										}
 										onMerge={ mergeBlocks }
 										onReplace={ onReplace }
-										__unstableOnSplitAtEnd={ () =>
-											insertBlocksAfter(
-												createBlock(
-													'core/navigation-link'
-												)
-											)
+										__unstableOnSplitAtEnd={
+											insertBlocksAfter
+												? () =>
+														insertBlocksAfter(
+															createBlock(
+																'core/navigation-link'
+															)
+														)
+												: undefined
 										}
 										aria-label={ __(
 											'Navigation link text'
@@ -470,7 +473,8 @@ export default function NavigationLinkEdit( {
 								// If there is no link and no binding, remove the auto-inserted block.
 								// This avoids empty blocks which can provided a poor UX.
 								// Don't remove if binding exists (even if entity is unavailable) so user can fix it.
-								if ( ! url && ! hasUrlBinding ) {
+								// `onReplace` is undefined when the block can't be removed.
+								if ( ! url && ! hasUrlBinding && onReplace ) {
 									onReplace( [] );
 									return;
 								}

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -133,10 +133,13 @@ export default function PostTermsEdit( {
 							setAttributes( { suffix: value } )
 						}
 						tagName="span"
-						__unstableOnSplitAtEnd={ () =>
-							insertBlocksAfter(
-								createBlock( getDefaultBlockName() )
-							)
+						__unstableOnSplitAtEnd={
+							insertBlocksAfter
+								? () =>
+										insertBlocksAfter(
+											createBlock( getDefaultBlockName() )
+										)
+								: undefined
 						}
 					/>
 				) }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -63,9 +63,11 @@ export default function PostTitleEdit( {
 		postId
 	);
 	const [ link ] = useEntityProp( 'postType', postType, 'link', postId );
-	const onSplitAtEnd = () => {
-		insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-	};
+	const onSplitAtEnd = insertBlocksAfter
+		? () => {
+				insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+		  }
+		: undefined;
 	const blockProps = useBlockProps();
 	const blockEditingMode = useBlockEditingMode();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -33,8 +33,13 @@ export default function PreformattedEdit( {
 			onMerge={ mergeBlocks }
 			{ ...blockProps }
 			__unstablePastePlainText
-			__unstableOnSplitAtDoubleLineEnd={ () =>
-				insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+			__unstableOnSplitAtDoubleLineEnd={
+				insertBlocksAfter
+					? () =>
+							insertBlocksAfter(
+								createBlock( getDefaultBlockName() )
+							)
+					: undefined
 			}
 		/>
 	);

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -55,10 +55,15 @@ function PullQuoteEdit( props ) {
 								} )
 							}
 							className="wp-block-pullquote__citation"
-							__unstableOnSplitAtEnd={ () =>
-								insertBlocksAfter(
-									createBlock( getDefaultBlockName() )
-								)
+							__unstableOnSplitAtEnd={
+								insertBlocksAfter
+									? () =>
+											insertBlocksAfter(
+												createBlock(
+													getDefaultBlockName()
+												)
+											)
+									: undefined
 							}
 						/>
 					) }

--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -64,8 +64,13 @@ export default function ReadMore( {
 				onChange={ ( newValue ) =>
 					setAttributes( { content: newValue } )
 				}
-				__unstableOnSplitAtEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				__unstableOnSplitAtEnd={
+					insertBlocksAfter
+						? () =>
+								insertBlocksAfter(
+									createBlock( getDefaultBlockName() )
+								)
+						: undefined
 				}
 				withoutInteractiveFormatting
 				{ ...blockProps }

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -59,8 +59,13 @@ export default function SiteTaglineEdit( props ) {
 			tagName={ TagName }
 			value={ tagline }
 			disableLineBreaks
-			__unstableOnSplitAtEnd={ () =>
-				insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+			__unstableOnSplitAtEnd={
+				insertBlocksAfter
+					? () =>
+							insertBlocksAfter(
+								createBlock( getDefaultBlockName() )
+							)
+					: undefined
 			}
 			{ ...blockProps }
 		/>

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -73,8 +73,13 @@ export default function SiteTitleEdit( props ) {
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks
-				__unstableOnSplitAtEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+				__unstableOnSplitAtEnd={
+					insertBlocksAfter
+						? () =>
+								insertBlocksAfter(
+									createBlock( getDefaultBlockName() )
+								)
+						: undefined
 				}
 			/>
 		</TagName>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -104,10 +104,13 @@ export function Caption( {
 							setAttributes( { [ attributeKey ]: value } )
 						}
 						inlineToolbar
-						__unstableOnSplitAtEnd={ () =>
-							insertBlocksAfter(
-								createBlock( getDefaultBlockName() )
-							)
+						__unstableOnSplitAtEnd={
+							insertBlocksAfter
+								? () =>
+										insertBlocksAfter(
+											createBlock( getDefaultBlockName() )
+										)
+								: undefined
 						}
 						readOnly={ readOnly }
 						{ ...props }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -40,8 +40,13 @@ export default function VerseEdit( props ) {
 			onMerge={ mergeBlocks }
 			{ ...blockProps }
 			__unstablePastePlainText
-			__unstableOnSplitAtDoubleLineEnd={ () =>
-				insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+			__unstableOnSplitAtDoubleLineEnd={
+				insertBlocksAfter
+					? () =>
+							insertBlocksAfter(
+								createBlock( getDefaultBlockName() )
+							)
+					: undefined
 			}
 		/>
 	);

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -148,6 +148,26 @@ test.describe( 'Heading', () => {
 		] );
 	} );
 
+	test( 'should not remove an empty heading on backspace when removal is locked', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { lock: { remove: true, move: false } },
+		} );
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.click();
+		await page.keyboard.press( 'Backspace' );
+
+		// The locked heading cannot be removed, so it should still be there.
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/heading' } ] );
+	} );
+
 	test( 'should keep the heading when there is an empty paragraph block before and backspace is pressed at the start', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/post-title.spec.js
+++ b/test/e2e/specs/editor/blocks/post-title.spec.js
@@ -28,4 +28,31 @@ test.describe( 'Post Title block', () => {
 		await expect( titleBlock ).toBeVisible();
 		await expect( titleBlock ).toHaveText( 'Just tweaking the post title' );
 	} );
+
+	test( 'should not insert a block on Enter at the end of the title in a locked template', async ( {
+		editor,
+		page,
+	} ) => {
+		// A parent with `templateLock` makes the editor pass an undefined
+		// `insertBlocksAfter` prop to the inner blocks.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: { templateLock: 'all' },
+			innerBlocks: [ { name: 'core/post-title' } ],
+		} );
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Title' } )
+			.click();
+		await page.keyboard.type( 'Hello' );
+		await page.keyboard.press( 'Enter' );
+
+		// No block should have been inserted after the title.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [ { name: 'core/post-title' } ],
+			},
+		] );
+	} );
 } );


### PR DESCRIPTION
Fixes crashes when attempting to do a write-like operation on a locked block. To reproduce, insert this post markup:
```
<!-- wp:heading {"lock":{"move":false,"remove":true}} -->
<h2 class="wp-block-heading"></h2>
<!-- /wp:heading -->

<!-- wp:group {"templateLock":"all"} -->
<div class="wp-block-group"><!-- wp:post-title /--></div>
<!-- /wp:group -->
```
The resulting post looks like this:
<img width="941" height="292" alt="Screenshot 2026-07-21 at 11 09 51" src="https://github.com/user-attachments/assets/bdf2ec92-4010-4ca6-bece-abc4d8b7b556" />

Then try to do two things:
1. Place cursor at the beginning of the empty heading block and press Backspace. Normally the block should be removed, but this one is locked, so nothing happens.
2. Place cursor at the end of the `post-title` block and press Enter. Normally this would create a new paragraph block after the title, but here the containing group is locked, so nothing happens.

The "nothing happens" part is correct, what's wrong is that both operations cause a JS error:

<img width="568" height="143" alt="Screenshot 2026-07-21 at 11 10 15" src="https://github.com/user-attachments/assets/b393f795-f8b1-491e-841a-76119bfa5b37" />

When a block is locked, then in the `BlockListBlock` component it receives `undefined` values for the write-like callbacks:

https://github.com/WordPress/gutenberg/blob/11fbad9e1caa486df7091d08f28697b8dcf20ee1/packages/block-editor/src/components/block-list/block.js#L126-L129

The `RichText` component itself checks for `undefined` callbacks. The trouble is that sometimes the blocks themselves, i.e. the code between `BlockListBlock` and `RichText`,  wrap the callback:
```js
onRemove={ ( ) => onReplace( [] ) }
```
An undefined `onReplace` is converted into failing and defined `onRemove`.

This bug was discovered by monitoring JS errors on WordPress.com. I asked Cursor/Fable to fix the one reported instance and also audit Core blocks for all instances of this crash pattern.

The PR fixes many unchecked potentially undefined callbacks, and also adds two new e2e tests for the `heading` and `post-title` scenarios I describe above.
