### PR TITLE
Fix: Pullquote custom line height in the editor.

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -15,3 +15,9 @@
 .wp-block-pullquote__citation {
 	color: inherit;
 }
+
+// Ensure custom line-height values applied to the block are inherited by the
+// paragraph instead of being overridden by the default editor styles.
+.wp-block-pullquote[style*="line-height"] :where(p) {
+	line-height: inherit;
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49261

In classic themes without `theme.json`, or when theme styles are disabled, the default editor styles set `line-height: 1.8` directly on the Pullquote paragraph. This overrides the custom line height applied to the block wrapper.

This PR makes the paragraph inherit an explicitly set line height from the Pullquote wrapper. The change is editor-only and does not affect saved markup or front-end styles.

## Testing Instructions

1. Activate a classic theme without `theme.json` that supports custom line height.
2. Disable **Use theme styles** in the editor preferences.
3. Add a Pullquote with multiple lines and set its line height to `4`.
4. Verify the paragraph uses the selected line height. On trunk, it remains at `1.8`.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: wrapper 96px and paragraph 43.2px](https://raw.githubusercontent.com/WordPress/gutenberg/d65c5ac3ec6acaa3c71bddf296cbb305586f3f70/screenshots/issue-49261/pullquote-line-height-before.jpg) | ![After: wrapper and paragraph both 96px](https://raw.githubusercontent.com/WordPress/gutenberg/d65c5ac3ec6acaa3c71bddf296cbb305586f3f70/screenshots/issue-49261/pullquote-line-height-after.jpg) |

## Use of AI Tools

OpenAI Codex was used to investigate, implement, test, and document this fix.