### PR TITLE
Perf Tests: Fix 'Selecting blocks' metric reporting 0 ms

### DIFF
--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Metrics.getSelectionEventDurations()`: Also collect `pointerup` and `selectionchange` durations, and omit event types that did not fire. Selecting a block within an editing host no longer fires `focus`/`focusin`, which made the metric report zero.
+
 ## 1.51.0 (2026-07-14)
 
 ## 1.50.0 (2026-07-01)

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -17,7 +17,9 @@ type EventType =
 	| 'keypress'
 	| 'keyup'
 	| 'mouseout'
-	| 'mouseover';
+	| 'mouseover'
+	| 'pointerup'
+	| 'selectionchange';
 
 interface TraceEvent {
 	cat: string;
@@ -299,13 +301,21 @@ export class Metrics {
 	}
 
 	/**
-	 * @return Durations of all traced `focus` and `focusin` events.
+	 * Selecting a block within an editing host moves only the native
+	 * selection, so `focus`/`focusin` do not fire for those clicks. Event
+	 * types that did not fire are left out: callers sum the durations, and an
+	 * empty list sums to `undefined`, which would poison the total.
+	 *
+	 * @return Durations of the traced `focus`, `focusin`, `pointerup`, and
+	 * `selectionchange` events that fired.
 	 */
 	getSelectionEventDurations() {
 		return [
 			this.getEventDurations( 'focus' ),
 			this.getEventDurations( 'focusin' ),
-		];
+			this.getEventDurations( 'pointerup' ),
+			this.getEventDurations( 'selectionchange' ),
+		].filter( ( durations ) => durations.length );
 	}
 
 	/**


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/79105#issuecomment-5031548459.
CodeVitals - https://codevitals.run/public/WordPress/gutenberg/metrics?metric=focus

`getSelectionEventDurations()` only collected `focus`/`focusin` durations. Since #79105 (`editableRoot` block support), clicking a sibling block moves only the native selection; focus stays on the writing flow editing host, so those events never fire. The "Selecting blocks" test has been reporting `0 ms +NaN% -NaN%` ever since.

The work didn't disappear, it moved: it now lands in `pointerup` and `selectionchange`.

## Why?

We lost coverage of a key interaction metric.

## How?

Collect `pointerup` and `selectionchange` durations too. `focus`/`focusin` are kept; they still fire when focus genuinely moves (e.g., first click into the canvas).

## Testing Instructions
Check performance test reports on CI. The `focus` metrics should be there.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="1210" height="561" alt="CleanShot 2026-07-21 at 17 29 17" src="https://github.com/user-attachments/assets/c11782b7-87ff-4ec8-b5a9-9a46016fdc58" />


## Use of AI Tools

Assisted by Claude.
