### PR TITLE
Notes: stop the highlight tint from deepening, emphasize markers with an underline

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Notes: Stop deepening an inline note marker's tint on hover, focus, and selection. The tint sits behind the text and is subtracted from whatever contrast the theme provides, so emphasis is now an author-colored underline instead ([#80543](https://github.com/WordPress/gutenberg/issues/80543)).
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 
 ## 14.51.0 (2026-07-14)

--- a/packages/editor/src/components/collab-sidebar/note-highlight-styles.js
+++ b/packages/editor/src/components/collab-sidebar/note-highlight-styles.js
@@ -9,11 +9,31 @@ import { useStyleOverride } from '@wordpress/block-editor';
  */
 import { getAvatarBorderColor } from './utils';
 
-// Hex alpha suffixes for the rest / active states. Kept low so the marker
-// reads as a soft tint at rest and gets noticeably stronger when focused or
-// hovered. (0x40 ≈ 25%, 0x80 ≈ 50%.)
-const REST_ALPHA = '40';
-const ACTIVE_ALPHA = '80';
+/*
+ * Hex alpha suffix for the tint painted behind the marker's text. One low value
+ * for every state, on purpose: the tint sits behind the glyphs, so raising it
+ * eats into whatever text/background contrast the theme already provides, and
+ * the canvas background comes from `theme.json`, so the composited result
+ * cannot be measured from CSS. (0x40 ≈ 25%.)
+ */
+const TINT_ALPHA = '40';
+
+/**
+ * Emphasis for hover / focus / the selected note. Carried by an opaque
+ * underline in the author's color rather than a stronger tint, so the marker
+ * reads more strongly without changing what sits behind the text.
+ *
+ * @param {string} color The author's `#RRGGBB` color.
+ * @return {string} Declarations for the emphasized state.
+ */
+function emphasis( color ) {
+	return (
+		'text-decoration-line:underline;' +
+		`text-decoration-color:${ color };` +
+		'text-decoration-thickness:0.125em;' +
+		'text-underline-offset:0.15em;'
+	);
+}
 
 // Reset the browser's default `<mark>` styling so the per-author rules below
 // are what readers actually see (without it, `mark` ships with a bright yellow
