### PR TITLE
Editor: Prevent Flash of Unstyled Content (FOUC) for Fit Text on frontend

### DIFF
--- a/packages/block-editor/src/utils/fit-text-frontend.ts
+++ b/packages/block-editor/src/utils/fit-text-frontend.ts
@@ -25,6 +25,10 @@ store( 'core/fit-text', {
 			const context = getContext< FitTextContext >();
 			const { ref } = getElement() as { ref: HTMLElement | null };
 
+			if ( ! ref ) {
+				return undefined;
+			}
+
 			const applyFontSize = ( fontSize: number ) => {
 				if ( ! ref ) {
 					return;
@@ -39,22 +43,30 @@ store( 'core/fit-text', {
 			// Initial fit text optimization.
 			context.fontSize = optimizeFitText( ref, applyFontSize );
 
+			// Reveal the element. It was hidden via CSS
+			// (.has-fit-text[data-wp-init---core-fit-text] { visibility: hidden })
+			// to prevent a flash of default-sized text while JS loads.
+			ref.style.visibility = 'visible';
+
 			// Starts ResizeObserver to handle dynamic resizing.
-			if ( window.ResizeObserver && ref?.parentElement ) {
-				const resizeObserver = new window.ResizeObserver( () => {
-					context.fontSize = optimizeFitText( ref, applyFontSize );
+			let resizeObserver: ResizeObserver | undefined;
+			if ( window.ResizeObserver && ref.parentElement ) {
+				resizeObserver = new window.ResizeObserver( () => {
+					context.fontSize = optimizeFitText(
+						ref,
+						applyFontSize
+					);
 				} );
 				resizeObserver.observe( ref.parentElement );
 				resizeObserver.observe( ref );
-
-				// Return cleanup function to be called when element is removed.
-				return () => {
-					if ( resizeObserver ) {
-						resizeObserver.disconnect();
-					}
-				};
 			}
-			return undefined;
+
+			// Return cleanup function to be called when element is removed.
+			return () => {
+				if ( resizeObserver ) {
+					resizeObserver.disconnect();
+				}
+			};
 		},
 	},
 } );

--- a/packages/block-editor/src/utils/fit-text-frontend.ts
+++ b/packages/block-editor/src/utils/fit-text-frontend.ts
@@ -44,7 +44,6 @@ store( 'core/fit-text', {
 			context.fontSize = optimizeFitText( ref, applyFontSize );
 
 			// Reveal the element. It was hidden via CSS
-			// (.has-fit-text[data-wp-init---core-fit-text] { visibility: hidden })
 			// to prevent a flash of default-sized text while JS loads.
 			ref.style.visibility = 'visible';
 
@@ -52,10 +51,7 @@ store( 'core/fit-text', {
 			let resizeObserver: ResizeObserver | undefined;
 			if ( window.ResizeObserver && ref.parentElement ) {
 				resizeObserver = new window.ResizeObserver( () => {
-					context.fontSize = optimizeFitText(
-						ref,
-						applyFontSize
-					);
+					context.fontSize = optimizeFitText( ref, applyFontSize );
 				} );
 				resizeObserver.observe( ref.parentElement );
 				resizeObserver.observe( ref );

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -55,6 +55,14 @@
 	white-space: nowrap !important;
 }
 
+// On the frontend, hide fit-text elements until JavaScript calculates the
+// correct font size, preventing a flash of default-sized text on page load.
+// The data-wp-init attribute is only added on the frontend by PHP,
+// so this does not affect the editor.
+.has-fit-text[data-wp-init---core-fit-text] {
+	visibility: hidden;
+}
+
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {
 	display: none;


### PR DESCRIPTION
## What?

Closes #80550 

This PR prevents a Flash of Unstyled Content (FOUC) that occurs on the frontend when using the "Fit Text" typography feature. It ensures the text does not flash at its default font size before being resized to fit its container.

## Why?

Previously, when a paragraph block had "Fit Text" enabled, the text would initially render at its default font size on page load. Once the JavaScript module loaded and the Interactivity API hydrated, a binary search calculation would run and apply the correct font size. The editor already has a guard against this flash, but the frontend lacked equivalent protection.

## How?

- We followed the existing pattern used in the editor code which guards against this flash. ( `packages/block-editor/src/hooks/fit-text.js` ).
- Implemented a CSS-first approach by hiding `.has-fit-text` elements on the frontend until the JavaScript calculates the correct font size. 
- The hiding is scoped using the `data-wp-init---core-fit-text` attribute (which is only added by PHP on the frontend), ensuring the editor remains unaffected.
- Simplified the frontend JavaScript to calculate the optimal font size and then reveal the element by setting `visibility: 'visible'`.

## Testing Instructions

1. Create a post and add a paragraph block.
2. Enable "Fit Text" for the paragraph and add some content.
3. Save and view the post on the frontend.
4. Reload the page. You should not see the text flash at a default font size before snapping to the correct fitted size.
5. Verify that resizing the browser window still dynamically resizes the text.

> Note : To verify the fix, You may need to open DevTools -> Network and enable "Disable Cache" and "Slow 3G" throttling.

## Screenshots or screencast

### Before Fix : 

https://github.com/user-attachments/assets/61413032-7cfb-4f52-874d-32355184a1b1

### After Fix : 

https://github.com/user-attachments/assets/1814cfb5-6269-4f76-88c8-ebf0cd3d7fa9

## Use of AI Tools

AI tool ( claude opus ) is used to simplify JS on the front-end and to draft PR desctiption for the issue. All changes are verified manually.