### PR TITLE
Pullquote: Inherit custom line height in the editor

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -15,3 +15,9 @@
 .wp-block-pullquote__citation {
 	color: inherit;
 }
+
+// Ensure custom line-height values applied to the block are inherited by the
+// paragraph instead of being overridden by the default editor styles.
+.wp-block-pullquote[style*="line-height"] :where(p) {
+	line-height: inherit;
+}


### PR DESCRIPTION
## What?

Closes #49261.

Ensures that the Pullquote block's paragraph inherits an explicitly selected line height from the block wrapper in the editor.

## Why?

In a classic theme without `theme.json`, or when **Use theme styles** is disabled, Gutenberg loads its default editor styles. Those styles apply `line-height: 1.8` directly to every `p` element.

The Pullquote typography support applies the selected line height to the outer `figure.wp-block-pullquote`. Because its inner paragraph already has a directly applied line height, it does not inherit the value selected for the block. This makes the editor differ from the saved content.

## How?

Adds an editor-only rule for Pullquote blocks with an inline `line-height` declaration:

```css
.wp-block-pullquote[style*="line-height"] :where(p) {
	line-height: inherit;
}
```

The conditional selector avoids changing Pullquotes without a custom line height. Keeping the rule in `editor.scss` means it does not change saved markup or front-end styles, and `:where(p)` keeps the child selector's specificity low.

## Testing Instructions

1. Build and start Gutenberg:

   ```sh
   npm run build
   npm run wp-env start
   ```

2. Create and activate a minimal classic theme without a `theme.json` file.

   `style.css`:

   ```css
   /*
   Theme Name: Pullquote Classic Test
   */
   ```

   `functions.php`:

   ```php
   <?php
   function pullquote_classic_test_setup() {
   	add_theme_support( 'custom-line-height' );
   }
   add_action( 'after_setup_theme', 'pullquote_classic_test_setup' );
   ```

   `index.php`:

   ```php
   <?php
   wp_head();
   the_content();
   wp_footer();
   ```

3. Ensure the Gutenberg plugin is active.
4. Open the post editor and disable **Use theme styles** under **Options → Preferences → Appearance**.
5. Switch to the code editor and paste:

   ```html
   <!-- wp:pullquote {"style":{"typography":{"fontSize":"24px","fontStyle":"normal","fontWeight":"700","letterSpacing":"5px","textDecoration":"line-through","textTransform":"uppercase","lineHeight":"4"}},"backgroundColor":"cyan-bluish-gray"} -->
   <figure class="wp-block-pullquote has-cyan-bluish-gray-background-color has-background" style="font-size:24px;font-style:normal;font-weight:700;letter-spacing:5px;line-height:4;text-decoration:line-through;text-transform:uppercase"><blockquote><p>Hello World! Hello World! Hello World!<br>Hello World!<br>Hello World! Hello World!</p><cite>Citation. Citation. Citation.</cite></blockquote></figure>
   <!-- /wp:pullquote -->
   ```

6. Return to the visual editor.
7. Confirm that the spacing between the Pullquote paragraph lines reflects the selected line height of `4`.
8. In browser developer tools, confirm that both the outer Pullquote and its paragraph have the same computed line height. With the markup above, both should compute to `96px`.

On `trunk`, the wrapper computes to `96px`, while the paragraph remains at `43.2px` because of the default `1.8` paragraph line height.

### Testing Instructions for Keyboard

1. Use the keyboard to open **Options**, select **Code editor**, and paste the test markup.
2. Use the keyboard to return to the visual editor.
3. Navigate to the Pullquote and confirm its content remains editable.

This change only affects CSS inheritance and does not introduce or change any interactive behavior.

## Screenshots or screencast

The screenshots were captured in an isolated `wp-env` on port `8892` using the classic test theme and the production-built default editor and Pullquote styles. The displayed values are the browser's computed line heights.

| Before | After |
| --- | --- |
| ![Before: wrapper 96px and paragraph 43.2px](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/d65c5ac3ec6acaa3c71bddf296cbb305586f3f70/screenshots/issue-49261/pullquote-line-height-before.jpg) | ![After: wrapper and paragraph both 96px](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/d65c5ac3ec6acaa3c71bddf296cbb305586f3f70/screenshots/issue-49261/pullquote-line-height-after.jpg) |

### Checks performed

- `npm run build`
- `npm run format -- packages/block-library/src/pullquote/editor.scss`
- `npm run lint:css -- packages/block-library/src/pullquote/editor.scss`
- Visual verification in the isolated `wp-env`: wrapper `96px`, paragraph `96px`

## Use of AI Tools

OpenAI Codex was used to investigate the issue, implement the CSS change, run the automated and visual checks, capture the screenshots, and draft this pull request description.