### PR TITLE
Add a Claude Code skill for back-merging PRs to WP Core

### DIFF
--- a/.claude/skills/gutenberg-backport-pr/SKILL.md
+++ b/.claude/skills/gutenberg-backport-pr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: gutenberg-backport-pr
+description: This skill should be used when the user asks to "create a backport PR", "backport to wordpress-develop", "backport to WP core", "backport this Gutenberg PR", or "add a backport-changelog entry". Handles the workflow of mirroring PHP changes from a Gutenberg PR into WordPress/wordpress-develop.
+---
+
+# Gutenberg → WordPress Core backport PR
+
+Mirror the PHP changes from a merged Gutenberg PR into a `WordPress/wordpress-develop` pull request, then add the matching `backport-changelog` entry to the Gutenberg PR.
+
+## Reference
+
+The full procedure lives at [`docs/contributors/code/back-merging-to-wp-core.md`](../../../docs/contributors/code/back-merging-to-wp-core.md). Read it before starting. It covers:
+
+- Which files require backporting and which are excluded
+- Path mapping rules (direct-sync, compat shims, class renames, aggregators, tests)
+- Trac ticket requirements
+- wordpress-develop PR conventions
+- How to add the `backport-changelog` entry
+
+The changelog file format is documented at [`backport-changelog/readme.md`](../../../backport-changelog/readme.md).
+
+## Before starting
+
+Check the Gutenberg PR labels first. If any of these are set, no back-merge is needed and the workflow can stop:
+
+- `Backport from WordPress Core`
+- `Backported to WordPress Core`
+- `No Core Sync Required`
+
+Then confirm with the user:
+
+- The target WordPress version (sets the `backport-changelog/<version>/` directory)
+- The Trac ticket number (reuse an existing one where possible)
+
+## Approach
+
+Either work from a local clone of `wordpress-develop`, or use the `gh` CLI to prepare the branch and PR on a fork via the GitHub API. The local-clone path is simpler when the checkout already exists; the API path avoids any local setup.
+
+For files that map mechanically (direct-sync, test filename stripping), copy the content across. For compat shims and aggregator files, apply the diff to the existing WP Core file rather than copying the shim wholesale.
+
+Run PHPCS on the proposed files before pushing (`vendor/bin/phpcs <file>`; `vendor/bin/phpcbf` for auto-fixable issues). wordpress-develop CI will otherwise fail the PR.
+
+Open the wordpress-develop PR as a draft until the Trac ticket is filled in and the diff has been reviewed.
+
+## After the wordpress-develop PR is open
+
+Commit the `backport-changelog/<wp-version>/<wp-develop-pr-number>.md` file to the Gutenberg PR's branch. This unblocks the "Verify Core Backport Changelog" CI check.


### PR DESCRIPTION
## What?

Add a lightweight `.claude/skills/gutenberg-backport-pr/SKILL.md` file that gives Claude Code contributors auto-discovered guidance for back-merging PRs to `wordpress-develop`. All durable content stays in [`docs/contributors/code/back-merging-to-wp-core.md`](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/back-merging-to-wp-core.md); this file is a thin pointer.

Depends on #80590 (the doc it delegates to). Fine to review in either order, but the skill won't be genuinely useful until the doc PR lands.

## Why?

Contributors using [Claude Code](https://claude.com/claude-code) can invoke skills by name or trigger phrase. Placing a small skill file at the conventional `.claude/skills/<name>/SKILL.md` path lets Claude Code discover it automatically when a contributor asks about backporting a PR, without embedding any Claude-specific procedural content in the wider docs.

Two design choices worth flagging:

- **`.claude/skills/` is a new pattern for this repo.** If maintainers would rather this pattern lived elsewhere, or not at all, the file can be dropped without affecting the doc improvements in #80590.
- **The SKILL.md is deliberately thin.** It contains only the trigger metadata, a pointer to the doc, and a short pre-flight checklist (check for skip labels, confirm target WP version, confirm Trac ticket). Anyone reading the file directly is told to read the doc for the actual procedure. This keeps the doc as the single source of truth so any AI tool or human reads the same thing.

## How?

Adds one file, ~50 lines:

- Frontmatter with trigger phrases (\"create a backport PR\", \"backport to wordpress-develop\", etc.)
- A pointer to `docs/contributors/code/back-merging-to-wp-core.md` (and to `backport-changelog/readme.md`)
- A pre-flight checklist so the model checks skip labels and confirms the target WP version + Trac ticket before doing anything

## Testing Instructions

1. Check out this branch alongside the branch from #80590.
2. Open the repo in [Claude Code](https://claude.com/claude-code).
3. Ask something like \"create a backport PR for Gutenberg #12345\" and confirm the skill loads, delegates to the doc, and asks the pre-flight questions.

## Use of AI Tools

This PR was drafted with Claude Code (Anthropic's Sonnet 4.6). Per the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/), the human author takes responsibility for the content.