### PR TITLE
Global Styles: Limit the inherited value treatment to the Gutenberg plugin

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Internal
 
--   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#TODO](https://github.com/WordPress/gutenberg/pull/TODO)).
+-   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#80555](https://github.com/WordPress/gutenberg/pull/80555)).
 
 ### Bug Fixes
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Inspector controls in the standard block-supports panels (Typography, Dimensions, Border, Color, Background, Filters) now reflect the value a block inherits from Global Styles when no local override is set. Inherited controls show that value at rest (as a placeholder, preselected option, or resolved value) and mark the label with a dotted underline; setting a local override reveals a reset affordance that clears the override back to the inherited value ([#77894](https://github.com/WordPress/gutenberg/pull/77894)).
 -   Inherited Global Styles now resolve per-level heading element styles for the heading-family blocks (`core/heading`, `core/site-title`, `core/post-title`, `core/query-title`, `core/comments-title`, `core/term-name`, `core/site-tagline`, `core/accordion-heading`), so inspector controls reflect values set on a specific heading level (`styles.elements.h1`–`h6`) in addition to the shared `heading` element. A block rendered at level 0 (a paragraph) folds no heading element styles; `core/accordion-heading` has no level-0 state and takes its level from the parent Accordion's block context ([#80495](https://github.com/WordPress/gutenberg/pull/80495)).
 
+### Internal
+
+-   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#TODO](https://github.com/WordPress/gutenberg/pull/TODO)).
+
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -18,7 +18,11 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	ENABLE_GLOBAL_STYLES_INHERITANCE,
+} from './inheritance';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -166,7 +170,7 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Background' ),
 	contrastWarning,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -21,7 +21,11 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	ENABLE_GLOBAL_STYLES_INHERITANCE,
+} from './inheritance';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -103,7 +107,7 @@ export default function BorderPanel( {
 	panelId,
 	name,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 } ) {
 	const colors = useColorsPerOrigin( settings );
 	const areCustomSolidsEnabled = settings?.color?.custom;

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -21,6 +21,7 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
+import { ENABLE_GLOBAL_STYLES_INHERITANCE } from './inheritance';
 
 // Despite the "ColorPanel" name, this gates only the element-level color
 // controls (link, heading, button, caption, h1–h6) — surfaced as the
@@ -148,7 +149,7 @@ export default function ColorPanel( {
 	label,
 	children,
 	contrastWarning,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,7 +33,11 @@ import {
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	ENABLE_GLOBAL_STYLES_INHERITANCE,
+} from './inheritance';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -355,7 +359,7 @@ export default function DimensionsPanel( {
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
 	styleState = DEFAULT_BLOCK_STYLE_STATE,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 } ) {
 	const { dimensions, spacing } = settings;
 

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -34,6 +34,7 @@ import {
 	getInheritanceProps,
 	InheritanceToolsPanelItem,
 	InheritanceResetButton,
+	ENABLE_GLOBAL_STYLES_INHERITANCE,
 } from './inheritance';
 
 const EMPTY_ARRAY = [];
@@ -186,7 +187,7 @@ export default function FiltersPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -15,6 +15,16 @@ import { reset as resetIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Whether the inspector surfaces inherited Global Styles values.
+ * Plugin-only, so Core builds show locally-set values alone.
+ *
+ * @type {boolean}
+ */
+export const ENABLE_GLOBAL_STYLES_INHERITANCE = globalThis.IS_GUTENBERG_PLUGIN
+	? true
+	: false;
+
+/**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
  * so its descendant label picks up the inherited-from-Global-Styles
  * visual treatment.

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -18,8 +18,12 @@ import { getVariationNameFromClass } from '../../hooks/block-style-variation';
 import { useBlockEditContext } from '../block-edit/context';
 import BlockContext from '../block-context';
 import { unlock } from '../../lock-unlock';
+import { ENABLE_GLOBAL_STYLES_INHERITANCE } from './inheritance';
 
 const { resolveStyle } = unlock( globalStylesEnginePrivateApis );
+
+// Undefined so the panels fall back to their `inheritedValue = value` default.
+const NO_RESOLVED_STYLE = { value: undefined, sources: undefined };
 
 /**
  * Reads the Global Styles payload and returns it as a `GlobalStylesConfig`
@@ -220,6 +224,9 @@ export function useResolvedStyle( blockName, className, selectedState = null ) {
 	const globalStyles = useRawGlobalStyles();
 
 	return useMemo( () => {
+		if ( ! ENABLE_GLOBAL_STYLES_INHERITANCE ) {
+			return NO_RESOLVED_STYLE;
+		}
 		if ( ! blockName ) {
 			return { value: {}, sources: {} };
 		}

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -224,6 +224,7 @@ export function useResolvedStyle( blockName, className, selectedState = null ) {
 	const globalStyles = useRawGlobalStyles();
 
 	return useMemo( () => {
+		// Skip the cascade merge entirely when the feature is off.
 		if ( ! ENABLE_GLOBAL_STYLES_INHERITANCE ) {
 			return NO_RESOLVED_STYLE;
 		}

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useResolvedStyle } from '../inherited-value-context';
+import { globalStylesDataKey } from '../../../store/private-keys';
+
+// Core-build coverage for `useResolvedStyle`. Tests run with
+// `IS_GUTENBERG_PLUGIN` true, so the core path needs a mock. `jest.mock` is
+// file-scoped, so these tests live apart from `inherited-value-context.js`.
+jest.mock( '../inheritance', () => ( {
+	...jest.requireActual( '../inheritance' ),
+	ENABLE_GLOBAL_STYLES_INHERITANCE: false,
+} ) );
+
+// Only `useSelect` is called by the hook. The other four are needed at import
+// time by the store modules this file pulls in transitively.
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	register: jest.fn(),
+	createReduxStore: jest.fn(),
+	createSelector: jest.fn( ( callback ) => callback ),
+	combineReducers: jest.fn( ( reducers ) => reducers ),
+} ) );
+
+jest.mock( '../../../store', () => ( {
+	store: { name: 'core/block-editor' },
+} ) );
+
+// `inherited-value-context.js` imports the blocks store for
+// `useVariationAndElements`. Its real import chain needs data-module exports
+// the stub above does not provide, so stub the blocks module too.
+jest.mock( '@wordpress/blocks', () => ( {
+	store: { name: 'core/blocks' },
+	getBlockType: ( blockName ) =>
+		( { 'core/heading': { title: 'Heading' } } )[ blockName ],
+} ) );
+
+jest.mock( '../../../hooks/block-style-variation', () => ( {
+	getVariationNameFromClass: ( className ) => {
+		const match = /is-style-([\w-]+)/.exec( className || '' );
+		return match ? match[ 1 ] : null;
+	},
+} ) );
+
+describe( 'useResolvedStyle — core build', () => {
+	beforeEach( () => {
+		useSelect.mockReset();
+		useSelect.mockImplementation( ( mapSelect ) =>
+			mapSelect( () => ( {
+				getSettings: () => ( {
+					// Root, block and element layers that the plugin path
+					// would resolve into a non-empty value for `core/heading`.
+					// The core path must ignore all of them.
+					[ globalStylesDataKey ]: {
+						typography: { lineHeight: '1.6' },
+						blocks: {
+							'core/heading': {
+								typography: { fontSize: '24px' },
+							},
+						},
+						elements: { h2: { color: { text: '#111111' } } },
+					},
+				} ),
+				getBlockStyles: () => [],
+				getBlockAttributes: () => ( { level: 2 } ),
+			} ) )
+		);
+	} );
+
+	// The hook must return undefined rather than an empty object. An empty
+	// object would still be passed down as `inheritedValue`, whereas undefined
+	// lets each panel apply its `inheritedValue = value` default. That default
+	// is what keeps core showing locally-set values only.
+	it( 'resolves nothing, so panels fall back to their `inheritedValue = value` default', () => {
+		const { result } = renderHook( () =>
+			useResolvedStyle( 'core/heading', 'is-style-fancy' )
+		);
+
+		expect( result.current.value ).toBeUndefined();
+		expect( result.current.sources ).toBeUndefined();
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -95,14 +95,12 @@ describe( 'TypographyPanel — core build defaults', () => {
 } );
 
 describe( 'TypographyPanel — core build setTextColor link sync', () => {
-	// These tests pass no `inheritedValue` on purpose. In core `useResolvedStyle`
-	// resolves to undefined, so the prop falls back to `value`. That is the shape
-	// the panel actually receives there.
-	async function pickRed( value ) {
+	async function pickRed( value, inheritedValue ) {
 		const onChange = jest.fn();
 		await renderAriakit(
 			<TypographyPanel
 				value={ value }
+				inheritedValue={ inheritedValue }
 				settings={ PALETTE_SETTINGS }
 				panelId="test"
 				onChange={ onChange }
@@ -140,5 +138,21 @@ describe( 'TypographyPanel — core build setTextColor link sync', () => {
 		expect( result?.elements?.link?.color?.text ).toBe(
 			'var:preset|color|red'
 		);
+	} );
+
+	// In Global Styles `value` is the user config and `inheritedValue` the
+	// merged one. Comparing `value` would find undefined on both sides.
+	it( 'reads the merged config, not the user config, in Global Styles', async () => {
+		const result = await pickRed(
+			{},
+			{
+				color: { text: 'var:preset|color|blue' },
+				elements: { link: { color: { text: 'var:preset|color|red' } } },
+			}
+		);
+
+		expect( result?.color?.text ).toBe( 'var:preset|color|red' );
+		// The theme's text and link colors differ, so the link does not track.
+		expect( result?.elements?.link?.color?.text ).toBeUndefined();
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -119,10 +119,10 @@ describe( 'TypographyPanel — core build setTextColor link sync', () => {
 	}
 
 	it( 'leaves an unset link color alone when a text color is already set', async () => {
-		// The plugin consults the inherited text and link colors here and syncs.
-		// Core has no inherited pair to consult, so only a link color that
-		// already matches the text color keeps tracking it. This is the
-		// behaviour core had before the inheritance treatment landed.
+		// The plugin falls back to the inherited link color here and syncs.
+		// Core compares the inherited text and link colors directly, which on
+		// this path is the block's own pair, so a link color that was never
+		// set does not start tracking.
 		const result = await pickRed( {
 			color: { text: 'var:preset|color|blue' },
 		} );

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { click, render as renderAriakit } from '@ariakit/test/react';
+
+/**
+ * Internal dependencies
+ */
+import TypographyPanel from '../typography-panel';
+
+// Core-build coverage for `TypographyPanel`. Tests run with
+// `IS_GUTENBERG_PLUGIN` true, so the core path needs a mock. `jest.mock` is
+// file-scoped, so these tests live apart from `typography-panel.js`.
+jest.mock( '../inheritance', () => ( {
+	...jest.requireActual( '../inheritance' ),
+	ENABLE_GLOBAL_STYLES_INHERITANCE: false,
+} ) );
+
+const baseSettings = {
+	typography: {
+		lineHeight: true,
+		letterSpacing: true,
+	},
+};
+
+// Two presets with distinct slugs and distinct hex values, enough to drive the
+// text color dropdown.
+const PALETTE_SETTINGS = {
+	color: {
+		text: true,
+		custom: false,
+		customGradient: false,
+		defaultPalette: false,
+		palette: {
+			theme: [
+				{ color: '#0000ff', name: 'Blue', slug: 'blue' },
+				{ color: '#ff0000', name: 'Red', slug: 'red' },
+			],
+		},
+	},
+};
+
+function renderPanel( props ) {
+	return render(
+		<TypographyPanel
+			value={ {} }
+			settings={ baseSettings }
+			onChange={ () => {} }
+			panelId="test-panel"
+			{ ...props }
+		/>
+	);
+}
+
+const getItem = ( name ) => {
+	const control = screen.getByRole( 'spinbutton', { name } );
+	// The class hooks sit on the wrapping ToolsPanelItem, which has no role.
+	// eslint-disable-next-line testing-library/no-node-access
+	return control.closest( '.components-tools-panel-item' );
+};
+
+describe( 'TypographyPanel — core build defaults', () => {
+	// `showInheritanceLabelIndicators` defaults to the build constant, so a
+	// caller that passes no prop gets no inheritance treatment in core. The
+	// layout className must still come through.
+	it( 'applies no inherited treatment by default, even when an inherited value is present', () => {
+		renderPanel( {
+			value: {},
+			inheritedValue: { typography: { lineHeight: '1.5' } },
+		} );
+
+		const lineHeightItem = getItem( /line height/i );
+		expect( lineHeightItem ).toHaveClass( 'single-column' );
+		expect( lineHeightItem ).not.toHaveClass(
+			'is-inherited-from-global-styles'
+		);
+	} );
+
+	it( 'renders no reset dot by default when a local value shadows an inherited one', () => {
+		renderPanel( {
+			value: { typography: { lineHeight: '2' } },
+			inheritedValue: { typography: { lineHeight: '1.5' } },
+		} );
+
+		expect( getItem( /line height/i ) ).not.toHaveClass(
+			'has-local-override-from-global-styles'
+		);
+		expect(
+			screen.queryByRole( 'button', {
+				name: 'Reset to inherited value',
+			} )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'TypographyPanel — core build setTextColor link sync', () => {
+	// These tests pass no `inheritedValue` on purpose. In core `useResolvedStyle`
+	// resolves to undefined, so the prop falls back to `value`. That is the shape
+	// the panel actually receives there.
+	async function pickRed( value ) {
+		const onChange = jest.fn();
+		await renderAriakit(
+			<TypographyPanel
+				value={ value }
+				settings={ PALETTE_SETTINGS }
+				panelId="test"
+				onChange={ onChange }
+			/>
+		);
+		await click(
+			screen.getByRole( 'button', { name: /Color/, expanded: false } )
+		);
+		// `findAllByRole` waits for the Popover/portal content to appear.
+		const swatches = await screen.findAllByRole( 'option' );
+		// swatch[0] = 'Blue', swatch[1] = 'Red'
+		await click( swatches[ 1 ] );
+		return onChange.mock.calls[ 0 ][ 0 ];
+	}
+
+	it( 'leaves an unset link color alone when a text color is already set', async () => {
+		// The plugin consults the inherited text and link colors here and syncs.
+		// Core has no inherited pair to consult, so only a link color that
+		// already matches the text color keeps tracking it. This is the
+		// behaviour core had before the inheritance treatment landed.
+		const result = await pickRed( {
+			color: { text: 'var:preset|color|blue' },
+		} );
+
+		expect( result?.color?.text ).toBe( 'var:preset|color|red' );
+		expect( result?.elements?.link?.color?.text ).toBeUndefined();
+	} );
+
+	it( 'starts a link color tracking when neither is set', async () => {
+		// Both sides are undefined, so they compare as matching and the link
+		// color starts following the text color.
+		const result = await pickRed( {} );
+
+		expect( result?.color?.text ).toBe( 'var:preset|color|red' );
+		expect( result?.elements?.link?.color?.text ).toBe(
+			'var:preset|color|red'
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -283,11 +283,11 @@ export default function TypographyPanel( {
 			newSlug
 		);
 		let changedObject = setImmutably( value, [ 'color', 'text' ], encoded );
-		// Letting an unset link color follow the text color relies on the
-		// inherited pair; without it, only an already-matching pair tracks.
+		// Core keeps the pre-inheritance comparison on `inheritedValue`.
 		const syncLinkColor = ENABLE_GLOBAL_STYLES_INHERITANCE
 			? shouldSyncLinkColor( value, inheritedValue )
-			: value?.color?.text === value?.elements?.link?.color?.text;
+			: inheritedValue?.color?.text ===
+			  inheritedValue?.elements?.link?.color?.text;
 		if ( syncLinkColor ) {
 			changedObject = setImmutably(
 				changedObject,

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -260,6 +260,8 @@ export default function TypographyPanel( {
 } ) {
 	const { colors, allColors, areCustomSolidsEnabled, decodeValue } =
 		useColorGradientSettings( settings );
+	// Always keep the layout className (e.g. `single-column`); only the
+	// inheritance treatment is gated on `showInheritanceLabelIndicators`.
 	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
 		getInheritanceProps(
 			showInheritanceLabelIndicators && isInherited,

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -38,7 +38,11 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	ENABLE_GLOBAL_STYLES_INHERITANCE,
+} from './inheritance';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -251,13 +255,11 @@ export default function TypographyPanel( {
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
 	isGlobalStyles = false,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
 	contrastWarning,
 } ) {
 	const { colors, allColors, areCustomSolidsEnabled, decodeValue } =
 		useColorGradientSettings( settings );
-	// Always keep the layout className (e.g. `single-column`); only the
-	// inheritance treatment is gated on `showInheritanceLabelIndicators`.
 	const inheritanceProps = ( isInherited, hasLocalOverride, className ) =>
 		getInheritanceProps(
 			showInheritanceLabelIndicators && isInherited,
@@ -279,7 +281,12 @@ export default function TypographyPanel( {
 			newSlug
 		);
 		let changedObject = setImmutably( value, [ 'color', 'text' ], encoded );
-		if ( shouldSyncLinkColor( value, inheritedValue ) ) {
+		// Letting an unset link color follow the text color relies on the
+		// inherited pair; without it, only an already-matching pair tracks.
+		const syncLinkColor = ENABLE_GLOBAL_STYLES_INHERITANCE
+			? shouldSyncLinkColor( value, inheritedValue )
+			: value?.color?.text === value?.elements?.link?.color?.text;
+		if ( syncLinkColor ) {
 			changedObject = setImmutably(
 				changedObject,
 				[ 'elements', 'link', 'color', 'text' ],


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/77894#issuecomment-5042484248

## What?

Enables the UI that surfaces inherited Global Styles values and local overrides only when the Gutenberg plugin is active.

## Why?

#77894 was merged to ship in 7.1 Beta 3. However, #80506 raised a number of concerns, and I judged that shipping the feature right before the Beta 3 release seems to be risky.

## How?

Guards the UI behind `IS_GUTENBERG_PLUGIN`. This stops the feature from shipping to Core without stopping iteration on it.

**Let's keep iterating and reconsider whether this UI is worth exposing before Beta 4.** If we desided to ship this UI in Beta4, we can simply remove the project-wide `ENABLE_GLOBAL_STYLES_INHERITANCE` variable and replace it with a simple boolean value.

## Testing Instructions

Use the following `theme.json`:

<details><summary>Details</summary>

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"writingMode": true,
			"fontFamilies": [
				{
					"slug": "georgia",
					"name": "Georgia",
					"fontFamily": "Georgia, 'Times New Roman', serif"
				},
				{
					"slug": "system",
					"name": "System",
					"fontFamily": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
				}
			]
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/paragraph": {
				"color": {
					"text": "#1e1e1e",
					"background": "#f6f7f7",
					"gradient": "linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%)"
				},
				"typography": {
					"fontFamily": "var:preset|font-family|georgia",
					"fontSize": "1.125rem",
					"fontStyle": "italic",
					"fontWeight": "600",
					"lineHeight": "1.7",
					"letterSpacing": "0.01em",
					"textAlign": "justify",
					"textColumns": "2",
					"textDecoration": "underline",
					"textIndent": "1.5em",
					"textTransform": "capitalize"
				},
				"spacing": {
					"margin": {
						"top": "0",
						"right": "0",
						"bottom": "1.5rem",
						"left": "0"
					},
					"padding": {
						"top": "0.5rem",
						"right": "1rem",
						"bottom": "0.5rem",
						"left": "1rem"
					}
				},
				"border": {
					"color": "#e0e0e0",
					"style": "solid",
					"width": "1px",
					"radius": "4px"
				},
				"elements": {
					"link": {
						"color": {
							"text": "#0073aa"
						},
						":hover": {
							"color": {
								"text": "#005177"
							}
						}
					}
				}
			},
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9J2cnIHgxPScwJyB5MT0nMCcgeDI9JzEnIHkyPScxJz48c3RvcCBvZmZzZXQ9JzAnIHN0b3AtY29sb3I9JyNjOWU3ZmYnLz48c3RvcCBvZmZzZXQ9JzAuNScgc3RvcC1jb2xvcj0nI2VhZTRmZicvPjxzdG9wIG9mZnNldD0nMScgc3RvcC1jb2xvcj0nI2ZmZDZlOCcvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJyBmaWxsPSd1cmwoI2cpJy8+PGNpcmNsZSBjeD0nNjAnIGN5PSc3MCcgcj0nMjgnIGZpbGw9JyNmZmZmZmYnIG9wYWNpdHk9JzAuMzUnLz48Y2lyY2xlIGN4PScxNTAnIGN5PScxNDAnIHI9JzQwJyBmaWxsPScjZmZmZmZmJyBvcGFjaXR5PScwLjI1Jy8+PC9zdmc+"
					},
					"backgroundSize": "cover",
					"backgroundPosition": "center center",
					"backgroundRepeat": "no-repeat",
					"backgroundAttachment": "fixed"
				},
				"color": {
					"text": "#1e1e1e",
					"background": "#ffffff",
					"gradient": "linear-gradient(135deg, #f6f7f7 0%, #e5f0f5 100%)"
				},
				"typography": {
					"fontFamily": "var:preset|font-family|system",
					"fontSize": "1rem",
					"fontStyle": "italic",
					"fontWeight": "500",
					"lineHeight": "1.6",
					"letterSpacing": "0.02em",
					"textDecoration": "underline",
					"textTransform": "uppercase"
				},
				"spacing": {
					"blockGap": "1.5rem",
					"margin": {
						"top": "2rem",
						"bottom": "2rem"
					},
					"padding": {
						"top": "2rem",
						"right": "2rem",
						"bottom": "2rem",
						"left": "2rem"
					}
				},
				"dimensions": {
					"minHeight": "120px",
					"minWidth": "200px"
				},
				"border": {
					"color": "#d5d5d5",
					"style": "solid",
					"width": "1px",
					"radius": "8px"
				},
				"elements": {
					"heading": {
						"color": {
							"text": "#0a1e2e"
						},
						"typography": {
							"fontWeight": "700",
							"lineHeight": "1.2"
						}
					},
					"button": {
						"color": {
							"text": "#ffffff",
							"background": "#0073aa"
						},
						"border": {
							"radius": "4px"
						},
						":hover": {
							"color": {
								"background": "#005177"
							}
						}
					},
					"link": {
						"color": {
							"text": "#0073aa"
						},
						":hover": {
							"color": {
								"text": "#005177"
							}
						}
					}
				}
			}
		}
	},
	"customTemplates": [
		{
			"name": "custom-template",
			"title": "Custom",
			"postTypes": [ "post" ]
		}
	],
	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
}
```

</details> 

- Everything should work as before.
- Run `IS_GUTENBERG_PLUGIN=false npm run dev`. The inspector panels should show none of the dots, label underlines or placeholder values.

Note that the flag is resolved when the dev process starts, so switching modes requires restarting the watcher rather than editing a file.

## Use of AI Tools

The code changes in this PR were written with Claude Code (Claude Opus 4.8), directed and reviewed by me.