@@ -24,6 +44,10 @@ const BASE_RESET = 'mark.wp-note{background-color:transparent;color:inherit;}';
 /**
  * Build the CSS rule set that tints each inline-note marker with its author's
  * avatar color. Pure helper extracted so it can be unit-tested without React.
+ *
+ * The tint stays at a single low alpha in every state and emphasis is expressed
+ * as an underline, so marking a note can only cost the theme's text contrast
+ * the one fixed amount, never more when the note is hovered or selected.
  *
  * @param {Array}       threads    Unresolved note threads (each with `id` and `author`).
  * @param {string|null} selectedId ID of the currently selected note, if any.
@@ -43,14 +67,12 @@ export function buildHighlightCss( threads, selectedId = null ) {
 		// from stored data.
 		const escapedId = String( thread.id ).replace( /["\\]/g, '\\$&' );
 		const sel = `mark.wp-note[data-id="${ escapedId }"]`;
-		rules.push( `${ sel }{background-color:${ color }${ REST_ALPHA };}` );
+		rules.push( `${ sel }{background-color:${ color }${ TINT_ALPHA };}` );
 		rules.push(
-			`${ sel }:hover,${ sel }:focus-within{background-color:${ color }${ ACTIVE_ALPHA };}`
+			`${ sel }:hover,${ sel }:focus-within{${ emphasis( color ) }}`
 		);
 		if ( selectedId && String( selectedId ) === String( thread.id ) ) {
-			rules.push(
-				`${ sel }{background-color:${ color }${ ACTIVE_ALPHA };}`
-			);
+			rules.push( `${ sel }{${ emphasis( color ) }}` );
 		}
 	}
 	return rules.join( '' );
@@ -65,8 +87,8 @@ export function buildHighlightCss( threads, selectedId = null ) {
  * Uses `useStyleOverride` so the styles reach the iframed canvas; a plain
  * `<style>` element rendered in the sidebar would only affect the parent doc.
  *
- * Opacity boosts on `:hover`, `:focus-within`, and when the matching thread is
- * the editor's selected note.
+ * An author-colored underline is added on `:hover`, `:focus-within`, and when
+ * the matching thread is the editor's selected note.
  *
  * @param {Object}      props
  * @param {Array}       props.threads      Unresolved note threads.

--- a/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
+++ b/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
@@ -28,15 +28,15 @@ describe( 'buildHighlightCss', () => {
 		);
 	} );
 
-	it( 'emits a higher-alpha (0x80) rule on hover and focus-within for each thread', () => {
+	it( 'emphasizes hover and focus-within with an author-colored underline', () => {
 		const css = buildHighlightCss( [ { id: 7, author: 1 } ] );
 		const color = getAvatarBorderColor( 1 );
 		expect( css ).toContain(
-			`mark.wp-note[data-id="7"]:hover,mark.wp-note[data-id="7"]:focus-within{background-color:${ color }80;}`
+			`mark.wp-note[data-id="7"]:hover,mark.wp-note[data-id="7"]:focus-within{text-decoration-line:underline;text-decoration-color:${ color };`
 		);
 	} );
 
-	it( 'boosts opacity for the selected thread by appending a second rule', () => {
+	it( 'emphasizes the selected thread by appending a second rule', () => {
 		const css = buildHighlightCss(
 			[ { id: 7, author: 1 } ],
 			'7' // selected
@@ -46,14 +46,38 @@ describe( 'buildHighlightCss', () => {
 		expect( css ).toContain(
 			`mark.wp-note[data-id="7"]{background-color:${ color }40;}`
 		);
-		// Active rule appended later, so the cascade picks it.
+		// Emphasis rule appended later, so the cascade picks it.
 		const restIndex = css.indexOf(
 			`mark.wp-note[data-id="7"]{background-color:${ color }40;}`
 		);
 		const activeIndex = css.lastIndexOf(
-			`mark.wp-note[data-id="7"]{background-color:${ color }80;}`
+			`mark.wp-note[data-id="7"]{text-decoration-line:underline;`
 		);
 		expect( activeIndex ).toBeGreaterThan( restIndex );
+	} );
+
+	/*
+	 * The tint sits behind the glyphs, so every increment of it is subtracted
+	 * from whatever text/background contrast the theme provides, and CSS cannot
+	 * measure the composited result because the canvas background comes from
+	 * `theme.json`. Emphasis therefore has to come from somewhere other than a
+	 * stronger wash. Guards against reintroducing a per-state alpha.
+	 */
+	it( 'never paints a stronger tint behind the text than the rest alpha', () => {
+		const css = buildHighlightCss(
+			[
+				{ id: 7, author: 1 },
+				{ id: 12, author: 3 },
+			],
+			'7'
+		);
+		const alphas = [
+			...css.matchAll( /background-color:#[0-9a-f]{6}([0-9a-f]{2})?/gi ),
+		]
+			.map( ( [ , alpha ] ) => alpha )
+			.filter( Boolean );
+		expect( alphas.length ).toBeGreaterThan( 0 );
+		expect( alphas.every( ( alpha ) => alpha === '40' ) ).toBe( true );
 	} );
 
 	it( 'matches numeric and string selectedId variants', () => {

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1327,9 +1327,9 @@ test.describe( 'Block Notes', () => {
 			const mark = editor.canvas.locator( 'mark.wp-note' ).first();
 			await expect( mark ).toBeVisible();
 
-			// Creating a note auto-selects it, which renders the marker at the
-			// active opacity. Move focus to the title to deselect so the marker
-			// settles back to its rest tint.
+			// Creating a note auto-selects it, which emphasizes the marker with
+			// an underline. Move focus to the title to deselect so only the
+			// tint is left to assert on.
 			await editor.canvas
 				.getByRole( 'textbox', { name: 'Add title' } )
 				.click();
@@ -1594,10 +1594,16 @@ test.describe( 'Block Notes', () => {
 			await expect( paragraph ).toHaveText( 'Hello brave new world.' );
 		} );
 
-		test( 'boosts the marker opacity when its note is selected', async ( {
+		test( 'underlines the marker when its note is selected, without deepening the tint', async ( {
 			editor,
 			page,
+			requestUtils,
 		} ) => {
+			const me = await requestUtils.rest( { path: '/wp/v2/users/me' } );
+			const expectedColor =
+				AVATAR_BORDER_COLORS[ me.id % AVATAR_BORDER_COLORS.length ];
+			const { r, g, b } = hexToRgb( expectedColor );
+
 			await editor.insertBlock( {
 				name: 'core/paragraph',
 				attributes: { content: 'Select my note.' },
@@ -1633,22 +1639,36 @@ test.describe( 'Block Notes', () => {
 				);
 				return match && match[ 4 ] ? Number( match[ 4 ] ) : 1;
 			};
+			const underlineOf = async () =>
+				mark.evaluate( ( el ) => {
+					const style = window.getComputedStyle( el );
+					return `${ style.textDecorationLine } ${ style.textDecorationColor }`;
+				} );
 
 			// Deselect the freshly added note (focus the title) so the marker
-			// drops to its rest tint (≈0x40/255).
+			// settles into its unemphasized state.
 			await editor.canvas
 				.getByRole( 'textbox', { name: 'Add title' } )
 				.click();
-			await expect.poll( alphaOf ).toBeLessThan( 0.35 );
+			await expect.poll( underlineOf ).toContain( 'none' );
 
-			// Selecting the note from the sidebar promotes its marker to the
-			// stronger active alpha (≈0x80/255) via the selected-note rule.
+			// Selecting the note from the sidebar emphasizes its marker with an
+			// underline in the author's color.
 			await page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'treeitem', { name: 'Note: Pick me' } )
 				.click();
 
-			await expect.poll( alphaOf ).toBeGreaterThan( 0.4 );
+			await expect
+				.poll( underlineOf )
+				.toBe( `underline rgb(${ r }, ${ g }, ${ b })` );
+
+			/*
+			 * The tint behind the text must not deepen with the emphasis: it is
+			 * subtracted from whatever contrast the theme already provides, and
+			 * CSS cannot measure the composited result. See #80543.
+			 */
+			expect( await alphaOf() ).toBeLessThan( 0.35 );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

Holds an inline note marker's tint at one low alpha in every state, and moves the hover / focus / selected emphasis to an opaque underline in the author's color.

Fixes https://github.com/WordPress/gutenberg/issues/80543, raised by @joedolson in https://github.com/WordPress/gutenberg/pull/80498#issuecomment-5036822161.

## Why?

The tint is painted behind the marker's text, so it is subtracted from whatever text/background contrast the theme already provides, and there is no contrast assessment anywhere in that path. Worse, the alpha doubled from `0x40` (25%) to `0x80` (50%) on hover, focus, and selection, so the strong state cost roughly twice as much as the resting one.

WCAG 2.1 contrast of the theme's own text color against the tinted background, worst palette member per state:

| Theme | Baseline | 25% | 50% |
| --- | --- | --- | --- |
| Default editor (`#fff` / `#1e1e1e`) | 16.67 | 11.35 | 7.29 |
| Dark (`#1e1e1e` / `#fff`) | 16.67 | 9.20 | 4.74 |
| Mid-tone (`#767676` / `#fff`) | 4.54 | 3.49 | **2.67** |
| Warm (`#f5e6c8` / `#4a3b1f`) | 8.80 | 6.14 | 4.10 |

The default editor is comfortable throughout. The damage lands on themes whose own pair is already near the 4.5:1 floor, where selecting a note could drop passing text to 2.67:1.

### Why not `color: contrast-color(...)`

That was the original suggestion, and it backfires here. `contrast-color()` only sees the color it is handed; it cannot know the backdrop, and through a 25% tint the backdrop is most of what the reader sees. Deriving the text color from the raw author color picks wrong in exactly the common case:

| Author color | picks | result on the default white canvas |
| --- | --- | --- |
| Purple `#6F42C1` | white | **1.5:1**, down from 11.35:1 |
| Teal `#0F766E` | white | **1.4:1**, down from 11.66:1 |
| Orange `#FBBF24` | black | fine on white, **2.3:1** on a dark canvas |

`contrast-color()` is sound over an opaque background, which a translucent highlight is not. (Browser support is not the obstacle: it went Baseline Newly Available in April 2026 and degrades to inherited color.)

So instead of trying to compute a text color we cannot compute, this bounds what the highlight is allowed to cost: one fixed, small tint, and emphasis that does not sit behind the glyphs.

## How?

In `note-highlight-styles.js`:

- `REST_ALPHA` / `ACTIVE_ALPHA` collapse to a single `TINT_ALPHA` (`0x40`, unchanged from today's resting value).
- `:hover`, `:focus-within`, and the selected-note rule now emit `text-decoration-line: underline` with `text-decoration-color` set to the opaque author color, `0.125em` thick at a `0.15em` offset. `text-decoration` follows text across line wraps natively, which `box-shadow` or `border-bottom` on an inline element would not.

An opaque line is a stronger signal than a heavier wash, so the emphasis state reads *more* clearly while costing the text nothing.

Scope: inline markers only, on trunk. https://github.com/WordPress/gutenberg/pull/80498 applies the same helper to whole text blocks and inherits `TINT_ALPHA` on merge; the right block-level equivalent of the underline is an open question there and in #80543, since a paragraph-wide underline is not appropriate.

## Testing Instructions

[![Try in WordPress Playground](https://img.shields.io/badge/Try%20in%20WordPress%20Playground-blue?logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=80544)

1. Enable notes, select a phrase in a paragraph, and add a note.
2. Click elsewhere to deselect. The phrase carries the soft tint, as before.
3. Hover the marker, and select the note in the sidebar. The marker gains an underline in the author's color, and the tint behind the text does not deepen.
4. Confirm the marker is still easy to spot and to trace back to its thread.

### Automated

- `npm run test:unit packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js` - 10 passing, including a new case asserting no rule can emit a background alpha above the rest value.
- `npm run test:e2e -- test/e2e/specs/editor/various/block-notes.spec.js` - 45 passing on a reset environment. The selected-marker case was rewritten to assert the underline and to assert the tint stays put; run against trunk's implementation first it fails, as expected.

## Screenshots

Selected inline marker, before (50% wash) 
<img width="610" height="69" alt="note-highlight-before" src="https://github.com/user-attachments/assets/7e9de6f7-380c-4e64-9d90-ec2b23b4711c" />


after (25% wash plus underline):
<img width="610" height="69" alt="note-highlight-after" src="https://github.com/user-attachments/assets/23981a34-3ace-4da5-aea7-8397e6327233" />



## Open question for review

@jasmussen @joedolson - the underline is deliberately conservative. If the emphasis reads too quietly for connecting a canvas marker to its sidebar thread, the thickness and offset are the dials, and #80543 also asks whether the at-rest marking should move off the background entirely.
