### PR TITLE
Media: Stop forcing crossorigin on IMG tags in media templates

### DIFF
--- a/backport-changelog/7.1/12615.md
+++ b/backport-changelog/7.1/12615.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12615
+
+* https://github.com/WordPress/gutenberg/pull/80532

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -471,8 +471,7 @@ function gutenberg_add_crossorigin_attributes( string $html ): string {
  * that already have the attribute are left untouched so the output does
  * not gain duplicates on WordPress versions where Core adds it itself.
  *
- * IMG is intentionally excluded, and any crossorigin attribute Core added
- * to IMG tags (WordPress 7.1 betas) is removed: under
+ * IMG is intentionally excluded: under
  * `Document-Isolation-Policy: isolate-and-credentialless` the browser
  * already loads cross-origin images in credentialless mode, so forcing
  * `crossorigin="anonymous"` triggers a CORS request that breaks previews
@@ -497,17 +496,11 @@ function gutenberg_update_media_template_crossorigin_attributes( string $html ):
 		}
 		$template_processor = new WP_HTML_Tag_Processor( $script_processor->get_modifiable_text() );
 		while ( $template_processor->next_tag() ) {
-			$tag = $template_processor->get_tag();
 			if (
-				in_array( $tag, array( 'AUDIO', 'VIDEO' ), true )
+				in_array( $template_processor->get_tag(), array( 'AUDIO', 'VIDEO' ), true )
 				&& ! is_string( $template_processor->get_attribute( 'crossorigin' ) )
 			) {
 				$template_processor->set_attribute( 'crossorigin', 'anonymous' );
-			} elseif (
-				'IMG' === $tag
-				&& null !== $template_processor->get_attribute( 'crossorigin' )
-			) {
-				$template_processor->remove_attribute( 'crossorigin' );
 			}
 		}
 		$script_processor->set_modifiable_text( $template_processor->get_updated_html() );

