### PR TITLE
Release: Require a working GitHub CLI for cherry-picking

### DIFF
--- a/tools/release/cherry-pick.mjs
+++ b/tools/release/cherry-pick.mjs
@@ -3,6 +3,7 @@
  */
 import fetch from 'node-fetch';
 import readline from 'readline';
+import { gte } from 'semver';
 
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
@@ -11,9 +12,15 @@ const REPO = 'WordPress/gutenberg';
 const LABEL = process.argv[ 2 ] || 'Backport to WP Beta/RC';
 const BACKPORT_COMPLETED_LABEL = 'Backported to WP Core';
 const BRANCH = getCurrentBranch();
+// Earlier versions query the sunset Projects (classic) API and always fail on
+// `gh pr edit`.
+// See https://github.com/cli/cli/pull/10942.
+const MINIMUM_GH_VERSION = '2.73.0';
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 	?.stdout?.toString()
 	.includes( '✓ Logged in to github.com' );
+const GITHUB_CLI_VERSION = getGhVersion();
+const GITHUB_CLI_SUPPORTED = isGhVersionSupported( GITHUB_CLI_VERSION );
 
 const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
 
@@ -32,6 +39,11 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
 async function main() {
 	if ( ! GITHUB_CLI_AVAILABLE ) {
 		await reportGhUnavailable();
+	} else if ( ! GITHUB_CLI_SUPPORTED ) {
+		console.error(
+			`GitHub CLI ${ GITHUB_CLI_VERSION } is too old. Upgrade to ${ MINIMUM_GH_VERSION } or newer.`
+		);
+		process.exit( 1 );
 	}
 
 	console.log( `You are on branch "${ BRANCH }".` );
@@ -518,6 +530,37 @@ function getMilestoneFromBranch() {
 }
 
 /**
+ * Extracts the version from the output of `gh --version`.
+ *
+ * @param {string} output Raw command output.
+ * @return {string|null} Version string such as "2.73.0", or null if not found.
+ */
+function parseGhVersion( output ) {
+	return output.match( /gh version (\d+\.\d+\.\d+)/ )?.[ 1 ] || null;
+}
+
+/**
+ * Returns the installed `gh` version.
+ *
+ * @return {string|null} Version string such as "2.73.0", or null if unavailable.
+ */
+function getGhVersion() {
+	return parseGhVersion(
+		spawnSync( 'gh', [ '--version' ] )?.stdout?.toString() || ''
+	);
+}
+
+/**
+ * Checks whether a `gh` version meets the minimum this script requires.
+ *
+ * @param {string|null} version The installed version.
+ * @return {boolean} Whether the version is supported.
+ */
+function isGhVersionSupported( version ) {
+	return !! version && gte( version, MINIMUM_GH_VERSION );
+}
+
+/**
  * Returns the current git branch.
  *
  * @return {string} Branch name.
@@ -585,4 +628,10 @@ if (
 	main();
 }
 
-export { cherryPickAll, cherryPickOne };
+export {
+	cherryPickAll,
+	cherryPickOne,
+	isGhVersionSupported,
+	parseGhVersion,
+	MINIMUM_GH_VERSION,
+};

--- a/tools/release/cherry-pick.mjs
+++ b/tools/release/cherry-pick.mjs
@@ -22,8 +22,6 @@ const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', [ 'auth', 'status' ] )
 const GITHUB_CLI_VERSION = getGhVersion();
 const GITHUB_CLI_SUPPORTED = isGhVersionSupported( GITHUB_CLI_VERSION );
 
-const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
-
 /**
  * The main function of this script. It:
  * * Confirms with the developer the current branch aligns with the expectations
@@ -33,13 +31,18 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
  * * It keeps track of the failed cherry-picks and then retries them
  * * Retrying keeps going as long as at least one cherry-pick succeeds
  * * Pushes the local branch to `origin`
- * * (optional) Uses the [`gh` console utility](https://cli.github.com/) to comment on the remote PRs and remove the labels
+ * * Uses the [`gh` console utility](https://cli.github.com/) to comment on the remote PRs and remove the labels
  * * Reports the results
  */
 async function main() {
 	if ( ! GITHUB_CLI_AVAILABLE ) {
-		await reportGhUnavailable();
-	} else if ( ! GITHUB_CLI_SUPPORTED ) {
+		console.error(
+			'GitHub CLI is not setup. Install the `gh` utility from https://cli.github.com/ ' +
+				'and log in with `gh auth login`.'
+		);
+		process.exit( 1 );
+	}
+	if ( ! GITHUB_CLI_SUPPORTED ) {
 		console.error(
 			`GitHub CLI ${ GITHUB_CLI_VERSION } is too old. Upgrade to ${ MINIMUM_GH_VERSION } or newer.`
 		);
@@ -75,17 +78,12 @@ async function main() {
 	reportSummaryNextSteps( successes, failures );
 
 	if ( successes.length ) {
-		if ( AUTO_PROPAGATE_RESULTS_TO_GITHUB ) {
-			console.log( `About to push to origin/${ BRANCH }` );
-			await promptDoYouWantToProceed();
-			cli( 'git', [ 'push', 'origin', BRANCH ] );
+		console.log( `About to push to origin/${ BRANCH }` );
+		await promptDoYouWantToProceed();
+		cli( 'git', [ 'push', 'origin', BRANCH ] );
 
-			console.log( `Commenting and removing labels...` );
-			successes.forEach( GHcommentAndRemoveLabel );
-		} else {
-			console.log( 'Cherry-picked PRs with copy-able comments:' );
-			successes.forEach( reportSuccessManual );
-		}
+		console.log( `Commenting and removing labels...` );
+		successes.forEach( GHcommentAndRemoveLabel );
 	}
 	if ( failures.length ) {
 		console.log( 'PRs that could not be cherry-picked automatically:' );
@@ -388,18 +386,6 @@ function reportSummaryNextSteps( successes, failures ) {
 	console.log( '' );
 
 	const nextSteps = [];
-	if ( successes.length && ! AUTO_PROPAGATE_RESULTS_TO_GITHUB ) {
-		nextSteps.push( 'Push this branch' );
-		nextSteps.push( 'Go to each of the cherry-picked Pull Requests' );
-		nextSteps.push( `Remove the ${ LABEL } label` );
-
-		if ( LABEL === 'Backport to WP Beta/RC' ) {
-			nextSteps.push( `Add the "${ BACKPORT_COMPLETED_LABEL }" label` );
-		}
-
-		nextSteps.push( 'Request a backport to wordpress-develop if required' );
-		nextSteps.push( 'Comment, say that PR just got cherry-picked' );
-	}
 	if ( failures.length ) {
 		nextSteps.push( 'Manually cherry-pick the PRs that failed' );
 	}
@@ -569,30 +555,6 @@ function getCurrentBranch() {
 	return spawnSync( 'git', [ 'rev-parse', '--abbrev-ref', 'HEAD' ] )
 		.stdout.toString()
 		.trim();
-}
-
-/**
- * Reports when the gh CLI tool is missing, describes the consequences, asks
- * whether to proceed.
- *
- * @return {Promise<void>}
- */
-async function reportGhUnavailable() {
-	console.log(
-		'GitHub CLI is not setup. This script will not be able to automatically'
-	);
-	console.log(
-		'comment on the processed PRs and remove the backport label from them.'
-	);
-	console.log(
-		'Instead, you will see a detailed list of next steps to perform manually.'
-	);
-	console.log( '' );
-	console.log(
-		'To enable automatic handling, install the `gh` utility from https://cli.github.com/'
-	);
-	console.log( '' );
-	await promptDoYouWantToProceed();
 }
 
 /**

--- a/tools/release/test/cherry-pick.js
+++ b/tools/release/test/cherry-pick.js
@@ -9,7 +9,13 @@ const { spawnSync } = require( 'node:child_process' );
 /**
  * Internal dependencies
  */
-const { cherryPickAll, cherryPickOne } = require( '../cherry-pick.mjs' );
+const {
+	cherryPickAll,
+	cherryPickOne,
+	isGhVersionSupported,
+	parseGhVersion,
+	MINIMUM_GH_VERSION,
+} = require( '../cherry-pick.mjs' );
 
 const LOCAL_AUTHOR = {
 	name: 'Marco Ciampini',
@@ -61,6 +67,36 @@ function initializeRepository() {
 	git( [ 'config', 'user.email', LOCAL_AUTHOR.email ] );
 	commitFile( 'base.txt', 'base\n', 'Base' );
 }
+
+describe( 'GitHub CLI version requirement', () => {
+	it( 'extracts the version from the `gh --version` output', () => {
+		expect(
+			parseGhVersion(
+				'gh version 2.96.0 (2026-07-02)\nhttps://github.com/cli/cli/releases/tag/v2.96.0\n'
+			)
+		).toBe( '2.96.0' );
+	} );
+
+	it( 'returns null when the output carries no version', () => {
+		expect( parseGhVersion( '' ) ).toBeNull();
+	} );
+
+	it( 'rejects versions that predate the `gh pr edit` fix', () => {
+		// 2.54.0 queries the sunset Projects (classic) API and always fails.
+		expect( isGhVersionSupported( '2.54.0' ) ).toBe( false );
+	} );
+
+	it( 'accepts the minimum version and newer ones', () => {
+		expect( isGhVersionSupported( MINIMUM_GH_VERSION ) ).toBe( true );
+		expect( isGhVersionSupported( '2.96.0' ) ).toBe( true );
+		// A lexical comparison would rank this below "2.73.0".
+		expect( isGhVersionSupported( '2.100.0' ) ).toBe( true );
+	} );
+
+	it( 'rejects a missing version', () => {
+		expect( isGhVersionSupported( null ) ).toBe( false );
+	} );
+} );
 
 describe( 'release cherry-picks', () => {
 	beforeEach( initializeRepository );


### PR DESCRIPTION
## What?

Adds a GitHub CLI check to the cherry-pick release script so it fails fast instead of breaking halfway through.

Noticed while releasing Gutenberg 23.6 RC.

https://wordpress.slack.com/archives/C02QB2JS7/p1784627617112449?thread_ts=1784624819.623139&cid=C02QB2JS7

## Why?

`gh pr edit` is broken on GitHub CLI older than `2.73.0`. Those versions always request the `projectCards` field, which the sunset [Projects (classic)](https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/) API no longer serves:

```
$ gh api graphql -f query='{ repository(owner:"WordPress", name:"gutenberg") {
    pullRequest(number: 80315) { projectCards(first:1) { nodes { id } } } } }'

{"data":{"repository":{"pullRequest":null}},"errors":[{"type":"NOT_FOUND",
"path":["repository","pullRequest","projectCards"],
"message":"Projects (classic) is being deprecated in favor of the new Projects experience..."}]}
```

The field is part of a fixed list in `pkg/cmd/pr/edit/edit.go`, so it is sent regardless of which flags you pass — plain `--add-label` / `--remove-label` calls fail too. Upstream fixed this in [cli/cli#10942](https://github.com/cli/cli/pull/10942) by feature-detecting Projects v1, first shipped in [v2.73.0](https://github.com/cli/cli/releases/tag/v2.73.0).

The problem is the timing. The script only reaches `gh pr edit` after every commit has already been cherry-picked and pushed. So the branch is updated, but milestones are never set and the `Backport to WP Beta/RC` labels are never removed — and re-running the script from that state isn't safe. The release manager is left having to reconstruct what did and didn't happen.

## How?

The script now verifies two things at startup, and prints an error and `process.exit( 1 )` before it pulls, cherry-picks, or pushes anything:

- `gh auth status` — the CLI is installed and logged in.
- `gh --version` compared against `MINIMUM_GH_VERSION` (`2.73.0`) with `semver.gte()`.

The missing-CLI case used to only warn and offer to continue, falling back to printing manual next steps. That fallback could never work anyway: `GitHubFetch` takes its token from `gh auth token`, so the script throws while fetching the PR list. Both checks now behave the same way, and the unreachable fallback paths are removed.

Unit tests cover the version parsing and the comparison, including that `2.100.0` is not ranked below `2.73.0` the way a lexical compare would.

## Testing Instructions

- Then check the script end to end. Passing a label that matches no PRs means nothing is ever cherry-picked:
   ```
   gh --version
   npm run other:cherry-pick -- "Dummy Label Do Not Use"
   ```
- If your CLI is older than `2.73.0`, the script should stop immediately, without touching the repository:
   ```
   GitHub CLI 2.72.0 is too old. Upgrade to 2.73.0 or newer.
   ```
- If you do hit the error, upgrade with:
  - macOS: `brew upgrade gh`
  - Debian / Ubuntu: `sudo apt install gh`
- If your CLI is `2.73.0` or newer, the script should reach the usual confirmation prompt. Answer `n` to cancel.

## Use of AI Tools

Claude Code was used to verify the root cause (confirming the `projectCards` GraphQL failure, and bisecting `cli/cli` releases to establish `2.73.0` as the first fixed version), and to draft the version check, its unit tests, and this description. All of it has been reviewed by me.
