### PR TITLE
Docs: Expand back-merging guide and add companion Claude Code skill

### DIFF
--- a/.claude/skills/gutenberg-backport-pr/SKILL.md
+++ b/.claude/skills/gutenberg-backport-pr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: gutenberg-backport-pr
+description: This skill should be used when the user asks to "create a backport PR", "backport to wordpress-develop", "backport to WP core", "backport this Gutenberg PR", or "add a backport-changelog entry". Handles the workflow of mirroring PHP changes from a Gutenberg PR into WordPress/wordpress-develop.
+---
+
+# Gutenberg → WordPress Core backport PR
+
+Mirror the PHP changes from a merged Gutenberg PR into a `WordPress/wordpress-develop` pull request, then add the matching `backport-changelog` entry to the Gutenberg PR.
+
+## Reference
+
+The full procedure lives at [`docs/contributors/code/back-merging-to-wp-core.md`](../../../docs/contributors/code/back-merging-to-wp-core.md). Read it before starting. It covers:
+
+- Which files require backporting and which are excluded
+- Path mapping rules (direct-sync, compat shims, class renames, aggregators, tests)
+- Trac ticket requirements
+- wordpress-develop PR conventions
+- How to add the `backport-changelog` entry
+
+The changelog file format is documented at [`backport-changelog/readme.md`](../../../backport-changelog/readme.md).
+
+## Before starting
+
+Check the Gutenberg PR labels first. If any of these are set, no back-merge is needed and the workflow can stop:
+
+- `Backport from WordPress Core`
+- `Backported to WordPress Core`
+- `No Core Sync Required`
+
+Then confirm with the user:
+
+- The target WordPress version (sets the `backport-changelog/<version>/` directory)
+- The Trac ticket number (reuse an existing one where possible)
+
+## Approach
+
+Either work from a local clone of `wordpress-develop`, or use the `gh` CLI to prepare the branch and PR on a fork via the GitHub API. The local-clone path is simpler when the checkout already exists; the API path avoids any local setup.
+
+For files that map mechanically (direct-sync, test filename stripping), copy the content across. For compat shims and aggregator files, apply the diff to the existing WP Core file rather than copying the shim wholesale.
+
+Run PHPCS on the proposed files before pushing (`vendor/bin/phpcs <file>`; `vendor/bin/phpcbf` for auto-fixable issues). wordpress-develop CI will otherwise fail the PR.
+
+Open the wordpress-develop PR as a draft until the Trac ticket is filled in and the diff has been reviewed.
+
+## After the wordpress-develop PR is open
+
+Commit the `backport-changelog/<wp-version>/<wp-develop-pr-number>.md` file to the Gutenberg PR's branch. This unblocks the "Verify Core Backport Changelog" CI check.

--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -32,6 +32,69 @@ There are however certain exceptions to that rule. PRs with the following criter
 -   Does not contain changes to PHP code.
 -   Has label `Backport from WordPress Core` - this code is already in WP Core and is being synchronized back to Gutenberg.
 -   Has label `Backported to WordPress Core` - this code has already been synchronized to WP Core.