--- a/lib/media/load.php
+++ b/lib/media/load.php
@@ -463,10 +463,65 @@ function gutenberg_add_crossorigin_attributes( string $html ): string {
 }
 
 /**
+ * Updates `crossorigin` attributes in the printed media templates.
+ *
+ * Adds `crossorigin="anonymous"` to AUDIO and VIDEO tags inside the
+ * Backbone `<script type="text/html">` templates so the media modal can
+ * play cross-origin audio and video under cross-origin isolation. Tags
+ * that already have the attribute are left untouched so the output does
+ * not gain duplicates on WordPress versions where Core adds it itself.
+ *
+ * IMG is intentionally excluded, and any crossorigin attribute Core added
+ * to IMG tags (WordPress 7.1 betas) is removed: under
+ * `Document-Isolation-Policy: isolate-and-credentialless` the browser
+ * already loads cross-origin images in credentialless mode, so forcing
+ * `crossorigin="anonymous"` triggers a CORS request that breaks previews
+ * of images served without CORS headers, such as media offloaded to a
+ * CDN. See https://core.trac.wordpress.org/ticket/65673.
+ *
+ * @param string $html The printed media templates.
+ *
+ * @return string Modified media templates.
+ */
+function gutenberg_update_media_template_crossorigin_attributes( string $html ): string {
+	/*
+	 * The media templates are inside <script type="text/html"> tags,
+	 * whose content is treated as raw text by the HTML Tag Processor.
+	 * Extract each script block's content, process it separately,
+	 * then reassemble the full output.
+	 */
+	$script_processor = new WP_HTML_Tag_Processor( $html );
+	while ( $script_processor->next_tag( 'SCRIPT' ) ) {
+		if ( 'text/html' !== $script_processor->get_attribute( 'type' ) ) {
+			continue;
+		}
+		$template_processor = new WP_HTML_Tag_Processor( $script_processor->get_modifiable_text() );
+		while ( $template_processor->next_tag() ) {
+			$tag = $template_processor->get_tag();
+			if (
+				in_array( $tag, array( 'AUDIO', 'VIDEO' ), true )
+				&& ! is_string( $template_processor->get_attribute( 'crossorigin' ) )
+			) {
+				$template_processor->set_attribute( 'crossorigin', 'anonymous' );
+			} elseif (
+				'IMG' === $tag
+				&& null !== $template_processor->get_attribute( 'crossorigin' )
+			) {
+				$template_processor->remove_attribute( 'crossorigin' );
+			}
+		}
+		$script_processor->set_modifiable_text( $template_processor->get_updated_html() );
+	}
+
+	return $script_processor->get_updated_html();
+}
+
+/**
  * Overrides templates from wp_print_media_templates with custom ones.
  *
- * Adds `crossorigin` attribute to all tags that
- * could have assets loaded from a different domain.
+ * Updates the `crossorigin` attributes on media tags so cross-origin
+ * audio and video can be processed under cross-origin isolation without
+ * breaking previews of images served without CORS headers.
  */
 function gutenberg_override_media_templates(): void {
 	remove_action( 'admin_footer', 'wp_print_media_templates' );
@@ -477,17 +532,7 @@ function gutenberg_override_media_templates(): void {
 			wp_print_media_templates();
 			$html = (string) ob_get_clean();
 
-			$tags = array(
-				'audio',
-				'img',
-				'video',
-			);
-
-			foreach ( $tags as $tag ) {
-				$html = (string) str_replace( "<$tag", "<$tag crossorigin=\"anonymous\"", $html );
-			}
-
-			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo gutenberg_update_media_template_crossorigin_attributes( $html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	);
 }

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -253,8 +253,63 @@ HTML;
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<audio crossorigin="anonymous"', $output );
-		$this->assertStringContainsString( '<img crossorigin="anonymous"', $output );
 		$this->assertStringContainsString( '<video crossorigin="anonymous"', $output );
+		$this->assertMatchesRegularExpression(
+			'/<img\b/i',
+			$output,
+			'Expected the media templates to contain IMG tags.'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/<img\b[^>]*\bcrossorigin/i',
+			$output,
+			'IMG tags in the media templates must not receive a crossorigin attribute, as it breaks previews of media served without CORS headers. See https://core.trac.wordpress.org/ticket/65673.'
+		);
+		$this->assertStringNotContainsString(
+			'crossorigin="anonymous" crossorigin=',
+			$output,
+			'Tags must not receive a duplicate crossorigin attribute when WordPress Core has already added one.'
+		);
+	}
+
+	/**
+	 * Tests that the media template processing adds crossorigin to AUDIO and
+	 * VIDEO tags, skips tags that already have it, and removes it from IMG
+	 * tags (WordPress 7.1 betas added it, breaking previews of media served
+	 * without CORS headers).
+	 *
+	 * @covers ::gutenberg_update_media_template_crossorigin_attributes
+	 */
+	public function test_gutenberg_update_media_template_crossorigin_attributes(): void {
+		$html = <<<HTML
+<script type="text/html" id="tmpl-test-media">
+	<img src="{{ data.url }}" draggable="false" alt="" />
+	<img crossorigin="anonymous" src="{{ data.url }}" draggable="false" alt="" />
+	<audio controls src="{{ data.url }}"></audio>
+	<audio crossorigin="anonymous" controls src="{{ data.url }}"></audio>
+	<video controls src="{{ data.url }}"></video>
+</script>
+<script type="text/javascript">var notATemplate = '<img src="test.jpg" />';</script>
+HTML;
+
+		$actual = gutenberg_update_media_template_crossorigin_attributes( $html );
+
+		$this->assertStringContainsString( '<audio crossorigin="anonymous" controls src="{{ data.url }}"></audio>', $actual );
+		$this->assertStringContainsString( '<video crossorigin="anonymous" controls src="{{ data.url }}"></video>', $actual );
+		$this->assertSame(
+			3,
+			substr_count( $actual, 'crossorigin' ),
+			'Only the two AUDIO tags and one VIDEO tag should carry a crossorigin attribute, with no duplicates.'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/<img\b[^>]*\bcrossorigin/i',
+			$actual,
+			'IMG tags must not carry a crossorigin attribute, including ones that already had it.'
+		);
+		$this->assertStringContainsString(
+			"var notATemplate = '<img src=\"test.jpg\" />';",
+			$actual,
+			'Script tags that are not text/html templates must not be modified.'
+		);
 	}
 
 	/**

--- a/phpunit/media/media-processing-test.php
+++ b/phpunit/media/media-processing-test.php
@@ -254,16 +254,6 @@ HTML;
 
 		$this->assertStringContainsString( '<audio crossorigin="anonymous"', $output );
 		$this->assertStringContainsString( '<video crossorigin="anonymous"', $output );
-		$this->assertMatchesRegularExpression(
-			'/<img\b/i',
-			$output,
-			'Expected the media templates to contain IMG tags.'
-		);
-		$this->assertDoesNotMatchRegularExpression(
-			'/<img\b[^>]*\bcrossorigin/i',
-			$output,
-			'IMG tags in the media templates must not receive a crossorigin attribute, as it breaks previews of media served without CORS headers. See https://core.trac.wordpress.org/ticket/65673.'
-		);
 		$this->assertStringNotContainsString(
 			'crossorigin="anonymous" crossorigin=',
 			$output,
@@ -273,9 +263,9 @@ HTML;
 
 	/**
 	 * Tests that the media template processing adds crossorigin to AUDIO and
-	 * VIDEO tags, skips tags that already have it, and removes it from IMG
-	 * tags (WordPress 7.1 betas added it, breaking previews of media served
-	 * without CORS headers).
+	 * VIDEO tags, skips tags that already have it, and leaves IMG tags
+	 * untouched (adding it breaks previews of media served without CORS
+	 * headers).
 	 *
 	 * @covers ::gutenberg_update_media_template_crossorigin_attributes
 	 */
