### PR TITLE
GradientPicker: select by slug so two presets sharing a gradient keep their identity

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -45,6 +45,7 @@ function ColorGradientControlInner( {
 	colorValue,
 	colorSlug,
 	gradientValue,
+	gradientSlug,
 	clearable,
 	showTitle = true,
 	enableAlpha,
@@ -102,13 +103,15 @@ function ColorGradientControlInner( {
 		[ TAB_IDS.gradient ]: (
 			<GradientPicker
 				value={ gradientValue }
+				selectedSlug={ gradientSlug }
 				onChange={
 					canChooseAColor
-						? ( newGradient ) => {
-								onGradientChange( newGradient );
+						? ( newGradient, _index, newSlug ) => {
+								onGradientChange( newGradient, newSlug );
 								onColorChange();
 						  }
-						: onGradientChange
+						: ( newGradient, _index, newSlug ) =>
+								onGradientChange( newGradient, newSlug )
 				}
 				{ ...{ gradients, disableCustomGradients } }
 				__experimentalIsRenderedInSidebar={

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -297,11 +297,11 @@ export default function BackgroundImagePanel( {
 	// Legacy `color.gradient` setters.
 	const legacyColorGradient = decodeValue( inheritedValue?.color?.gradient );
 	const userLegacyColorGradient = decodeValue( value?.color?.gradient );
-	const setLegacyColorGradient = ( newGradient ) => {
+	const setLegacyColorGradient = ( newGradient, newSlug ) => {
 		const newValue = setImmutably(
 			value,
 			[ 'color', 'gradient' ],
-			encodeGradientValue( newGradient )
+			encodeGradientValue( newGradient, newSlug )
 		);
 		newValue.color.background = undefined;
 		onChange( newValue );
@@ -323,11 +323,11 @@ export default function BackgroundImagePanel( {
 	// Set gradient value, encoding preset matches as slug references.
 	// Also clear color.gradient to migrate from the legacy location,
 	// matching the block inspector behavior in hooks/background.js.
-	const setGradient = ( newGradient ) => {
+	const setGradient = ( newGradient, newSlug ) => {
 		let newValue = setImmutably(
 			value,
 			[ 'background', 'gradient' ],
-			encodeGradientValue( newGradient )
+			encodeGradientValue( newGradient, newSlug )
 		);
 		newValue = setImmutably( newValue, [ 'color', 'gradient' ], undefined );
 		onChange( newValue );
@@ -450,6 +450,16 @@ export default function BackgroundImagePanel( {
 							key: 'gradient',
 							label: __( 'Gradient' ),
 							inheritedValue: inheritedGradient,
+							inheritedSlug: extractPresetSlug(
+								inheritedValue?.background?.gradient ??
+									inheritedValue?.color?.gradient,
+								'gradient'
+							),
+							userSlug: extractPresetSlug(
+								value?.background?.gradient ??
+									value?.color?.gradient,
+								'gradient'
+							),
 							setValue: setGradient,
 							userValue: currentGradient,
 							isGradient: true,
@@ -487,6 +497,14 @@ export default function BackgroundImagePanel( {
 							key: 'gradient',
 							label: __( 'Gradient' ),
 							inheritedValue: legacyColorGradient,
+							inheritedSlug: extractPresetSlug(
+								inheritedValue?.color?.gradient,
+								'gradient'
+							),
+							userSlug: extractPresetSlug(
+								value?.color?.gradient,
+								'gradient'
+							),
 							setValue: setLegacyColorGradient,
 							userValue: userLegacyColorGradient,
 							isGradient: true,

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -170,6 +170,7 @@ function ColorGradientTab( {
 			colorValue={ isGradient ? undefined : displayed }
 			colorSlug={ isGradient ? undefined : displayedSlug }
 			gradientValue={ isGradient ? displayed : undefined }
+			gradientSlug={ isGradient ? displayedSlug : undefined }
 			onColorChange={ isGradient ? undefined : onChange }
 			onGradientChange={ isGradient ? onChange : undefined }
 			/*

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -423,11 +423,11 @@ export default function ColorPanel( {
 			newValue.elements[ name ].color.gradient = undefined;
 			onChange( newValue );
 		};
-		const setElementGradient = ( newGradient ) => {
+		const setElementGradient = ( newGradient, newSlug ) => {
 			const newValue = setImmutably(
 				value,
 				[ 'elements', name, 'color', 'gradient' ],
-				encodeGradientValue( newGradient )
+				encodeGradientValue( newGradient, newSlug )
 			);
 			newValue.elements[ name ].color.background = undefined;
 			onChange( newValue );
@@ -516,6 +516,14 @@ export default function ColorPanel( {
 						key: 'gradient',
 						label: __( 'Gradient' ),
 						inheritedValue: elementGradient,
+						inheritedSlug: extractPresetSlug(
+							inheritedValue?.elements?.[ name ]?.color?.gradient,
+							'gradient'
+						),
+						userSlug: extractPresetSlug(
+							value?.elements?.[ name ]?.color?.gradient,
+							'gradient'
+						),
 						setValue: setElementGradient,
 						userValue: elementGradientUserColor,
 						isGradient: true,

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -328,7 +328,14 @@ export function useColorGradientSettings( settings ) {
 	);
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
-	const encodeGradientValue = ( gradientValue ) => {
+	// When a slug is provided it is used directly: two presets can share the
+	// same gradient string, and matching by string alone would collapse them
+	// onto whichever entry appears first. Without a slug, fall back to
+	// matching the gradient string against the presets.
+	const encodeGradientValue = ( gradientValue, slug ) => {
+		if ( slug ) {
+			return 'var:preset|gradient|' + slug;
+		}
 		const allGradients = gradients.flatMap(
 			( { gradients: originGradients } ) => originGradients
 		);

--- a/packages/block-editor/src/components/global-styles/test/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.js
@@ -130,6 +130,89 @@ const baseSettings = {
 	},
 };
 
+describe( 'BackgroundPanel — duplicate gradient preset slug identity', () => {
+	const SHARED_GRADIENT =
+		'linear-gradient(135deg, rgb(74, 0, 224) 0%, rgb(142, 45, 226) 100%)';
+	const duplicateGradientSettings = {
+		background: {
+			gradient: true,
+		},
+		color: {
+			gradients: {
+				theme: [
+					{
+						name: 'Dark background',
+						slug: 'dup-background',
+						gradient: SHARED_GRADIENT,
+					},
+					{
+						name: 'Dark text',
+						slug: 'dup-text',
+						gradient: SHARED_GRADIENT,
+					},
+				],
+			},
+		},
+	};
+
+	async function openGradientDropdown( user ) {
+		await user.click( screen.getByRole( 'button', { name: /Gradient/ } ) );
+		return screen.findAllByRole( 'option' );
+	}
+
+	it( 'commits the inherited preset slug when accepting the preselected inherited gradient', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BackgroundPanel
+				value={ {} }
+				inheritedValue={ {
+					background: { gradient: 'var:preset|gradient|dup-text' },
+				} }
+				settings={ duplicateGradientSettings }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		const swatches = await openGradientDropdown( user );
+		// swatch[1] ('Dark text') is the preselected inherited option;
+		// activating it is the "accept inherited value" gesture. The commit
+		// must carry the inherited slug, not re-encode the shared gradient
+		// string to whichever duplicate appears first.
+		await user.click( swatches[ 1 ] );
+
+		const result = onChange.mock.calls[ 0 ][ 0 ];
+		expect( result?.background?.gradient ).toBe(
+			'var:preset|gradient|dup-text'
+		);
+	} );
+
+	it( 'marks only the local preset as selected when another preset shares its gradient', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<BackgroundPanel
+				value={ {
+					background: { gradient: 'var:preset|gradient|dup-text' },
+				} }
+				inheritedValue={ {} }
+				settings={ duplicateGradientSettings }
+				onChange={ jest.fn() }
+				panelId="test-panel"
+			/>
+		);
+
+		// swatch[0] = 'Dark background', swatch[1] = 'Dark text'. Selection
+		// must follow the stored slug; matching by gradient string would
+		// mark both.
+		const swatches = await openGradientDropdown( user );
+		expect( swatches[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( swatches[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+	} );
+} );
+
 describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 	describe( 'Background gradient slot', () => {
 		it( 'applies the local-override className when a local gradient is set', () => {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `GradientPicker`: Add `selectedSlug` prop for slug-based selection and pass the selected preset's slug to `onChange`, so two presets sharing a gradient keep their identity ([#80554](https://github.com/WordPress/gutenberg/pull/80554)).
+
 ### Bug Fixes
 
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -141,11 +141,29 @@ Only used when `asButtons` is not true.
 
 ### `onChange`
 
- - Type: `(currentGradient: string | undefined) => void`
+ - Type: `(currentGradient: string | undefined, index?: number | undefined, slug?: string | undefined) => void`
  - Required: Yes
 
-The function called when a new gradient has been defined. It is passed to
-the `currentGradient` as an argument.
+The function called when a new gradient has been defined. It is passed
+the `currentGradient` as an argument. When a predefined gradient is
+selected, the second argument is its index (or, for multiple-origin
+gradients, the origin index) and the third argument is its slug.
+
+### `selectedSlug`
+
+ - Type: `string`
+ - Required: No
+
+The slug of the currently selected predefined gradient.
+
+When set to a non-empty string, selection is determined by slug rather
+than by gradient value, which correctly handles palettes where two
+entries share the same gradient. Entries whose slug does not match will
+not appear selected in this mode, even if their gradient value matches
+`value`.
+
+An empty string is treated the same as `undefined`: selection falls
+back to matching by gradient value.
 
 ### `value`
 

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -41,35 +41,48 @@ function SingleOrigin( {
 	gradients,
 	onChange,
 	value,
+	selectedSlug,
 	...additionalProps
 }: PickerProps< GradientObject > ) {
 	const gradientOptions = useMemo( () => {
-		return gradients.map( ( { gradient, name, slug }, index ) => (
-			<CircularOptionPicker.Option
-				key={ slug }
-				value={ gradient }
-				isSelected={ value === gradient }
-				tooltipText={
-					name ||
-					// translators: %s: gradient code e.g: "linear-gradient(90deg, rgba(98,16,153,1) 0%, rgba(172,110,22,1) 100%);".
-					sprintf( __( 'Gradient code: %s' ), gradient )
-				}
-				style={ { color: 'rgba( 0,0,0,0 )', background: gradient } }
-				onClick={
-					value === gradient
-						? clearGradient
-						: () => onChange( gradient, index )
-				}
-				aria-label={
-					name
-						? // translators: %s: The name of the gradient e.g: "Angular red to blue".
-						  sprintf( __( 'Gradient: %s' ), name )
-						: // translators: %s: gradient code e.g: "linear-gradient(90deg, rgba(98,16,153,1) 0%, rgba(172,110,22,1) 100%);".
-						  sprintf( __( 'Gradient code: %s' ), gradient )
-				}
-			/>
-		) );
-	}, [ gradients, value, onChange, clearGradient ] );
+		return gradients.map( ( { gradient, name, slug }, index ) => {
+			// When a non-empty selectedSlug is provided, selection is decided
+			// strictly by slug, which keeps two entries with the same gradient
+			// value apart. Otherwise selection falls back to matching the
+			// gradient value.
+			const isSelected = selectedSlug
+				? slug === selectedSlug
+				: value === gradient;
+			return (
+				<CircularOptionPicker.Option
+					key={ slug }
+					value={ gradient }
+					isSelected={ isSelected }
+					tooltipText={
+						name ||
+						// translators: %s: gradient code e.g: "linear-gradient(90deg, rgba(98,16,153,1) 0%, rgba(172,110,22,1) 100%);".
+						sprintf( __( 'Gradient code: %s' ), gradient )
+					}
+					style={ {
+						color: 'rgba( 0,0,0,0 )',
+						background: gradient,
+					} }
+					onClick={
+						isSelected
+							? clearGradient
+							: () => onChange( gradient, index, slug )
+					}
+					aria-label={
+						name
+							? // translators: %s: The name of the gradient e.g: "Angular red to blue".
+							  sprintf( __( 'Gradient: %s' ), name )
+							: // translators: %s: gradient code e.g: "linear-gradient(90deg, rgba(98,16,153,1) 0%, rgba(172,110,22,1) 100%);".
+							  sprintf( __( 'Gradient code: %s' ), gradient )
+					}
+				/>
+			);
+		} );
+	}, [ gradients, value, onChange, clearGradient, selectedSlug ] );
 	return (
 		<CircularOptionPicker.OptionGroup
 			className={ className }
@@ -85,6 +98,7 @@ function MultipleOrigin( {
 	gradients,
 	onChange,
 	value,
+	selectedSlug,
 	headingLevel,
 }: PickerProps< OriginObject > ) {
 	const instanceId = useInstanceId( MultipleOrigin );
@@ -101,10 +115,11 @@ function MultipleOrigin( {
 						<SingleOrigin
 							clearGradient={ clearGradient }
 							gradients={ gradientSet }
-							onChange={ ( gradient ) =>
-								onChange( gradient, index )
+							onChange={ ( gradient, _index, slug ) =>
+								onChange( gradient, index, slug )
 							}
 							value={ value }
+							selectedSlug={ selectedSlug }
 							aria-labelledby={ id }
 						/>
 					</VStack>

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -31,6 +31,7 @@ const meta: Meta< typeof GradientPicker > = {
 		onChange: fn(),
 	},
 	argTypes: {
+		selectedSlug: { control: false },
 		value: { control: false },
 	},
 };
@@ -91,17 +92,23 @@ const GRADIENTS = [
 
 const Template = ( {
 	onChange,
+	value,
+	selectedSlug,
 	...props
 }: React.ComponentProps< typeof GradientPicker > ) => {
-	const [ gradient, setGradient ] =
-		useState< ( typeof props )[ 'value' ] >( null );
+	const [ gradient, setGradient ] = useState< ( typeof props )[ 'value' ] >(
+		value ?? null
+	);
+	const [ slug, setSlug ] = useState< string | undefined >( selectedSlug );
 	return (
 		<GradientPicker
 			{ ...props }
 			value={ gradient }
-			onChange={ ( currentGradient, index, slug ) => {
+			selectedSlug={ slug }
+			onChange={ ( currentGradient, index, newSlug ) => {
 				setGradient( currentGradient );
-				onChange?.( currentGradient, index, slug );
+				setSlug( newSlug );
+				onChange?.( currentGradient, index, newSlug );
 			} }
 		/>
 	);
@@ -118,6 +125,35 @@ export const WithNoExistingGradients: GradientPickerStory = {
 	render: Template,
 	args: {
 		gradients: [],
+	},
+};
+
+export const DuplicateGradients: GradientPickerStory = {
+	render: Template,
+	args: {
+		gradients: [
+			{
+				name: 'Dark Background',
+				slug: 'dark-background',
+				gradient:
+					'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+			},
+			{
+				name: 'Dark Text',
+				slug: 'dark-text',
+				gradient:
+					'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+			},
+			{
+				name: 'Brand',
+				slug: 'brand',
+				gradient:
+					'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
+			},
+		],
+		value: 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+		selectedSlug: 'dark-text',
+		disableCustomGradients: true,
 	},
 };
 

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -99,9 +99,9 @@ const Template = ( {
 		<GradientPicker
 			{ ...props }
 			value={ gradient }
-			onChange={ ( ...changeArgs ) => {
-				setGradient( ...changeArgs );
-				onChange?.( ...changeArgs );
+			onChange={ ( currentGradient, index, slug ) => {
+				setGradient( currentGradient );
+				onChange?.( currentGradient, index, slug );
 			} }
 		/>
 	);

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -96,9 +96,9 @@ const Template = ( {
 	selectedSlug,
 	...props
 }: React.ComponentProps< typeof GradientPicker > ) => {
-	const [ gradient, setGradient ] = useState< ( typeof props )[ 'value' ] >(
-		value ?? null
-	);
+	const [ gradient, setGradient ] = useState<
+		React.ComponentProps< typeof GradientPicker >[ 'value' ]
+	>( value ?? null );
 	const [ slug, setSlug ] = useState< string | undefined >( selectedSlug );
 	return (
 		<GradientPicker

--- a/packages/components/src/gradient-picker/test/index.tsx
+++ b/packages/components/src/gradient-picker/test/index.tsx
@@ -1,0 +1,148 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import GradientPicker from '..';
+
+const GRADIENT_A =
+	'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)';
+const GRADIENT_B =
+	'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)';
+
+const DUPLICATE_GRADIENTS = [
+	{ name: 'Dark Background', slug: 'dark-background', gradient: GRADIENT_A },
+	{ name: 'Dark Text', slug: 'dark-text', gradient: GRADIENT_A },
+];
+
+describe( 'GradientPicker', () => {
+	describe( 'duplicate gradients in palette', () => {
+		it( 'should render all swatches even when two entries share the same gradient value', () => {
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ DUPLICATE_GRADIENTS }
+					value={ undefined }
+					onChange={ jest.fn() }
+					disableCustomGradients
+				/>
+			);
+
+			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should select by slug when selectedSlug is provided, marking only the matching entry', () => {
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ DUPLICATE_GRADIENTS }
+					value={ GRADIENT_A }
+					selectedSlug="dark-text"
+					onChange={ jest.fn() }
+					disableCustomGradients
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			// "dark-background" is index 0, "dark-text" is index 1.
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should fall back to value selection and mark all matching duplicates when no selectedSlug is provided', () => {
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ DUPLICATE_GRADIENTS }
+					value={ GRADIENT_A }
+					onChange={ jest.fn() }
+					disableCustomGradients
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should treat an empty-string selectedSlug as no slug and fall back to value selection', () => {
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ DUPLICATE_GRADIENTS }
+					value={ GRADIENT_A }
+					selectedSlug=""
+					onChange={ jest.fn() }
+					disableCustomGradients
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should pass slug as third argument to onChange when a swatch is clicked', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ DUPLICATE_GRADIENTS }
+					value={ undefined }
+					onChange={ onChange }
+					disableCustomGradients
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Gradient: Dark Text' } )
+			);
+
+			expect( onChange ).toHaveBeenCalledWith(
+				GRADIENT_A,
+				1,
+				'dark-text'
+			);
+		} );
+
+		it( 'should pass slug as third argument to onChange for multiple-origin gradients', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<GradientPicker
+					aria-label="Gradient"
+					gradients={ [
+						{
+							name: 'Theme',
+							gradients: [
+								{
+									name: 'Blush',
+									slug: 'blush',
+									gradient: GRADIENT_B,
+								},
+							],
+						},
+					] }
+					value={ undefined }
+					onChange={ onChange }
+					disableCustomGradients
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Gradient: Blush' } )
+			);
+
+			// The second argument is the origin index, mirroring the existing
+			// multiple-origin behavior.
+			expect( onChange ).toHaveBeenCalledWith( GRADIENT_B, 0, 'blush' );
+		} );
+	} );
+} );

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -17,10 +17,16 @@ type GradientPickerBaseProps = {
 	 */
 	className?: string;
 	/**
-	 * The function called when a new gradient has been defined. It is passed to
-	 * the `currentGradient` as an argument.
+	 * The function called when a new gradient has been defined. It is passed
+	 * the `currentGradient` as an argument. When a predefined gradient is
+	 * selected, the second argument is its index (or, for multiple-origin
+	 * gradients, the origin index) and the third argument is its slug.
 	 */
-	onChange: ( currentGradient: string | undefined ) => void;
+	onChange: (
+		currentGradient: string | undefined,
+		index?: number,
+		slug?: string
+	) => void;
 	/**
 	 * The current value of the gradient. Pass a css gradient string (See default value for example).
 	 * Optionally pass in a `null` value to specify no gradient is currently selected.
@@ -28,6 +34,19 @@ type GradientPickerBaseProps = {
 	 * @default 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)'
 	 */
 	value?: GradientObject[ 'gradient' ] | null;
+	/**
+	 * The slug of the currently selected predefined gradient.
+	 *
+	 * When set to a non-empty string, selection is determined by slug rather
+	 * than by gradient value, which correctly handles palettes where two
+	 * entries share the same gradient. Entries whose slug does not match will
+	 * not appear selected in this mode, even if their gradient value matches
+	 * `value`.
+	 *
+	 * An empty string is treated the same as `undefined`: selection falls
+	 * back to matching by gradient value.
+	 */
+	selectedSlug?: string;
 	/**
 	 * Whether the palette should have a clearing button or not.
 	 *
@@ -121,7 +140,8 @@ export type PickerProps< TOriginType extends GradientObject | OriginObject > =
 		clearGradient: () => void;
 		onChange: (
 			currentGradient: string | undefined,
-			index: number
+			index: number,
+			slug?: string
 		) => void;
 		actions?: React.ReactNode;
 		gradients: TOriginType[];


### PR DESCRIPTION


## What?

Follow up to https://github.com/WordPress/gutenberg/pull/80497

Gradient counterpart to #80497, as noted in that PR's review. When a palette contains two gradient presets with the same gradient string:

1. Accepting an inherited gradient by clicking its preselected swatch committed the wrong preset. The gradient string was re-encoded by palette lookup, which returns the first entry with that string.
2. Once a local gradient preset was set, the picker matched selection by string, so both swatches rendered as selected.

## How?

- `GradientPicker` gains an optional `selectedSlug` prop that selects strictly by slug when set, and passes the clicked preset's slug as a third `onChange` argument. Mirrors `ColorPalette`'s `selectedSlug` API. Both changes are additive; consumers that do not opt in are unaffected.
- The Global Styles gradient tabs (background gradient, legacy `color.gradient`, element gradients) pass inherited and user slugs, and `encodeGradientValue` uses a provided slug instead of matching the gradient string.

## Testing Instructions

Add to `test/emptytheme/theme.json` and activate emptytheme:

```json
{
	"settings": {
		"color": {
			"defaultGradients": false,
			"gradients": [
				{
					"slug": "dup-background",
					"gradient": "linear-gradient(135deg,#0693e3 0%,#9b51e0 100%)",
					"name": "Dup background"
				},
				{
					"slug": "dup-text",
					"gradient": "linear-gradient(135deg,#0693e3 0%,#9b51e0 100%)",
					"name": "Dup text"
				}
			]
		}
	},
	"styles": {
		"blocks": {
			"core/paragraph": {
				"color": { "gradient": "var:preset|gradient|dup-text" }
			}
		}
	}
}
```

### Accepting the inherited gradient commits the right preset

1. New post, add a Paragraph block. Confirm in the Code editor the Group has no `gradient` or `style` attribute.
2. Open the Paragraph's Background panel and its Gradient control. The "Dup text" swatch is checked (hover to confirm the name). Click it.
3. Check the Code editor: the committed reference must name `dup-text`. On trunk it names `dup-background`.

### Selection follows the stored preset

4. Reopen the gradient popover. Only "Dup text" is checked. On trunk both swatches render as selected.

### Custom gradients unchanged

5. Set a custom gradient via the gradient bar. Reopen: no preset swatch is checked, same as trunk.


### Before

https://github.com/user-attachments/assets/a7e4ad97-7af0-478c-92e6-8e9249569018


### After

https://github.com/user-attachments/assets/1546fee9-bb90-45a6-811d-41a9d65a5027

To confirm no regressions when the global inheritance styles are off:

`IS_GUTENBERG_PLUGIN=false npm run dev` See https://github.com/WordPress/gutenberg/pull/80555

https://github.com/user-attachments/assets/d67a38d9-09e3-43a4-91cd-5e5478ebf5c1


