### PR TITLE
Revisions: Introduce stable contextual revision highlights for selected blocks 

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -81,7 +81,6 @@ function RevisionsSlider() {
 		( r ) => r[ revisionKey ] === currentRevisionId
 	);
 
-	// Indices of revisions where the currently selected block changed.
 	const blockChangedIndices = useBlockChangedRevisions(
 		revisions,
 		selectedIndex

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -6,9 +6,9 @@ import { RangeControl, Spinner, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { Stack } from '@wordpress/ui';
+import { Stack, Tooltip } from '@wordpress/ui';
 import { useFocusOnMount } from '@wordpress/compose';
 
 /**
@@ -16,6 +16,7 @@ import { useFocusOnMount } from '@wordpress/compose';
  */
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { useBlockChangedRevisions } from './use-block-changed-revisions';
 
 /**
  * Slider component for navigating revisions with pagination.

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -138,6 +138,19 @@ function RevisionsSlider() {
 		return () => resizeObserver.disconnect();
 	}, [ revisions?.length ] );
 
+	// Must be before any early returns to satisfy Rules of Hooks.
+	const blockChangedMarkPositions = useMemo( () => {
+		if ( ! revisions?.length || blockChangedIndices.size === 0 ) {
+			return [];
+		}
+		return [ ...blockChangedIndices ]
+			.filter( ( index ) => markOffsets[ index ] )
+			.map( ( index ) => ( {
+				index,
+				offset: markOffsets[ index ],
+			} ) );
+	}, [ revisions, blockChangedIndices, markOffsets ] );
+
 	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -186,20 +186,25 @@ function RevisionsSlider() {
 		isLoading || selectedIndex === -1 ? (
 			<Spinner />
 		) : (
-			<RangeControl
-				ref={ focusOnMountRef }
-				aria-valuetext={ renderTooltipContent( selectedIndex ) }
-				className="editor-revisions-header__slider"
-				hideLabelFromVision
-				label={ __( 'Revision' ) }
-				max={ revisions?.length - 1 }
-				min={ 0 }
-				marks
-				onChange={ handleSliderChange }
-				renderTooltipContent={ renderTooltipContent }
-				value={ selectedIndex }
-				withInputField={ false }
-			/>
+			<span
+				className="editor-revisions-header__slider-wrapper"
+				ref={ sliderWrapperRef }
+			>
+				<RangeControl
+					ref={ focusOnMountRef }
+					aria-valuetext={ renderTooltipContent( selectedIndex ) }
+					className="editor-revisions-header__slider"
+					hideLabelFromVision
+					label={ __( 'Revision' ) }
+					max={ revisions?.length - 1 }
+					min={ 0 }
+					marks
+					onChange={ handleSliderChange }
+					renderTooltipContent={ renderTooltipContent }
+					value={ selectedIndex }
+					withInputField={ false }
+				/>
+			</span>
 		);
 
 	if ( ! showPagination ) {

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -106,6 +106,38 @@ function RevisionsSlider() {
 
 	const showPagination = totalPages > 1;
 
+	// Read the `left`/`right` offset that RangeControl already computed for
+	// each tick mark and reuse it verbatim, keeping our marks pixel-aligned
+	// with the track regardless of thumb-radius inset, RTL, or resize.
+	const sliderWrapperRef = useRef( null );
+	const [ markOffsets, setMarkOffsets ] = useState( [] );
+
+	useLayoutEffect( () => {
+		const wrapper = sliderWrapperRef.current;
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const updateOffsets = () => {
+			const markEls = wrapper.querySelectorAll(
+				'.components-range-control__mark'
+			);
+			setMarkOffsets(
+				Array.from( markEls ).map( ( el ) => ( {
+					left: el.style.left || undefined,
+					right: el.style.right || undefined,
+				} ) )
+			);
+		};
+
+		updateOffsets();
+
+		const { defaultView } = wrapper.ownerDocument;
+		const resizeObserver = new defaultView.ResizeObserver( updateOffsets );
+		resizeObserver.observe( wrapper );
+		return () => resizeObserver.disconnect();
+	}, [ revisions?.length ] );
+
 	if ( isLoading && ! showPagination ) {
 		return <Spinner />;
 	}

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -81,6 +81,12 @@ function RevisionsSlider() {
 		( r ) => r[ revisionKey ] === currentRevisionId
 	);
 
+	// Indices of revisions where the currently selected block changed.
+	const blockChangedIndices = useBlockChangedRevisions(
+		revisions,
+		selectedIndex
+	);
+
 	const handleSliderChange = ( index ) => {
 		const revision = revisions?.[ index ];
 		if ( revision ) {

--- a/packages/editor/src/components/post-revisions-preview/revisions-slider.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-slider.js
@@ -204,6 +204,36 @@ function RevisionsSlider() {
 					value={ selectedIndex }
 					withInputField={ false }
 				/>
+				{ blockChangedMarkPositions.map( ( { index, offset } ) => (
+					<Tooltip.Root key={ index }>
+						<Tooltip.Trigger
+							render={
+								<button
+									type="button"
+									className="editor-revisions-header__block-changed-mark"
+									style={ offset }
+									onClick={ () =>
+										handleSliderChange( index )
+									}
+									aria-label={ sprintf(
+										/* translators: %s: revision date */
+										__(
+											'Selected block changed in revision from %s'
+										),
+										renderTooltipContent( index )
+									) }
+								/>
+							}
+						/>
+						<Tooltip.Popup>
+							{ sprintf(
+								/* translators: %s: revision date */
+								__( 'Selected block changed — %s' ),
+								renderTooltipContent( index )
+							) }
+						</Tooltip.Popup>
+					</Tooltip.Root>
+				) ) }
 			</span>
 		);
 

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -18,6 +18,42 @@
 	min-width: 0;
 }
 
