### PR TITLE
ExternalLink: Use shared focus ring mixin

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
 -   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
+-   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).
 
 ### TypeScript
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,6 @@
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
 -   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
--   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).
 
 ### TypeScript
 
@@ -24,6 +23,7 @@
 ### Internal
 
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
+-   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).
 -   `SearchControl`: Migrate styles from Emotion to an SCSS Module ([#80474](https://github.com/WordPress/gutenberg/pull/80474)).
 -   `FormTokenField`: Migrate styles from Emotion to an SCSS Module ([#80472](https://github.com/WordPress/gutenberg/pull/80472)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`, `ToggleGroupControl`, and `RangeControl`: Remove obsolete internal `__shouldNotWarnDeprecated36pxSize` prop ([#80323](https://github.com/WordPress/gutenberg/pull/80323)).

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -1,15 +1,8 @@
+@use "@wordpress/base-styles/mixins";
+
 .components-external-link {
 	color: var(--wpds-color-foreground-interactive-brand);
 	text-decoration: none;
-
-	// Match the `outset-ring--focus` utility used by `Link` in `@wordpress/ui`.
-	@media not ( prefers-reduced-motion ) {
-		transition: outline 0.1s ease-out;
-	}
-	// Outline width must be kept at 0 even with a transparent color,
-	// or else the outline will be visible in forced-colors mode.
-	outline: 0 solid transparent;
-	outline-offset: 1px;
 
 	&:visited {
 		color: var(--wpds-color-foreground-interactive-brand);
@@ -20,13 +13,11 @@
 		color: var(--wpds-color-foreground-interactive-brand-active);
 	}
 
-	&:focus {
-		outline:
-			var(--wpds-border-width-focus) solid
-			var(--wpds-color-stroke-focus);
+	&:focus:not(:active) {
 		// Override style from wp-admin common.css.
 		box-shadow: none;
 		border-radius: 0;
+		@include mixins.outset-ring__focus();
 	}
 }
 

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -13,11 +13,14 @@
 		color: var(--wpds-color-foreground-interactive-brand-active);
 	}
 
-	&:focus:not(:active) {
+	&:focus {
 		// Override style from wp-admin common.css.
 		box-shadow: none;
 		border-radius: 0;
-		@include mixins.outset-ring__focus();
+
+		&:not(:active) {
+			@include mixins.outset-ring__focus();
+		}
 	}
 }
 


### PR DESCRIPTION
## What?

Updates `ExternalLink` to use the shared `outset-ring__focus` mixin for its focus ring.

## Why?

The component had a hand-rolled focus outline that duplicated the design system focus ring. Using the shared mixin keeps it aligned with other components and with `Link` in `@wordpress/ui`.

## How?

- Import `@wordpress/base-styles/mixins` in `ExternalLink` styles.
- Replace inline focus outline rules with `@include mixins.outset-ring__focus()`.
- Keep wp-admin `common.css` overrides (`box-shadow`, `border-radius`) on `:focus`, and apply the ring on `:focus:not(:active)` to match `@wordpress/ui` `Link` behavior.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **Components → Navigation → ExternalLink → Default**.
3. Tab to the link and confirm the focus ring matches other components using the shared mixin.
4. Click the link and confirm the ring is not shown while active.

Also use the global style injector to check with the WP stylesheets loaded.

<img width="300" alt="Global style injector" src="https://github.com/user-attachments/assets/f99c57ce-c643-47d5-baf7-10df14724e93" />

