### PR TITLE
feat(docker): use pie to install xdebug for PHP versions above 8.1

### DIFF
--- a/packages/env/lib/runtime/docker/docker-config.js
+++ b/packages/env/lib/runtime/docker/docker-config.js
@@ -249,6 +249,7 @@ function getXdebugConfig( xdebugMode = 'off', phpVersion ) {
 	}
 
 	let xdebugVersion = 'xdebug';
+	let usePieForXdebug = false;
 
 	if ( phpVersion ) {
 		const versionTokens = phpVersion.split( '.' );
@@ -275,10 +276,22 @@ function getXdebugConfig( xdebugMode = 'off', phpVersion ) {
 		if ( majorVer === 7 ) {
 			xdebugVersion = 'xdebug-3.1.6';
 		}
+
+		// PECL installation fails on newer PHP versions where PIE is expected.
+		if ( majorVer > 8 || ( majorVer === 8 && minorVer > 1 ) ) {
+			usePieForXdebug = true;
+		}
 	}
 
+	const installCommand = usePieForXdebug
+		? `
+RUN if ! command -v pie > /dev/null 2>&1; then curl -fL --output /tmp/pie.phar https://github.com/php/pie/releases/latest/download/pie.phar && mv /tmp/pie.phar /usr/local/bin/pie && chmod +x /usr/local/bin/pie; fi
+RUN if ! php -m | grep -q xdebug; then pie install xdebug/xdebug; fi`
+		: `
+RUN if [ -z "$(pecl list | grep ${ xdebugVersion })" ] ; then pecl install ${ xdebugVersion } ; fi`;
+
 	return `
-RUN if [ -z "$(pecl list | grep ${ xdebugVersion })" ] ; then pecl install ${ xdebugVersion } ; fi
+${ installCommand }
 RUN docker-php-ext-enable xdebug
 RUN echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.mode=${ xdebugMode }' >> /usr/local/etc/php/php.ini

--- a/packages/env/lib/test/build-docker-compose-config.js
+++ b/packages/env/lib/test/build-docker-compose-config.js
@@ -324,4 +324,35 @@ describe( 'wordpressDockerFileContents', () => {
 		expect( dockerfile ).toContain( 'Listen 8889' );
 		expect( dockerfile ).not.toContain( 'Listen 8888' );
 	} );
+
+	it( 'uses pie to install xdebug on php versions higher than 8.1', () => {
+		const config = {
+			xdebug: 'debug',
+			spx: 'off',
+			env: {
+				development: { port: 8888, phpVersion: '8.2' },
+				tests: { port: 8889, phpVersion: '8.2' },
+			},
+		};
+		const dockerfile = wordpressDockerFileContents( 'development', config );
+
+		expect( dockerfile ).toContain( 'command -v pie' );
+		expect( dockerfile ).toContain( 'pie install xdebug/xdebug' );
+		expect( dockerfile ).not.toContain( 'pecl install xdebug' );
+	} );
+
+	it( 'uses pecl to install xdebug on php 8.1 and lower', () => {
+		const config = {
+			xdebug: 'debug',
+			spx: 'off',
+			env: {
+				development: { port: 8888, phpVersion: '8.1' },
+				tests: { port: 8889, phpVersion: '8.1' },
+			},
+		};
+		const dockerfile = wordpressDockerFileContents( 'development', config );
+
+		expect( dockerfile ).toContain( 'pecl install xdebug' );
+		expect( dockerfile ).not.toContain( 'pie install xdebug/xdebug' );
+	} );
 } );


### PR DESCRIPTION
## What?

Detect what version of PHP is being used and if PHP 8.1 is being used, then use [php pie](https://github.com/php/pie) to install xedebug.

Closes https://github.com/WordPress/gutenberg/issues/80520

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Fixes https://github.com/WordPress/gutenberg/issues/80520