### PR TITLE
Backport from Core: improve icon name unit tests

### DIFF
--- a/phpunit/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/class-wp-icons-registry-gutenberg-test.php
@@ -98,18 +98,22 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides valid namespaced icon names.
+	 * Provides valid namespaced icon names, including names that contain,
+	 * start or end with digits, as well as underscores and hyphens.
 	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public function data_valid_icon_names() {
 		return array(
-			'simple name'            => array( 'test-collection/myicon' ),
-			'digit at the start'     => array( 'test-collection/1-icon' ),
-			'digit in the name'      => array( 'test-collection/my-1-icon' ),
-			'digit at the end'       => array( 'test-collection/icon1' ),
-			'underscore in the name' => array( 'test-collection/my_icon' ),
-			'hyphen in the name'     => array( 'test-collection/my-icon' ),
+			'single character'                => array( 'test-collection/a' ),
+			'simple name'                     => array( 'test-collection/icon' ),
+			'digit at the start'              => array( 'test-collection/1icon' ),
+			'digit in the name'               => array( 'test-collection/my1icon' ),
+			'digit at the end'                => array( 'test-collection/icon1' ),
+			'underscore in the name'          => array( 'test-collection/my_icon' ),
+			'hyphen in the name'              => array( 'test-collection/my-icon' ),
+			'digit adjacent to a hyphen'      => array( 'test-collection/my-1-icon' ),
+			'digit adjacent to an underscore' => array( 'test-collection/my_1_icon' ),
 		);
 	}
 


### PR DESCRIPTION
## What?

Partial backport of https://github.com/WordPress/wordpress-develop/pull/12624.

Aligns the `data_valid_icon_names` data provider in `WP_Icons_Registry_Gutenberg` tests with the one in Core.

## Why?

The Core PR changed both the icon name validation regexp and its test data providers. Gutenberg already has the updated regexp, so only the test data needs to be synced.

## Testing Instructions

No production logic changes. All CI checks should pass.

## Use of AI Tools

Claude Code was used to port the data provider from the Core PR and to write this description. All changes were reviewed by me.
