### PR TITLE
Base styles: Allow overriding focus ring color in outset-ring__focus

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -32,7 +32,7 @@
 ### Breaking Changes
 
 -   Remove the following entries from the `z-index()` helper ([#77773](https://github.com/WordPress/gutenberg/pull/77773)):
-    -   `.nux-dot-tip`
+   -   `.nux-dot-tip`
 
 ## 9.0.0 (2026-05-27)
 

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `outset-ring__focus`: Allow overriding the focus ring color via the `--focus-color` custom property.
+-   `outset-ring__focus`: Allow overriding the focus ring color via the `--focus-color` custom property ([#80587](https://github.com/WordPress/gutenberg/pull/80587)).
 
 ### Internal
 
@@ -32,7 +32,7 @@
 ### Breaking Changes
 
 -   Remove the following entries from the `z-index()` helper ([#77773](https://github.com/WordPress/gutenberg/pull/77773)):
-   -   `.nux-dot-tip`
+    -   `.nux-dot-tip`
 
 ## 9.0.0 (2026-05-27)
 

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `outset-ring__focus`: Allow overriding the focus ring color via the `--focus-color` custom property.
+
 ### Internal
 
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -189,7 +189,9 @@
  */
 
 @mixin outset-ring__focus() {
-	outline: wpds.var("--wpds-border-width-focus") solid wpds.var("--wpds-color-stroke-focus");
+	--focus-color: #{ wpds.var("--wpds-color-stroke-focus") };
+
+	outline: wpds.var("--wpds-border-width-focus") solid var(--focus-color);
 	outline-offset: wpds.var("--wpds-border-width-focus");
 }
 


### PR DESCRIPTION
Extracted from #80417

## What?

Updates `outset-ring__focus` to expose the focus ring color through a `--focus-color` custom property, defaulting to `--wpds-color-stroke-focus`.

## Why?

Several legacy form controls need to align their focus rings with the design system, and some validated controls need to override the ring color. Moving the color into a custom property lets consumers override it without redefining the whole mixin.

For consumers, this is safer than overriding with `outline-color`, and also avoids specificity issues.

## How?

- Set `--focus-color` inside `outset-ring__focus`, defaulting to the WPDS focus stroke token.
- Use `var(--focus-color)` for the outline color.

## Testing Instructions

No user-facing behavior changes unless a consumer sets `--focus-color`.