### PR TITLE
Playlist: Fix playback of tracks served without CORS headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -256,6 +256,19 @@
 			"integrity": "sha512-gIC/FR/gcOtp2FQQDOnRPfxizJjqp4PSQWS7fH2tNr6O6iTwwW8CPao7VUpu8Y8xKeMXrvzHvkOHhBhfBf4OrA==",
 			"license": "MIT"
 		},
+		"node_modules/@arraypress/waveform-player": {
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.23.0.tgz",
+			"integrity": "sha512-1k+M9p960MktJ0djX7HA6USIQvQsEv2UzcLzvbbVmn6S5dpJNhbGFO0e5b4o2yoOeevvHI9hsP+oyOAOlUESOw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/arraypress"
+			}
+		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -43875,7 +43888,7 @@
 			"version": "10.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@arraypress/waveform-player": "^1.21.0",
+				"@arraypress/waveform-player": "^1.23.0",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/autop": "file:../autop",
@@ -43947,19 +43960,6 @@
 				"@types/react": {
 					"optional": true
 				}
-			}
-		},
-		"packages/block-library/node_modules/@arraypress/waveform-player": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.21.0.tgz",
-			"integrity": "sha512-ERRlqZR7qCl7qzj6H8KpIV3y7rUDh/0W4p5vz0/iIoxxeK7SXBENCrN2Q3h5XlawKKQnw6cVpcjAk1IY6gLbYA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/arraypress"
 			}
 		},
 		"packages/block-serialization-default-parser": {

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
+
 ### Internal
 
 -   Image: Check only `window.__clientSideMediaProcessing` for sideloading status, following the removal of the redundant `window.__heicUploadSupport` flag ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -92,7 +92,7 @@
 		"build-module/*/init.mjs"
 	],
 	"dependencies": {
-		"@arraypress/waveform-player": "^1.21.0",
+		"@arraypress/waveform-player": "^1.23.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -689,8 +689,8 @@ describe( 'Waveform utilities', () => {
 			// (and canvas work jsdom cannot perform) to a
 			// requestAnimationFrame callback. Fake timers keep that callback
 			// from running so the test only exercises the synchronous
-			// construction path — the same window in which the crossOrigin
-			// attribute must be cleared, before any request is made.
+			// construction path, where the crossOrigin behavior is decided
+			// before any request is made.
 			jest.useFakeTimers();
 
 			// jsdom does not implement canvas rendering or media playback;
@@ -715,7 +715,7 @@ describe( 'Waveform utilities', () => {
 			document.body.innerHTML = '';
 		} );
 
-		it( 'clears the crossOrigin attribute the library sets on its audio element', () => {
+		it( 'does not set the crossOrigin attribute on the audio element', () => {
 			const element = document.createElement( 'div' );
 			document.body.appendChild( element );
 
@@ -726,9 +726,11 @@ describe( 'Waveform utilities', () => {
 			} );
 
 			/*
-			 * The library hardcodes crossOrigin="anonymous", which forces a
-			 * CORS request and breaks playback of tracks served without CORS
-			 * headers (e.g. media offloaded to a CDN).
+			 * crossOrigin forces a CORS request and breaks playback of tracks
+			 * served without CORS headers (e.g. media offloaded to a CDN).
+			 * waveform-player < 1.23.0 hardcoded crossOrigin="anonymous";
+			 * 1.23.0 leaves it unset by default. Guard against a regression
+			 * (e.g. a dependency downgrade or a default flip upstream).
 			 * See https://core.trac.wordpress.org/ticket/65673.
 			 */
 			expect( player.instance.audio ).not.toBeNull();

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -11,6 +11,7 @@ import {
 	createWaveformContainer,
 	getWaveformColors,
 	getWaveformGradientStops,
+	initWaveformPlayer,
 	styleSvgIcons,
 	setupPlayButtonAccessibility,
 	setupPlayButtonArtwork,
@@ -677,6 +678,66 @@ describe( 'Waveform utilities', () => {
 					'--wp--playlist--play-button-artwork'
 				)
 			).toBe( '' );
+		} );
+	} );
+
+	describe( 'initWaveformPlayer', () => {
+		let jsdomStubs;
+
+		beforeEach( () => {
+			// The WaveformPlayer library defers loading the audio source
+			// (and canvas work jsdom cannot perform) to a
+			// requestAnimationFrame callback. Fake timers keep that callback
+			// from running so the test only exercises the synchronous
+			// construction path — the same window in which the crossOrigin
+			// attribute must be cleared, before any request is made.
+			jest.useFakeTimers();
+
+			// jsdom does not implement canvas rendering or media playback;
+			// stub them out so the library's construction and destroy paths
+			// do not emit "Not implemented" console errors.
+			jsdomStubs = [
+				jest
+					.spyOn( window.HTMLCanvasElement.prototype, 'getContext' )
+					.mockReturnValue( null ),
+				jest
+					.spyOn( window.HTMLMediaElement.prototype, 'pause' )
+					.mockImplementation( () => {} ),
+				jest
+					.spyOn( window.HTMLMediaElement.prototype, 'load' )
+					.mockImplementation( () => {} ),
+			];
+		} );
+
+		afterEach( () => {
+			jsdomStubs.forEach( ( stub ) => stub.mockRestore() );
+			jest.useRealTimers();
+			document.body.innerHTML = '';
+		} );
+
+		it( 'clears the crossOrigin attribute the library sets on its audio element', () => {
+			const element = document.createElement( 'div' );
+			document.body.appendChild( element );
+
+			const player = initWaveformPlayer( element, {
+				src: 'https://cdn.example.com/track.mp3',
+				title: 'Test track',
+				labels: { seek: 'Seek' },
+			} );
+
+			/*
+			 * The library hardcodes crossOrigin="anonymous", which forces a
+			 * CORS request and breaks playback of tracks served without CORS
+			 * headers (e.g. media offloaded to a CDN).
+			 * See https://core.trac.wordpress.org/ticket/65673.
+			 */
+			expect( player.instance.audio ).not.toBeNull();
+			expect( player.instance.audio.crossOrigin ).toBeNull();
+			expect( player.instance.audio ).not.toHaveAttribute(
+				'crossorigin'
+			);
+
+			player.destroy();
 		} );
 	} );
 

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -584,7 +584,6 @@ export function initWaveformPlayer(
 	if ( instance.artworkEl ) {
 		instance.artworkEl.alt = imageAlt || '';
 	}
-
 	applyWaveformPlayerStyles( container, {
 		backgroundColor,
 		backgroundGradient,

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -585,20 +585,6 @@ export function initWaveformPlayer(
 		instance.artworkEl.alt = imageAlt || '';
 	}
 
-	/*
-	 * The WaveformPlayer library hardcodes crossOrigin="anonymous" on its
-	 * audio element, which forces a CORS request and breaks playback of
-	 * tracks served without CORS headers (e.g. media offloaded to a CDN).
-	 * The attribute isn't needed: the audio element is never wired into an
-	 * AudioContext, and waveform peak analysis uses a separate fetch() that
-	 * already falls back to placeholder peaks. The library defers assigning
-	 * the src to a requestAnimationFrame callback, so clearing the
-	 * attribute here is guaranteed to happen before any request is made.
-	 * See https://core.trac.wordpress.org/ticket/65673.
-	 */
-	if ( instance.audio ) {
-		instance.audio.crossOrigin = null;
-	}
 	applyWaveformPlayerStyles( container, {
 		backgroundColor,
 		backgroundGradient,

--- a/packages/block-library/src/utils/waveform-utils.js
+++ b/packages/block-library/src/utils/waveform-utils.js
@@ -584,6 +584,21 @@ export function initWaveformPlayer(
 	if ( instance.artworkEl ) {
 		instance.artworkEl.alt = imageAlt || '';
 	}
+
+	/*
+	 * The WaveformPlayer library hardcodes crossOrigin="anonymous" on its
+	 * audio element, which forces a CORS request and breaks playback of
+	 * tracks served without CORS headers (e.g. media offloaded to a CDN).
+	 * The attribute isn't needed: the audio element is never wired into an
+	 * AudioContext, and waveform peak analysis uses a separate fetch() that
+	 * already falls back to placeholder peaks. The library defers assigning
+	 * the src to a requestAnimationFrame callback, so clearing the
+	 * attribute here is guaranteed to happen before any request is made.
+	 * See https://core.trac.wordpress.org/ticket/65673.
+	 */
+	if ( instance.audio ) {
+		instance.audio.crossOrigin = null;
+	}
 	applyWaveformPlayerStyles( container, {
 		backgroundColor,
 		backgroundGradient,


### PR DESCRIPTION
## What?

Fixes #80536

Updates `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on the audio element it creates for the Playlist block.

Follow-up to [Trac #65673](https://core.trac.wordpress.org/ticket/65673): the reporter found that the Playlist block cannot play media served from a CDN, while the Audio block plays the same files fine.

## Why?

Before 1.23.0, the library's `createAudio()` set `this.audio.crossOrigin = 'anonymous'` unconditionally. That forces a CORS request, so tracks served from a host without `Access-Control-Allow-Origin` headers (e.g. media offloaded to a CDN) fail to load with a CORS error. The Audio block works because its `<audio>` element carries no `crossorigin` attribute.

The attribute buys the player nothing:

- The audio element is never wired into an `AudioContext` (no `createMediaElementSource` anywhere in the library), so playback needs no CORS access.
- Waveform peak analysis uses a separate `fetch()` + `decodeAudioData` path that already falls back to placeholder peaks when the fetch fails.

## How?

An earlier revision of this PR worked around the hardcode by clearing `audio.crossOrigin` right after constructing the player. The upstream request ([arraypress/waveform-player#18](https://github.com/arraypress/waveform-player/issues/18)) was resolved promptly in [`@arraypress/waveform-player@1.23.0`](https://www.npmjs.com/package/@arraypress/waveform-player/v/1.23.0): `crossOrigin` is now an option (also settable via `data-cross-origin`) and the default is unset, matching a plain `<audio>` element. This PR now simply bumps the dependency to `^1.23.0` and drops the workaround.

## Testing Instructions

[![Test in Playground](https://img.shields.io/badge/Test%20in-Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?gutenberg-pr=80533)

1. Create a Playlist block with a track whose audio URL is on a host without CORS headers (e.g. edit the track URL to point at an external MP3, or use an offloading plugin).
2. On the front end, press play.
3. Without this PR: playback fails and the console logs a CORS error for the media request. With this PR: the track plays (the waveform may show placeholder peaks - see below).
4. The Audio block behaves identically before and after (control).

Note: waveform *peak analysis* still `fetch()`es the file and falls back to placeholder peaks for no-CORS hosts. That degradation exists before this PR and is tracked in #80534.

## Automated tests

Unit test in `packages/block-library/src/utils/test/waveform-utils.js` asserts the audio element created by `initWaveformPlayer()` has no `crossorigin` attribute. It guards against a regression: a dependency downgrade below 1.23.0, or an upstream default flip, would fail it.
