### PR TITLE
Fix undo shortcuts in text fields

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -11,6 +11,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 import { store as editorStore } from '../../store';
 
+function isKeyboardEventFromInputOrTextarea( event ) {
+	return [ 'INPUT', 'TEXTAREA' ].includes( event.target?.nodeName );
+}
+
 /**
  * Handles the keyboard shortcuts for the editor.
  *
@@ -61,11 +65,19 @@ export default function EditorKeyboardShortcuts() {
 	} );
 
 	useShortcut( 'core/editor/undo', ( event ) => {
+		if ( isKeyboardEventFromInputOrTextarea( event ) ) {
+			return;
+		}
+
 		undo();
 		event.preventDefault();
 	} );
 
 	useShortcut( 'core/editor/redo', ( event ) => {
+		if ( isKeyboardEventFromInputOrTextarea( event ) ) {
+			return;
+		}
+
 		redo();
 		event.preventDefault();
 	} );


### PR DESCRIPTION
## What?
Closes #80541.

See #18755 and #38731.

This PR prevents editor-level undo/redo shortcuts from running when focus is inside an input or textarea.

## Why?
Native form controls should keep their browser undo/redo behavior instead of triggering post editor history, which fixes the redesigned Custom HTML modal and related input/textarea cases.

## How?
The editor undo/redo shortcut callbacks now return without calling editor history or `preventDefault()` when the keyboard event target is an input or textarea.

## Testing Instructions
1. Open a post or page.
2. Insert a Custom HTML block.
3. Open the HTML editor and type into the HTML, CSS, or JavaScript field.
4. Press `Cmd+Z` or `Ctrl+Z` and confirm the focused text field undoes its own text change instead of undoing a block editor change.
5. Confirm `Cmd+Z` or `Ctrl+Z` still undoes editor history when focus is not inside an input or textarea.

### Testing Instructions for Keyboard
1. Use the keyboard to focus the Custom HTML editor field.
2. Type text, then press `Cmd+Z` or `Ctrl+Z`.
3. Confirm the focused text field handles undo, and use `Cmd+Shift+Z`, `Ctrl+Shift+Z`, or `Ctrl+Y` to confirm redo behavior where supported by the browser and OS.

## Screenshots or screencast
N/A.

## Use of AI Tools
AI tooling used: OpenAI Codex assisted with implementation, tests, and PR preparation; changes were reviewed by the author.
