### PR TITLE
View config: reject shape-mismatched merges, define empty-array semantics, strip nulls from appended members

### DIFF
--- a/backport-changelog/7.1/12644.md
+++ b/backport-changelog/7.1/12644.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12644
+
+* https://github.com/WordPress/gutenberg/pull/80571

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -39,7 +39,10 @@
  * key by key (an associative array merges member by member, a nested `null`
  * deletes just that leaf, a scalar replaces just that value), while `set()`
  * swaps the whole value. A nested `null` deletes just the leaf it names in
- * every case. Each patch also declares the configuration schema
+ * every case. A patch value whose shape does not match the current value —
+ * an associative array where a list lives, or the reverse — is rejected with
+ * a notice rather than merged, and an empty array under `merge()` is a
+ * no-op. Each patch also declares the configuration schema
  * version it was written against (currently 1), so a future WordPress release
  * that changes the configuration shape can migrate existing patches forward
  * instead of breaking them.
@@ -349,6 +352,13 @@ class Gutenberg_View_Config_Data {
 	 * - default_layouts will be updated so that newField is appended to the badgeFields.
 	 * - view_list will be updated so that the view with slug 'table' has its title changed to 'New title'.
 	 *
+	 * A patch value only merges into a current value of the same shape: an
+	 * associative array where a list lives, or a non-empty list where an
+	 * associative value lives, is rejected with a notice and leaves the current
+	 * value unchanged. An empty array merges nothing and is a no-op — clear a
+	 * list with replace() and an empty list, or reset a key to its default with
+	 * a top-level `null`.
+	 *
 	 * A patch that declares an unsupported schema version is rejected and does
 	 * not change anything.
 	 *
@@ -420,7 +430,7 @@ class Gutenberg_View_Config_Data {
 			// nested null still drops the property it names.
 			$this->config[ $key ] = 'set' === $mode
 				? $this->strip_nulls( $value )
-				: $this->merge_properties( $this->config[ $key ] ?? array(), $value, 'replace' === $mode );
+				: $this->merge_properties( $this->config[ $key ] ?? array(), $value, 'replace' === $mode, $method );
 		}
 
 		return $this;
@@ -472,15 +482,25 @@ class Gutenberg_View_Config_Data {
 	 * $replace_lists flag is carried down through associative nesting so that,
 	 * under replace(), every list reached along the way is swapped wholesale.
 	 *
+	 * An array in $incoming only merges into a current value of the same shape.
+	 * A non-empty mismatch — an associative array where a list lives, or a
+	 * non-empty list where an associative value lives — is reported with
+	 * _doing_it_wrong() and leaves the current value unchanged, so a malformed
+	 * patch cannot silently destroy configuration. An empty array is
+	 * shape-ambiguous and merges nothing, so it is a no-op: clearing a list is
+	 * spelled replace() with an empty list, and resetting a key is spelled
+	 * `null`.
+	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed $current       The current value.
-	 * @param mixed $incoming      The incoming value.
-	 * @param bool  $replace_lists Whether a list in $incoming replaces the current list
-	 *                             wholesale instead of merging into it by member identity.
+	 * @param mixed  $current       The current value.
+	 * @param mixed  $incoming      The incoming value.
+	 * @param bool   $replace_lists Whether a list in $incoming replaces the current list
+	 *                              wholesale instead of merging into it by member identity.
+	 * @param string $method        The public method the patch was passed to, for misuse reporting.
 	 * @return mixed The merged value.
 	 */
-	private function merge_properties( $current, $incoming, $replace_lists ) {
+	private function merge_properties( $current, $incoming, $replace_lists, $method ) {
 		// Scalar properties are merged as-is.
 		if ( ! is_array( $incoming ) ) {
 			return $incoming;
@@ -495,13 +515,39 @@ class Gutenberg_View_Config_Data {
 				// set()), so a null member is dropped rather than stored.
 				return $this->strip_nulls( $incoming );
 			}
+
+			// An empty list has no members to merge, and an empty array is
+			// shape-ambiguous, so merging one is a no-op rather than a reset.
+			if ( array() === $incoming ) {
+				return $current;
+			}
+
+			if ( is_array( $current ) && ! array_is_list( $current ) && array() !== $current ) {
+				_doing_it_wrong(
+					esc_html( $method ),
+					esc_html__( 'A list cannot be merged into an associative value; name the keys to change instead.', 'gutenberg' ),
+					'7.1.0'
+				);
+				return $current;
+			}
+
 			return $this->merge_list_by_identity(
 				is_array( $current ) && array_is_list( $current ) ? $current : array(),
-				$incoming
+				$incoming,
+				$method
 			);
 		}
 
 		// Consider any other array as associative (keys are strings).
+		if ( is_array( $current ) && array_is_list( $current ) && array() !== $current ) {
+			_doing_it_wrong(
+				esc_html( $method ),
+				esc_html__( 'An associative array cannot be merged into a list; address list members by their identity instead.', 'gutenberg' ),
+				'7.1.0'
+			);
+			return $current;
+		}
+
 		$result = is_array( $current ) && ! array_is_list( $current ) ? $current : array();
 		foreach ( $incoming as $key => $value ) {
 			// A null patch value deletes the property.
@@ -513,7 +559,8 @@ class Gutenberg_View_Config_Data {
 			$result[ $key ] = $this->merge_properties(
 				array_key_exists( $key, $result ) ? $result[ $key ] : array(),
 				$value,
-				$replace_lists
+				$replace_lists,
+				$method
 			);
 		}
 
@@ -598,7 +645,9 @@ class Gutenberg_View_Config_Data {
 	 * A member of the incoming list whose identity matches one already present
 	 * merges into it in place, keeping its position; an unmatched member is
 	 * appended to the end, except a literal `null`, which carries no identity
-	 * and holds nothing to merge and so is dropped. A matched member's contents
+	 * and holds nothing to merge and so is dropped. An appended member has no
+	 * existing leaf for a nested `null` to delete (the same rationale as set()),
+	 * so its nulls are stripped rather than stored. A matched member's contents
 	 * merge recursively with the same rules (merge_properties), so the
 	 * identity-aware merge applies at
 	 * any nesting level: each key named by the patch is substituted while the
@@ -607,11 +656,12 @@ class Gutenberg_View_Config_Data {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array $current  The current list.
-	 * @param array $incoming The incoming list.
+	 * @param array  $current  The current list.
+	 * @param array  $incoming The incoming list.
+	 * @param string $method   The public method the patch was passed to, for misuse reporting.
 	 * @return array The merged list.
 	 */
-	private function merge_list_by_identity( array $current, array $incoming ) {
+	private function merge_list_by_identity( array $current, array $incoming, $method ) {
 		$result = $current;
 		foreach ( $incoming as $item ) {
 			// A null member carries no identity and holds nothing to merge,
@@ -634,12 +684,14 @@ class Gutenberg_View_Config_Data {
 				}
 			}
 			if ( null === $index ) {
-				$result[] = $item;
+				// An appended member has no existing leaf for a nested null to
+				// delete, so nulls are dropped rather than stored.
+				$result[] = $this->strip_nulls( $item );
 				continue;
 			}
 
 			// Otherwise, merge the incoming member into the existing one in place.
-			$result[ $index ] = $this->merge_properties( $result[ $index ], $item, false );
+			$result[ $index ] = $this->merge_properties( $result[ $index ], $item, false, $method );
 		}
 
 		return $result;

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -430,7 +430,7 @@ class Gutenberg_View_Config_Data {
 			// nested null still drops the property it names.
 			$this->config[ $key ] = 'set' === $mode
 				? $this->strip_nulls( $value )
-				: $this->merge_properties( $this->config[ $key ] ?? array(), $value, 'replace' === $mode, $method );
+				: $this->merge_properties( $this->config[ $key ] ?? array(), $value, 'replace' === $mode );
 		}
 
 		return $this;
@@ -493,14 +493,13 @@ class Gutenberg_View_Config_Data {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed  $current       The current value.
-	 * @param mixed  $incoming      The incoming value.
-	 * @param bool   $replace_lists Whether a list in $incoming replaces the current list
-	 *                              wholesale instead of merging into it by member identity.
-	 * @param string $method        The public method the patch was passed to, for misuse reporting.
+	 * @param mixed $current       The current value.
+	 * @param mixed $incoming      The incoming value.
+	 * @param bool  $replace_lists Whether a list in $incoming replaces the current list
+	 *                             wholesale instead of merging into it by member identity.
 	 * @return mixed The merged value.
 	 */
-	private function merge_properties( $current, $incoming, $replace_lists, $method ) {
+	private function merge_properties( $current, $incoming, $replace_lists ) {
 		// Scalar properties are merged as-is.
 		if ( ! is_array( $incoming ) ) {
 			return $incoming;
@@ -524,8 +523,8 @@ class Gutenberg_View_Config_Data {
 
 			if ( is_array( $current ) && ! array_is_list( $current ) && array() !== $current ) {
 				_doing_it_wrong(
-					esc_html( $method ),
-					esc_html__( 'A list cannot be merged into an associative value; name the keys to change instead.', 'gutenberg' ),
+					__METHOD__,
+					esc_html__( 'A view configuration patch value must match the shape of the value it patches: a list merges into a list, and an associative array into an associative array.', 'gutenberg' ),
 					'7.1.0'
 				);
 				return $current;
@@ -533,16 +532,15 @@ class Gutenberg_View_Config_Data {
 
 			return $this->merge_list_by_identity(
 				is_array( $current ) && array_is_list( $current ) ? $current : array(),
-				$incoming,
-				$method
+				$incoming
 			);
 		}
 
 		// Consider any other array as associative (keys are strings).
 		if ( is_array( $current ) && array_is_list( $current ) && array() !== $current ) {
 			_doing_it_wrong(
-				esc_html( $method ),
-				esc_html__( 'An associative array cannot be merged into a list; address list members by their identity instead.', 'gutenberg' ),
+				__METHOD__,
+				esc_html__( 'A view configuration patch value must match the shape of the value it patches: a list merges into a list, and an associative array into an associative array.', 'gutenberg' ),
 				'7.1.0'
 			);
 			return $current;
@@ -559,8 +557,7 @@ class Gutenberg_View_Config_Data {
 			$result[ $key ] = $this->merge_properties(
 				array_key_exists( $key, $result ) ? $result[ $key ] : array(),
 				$value,
-				$replace_lists,
-				$method
+				$replace_lists
 			);
 		}
 
@@ -656,12 +653,11 @@ class Gutenberg_View_Config_Data {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array  $current  The current list.
-	 * @param array  $incoming The incoming list.
-	 * @param string $method   The public method the patch was passed to, for misuse reporting.
+	 * @param array $current  The current list.
+	 * @param array $incoming The incoming list.
 	 * @return array The merged list.
 	 */
-	private function merge_list_by_identity( array $current, array $incoming, $method ) {
+	private function merge_list_by_identity( array $current, array $incoming ) {
 		$result = $current;
 		foreach ( $incoming as $item ) {
 			// A null member carries no identity and holds nothing to merge,
@@ -691,7 +687,7 @@ class Gutenberg_View_Config_Data {
 			}
 
 			// Otherwise, merge the incoming member into the existing one in place.
-			$result[ $index ] = $this->merge_properties( $result[ $index ], $item, false, $method );
+			$result[ $index ] = $this->merge_properties( $result[ $index ], $item, false );
 		}
 
 		return $result;

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -306,6 +306,12 @@ class Gutenberg_View_Config_Data {
 	 * stops inheriting core's future additions to it — but it's useful when a
 	 * contributor needs to pin a list to an exact set of members.
 	 *
+	 * The shape rule applies here too: a patch value whose shape does not match
+	 * the current value — an associative array where a list lives, or a
+	 * non-empty list where an associative value lives — is rejected with a
+	 * notice and leaves the current value unchanged. An empty array is exempt,
+	 * so replacing a list with an empty list still clears it.
+	 *
 	 * A patch that declares an unsupported schema version is rejected and does
 	 * not change anything.
 	 *
@@ -507,6 +513,18 @@ class Gutenberg_View_Config_Data {
 
 		// Numerical indexed arrays are expected to be lists (sequential integer keys starting at 0).
 		if ( array_is_list( $incoming ) ) {
+			// A non-empty list only lands where a list (or nothing) lives, under
+			// merge() and replace() alike. An empty array is shape-ambiguous and
+			// exempt, so replace() with an empty list can still clear a list.
+			if ( array() !== $incoming && is_array( $current ) && ! array_is_list( $current ) && array() !== $current ) {
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html__( 'A view configuration patch value must match the shape of the value it patches: a list merges into a list, and an associative array into an associative array.', 'gutenberg' ),
+					'7.1.0'
+				);
+				return $current;
+			}
+
 			// replace() takes an incoming list as-is; merge() merges it by member identity.
 			if ( $replace_lists ) {
 				// As-is except for nulls: a list swapped in wholesale has no
@@ -518,15 +536,6 @@ class Gutenberg_View_Config_Data {
 			// An empty list has no members to merge, and an empty array is
 			// shape-ambiguous, so merging one is a no-op rather than a reset.
 			if ( array() === $incoming ) {
-				return $current;
-			}
-
-			if ( is_array( $current ) && ! array_is_list( $current ) && array() !== $current ) {
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html__( 'A view configuration patch value must match the shape of the value it patches: a list merges into a list, and an associative array into an associative array.', 'gutenberg' ),
-					'7.1.0'
-				);
 				return $current;
 			}
 

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -1876,6 +1876,64 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * replace() rejects a non-empty list patch value where an associative value
+	 * lives, the same rule merge() enforces: a list in the patch replaces the
+	 * current list wholesale, but it cannot land where a map lives. The current
+	 * map survives untouched instead of being discarded.
+	 *
+	 * @covers ::replace
+	 */
+	public function test_replace_rejects_list_patch_over_an_associative_value() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge_properties' );
+
+		$data   = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'sort' => array(
+						'field'     => 'title',
+						'direction' => 'asc',
+					),
+				),
+			)
+		);
+		$before = self::read_config( $data );
+
+		$data->replace(
+			array(
+				'default_view' => array(
+					'sort' => array( 'title', 'asc' ),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( $before, self::read_config( $data ) );
+	}
+
+	/**
+	 * An empty array is exempt from the shape guard, so replace() with an
+	 * empty list stays the documented way to clear a list.
+	 *
+	 * @covers ::replace
+	 */
+	public function test_replace_empty_list_still_clears_a_list() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'all',
+						'title' => 'All items',
+					),
+				),
+			)
+		);
+
+		$data->replace( array( 'view_list' => array() ), 1 );
+
+		$this->assertSame( array( 'view_list' => array() ), self::read_config( $data ) );
+	}
+
 
 	/**
 	 * merge() treats a scalar list member as its own identity: an incoming

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -1719,6 +1719,163 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 		$this->assertSame( array( 'default_view' => array( 'type' => 'table' ) ), self::read_config( $data ) );
 	}
 
+	/**
+	 * merge() rejects an associative patch value where a list lives: the shapes
+	 * do not line up, so merging would have to guess what the string keys mean.
+	 * The current list survives untouched instead of being discarded.
+	 *
+	 * @covers ::merge
+	 */
+	public function test_merge_rejects_associative_patch_over_a_list() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge' );
+
+		$data   = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'all',
+						'title' => 'All items',
+					),
+				),
+			)
+		);
+		$before = self::read_config( $data );
+
+		// The pre-7.1 slug-keyed shape, not the documented list of members.
+		$data->merge(
+			array(
+				'view_list' => array(
+					'published' => array( 'title' => 'Live' ),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( $before, self::read_config( $data ) );
+	}
+
+	/**
+	 * merge() rejects a non-empty list patch value where an associative value
+	 * lives, the mirror of the associative-over-list mismatch: the current map
+	 * survives untouched instead of being discarded.
+	 *
+	 * @covers ::merge
+	 */
+	public function test_merge_rejects_list_patch_over_an_associative_value() {
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge' );
+
+		$data   = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'sort' => array(
+						'field'     => 'title',
+						'direction' => 'asc',
+					),
+				),
+			)
+		);
+		$before = self::read_config( $data );
+
+		$data->merge(
+			array(
+				'default_view' => array(
+					'sort' => array( 'title', 'asc' ),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( $before, self::read_config( $data ) );
+	}
+
+	/**
+	 * An empty array under merge() is a no-op for both shapes: it has no
+	 * members to merge, and being shape-ambiguous it must not reset the
+	 * current value either. Clearing a list is spelled replace() with an
+	 * empty list; resetting a key is spelled null.
+	 *
+	 * @covers ::merge
+	 */
+	public function test_merge_empty_array_is_a_noop() {
+		$data   = new Gutenberg_View_Config_Data(
+			array(
+				'default_view' => array(
+					'filters' => array(
+						array(
+							'field'    => 'author',
+							'operator' => 'isAny',
+						),
+					),
+					'sort'    => array(
+						'field'     => 'title',
+						'direction' => 'asc',
+					),
+				),
+			)
+		);
+		$before = self::read_config( $data );
+
+		$data->merge(
+			array(
+				'default_view' => array(
+					'filters' => array(),
+					'sort'    => array(),
+				),
+			),
+			1
+		);
+
+		$this->assertSame( $before, self::read_config( $data ) );
+	}
+
+	/**
+	 * A nested null deletes just the leaf it names in every case, including
+	 * inside a list member that did not exist yet: an appended member has no
+	 * existing leaf to delete, so its nulls are dropped rather than stored
+	 * (the same rationale as set() and the lists replace() swaps in).
+	 *
+	 * @covers ::merge
+	 */
+	public function test_merge_appended_member_drops_nested_nulls() {
+		$data = new Gutenberg_View_Config_Data(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'all',
+						'title' => 'All items',
+					),
+				),
+			)
+		);
+		$data->merge(
+			array(
+				'view_list' => array(
+					array(
+						'slug' => 'mine',
+						'view' => array( 'filters' => null ),
+					),
+				),
+			),
+			1
+		);
+
+		$this->assertSame(
+			array(
+				'view_list' => array(
+					array(
+						'slug'  => 'all',
+						'title' => 'All items',
+					),
+					array(
+						'slug' => 'mine',
+						'view' => array(),
+					),
+				),
+			),
+			self::read_config( $data )
+		);
+	}
+
 
 	/**
 	 * merge() treats a scalar list member as its own identity: an incoming

--- a/phpunit/class-gutenberg-view-config-data-test.php
+++ b/phpunit/class-gutenberg-view-config-data-test.php
@@ -1727,7 +1727,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	 * @covers ::merge
 	 */
 	public function test_merge_rejects_associative_patch_over_a_list() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge_properties' );
 
 		$data   = new Gutenberg_View_Config_Data(
 			array(
@@ -1762,7 +1762,7 @@ class Tests_View_Config_Data extends WP_UnitTestCase {
 	 * @covers ::merge
 	 */
 	public function test_merge_rejects_list_patch_over_an_associative_value() {
-		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge' );
+		$this->setExpectedIncorrectUsage( 'Gutenberg_View_Config_Data::merge_properties' );
 
 		$data   = new Gutenberg_View_Config_Data(
 			array(


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/80319. Core PR: https://github.com/WordPress/wordpress-develop/pull/12644.

Fixes three silent data-loss defects in `Gutenberg_View_Config_Data`'s merge engine:

- An associative patch value over a list (or a non-empty list over an associative value) discarded the whole current value. It is now rejected with `_doing_it_wrong()` and the current value is kept.
- An empty array under `merge()` wiped associative values but no-oped on lists. It is now a no-op for both shapes — clear a list with `replace()` and an empty list, reset a key with `null`.
- A list member appended by `merge()` kept nested `null`s that every other write path drops. Appended members now go through `strip_nulls()`.


## How?

- `merge_properties()`: a patch value only merges into a current value of the same shape. Non-empty mismatches warn and keep the current value; an empty array merges nothing. Empty arrays stay exempt from the guards, so an associative patch still creates new nested maps.
- `merge_list_by_identity()`: appended members go through `strip_nulls()`.
- Docblocks document the rule.

## Testing

Verify unit tests are passing:

```
npm run test:unit:php:base -- --filter Tests_View_Config_Data
```

One new test per fix; the inline PR comments show each assertion's result without the fix.

AI usage disclosure: issues found via AI-assisted code review; fix, tests, and description drafted with AI assistance (Claude Code) and reviewed by me.