### PR TITLE
Notes: Render @ mentions as span chips and narrow the kses class allowance

### DIFF
--- a/backport-changelog/7.1/12503.md
+++ b/backport-changelog/7.1/12503.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/12503
 
 * https://github.com/WordPress/gutenberg/pull/79604
 * https://github.com/WordPress/gutenberg/pull/80221
+* https://github.com/WordPress/gutenberg/pull/80528

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -110,9 +110,9 @@ add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
  * mention markup itself. Keeping it unconditional avoids per-comment-type
  * arming and disarming of kses state across the direct and REST write paths.
  *
-* @param array<string, array<string, bool> $allowed The allowed tags structure for the context.
-* @param string                            $context The kses context.
-* @return array<string, array<string, bool> Modified allowed tags structure.
+ * @param array<string, array<string, bool>> $allowed The allowed tags structure for the context.
+ * @param string                             $context The kses context.
+ * @return array<string, array<string, bool>> Modified allowed tags structure.
  */
 function gutenberg_notes_allow_mention_span( $allowed, string $context ): array {
 	if ( ! is_array( $allowed ) ) {

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -158,13 +158,7 @@ function gutenberg_notes_sanitize_mention_classes( $content ): string {
 		return $content;
 	}
 
-	$unslashed = wp_unslash( $content );
-
-	if ( ! str_contains( $unslashed, '<span' ) ) {
-		return $content;
-	}
-
-	$processor = new WP_HTML_Tag_Processor( $unslashed );
+	$processor = new WP_HTML_Tag_Processor( wp_unslash( $content ) );
 
 	while ( $processor->next_tag( 'SPAN' ) ) {
 		foreach ( $processor->class_list() as $token ) {

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -161,27 +161,11 @@ function gutenberg_notes_sanitize_mention_classes( $content ) {
 	$processor = new WP_HTML_Tag_Processor( $unslashed );
 
 	while ( $processor->next_tag( 'SPAN' ) ) {
-		$class = $processor->get_attribute( 'class' );
-
-		if ( null === $class ) {
-			continue;
-		}
-
-		$kept = array();
-
-		if ( is_string( $class ) ) {
-			foreach ( preg_split( '/\s+/', trim( $class ), -1, PREG_SPLIT_NO_EMPTY ) as $token ) {
-				if ( 'wp-note-mention' === $token || preg_match( '/^user-[1-9][0-9]*$/', $token ) ) {
-					$kept[] = $token;
-				}
+		foreach ( $processor->class_list() as $token ) {
+			if ( 'wp-note-mention' !== $token && ! preg_match( '/^user-[1-9][0-9]*$/', $token ) ) {
+				// Removing the last class also removes the attribute itself.
+				$processor->remove_class( $token );
 			}
-			$kept = array_values( array_unique( $kept ) );
-		}
-
-		if ( empty( $kept ) ) {
-			$processor->remove_attribute( 'class' );
-		} else {
-			$processor->set_attribute( 'class', implode( ' ', $kept ) );
 		}
 	}
 

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -94,148 +94,105 @@ function gutenberg_strip_inline_note_markers( $block_content ) {
 add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
 
 /**
- * Allows note mention markup in the content of `note` comments for users
- * without `unfiltered_html`.
+ * Allows the note mention chip markup through comment kses.
  *
- * The notes `@` mention completer stores a mention as a link to the mentioned
- * user's author page carrying the user's ID in a class:
- * `<a class="wp-note-mention user-N" href="…">@Name</a>`. The default comment
- * kses allowlist includes `a` but only its `href` and `title` attributes, so
- * for users without `unfiltered_html` the mention classes would be stripped
- * on save.
+ * The notes `@` mention completer stores a mention as a chip carrying the
+ * mentioned user's ID in a class token:
+ * `<span class="wp-note-mention user-N">@Name</span>`. The default comment
+ * kses allowlist (the minimal `$allowedtags` used in the
+ * `pre_comment_content` context) does not allow `span` at all, so for users
+ * without `unfiltered_html` the mention would be stripped on save.
  *
- * This callback is deliberately not attached globally: `class` attributes are
- * CSS and JavaScript selector hooks, so allowing them in every comment would
- * extend what regular (including anonymous) commenters can publish. Instead
- * gutenberg_notes_arm_mention_kses() attaches it only while
- * a `note` comment is being filtered and detaches it right after, so the
- * sanitization of other comment types is unchanged. Notes can only be written
- * by logged-in users who can edit the post, and are never rendered on the
- * front end.
+ * This allowance is deliberately narrow and always on: `span` is a
+ * semantics-free element and gutenberg_notes_sanitize_mention_classes()
+ * reduces its `class` to the two mention tokens right after kses runs, so
+ * regular (including anonymous) commenters gain nothing beyond the inert
+ * mention markup itself. Keeping it unconditional avoids per-comment-type
+ * arming and disarming of kses state across the direct and REST write paths.
  *
  * @param array|string $allowed The allowed tags structure for the context.
  * @param string       $context The kses context.
  * @return array|string Modified allowed tags structure.
  */
-function gutenberg_notes_allow_mention_attributes( $allowed, $context ) {
+function gutenberg_notes_allow_mention_span( $allowed, $context ) {
 	if ( 'pre_comment_content' !== $context || ! is_array( $allowed ) ) {
 		return $allowed;
 	}
 
-	if ( ! isset( $allowed['a'] ) || ! is_array( $allowed['a'] ) ) {
-		$allowed['a'] = array();
+	if ( ! isset( $allowed['span'] ) || ! is_array( $allowed['span'] ) ) {
+		$allowed['span'] = array();
 	}
 
-	$allowed['a']['class'] = true;
+	$allowed['span']['class'] = true;
 
 	return $allowed;
 }
 
 /**
- * Arms the mention markup allowance for a single note kses pass.
+ * Reduces `span` classes in comment content to the note mention tokens.
  *
- * @see gutenberg_notes_allow_mention_attributes()
+ * gutenberg_notes_allow_mention_span() lets `class` through kses on `span`
+ * so the mention chip survives, but `class` is an open-ended styling and
+ * scripting hook, so this companion pass - running right after
+ * `wp_filter_kses` at priority 10 - strips every class token except the two
+ * the mention markup uses: `wp-note-mention` and `user-N`. `span` is the only
+ * comment tag allowed to carry `class` at all, so walking `span` tags covers
+ * the entire allowance.
+ *
+ * The pass only applies while the restrictive comment allowlist is active:
+ * users with `unfiltered_html` are filtered through `wp_filter_post_kses`
+ * (or not at all), where arbitrary classes are already permitted, and
+ * narrowing their markup here would restrict what core allows them to post.
+ *
+ * @param string $content Slashed comment content, already filtered by kses.
+ * @return string Slashed comment content with span classes reduced.
  */
-function gutenberg_notes_arm_mention_kses() {
-	add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes', 10, 2 );
-
-	/*
-	 * Disarm once this one comment's content has been filtered, so the
-	 * allowance cannot apply to any later comment. PHP_INT_MAX runs after
-	 * every other 'pre_comment_content' callback (wp_filter_kses at 10,
-	 * wp_rel_ugc at 15, anything a plugin adds): when a callback empties its
-	 * own priority bucket mid-run, WP_Hook skips the bucket that follows, so
-	 * a self-removing disarm must be the final bucket or it would silently
-	 * swallow the next callback.
-	 */
-	add_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses', PHP_INT_MAX );
-
-	/*
-	 * Backstop: if the write aborts between arming and content filtering (for
-	 * example a failed capability or flood check in a batched REST request),
-	 * disarm at the end of the REST request so the allowance cannot leak into
-	 * a later write.
-	 */
-	add_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' );
-}
-
-/**
- * Disarms the mention markup allowance after a note kses pass.
- *
- * Attached by gutenberg_notes_arm_mention_kses(); self-removes from both of
- * its hooks so the extended allowlist never outlives the single note write
- * that armed it.
- *
- * @param mixed $value The filtered value, passed through untouched.
- * @return mixed The unchanged value.
- */
-function gutenberg_notes_disarm_mention_kses( $value = null ) {
-	remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' );
-	remove_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses', PHP_INT_MAX );
-	remove_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' );
-
-	return $value;
-}
-
-/**
- * Arms the mention markup allowance when a `note` comment is inserted.
- *
- * Covers every wp_new_comment() caller; runs before wp_filter_comment()
- * sanitizes the content.
- *
- * @param array $commentdata Comment data.
- * @return array Unchanged comment data.
- */
-function gutenberg_notes_scope_mention_kses( $commentdata ) {
-	if ( isset( $commentdata['comment_type'] ) && 'note' === $commentdata['comment_type'] ) {
-		gutenberg_notes_arm_mention_kses();
+function gutenberg_notes_sanitize_mention_classes( $content ) {
+	if ( ! is_string( $content ) || false === has_filter( 'pre_comment_content', 'wp_filter_kses' ) ) {
+		return $content;
 	}
 
-	return $commentdata;
-}
+	$unslashed = wp_unslash( $content );
 
-/**
- * Arms the mention markup allowance for REST note writes.
- *
- * Runs in WP_REST_Comments_Controller::prepare_item_for_database() for both
- * creates and updates, before the comment is sanitized. Neither carries the
- * comment type in the prepared data, so it is resolved from the comment being
- * updated or, on creation, from the request's `type` param.
- *
- * @param array           $prepared_comment Prepared comment data.
- * @param WP_REST_Request $request          The REST request.
- * @return array Unchanged prepared comment data.
- */
-function gutenberg_notes_scope_mention_kses_rest( $prepared_comment, $request ) {
-	$comment_type = isset( $prepared_comment['comment_type'] ) ? $prepared_comment['comment_type'] : '';
-
-	if ( '' === $comment_type && ! empty( $request['id'] ) ) {
-		$comment_type = get_comment_type( (int) $request['id'] );
+	if ( ! str_contains( $unslashed, '<span' ) ) {
+		return $content;
 	}
 
-	/*
-	 * On creation the controller only copies the `type` param into the
-	 * prepared data after this filter has run, and it inserts through
-	 * wp_filter_comment() directly - never through wp_new_comment() and its
-	 * 'preprocess_comment' filter - so this is the only chance to arm and the
-	 * type must be resolved from the request.
-	 */
-	if ( '' === $comment_type && isset( $request['type'] ) ) {
-		$comment_type = $request['type'];
+	$processor = new WP_HTML_Tag_Processor( $unslashed );
+
+	while ( $processor->next_tag( 'SPAN' ) ) {
+		$class = $processor->get_attribute( 'class' );
+
+		if ( null === $class ) {
+			continue;
+		}
+
+		$kept = array();
+
+		if ( is_string( $class ) ) {
+			foreach ( preg_split( '/\s+/', trim( $class ), -1, PREG_SPLIT_NO_EMPTY ) as $token ) {
+				if ( 'wp-note-mention' === $token || preg_match( '/^user-[1-9][0-9]*$/', $token ) ) {
+					$kept[] = $token;
+				}
+			}
+			$kept = array_values( array_unique( $kept ) );
+		}
+
+		if ( empty( $kept ) ) {
+			$processor->remove_attribute( 'class' );
+		} else {
+			$processor->set_attribute( 'class', implode( ' ', $kept ) );
+		}
 	}
 
-	if ( 'note' === $comment_type ) {
-		gutenberg_notes_arm_mention_kses();
-	}
-
-	return $prepared_comment;
+	return wp_slash( $processor->get_updated_html() );
 }
 
 /*
- * When WordPress itself scopes the mention allowance inside
- * wp_filter_comment() (WordPress 7.1+), defer to it.
+ * When WordPress itself carries the mention allowance (WordPress 7.1+),
+ * defer to it.
  */
-if ( ! function_exists( '_wp_kses_allow_note_mention_attributes' ) ) {
-	add_filter( 'preprocess_comment', 'gutenberg_notes_scope_mention_kses' );
-	add_filter( 'rest_preprocess_comment', 'gutenberg_notes_scope_mention_kses_rest', 10, 2 );
+if ( ! function_exists( '_wp_kses_allow_note_mention_span' ) ) {
+	add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span', 10, 2 );
+	add_filter( 'pre_comment_content', 'gutenberg_notes_sanitize_mention_classes', 11 );
 }

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -110,11 +110,11 @@ add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
  * mention markup itself. Keeping it unconditional avoids per-comment-type
  * arming and disarming of kses state across the direct and REST write paths.
  *
- * @param array<string, array<string, bool>> $allowed The allowed tags structure for the context.
- * @param string                             $context The kses context.
+ * @param array<string, array<string, bool>>        $allowed The allowed tags structure for the context.
+ * @param string|array<string, array<string, bool>> $context The kses context.
  * @return array<string, array<string, bool>> Modified allowed tags structure.
  */
-function gutenberg_notes_allow_mention_span( $allowed, string $context ): array {
+function gutenberg_notes_allow_mention_span( $allowed, $context ): array {
 	if ( ! is_array( $allowed ) ) {
 		$allowed = array();
 	}

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -110,8 +110,8 @@ add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
  * mention markup itself. Keeping it unconditional avoids per-comment-type
  * arming and disarming of kses state across the direct and REST write paths.
  *
- * @param array<string, array<string, bool>>        $allowed The allowed tags structure for the context.
- * @param string|array<string, array<string, bool>> $context The kses context.
+ * @param array<string, array<string, bool>> $allowed The allowed tags structure for the context.
+ * @param string                             $context The kses context.
  * @return array<string, array<string, bool>> Modified allowed tags structure.
  */
 function gutenberg_notes_allow_mention_span( $allowed, $context ): array {

--- a/lib/compat/wordpress-7.1/block-comments.php
+++ b/lib/compat/wordpress-7.1/block-comments.php
@@ -110,12 +110,15 @@ add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
  * mention markup itself. Keeping it unconditional avoids per-comment-type
  * arming and disarming of kses state across the direct and REST write paths.
  *
- * @param array|string $allowed The allowed tags structure for the context.
- * @param string       $context The kses context.
- * @return array|string Modified allowed tags structure.
+* @param array<string, array<string, bool> $allowed The allowed tags structure for the context.
+* @param string                            $context The kses context.
+* @return array<string, array<string, bool> Modified allowed tags structure.
  */
-function gutenberg_notes_allow_mention_span( $allowed, $context ) {
-	if ( 'pre_comment_content' !== $context || ! is_array( $allowed ) ) {
+function gutenberg_notes_allow_mention_span( $allowed, string $context ): array {
+	if ( ! is_array( $allowed ) ) {
+		$allowed = array();
+	}
+	if ( 'pre_comment_content' !== $context ) {
 		return $allowed;
 	}
 
@@ -147,8 +150,11 @@ function gutenberg_notes_allow_mention_span( $allowed, $context ) {
  * @param string $content Slashed comment content, already filtered by kses.
  * @return string Slashed comment content with span classes reduced.
  */
-function gutenberg_notes_sanitize_mention_classes( $content ) {
-	if ( ! is_string( $content ) || false === has_filter( 'pre_comment_content', 'wp_filter_kses' ) ) {
+function gutenberg_notes_sanitize_mention_classes( $content ): string {
+	if ( ! is_string( $content ) ) {
+		$content = '';
+	}
+	if ( false === has_filter( 'pre_comment_content', 'wp_filter_kses' ) ) {
 		return $content;
 	}
 

--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -28,9 +28,10 @@ import noteMentionCompleter from './note-mention-completer';
 const { RichTextControl } = unlock( dataviewsPrivateApis );
 
 /*
- * `core/link` also carries `@` mentions: the completer inserts a mention as a
- * link to the user's author page with a `wp-note-mention user-N` class, which
- * rich text preserves as an unregistered attribute of the link format.
+ * `@` mentions are not on this list: the completer inserts a mention as a
+ * `<span class="wp-note-mention user-N">` chip, which rich text preserves as
+ * unregistered markup, so no format is involved and the Link UI never picks a
+ * mention up as an editable link.
  */
 const ALLOWED_NOTE_FORMATS = [
 	'core/bold',

--- a/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
+++ b/packages/editor/src/components/collab-sidebar/note-mention-completer.tsx
@@ -16,17 +16,19 @@ import { getUserLabel } from '../autocompleters/user';
 type MentionableUser = {
 	id: number;
 	name: string;
-	link: string;
 };
 
 /**
  * A user mention completer for notes.
  *
- * Mirrors the editor's `@` user completer but inserts the mention as a link
- * to the user's author page, carrying the mentioned user's ID in a `user-N`
- * class so the mention can be styled as a chip and, in a follow-up, resolved
- * to a notification recipient. A plain `core/link` format handles the anchor,
- * so no dedicated mention format is needed.
+ * Mirrors the editor's `@` user completer but inserts the mention as a
+ * `<span class="wp-note-mention user-N">` chip, carrying the mentioned user's
+ * ID in the `user-N` class so the mention can be styled and, in a follow-up,
+ * resolved to a notification recipient. A mention is deliberately not a link:
+ * a `span` keeps it out of the Link format UI (which would strip the mention
+ * markup on edit), and the `wp-note-mention` class keeps other formats from
+ * claiming the element. RichText preserves the unregistered `span` as-is, so
+ * no dedicated mention format is needed.
  */
 const noteMentionCompleter = {
 	name: 'note-mentions',
@@ -65,12 +67,9 @@ const noteMentionCompleter = {
 		return {
 			action: 'insert-at-caret' as const,
 			value: (
-				<a
-					className={ `wp-note-mention user-${ user.id }` }
-					href={ user.link }
-				>
+				<span className={ `wp-note-mention user-${ user.id }` }>
 					{ '@' + user.name }
-				</a>
+				</span>
 			),
 		};
 	},

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -170,7 +170,7 @@
 		border-radius: 2px;
 	}
 
-	a:not(.wp-note-mention) {
+	a {
 		color: var(--wp-admin-theme-color);
 		text-decoration: underline;
 	}
@@ -246,8 +246,8 @@ mark.wp-note {
 }
 
 // Mention chips, both in the note input and the rendered note content. A
-// mention is a link to the mentioned user's author page, styled as a chip
-// rather than an underlined link.
+// mention is a non-interactive `span` carrying the mentioned user's ID in a
+// `user-N` class, styled as a chip.
 .wp-note-mention {
 	display: inline;
 	padding: 0 var(--wpds-dimension-padding-xs);
@@ -256,32 +256,10 @@ mark.wp-note {
 	color: var(--wpds-color-foreground-interactive-brand);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 	white-space: nowrap;
-	text-decoration: none;
 
-	// Focus ring matching `ExternalLink`/`Link`; 0-width at rest avoids a stray forced-colors outline.
-	outline: 0 solid transparent;
-	outline-offset: 1px;
-
-	// Also clears the wp-admin common.css `a:focus` shadow/color/radius, which outrank the base rule.
-	&:focus {
-		outline:
-			var(--wpds-border-width-focus) solid
-			var(--wpds-color-stroke-focus);
-		box-shadow: none;
-		border-radius: var(--wpds-border-radius-sm);
-		color: var(--wpds-color-foreground-interactive-brand);
-	}
-
-	// Interactive states, since the chip look drops the link underline. After `:focus` so hover wins when both apply.
-	&:hover,
-	&:active {
-		background: var(--wpds-color-background-interactive-brand-weak-active);
-		color: var(--wpds-color-foreground-interactive-brand-active);
-	}
-
-	// Restore the underline when forced-colors drops the background tint.
+	// Keep the chip boundary visible when forced-colors drops the background tint.
 	@media (forced-colors: active) {
-		text-decoration: underline;
+		border: 1px solid;
 	}
 }
 

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -108,17 +108,11 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 
 		$content = 'Hi <span class="components-button is-destructive">there</span>!';
 
-		try {
-			$this->assertSame(
-				wp_slash( $content ),
-				gutenberg_notes_sanitize_mention_classes( wp_slash( $content ) ),
-				'Span classes should be left untouched when wp_filter_kses is not active.'
-			);
-		} finally {
-			if ( $had_filter ) {
-				add_filter( 'pre_comment_content', 'wp_filter_kses' );
-			}
-		}
+		$this->assertSame(
+			wp_slash( $content ),
+			gutenberg_notes_sanitize_mention_classes( wp_slash( $content ) ),
+			'Span classes should be left untouched when wp_filter_kses is not active.'
+		);
 	}
 
 	public function test_mention_markup_survives_note_insert_end_to_end() {

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -62,11 +62,12 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 			'Hi <span class="is-destructive user-0 user-x wp-note-mention-foo">there</span>!'
 		);
 
-		// The HTML API leaves the removed attribute's surrounding whitespace
-		// in place, hence `<span >`.
-		$this->assertSame(
-			'Hi <span >there</span>!',
+		// Markup-equivalence assertion: the HTML API's whitespace handling
+		// when removing the final attribute is not part of its contract.
+		$this->assertEqualHTML(
+			'Hi <span>there</span>!',
 			wp_unslash( $filtered['comment_content'] ),
+			'<body>',
 			'A span with no valid mention tokens should lose its class attribute entirely.'
 		);
 	}

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -1,140 +1,123 @@
 <?php
 /**
- * Tests that the note mention kses allowance is scoped to `note` comments.
+ * Tests the note mention kses allowance.
  *
- * The `<a class="wp-note-mention user-N" href="…">` markup must survive
- * sanitization when a note is written by a user without `unfiltered_html`,
- * while the sanitization of every other comment type - which reaches back to
- * anonymous front-end comments - stays byte-identical to core's defaults.
+ * The `<span class="wp-note-mention user-N">` mention chip must survive
+ * sanitization when a note is written by a user without `unfiltered_html`.
+ * The allowance is always on - it applies to every comment type - but it is
+ * narrow: `span` may only carry the two mention class tokens, and every other
+ * tag and attribute is sanitized exactly as by core's defaults.
  *
  * @group notes
  */
 class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 
-	/*
-	 * The mention href is external to the test site so that core's
-	 * wp_rel_ugc() 'pre_comment_content' filter - which applies to notes like
-	 * any other comment - deterministically appends `rel="nofollow ugc"`
-	 * regardless of the test environment's home URL.
-	 */
-	const MENTION_CONTENT  = 'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/">@admin</a>!';
-	const MENTION_FILTERED = 'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/" rel="nofollow ugc">@admin</a>!';
-	const STRIPPED_CONTENT = 'Hi <a href="https://example.com/author/admin/" rel="nofollow ugc">@admin</a>!';
+	const MENTION_CONTENT = 'Hi <span class="wp-note-mention user-2">@admin</span>!';
 
 	public function test_mention_markup_survives_note_content_filtering() {
 		$filtered = $this->filter_comment_with_kses( 'note' );
 
-		$this->assertSame( self::MENTION_FILTERED, wp_unslash( $filtered['comment_content'] ) );
+		$this->assertSame( self::MENTION_CONTENT, wp_unslash( $filtered['comment_content'] ) );
 	}
 
-	public function test_mention_markup_stripped_from_regular_comment_content() {
+	public function test_mention_markup_survives_regular_comment_content_filtering() {
+		// The allowance is always on rather than armed per note write: the
+		// mention markup is inert, so uniform sanitization beats stateful
+		// per-comment-type kses arming.
 		$filtered = $this->filter_comment_with_kses( 'comment' );
 
-		$this->assertSame( self::STRIPPED_CONTENT, wp_unslash( $filtered['comment_content'] ) );
+		$this->assertSame( self::MENTION_CONTENT, wp_unslash( $filtered['comment_content'] ) );
 	}
 
-	public function test_only_default_link_attributes_and_class_are_allowed_on_note_links() {
+	public function test_comment_kses_strips_mention_span_by_default() {
+		// Baseline proving the allowance is required at all: without the
+		// notes filter, the comment kses context strips `span` entirely.
+		remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span' );
+
+		try {
+			$stripped = wp_kses( self::MENTION_CONTENT, 'pre_comment_content' );
+		} finally {
+			add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span', 10, 2 );
+		}
+
+		$this->assertSame( 'Hi @admin!', $stripped );
+	}
+
+	public function test_class_tokens_beyond_the_mention_tokens_are_stripped() {
 		$filtered = $this->filter_comment_with_kses(
 			'note',
-			'Hi <a class="wp-note-mention user-2" href="https://example.com/author/admin/" data-user-id="2" onclick="alert(1)" style="color:red">@admin</a>!'
+			'Hi <span class="wp-note-mention user-2 is-destructive components-button">@admin</span>!'
 		);
 
 		$this->assertSame(
-			self::MENTION_FILTERED,
+			self::MENTION_CONTENT,
 			wp_unslash( $filtered['comment_content'] ),
-			'Attributes beyond `class` and the default link attributes should be stripped from note links.'
+			'Class tokens beyond `wp-note-mention` and `user-N` should be stripped from spans.'
 		);
 	}
 
-	public function test_mention_allowance_does_not_leak_after_note_filtering() {
-		$this->filter_comment_with_kses( 'note' );
+	public function test_class_attribute_is_removed_when_no_mention_tokens_remain() {
+		$filtered = $this->filter_comment_with_kses(
+			'comment',
+			'Hi <span class="is-destructive user-0 user-x wp-note-mention-foo">there</span>!'
+		);
 
-		// A regular comment filtered after a note still gets the default rules.
-		$filtered = $this->filter_comment_with_kses( 'comment' );
+		// The HTML API leaves the removed attribute's surrounding whitespace
+		// in place, hence `<span >`.
 		$this->assertSame(
-			self::STRIPPED_CONTENT,
+			'Hi <span >there</span>!',
 			wp_unslash( $filtered['comment_content'] ),
-			'The mention markup should be stripped from a regular comment filtered after a note.'
-		);
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'The allowlist filter should not outlive the note write that armed it.'
-		);
-		$this->assertFalse(
-			has_filter( 'pre_comment_content', 'gutenberg_notes_disarm_mention_kses' ),
-			'The disarm filter should remove itself.'
-		);
-		$this->assertFalse(
-			has_filter( 'rest_request_after_callbacks', 'gutenberg_notes_disarm_mention_kses' ),
-			'The disarm backstop should remove itself.'
+			'A span with no valid mention tokens should lose its class attribute entirely.'
 		);
 	}
 
-	public function test_rest_prepare_arms_for_note_update() {
-		$post_id = self::factory()->post->create();
-		$note_id = self::factory()->comment->create(
-			array(
-				'comment_post_ID' => $post_id,
-				'comment_type'    => 'note',
-			)
+	public function test_other_span_attributes_are_stripped() {
+		$filtered = $this->filter_comment_with_kses(
+			'note',
+			'Hi <span class="wp-note-mention user-2" data-user-id="2" onclick="alert(1)" style="color:red" id="mention">@admin</span>!'
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $note_id );
-		$request->set_param( 'id', $note_id );
-
-		// Updates do not carry the comment type in the prepared data.
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertNotFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Updating a note should arm the mention allowance.'
-		);
-
-		gutenberg_notes_disarm_mention_kses();
-	}
-
-	public function test_rest_prepare_arms_for_note_creation() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->set_param( 'type', 'note' );
-
-		// On creation the prepared data does not carry the comment type either:
-		// the controller only copies the `type` param in after preparing.
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertNotFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Creating a note should arm the mention allowance.'
-		);
-
-		gutenberg_notes_disarm_mention_kses();
-	}
-
-	public function test_rest_prepare_does_not_arm_for_regular_comment_creation() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->set_param( 'type', 'comment' );
-
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Creating a regular comment should not arm the mention allowance.'
+		$this->assertSame(
+			self::MENTION_CONTENT,
+			wp_unslash( $filtered['comment_content'] ),
+			'Attributes beyond `class` should be stripped from spans.'
 		);
 	}
 
-	public function test_rest_prepare_does_not_arm_for_regular_comment_update() {
-		$post_id    = self::factory()->post->create();
-		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
-
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . $comment_id );
-		$request->set_param( 'id', $comment_id );
-
-		gutenberg_notes_scope_mention_kses_rest( array(), $request );
-
-		$this->assertFalse(
-			has_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_attributes' ),
-			'Updating a regular comment should not arm the mention allowance.'
+	public function test_class_is_still_stripped_from_other_tags() {
+		$filtered = $this->filter_comment_with_kses(
+			'note',
+			'Hi <a class="wp-note-mention user-2" href="https://example.com/">@admin</a>!'
 		);
+
+		$this->assertSame(
+			'Hi <a href="https://example.com/" rel="nofollow ugc">@admin</a>!',
+			wp_unslash( $filtered['comment_content'] ),
+			'The class allowance is scoped to spans; links keep core\'s default sanitization.'
+		);
+	}
+
+	public function test_class_reduction_skipped_when_restrictive_kses_is_inactive() {
+		// Users with `unfiltered_html` are filtered through
+		// `wp_filter_post_kses` (or not at all); the mention class reduction
+		// must not narrow what core allows them to post. kses_init() hooks
+		// wp_filter_kses by default in the test environment, so detach it to
+		// simulate the unfiltered_html configuration.
+		$had_filter = remove_filter( 'pre_comment_content', 'wp_filter_kses' );
+
+		$content = 'Hi <span class="components-button is-destructive">there</span>!';
+
+		try {
+			$this->assertSame(
+				wp_slash( $content ),
+				gutenberg_notes_sanitize_mention_classes( wp_slash( $content ) ),
+				'Span classes should be left untouched when wp_filter_kses is not active.'
+			);
+		} finally {
+			if ( $had_filter ) {
+				add_filter( 'pre_comment_content', 'wp_filter_kses' );
+			}
+		}
 	}
 
 	public function test_mention_markup_survives_note_insert_end_to_end() {
@@ -159,7 +142,7 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		remove_filter( 'pre_comment_content', 'wp_filter_kses' );
 
 		$this->assertIsInt( $comment_id );
-		$this->assertSame( self::MENTION_FILTERED, get_comment( $comment_id )->comment_content );
+		$this->assertSame( self::MENTION_CONTENT, get_comment( $comment_id )->comment_content );
 	}
 
 	public function test_mention_markup_survives_rest_note_creation_end_to_end() {
@@ -180,13 +163,12 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 
 		/*
 		 * REST creation reaches kses through wp_filter_comment() directly, not
-		 * through wp_new_comment() and its 'preprocess_comment' filter, so the
-		 * REST-specific arming must cover it or mentions written by users
-		 * without `unfiltered_html` are silently stripped on save.
+		 * through wp_new_comment(), so this proves the always-on allowance
+		 * covers the REST write path too.
 		 */
 		$data = $response->get_data();
 		$this->assertSame(
-			self::MENTION_FILTERED,
+			self::MENTION_CONTENT,
 			get_comment( (int) $data['id'] )->comment_content
 		);
 	}
@@ -194,9 +176,8 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 	/**
 	 * Runs commentdata of the given type through the insert-path sanitization.
 	 *
-	 * Mirrors wp_new_comment(): the 'preprocess_comment' filter (which arms the
-	 * allowance for notes) followed by wp_filter_comment() with kses attached as
-	 * it is for users without `unfiltered_html`.
+	 * Mirrors wp_new_comment(): wp_filter_comment() with kses attached as it
+	 * is for users without `unfiltered_html`.
 	 *
 	 * @param string $comment_type The comment type to filter.
 	 * @param string $content      Optional. The comment content to filter.
@@ -205,8 +186,7 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 	private function filter_comment_with_kses( $comment_type, $content = self::MENTION_CONTENT ) {
 		add_filter( 'pre_comment_content', 'wp_filter_kses' );
 
-		$commentdata = apply_filters( 'preprocess_comment', wp_slash( $this->get_commentdata( $comment_type, $content ) ) );
-		$filtered    = wp_filter_comment( $commentdata );
+		$filtered = wp_filter_comment( wp_slash( $this->get_commentdata( $comment_type, $content ) ) );
 
 		remove_filter( 'pre_comment_content', 'wp_filter_kses' );
 

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -34,11 +34,7 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		// notes filter, the comment kses context strips `span` entirely.
 		remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span' );
 
-		try {
-			$stripped = wp_kses( self::MENTION_CONTENT, 'pre_comment_content' );
-		} finally {
-			add_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span', 10, 2 );
-		}
+		$stripped = wp_kses( self::MENTION_CONTENT, 'pre_comment_content' );
 
 		$this->assertSame( 'Hi @admin!', $stripped );
 	}
@@ -104,7 +100,7 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		// must not narrow what core allows them to post. kses_init() hooks
 		// wp_filter_kses by default in the test environment, so detach it to
 		// simulate the unfiltered_html configuration.
-		$had_filter = remove_filter( 'pre_comment_content', 'wp_filter_kses' );
+		remove_filter( 'pre_comment_content', 'wp_filter_kses' );
 
 		$content = 'Hi <span class="components-button is-destructive">there</span>!';
 

--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -52,6 +52,22 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_class_tokens_are_stripped_from_uppercase_span_tags() {
+		// kses preserves tag-name casing, so the class reduction must match
+		// `SPAN` case-insensitively rather than bail on a `<span` substring check.
+		$filtered = $this->filter_comment_with_kses(
+			'note',
+			'Hi <SPAN class="wp-note-mention user-2 is-destructive">@admin</SPAN>!'
+		);
+
+		$this->assertEqualHTML(
+			self::MENTION_CONTENT,
+			wp_unslash( $filtered['comment_content'] ),
+			'<body>',
+			'Class tokens should be reduced on spans regardless of tag-name casing.'
+		);
+	}
+
 	public function test_class_attribute_is_removed_when_no_mention_tokens_remain() {
 		$filtered = $this->filter_comment_with_kses(
 			'comment',

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1859,17 +1859,16 @@ test.describe( 'Block Notes', () => {
 			await page.keyboard.press( 'Enter' );
 
 			/*
-			 * The completer inserts the mention as a chip: a link to the
-			 * user's author page whose `user-N` class carries the mentioned
-			 * user's ID.
+			 * The completer inserts the mention as a chip: a `span` (not a
+			 * link, so the Link format UI cannot break it) whose `user-N`
+			 * class carries the mentioned user's ID.
 			 */
 			const mentionClasses = new RegExp(
 				`^wp-note-mention user-${ mentionedUserId }$`
 			);
-			const draftChip = textbox.locator( 'a.wp-note-mention' );
+			const draftChip = textbox.locator( 'span.wp-note-mention' );
 			await expect( draftChip ).toHaveText( '@Mentionable Teammate' );
 			await expect( draftChip ).toHaveClass( mentionClasses );
-			await expect( draftChip ).toHaveAttribute( 'href', /author/ );
 
 			await page.keyboard.type( 'please review' );
 			await page
@@ -1885,7 +1884,7 @@ test.describe( 'Block Notes', () => {
 			const savedChip = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'treeitem' )
-				.locator( 'a.wp-note-mention' );
+				.locator( 'span.wp-note-mention' );
 			await expect( savedChip ).toHaveText( '@Mentionable Teammate' );
 			await expect( savedChip ).toHaveClass( mentionClasses );
 		} );


### PR DESCRIPTION
Closes #80502.
Supersedes #80496 with the approach agreed in [its discussion](https://github.com/WordPress/gutenberg/pull/80496#issuecomment-5035622583).

## What

Switch the Notes `@` mention markup from a link to a non-interactive `span` chip:

```diff
-<a class="wp-note-mention user-N" href="…">@Name</a>
+<span class="wp-note-mention user-N">@Name</span>
```

and replace the per-note kses arm/disarm machinery in `lib/compat/wordpress-7.1/block-comments.php` with two small always-on filters:

1. a `wp_kses_allowed_html` filter that allows `span` with `class` in the `pre_comment_content` context, and
2. a `pre_comment_content` filter at priority 11 (right after `wp_filter_kses`) that reduces every span's `class` to the only two tokens the mention markup uses: `wp-note-mention` and `user-N`.

## Why

This lands the consensus from #80496:

- **Mentions aren't links** ([@Mamaduka](https://github.com/WordPress/gutenberg/pull/80496#issuecomment-5035622583)): they are tokens rendered as chips. Making them a `span` takes them out of the Link format UI entirely, which fixes the behavior in Mamaduka's [screencast](https://github.com/WordPress/gutenberg/pull/80496#issuecomment-5031111542) where editing a mention through the Link UI destroyed the mention markup. The `wp-note-mention` class stays so no registered format claims the element (formats are differentiated by tag name and class), and per Mamaduka's testing RichText preserves the unregistered span without a dedicated mention format.
- **Keep classes, drop the data attribute** ([discussion](https://github.com/WordPress/gutenberg/pull/80496#issuecomment-5035488089)): since the comment kses context requires an explicit allowance either way (`data-*` is *not* allowed by default in `pre_comment_content`, see the #80496 write-up), a data attribute has no security edge over a class whose tokens are strictly allowlisted. The class also keeps working as the format-differentiation and styling hook.
- **Close the open-`class` hole without stateful kses arming** (@westonruter's original [concern](https://github.com/WordPress/wordpress-develop/pull/12503#issuecomment-5029034877)): the previous approach allowed *any* class on note links, guarded by ~120 lines of per-write arm/disarm across two request paths. Now the allowance is unconditional but reduced to exactly two inert tokens, so there is no styling/scripting selector surface to protect and no kses state to arm and disarm.

## Behavior change

All commenters (including anonymous ones) can now persist `<span>` elements whose `class` is limited to `wp-note-mention` and/or `user-N` in comment content. This is inert: `span` is semantics-free, the two tokens are not styling or scripting hooks outside the notes sidebar, and mention notification parsing (#79606) only processes `note`-type comments.

The class reduction only runs while the restrictive comment allowlist (`wp_filter_kses`) is active: users with `unfiltered_html` are filtered through `wp_filter_post_kses`, where arbitrary classes are already permitted, and narrowing their markup would restrict what core allows them to post.

## Coordination follow-ups

- **Gutenberg #79606** (mention notifications): the PHP parser should match mention *spans* rather than anchors (the `user-N` class parsing itself is unchanged), and per Mamaduka's [last review note](https://github.com/WordPress/gutenberg/pull/80496#issuecomment-5035622583) it should add an identity check before notifying - the chip text can be partially edited while the span retains its `user-N` class, so the parser should verify the remaining text still matches the mentioned user before emailing.
- **wordpress-develop** https://github.com/WordPress/wordpress-develop/pull/12503:  reduces to the same two filters in core, at which point the `function_exists( '_wp_kses_allow_note_mention_span' )` guard here disables this plugin copy.

## Testing instructions

[![Test with WordPress Playground](https://img.shields.io/badge/Test%20with-WordPress%20Playground-3858E9?logo=wordpress)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/gutenberg/update/note-mention-span-chip/.github/workflows/tryitout.blueprint.json)

1. As a user **without** `unfiltered_html` (e.g. an author), open a post, select a block, and add a note.
2. Type `@` and pick a teammate. The mention renders as a chip.
3. Save the note. The chip survives the round-trip as `<span class="wp-note-mention user-<id>">` (inspect the element). This is the case the kses allowance exists for.
4. Place the caret inside a saved mention: no Link format popover appears, and editing surrounding text leaves the chip intact.

Automated coverage:

- PHP: `phpunit/tests/notes-mention-kses-test.php`
- e2e: the `Mentions in the note form` describe in `test/e2e/specs/editor/various/block-notes.spec.js`
