### PR TITLE
Combobox, Select, SelectControl: Add Group and GroupLabel

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Enhancements
 
--   `Combobox`: Add `Combobox.Group` and `Combobox.GroupLabel` subcomponents.
--   `Select`: Add `Select.Group` and `Select.GroupLabel` subcomponents.
--   `SelectControl`: Add `SelectControl.Group` and `SelectControl.GroupLabel` subcomponents.
+-   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 -   `Button`: Add Storybook example demonstrating manual keyboard shortcut composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description ([#80353](https://github.com/WordPress/gutenberg/pull/80353)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+-   `Combobox`: Add `Combobox.Group` and `Combobox.GroupLabel` subcomponents.
+-   `Select`: Add `Select.Group` and `Select.GroupLabel` subcomponents.
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 -   `Button`: Add Storybook example demonstrating manual keyboard shortcut composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description ([#80353](https://github.com/WordPress/gutenberg/pull/80353)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Combobox`: Add `Combobox.Group` and `Combobox.GroupLabel` subcomponents.
 -   `Select`: Add `Select.Group` and `Select.GroupLabel` subcomponents.
+-   `SelectControl`: Add `SelectControl.Group` and `SelectControl.GroupLabel` subcomponents.
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 -   `Button`: Add Storybook example demonstrating manual keyboard shortcut composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description ([#80353](https://github.com/WordPress/gutenberg/pull/80353)).
 

--- a/packages/ui/src/form/primitives/combobox/group-label.tsx
+++ b/packages/ui/src/form/primitives/combobox/group-label.tsx
@@ -1,0 +1,27 @@
+import { Combobox as _Combobox } from '@base-ui/react/combobox';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { Text } from '../../../text';
+import type { ComboboxGroupLabelProps } from './types';
+import itemPopupStyles from '../../../utils/css/item-popup.module.css';
+
+/**
+ * Renders a label for a `Combobox.Group`, describing the group of items
+ * it is associated with.
+ */
+export const GroupLabel = forwardRef< HTMLDivElement, ComboboxGroupLabelProps >(
+	function GroupLabel( { className, children, ...restProps }, ref ) {
+		return (
+			<Text
+				variant="heading-sm"
+				className={ clsx(
+					itemPopupStyles[ 'group-label' ],
+					className
+				) }
+				render={ <_Combobox.GroupLabel ref={ ref } { ...restProps } /> }
+			>
+				{ children }
+			</Text>
+		);
+	}
+);

--- a/packages/ui/src/form/primitives/combobox/group.tsx
+++ b/packages/ui/src/form/primitives/combobox/group.tsx
@@ -1,0 +1,24 @@
+import { Combobox as _Combobox } from '@base-ui/react/combobox';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { ComboboxGroupProps } from './types';
+import itemPopupStyles from '../../../utils/css/item-popup.module.css';
+
+/**
+ * Groups related items together with an associated label rendered by
+ * `Combobox.GroupLabel`. When `items` is provided, child
+ * `Combobox.Collection` components iterate over them.
+ */
+export const Group = forwardRef< HTMLDivElement, ComboboxGroupProps >(
+	function Group( { className, children, ...restProps }, ref ) {
+		return (
+			<_Combobox.Group
+				className={ clsx( itemPopupStyles.group, className ) }
+				ref={ ref }
+				{ ...restProps }
+			>
+				{ children }
+			</_Combobox.Group>
+		);
+	}
+);

--- a/packages/ui/src/form/primitives/combobox/index.ts
+++ b/packages/ui/src/form/primitives/combobox/index.ts
@@ -3,6 +3,8 @@ export { ChipWithRemove } from './chip-with-remove';
 export { Clear } from './clear';
 export { Collection } from './collection';
 export { Empty } from './empty';
+export { Group } from './group';
+export { GroupLabel } from './group-label';
 export { Input } from './input';
 export { Item } from './item';
 export { List } from './list';

--- a/packages/ui/src/form/primitives/combobox/stories/fixtures.ts
+++ b/packages/ui/src/form/primitives/combobox/stories/fixtures.ts
@@ -3,6 +3,11 @@ export interface FixtureItem {
 	label: string;
 }
 
+export interface FixtureGroup {
+	label: string;
+	items: FixtureItem[];
+}
+
 export const ITEMS: FixtureItem[] = [
 	{ value: 'apple', label: 'Apple' },
 	{ value: 'apricot', label: 'Apricot' },
@@ -54,4 +59,31 @@ export const ITEMS: FixtureItem[] = [
 	{ value: 'strawberry', label: 'Strawberry' },
 	{ value: 'tangerine', label: 'Tangerine' },
 	{ value: 'watermelon', label: 'Watermelon' },
+];
+
+export const GROUPED_ITEMS: FixtureGroup[] = [
+	{
+		label: 'Common',
+		items: [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+			{ value: 'orange', label: 'Orange' },
+		],
+	},
+	{
+		label: 'Berries',
+		items: [
+			{ value: 'strawberry', label: 'Strawberry' },
+			{ value: 'blueberry', label: 'Blueberry' },
+			{ value: 'raspberry', label: 'Raspberry' },
+		],
+	},
+	{
+		label: 'Tropical',
+		items: [
+			{ value: 'mango', label: 'Mango' },
+			{ value: 'pineapple', label: 'Pineapple' },
+			{ value: 'papaya', label: 'Papaya' },
+		],
+	},
 ];

--- a/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from '@wordpress/element';
 import * as Combobox from '../index';
-import { ITEMS, type FixtureItem } from './fixtures';
+import {
+	ITEMS,
+	GROUPED_ITEMS,
+	type FixtureGroup,
+	type FixtureItem,
+} from './fixtures';
 
 const meta: Meta< typeof Combobox.Root > = {
 	title: 'Design System/Components/Form/Primitives/Combobox',
@@ -16,6 +21,8 @@ const meta: Meta< typeof Combobox.Root > = {
 		'Combobox.ListBody': Combobox.ListBody,
 		'Combobox.ListFooter': Combobox.ListFooter,
 		'Combobox.Collection': Combobox.Collection,
+		'Combobox.Group': Combobox.Group,
+		'Combobox.GroupLabel': Combobox.GroupLabel,
 		'Combobox.Item': Combobox.Item,
 		'Combobox.Value': Combobox.Value,
 		'Combobox.Chips': Combobox.Chips,
@@ -325,6 +332,51 @@ export const WithCustomTriggerAndItem: Story = {
 										</span>
 									</div>
 								</Combobox.Item>
+							) }
+						</Combobox.Collection>
+					</Combobox.ListBody>
+				</Combobox.List>
+			</Combobox.Popup>,
+		],
+	},
+};
+
+/**
+ * Options can be organized into labeled groups with `Combobox.Group`
+ * and `Combobox.GroupLabel`.
+ */
+export const Grouped: Story = {
+	args: {
+		items: GROUPED_ITEMS,
+		children: [
+			<Combobox.Trigger key="trigger" />,
+			<Combobox.Popup key="popup">
+				<div style={ inputWrapperStyle }>
+					<Combobox.Input placeholder="Search" />
+				</div>
+				<Combobox.Empty>No results found.</Combobox.Empty>
+				<Combobox.List>
+					<Combobox.ListBody>
+						<Combobox.Collection>
+							{ ( group: FixtureGroup ) => (
+								<Combobox.Group
+									key={ group.label }
+									items={ group.items }
+								>
+									<Combobox.GroupLabel>
+										{ group.label }
+									</Combobox.GroupLabel>
+									<Combobox.Collection>
+										{ ( item: FixtureItem ) => (
+											<Combobox.Item
+												key={ item.value }
+												value={ item }
+											>
+												{ item.label }
+											</Combobox.Item>
+										) }
+									</Combobox.Collection>
+								</Combobox.Group>
 							) }
 						</Combobox.Collection>
 					</Combobox.ListBody>

--- a/packages/ui/src/form/primitives/combobox/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/combobox/test/index.test.tsx
@@ -507,6 +507,81 @@ describe( 'Combobox', () => {
 	} );
 	/* eslint-enable testing-library/no-node-access */
 
+	describe( 'grouped items', () => {
+		const GROUPED_ITEMS = [
+			{
+				label: 'Group 1',
+				items: [
+					{ id: '1', value: 'Item 1' },
+					{ id: '2', value: 'Item 2' },
+				],
+			},
+			{
+				label: 'Group 2',
+				items: [ { id: '3', value: 'Item 3' } ],
+			},
+		];
+
+		it( 'forwards refs', async () => {
+			const user = userEvent.setup();
+			const groupRef = createRef< HTMLDivElement >();
+			const groupLabelRef = createRef< HTMLDivElement >();
+
+			render(
+				<Combobox.Root items={ GROUPED_ITEMS }>
+					<Combobox.Trigger />
+					<Combobox.Popup>
+						<Combobox.Input placeholder="Search" />
+						<Combobox.List>
+							<Combobox.ListBody>
+								<Combobox.Collection>
+									{ ( group ) => (
+										<Combobox.Group
+											key={ group.label }
+											ref={
+												group.label === 'Group 1'
+													? groupRef
+													: undefined
+											}
+											items={ group.items }
+										>
+											<Combobox.GroupLabel
+												ref={
+													group.label === 'Group 1'
+														? groupLabelRef
+														: undefined
+												}
+											>
+												{ group.label }
+											</Combobox.GroupLabel>
+											<Combobox.Collection>
+												{ ( item ) => (
+													<Combobox.Item
+														key={ item.id }
+														value={ item }
+													>
+														{ item.value }
+													</Combobox.Item>
+												) }
+											</Combobox.Collection>
+										</Combobox.Group>
+									) }
+								</Combobox.Collection>
+							</Combobox.ListBody>
+						</Combobox.List>
+					</Combobox.Popup>
+				</Combobox.Root>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			await waitFor( () => {
+				expect( groupRef.current ).toBeInstanceOf( HTMLDivElement );
+			} );
+			expect( groupLabelRef.current ).toBeInstanceOf( HTMLDivElement );
+		} );
+	} );
+
 	describe( 'when disabled', () => {
 		it( 'hides the chip remove button from screen readers', () => {
 			renderDisabledMultiSelect();

--- a/packages/ui/src/form/primitives/combobox/types.ts
+++ b/packages/ui/src/form/primitives/combobox/types.ts
@@ -38,6 +38,16 @@ export type ComboboxEmptyProps = ComponentProps< typeof _Combobox.Empty > & {
 	children?: React.ReactNode;
 };
 
+export type ComboboxGroupProps = ComponentProps< typeof _Combobox.Group > & {
+	children?: React.ReactNode;
+};
+
+export type ComboboxGroupLabelProps = ComponentProps<
+	typeof _Combobox.GroupLabel
+> & {
+	children?: React.ReactNode;
+};
+
 export type ComboboxInputProps = Omit<
 	ComponentProps< typeof _Combobox.Input >,
 	'size'

--- a/packages/ui/src/form/primitives/select/group-label.tsx
+++ b/packages/ui/src/form/primitives/select/group-label.tsx
@@ -1,0 +1,27 @@
+import { Select as _Select } from '@base-ui/react/select';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import { Text } from '../../../text';
+import type { SelectGroupLabelProps } from './types';
+import itemPopupStyles from '../../../utils/css/item-popup.module.css';
+
+/**
+ * Renders a label for a `Select.Group`, describing the group of items
+ * it is associated with.
+ */
+export const GroupLabel = forwardRef< HTMLDivElement, SelectGroupLabelProps >(
+	function GroupLabel( { className, children, ...restProps }, ref ) {
+		return (
+			<Text
+				variant="heading-sm"
+				className={ clsx(
+					itemPopupStyles[ 'group-label' ],
+					className
+				) }
+				render={ <_Select.GroupLabel ref={ ref } { ...restProps } /> }
+			>
+				{ children }
+			</Text>
+		);
+	}
+);

--- a/packages/ui/src/form/primitives/select/group.tsx
+++ b/packages/ui/src/form/primitives/select/group.tsx
@@ -1,0 +1,23 @@
+import { Select as _Select } from '@base-ui/react/select';
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import type { SelectGroupProps } from './types';
+import itemPopupStyles from '../../../utils/css/item-popup.module.css';
+
+/**
+ * Groups related items together with an associated label rendered by
+ * `Select.GroupLabel`.
+ */
+export const Group = forwardRef< HTMLDivElement, SelectGroupProps >(
+	function Group( { className, children, ...restProps }, ref ) {
+		return (
+			<_Select.Group
+				className={ clsx( itemPopupStyles.group, className ) }
+				ref={ ref }
+				{ ...restProps }
+			>
+				{ children }
+			</_Select.Group>
+		);
+	}
+);

--- a/packages/ui/src/form/primitives/select/index.ts
+++ b/packages/ui/src/form/primitives/select/index.ts
@@ -1,3 +1,5 @@
+export { Group } from './group';
+export { GroupLabel } from './group-label';
 export { Item } from './item';
 export { Popup } from './popup';
 export { Portal } from './portal';

--- a/packages/ui/src/form/primitives/select/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/select/stories/index.story.tsx
@@ -9,6 +9,8 @@ const meta: Meta< typeof Select.Root > = {
 		'Select.Portal': Select.Portal,
 		'Select.Positioner': Select.Positioner,
 		'Select.Popup': Select.Popup,
+		'Select.Group': Select.Group,
+		'Select.GroupLabel': Select.GroupLabel,
 		'Select.Item': Select.Item,
 	},
 	parameters: {
@@ -90,6 +92,58 @@ export const Minimal: Story = {
 		],
 
 		defaultValue: '1',
+	},
+};
+
+const groupedItems = [
+	{
+		label: 'Common',
+		items: [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+			{ value: 'orange', label: 'Orange' },
+		],
+	},
+	{
+		label: 'Berries',
+		items: [
+			{ value: 'strawberry', label: 'Strawberry' },
+			{ value: 'blueberry', label: 'Blueberry' },
+			{ value: 'raspberry', label: 'Raspberry' },
+		],
+	},
+	{
+		label: 'Tropical',
+		items: [
+			{ value: 'mango', label: 'Mango' },
+			{ value: 'pineapple', label: 'Pineapple' },
+			{ value: 'papaya', label: 'Papaya' },
+		],
+	},
+];
+
+/**
+ * Options can be organized into labeled groups with `Select.Group`
+ * and `Select.GroupLabel`.
+ */
+export const Grouped: Story = {
+	args: {
+		items: groupedItems.flatMap( ( group ) => group.items ),
+		children: [
+			<Select.Trigger key="trigger" />,
+			<Select.Popup key="popup">
+				{ groupedItems.map( ( group ) => (
+					<Select.Group key={ group.label }>
+						<Select.GroupLabel>{ group.label }</Select.GroupLabel>
+						{ group.items.map( ( item ) => (
+							<Select.Item key={ item.value } value={ item }>
+								{ item.label }
+							</Select.Item>
+						) ) }
+					</Select.Group>
+				) ) }
+			</Select.Popup>,
+		],
 	},
 };
 

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -321,4 +321,69 @@ describe( 'Select', () => {
 		} );
 	} );
 	/* eslint-enable testing-library/no-node-access */
+
+	describe( 'grouped items', () => {
+		const GROUPED_ITEMS = [
+			{
+				label: 'Group 1',
+				items: [
+					{ value: 'item-1', label: 'Item 1' },
+					{ value: 'item-2', label: 'Item 2' },
+				],
+			},
+			{
+				label: 'Group 2',
+				items: [ { value: 'item-3', label: 'Item 3' } ],
+			},
+		];
+
+		it( 'forwards refs', async () => {
+			const user = userEvent.setup();
+			const groupRef = createRef< HTMLDivElement >();
+			const groupLabelRef = createRef< HTMLDivElement >();
+
+			render(
+				<Select.Root
+					items={ GROUPED_ITEMS.flatMap( ( group ) => group.items ) }
+				>
+					<Select.Trigger />
+					<Select.Popup>
+						{ GROUPED_ITEMS.map( ( group ) => (
+							<Select.Group
+								key={ group.label }
+								ref={
+									group.label === 'Group 1'
+										? groupRef
+										: undefined
+								}
+							>
+								<Select.GroupLabel
+									ref={
+										group.label === 'Group 1'
+											? groupLabelRef
+											: undefined
+									}
+								>
+									{ group.label }
+								</Select.GroupLabel>
+								{ group.items.map( ( item ) => (
+									<Select.Item
+										key={ item.value }
+										value={ item }
+									>
+										{ item.label }
+									</Select.Item>
+								) ) }
+							</Select.Group>
+						) ) }
+					</Select.Popup>
+				</Select.Root>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			expect( groupRef.current ).toBeInstanceOf( HTMLDivElement );
+			expect( groupLabelRef.current ).toBeInstanceOf( HTMLDivElement );
+		} );
+	} );
 } );

--- a/packages/ui/src/form/primitives/select/types.ts
+++ b/packages/ui/src/form/primitives/select/types.ts
@@ -44,6 +44,16 @@ export type SelectTriggerProps = ComponentProps< typeof _Select.Trigger > & {
 	children?: _Select.Value.Props[ 'children' ];
 };
 
+export type SelectGroupProps = ComponentProps< typeof _Select.Group > & {
+	children?: React.ReactNode;
+};
+
+export type SelectGroupLabelProps = ComponentProps<
+	typeof _Select.GroupLabel
+> & {
+	children?: React.ReactNode;
+};
+
 export type SelectPopupProps = ComponentProps< typeof _Select.Popup > & {
 	/**
 	 * The content to be rendered inside the popup.

--- a/packages/ui/src/form/select-control/index.ts
+++ b/packages/ui/src/form/select-control/index.ts
@@ -1,12 +1,25 @@
 import { SelectControl as _SelectControl } from './select-control';
+import { Group } from '../primitives/select/group';
+import { GroupLabel } from '../primitives/select/group-label';
 import { Item } from './item';
 
+Group.displayName = 'SelectControl.Group';
+GroupLabel.displayName = 'SelectControl.GroupLabel';
 Item.displayName = 'SelectControl.Item';
 
 /**
  * A complete select field with integrated label and description.
  */
 export const SelectControl = Object.assign( _SelectControl, {
+	/**
+	 * Groups related items together with an associated label rendered by
+	 * `SelectControl.GroupLabel`.
+	 */
+	Group,
+	/**
+	 * Renders a label for a `SelectControl.Group`.
+	 */
+	GroupLabel,
 	/**
 	 * An item rendered inside a `SelectControl` popup.
 	 */

--- a/packages/ui/src/form/select-control/stories/index.story.tsx
+++ b/packages/ui/src/form/select-control/stories/index.story.tsx
@@ -9,6 +9,8 @@ const meta: Meta< typeof SelectControl > = {
 	title: 'Design System/Components/Form/SelectControl',
 	component: SelectControl,
 	subcomponents: {
+		'SelectControl.Group': SelectControl.Group,
+		'SelectControl.GroupLabel': SelectControl.GroupLabel,
 		'SelectControl.Item': SelectControl.Item,
 	},
 	argTypes: {
@@ -120,6 +122,64 @@ export const WithDisabledOption: Story = {
 		label: 'Label',
 		description: 'This is the description.',
 		defaultValue: disabledOptionItems[ 0 ],
+	},
+};
+
+const groupedItems = [
+	{
+		label: 'Common',
+		items: [
+			{ value: 'apple', label: 'Apple' },
+			{ value: 'banana', label: 'Banana' },
+			{ value: 'orange', label: 'Orange' },
+		],
+	},
+	{
+		label: 'Berries',
+		items: [
+			{ value: 'strawberry', label: 'Strawberry' },
+			{ value: 'blueberry', label: 'Blueberry' },
+			{ value: 'raspberry', label: 'Raspberry' },
+		],
+	},
+	{
+		label: 'Tropical',
+		items: [
+			{ value: 'mango', label: 'Mango' },
+			{ value: 'pineapple', label: 'Pineapple' },
+			{ value: 'papaya', label: 'Papaya' },
+		],
+	},
+];
+
+/**
+ * Options can be organized into labeled groups with `SelectControl.Group`
+ * and `SelectControl.GroupLabel`. Pass a flat `items` array for trigger label
+ * resolution, and use `children` to render the grouped popup content.
+ */
+export const Grouped: Story = {
+	args: {
+		label: 'Fruit',
+		description: 'Choose a fruit.',
+		items: groupedItems.flatMap( ( group ) => group.items ),
+		children: [
+			groupedItems.map( ( group ) => (
+				<SelectControl.Group key={ group.label }>
+					<SelectControl.GroupLabel>
+						{ group.label }
+					</SelectControl.GroupLabel>
+					{ group.items.map( ( item ) => (
+						<SelectControl.Item
+							key={ item.value }
+							value={ item }
+							label={ item.label }
+						>
+							{ item.label }
+						</SelectControl.Item>
+					) ) }
+				</SelectControl.Group>
+			) ),
+		],
 	},
 };
 


### PR DESCRIPTION
## What?

Adds `Group` and `GroupLabel` subcomponents to the Combobox and Select item-popup primitive families, and re-exports them from `SelectControl`.

## Why?

`Autocomplete` already supports labeled item groups. Combobox and Select share the same item-popup styling but were missing equivalent subcomponents, so grouped options could not be composed consistently across these families.

## How?

- Add `group.tsx` and `group-label.tsx` wrappers for Combobox and Select, following the existing Autocomplete implementation.
- Apply shared item-popup styles for group spacing and label typography.
- Re-export `SelectControl.Group` and `SelectControl.GroupLabel`.
- Add Storybook grouped examples and ref-forwarding unit tests.

## Testing Instructions

2. Start Storybook and open:
   - Design System / Components / Form / Primitives / Combobox → **Grouped**
   - Design System / Components / Form / Primitives / Select → **Grouped**
   - Design System / Components / Form / SelectControl → **Grouped**
3. Confirm group labels render with heading-sm styling and items remain selectable.

## Screenshots or screencast

<img width="272" height="347" alt="grouped combobox" src="https://github.com/user-attachments/assets/c13bbbb7-86ed-4ad1-a957-ce707f4820f9" />
<img width="282" height="306" alt=" grouped select" src="https://github.com/user-attachments/assets/9d15627d-0b65-4673-b27b-718168686084" />
