### PR TITLE
Account for non-lowercase `VIDEO` tag in `render_block_core_video()`

### DIFF
--- a/packages/block-library/src/video/index.php
+++ b/packages/block-library/src/video/index.php
@@ -17,8 +17,8 @@
  * @return string The block content with the dimensions added.
  */
 function render_block_core_video( array $attributes, string $content ): string {
-	// if the content lacks any video tag, abort.
-	if ( ! str_contains( $content, '<video' ) ) {
+	// If the content lacks any video tag (either <video> or <VIDEO>), abort. Note that str_contains() is case-sensitive.
+	if ( stripos( $content, '<video' ) === false ) {
 		return $content;
 	}
 


### PR DESCRIPTION
This is a follow-up to #70293. 

I realized that the `str_contains( '<video' )` check was incomplete, since HTML allows `<VIDEO>` as well as `<video>`. This covers all the bases. It also matches what is done in the Image block:

https://github.com/WordPress/gutenberg/blob/1048917d4f53d70c6aece1c628afa1e4ab42b12c/packages/block-library/src/image/index.php#L21

## Use of AI Tools

Copilot brought this to my attention somewhere else: https://github.com/WordPress/wordpress-develop/pull/12503/changes#r3623776272
