### PR TITLE
DependencyExtractionWebpackPlugin: Include extracted styles in the asset version hash

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Include extracted styles (e.g. the `style.css` cache group output) in the version hash of the entry point's asset file, so that style-only changes produce a new version ([#80601](https://github.com/WordPress/gutenberg/pull/80601)).
+
 ## 6.51.0 (2026-07-14)
 
 ### Bug Fixes

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -62,7 +62,7 @@ const webpackConfig = {
 
 ### Behavior with scripts
 
-Each entry point in the webpack bundle will include an asset file that declares the WordPress script dependencies that should be enqueued. This file also contains the unique version hash calculated based on the file content.
+Each entry point in the webpack bundle will include an asset file that declares the WordPress script dependencies that should be enqueued. This file also contains the unique version hash calculated based on the content of the entry point's files, including any extracted styles.
 
 For example:
 
@@ -129,7 +129,7 @@ const webpackConfig = {
 };
 ```
 
-Each entry point in the webpack bundle will include an asset file that declares the WordPress script module dependencies that should be enqueued. This file also contains the unique version hash calculated based on the file content.
+Each entry point in the webpack bundle will include an asset file that declares the WordPress script module dependencies that should be enqueued. This file also contains the unique version hash calculated based on the content of the entry point's files, including any extracted styles.
 
 For example:
 

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -263,19 +263,47 @@ class DependencyExtractionWebpackPlugin {
 
 		const combinedAssetsData = {};
 
+		const jsExtensionRegExp = this.useModules ? /\.m?js$/i : /\.js$/i;
+
 		// Accumulate all entrypoint chunks, some of them shared
 		const entrypointChunks = new Set();
+
+		/**
+		 * Track the files of each entrypoint's JS-less chunks, typically styles
+		 * extracted by a `style.css` cache group. Those chunks don't get an
+		 * asset file of their own, but their content must contribute to the
+		 * version hash of the entrypoint's entry chunk so that style-only
+		 * changes still produce a new version.
+		 *
+		 * @type {Map<webpack.Chunk, Set<string>>}
+		 */
+		const styleFilesByEntryChunk = new Map();
 		for ( const entrypoint of compilation.entrypoints.values() ) {
+			const entryChunk = entrypoint.getEntrypointChunk();
 			for ( const chunk of entrypoint.chunks ) {
 				entrypointChunks.add( chunk );
+
+				if (
+					chunk === entryChunk ||
+					Array.from( chunk.files ).some( ( f ) =>
+						jsExtensionRegExp.test( f )
+					)
+				) {
+					continue;
+				}
+
+				const styleFiles =
+					styleFilesByEntryChunk.get( entryChunk ) ?? new Set();
+				for ( const file of chunk.files ) {
+					styleFiles.add( file );
+				}
+				styleFilesByEntryChunk.set( entryChunk, styleFiles );
 			}
 		}
 
 		// Process each entrypoint chunk independently
 		for ( const chunk of entrypointChunks ) {
 			const chunkFiles = Array.from( chunk.files );
-
-			const jsExtensionRegExp = this.useModules ? /\.m?js$/i : /\.js$/i;
 
 			const chunkJSFile = chunkFiles.find( ( f ) =>
 				jsExtensionRegExp.test( f )
@@ -402,9 +430,19 @@ class DependencyExtractionWebpackPlugin {
 				}
 			};
 
+			// Include the files of the entrypoint's JS-less sibling chunks,
+			// typically extracted styles, in the version hash so that
+			// style-only changes still produce a new version.
+			const filesToHash = [
+				...new Set( [
+					...chunkFiles,
+					...( styleFilesByEntryChunk.get( chunk ) ?? [] ),
+				] ),
+			];
+
 			// Go through the assets to process the sources.
 			// This allows us to generate hashes, as well as look for magic comments.
-			chunkFiles.sort().forEach( ( filename ) => {
+			filesToHash.sort().forEach( ( filename ) => {
 				const asset = compilation.getAsset( filename );
 				const content = asset.source.buffer();
 

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -309,6 +309,21 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '05ab538fc7abc794bf3a', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\` should produce expected output: External modules should match snapshot 1`] = `
+[
+  {
+    "externalType": "import",
+    "request": "@wordpress/blob",
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '92ea15aace211d977373', 'type' => 'module');
 "
@@ -735,6 +750,24 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-singl
     "request": "lodash",
     "userRequest": "lodash",
   },
+  {
+    "externalType": "window",
+    "request": [
+      "wp",
+      "blob",
+    ],
+    "userRequest": "@wordpress/blob",
+  },
+]
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'fe584d4d3343f27d9d98');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\` should produce expected output: External modules should match snapshot 1`] = `
+[
   {
     "externalType": "window",
     "request": [

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -2,9 +2,9 @@
  * External dependencies
  */
 const fs = require( 'fs' );
+const path = require( 'path' );
 const glob = require( 'glob' ).sync;
 const mkdirp = require( 'mkdirp' ).mkdirp.sync;
-const path = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 
@@ -130,6 +130,113 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 					'External modules should match snapshot'
 				);
 			} );
+		} );
+	}
+);
+
+describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
+	'DependencyExtractionWebpackPlugin %s asset version',
+	( moduleMode ) => {
+		const fixtureDirectory = path.join( fixturesPath, 'style-cache-group' );
+		const workingDirectory = path.join(
+			__dirname,
+			'build',
+			moduleMode,
+			'style-cache-group-version'
+		);
+		const sourceDirectory = path.join( workingDirectory, 'src' );
+
+		beforeEach( () => {
+			rimraf( workingDirectory );
+			mkdirp( sourceDirectory );
+			for ( const file of [ 'index.js', 'style.css' ] ) {
+				fs.copyFileSync(
+					path.join( fixtureDirectory, file ),
+					path.join( sourceDirectory, file )
+				);
+			}
+		} );
+
+		afterEach( () => rimraf( workingDirectory ) );
+
+		const build = async ( outputDirectory ) => {
+			const options = Object.assign(
+				{
+					name: `style-cache-group-version-${ moduleMode }`,
+					target: 'web',
+					context: sourceDirectory,
+					entry: './index.js',
+					mode: 'production',
+					optimization: {
+						minimize: false,
+						chunkIds: 'named',
+						moduleIds: 'named',
+					},
+					output: {},
+					experiments: {},
+				},
+				require( path.join( fixtureDirectory, 'webpack.config.js' ) )
+			);
+			options.output.path = outputDirectory;
+
+			if ( moduleMode === 'modules' ) {
+				options.target = 'es2024';
+				options.output.module = true;
+				options.output.chunkFormat = 'module';
+				options.output.library = options.output.library || {};
+				options.output.library.type = 'module';
+				options.experiments.outputModule = true;
+			}
+
+			/** @type {webpack.Stats} */
+			const stats = await new Promise( ( resolve, reject ) =>
+				webpack( options, ( err, _stats ) => {
+					if ( err ) {
+						return reject( err );
+					}
+					resolve( _stats );
+				} )
+			);
+
+			if ( stats.hasErrors() ) {
+				throw new Error(
+					stats.toString( { errors: true, all: false } )
+				);
+			}
+
+			const assetFile = path.join( outputDirectory, 'main.asset.php' );
+			const content = fs.readFileSync( assetFile, 'utf-8' );
+			const version = content.match( /'version' => '(\w+)'/ )[ 1 ];
+
+			return { content, version };
+		};
+
+		test( 'changes when only imported styles change', async () => {
+			const assetA = await build(
+				path.join( workingDirectory, 'build-a' )
+			);
+			const assetB = await build(
+				path.join( workingDirectory, 'build-b' )
+			);
+
+			// A rebuild without changes produces the same version.
+			expect( assetB.content ).toBe( assetA.content );
+
+			fs.writeFileSync(
+				path.join( sourceDirectory, 'style.css' ),
+				'body {\n\tcolor: #000;\n}\n'
+			);
+
+			const assetC = await build(
+				path.join( workingDirectory, 'build-c' )
+			);
+
+			// A style-only change produces a new version…
+			expect( assetC.version ).not.toBe( assetA.version );
+			// …and changes nothing else in the asset file.
+			expect( assetC.content.replace( assetC.version, '' ) ).toBe(
+				assetA.content.replace( assetA.version, '' )
+			);
 		} );
 	}
 );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/index.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import './style.css';
+
+isBlobURL( '' );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/style.css
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/style.css
@@ -1,0 +1,3 @@
+body {
+	color: #fff;
+}

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/webpack.config.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
+
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	optimization: {
+		minimize: false,
+		chunkIds: 'named',
+		moduleIds: 'named',
+		splitChunks: {
+			cacheGroups: {
+				style: {
+					type: 'css/mini-extract',
+					test: /[\\/]style\.css$/,
+					chunks: 'all',
+					enforce: true,
+					name( _, chunks, cacheGroupKey ) {
+						return `${ cacheGroupKey }-${ chunks[ 0 ].name }`;
+					},
+				},
+				default: false,
+			},
+		},
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: MiniCSSExtractPlugin.loader,
+					},
+					{
+						loader: require.resolve( 'css-loader' ),
+					},
+				],
+			},
+		],
+	},
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				return request.startsWith( '@wordpress/' );
+			},
+		} ),
+		new MiniCSSExtractPlugin(),
+	],
+};


### PR DESCRIPTION
## What?

Fixes #72571.
Fixes #69895.

-   Include the files of an entry point's JS-less sibling chunks — typically styles extracted by the `style.css` cache group of `@wordpress/scripts` — in the `version` hash written to the entry's `*.asset.php`.
-   Add a `style-cache-group` test fixture and tests asserting that a style-only change produces a new version, that an unchanged rebuild keeps an identical version, and that nothing else in the asset file changes.
-   Update the README wording about how the version hash is computed.

## Why?

`addAssets()` only hashes the files of chunks that contain a JS file; chunks holding only extracted styles (e.g. `style-index.css` produced by the `style.css` cache group) are skipped entirely. A style-only change therefore leaves `version` unchanged, so consumers that use it for cache busting (`wp_enqueue_style( …, $asset['version'] )`) keep serving stale CSS.

The `dependencies` array is not affected — style files only contribute to the hash.

## Testing Instructions

### Automated

```bash
npm run test:unit packages/dependency-extraction-webpack-plugin
```

To see the failure without the fix:

```bash
git checkout trunk -- packages/dependency-extraction-webpack-plugin/lib/index.js
npm run test:unit packages/dependency-extraction-webpack-plugin # 4 tests fail
git checkout HEAD -- packages/dependency-extraction-webpack-plugin/lib/index.js
```

### Manual

1. From the repo root on this branch, run `npm ci`, then `cd packages/dependency-extraction-webpack-plugin`.
2. Build the new fixture and print its asset file:

    ```bash
    node -e "
    const path = require( 'path' );
    const webpack = require( 'webpack' );
    const fixture = path.resolve( 'test/fixtures/style-cache-group' );
    const config = {
      ...require( path.join( fixture, 'webpack.config.js' ) ),
      context: fixture,
      entry: './index.js',
      mode: 'production',
      output: { path: '/tmp/dewp-manual' },
    };
    webpack( config, ( err, stats ) => {
      if ( err || stats.hasErrors() ) { throw err || new Error( stats.toString() ); }
      console.log( require( 'fs' ).readFileSync( '/tmp/dewp-manual/main.asset.php', 'utf8' ) );
    } );
    "
    ```

3. Note the `version` value.
4. Edit `test/fixtures/style-cache-group/style.css` and change `#fff` to `#000` (a style-only change; `index.js` untouched).
5. Re-run the command from step 2: the `version` changes, while `dependencies` stays the same.
6. Repeat steps 2–5 after `git checkout trunk -- packages/dependency-extraction-webpack-plugin/lib/index.js`: the `version` stays identical despite the CSS change — the reported bug. Restore with `git checkout HEAD -- packages/dependency-extraction-webpack-plugin/lib/index.js` and `git checkout HEAD -- packages/dependency-extraction-webpack-plugin/test/fixtures/style-cache-group/style.css`.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
