### PR TITLE
GitHub workflows: Fix changelog checks for forked PRs

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -71,8 +71,8 @@ jobs:
                   fetch-depth: ${{ env.PR_COMMIT_COUNT }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
-            - name: 'Fetch relevant history from origin'
-              run: git fetch origin "$GITHUB_BASE_REF"
+            - name: 'Fetch relevant history from base repository'
+              run: git fetch "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "$GITHUB_BASE_REF"
             - name: Determine if package has relevant changes
               id: filter
               env:

--- a/packages/components/changelog-workflow-test.txt
+++ b/packages/components/changelog-workflow-test.txt
@@ -1,1 +1,0 @@
-Temporary file used to exercise the package changelog workflow.

--- a/packages/components/changelog-workflow-test.txt
+++ b/packages/components/changelog-workflow-test.txt
@@ -1,0 +1,1 @@
+Temporary file used to exercise the package changelog workflow.


### PR DESCRIPTION
## What?

Fixes the optional package changelog workflow to fetch the base branch history from the base repository instead of the pull request author's fork.

## Why?

When a pull request comes from a fork whose `trunk` branch is behind upstream, the current fetch may not include the pull request's base SHA. The subsequent three-dot diff cannot resolve the merge base and may incorrectly skip the changelog check. This occurred in #80472.

## How?

Fetches the base branch from `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git`. These variables identify the repository running the workflow, so forked and same-repository pull requests use the upstream base history consistently.

## Testing Instructions

The fork's `trunk` was at `ae9a734`, while this PR's upstream base was `1048917`. The baseline and fix commits can be seen in the PR history.

1. Open the [baseline workflow run without the fix](https://github.com/WordPress/gutenberg/actions/runs/29856700676/job/88722708126).
2. Confirm the Components check fetches `trunk` from `mirka/gutenberg`, fails to resolve `1048917...HEAD`, and incorrectly succeeds after reporting no relevant changes.
3. Open the [workflow run after applying the fix](https://github.com/WordPress/gutenberg/actions/runs/29856780604).
4. Confirm the Components check fetches `trunk` from `WordPress/gutenberg`, resolves the diff, and reaches the expected `Please add a CHANGELOG entry to packages/components/CHANGELOG.md` failure.
