### PR TITLE
Query Loop: Add translation context to the 'Offset' setting label

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
 
@@ -367,7 +367,10 @@ export default function QueryInspectorControls( props ) {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						label={ __( 'Offset' ) }
+						label={ _x(
+							'Offset',
+							'Number of posts to skip in a query'
+						) }
 						hasValue={ () => offset > 0 }
 						onDeselect={ () => setQuery( { offset: 0 } ) }
 					>

--- a/packages/block-library/src/query/edit/inspector-controls/offset-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/offset-controls.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 const MIN_OFFSET = 0;
 const MAX_OFFSET = 100;
@@ -10,7 +10,7 @@ const MAX_OFFSET = 100;
 export const OffsetControl = ( { offset = 0, onChange } ) => {
 	return (
 		<NumberControl
-			label={ __( 'Offset' ) }
+			label={ _x( 'Offset', 'Number of posts to skip in a query' ) }
 			value={ offset }
 			min={ MIN_OFFSET }
 			onChange={ ( newOffset ) => {


### PR DESCRIPTION
## What?

Fixes #33715.

- Adds translation context to the Query Loop "Offset" setting label: `__( 'Offset' )` becomes `_x( 'Offset', 'Number of posts to skip in a query' )` (both occurrences in the block's inspector controls).

## Why?

"Offset" has two unrelated meanings in the editor UI: the **Offset block pattern**, where it names a staggered layout, and the **Query Loop setting**, where it means the number of posts to skip. The pattern name already carries the `Block pattern title` translation context (added in #33734), but the Query Loop label had none, so both meanings shared a single translation entry. Some locales need different translations — in zh_TW the pattern is "位移" while the query setting should read like "需要略過的文章數量". With the context added, translators get a separate entry for the Query Loop meaning.

## Testing

- Insert a Query Loop block and disable "Inherit query from template".
- Verify the "Offset" control in the Display panel renders and works as before (no change in English).

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
