### PR TITLE
Feat: Notes at a glance

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -22,6 +22,7 @@ import {
 	SIDEBARS,
 } from './constants';
 import { Notes } from './notes';
+import { NotesBlockIndicators } from './notes-block-indicators';
 import { store as editorStore } from '../../store';
 import { AddNoteMenuItem } from './add-note-menu-item';
 import { NoteAvatarIndicator } from './note-indicator-toolbar';
@@ -74,6 +75,13 @@ function NotesSidebar( { postId } ) {
 	}, [] );
 	const selectedNoteId = useSelect(
 		( select ) => unlock( select( editorStore ) ).getSelectedNote(),
+		[]
+	);
+	const isNotesSidebarOpen = useSelect(
+		( select ) =>
+			SIDEBARS.includes(
+				select( interfaceStore ).getActiveComplementaryArea( 'core' )
+			),
 		[]
 	);
 
@@ -177,6 +185,12 @@ function NotesSidebar( { postId } ) {
 				<NoteAvatarIndicator
 					note={ currentThread }
 					onClick={ () => openNoteForBlock( clientId ) }
+				/>
+			) }
+			{ isNotesSidebarOpen && (
+				<NotesBlockIndicators
+					notes={ unresolvedNotes }
+					onSelectBlockNote={ openNoteForBlock }
 				/>
 			) }
 			<AddNoteMenuItem

--- a/packages/editor/src/components/collab-sidebar/note-indicator-avatar.js
+++ b/packages/editor/src/components/collab-sidebar/note-indicator-avatar.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getAvatarBorderColor } from './utils';
+
+/**
+ * A small persistent avatar shown over a block that has an open note
+ * attached, so notes are discoverable without selecting every block.
+ *
+ * @param {Object}   props         Component props.
+ * @param {Object}   props.note    The block's primary note thread.
+ * @param {Function} props.onClick Called when the avatar is activated.
+ */
+export default function NoteIndicatorAvatar( { note, onClick } ) {
+	const avatarUrl =
+		note.author_avatar_urls?.[ '48' ] || note.author_avatar_urls?.[ '96' ];
+
+	return (
+		<button
+			type="button"
+			className="editor-collab-sidebar__note-indicator-avatar"
+			aria-label={ __( 'This block has a note' ) }
+			onClick={ onClick }
+		>
+			<img
+				src={ avatarUrl }
+				alt=""
+				className="editor-collab-sidebar__note-indicator-avatar-image"
+				style={ { borderColor: getAvatarBorderColor( note.author ) } }
+			/>
+		</button>
+	);
+}