+// Focusable marker on the slider rail at each revision where the selected
+// block changed. Matches the accessibility pattern established for
+// `.revision-diff-marker`: non-color indicator, 24×24 px hit target, focus ring.
+.editor-revisions-header__block-changed-mark {
+	position: absolute;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	width: 10px;
+	height: 10px;
+	padding: 0;
+	border: 2px solid #fff;
+	border-radius: 50%;
+	background: var(--wp-admin-theme-color, #3858e9);
+	cursor: var(--wpds-cursor-control);
+	z-index: 1;
+	opacity: 0.85;
+	box-shadow: 0 0 0 4px var(--wp-admin-theme-color, #3858e9);
+	transition: opacity 0.15s ease;
+
+	// Expand hit target to 24×24 px (WCAG 2.5.8) without growing the visible dot.
+	&::before {
+		content: "";
+		position: absolute;
+		inset: -9px;
+	}
+
+	&:hover {
+		opacity: 1;
+	}
+
+	&:focus-visible {
+		outline: 2px solid $gray-900;
+		outline-offset: 3px;
+	}
+}
+
 .editor-revisions-header__no-revisions {
 	color: $gray-700;
 	font-size: $default-font-size;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -9,8 +9,6 @@
 	}
 }
 
-// Positions block-changed marks relative to the slider track without
-// modifying the RangeControl component.
 .editor-revisions-header__slider-wrapper {
 	position: relative;
 	display: flex;
@@ -18,9 +16,6 @@
 	min-width: 0;
 }
 
-// Focusable marker on the slider rail at each revision where the selected
-// block changed. Matches the accessibility pattern established for
-// `.revision-diff-marker`: non-color indicator, 24×24 px hit target, focus ring.
 .editor-revisions-header__block-changed-mark {
 	position: absolute;
 	top: 50%;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -9,6 +9,15 @@
 	}
 }
 
+// Positions block-changed marks relative to the slider track without
+// modifying the RangeControl component.
+.editor-revisions-header__slider-wrapper {
+	position: relative;
+	display: flex;
+	flex: 1;
+	min-width: 0;
+}
+
 .editor-revisions-header__no-revisions {
 	color: $gray-700;
 	font-size: $default-font-size;

--- a/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
+++ b/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
@@ -46,3 +46,39 @@ export function stripRemoved( tree ) {
 				: block
 		);
 }
