### PR TITLE
Resolve Prettier explicitly for isolated layout

### DIFF
--- a/packages/prettier-config/test/index.js
+++ b/packages/prettier-config/test/index.js
@@ -20,8 +20,12 @@ describe( 'prettier config tests', () => {
 
 	it( 'should resolve file-specific options from the root config', async () => {
 		const repositoryRoot = path.resolve( __dirname, '../../..' );
+		/*
+		* Resolve prettier from this file
+		*/
+		const prettierPath = require.resolve( 'prettier' );
 		const resolveConfigScript = `
-			const prettier = require( 'prettier' );
+			const prettier = require( ${ JSON.stringify( prettierPath ) } );
 			Promise.all(
 				process.argv
 					.slice( 1 )

--- a/packages/prettier-config/test/index.js
+++ b/packages/prettier-config/test/index.js
@@ -20,9 +20,7 @@ describe( 'prettier config tests', () => {
 
 	it( 'should resolve file-specific options from the root config', async () => {
 		const repositoryRoot = path.resolve( __dirname, '../../..' );
-		/*
-		* Resolve prettier from this file
-		*/
+		// Resolve prettier from this file
 		const prettierPath = require.resolve( 'prettier' );
 		const resolveConfigScript = `
 			const prettier = require( ${ JSON.stringify( prettierPath ) } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? ## Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow Up of https://github.com/WordPress/gutenberg/pull/80422#discussion_r3612777776

Resolves `prettier` explicitly from within the test file instead of relying on it being hoisted to the root `node_modules`.

<!-- In a few words, what is the PR actually doing? -->

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Resolve `prettier`'s path from `packages/prettier-config/test/index.js` using `require.resolve( 'prettier' )`.
- Pass the resolved path into the generated `resolveConfigScript` via `JSON.stringify( prettierPath )` instead of using a bare `require( 'prettier' )` string.


## Use of AI Tools
- None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
