### PR TITLE
Build: Handle project paths containing spaces in dev script

### DIFF
--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -160,7 +160,7 @@ async function dev() {
 		console.log( '\n🧹 Cleaning packages...' );
 		await exec(
 			'node',
-			[ path.join( __dirname, 'clean.mjs' ), '--packages' ],
+			[ `"${ path.join( __dirname, 'clean.mjs' ) }"`, '--packages' ],
 			{ silent: true }
 		);
 
@@ -174,7 +174,7 @@ async function dev() {
 		// This must happen before TypeScript compilation because some packages
 		// (like vips) have source files that import from generated worker-code.ts
 		await exec( 'node', [
-			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
+			`"${ path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ) }"`,
 		] );
 
 		if ( ! skipTypes ) {
@@ -191,16 +191,16 @@ async function dev() {
 
 			console.log( '\n✅ Checking type declaration files...' );
 			await exec( 'node', [
-				path.join(
+				`"${ path.join(
 					__dirname,
 					'packages/check-build-type-declaration-files.cjs'
-				),
+				) }"`,
 			] );
 		}
 
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [
-			path.join( __dirname, 'packages/build-vendors.mjs' ),
+			`"${ path.join( __dirname, 'packages/build-vendors.mjs' ) }"`,
 		] );
 
 		const setupTime = Date.now() - startTime;

--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { execSync, spawn } from 'child_process';
+import { execSync } from 'child_process';
+import spawn from 'cross-spawn';
 import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
 import path from 'path';
@@ -29,7 +30,6 @@ function exec( command, args = [], options = {} ) {
 		const childOptions = {
 			cwd: ROOT_DIR,
 			stdio: silent ? 'pipe' : 'inherit',
-			shell: true,
 			...spawnOptions,
 		};
 
@@ -90,7 +90,6 @@ function execAsync( command, args = [], options = {} ) {
 	return spawn( command, args, {
 		cwd: ROOT_DIR,
 		stdio: 'inherit',
-		shell: true,
 		...options,
 	} );
 }
@@ -160,7 +159,7 @@ async function dev() {
 		console.log( '\n🧹 Cleaning packages...' );
 		await exec(
 			'node',
-			[ `"${ path.join( __dirname, 'clean.mjs' ) }"`, '--packages' ],
+			[ path.join( __dirname, 'clean.mjs' ), '--packages' ],
 			{ silent: true }
 		);
 
@@ -174,7 +173,7 @@ async function dev() {
 		// This must happen before TypeScript compilation because some packages
 		// (like vips) have source files that import from generated worker-code.ts
 		await exec( 'node', [
-			`"${ path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ) }"`,
+			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
 		] );
 
 		if ( ! skipTypes ) {
@@ -191,16 +190,16 @@ async function dev() {
 
 			console.log( '\n✅ Checking type declaration files...' );
 			await exec( 'node', [
-				`"${ path.join(
+				path.join(
 					__dirname,
 					'packages/check-build-type-declaration-files.cjs'
-				) }"`,
+				),
 			] );
 		}
 
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [
-			`"${ path.join( __dirname, 'packages/build-vendors.mjs' ) }"`,
+			path.join( __dirname, 'packages/build-vendors.mjs' ),
 		] );
 
 		const setupTime = Date.now() - startTime;
@@ -231,7 +230,6 @@ async function dev() {
 		const buildWatch = spawn( 'wp-build', [ '--watch' ], {
 			cwd: ROOT_DIR,
 			stdio: [ 'inherit', 'pipe', 'inherit' ],
-			shell: true,
 			env: { ...process.env, NODE_ENV: 'development' },
 		} );
 


### PR DESCRIPTION
## What?

Closes #80516.

Fixes the build scripts so `npm run dev` works correctly when the Gutenberg repository is located in a directory whose path contains spaces (for example, LocalWP's default `Local Sites` directory).

## Why?

The development build script was using `child_process.spawn()` with `shell: true`. When script paths contained spaces, the shell split the path before execution, causing commands such as `clean.mjs` to fail with a `MODULE_NOT_FOUND` error.

Instead of manually quoting script paths, this PR adopts the same approach already used by `build.mjs` by switching to `cross-spawn`. This avoids shell parsing issues and provides a more robust, cross-platform solution.

## How?

* Replace `child_process.spawn` with `cross-spawn` in `tools/build-scripts/dev.mjs`.
* Remove `shell: true` from:

  * `exec()`
  * `execAsync()`
  * the `wp-build --watch` process
* Keep script paths unchanged, allowing `cross-spawn` to handle paths containing spaces correctly.

## Testing Instructions

1. Clone or move the Gutenberg repository into a directory containing spaces, for example:
   ```text
   /Users/<username>/Local Sites/gutenberg
   ```
2. Install dependencies.
   ```bash
   npm install
   composer install
   ```
3. Run:
   ```bash
   npm run dev
   ```
4. Verify the development build starts successfully.
5. Verify the build progresses past the **Cleaning packages...** step without failing with a `MODULE_NOT_FOUND` error.

## Screenshots or screencast

N/A
