### PR TITLE
Device type preview: fix collapsing to content height

### DIFF
--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -45,9 +45,8 @@ function isAtMaxWidth( currentWidth, containerWidth, tolerance = 0 ) {
 function ResizableEditor( {
 	className,
 	enableResizing,
-	height,
-	canvasWidth,
-	canvasHeight,
+	width = '100%',
+	height = '100%',
 	onResizeStart,
 	onResizeStop,
 	children,
@@ -97,12 +96,8 @@ function ResizableEditor( {
 				resizableRef.current = api?.resizable;
 			} }
 			size={ {
-				width:
-					enableResizing && canvasWidth ? canvasWidth + 'px' : '100%',
-				height:
-					enableResizing && canvasHeight
-						? canvasHeight + 'px'
-						: height || '100%',
+				width,
+				height,
 			} }
 			onResizeStart={ () => {
 				setIsResizing( true );

--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -48,6 +48,8 @@ function ResizableEditor( {
 	height,
 	canvasWidth,
 	canvasHeight,
+	onResizeStart,
+	onResizeStop,
 	children,
 } ) {
 	const [ isResizing, setIsResizing ] = useState( false );
@@ -104,13 +106,15 @@ function ResizableEditor( {
 			} }
 			onResizeStart={ () => {
 				setIsResizing( true );
+				onResizeStart?.();
 			} }
 			onResize={ ( event, direction, element ) => {
 				updateCanvasWidth( element );
 			} }
 			onResizeStop={ ( event, direction, element ) => {
-				setIsResizing( false );
 				updateCanvasWidth( element );
+				setIsResizing( false );
+				onResizeStop?.();
 			} }
 			minWidth={ 300 }
 			maxWidth="100%"

--- a/packages/editor/src/components/resizable-editor/index.js
+++ b/packages/editor/src/components/resizable-editor/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useRef, useCallback, useState } from '@wordpress/element';
 import { ResizableBox } from '@wordpress/components';
 
@@ -42,24 +42,16 @@ function isAtMaxWidth( currentWidth, containerWidth, tolerance = 0 ) {
 	return containerWidth > 0 && currentWidth >= containerWidth - tolerance;
 }
 
-function ResizableEditor( { className, enableResizing, height, children } ) {
+function ResizableEditor( {
+	className,
+	enableResizing,
+	height,
+	canvasWidth,
+	canvasHeight,
+	children,
+} ) {
 	const [ isResizing, setIsResizing ] = useState( false );
 	const { setCanvasWidth } = unlock( useDispatch( editorStore ) );
-	const { canvasWidth, canvasHeight } = useSelect(
-		( select ) => {
-			if ( ! enableResizing ) {
-				return { canvasWidth: undefined, canvasHeight: undefined };
-			}
-			const { getCanvasWidth, getCanvasHeight } = unlock(
-				select( editorStore )
-			);
-			return {
-				canvasWidth: getCanvasWidth(),
-				canvasHeight: getCanvasHeight(),
-			};
-		},
-		[ enableResizing ]
-	);
 
 	const resizableRef = useRef();
 	const resizeWidthBy = useCallback(

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -323,12 +323,14 @@ function VisualEditor( {
 		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
 		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
+	const isResizablePostType = [
+		NAVIGATION_POST_TYPE,
+		TEMPLATE_PART_POST_TYPE,
+		PATTERN_POST_TYPE,
+	].includes( postType );
+
 	const enableResizing =
-		( [
-			NAVIGATION_POST_TYPE,
-			TEMPLATE_PART_POST_TYPE,
-			PATTERN_POST_TYPE,
-		].includes( postType ) &&
+		( isResizablePostType &&
 			// Disable in previews / view mode.
 			! isPreview &&
 			// Disable resizing in mobile viewport.
@@ -346,7 +348,9 @@ function VisualEditor( {
 
 	const centerContentCSS = `display:flex;align-items:center;justify-content:center;`;
 	const shouldExpandIframeBody =
-		canvasHeight !== undefined && ! isDesignPostType && ! isResizingCanvas;
+		canvasHeight !== undefined &&
+		! isResizablePostType &&
+		! isResizingCanvas;
 	const iframeBodyMinHeightCSS = shouldExpandIframeBody
 		? 'min-height:100vh;'
 		: '';
@@ -425,9 +429,14 @@ function VisualEditor( {
 			<SyncConnectionErrorModal />
 			<ResizableEditor
 				enableResizing={ enableResizing }
-				height="100%"
-				canvasWidth={ canvasWidth }
-				canvasHeight={ isResizingCanvas ? undefined : canvasHeight }
+				width={
+					enableResizing && canvasWidth ? canvasWidth + 'px' : '100%'
+				}
+				height={
+					enableResizing && canvasHeight && ! isResizingCanvas
+						? canvasHeight + 'px'
+						: '100%'
+				}
 				onResizeStart={ () => setIsResizingCanvas( true ) }
 				onResizeStop={ () => setIsResizingCanvas( false ) }
 			>

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -14,7 +14,7 @@ import {
 	RecursionProvider,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useEffect, useRef, useMemo } from '@wordpress/element';
+import { useEffect, useRef, useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
@@ -191,6 +191,7 @@ function VisualEditor( {
 	}, [] );
 
 	const localRef = useRef();
+	const [ isResizingCanvas, setIsResizingCanvas ] = useState( false );
 	const [ globalLayoutSettings ] = useSettings( 'layout' );
 
 	// fallbackLayout is used if there is no Post Content,
@@ -345,7 +346,7 @@ function VisualEditor( {
 
 	const centerContentCSS = `display:flex;align-items:center;justify-content:center;`;
 	const shouldExpandIframeBody =
-		canvasHeight !== undefined && ! isDesignPostType;
+		canvasHeight !== undefined && ! isDesignPostType && ! isResizingCanvas;
 	const iframeBodyMinHeightCSS = shouldExpandIframeBody
 		? 'min-height:100vh;'
 		: '';
@@ -426,7 +427,9 @@ function VisualEditor( {
 				enableResizing={ enableResizing }
 				height="100%"
 				canvasWidth={ canvasWidth }
-				canvasHeight={ canvasHeight }
+				canvasHeight={ isResizingCanvas ? undefined : canvasHeight }
+				onResizeStart={ () => setIsResizingCanvas( true ) }
+				onResizeStop={ () => setIsResizingCanvas( false ) }
 			>
 				<BlockCanvas
 					shouldIframe

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -110,6 +110,8 @@ function VisualEditor( {
 		isPreview,
 		styles,
 		hasCanvasWidth,
+		canvasWidth,
+		canvasHeight,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -119,6 +121,7 @@ function VisualEditor( {
 			getRenderingMode,
 			getDeviceType,
 			getCanvasWidth,
+			getCanvasHeight,
 		} = unlock( select( editorStore ) );
 		const { getPostType, getEditedEntityRecord } = select( coreStore );
 		const postTypeSlug = getCurrentPostType();
@@ -135,6 +138,7 @@ function VisualEditor( {
 		const supportsTemplateMode = editorSettings.supportsTemplateMode;
 		const postTypeObject = getPostType( postTypeSlug );
 		const currentTemplateId = getCurrentTemplateId();
+		const _canvasWidth = getCanvasWidth();
 		const template = currentTemplateId
 			? getEditedEntityRecord(
 					'postType',
@@ -160,7 +164,9 @@ function VisualEditor( {
 			postType: postTypeSlug,
 			isPreview: editorSettings.isPreviewMode,
 			styles: editorSettings.styles,
-			hasCanvasWidth: getCanvasWidth() !== undefined,
+			hasCanvasWidth: _canvasWidth !== undefined,
+			canvasWidth: _canvasWidth,
+			canvasHeight: getCanvasHeight(),
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -338,6 +344,11 @@ function VisualEditor( {
 	);
 
 	const centerContentCSS = `display:flex;align-items:center;justify-content:center;`;
+	const shouldExpandIframeBody =
+		canvasHeight !== undefined && ! isDesignPostType;
+	const iframeBodyMinHeightCSS = shouldExpandIframeBody
+		? 'min-height:100vh;'
+		: '';
 
 	const iframeStyles = useMemo( () => {
 		return [
@@ -356,7 +367,7 @@ function VisualEditor( {
 				${ paddingStyle ? paddingStyle : '' }
 				${
 					enableResizing
-						? `.block-editor-iframe__html{background:var(--wp-editor-canvas-background);min-height:100vh;${ centerContentCSS }}.block-editor-iframe__body{width:100%;}`
+						? `.block-editor-iframe__html{background:var(--wp-editor-canvas-background);min-height:100vh;${ centerContentCSS }}.block-editor-iframe__body{width:100%;${ iframeBodyMinHeightCSS }}`
 						: ''
 				}${
 					isNavigationPreview
@@ -368,7 +379,14 @@ function VisualEditor( {
 				// The CSS for isNavigationPreview centers the body content vertically and horizontally when the navigation is in preview mode.
 			},
 		];
-	}, [ styles, enableResizing, isNavigationPreview, paddingStyle ] );
+	}, [
+		styles,
+		enableResizing,
+		centerContentCSS,
+		iframeBodyMinHeightCSS,
+		isNavigationPreview,
+		paddingStyle,
+	] );
 
 	const typewriterRef = useTypewriter();
 	contentRef = useMergeRefs( [
@@ -404,7 +422,12 @@ function VisualEditor( {
 			) }
 		>
 			<SyncConnectionErrorModal />
-			<ResizableEditor enableResizing={ enableResizing } height="100%">
+			<ResizableEditor
+				enableResizing={ enableResizing }
+				height="100%"
+				canvasWidth={ canvasWidth }
+				canvasHeight={ canvasHeight }
+			>
 				<BlockCanvas
 					shouldIframe
 					contentRef={ contentRef }


### PR DESCRIPTION
## What?
Small follow up to #80271

After that PR, I noticed when the block editor doesn't have much content, the device previews collapse to the height of the content, so still don't display the correct device heights. The height only works correctly when the content height is greater than or equal to the device height.

This would look like a regression compared to 7.0, where the device height worked correctly even for an empty canvas.

## Why?
The issue is the `body` of the iframe collapsing, and this is the thing that's styled to look like the editor canvas, so it visually looks as thought the height of the preview is wrong. This happens even though all the other wrapping elements have the correct height.

## How?
When the canvas has a specific `height` set, forces the iframe `body` to `100vh`.

Achieves this by moving the `canvasWidth` / `canvasHeight` `useSelect` from `ResizableEditor` up to `VisualEditor`, and adding a style to the iframe when the canvas has `canvasHeight`.

After this there were a few little refinements to make. When the user is dragging, whenever they crossed the specific device sizes, the height would suddenly jump to the device's height. I added some suppression for this, which meant adding a bit more logic about resizing to `VisualEditor`.

## Testing Instructions
In general it should work like 7.0, the only difference being that drag handles are shown for all post types after https://github.com/WordPress/gutenberg/pull/75121.

1. Create a new post or template (ideally test both)
2. With the canvas empty, try selecting tablet or mobile device viewport from the 'View' dropdown
3. In trunk observe the canvas height collapses, while on this branch the correct device height is shown
4. Resize manually using the drag handles. Observe when setting to a manual width, the canvas height still collapses to the content height (maintains the decision made in #80271)
5. Edit a pattern or template part
6. Observe these post types still collapse to the content height when selecting a mobile or tablet viewport, or when resizing to a manual width

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="942" height="1086" alt="Screenshot 2026-07-22 at 12 31 51 pm" src="https://github.com/user-attachments/assets/3d58538b-3629-4565-845a-ba9094081579" /> | <img width="947" height="1085" alt="Screenshot 2026-07-22 at 12 30 19 pm" src="https://github.com/user-attachments/assets/304ee8a8-3c3f-4df6-825f-e4d4086dabb9" /> |

## Use of AI Tools
OpenCode / Codex