### PR TITLE
RichText: Stop every instance from handling every keystroke

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -39,7 +39,6 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
-import { useHasEditableRoot } from '../writing-flow/use-editable-root';
 import { unlock } from '../../lock-unlock';
 
 // `RichTextShortcut` and `RichTextInputEvent` now live in
@@ -243,12 +242,36 @@ export function RichTextWrapper(
 	const shouldDisableEditing =
 		readOnly || disableBoundBlock || shouldDisableForPattern;
 
-	const hasEditableRoot = useHasEditableRoot();
-	const hasDefaultEditingMode = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockEditingMode( clientId ) ===
-			'default',
-		[ clientId ]
+	// The editing host state only adjusts this instance when the block is
+	// selected, or to strip an explicit tabIndex while the wrapper is the
+	// editing host. Otherwise avoid subscribing to the block editor store.
+	const needsEditableRoot = isBlockSelected || props.tabIndex === 0;
+	const { hasEditableRoot, hasDefaultEditingMode } = useSelect(
+		( select ) => {
+			if ( ! needsEditableRoot ) {
+				return { hasEditableRoot: false, hasDefaultEditingMode: false };
+			}
+
+			const {
+				getSelectedBlockClientId,
+				canHostEditableRoot,
+				getBlockEditingMode,
+			} = unlock( select( blockEditorStore ) );
+
+			return {
+				// Whether the wrapper is an editing host, which depends on the
+				// selected block. That is this block when it is selected, but
+				// not on the `tabIndex` path below, which also runs while
+				// another block is selected.
+				hasEditableRoot: canHostEditableRoot(
+					getSelectedBlockClientId()
+				),
+				hasDefaultEditingMode:
+					isBlockSelected &&
+					getBlockEditingMode( clientId ) === 'default',
+			};
+		},
+		[ needsEditableRoot, isBlockSelected, clientId ]
 	);
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );

