### PR TITLE
Widget Dashboard: preserve widget chrome flex layout

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Enhancements
 
+-   Widget chrome: preserve its flex-column layout when host styles reset
+    semantic elements ([#80570](https://github.com/WordPress/gutenberg/pull/80570)).
 -   Widget settings: use the `drawerRight` icon for the per-tile settings
     trigger instead of `moreVertical` ([#80208](https://github.com/WordPress/gutenberg/pull/80208)).
 -   Widget toolbar: when the tile header lacks room for the inline attribute

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Enhancements
 
--   Widget chrome: preserve its flex-column layout when host styles reset
-    semantic elements ([#80570](https://github.com/WordPress/gutenberg/pull/80570)).
+-   Widget chrome and picker preview chrome: preserve their flex-column layout
+    when host styles reset semantic elements ([#80570](https://github.com/WordPress/gutenberg/pull/80570)).
 -   Widget settings: use the `drawerRight` icon for the per-tile settings
     trigger instead of `moreVertical` ([#80208](https://github.com/WordPress/gutenberg/pull/80208)).
 -   Widget toolbar: when the tile header lacks room for the inline attribute

--- a/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
+++ b/packages/widget-dashboard/src/components/widget-chrome/widget-chrome.module.css
@@ -1,3 +1,12 @@
+/*
+ * Keep the structural layout local to the widget chrome. Host styles may reset
+ * `section` elements and override the layered Card styles.
+ */
+.widget-chrome {
+	display: flex;
+	flex-direction: column;
+}
+
 /* Outward tile focus ring; paint space reserved on `.grid`. */
 .widget-chrome:has(:focus-visible) {
 	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);

--- a/packages/widget-dashboard/src/components/widget-preview-chrome/widget-preview-chrome.module.css
+++ b/packages/widget-dashboard/src/components/widget-preview-chrome/widget-preview-chrome.module.css
@@ -16,7 +16,13 @@
 	height: 100%;
 }
 
+/*
+ * Keep the structural layout local to the preview chrome. Host styles may
+ * reset `section` elements and override the layered Card styles.
+ */
 .card {
+	display: flex;
+	flex-direction: column;
 	height: 100%;
 	min-height: 0;
 }


### PR DESCRIPTION
## Why

On a production WordPress site, the hosting platform concatenates a legacy admin-wide stylesheet into every wp-admin page (it's platform-level CSS, not something a plugin or theme on the site enqueues), and it ships an unscoped HTML5 display reset — `article, aside, …, section, summary { display: block; }` — **unlayered**. The Card styles live inside `@layer wp-ui.components`, and unlayered rules beat layered ones regardless of specificity, so the widget chrome's `<section>` computed `display: block`. The chrome's content area then lost its flex height constraint (`flex: 1` / `min-height: 0` are inert without a flex parent, while its `height: 100%` still applies in block flow), quietly overflowed the tile, and the tile's `overflow: clip` cut off the bottom of every widget — e.g. a chart's x-axis labels.

Any host page can carry such CSS (wp-admin loads arbitrary plugin, theme, and platform styles), so the dashboard should not depend on a layered rule for its structural layout.

## What

- Restate the widget chrome's structural flex-column layout on its **own module class** (`widget-chrome.module.css`). No `Card.Root` styles are modified.
- The module CSS ships unlayered, so within the unlayered tier normal specificity applies and the class rule beats element-selector resets — no `!important` needed.
- The chrome's children already rely on this invariant (`flex: 1` + `min-height: 0` on the content assume a column flex parent), so in a clean host this is a visual no-op; the change only makes the existing contract self-contained.
- Document the hardening in the package changelog.

## Test plan

1. Open any Widget Dashboard story with a rendered widget tile.
2. In DevTools, inject an unlayered reset: `document.head.insertAdjacentHTML('beforeend', '<style>section{display:block}</style>')`.
3. **Before this patch**: the chrome `<section>` computes `display: block` and the widget body overflows the tile (bottom clipped, e.g. chart x-axis labels).
4. **With this patch**: computed styles remain `display: flex; flex-direction: column` and the layout is unaffected.
5. Without the injected reset, confirm tiles render identically to trunk (visual no-op).