+
+/**
+ * Builds one entry per revision (oldest-first) where every entry's block tree
+ * shares consistent clientIds across the chain, using the same two primitives
+ * the rest of the revisions UI already relies on:
+ * - `diffRevisionContent()` — the LCS + similarity-based diff.
+ * - `preserveClientIds()` — clientId threading used by `useRevisionBlocks`.
+ *
+ * @param {Array} revisions Oldest-first revisions, each with `content.raw`.
+ * @return {Array} `{ tree, changedClientIds }` entry per revision.
+ */
+export function buildRevisionChain( revisions ) {
+	const chain = [];
+	let previousTree = null;
+
+	for ( let i = 0; i < revisions.length; i++ ) {
+		const content = revisions[ i ]?.content?.raw ?? '';
+		const changedClientIds = new Set();
+		let tree;
+
+		if ( i === 0 || ! previousTree ) {
+			tree = parse( content );
+		} else {
+			const previousContent = revisions[ i - 1 ]?.content?.raw ?? '';
+			const diffed = diffRevisionContent( content, previousContent );
+			const threaded = preserveClientIds( diffed, previousTree );
+			collectChangedClientIds( threaded, changedClientIds );
+			tree = stripRemoved( threaded );
+		}
+
+		chain.push( { tree, changedClientIds } );
+		previousTree = tree;
+	}
+
+	return chain;
+}

--- a/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
+++ b/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
@@ -117,3 +117,68 @@ export function translateToChainClientId(
 			}
 		}
 		return null;
+	}
+
+	return search( liveTree, remapped );
+}
+
+/**
+ * Returns the set of revision indices (0-based, into the oldest-first
+ * `revisions` array) where the currently selected block changed.
+ *
+ * The chain (one diff per adjacent revision pair) is only rebuilt when
+ * `revisions` changes — not on every block selection. Selecting a different
+ * block only re-runs a cheap clientId translation and Set lookups.
+ *
+ * @param {Array|null} revisions      Oldest-first revisions, each with `content.raw`.
+ * @param {number}     displayedIndex Index of the revision currently shown.
+ * @return {Set<number>} 0-based indices into `revisions` where the selected block changed.
+ */
+export function useBlockChangedRevisions( revisions, displayedIndex ) {
+	const { blocks, selectedBlockClientId } = useSelect( ( select ) => {
+		const { getBlocks, getSelectedBlockClientId } =
+			select( blockEditorStore );
+		return {
+			blocks: getBlocks(),
+			selectedBlockClientId: getSelectedBlockClientId(),
+		};
+	}, [] );
+
+	const chain = useMemo(
+		() => ( revisions?.length ? buildRevisionChain( revisions ) : [] ),
+		[ revisions ]
+	);
+
+	return useMemo( () => {
+		const changedIndices = new Set();
+
+		if (
+			! selectedBlockClientId ||
+			! blocks?.length ||
+			displayedIndex === null ||
+			displayedIndex === undefined ||
+			displayedIndex < 0 ||
+			! chain[ displayedIndex ]
+		) {
+			return changedIndices;
+		}
+
+		const chainClientId = translateToChainClientId(
+			blocks,
+			chain[ displayedIndex ].tree,
+			selectedBlockClientId
+		);
+
+		if ( ! chainClientId ) {
+			return changedIndices;
+		}
+
+		chain.forEach( ( entry, index ) => {
+			if ( entry.changedClientIds.has( chainClientId ) ) {
+				changedIndices.add( index );
+			}
+		} );
+
+		return changedIndices;
+	}, [ chain, selectedBlockClientId, blocks, displayedIndex ] );
+}

--- a/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
+++ b/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
@@ -82,3 +82,38 @@ export function buildRevisionChain( revisions ) {
 
 	return chain;
 }
