### PR TITLE
RTC: Use array_any() for newer-compaction check in polling sync server

### DIFF
--- a/lib/experimental/collaboration/class-wp-http-polling-sync-server.php
+++ b/lib/experimental/collaboration/class-wp-http-polling-sync-server.php
@@ -407,14 +407,11 @@ if ( ! class_exists( 'WP_HTTP_Polling_Sync_Server' ) ) {
 					 * compaction to avoid overwriting it.
 					 */
 					$updates_after_cursor = $this->storage->get_updates_after_cursor( $room, $cursor );
-					$has_newer_compaction = false;
 
-					foreach ( $updates_after_cursor as $existing ) {
-						if ( self::UPDATE_TYPE_COMPACTION === $existing['type'] ) {
-							$has_newer_compaction = true;
-							break;
-						}
-					}
+					$has_newer_compaction = array_any(
+						$updates_after_cursor,
+						fn( $existing ) => self::UPDATE_TYPE_COMPACTION === $existing['type']
+					);
 
 					if ( ! $has_newer_compaction ) {
 						if ( ! $this->storage->remove_updates_before_cursor( $room, $cursor ) ) {


### PR DESCRIPTION
## What?

Simplifies the "is there a newer compaction after the cursor?" check in `WP_HTTP_Polling_Sync_Server` by replacing the manual `foreach` loop and boolean flag with a single `array_any()` call.

## Why?

The loop only existed to set a boolean flag and `break` on the first match — exactly what `array_any()` expresses in one statement. The declarative form is easier to read and makes the intent explicit.

`array_any()` is a PHP 8.4 function, but WordPress core ships a polyfill for it in `wp-includes/compat.php` (added in WP 6.8). Gutenberg requires WordPress 6.9 or newer (`Requires at least: 6.9`), so the function is guaranteed to be available on every supported PHP version.