### PR TITLE
Rich text: read the contentEditable attribute in ownsSelection to avoid forced layout

### DIFF
--- a/packages/rich-text/src/owns-selection.js
+++ b/packages/rich-text/src/owns-selection.js
@@ -16,10 +16,16 @@ export function ownsSelection( element ) {
 		return true;
 	}
 
+	// Read the `contentEditable` attribute, not `isContentEditable`: the latter
+	// computes the effective editable state and forces a style and layout tree
+	// update. Since each editable element checks this on every keystroke, that
+	// forced update would scale with the number of blocks in the post. The
+	// editing host and the editable both set the attribute explicitly, so the
+	// attribute is equivalent here.
 	if (
 		! activeElement ||
-		! activeElement.isContentEditable ||
-		! element.isContentEditable ||
+		activeElement.contentEditable !== 'true' ||
+		element.contentEditable !== 'true' ||
 		! activeElement.contains( element )
 	) {
 		return false;


### PR DESCRIPTION
## What?

Reads the `contentEditable` attribute in `ownsSelection` instead of `isContentEditable`.

Alternative to #80548, which reorders the same checks to keep the read off the hot path. This removes the cost at the source instead.

## Why?

Typing performance regression from `editableRoot` (#79105). Each RichText subscribes owned listeners that call `ownsSelection` on every keystroke. `isContentEditable` computes the *effective* editable state, which forces a style and layout tree update. Under `editableRoot` the editing host is the canvas wrapper containing every editable element, so every instance runs that read and forces layout on every keystroke, scaling with block count.

## How?

Read the reflected `contentEditable` attribute (`element.contentEditable === 'true'`) rather than the computed `isContentEditable`. Reading an attribute does not force layout.

This is equivalent here: the checks only run when the focused element is not the editable itself (the `editableRoot` host case), and there both the host and the editable set `contenteditable="true"` explicitly (the wrapper via `useEditableRoot`, the editable via `contentEditable={ ! shouldDisableEditing }`). Nothing in this path relies on inherited editability.

## Testing Instructions

1. Behavior is unchanged: `ownsSelection` returns the same value for the same state.
2. `npm run test:unit packages/rich-text` passes.
3. In a large post (hundreds of blocks), typing should no longer force a style recalc per editable per keystroke.

## Use of AI Tools

Written with the help of Claude Code.