--- a/packages/block-editor/src/components/writing-flow/use-editable-root.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root.js
@@ -13,29 +13,6 @@ import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Returns true when the writing flow wrapper should be contentEditable: the
- * selected block supports `editableRoot`.
- *
- * @return {boolean} Whether the wrapper should be editable.
- */
-export function useHasEditableRoot() {
-	return useSelect( ( select ) => {
-		const { getSelectedBlockClientId, canHostEditableRoot } = unlock(
-			select( blockEditorStore )
-		);
-		return canHostEditableRoot( getSelectedBlockClientId() );
-	}, [] );
-}
-
-/**
- * Keeps the writing flow wrapper contentEditable while the selected block
- * supports `editableRoot`, so the native selection can extend across blocks.
- * While the wrapper is editable it must also hold focus: a nested editable
- * element cannot retain focus once an ancestor becomes an editing host (the
- * first DOM mutation moves focus to the host, inconsistently across
- * browsers).
- */
-/**
  * Keeps the writing flow wrapper contentEditable while the selected block
  * supports `editableRoot`, so the native selection can extend across blocks.
  * While the wrapper is editable it must also hold focus: a nested editable
@@ -45,11 +22,13 @@ export function useHasEditableRoot() {
  */
 export default function useEditableRoot() {
 	const registry = useRegistry();
-	const isZoomOut = useSelect(
-		( select ) => unlock( select( blockEditorStore ) ).isZoomOut(),
-		[]
-	);
-	const enabled = useHasEditableRoot() && ! isZoomOut;
+	const enabled = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, canHostEditableRoot, isZoomOut } =
+			unlock( select( blockEditorStore ) );
+		return (
+			! isZoomOut() && canHostEditableRoot( getSelectedBlockClientId() )
+		);
+	}, [] );
 
 	return useRefEffect(
 		( node ) => {

--- a/packages/block-editor/src/components/writing-flow/use-editable-root.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root.js
@@ -3,7 +3,6 @@
  */
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
-import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,53 +13,6 @@ import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Returns true when the writing flow wrapper can host editing for the given
- * block: it supports `editableRoot`, is edited visually in the default
- * editing mode, and has sibling blocks for a native selection to extend
- * into, all of them editable.
- *
- * @param {Object} select   Bound block editor store selectors.
- * @param {string} clientId Block client ID.
- *
- * @return {boolean} Whether an editing host can host the block.
- */
-export function canHostEditableRoot( select, clientId ) {
-	const {
-		getBlockName,
-		getBlockEditingMode,
-		getBlockMode,
-		getBlockRootClientId,
-		getBlockOrder,
-	} = select;
-
-	if (
-		! clientId ||
-		getBlockEditingMode( clientId ) !== 'default' ||
-		// Not when the block is edited as HTML: there is no rich text to
-		// host then, only a textarea, which the editing host would
-		// interfere with.
-		getBlockMode( clientId ) !== 'visual' ||
-		! hasBlockSupport( getBlockName( clientId ), 'editableRoot', false )
-	) {
-		return false;
-	}
-
-	// Only host when the block has sibling blocks for a native selection to
-	// extend into, all of them editable. A lone block (e.g. a single
-	// paragraph nested in an HTML block) is edited on its own element, and
-	// read-only siblings (e.g. pattern content without overrides enabled)
-	// must not become editable by inheriting from the host.
-	const siblings = getBlockOrder( getBlockRootClientId( clientId ) );
-	return (
-		siblings.length > 1 &&
-		siblings.every(
-			( siblingClientId ) =>
-				getBlockEditingMode( siblingClientId ) === 'default'
-		)
-	);
-}
-
-/**
  * Returns true when the writing flow wrapper should be contentEditable: the
  * selected block supports `editableRoot`.
  *
@@ -68,11 +20,10 @@ export function canHostEditableRoot( select, clientId ) {
  */
 export function useHasEditableRoot() {
 	return useSelect( ( select ) => {
-		const selectors = select( blockEditorStore );
-		return canHostEditableRoot(
-			selectors,
-			selectors.getSelectedBlockClientId()
+		const { getSelectedBlockClientId, canHostEditableRoot } = unlock(
+			select( blockEditorStore )
 		);
+		return canHostEditableRoot( getSelectedBlockClientId() );
 	}, [] );
 }
 

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -14,7 +14,6 @@ import { isSelectionForward } from '@wordpress/dom';
  */
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
-import { canHostEditableRoot } from './use-editable-root';
 import { setContentEditableWrapper } from './utils';
 import { unlock } from '../../lock-unlock';
 
@@ -109,7 +108,6 @@ export default function useSelectionObserver() {
 		startMultiSelect,
 		stopMultiSelect,
 	} = useDispatch( blockEditorStore );
-	const blockEditorSelectors = useSelect( blockEditorStore );
 	const {
 		getBlockParents,
 		getBlockSelectionStart,
@@ -117,7 +115,8 @@ export default function useSelectionObserver() {
 		getSelectionStart,
 		getSelectionEnd,
 		getSelectedBlockClientId,
-	} = blockEditorSelectors;
+		canHostEditableRoot,
+	} = unlock( useSelect( blockEditorStore ) );
 	return useRefEffect(
 		( node ) => {
 			const { ownerDocument } = node;
@@ -185,10 +184,7 @@ export default function useSelectionObserver() {
 						// always move it), which must not re-enable the wrapper
 						// after another block has been selected.
 						collapsedClientId === getSelectedBlockClientId() &&
-						canHostEditableRoot(
-							blockEditorSelectors,
-							collapsedClientId
-						)
+						canHostEditableRoot( collapsedClientId )
 					) {
 						setContentEditableWrapper( node, true );
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -15,6 +15,7 @@ import {
 	getBlockOrder,
 	getBlockParents,
 	getBlockEditingMode,
+	getBlockMode,
 	getBlockListSettings,
 	getSettings,
 	canInsertBlockType,
@@ -242,6 +243,62 @@ function hasExplicitDisabledParent( state, clientId ) {
 
 	return false;
 }
+
+/**
+ * Returns true when the writing flow wrapper can host editing for the given
+ * block: it supports `editableRoot`, is edited visually in the default
+ * editing mode, and has sibling blocks for a native selection to extend
+ * into, all of them editable.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Block client ID.
+ *
+ * @return {boolean} Whether an editing host can host the block.
+ */
+export const canHostEditableRoot = createSelector(
+	( state, clientId ) => {
+		if (
+			! clientId ||
+			getBlockEditingMode( state, clientId ) !== 'default' ||
+			// Not when the block is edited as HTML: there is no rich text to
+			// host then, only a textarea, which the editing host would
+			// interfere with.
+			getBlockMode( state, clientId ) !== 'visual' ||
+			! hasBlockSupport(
+				getBlockName( state, clientId ),
+				'editableRoot',
+				false
+			)
+		) {
+			return false;
+		}
+
+		// Only host when the block has sibling blocks for a native selection to
+		// extend into, all of them editable. A lone block (e.g. a single
+		// paragraph nested in an HTML block) is edited on its own element, and
+		// read-only siblings (e.g. pattern content without overrides enabled)
+		// must not become editable by inheriting from the host.
+		const siblings = getBlockOrder(
+			state,
+			getBlockRootClientId( state, clientId )
+		);
+		return (
+			siblings.length > 1 &&
+			siblings.every(
+				( siblingClientId ) =>
+					getBlockEditingMode( state, siblingClientId ) === 'default'
+			)
+		);
+	},
+	( state ) => [
+		state.blocks.order,
+		state.blocks.parents,
+		state.blocks.byClientId,
+		state.blocks.blockEditingModes,
+		state.derivedBlockEditingModes,
+		state.blocksMode,
+	]
+);
 
 /**
  * Returns the block tree displayed by List View.

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -34,6 +34,7 @@ import {
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
+import reducer from '../reducer';
 
 describe( 'private selectors', () => {
 	describe( 'isBlockInterfaceHidden', () => {
@@ -2603,33 +2604,6 @@ describe( 'private selectors', () => {
 			expect( canHostEditableRoot( createState(), 'a' ) ).toBe( true );
 		} );
 
-		it( 'should return false without a client ID', () => {
-			expect( canHostEditableRoot( createState(), null ) ).toBe( false );
-		} );
-
-		it( 'should return false when the block does not support editableRoot', () => {
-			const state = createState();
-			state.blocks.byClientId.set( 'a', { name: 'core/test-plain' } );
-
-			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
-		} );
-
-		it( 'should return false when the block is edited as HTML', () => {
-			const state = createState();
-			state.blocksMode = { a: 'html' };
-
-			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
-		} );
-
-		it( 'should return false when the block is not in the default editing mode', () => {
-			const state = createState();
-			state.blocks.blockEditingModes = new Map( [
-				[ 'a', 'contentOnly' ],
-			] );
-
-			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
-		} );
-
 		it( 'should return false for a lone block', () => {
 			const state = createState();
 			state.blocks.order = new Map( [
@@ -2647,15 +2621,12 @@ describe( 'private selectors', () => {
 			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
 		} );
 
-		// The sibling scan is O(number of siblings) and runs in every rich text
-		// instance, so it must not recompute while typing, which only replaces
-		// block attributes.
+		// The sibling scan is O(siblings) and runs in every rich text instance.
 		it( 'should not recompute when only block attributes change', () => {
 			const state = createState();
 			expect( canHostEditableRoot( state, 'a' ) ).toBe( true );
 
-			// Make the uncached result differ without touching any dependant,
-			// so a cache hit is the only way to still get the primed value.
+			// Change the uncached result without touching a dependant.
 			state.blocks.byClientId.set( 'a', { name: 'core/test-plain' } );
 
 			const nextState = {
@@ -2671,9 +2642,42 @@ describe( 'private selectors', () => {
 
 			expect( canHostEditableRoot( nextState, 'a' ) ).toBe( true );
 
-			// The same state does recompute once a dependant changes.
 			nextState.blocks.byClientId = new Map( state.blocks.byClientId );
 			expect( canHostEditableRoot( nextState, 'a' ) ).toBe( false );
+		} );
+
+		// The memoization above is only reachable if the reducer preserves
+		// these references through a keystroke.
+		it( 'should keep its dependants referentially stable while typing', () => {
+			const block = ( clientId ) => ( {
+				clientId,
+				name: 'core/test-editable-root',
+				attributes: { content: clientId },
+				innerBlocks: [],
+			} );
+			const state = reducer( reducer( undefined, { type: '@@init' } ), {
+				type: 'RESET_BLOCKS',
+				blocks: [ block( 'a' ), block( 'b' ) ],
+			} );
+
+			const next = reducer( state, {
+				type: 'UPDATE_BLOCK_ATTRIBUTES',
+				clientIds: [ 'a' ],
+				attributes: { content: 'typed' },
+			} );
+
+			// Guards against the assertions below passing vacuously.
+			expect( next.blocks.attributes ).not.toBe(
+				state.blocks.attributes
+			);
+
+			const before = canHostEditableRoot.getDependants( state );
+			const after = canHostEditableRoot.getDependants( next );
+
+			expect( after ).toHaveLength( before.length );
+			after.forEach( ( dependant, index ) => {
+				expect( dependant ).toBe( before[ index ] );
+			} );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -30,6 +30,7 @@ import {
 	isSelectedBlockStyleStateShownOnCanvas,
 	shouldRenderBlockListView,
 	getStyleOverrides,
+	canHostEditableRoot,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
 import { deviceTypeKey } from '../private-keys';
@@ -2548,6 +2549,131 @@ describe( 'private selectors', () => {
 			expect( getParentSectionBlock( state, 'inner-block' ) ).toBe(
 				'pattern-a'
 			);
+		} );
+	} );
+
+	describe( 'canHostEditableRoot', () => {
+		beforeEach( () => {
+			registerBlockType( 'core/test-editable-root', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'Editable root',
+				supports: { editableRoot: true },
+			} );
+			registerBlockType( 'core/test-plain', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'Plain',
+			} );
+		} );
+
+		afterEach( () => {
+			unregisterBlockType( 'core/test-editable-root' );
+			unregisterBlockType( 'core/test-plain' );
+		} );
+
+		const createState = () => ( {
+			blocks: {
+				byClientId: new Map( [
+					[ 'a', { name: 'core/test-editable-root' } ],
+					[ 'b', { name: 'core/test-editable-root' } ],
+				] ),
+				attributes: new Map( [
+					[ 'a', { content: 'a' } ],
+					[ 'b', { content: 'b' } ],
+				] ),
+				order: new Map( [
+					[ '', [ 'a', 'b' ] ],
+					[ 'a', [] ],
+					[ 'b', [] ],
+				] ),
+				parents: new Map( [
+					[ 'a', '' ],
+					[ 'b', '' ],
+				] ),
+				blockEditingModes: new Map(),
+			},
+			derivedBlockEditingModes: new Map(),
+			blocksMode: {},
+		} );
+
+		it( 'should return true for a block supporting editableRoot with editable siblings', () => {
+			expect( canHostEditableRoot( createState(), 'a' ) ).toBe( true );
+		} );
+
+		it( 'should return false without a client ID', () => {
+			expect( canHostEditableRoot( createState(), null ) ).toBe( false );
+		} );
+
+		it( 'should return false when the block does not support editableRoot', () => {
+			const state = createState();
+			state.blocks.byClientId.set( 'a', { name: 'core/test-plain' } );
+
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
+		} );
+
+		it( 'should return false when the block is edited as HTML', () => {
+			const state = createState();
+			state.blocksMode = { a: 'html' };
+
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
+		} );
+
+		it( 'should return false when the block is not in the default editing mode', () => {
+			const state = createState();
+			state.blocks.blockEditingModes = new Map( [
+				[ 'a', 'contentOnly' ],
+			] );
+
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
+		} );
+
+		it( 'should return false for a lone block', () => {
+			const state = createState();
+			state.blocks.order = new Map( [
+				[ '', [ 'a' ] ],
+				[ 'a', [] ],
+			] );
+
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
+		} );
+
+		it( 'should return false when a sibling is not editable', () => {
+			const state = createState();
+			state.derivedBlockEditingModes = new Map( [ [ 'b', 'disabled' ] ] );
+
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( false );
+		} );
+
+		// The sibling scan is O(number of siblings) and runs in every rich text
+		// instance, so it must not recompute while typing, which only replaces
+		// block attributes.
+		it( 'should not recompute when only block attributes change', () => {
+			const state = createState();
+			expect( canHostEditableRoot( state, 'a' ) ).toBe( true );
+
+			// Make the uncached result differ without touching any dependant,
+			// so a cache hit is the only way to still get the primed value.
+			state.blocks.byClientId.set( 'a', { name: 'core/test-plain' } );
+
+			const nextState = {
+				...state,
+				blocks: {
+					...state.blocks,
+					attributes: new Map( [
+						[ 'a', { content: 'typed' } ],
+						[ 'b', { content: 'b' } ],
+					] ),
+				},
+			};
+
+			expect( canHostEditableRoot( nextState, 'a' ) ).toBe( true );
+
+			// The same state does recompute once a dependant changes.
+			nextState.blocks.byClientId = new Map( state.blocks.byClientId );
+			expect( canHostEditableRoot( nextState, 'a' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -348,8 +348,8 @@ export default ( props ) => ( element ) => {
 	// `handleSelectionChange` checks whether the element is focused itself,
 	// and the shared underlying delegated listener keeps the number of native
 	// listeners constant.
-	const unsubscribeSelectionChange = subscribeDelegatedListener(
-		ownerDocument,
+	const unsubscribeSelectionChange = subscribeOwnedListener(
+		element,
 		'selectionchange',
 		handleSelectionChange
 	);
@@ -362,7 +362,9 @@ export default ( props ) => ( element ) => {
 	// Synchronize on capture of the events that consume the record,
 	// the store selection, or a value rendered from them, before any other
 	// handler runs. The snapshot comparison in `handleSelectionChange` skips
-	// selections that have already been processed.
+	// selections that have already been processed. Subscribing as an owned
+	// listener keeps this ahead of the other owned listeners for the same
+	// element, which `useEventListeners` orders `inputAndSelection` first for.
 	const unsubscribeEnsureSelectionSync = [
 		'keydown',
 		'beforeinput',
@@ -370,8 +372,8 @@ export default ( props ) => ( element ) => {
 		'cut',
 		'paste',
 	].map( ( eventType ) =>
-		subscribeDelegatedListener(
-			ownerDocument,
+		subscribeOwnedListener(
+			element,
 			eventType,
 			handleSelectionChange,
 			true

--- a/packages/rich-text/src/owns-selection.js
+++ b/packages/rich-text/src/owns-selection.js
@@ -16,22 +16,31 @@ export function ownsSelection( element ) {
 		return true;
 	}
 
+	if ( ! activeElement ) {
+		return false;
+	}
+
+	// Test the selection before the editing host. When the host is the
+	// editable canvas wrapper it contains every instance, so the host checks
+	// pass for all of them and only the selection discriminates. Reading
+	// `isContentEditable` also forces a style and layout tree update, so it
+	// is kept off the path that every unrelated instance walks.
+	const selection = ownerDocument.defaultView?.getSelection();
+	const anchorNode = selection?.anchorNode;
+	const focusNode = selection?.focusNode;
+
 	if (
-		! activeElement ||
-		! activeElement.isContentEditable ||
-		! element.isContentEditable ||
-		! activeElement.contains( element )
+		! anchorNode ||
+		! focusNode ||
+		! element.contains( anchorNode ) ||
+		! element.contains( focusNode )
 	) {
 		return false;
 	}
 
-	const selection = ownerDocument.defaultView.getSelection();
-	const { anchorNode, focusNode } = selection;
-
 	return (
-		!! anchorNode &&
-		!! focusNode &&
-		element.contains( anchorNode ) &&
-		element.contains( focusNode )
+		activeElement.isContentEditable &&
+		element.isContentEditable &&
+		activeElement.contains( element )
 	);
 }

--- a/packages/rich-text/src/owns-selection.js
+++ b/packages/rich-text/src/owns-selection.js
@@ -20,11 +20,11 @@ export function ownsSelection( element ) {
 		return false;
 	}
 
-	// Test the selection before the editing host. When the host is the
-	// editable canvas wrapper it contains every instance, so the host checks
-	// pass for all of them and only the selection discriminates. Reading
-	// `isContentEditable` also forces a style and layout tree update, so it
-	// is kept off the path that every unrelated instance walks.
+	// Order matters: the selection is checked before the editing host. When
+	// the host is the canvas wrapper it contains every editable element, so
+	// the host checks pass for all of them and only the selection tells them
+	// apart. Reading `isContentEditable` also forces a style and layout tree
+	// update, which every instance would then pay on every keystroke.
 	const selection = ownerDocument.defaultView?.getSelection();
 	const anchorNode = selection?.anchorNode;
 	const focusNode = selection?.focusNode;

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -13,19 +13,17 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
 // ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >
 //
-// One shared delegated subscription per document, event type and phase.
-// Subscribing each element separately would bind every subscriber to the
-// document, so a single event would run all of them to let all but one
-// filter itself out: with an editable element per block that is O(blocks)
-// on every keystroke. Instead the owning elements are resolved from the
-// event and the selection, which only ever walks two ancestor chains.
+// Subscribers share one subscription per document, event type and phase, and
+// `dispatch` works out which elements own the event. Do not give each element
+// its own subscription: they all bind to the document, so every subscriber
+// would run on every event just to discover it wasn't the one that owned it.
+// With an editable element per block that is O(blocks) per keystroke.
 //
-// The inner registry is a `WeakMap` so removing an editable element (or the
-// iframe holding it) lets it be garbage-collected, matching
-// `subscribeDelegatedListener`.
+// The inner map is weak so a removed editable element (or the iframe holding
+// it) can be garbage-collected.
 const registries = new WeakMap();
 
-function dispatch( elements, ownerDocument, event ) {
+function dispatch( elements, ownerDocument, event, capture ) {
 	const fired = new Set();
 
 	function fire( node ) {
@@ -39,28 +37,50 @@ function dispatch( elements, ownerDocument, event ) {
 		}
 	}
 
-	// Events targeting the element or one of its descendants: every element
-	// containing the target is on the target's ancestor chain.
-	for ( let node = event.target; node; node = node.parentNode ) {
-		fire( node );
+	// Fires the subscribed elements on an ancestor chain, innermost first for
+	// bubble and outermost first for capture, as the DOM would. Only reachable
+	// with editable elements nested in each other, but getting the phase wrong
+	// there is near impossible to debug.
+	function fireChain( from, isOwned ) {
+		let captured;
+		for ( let node = from; node; node = node.parentNode ) {
+			if ( ! elements.get( node ) || ( isOwned && ! isOwned( node ) ) ) {
+				continue;
+			}
+			if ( ! capture ) {
+				fire( node );
+			} else {
+				if ( ! captured ) {
+					captured = [];
+				}
+				captured.push( node );
+			}
+		}
+		if ( captured ) {
+			for ( let i = captured.length - 1; i >= 0; i-- ) {
+				fire( captured[ i ] );
+			}
+		}
 	}
+
+	// Any element containing the target is an ancestor of it.
+	fireChain( event.target );
 
 	const { activeElement } = ownerDocument;
 	if ( ! activeElement ) {
 		return;
 	}
 
-	// A focused element always owns the selection.
+	// A focused element owns the selection even when the selection sits
+	// elsewhere, so it may not appear on the anchor chain below.
 	fire( activeElement );
 
-	// An element owning the selection through a focused editing host contains
-	// the selection anchor, so only the anchor's ancestor chain can qualify.
+	// An element owning the selection through a focused editing host has to
+	// contain the anchor, so nothing off the anchor chain can qualify.
+	// `ownsSelection` is called whole, repeating the anchor check the walk
+	// already made, so the two can't drift apart.
 	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
-	for ( let node = anchorNode; node; node = node.parentNode ) {
-		if ( elements.get( node ) && ownsSelection( node ) ) {
-			fire( node );
-		}
-	}
+	fireChain( anchorNode, ownsSelection );
 }
 
 /**
@@ -96,10 +116,16 @@ export function subscribeOwnedListener(
 	if ( ! elements ) {
 		elements = new WeakMap();
 		perDocument.set( key, elements );
+		// This rides the delegated listener for ordering, not for filtering:
+		// being bound to the document, it is reached for every event and
+		// `dispatch` picks the owners itself. Sharing the one native listener
+		// keeps owned and element-bound subscribers in DOM order relative to
+		// each other. Listening on the document directly would instead order
+		// them by whichever native listener happened to be registered first.
 		subscribeDelegatedListener(
 			ownerDocument,
 			eventType,
-			( event ) => dispatch( elements, ownerDocument, event ),
+			( event ) => dispatch( elements, ownerDocument, event, capture ),
 			capture
 		);
 	}

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -11,6 +11,58 @@ import { unlock } from './lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
+// ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >
+//
+// One shared delegated subscription per document, event type and phase.
+// Subscribing each element separately would bind every subscriber to the
+// document, so a single event would run all of them to let all but one
+// filter itself out: with an editable element per block that is O(blocks)
+// on every keystroke. Instead the owning elements are resolved from the
+// event and the selection, which only ever walks two ancestor chains.
+//
+// The inner registry is a `WeakMap` so removing an editable element (or the
+// iframe holding it) lets it be garbage-collected, matching
+// `subscribeDelegatedListener`.
+const registries = new WeakMap();
+
+function dispatch( elements, ownerDocument, event ) {
+	const fired = new Set();
+
+	function fire( node ) {
+		const callbacks = elements.get( node );
+		if ( ! callbacks || fired.has( node ) ) {
+			return;
+		}
+		fired.add( node );
+		for ( const callback of callbacks ) {
+			callback( event );
+		}
+	}
+
+	// Events targeting the element or one of its descendants: every element
+	// containing the target is on the target's ancestor chain.
+	for ( let node = event.target; node; node = node.parentNode ) {
+		fire( node );
+	}
+
+	const { activeElement } = ownerDocument;
+	if ( ! activeElement ) {
+		return;
+	}
+
+	// A focused element always owns the selection.
+	fire( activeElement );
+
+	// An element owning the selection through a focused editing host contains
+	// the selection anchor, so only the anchor's ancestor chain can qualify.
+	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
+	for ( let node = anchorNode; node; node = node.parentNode ) {
+		if ( elements.get( node ) && ownsSelection( node ) ) {
+			fire( node );
+		}
+	}
+}
+
 /**
  * Subscribes a callback for events owned by the given editable element:
  * events targeting the element or its descendants, and events targeting a
@@ -31,18 +83,35 @@ export function subscribeOwnedListener(
 	callback,
 	capture = false
 ) {
-	return subscribeDelegatedListener(
-		element.ownerDocument,
-		eventType,
-		( event ) => {
-			if (
-				! element.contains( event.target ) &&
-				! ownsSelection( element )
-			) {
-				return;
-			}
-			callback( event );
-		},
-		capture
-	);
+	const { ownerDocument } = element;
+
+	let perDocument = registries.get( ownerDocument );
+	if ( ! perDocument ) {
+		perDocument = new Map();
+		registries.set( ownerDocument, perDocument );
+	}
+
+	const key = capture ? `${ eventType }:capture` : eventType;
+	let elements = perDocument.get( key );
+	if ( ! elements ) {
+		elements = new WeakMap();
+		perDocument.set( key, elements );
+		subscribeDelegatedListener(
+			ownerDocument,
+			eventType,
+			( event ) => dispatch( elements, ownerDocument, event ),
+			capture
+		);
+	}
+
+	let callbacks = elements.get( element );
+	if ( ! callbacks ) {
+		callbacks = new Set();
+		elements.set( element, callbacks );
+	}
+	callbacks.add( callback );
+
+	return () => {
+		callbacks.delete( callback );
+	};
 }


### PR DESCRIPTION
## What?
Fixes a post-editor typing performance regression introduced by https://github.com/WordPress/gutenberg/pull/79105#issuecomment-5031548459.
Stacked on #80507.

`subscribeOwnedListener` binds each element's listeners to the **document**, so they all land in one list and **every subscriber runs on every event**, each checking "was that me?" and bailing. With ~8 keydown listeners per instance, a 1250-block post ran ~10,000 of those checks per keystroke — plus more for `beforeinput`, `input,` and `selectionchange`.

The check also got more expensive. It starts with a cheap bail-out — _is this element focused?_ Before #79105, the focused element was the paragraph you were typing in, so every other instance bailed immediately. With `editableRoot`, the writing-flow wrapper is the editing host, and it contains _every_ block, so the bail-out never fires and all 1250 instances run the full check: `getSelection()`, three `contains()` walks, and two `isContentEditable` reads that force a style/layout-tree update.

In the typing trace, `ownsSelection` was 98.6ms of self-time over 11 keystrokes, with style recalc up from 75.8ms to 104.1ms.

## How?
Resolve _which_ element owns an event once, instead of asking every subscriber. One shared subscription per document/event type/phase, and dispatch walks two ancestor chains — up from `event.target`, and up from the selection anchor (an element owning the selection must contain the anchor). That's proportional to DOM depth, not to block count.

Supporting: `ownsSelection` reordered so the selection check — the one that actually distinguishes instances — runs first, keeping the forced style update off the hot path. And `ensureSelectionSync` now subscribes through the same dispatcher, required so the record still syncs before the other keydown handlers.

## Testing Instructions
CI checks are green.

## Use of AI Tools

Assisted by Claude.