### PR TITLE
Tabs : Remove default paragraph from tab-panel template

### DIFF
--- a/packages/block-library/src/tab-panel/edit.js
+++ b/packages/block-library/src/tab-panel/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -15,14 +14,7 @@ import { useEffect } from '@wordpress/element';
  */
 import Controls from './controls';
 
-const TEMPLATE = [
-	[
-		'core/paragraph',
-		{
-			placeholder: __( 'Type / to choose a block' ),
-		},
-	],
-];
+const TEMPLATE = [ [ 'core/paragraph' ] ];
 
 export default function Edit( { clientId, isSelected } ) {
 	const {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The default paragraph block placeholder for the tab panel template is the same as the default, so it is unnecessary. I have removed it to simplify the code.

https://github.com/WordPress/gutenberg/blob/ff229a4da8639f70f87817eb60a0392731203c5b/packages/block-library/src/paragraph/edit.js#L181

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a tab block.
3. You can confirm that the placeholder is set as it was before.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

The only difference is in the initial template inserted.

### Before

```html
<!-- wp:tab-panel {"label":"Tab"} -->
<section role="tabpanel" tabindex="0" class="wp-block-tab-panel"><!-- wp:paragraph {"placeholder":"Type / to choose a block"} -->
<p></p>
<!-- /wp:paragraph --></section>
<!-- /wp:tab-panel -->
```

### After
```html
<!-- wp:tab-panel {"label":"Tab"} -->
<section role="tabpanel" tabindex="0" class="wp-block-tab-panel"><!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph --></section>
<!-- /wp:tab-panel -->
```
<img width="403" height="168" alt="tab" src="https://github.com/user-attachments/assets/682352cf-8d67-43d8-a232-539b36b869f1" />

There is no visible change.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