+-   Has label `No Core Sync Required` - the changes do not need to be synced to WP Core.
+
+## How to back-merge a PR
+
+The back-merge itself is a pull request against [`WordPress/wordpress-develop`](https://github.com/WordPress/wordpress-develop) that mirrors the PHP changes from the Gutenberg PR. This can be prepared from a local checkout, or by using the GitHub API from your own fork of `wordpress-develop`.
+
+### 1. Identify the files to back-merge
+
+Fetch the changed files from the Gutenberg PR and filter for the paths listed under [Criteria](#criteria) above. Skip anything that matches the ignored files/directories.
+
+### 2. Map each Gutenberg path to a WP Core path
+
+Most files fall into one of these patterns:
+
+**Direct-sync files** — kept byte-for-byte identical to their WP Core counterparts. Copy the file across.
+
+|  Gutenberg | wordpress-develop |
+| --- | --- |
+| `lib/<subpath>/*.php` | `src/wp-includes/<subpath>/*.php` |
+
+For example, `lib/block-supports/layout.php` maps to `src/wp-includes/block-supports/layout.php`.
+
+**Compat shim files** — files under `lib/compat/wordpress-X.Y/` are addition-only shims wrapped in `if ( ! function_exists() )` guards. Do not copy the whole file. Instead, apply just the additions to the equivalent WP Core file with the versioned prefix stripped:
+
+|  Gutenberg | wordpress-develop |
+| --- | --- |
+| `lib/compat/wordpress-X.Y/<filename>` | `src/wp-includes/<filename>` |
+
+The destination sometimes lives in a subdirectory that isn't reflected in the Gutenberg path (for example, `lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php` lands in `src/wp-includes/collaboration/`). Search WP Core for the file or class name to locate it.
+
+**Class files with `-gutenberg` in the name** — strip the Gutenberg-specific naming when translating:
+
+|  Gutenberg | wordpress-develop |
+| --- | --- |
+| `lib/class-wp-<name>-gutenberg.php` | `src/wp-includes/class-wp-<name>.php` |
+| `lib/media/class-gutenberg-rest-<name>.php` | `src/wp-includes/rest-api/endpoints/class-wp-rest-<name>.php` |
+
+**Aggregator files** — files like `lib/media/load.php` have no direct WP Core counterpart. Each change fans out to the appropriate WP Core file (a filter added on `admin_init` may land in `src/wp-includes/default-filters.php`, a function body change in `src/wp-includes/media.php`, and so on). Read the diff and apply each piece where it belongs.
+
+**PHP unit tests**:
+
+|  Gutenberg | wordpress-develop |
+| --- | --- |
+| `phpunit/<subpath>/<name>-test.php` | `tests/phpunit/tests/<subpath>/<name>.php` |
+
+Strip the `-test` suffix. Class-based test files (`class-wp-<name>-test.php`) may land in a different subdirectory than their Gutenberg location; search WP Core by class name.
+
+### 3. Create a Trac ticket
+
+Every WP Core PR must reference a [Trac ticket](https://core.trac.wordpress.org/). Reuse an existing ticket if one applies, or create one before opening the PR.
+
+### 4. Open the wordpress-develop PR
+
+Push the changes to a branch on your fork of `wordpress-develop` and open a pull request against `trunk`. A common naming convention is:
+
+-   Branch: `backport/<gutenberg-pr-number>-<short-description>`
+-   Title: `<Component>: <Description> (backport GB #<gutenberg-pr-number>)`
+
+The PR body should reference the Gutenberg PR and the Trac ticket. See existing examples such as [WordPress/wordpress-develop#12324](https://github.com/WordPress/wordpress-develop/pull/12324) or [WordPress/wordpress-develop#12516](https://github.com/WordPress/wordpress-develop/pull/12516).
+
+### 5. Add a backport-changelog entry
+
+After the wordpress-develop PR is open, add a corresponding markdown file to the Gutenberg PR at `backport-changelog/<wp-version>/<wp-develop-pr-number>.md`. See [backport-changelog/readme.md](https://github.com/WordPress/gutenberg/blob/trunk/backport-changelog/readme.md) for the exact format. The CI check on the Gutenberg PR will fail until this file exists (or a skip label is applied).
 
 ## Further Reading
 


### PR DESCRIPTION
## What?

Enrich the existing [back-merging to WP Core](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/back-merging-to-wp-core.md) doc with the step-by-step procedure that experienced contributors have accumulated but that hasn't been written down anywhere. Also adds a lightweight `.claude/skills/gutenberg-backport-pr/SKILL.md` pointer so that contributors using Claude Code get auto-discovered guidance that delegates to the same doc.

## Why?

Today the doc explains *when* a PHP change needs a Core back-merge but not *how* to do it. Newer contributors have to reverse-engineer path mappings, PR conventions, and the backport-changelog step from prior PRs. This PR captures the procedure in one place.

Two goals:
- Make the doc actually procedural, not just criteria-based.
- Establish a `.claude/skills/` pattern for the repo, but keep all durable content in `docs/` so any AI tool (or human) can use it. The SKILL.md is a thin pointer with just the trigger metadata and a "read that doc" instruction.

## How?

**`docs/contributors/code/back-merging-to-wp-core.md`** now includes:
- Adds `No Core Sync Required` to the skip-label list (previously missing).
- A new "How to back-merge a PR" section with numbered steps: identify files, map paths, create the Trac ticket, open the wordpress-develop PR, add the backport-changelog entry.
- Path-mapping tables covering the five patterns that come up in practice: direct-sync, compat shims (`lib/compat/wordpress-X.Y/`), class files with `-gutenberg` in the name, aggregator files (`lib/media/load.php`), and PHP unit tests.
- References to real example backport PRs so contributors can cross-check.

**`.claude/skills/gutenberg-backport-pr/SKILL.md`** is a ~50-line file with:
- Frontmatter listing the trigger phrases (\"create a backport PR\", \"backport to wordpress-develop\", etc.).
- A pointer to the doc as the source of truth.
- A short pre-flight checklist (check skip labels, confirm target WP version, confirm Trac ticket).

The `.claude/` directory is new to the repo. If maintainers would rather this pattern lived elsewhere (or not at all), the skill file can be dropped without affecting the doc improvements.

## Testing Instructions

1. Read [the updated doc](../blob/add/gutenberg-backport-skill/docs/contributors/code/back-merging-to-wp-core.md) end-to-end and confirm the path mappings match your understanding of how existing backports have been done.
2. Cross-reference the linked example PRs ([#12324](https://github.com/WordPress/wordpress-develop/pull/12324), [#12516](https://github.com/WordPress/wordpress-develop/pull/12516)) against the doc's path-mapping tables.
3. If you use Claude Code with this repo checked out, ask something like \"create a backport PR for Gutenberg #12345\" and confirm the skill loads and delegates to the doc.

## Use of AI Tools

This PR was drafted with Claude Code (Anthropic's Sonnet 4.6). Every line was reviewed by @scruffian; the doc content is derived from real backport PRs and the existing [make.wordpress.org syncing guidelines](https://make.wordpress.org/core/2026/06/30/guidelines-for-syncing-code-from-gutenberg-into-wordpress-develop/) as well as the existing back-merging doc. Per the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/), the human author takes responsibility for the content.