--- a/packages/editor/src/components/collab-sidebar/notes-block-indicators.js
+++ b/packages/editor/src/components/collab-sidebar/notes-block-indicators.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { getPrimaryNoteByBlock } from './utils';
+import NoteIndicatorAvatar from './note-indicator-avatar';
+
+const { PrivateBlockPopover } = unlock( blockEditorPrivateApis );
+
+const INDICATOR_PLACEMENT = isRTL() ? 'left-start' : 'right-start';
+
+/**
+ * Renders a persistent avatar over every block that has an unresolved note,
+ * so notes are discoverable at a glance instead of only on block selection.
+ *
+ * @param {Object}   props                   Component props.
+ * @param {Array}    props.notes             Unresolved note threads.
+ * @param {Function} props.onSelectBlockNote Called with a block's clientId when its indicator is clicked.
+ */
+export function NotesBlockIndicators( { notes, onSelectBlockNote } ) {
+	const blockNotes = useMemo(
+		() => getPrimaryNoteByBlock( notes ),
+		[ notes ]
+	);
+
+	return (
+		<>
+			{ blockNotes.map( ( { clientId, note } ) => (
+				<PrivateBlockPopover
+					key={ clientId }
+					clientId={ clientId }
+					placement={ INDICATOR_PLACEMENT }
+					offset={ 8 }
+					resize={ false }
+					flip={ false }
+					className="editor-collab-sidebar__note-indicator-popover"
+					__unstablePopoverSlot="__unstable-block-tools-after"
+				>
+					<NoteIndicatorAvatar
+						note={ note }
+						onClick={ () => onSelectBlockNote( clientId ) }
+					/>
+				</PrivateBlockPopover>
+			) ) }
+		</>
+	);
+}

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -291,3 +291,21 @@ mark.wp-note {
 .editor-collab-sidebar-panel__mention-suggestion .editor-autocompleters__user-avatar {
 	border-radius: $radius-round;
 }
+
+.editor-collab-sidebar__note-indicator-avatar {
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: none;
+	background: transparent;
+	line-height: 0;
+	cursor: var(--wpds-cursor-control);
+}
+
+.editor-collab-sidebar__note-indicator-avatar-image {
+	width: 20px;
+	height: 20px;
+	border-radius: $radius-round;
+	border: 2px solid $white;
+	object-fit: cover;
+}

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -26,6 +26,8 @@ import {
 	pickPrimaryNote,
 	BLOCK_LEVEL_NOTE_START,
 	getInlineMarkerStart,
+	getBlockIdsWithNotes,
+	getPrimaryNoteByBlock,
 } from '../utils';
 
 function makeRect( top ) {
@@ -922,6 +924,50 @@ describe( 'getInlineMarkerStart', () => {
 			return a.id - b.id;
 		} );
 		expect( sorted.map( ( t ) => t.id ) ).toEqual( [ 99, 2, 3, 1 ] );
+	} );
+} );
+
+describe( 'getBlockIdsWithNotes', () => {
+	it( 'returns the distinct blockClientIds referenced by the given notes', () => {
+		expect(
+			getBlockIdsWithNotes( [
+				{ id: 1, blockClientId: 'block-a' },
+				{ id: 2, blockClientId: 'block-b' },
+				{ id: 3, blockClientId: 'block-a' },
+			] )
+		).toEqual( [ 'block-a', 'block-b' ] );
+	} );
+
+	it( 'skips notes with no blockClientId', () => {
+		expect(
+			getBlockIdsWithNotes( [
+				{ id: 1, blockClientId: 'block-a' },
+				{ id: 2, blockClientId: null },
+				{ id: 3 },
+			] )
+		).toEqual( [ 'block-a' ] );
+	} );
+
+	it( 'returns an empty array for no notes', () => {
+		expect( getBlockIdsWithNotes( [] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getPrimaryNoteByBlock', () => {
+	it( 'picks the unresolved thread per block over an approved one', () => {
+		const notes = [
+			{ id: 1, blockClientId: 'block-a', status: 'approved' },
+			{ id: 2, blockClientId: 'block-a', status: 'hold' },
+			{ id: 3, blockClientId: 'block-b', status: 'hold' },
+		];
+		expect( getPrimaryNoteByBlock( notes ) ).toEqual( [
+			{ clientId: 'block-a', note: notes[ 1 ] },
+			{ clientId: 'block-b', note: notes[ 2 ] },
+		] );
+	} );
+
+	it( 'returns an empty array for no notes', () => {
+		expect( getPrimaryNoteByBlock( [] ) ).toEqual( [] );
 	} );
 } );
 

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -367,6 +367,39 @@ export function pickPrimaryNote( threads ) {
 }
 
 /**
+ * Gets the distinct block clientIds referenced by a list of note threads.
+ *
+ * @param {Array<{blockClientId?: string}>} notes Note threads.
+ * @return {string[]} Distinct blockClientIds, in first-seen order.
+ */
+export function getBlockIdsWithNotes( notes ) {
+	const ids = [];
+	for ( const note of notes ) {
+		if ( note.blockClientId && ! ids.includes( note.blockClientId ) ) {
+			ids.push( note.blockClientId );
+		}
+	}
+	return ids;
+}
+
+/**
+ * Picks one representative note thread per block, for blocks that have notes.
+ *
+ * @param {Array<{blockClientId?: string, status?: string}>} notes Note threads.
+ * @return {Array<{clientId: string, note: Object}>} One entry per distinct
+ *                                                    blockClientId, in
+ *                                                    first-seen order.
+ */
+export function getPrimaryNoteByBlock( notes ) {
+	return getBlockIdsWithNotes( notes ).map( ( clientId ) => ( {
+		clientId,
+		note: pickPrimaryNote(
+			notes.filter( ( note ) => note.blockClientId === clientId )
+		),
+	} ) );
+}
+
+/**
  * Removes a note ID from the metadata.
  *
  * @param {Object} metadata Existing block metadata


### PR DESCRIPTION
## What?
Closes #73414

Adds a persistent per-block avatar indicator, shown while a Notes sidebar (All Notes or Floating) is open, so blocks with an open note are visible at a glance instead of only on selection.

## Why?
> In the following screenshot, a number of these blocks have Notes attached to them. But you can't tell. There are a handful of notes in the panel, but there's no way to tell which one belongs to which block without clicking on them, which may be the way it's supposed to work.
>
> However, figuring out which blocks have comments and which don't requires the user to click on all of them. Even if the Visual Indicator is the Small avatars in the block's toolbar, it doesn't help distinguish, at a glance, which blocks have notes and which don't.

The only existing visual indicator is a small avatar stack in the block toolbar, which only renders for the currently *selected* block — it doesn't help a user scan a whole post to see which blocks have notes.

## How?
- `getBlockIdsWithNotes` / `getPrimaryNoteByBlock` (`packages/editor/src/components/collab-sidebar/utils.js`): pure helpers that reduce a list of unresolved note threads down to one representative note per distinct `blockClientId`.
- `NoteIndicatorAvatar` (`note-indicator-avatar.js`): small presentational avatar button, styled like the existing toolbar avatar indicator.
- `NotesBlockIndicators` (`notes-block-indicators.js`): for every block with an unresolved note, anchors a `NoteIndicatorAvatar` to that block's on-canvas position using `PrivateBlockPopover` (the same private API the block toolbar itself uses), portaled into the `__unstable-block-tools-after` slot so it's positioned/stacked correctly even though it's mounted from the sidebar rather than the canvas tree.
- Wired into `NotesSidebar` (`index.js`): renders `NotesBlockIndicators` only while a Notes sidebar (`SIDEBARS`) is active, passing `unresolvedNotes` and reusing the existing `openNoteForBlock` handler so clicking an avatar opens/focuses that block's thread — the same behavior as the existing toolbar avatar.

No new data store, reducer, or `block-editor` core changes: `block-editor` stays notes-agnostic, and `editor` continues to own all note logic, consistent with the existing toolbar indicator.

## Testing Instructions
1. Open a post with several blocks.
2. Add a note to one or two blocks (block toolbar "Add note", or via `AddNoteMenuItem`).
3. Open the "All notes" sidebar.
4. Confirm a small avatar appears next to each block that has an open note, and that blocks without notes show no avatar.
5. Click an avatar and confirm it opens/focuses that block's note thread.
6. Close the Notes sidebar and confirm the avatars disappear.
7. Switch to the "Floating" notes sidebar and repeat steps 4-6.

## Screenshots or screencast <!-- if applicable -->

### Before:

https://github.com/user-attachments/assets/a5290205-ca6e-4c7a-8c07-0291174dfff4

### After:
https://github.com/user-attachments/assets/fbb04b99-5eda-40d1-8db4-a39b6b836b91



## Use of AI Tools

Claude Code was used to help and verify the change and to draft this PR description. All code was reviewed, tested, and verified by me before submission.