### PR TITLE
Contrast checker: defer color evaluation to pointer release

### DIFF
--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useLayoutEffect, useReducer } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useReducer,
+	useRef,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { getBlockSelector } from '@wordpress/global-styles-engine';
@@ -119,32 +125,97 @@ export default function useBlockColorContrastWarning( {
 		[ name, enabled ]
 	);
 
-	// There are so many things that can change the color of a block
-	// So we perform this check on every render.
+	// Re-read the block's rendered colors and update state. The FIRST read
+	// (e.g. opening the picker on an already-poor color) runs immediately.
+	// While a pointer is held down — most importantly dragging in the color
+	// picker, which changes the block's color on every pointer move — the read
+	// is deferred and then runs the instant the pointer is released. This keeps
+	// the contrast notice from flashing on and off mid-drag (which resizes the
+	// color popover and makes the picker handle jump), while still showing the
+	// result the moment the user settles on a color, with no timer-based delay.
+	const hasReadRef = useRef( false );
+	const isPointerDownRef = useRef( false );
+	const pendingReadRef = useRef( false );
+
+	const readColors = useCallback( () => {
+		if ( ! blockEl || ! blockType ) {
+			return;
+		}
+		setColors( getBlockElementColors( blockEl, blockType ) );
+	}, [ blockEl, blockType ] );
+
+	const scheduleRead = useCallback( () => {
+		if ( ! hasReadRef.current ) {
+			hasReadRef.current = true;
+			readColors();
+			return;
+		}
+		// A drag is in progress; hold off until the pointer is released.
+		if ( isPointerDownRef.current ) {
+			pendingReadRef.current = true;
+			return;
+		}
+		readColors();
+	}, [ readColors ] );
+
+	// Track whether a pointer is pressed anywhere (e.g. a color-picker drag),
+	// and flush any deferred read the instant it is released.
+	useEffect( () => {
+		const handlePointerDown = () => {
+			isPointerDownRef.current = true;
+		};
+		const handlePointerUp = () => {
+			isPointerDownRef.current = false;
+			if ( ! pendingReadRef.current ) {
+				return;
+			}
+			pendingReadRef.current = false;
+			// Let the final color commit to the DOM before reading it.
+			window.requestAnimationFrame( () => readColors() );
+		};
+		window.addEventListener( 'pointerdown', handlePointerDown, true );
+		window.addEventListener( 'pointerup', handlePointerUp, true );
+		window.addEventListener( 'pointercancel', handlePointerUp, true );
+		return () => {
+			window.removeEventListener(
+				'pointerdown',
+				handlePointerDown,
+				true
+			);
+			window.removeEventListener( 'pointerup', handlePointerUp, true );
+			window.removeEventListener(
+				'pointercancel',
+				handlePointerUp,
+				true
+			);
+		};
+	}, [ readColors ] );
+
+	// There are so many things that can change the color of a block, so we
+	// re-check on every render (deferred to after the current paint but before
+	// the next, via two rAFs).
 	useLayoutEffect( () => {
 		if ( ! enabled || ! blockEl || ! blockType ) {
 			return;
 		}
 
-		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read
-		// after the current paint but before the next paint.
 		window.requestAnimationFrame( () =>
-			window.requestAnimationFrame( () =>
-				setColors( getBlockElementColors( blockEl, blockType ) )
-			)
+			window.requestAnimationFrame( () => scheduleRead() )
 		);
 	} );
 
-	// Runs in its own effect with dependencies so the observer is only
-	// recreated when the block element or block type changes.
+	// Watch the block element for the class/style changes a live edit makes.
+	// Recreated only when the block element or block type changes; on that
+	// change the next read is immediate again, while the observer's own
+	// mid-drag churn is deferred to pointer release through `scheduleRead`.
 	useLayoutEffect( () => {
 		if ( ! enabled || ! blockEl || ! blockType ) {
 			return;
 		}
 
-		const observer = new window.MutationObserver( () => {
-			setColors( getBlockElementColors( blockEl, blockType ) );
-		} );
+		hasReadRef.current = false;
+
+		const observer = new window.MutationObserver( () => scheduleRead() );
 
 		observer.observe( blockEl, {
 			attributes: true,
@@ -155,7 +226,7 @@ export default function useBlockColorContrastWarning( {
 		return () => {
 			observer.disconnect();
 		};
-	}, [ enabled, blockEl, blockType ] );
+	}, [ enabled, blockEl, blockType, scheduleRead ] );
 
 	const warning = enabled
 		? getContrastWarning( {


### PR DESCRIPTION
## What?

Stops the block colour-contrast notice from flickering and making the colour picker "jump" while you drag to pick a colour. Contrast is now evaluated when the pointer is released rather than continuously during the drag.

Fixes #79514.

## Why?

`useBlockColorContrastWarning` re-reads the block's rendered colours on every render and on every `class`/`style` mutation of the block element. Dragging in the colour picker changes the block's colour on each pointer move, so the "poor contrast" notice flashed on and off mid-drag. Each toggle grew/shrank the colour popover, which shifted the picker handle out from under the cursor.

## How?

Gate the re-read on pointer state instead of running it continuously:

- The **first** read (e.g. opening the picker on an already-poor colour) stays immediate, so an existing problem is flagged right away.
- Reads triggered **while a pointer is held down** are deferred.
- The deferred read runs the **instant the pointer is released** (`pointerup` / `pointercancel`), via a single `requestAnimationFrame` so the final colour has committed to the DOM.

There is no timer, so the notice never appears or flickers mid-drag, and it shows the moment you settle on a colour. Non-pointer changes (e.g. typing a hex value) are unaffected and evaluate immediately.

## Testing Instructions

1. Add a Paragraph on a light-background theme (e.g. Twenty Twenty-Five).
2. Select it → **Block → Typography → Color** → open the custom colour picker.
3. Drag the saturation handle from a dark colour up into a light one, crossing the point where contrast becomes poor.

**Expected:** the picker handle no longer jumps under the cursor while dragging, and the "This colour has poor contrast…" notice appears immediately when you release — not on a timer while you are still holding on a colour.

Also confirm the notice still appears immediately when you *open* the picker on a block that already has poor contrast.

## Screenshots or screencast

_Behaviour verified in the editor by instrumenting the drag: during the drag the notice never toggles, and it appears ~1 frame after `pointerup`. Screencast to be added._

## AI assistance

- **AI assistance:** Yes
- **Tool(s) used:** Claude Code (Claude Opus 4.8)
- AI drafted the code change and this description. The behaviour was verified live in the editor (dragging across the contrast threshold and measuring that the notice appears only after pointer release), and the change has been reviewed by the contributor.
