### PR TITLE
Notes: Register the inline note format at import time

### DIFF
--- a/packages/editor/src/components/collab-sidebar/format.js
+++ b/packages/editor/src/components/collab-sidebar/format.js
@@ -7,12 +7,11 @@ export const NOTE_FORMAT_NAME = 'core/note';
 
 /*
  * Anchoring-only format: it serializes an inline note's in-content marker as
- * `<mark class="wp-note" data-id="N">`, and deliberately has no `edit`. Notes
- * are added from the block options menu (or its keyboard shortcut), which
- * creates an inline note whenever a text selection is active. A format `edit`
- * would fill `RichText.ToolbarControls`, which the format toolbar renders
- * inside the "More" (inline styles) dropdown - the wrong home for an action
- * that is neither an inline style nor exclusive to text selections.
+ * `<mark class="wp-note" data-id="N">`. Notes are added from the block options
+ * menu instead, since an `edit` with UI would fill `RichText.ToolbarControls`,
+ * which the format toolbar renders inside the "More" (inline styles) dropdown -
+ * the wrong home for an action that is neither an inline style nor exclusive to
+ * text selections.
  */
 export const noteFormat = {
 	title: __( 'Note' ),
@@ -21,4 +20,5 @@ export const noteFormat = {
 	attributes: {
 		'data-id': 'data-id',
 	},
+	edit: () => null,
 };

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -3,14 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { comment as commentIcon } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -29,18 +28,10 @@ import { NoteHighlightStyles } from './note-highlight-styles';
 import { useGlobalStyles } from '../global-styles';
 import { useEnableFloatingSidebar, useNoteThreads } from './hooks';
 import { getNoteIdsFromMetadata, pickPrimaryNote } from './utils';
-import { NOTE_FORMAT_NAME, noteFormat } from './format';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
 
 function NotesSidebar( { postId } ) {
-	useEffect( () => {
-		registerFormatType( NOTE_FORMAT_NAME, noteFormat );
-		return () => {
-			unregisterFormatType( NOTE_FORMAT_NAME );
-		};
-	}, [] );
-
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const { toggleBlockSpotlight, selectBlock } = unlock(

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -8,3 +8,4 @@ import './pattern-overrides';
 import './navigation-link-view-button';
 import './template-part-navigation-edit-button';
 import './push-changes-to-global-styles';
+import './note-format';

--- a/packages/editor/src/hooks/note-format.js
+++ b/packages/editor/src/hooks/note-format.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { registerFormatType } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import {
+	NOTE_FORMAT_NAME,
+	noteFormat,
+} from '../components/collab-sidebar/format';
+
+/*
+ * Registered on import rather than from a component: HTML is converted to a
+ * rich text record eagerly, both when blocks are parsed and while a rich text
+ * field first renders. A format registered after that leaves already-parsed
+ * markers as `core/unknown` until their content changes.
+ */
+registerFormatType( NOTE_FORMAT_NAME, noteFormat );


### PR DESCRIPTION
## What?
PR fixes bug where inline note markers were displayed as `core/unknown` format.

Moves `core/note` registration out of the `NotesSidebar` mount effect into `editor/src/hooks/note-format.js`, which runs when `@wordpress/editor` is imported.

## Why?

HTML is eagerly converted to a rich text record when blocks are parsed, and again when a rich text field first renders. Both happen before `useEffect` runs, so on reload, the `<mark class="wp-note">` markers had no registered format type yet and fell through to `core/unknown`; selecting one showed "Clear Unknown Formatting". `useRichText` only re-parses when the value string changes, so they stayed unknown until the content was edited. The cleanup caused the same degradation on unmount, e.g., when switching to the code editor.

Core formats aren't affected because `@wordpress/format-library` registers them as an import side effect.

`hooks/` is used rather than the format module itself because `packages/editor/package.json` declares a `sideEffects` allowlist; `src/components/**` isn't in it, so bundlers could drop a bare side-effect import from there.

## Testing Instructions
1. Open a post or page.
2. Add an inline note to a paragraph and save.
3. Reload the editor.
4. Select the note marker.
5. The toolbar should no longer offer "Clear Unknown Formatting".

## Screenshots or screencast <!-- if applicable -->

<img width="675" height="424" alt="CleanShot 2026-07-22 at 19 22 46" src="https://github.com/user-attachments/assets/39d4f308-75d5-4c4d-b891-e99f6dfc176a" />


## Use of AI Tools

Assisted by Claude.