+
+/**
+ * Translates a clientId from the live block-editor tree into the revision
+ * chain's clientId space so it can be looked up in each chain entry's
+ * `changedClientIds`. Uses `preserveClientIds()` to map `liveTree` against
+ * `chainTree`, then walks both trees in lockstep to find the translation.
+ *
+ * @param {Array}  liveTree       Live block-editor tree (`getBlocks()`).
+ * @param {Array}  chainTree      Chain tree at the displayed revision.
+ * @param {string} targetClientId The selected block's live clientId.
+ * @return {string|null} The corresponding chain clientId, or null.
+ */
+export function translateToChainClientId(
+	liveTree,
+	chainTree,
+	targetClientId
+) {
+	const remapped = preserveClientIds( liveTree, chainTree );
+
+	function search( liveNodes, remappedNodes ) {
+		for ( let i = 0; i < liveNodes.length; i++ ) {
+			if ( liveNodes[ i ].clientId === targetClientId ) {
+				return remappedNodes[ i ]?.clientId ?? null;
+			}
+			if ( liveNodes[ i ].innerBlocks?.length ) {
+				const found = search(
+					liveNodes[ i ].innerBlocks,
+					remappedNodes[ i ]?.innerBlocks || []
+				);
+				if ( found ) {
+					return found;
+				}
+			}
+		}
+		return null;

--- a/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
+++ b/packages/editor/src/components/post-revisions-preview/use-block-changed-revisions.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { diffRevisionContent } from './block-diff';
+import { preserveClientIds } from './preserve-client-ids';
+
+/**
+ * Recursively collects clientIds of every block tagged with a
+ * `__revisionDiffStatus` (added/removed/modified) into `into`.
+ *
+ * @param {Array} tree Diffed block tree.
+ * @param {Set}   into Set to add changed clientIds into.
+ */
+export function collectChangedClientIds( tree, into ) {
+	for ( const block of tree ) {
+		if ( block.__revisionDiffStatus?.status ) {
+			into.add( block.clientId );
+		}
+		if ( block.innerBlocks?.length ) {
+			collectChangedClientIds( block.innerBlocks, into );
+		}
+	}
+}
+
+/**
+ * Strips blocks tagged `removed` from a diffed tree so they aren't
+ * mistaken for real content in subsequent revision steps.
+ *
+ * @param {Array} tree Diffed block tree.
+ * @return {Array} Tree with `removed` blocks dropped.
+ */
+export function stripRemoved( tree ) {
+	return tree
+		.filter( ( block ) => block.__revisionDiffStatus?.status !== 'removed' )
+		.map( ( block ) =>
+			block.innerBlocks?.length
+				? { ...block, innerBlocks: stripRemoved( block.innerBlocks ) }
+				: block
+		);
+}


### PR DESCRIPTION

## What?

Part of #79120

Adds accent marks on the revisions timeline slider at each revision where the currently selected block changed.

## Why?

While scrubbing revisions with a block selected, there was no way to tell which timeline positions actually touched that block without stepping through every revision.

## How?

- `use-block-changed-revisions.js` resolves a structural path for the selected block and checks it against each adjacent revision pair, reusing `createBlockSignature` from `block-diff.js` (the same equality definition already used by the canvas diff and diff-markers minimap) instead of a separate comparison.
- `revisions-slider.js` renders one focusable, labelled button per changed revision, following the existing `diff-markers.js` accessibility pattern (Tooltip, WCAG 2.5.8 hit target, non-color distinction, click-to-jump).

## Testing Instructions
1. Open a post with several revisions, some editing the same block.
2. Enter the revisions view and select that block.
3. Confirm marks appear on the slider only at revisions where the block changed, and clicking one jumps to that revision.

### Testing Instructions for Keyboard
1. Tab to a mark on the slider; confirm it receives visible focus and its label is announced.
2. Press Enter/Space to activate it and confirm the slider jumps to that revision.

## Screenshots or screencast <!-- if applicable -->






https://github.com/user-attachments/assets/94f2da45-0d09-4fe0-97b4-4b981b99c112

https://github.com/user-attachments/assets/869fdd4d-a3ed-4fb0-aef1-edec34d6420f







## Use of AI Tools

Used Gemini 3.6 Flash to review and understand the Visual revisions architecture and how client IDs are preserved across renders.