### PR TITLE
Remove unnecessary __next40pxDefaultSize props from form controls

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -510,7 +510,6 @@ class URLInput extends Component {
 					{ ...( this.hasRenderedValidation.current
 						? validationProps
 						: {} ) }
-					__next40pxDefaultSize
 				/>
 				{ loading && <Spinner /> }
 			</BaseControl>

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -79,7 +79,6 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 					<div style={ { padding: '4px', minWidth: '300px' } }>
 						<VStack spacing={ 1 }>
 							<TextareaControl
-								__next40pxDefaultSize
 								label={ __( 'LaTeX math syntax' ) }
 								hideLabelFromVision
 								value={ latex }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -156,7 +156,6 @@ function SingleTrackEditor( {
 					}
 				/>
 				<ToggleControl
-					__next40pxDefaultSize
 					label={ __( 'Set as default track' ) }
 					checked={ isDefaultTrack }
 					disabled={ ! allowSettingDefault }

--- a/packages/dataviews/src/components/dataform-controls/textarea.tsx
+++ b/packages/dataviews/src/components/dataform-controls/textarea.tsx
@@ -51,7 +51,6 @@ export default function Textarea< Item >( {
 			maxLength={
 				isValid.maxLength ? isValid.maxLength.constraint : undefined
 			}
-			__next40pxDefaultSize
 			hideLabelFromVision={ hideLabelFromVision }
 		/>
 	);

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -67,7 +67,6 @@ function CustomEditControl< Item >( {
 			value={ value ?? '' }
 			help={ description }
 			onChange={ onChangeControl }
-			__next40pxDefaultSize
 			hideLabelFromVision={ hideLabelFromVision }
 		/>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes redundant `__next40pxDefaultSize` props from `TextControl`, `TextareaControl`, and `ToggleControl` usages in block editor, block library, and dataviews.

## Why?

The 40px default control size is now the default behavior for form controls in `@wordpress/components`. These props were leftover from the migration and no longer change behavior.

I don't think we need to tighten the [lint rules](https://github.com/WordPress/gutenberg/blob/1048917d4f53d70c6aece1c628afa1e4ab42b12c/tools/eslint/config.mjs#L212) at this time, since these specific instances don't seem like widespread problems. We can reconsider if these start to sneak in again.


## How?

Delete the `__next40pxDefaultSize` prop from five call sites that don't need it.

## Testing Instructions

Confirm that they are all components that no longer need the prop.