### PR TITLE
Flaky tests: fix router navigate URL fragment race

### DIFF
--- a/test/e2e/specs/interactivity/router-navigate.spec.ts
+++ b/test/e2e/specs/interactivity/router-navigate.spec.ts
@@ -123,10 +123,23 @@ test.describe( 'Router navigate', () => {
 		await expect( navigations ).toHaveText( '0' );
 		await expect( status ).toHaveText( 'idle' );
 
-		const resolvers: Function[] = [];
+		const resolvers: Array< () => void > = [];
+
+		// Both navigations target the same page path (they only differ in the
+		// URL fragment, which is stripped when building the cache key), so both
+		// requests reach this single route handler.
+		let resolveBothRequests: () => void;
+		const bothRequests = new Promise< void >( ( resolve ) => {
+			resolveBothRequests = resolve;
+		} );
 
 		await page.route( link1, async ( route ) => {
-			await new Promise( ( r ) => resolvers.push( r ) );
+			await new Promise< void >( ( resolve ) => {
+				resolvers.push( resolve );
+				if ( resolvers.length === 2 ) {
+					resolveBothRequests();
+				}
+			} );
 			await route.continue();
 		} );
 
@@ -141,14 +154,28 @@ test.describe( 'Router navigate', () => {
 		await expect( status ).toHaveText( 'busy' );
 		await expect( title ).toHaveText( 'Main' );
 
-		resolvers.pop()!();
+		// Wait until both requests have reached the route handler before
+		// releasing any of them. The navigations counter above only tracks that
+		// both navigate actions have started; the actual fetches happen later
+		// (after a dynamic import), so without this barrier `resolvers.pop()`
+		// could release the first navigation's request instead of the last
+		// one's. That earlier navigation bails out (its destination is no longer
+		// the current one), leaving the title as "Main" and making this test
+		// flaky.
+		await bothRequests;
+
+		// Release the last navigation (the one with the hash) first. It should
+		// win and update both the title and the URL.
+		await Promise.resolve().then( () => resolvers.pop()!() );
 
 		await expect( navigations ).toHaveText( '1' );
 		await expect( status ).toHaveText( 'busy' );
 		await expect( title ).toHaveText( 'Link 1' );
 		await expect( page ).toHaveURL( href );
 
-		resolvers.pop()!();
+		// Release the earlier navigation. It must not replace the HTML from the
+		// last navigation.
+		await Promise.resolve().then( () => resolvers.pop()!() );
 
 		await expect( navigations ).toHaveText( '0' );
 		await expect( status ).toHaveText( 'idle' );


### PR DESCRIPTION
## What

Fixes #80447.

This fixes a race in the router navigation E2E test `should update the URL from the last navigation if only varies in the URL fragment`. The test could fail intermittently with the title stuck on `"Main"` instead of updating to `"Link 1"`:

```
Error: expect(locator).toHaveText(expected) failed
Locator:  getByTestId('title')
Expected: "Link 1"
Received: "Main"
Timeout:  5000ms
    at test/e2e/specs/interactivity/router-navigate.spec.ts:148
```

## Why

Both navigations in this test target the same page path — they only differ in the URL fragment, which is stripped when building the router's cache key (`getPagePath`). As a result, both requests go through the **same** `page.route()` handler and their resolvers are collected in a shared `resolvers` array.

Asserting that the pending navigations counter is `2` only guarantees both `navigate` actions have *started* (the counter is incremented synchronously in the view action). The actual `fetch()` calls happen later, inside the router action after a dynamic `import()`. So `resolvers.pop()` could release the **first** navigation's request instead of the last one's, before the second request had even reached the route handler.

That earlier navigation then bails out — its destination is no longer the current one (`if ( navigatingTo !== href ) return;`) — so nothing re-renders, the title stays `"Main"`, and the assertion for `"Link 1"` times out.

This is the same class of race that was fixed for the sibling test in this file in #80178.

## How

Wait until **both** requests have reached the route handler before releasing any of them, using a `bothRequests` barrier that resolves once two resolvers have been collected. Releasing responses only after both requests are intercepted makes the ordering deterministic: the last navigation (the one with the hash) is released first and wins, then the earlier one is released and correctly bails out without replacing the latest HTML.

No production code changes — the router already handles this correctly at runtime; only the test's timing assumptions were unsound.

## Testing Instructions

1. Repeat the target test:
   `npm run test:e2e -- test/e2e/specs/interactivity/router-navigate.spec.ts -g "should update the URL from the last navigation if only varies in the URL fragment" --repeat-each=30`
2. Run the full spec:
   `npm run test:e2e -- test/e2e/specs/interactivity/router-navigate.spec.ts`

