### PR TITLE
Rich text: check the selection first in ownsSelection

### DIFF
--- a/packages/rich-text/src/owns-selection.js
+++ b/packages/rich-text/src/owns-selection.js
@@ -16,28 +16,30 @@ export function ownsSelection( element ) {
 		return true;
 	}
 
-	// Read the `contentEditable` attribute, not `isContentEditable`: the latter
-	// computes the effective editable state and forces a style and layout tree
-	// update. Since each editable element checks this on every keystroke, that
-	// forced update would scale with the number of blocks in the post. The
-	// editing host and the editable both set the attribute explicitly, so the
-	// attribute is equivalent here.
+	if ( ! activeElement ) {
+		return false;
+	}
+
+	// Check the selection before the editing host. When the host is the canvas
+	// wrapper it contains every editable element, so the host checks pass for
+	// all of them and only the selection tells them apart. Running the
+	// discriminating check first lets a non-owning instance bail before the
+	// host checks.
+	const selection = ownerDocument.defaultView.getSelection();
+	const { anchorNode, focusNode } = selection;
+
 	if (
-		! activeElement ||
-		activeElement.contentEditable !== 'true' ||
-		element.contentEditable !== 'true' ||
-		! activeElement.contains( element )
+		! anchorNode ||
+		! focusNode ||
+		! element.contains( anchorNode ) ||
+		! element.contains( focusNode )
 	) {
 		return false;
 	}
 
-	const selection = ownerDocument.defaultView.getSelection();
-	const { anchorNode, focusNode } = selection;
-
 	return (
-		!! anchorNode &&
-		!! focusNode &&
-		element.contains( anchorNode ) &&
-		element.contains( focusNode )
+		activeElement.contentEditable === 'true' &&
+		element.contentEditable === 'true' &&
+		activeElement.contains( element )
 	);
 }


### PR DESCRIPTION
## What?

Reorders `ownsSelection` so the selection-containment check runs before the editing-host checks.

Follow-up to #80549 (merged). That one read the `contentEditable` attribute to drop the forced layout, but didn't move the typing metric. This tries the other axis: ordering.

## Why?

`ownsSelection` runs once per editable per keystroke. Under `editableRoot` the host is the canvas wrapper, which contains every editable element, so the host checks (`contentEditable` reads + `contains`) pass for **every** instance and don't tell them apart. Only the selection does.

With the host checks first, each of the ~N non-owning instances does two `contentEditable` reads and an `activeElement.contains( element )` walk before reaching the check that eliminates it. Doing the discriminating check first lets them bail sooner.

## How?

Move the anchor/focus containment check ahead of the host checks. A non-owning instance now returns after one `element.contains( anchorNode )`, instead of also doing the two `contentEditable` reads and the `activeElement.contains( element )` walk.

Same boolean, behavior unchanged. This is purely about the order of cheap checks; the forced-layout read is already gone in trunk via #80549.

## Testing Instructions

1. Behavior is unchanged: `ownsSelection` returns the same value for the same state.
2. `npm run test:unit packages/rich-text` passes.
3. Watch the `type` metric on codevitals for whether the reordering alone moves it.

## Use of AI Tools

Written with the help of Claude Code.
