### PR TITLE
UI: Set noopener noreferrer on Link openInNewTab

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fixes
 
--   `Link`: Set `rel="noopener noreferrer"` when `openInNewTab` is enabled ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `Link`: Set `rel="noopener noreferrer"` when `openInNewTab` is enabled ([#80513](https://github.com/WordPress/gutenberg/pull/80513)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 
 ### Code Quality

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   `Link`: Set `rel="noopener noreferrer"` when `openInNewTab` is enabled ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 
 ### Code Quality

--- a/packages/ui/src/link/ensure-rel-tokens.ts
+++ b/packages/ui/src/link/ensure-rel-tokens.ts
@@ -1,0 +1,20 @@
+/**
+ * Merges space-separated `rel` tokens into an existing value, deduplicating.
+ *
+ * @param rel    Existing `rel` attribute value, if any.
+ * @param tokens Tokens to ensure are present.
+ * @return Deduplicated `rel` string.
+ */
+export function ensureRelTokens(
+	rel: string | undefined,
+	tokens: readonly string[]
+): string {
+	const merged = new Set(
+		`${ rel ?? '' } ${ tokens.join( ' ' ) }`
+			.trim()
+			.split( /\s+/ )
+			.filter( Boolean )
+	);
+
+	return [ ...merged ].join( ' ' );
+}

--- a/packages/ui/src/link/ensure-rel-tokens.ts
+++ b/packages/ui/src/link/ensure-rel-tokens.ts
@@ -1,9 +1,9 @@
 /**
  * Merges space-separated `rel` tokens into an existing value, deduplicating.
  *
- * @param rel    Existing `rel` attribute value, if any.
- * @param tokens Tokens to ensure are present.
- * @return Deduplicated `rel` string.
+ * @param {string | undefined}    rel    - Existing `rel` attribute value, if any.
+ * @param {ReadonlyArray<string>} tokens - Tokens to ensure are present.
+ * @return {string} Deduplicated `rel` string.
  */
 export function ensureRelTokens(
 	rel: string | undefined,

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { type LinkProps } from './types';
+import { ensureRelTokens } from './ensure-rel-tokens';
 import resetStyles from '../utils/css/resets.module.css';
 import focusStyles from '../utils/css/focus.module.css';
 import styles from './style.module.css';
@@ -28,17 +29,6 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 	},
 	ref
 ) {
-	let resolvedRel = rel;
-	if ( openInNewTab ) {
-		const tokens = new Set(
-			`${ rel ?? '' } noopener noreferrer`
-				.trim()
-				.split( /\s+/ )
-				.filter( Boolean )
-		);
-		resolvedRel = [ ...tokens ].join( ' ' );
-	}
-
 	const element = useRender( {
 		render,
 		defaultTagName: 'a',
@@ -54,7 +44,9 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				className
 			),
 			target: openInNewTab ? '_blank' : undefined,
-			rel: resolvedRel,
+			rel: openInNewTab
+				? ensureRelTokens( rel, [ 'noopener', 'noreferrer' ] )
+				: rel,
 			children: (
 				<>
 					{ children }

--- a/packages/ui/src/link/link.tsx
+++ b/packages/ui/src/link/link.tsx
@@ -23,10 +23,22 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 		openInNewTab = false,
 		render,
 		className,
+		rel,
 		...props
 	},
 	ref
 ) {
+	let resolvedRel = rel;
+	if ( openInNewTab ) {
+		const tokens = new Set(
+			`${ rel ?? '' } noopener noreferrer`
+				.trim()
+				.split( /\s+/ )
+				.filter( Boolean )
+		);
+		resolvedRel = [ ...tokens ].join( ' ' );
+	}
+
 	const element = useRender( {
 		render,
 		defaultTagName: 'a',
@@ -42,6 +54,7 @@ export const Link = forwardRef< HTMLAnchorElement, LinkProps >( function Link(
 				className
 			),
 			target: openInNewTab ? '_blank' : undefined,
+			rel: resolvedRel,
 			children: (
 				<>
 					{ children }

--- a/packages/ui/src/link/test/ensure-rel-tokens.test.ts
+++ b/packages/ui/src/link/test/ensure-rel-tokens.test.ts
@@ -1,0 +1,31 @@
+import { ensureRelTokens } from '../ensure-rel-tokens';
+
+describe( 'ensureRelTokens', () => {
+	it( 'returns the required tokens when rel is undefined', () => {
+		expect(
+			ensureRelTokens( undefined, [ 'noopener', 'noreferrer' ] )
+		).toBe( 'noopener noreferrer' );
+	} );
+
+	it( 'merges tokens into an existing rel value', () => {
+		expect(
+			ensureRelTokens( 'nofollow', [ 'noopener', 'noreferrer' ] )
+				.split( /\s+/ )
+				.sort()
+		).toEqual( [ 'nofollow', 'noopener', 'noreferrer' ].sort() );
+	} );
+
+	it( 'deduplicates tokens already present in rel', () => {
+		expect(
+			ensureRelTokens( 'noopener nofollow', [ 'noopener', 'noreferrer' ] )
+				.split( /\s+/ )
+				.sort()
+		).toEqual( [ 'nofollow', 'noopener', 'noreferrer' ].sort() );
+	} );
+
+	it( 'ignores empty tokens from a sparse rel string', () => {
+		expect( ensureRelTokens( '  nofollow  ', [ 'noopener' ] ) ).toBe(
+			'nofollow noopener'
+		);
+	} );
+} );

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -48,12 +48,44 @@ describe( 'Link', () => {
 			);
 		} );
 
+		it( 'sets rel="noopener noreferrer" when true', () => {
+			render(
+				<Link href="https://example.com" openInNewTab>
+					External
+				</Link>
+			);
+
+			expect( screen.getByRole( 'link' ) ).toHaveAttribute(
+				'rel',
+				'noopener noreferrer'
+			);
+		} );
+
+		it( 'merges noopener noreferrer into a caller-supplied rel', () => {
+			render(
+				<Link href="https://example.com" openInNewTab rel="nofollow">
+					External
+				</Link>
+			);
+
+			const rel = screen.getByRole( 'link' ).getAttribute( 'rel' );
+			expect( rel?.split( /\s+/ ).sort() ).toEqual(
+				[ 'nofollow', 'noopener', 'noreferrer' ].sort()
+			);
+		} );
+
 		it( 'does not set target="_blank" when false', () => {
 			render( <Link href="https://example.com">External</Link> );
 
 			expect( screen.getByRole( 'link' ) ).not.toHaveAttribute(
 				'target'
 			);
+		} );
+
+		it( 'does not force a rel when openInNewTab is false', () => {
+			render( <Link href="https://example.com">External</Link> );
+
+			expect( screen.getByRole( 'link' ) ).not.toHaveAttribute( 'rel' );
 		} );
 
 		it( 'renders an accessible arrow indicator', () => {

--- a/packages/ui/src/link/types.ts
+++ b/packages/ui/src/link/types.ts
@@ -22,7 +22,9 @@ export interface LinkProps extends Omit< ComponentProps< 'a' >, 'target' > {
 
 	/**
 	 * Whether to open the link in a new browser tab.
-	 * When true, sets `target="_blank"` and appends a visual arrow indicator.
+	 * When true, sets `target="_blank"`, adds `rel="noopener noreferrer"`
+	 * (merged with any caller-supplied `rel`), and appends a visual arrow
+	 * indicator.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
## Summary
- When `openInNewTab` is enabled, `@wordpress/ui` `Link` now sets `rel="noopener noreferrer"`.
- Caller-supplied `rel` tokens (e.g. `nofollow`) are preserved and merged.

Split out from the dashboard widgets href hardening work so the design-system change can land on its own. Complementary to #80510 (no overlapping files).

## Test plan
- [ ] `Link` with `openInNewTab` renders `target="_blank"` and `rel="noopener noreferrer"`.
- [ ] `Link` with `openInNewTab` and `rel="nofollow"` includes `nofollow`, `noopener`, and `noreferrer`.
- [ ] `Link` without `openInNewTab` does not force a `rel`.
- [ ] Unit tests in `packages/ui/src/link/test/index.test.tsx` pass.