@@ -283,7 +273,6 @@ HTML;
 		$html = <<<HTML
 <script type="text/html" id="tmpl-test-media">
 	<img src="{{ data.url }}" draggable="false" alt="" />
-	<img crossorigin="anonymous" src="{{ data.url }}" draggable="false" alt="" />
 	<audio controls src="{{ data.url }}"></audio>
 	<audio crossorigin="anonymous" controls src="{{ data.url }}"></audio>
 	<video controls src="{{ data.url }}"></video>
@@ -303,7 +292,7 @@ HTML;
 		$this->assertDoesNotMatchRegularExpression(
 			'/<img\b[^>]*\bcrossorigin/i',
 			$actual,
-			'IMG tags must not carry a crossorigin attribute, including ones that already had it.'
+			'IMG tags must not receive a crossorigin attribute.'
 		);
 		$this->assertStringContainsString(
 			"var notATemplate = '<img src=\"test.jpg\" />';",


### PR DESCRIPTION
## What?

Fixes #80535

Stops forcing `crossorigin="anonymous"` onto `img` tags in the media manager templates.

Companion to the Core fix for [Trac #65673](https://core.trac.wordpress.org/ticket/65673) ([wordpress-develop#12615](https://github.com/WordPress/wordpress-develop/pull/12615), [wordpress-develop#12616](https://github.com/WordPress/wordpress-develop/pull/12616)).

## Why?

Under `Document-Isolation-Policy: isolate-and-credentialless` the browser already loads cross-origin images in credentialless mode. Forcing `crossorigin="anonymous"` triggers a CORS request that fails for images served without `Access-Control-Allow-Origin` headers, so media library previews break for offloaded/CDN media.

[#76618](https://github.com/WordPress/gutenberg/pull/76618) removed `img` from `gutenberg_add_crossorigin_attributes()` and the editor content hook for exactly this reason, but missed the third injection path: `gutenberg_override_media_templates()` still `str_replace`s `crossorigin="anonymous"` onto every `<img`, `<audio`, and `<video` in the Backbone media templates. That stale `img` entry was carried into Core by the client-side media processing backport, producing the regression reported in Trac #65673.

The plain `str_replace` also produces **duplicate** attributes on WordPress 7.1, where Core's `wp_print_media_templates()` now injects `crossorigin` itself (`<img crossorigin="anonymous" crossorigin="anonymous" …>` — visible in the phpunit output before this fix).

## How?

Reworks the override to mirror Core's Tag Processor approach:

- Extracts each `<script type="text/html">` template's content and processes it with `WP_HTML_Tag_Processor` (template text is raw text to the processor, matching Core's implementation in `wp_print_media_templates()`).
- Adds `crossorigin="anonymous"` only to `AUDIO` and `VIDEO` tags that don't already have it — no duplicates on WP 7.1, still effective on older WordPress versions.
- Leaves `IMG` tags untouched. (An earlier revision also stripped the attribute where Core had added it, but no released WordPress version does that — only 7.1 Beta 1/2 did, and the Core fix ([r62819](https://core.trac.wordpress.org/changeset/62819)) shipped in 7.1 Beta 3 — so the extra code wasn't worth carrying.)

The processing logic is extracted into `gutenberg_update_media_template_crossorigin_attributes()` so it can be unit tested directly.

## Testing Instructions

[![Test in Playground](https://img.shields.io/badge/Test%20in-Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?core-pr=&gutenberg-pr=80532)

1. Run a site whose media is served from a host without CORS headers (e.g. install a mu-plugin that filters `wp_prepare_attachment_for_js` to rewrite `url`/`sizes[*].url` to an external host, per [this gist](https://gist.github.com/i-am-chitti/3bcbd7d41221a1fd7d8d65bb4ca61d2f)), on Chrome ≥ 137 over HTTPS or localhost so DIP is active.
2. Open the post editor → Image block → Media Library.
3. Without this PR: grid thumbnails carry `crossorigin="anonymous"` and previews fail with CORS errors in the console. With this PR: no `crossorigin` on `img` tags, previews load.
4. `npm run test:unit:php:base -- --filter media_template` passes.

## Automated tests

- `test_gutenberg_override_media_templates` asserts `audio`/`video` get `crossorigin` and no duplicates are produced.
- New `test_gutenberg_update_media_template_crossorigin_attributes` covers the add/skip branches and IMG exclusion directly, including non-template `<script>` content being left untouched.

