### PR TITLE
URLInput: Skip search requests while an IME composition is in progress

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -33,6 +33,7 @@
 -   `RichText`: Ignore pasted files, which carry no text to paste inline ([#81010](https://github.com/WordPress/gutenberg/pull/81010)).
 -   Background block support: Fix gradients not being applied to a block when a theme opts out of `settings.background.gradient` in `theme.json` ([#81056](https://github.com/WordPress/gutenberg/pull/81056)).
 -   `LinkControl`: Restore the preview title underline by slightly increasing the title's line height, which was too tight for the underline to be visible ([#81083](https://github.com/WordPress/gutenberg/pull/81083)).
+-   `URLInput`: Skip link search requests while an IME composition is in progress; the search now fires once with the confirmed value on `compositionend` ([#80602](https://github.com/WordPress/gutenberg/pull/80602)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -93,6 +93,11 @@ export default function URLInput( props ) {
 	// A fetch Promise can't be aborted. It's mimicked by holding on to the
 	// pending request so that responses of superseded requests can be ignored.
 	const suggestionsRequestRef = useRef( null );
+	// Whether characters are currently being composed with an IME. Composition
+	// state is tracked with explicit `compositionstart` and `compositionend`
+	// listeners because the `isComposing` property of native events is not
+	// reliable across browsers (e.g. Safari).
+	const isComposingRef = useRef( false );
 
 	const controlInputRef = inputRef ?? fallbackInputRef;
 
@@ -198,10 +203,15 @@ export default function URLInput( props ) {
 	const debouncedUpdateSuggestions = useDebounce( updateSuggestions, 200 );
 
 	// Keep the suggestions in sync with the value being searched for. An empty
-	// value requests the initial suggestions, when those are enabled.
+	// value requests the initial suggestions, when those are enabled. The sync
+	// is skipped while characters are being composed with an IME: intermediate
+	// composition updates must not fire search requests.
+	// `handleCompositionEnd` updates the suggestions once the composed value
+	// is confirmed.
 	useEffect( () => {
 		if (
 			! disableSuggestions &&
+			! isComposingRef.current &&
 			( value.length || showInitialSuggestions )
 		) {
 			debouncedUpdateSuggestions( value );
@@ -254,6 +264,32 @@ export default function URLInput( props ) {
 		// `InputControl` passes an `{ event }` object as its second argument,
 		// which callers would mistake for a selected suggestion.
 		onChange( newValue );
+	}
+
+	function handleCompositionStart() {
+		isComposingRef.current = true;
+		// Cancel any debounced suggestions update scheduled before the
+		// composition started so no request fires while composing.
+		debouncedUpdateSuggestions.cancel();
+	}
+
+	function handleCompositionEnd( event ) {
+		isComposingRef.current = false;
+
+		if ( disableSuggestions ) {
+			return;
+		}
+
+		// Update the suggestions with the confirmed composition value,
+		// mirroring the sync skipped while composing. Some browsers
+		// (e.g. Safari) emit a final `input` event after `compositionend`;
+		// the debounce coalesces the update from that value sync with this
+		// one.
+		const composedValue = event.target.value;
+
+		if ( composedValue.length || showInitialSuggestions ) {
+			debouncedUpdateSuggestions( composedValue );
+		}
 	}
 
 	function handleFocus() {
@@ -358,6 +394,8 @@ export default function URLInput( props ) {
 		name: inputId,
 		autoComplete: 'off',
 		onChange: disabled ? noop : handleChange,
+		onCompositionStart: disabled ? noop : handleCompositionStart,
+		onCompositionEnd: disabled ? noop : handleCompositionEnd,
 		onFocus: disabled ? noop : handleFocus,
 		onKeyDown: disabled ? noop : handleKeyDown,
 		placeholder,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -203,11 +203,9 @@ export default function URLInput( props ) {
 	const debouncedUpdateSuggestions = useDebounce( updateSuggestions, 200 );
 
 	// Keep the suggestions in sync with the value being searched for. An empty
-	// value requests the initial suggestions, when those are enabled. The sync
-	// is skipped while characters are being composed with an IME: intermediate
-	// composition updates must not fire search requests.
-	// `handleCompositionEnd` updates the suggestions once the composed value
-	// is confirmed.
+	// 	value requests the initial suggestions, when those are enabled.
+	// Composition state is a dependency, so the composed value is picked up
+	// whether the browser reports it before or after `compositionend`.
 	useEffect( () => {
 		if (
 			! disableSuggestions &&

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -87,17 +87,13 @@ export default function URLInput( props ) {
 	const [ isSuggestionsListOpen, setIsSuggestionsListOpen ] =
 		useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isComposing, setIsComposing ] = useState( false );
 
 	const fallbackInputRef = useRef();
 	const suggestionNodesRef = useRef( [] );
 	// A fetch Promise can't be aborted. It's mimicked by holding on to the
 	// pending request so that responses of superseded requests can be ignored.
 	const suggestionsRequestRef = useRef( null );
-	// Whether characters are currently being composed with an IME. Composition
-	// state is tracked with explicit `compositionstart` and `compositionend`
-	// listeners because the `isComposing` property of native events is not
-	// reliable across browsers (e.g. Safari).
-	const isComposingRef = useRef( false );
 
 	const controlInputRef = inputRef ?? fallbackInputRef;
 
@@ -203,19 +199,20 @@ export default function URLInput( props ) {
 	const debouncedUpdateSuggestions = useDebounce( updateSuggestions, 200 );
 
 	// Keep the suggestions in sync with the value being searched for. An empty
-	// 	value requests the initial suggestions, when those are enabled.
+	// value requests the initial suggestions, when those are enabled.
 	// Composition state is a dependency, so the composed value is picked up
 	// whether the browser reports it before or after `compositionend`.
 	useEffect( () => {
 		if (
 			! disableSuggestions &&
-			! isComposingRef.current &&
+			! isComposing &&
 			( value.length || showInitialSuggestions )
 		) {
 			debouncedUpdateSuggestions( value );
 		}
 	}, [
 		value,
+		isComposing,
 		disableSuggestions,
 		showInitialSuggestions,
 		debouncedUpdateSuggestions,
@@ -265,29 +262,14 @@ export default function URLInput( props ) {
 	}
 
 	function handleCompositionStart() {
-		isComposingRef.current = true;
+		setIsComposing( true );
 		// Cancel any debounced suggestions update scheduled before the
 		// composition started so no request fires while composing.
 		debouncedUpdateSuggestions.cancel();
 	}
 
-	function handleCompositionEnd( event ) {
-		isComposingRef.current = false;
-
-		if ( disableSuggestions ) {
-			return;
-		}
-
-		// Update the suggestions with the confirmed composition value,
-		// mirroring the sync skipped while composing. Some browsers
-		// (e.g. Safari) emit a final `input` event after `compositionend`;
-		// the debounce coalesces the update from that value sync with this
-		// one.
-		const composedValue = event.target.value;
-
-		if ( composedValue.length || showInitialSuggestions ) {
-			debouncedUpdateSuggestions( composedValue );
-		}
+	function handleCompositionEnd() {
+		setIsComposing( false );
 	}
 
 	function handleFocus() {

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -337,98 +337,59 @@ describe( 'URLInput', () => {
 	} );
 
 	describe( 'IME composition', () => {
-		it( 'should fetch suggestions when typing without a composition', async () => {
-			const { input } = renderURLInput();
-
-			fireEvent.change( input, { target: { value: 'Hello' } } );
-
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
-			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
-				'Hello',
-				expect.anything()
-			);
-		} );
-
-		it( 'should not fetch suggestions while a composition is in progress', async () => {
+		it( 'should not fetch suggestions for the intermediate values of an IME composition', async () => {
 			const { input } = renderURLInput();
 
 			fireEvent.compositionStart( input );
+			fireEvent.change( input, { target: { value: 'ほ' } } );
 			fireEvent.change( input, { target: { value: 'ほん' } } );
 			fireEvent.change( input, { target: { value: 'ほんだ' } } );
-
-			await flushDebounce();
-
-			// The typed value still propagates while composing.
-			expect( input ).toHaveValue( 'ほんだ' );
-			// But no requests fire until the composition is confirmed.
-			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
-
-			fireEvent.compositionEnd( input, { data: 'ほんだ' } );
-
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
-			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
-				'ほんだ',
-				expect.anything()
-			);
-		} );
-
-		it( 'should fetch suggestions once when the final change event arrives after the composition ends', async () => {
-			const { input } = renderURLInput();
-
-			fireEvent.compositionStart( input );
-			fireEvent.change( input, { target: { value: 'ほん' } } );
-			// Some browsers (e.g. Safari) emit the final input event after
-			// `compositionend`.
-			fireEvent.compositionEnd( input, { data: 'ほんだ' } );
-			fireEvent.change( input, { target: { value: 'ほんだ' } } );
-
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
-			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
-				'ほんだ',
-				expect.anything()
-			);
-		} );
-
-		it( 'should cancel an update scheduled before the composition started', async () => {
-			const { input } = renderURLInput();
-
-			// Schedule a debounced update, then start composing before it runs.
-			fireEvent.change( input, { target: { value: 'He' } } );
-			fireEvent.compositionStart( input );
-			fireEvent.change( input, { target: { value: 'Heほ' } } );
-
 			await flushDebounce();
 
 			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
-
-			fireEvent.compositionEnd( input, { data: 'ほ' } );
-
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
-			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
-				'Heほ',
-				expect.anything()
-			);
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'should not fetch suggestions on composition end when suggestions are disabled', async () => {
-			const { input } = renderURLInput( { disableSuggestions: true } );
+		it( 'should not fetch suggestions for a value superseded by an IME composition', async () => {
+			const { user, input } = renderURLInput();
 
+			await user.type( input, 'ab' );
 			fireEvent.compositionStart( input );
-			fireEvent.change( input, { target: { value: 'ほん' } } );
-			fireEvent.compositionEnd( input, { data: 'ほん' } );
-
+			fireEvent.change( input, { target: { value: 'abほ' } } );
 			await flushDebounce();
 
 			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
 		} );
+
+		// Firefox reports the confirmed value of a composition after
+		// `compositionend`, Chrome and Safari before it.
+		// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1305387
+		it.each( [ 'before', 'after' ] )(
+			'should fetch suggestions for a composed value reported %s the composition ends',
+			async ( order ) => {
+				const { input } = renderURLInput();
+
+				fireEvent.compositionStart( input );
+				fireEvent.change( input, { target: { value: 'ほんだ' } } );
+				// Compositions outlast the debounce, so the confirmed value is
+				// the only one a request is made for.
+				await flushDebounce();
+
+				if ( order === 'before' ) {
+					fireEvent.change( input, { target: { value: 'ホンダ' } } );
+					fireEvent.compositionEnd( input );
+				} else {
+					fireEvent.compositionEnd( input );
+					fireEvent.change( input, { target: { value: 'ホンダ' } } );
+				}
+
+				expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+				expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'ホンダ', {
+					isInitialSuggestions: false,
+				} );
+			}
+		);
 	} );
 
 	describe( 'announcements', () => {

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -336,6 +336,101 @@ describe( 'URLInput', () => {
 		} );
 	} );
 
+	describe( 'IME composition', () => {
+		it( 'should fetch suggestions when typing without a composition', async () => {
+			const { input } = renderURLInput();
+
+			fireEvent.change( input, { target: { value: 'Hello' } } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
+				'Hello',
+				expect.anything()
+			);
+		} );
+
+		it( 'should not fetch suggestions while a composition is in progress', async () => {
+			const { input } = renderURLInput();
+
+			fireEvent.compositionStart( input );
+			fireEvent.change( input, { target: { value: 'ほん' } } );
+			fireEvent.change( input, { target: { value: 'ほんだ' } } );
+
+			await flushDebounce();
+
+			// The typed value still propagates while composing.
+			expect( input ).toHaveValue( 'ほんだ' );
+			// But no requests fire until the composition is confirmed.
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+
+			fireEvent.compositionEnd( input, { data: 'ほんだ' } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
+				'ほんだ',
+				expect.anything()
+			);
+		} );
+
+		it( 'should fetch suggestions once when the final change event arrives after the composition ends', async () => {
+			const { input } = renderURLInput();
+
+			fireEvent.compositionStart( input );
+			fireEvent.change( input, { target: { value: 'ほん' } } );
+			// Some browsers (e.g. Safari) emit the final input event after
+			// `compositionend`.
+			fireEvent.compositionEnd( input, { data: 'ほんだ' } );
+			fireEvent.change( input, { target: { value: 'ほんだ' } } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
+				'ほんだ',
+				expect.anything()
+			);
+		} );
+
+		it( 'should cancel an update scheduled before the composition started', async () => {
+			const { input } = renderURLInput();
+
+			// Schedule a debounced update, then start composing before it runs.
+			fireEvent.change( input, { target: { value: 'He' } } );
+			fireEvent.compositionStart( input );
+			fireEvent.change( input, { target: { value: 'Heほ' } } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+
+			fireEvent.compositionEnd( input, { data: 'ほ' } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
+				'Heほ',
+				expect.anything()
+			);
+		} );
+
+		it( 'should not fetch suggestions on composition end when suggestions are disabled', async () => {
+			const { input } = renderURLInput( { disableSuggestions: true } );
+
+			fireEvent.compositionStart( input );
+			fireEvent.change( input, { target: { value: 'ほん' } } );
+			fireEvent.compositionEnd( input, { data: 'ほん' } );
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'announcements', () => {
 		it( 'should announce the number of results', async () => {
 			await renderWithSuggestions();

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -1285,6 +1285,78 @@ test.describe( 'Links', () => {
 		// Verify focus is still on the input
 		await expect( urlInput ).toBeFocused();
 	} );
+
+	test( 'does not fire search requests while an IME composition is in progress', async ( {
+		page,
+		editor,
+		pageUtils,
+	} ) => {
+		// Create a block with some text and select some of it.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+		} );
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
+
+		// Open the Link UI.
+		await pageUtils.pressKeys( 'primary+k' );
+
+		const urlInput = page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+		await expect( urlInput ).toBeFocused();
+
+		// Track link search requests that carry a search term. The initial
+		// suggestions request has an empty search term and is ignored.
+		const searchedTerms = [];
+		page.on( 'request', ( request ) => {
+			const url = request.url();
+			if (
+				! url.includes( 'wp/v2/search' ) &&
+				! url.includes( 'wp%2Fv2%2Fsearch' )
+			) {
+				return;
+			}
+			const searchTerm = new URL( url ).searchParams.get( 'search' );
+			if ( searchTerm ) {
+				searchedTerms.push( searchTerm );
+			}
+		} );
+
+		// Compose text with an IME. CDP is only available in Chromium, which
+		// is the only project this untagged test runs in.
+		const cdpSession = await page.context().newCDPSession( page );
+		await cdpSession.send( 'Input.imeSetComposition', {
+			text: 'ほ',
+			selectionStart: 1,
+			selectionEnd: 1,
+		} );
+		await cdpSession.send( 'Input.imeSetComposition', {
+			text: 'ほん',
+			selectionStart: 2,
+			selectionEnd: 2,
+		} );
+
+		// The composed text is visible in the input.
+		await expect( urlInput ).toHaveValue( 'ほん' );
+
+		// Wait past the suggestions debounce to verify that no search request
+		// fires for the intermediate composition value. A fixed wait is
+		// required because the expected outcome is that nothing happens.
+		// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
+		await page.waitForTimeout( 500 );
+		expect( searchedTerms ).toHaveLength( 0 );
+
+		// Confirm the composition: search requests fire for the confirmed
+		// value only. A single suggestions update fans out to one request
+		// per search type, so assert on the searched terms, not the count.
+		await cdpSession.send( 'Input.insertText', { text: 'ほんだ' } );
+		await expect( urlInput ).toHaveValue( 'ほんだ' );
+		await expect.poll( () => searchedTerms.length ).toBeGreaterThan( 0 );
+		expect( searchedTerms.every( ( term ) => term === 'ほんだ' ) ).toBe(
+			true
+		);
+	} );
 } );
 
 class LinkUtils {


### PR DESCRIPTION
## What?

Fixes #72364.

- Track IME composition state in `URLInput` via explicit `compositionstart`/`compositionend` handlers on the input.
- While composing, the typed value still propagates (the field keeps updating) but the debounced suggestions fetch is skipped.
- On `compositionend`, fetch suggestions once with the confirmed value.
- Adds Jest coverage for `URLInput` composition handling and a Chromium (CDP-driven) IME regression test to the Links e2e suite.

## Why?

When typing with an IME (Japanese, Chinese, Korean, …), every composition update fires a change event, so `URLInput` (and the Link UI built on it) sends `/wp/v2/search` requests for intermediate values while the user is still composing. Requests should wait until the composition is confirmed. This mirrors the composition handling already used by rich text (`packages/rich-text/src/hook/event-listeners/input-and-selection.js`).

## Testing Instructions

### Automated

```bash
npm run test:unit packages/block-editor/src/components/url-input
npm run test:unit packages/block-editor/src/components/link-control
npm run test:e2e -- test/e2e/specs/editor/blocks/links.spec.js
```

To see the failure without the fix:

```bash
git checkout trunk -- packages/block-editor/src/components/url-input/index.js
npm run test:unit packages/block-editor/src/components/url-input # fails
git checkout HEAD -- packages/block-editor/src/components/url-input/index.js
```

### Manual

1. Enable a Japanese IME (macOS: System Settings → Keyboard → Input Sources → add Japanese – Romaji).
2. Open a post, add a Paragraph block with some text, select a word and press the Link button in the block toolbar.
3. Open DevTools → Network and filter requests by `search`.
4. Switch the input source to Japanese and type e.g. `honda` (ほんだ) in the link field WITHOUT confirming the composition: on trunk each keystroke fires search requests; on this branch nothing fires while the underlined composition text is active.
5. Press Enter to confirm the composition: the search fires once for the confirmed value and suggestions appear.
6. Switch back to a Latin keyboard and type normally: suggestions still appear as you type, as before.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
