### PR TITLE
Block Tools: Fix empty block appender position inside blocks that capture toolbars

### DIFF
--- a/packages/block-editor/src/components/block-tools/empty-block-inserter.js
+++ b/packages/block-editor/src/components/block-tools/empty-block-inserter.js
@@ -15,12 +15,8 @@ export default function EmptyBlockInserter( {
 	clientId,
 	__unstableContentRef,
 } ) {
-	const {
-		capturingClientId,
-		isInsertionPointVisible,
-		lastClientId,
-		rootClientId,
-	} = useSelectedBlockToolProps( clientId );
+	const { isInsertionPointVisible, lastClientId, rootClientId } =
+		useSelectedBlockToolProps( clientId );
 
 	const popoverProps = useBlockToolbarPopoverProps( {
 		contentElement: __unstableContentRef?.current,
@@ -29,7 +25,7 @@ export default function EmptyBlockInserter( {
 
 	return (
 		<BlockPopoverCover
-			clientId={ capturingClientId || clientId }
+			clientId={ clientId }
 			bottomClientId={ lastClientId }
 			className={ clsx(
 				'block-editor-block-list__block-side-inserter-popover',


### PR DESCRIPTION
## What?

Fixes #63517.

- Anchors the empty block "+" appender (side inserter) to the selected empty block itself, instead of the topmost ancestor that sets `__experimentalCaptureToolbars` (Quote, Details, Tabs).

## Why?

`EmptyBlockInserter` reused the block toolbar's anchoring logic. Positioning over the capturing ancestor is intended for the toolbar, but it also applied to the side inserter popover, so the "+" rendered at the ancestor's top-right corner instead of next to the empty paragraph being edited. This is especially visible in themes where these blocks have inner padding (e.g. Twenty Twenty-Four).

## Testing

- Activate Twenty Twenty-Four.
- Insert a Quote, Details, or Tabs block and select the empty paragraph inside it.
- The "+" appender should be vertically aligned with the paragraph placeholder, just like for a top-level empty paragraph (whose position is unchanged by this PR).

| Block | Before | After |
| --- | --- | --- |
| Quote | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/quote-before.png" width="380"> | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/quote-after.png" width="380"> |
| Details | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/details-before.png" width="380"> | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/details-after.png" width="380"> |
| Tabs | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/tabs-before.png" width="380"> | <img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/63517-empty-block-inserter/tabs-after.png" width="380"> |

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
