### PR TITLE
Color panel: let the picker grow instead of scrolling

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -111,6 +111,13 @@ const popoverProps = {
 	placement: 'left-start',
 	offset: 36,
 	shift: true,
+	// Grow to fit the content instead of capping the height and scrolling.
+	// When the contrast-warning notice appears the popover gets taller, and
+	// with the default resize behaviour `shift` moves it up while the height
+	// is still capped to the space below its original anchor — leaving the
+	// notice behind a scrollbar. Disabling resize lets it use the room `shift`
+	// frees up, so the whole picker and its warning stay readable at once.
+	resize: false,
 };
 
 const LabeledColorIndicators = ( { indicators, label } ) => (


### PR DESCRIPTION
## What?

When a block's colour has poor contrast, the colour-settings popover can grow tall enough to get an internal scrollbar, hiding part of the contrast notice. This lets the popover grow to its natural height instead, so the whole picker — including the notice — stays readable at once.

## Why?

The colour dropdown's `Popover` uses the `size` middleware, which caps the popover's height and adds `overflow: auto` when its content would run past the viewport. But `size` measures the space available from the popover's **anchored** position, before `shift` moves it up. So when the contrast notice made the panel taller, the popover was capped and given a scrollbar even though `shift` had already moved it to the top of the viewport with plenty of room for the full content below.

Observed in the editor: content needed ~500px and the viewport was ~732px with the popover sitting at the top, yet it was capped at ~477px and scrolled — leaving ~246px of empty space below the scrollbar.

## How?

Set `resize: false` on this popover (keeping `shift: true`) so the `size` cap is not applied and the popover grows to its natural height; `shift` continues to keep it within the viewport.

Trade-off: without the cap, a popover taller than the entire viewport would clip rather than scroll. In practice this picker plus its notice is ~500px, well under a normal viewport, so there is ample headroom; the change trades a scrollbar that is essentially always avoidable for that rare edge case.

## Testing Instructions

1. On a light-background theme (e.g. Twenty Twenty-Five), select a Paragraph.
2. **Block → Typography → Color**, and give it a light colour so the contrast notice appears (white text on a cream background is reliably "poor").
3. Observe the colour-settings popover with the notice at the bottom.

**Expected:** the whole popover — swatches, picker, and the full "poor contrast" notice — is visible with no internal scrollbar, and the popover stays within the viewport.

## Screenshots or screencast

_Verified in the editor: `max-height` becomes `none`, `overflow` `visible`, and the popover renders top 1px → bottom 501px within a 732px viewport (no scroll). Screenshot to be added._

## AI assistance

- **AI assistance:** Yes
- **Tool(s) used:** Claude Code (Claude Opus 4.8)
- AI diagnosed the cause (measuring the popover geometry against the viewport), drafted the one-line change and this description, and the change has been reviewed by the contributor.
