### PR TITLE
Block Settings Menu: Make Copy and Cut write both HTML and plain text clipboard data

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
+-   Block Settings Menu: The `Copy` and `Cut` items now write the same `text/plain` and `text/html` clipboard data as the keyboard shortcuts, so blocks copied from the menu paste as formatted content in rich text targets instead of raw block markup ([#80603](https://github.com/WordPress/gutenberg/pull/80603)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -26,7 +26,7 @@ import BlockParentSelectorMenuItem from './block-parent-selector-menu-item';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
-import { setClipboardBlocks } from '../writing-flow/utils';
+import { copyBlocksToClipboard } from '../writing-flow/utils';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -46,65 +46,51 @@ function CopyMenuItem( {
 	const { removeBlocks } = useDispatch( blockEditorStore );
 	const notifyCopy = useNotifyCopy();
 
-	function onSuccess() {
-		switch ( eventType ) {
-			case 'copy':
-			case 'copyStyles':
-				onCopy();
-				notifyCopy( eventType, clientIds );
-				break;
-			case 'cut':
-				notifyCopy( eventType, clientIds );
-				removeBlocks( clientIds, updateSelection );
-				break;
-			default:
-				break;
-		}
-	}
-
-	// "Copy styles" writes the serialized blocks as plain text so that
-	// `usePasteStyles` can read them back from the clipboard.
-	const ref = useCopyToClipboard(
-		() => serialize( getBlocksByClientId( clientIds ) ),
-		onSuccess
-	);
-
-	// "Copy" and "Cut" set the same `text/plain` and `text/html` clipboard
-	// data as the keyboard shortcuts do, so that pasting behaves consistently
-	// no matter how the blocks were copied.
+	// Write the same `text/plain` and `text/html` clipboard data as the
+	// keyboard shortcuts do, so that pasting behaves consistently no matter
+	// how the blocks were copied.
 	function onClick( event ) {
-		const { ownerDocument } = event.currentTarget;
-		const blocks = getBlocksByClientId( clientIds );
+		const hasCopied = copyBlocksToClipboard(
+			event.currentTarget.ownerDocument,
+			getBlocksByClientId( clientIds ),
+			registry
+		);
 
-		function onCopyEvent( copyEvent ) {
-			setClipboardBlocks( copyEvent, blocks, registry );
-			copyEvent.preventDefault();
+		if ( ! hasCopied ) {
+			return;
 		}
 
-		ownerDocument.addEventListener( 'copy', onCopyEvent, true );
-		let hasCopied = false;
-		try {
-			hasCopied = ownerDocument.execCommand( 'copy' );
-		} finally {
-			ownerDocument.removeEventListener( 'copy', onCopyEvent, true );
-		}
+		notifyCopy( eventType, clientIds );
 
-		if ( hasCopied ) {
-			onSuccess();
+		if ( eventType === 'cut' ) {
+			removeBlocks( clientIds, updateSelection );
+		} else {
+			onCopy();
 		}
 	}
 
-	const isCopyStyles = eventType === 'copyStyles';
-	const copyMenuItemLabel = label ? label : __( 'Copy' );
 	return (
-		<MenuItem
-			ref={ isCopyStyles ? ref : undefined }
-			onClick={ isCopyStyles ? undefined : onClick }
-			shortcut={ shortcut }
-		>
-			{ copyMenuItemLabel }
+		<MenuItem onClick={ onClick } shortcut={ shortcut }>
+			{ label ? label : __( 'Copy' ) }
 		</MenuItem>
 	);
+}
+
+function CopyStylesMenuItem( { clientIds, onCopy, label } ) {
+	const { getBlocksByClientId } = useSelect( blockEditorStore );
+	const notifyCopy = useNotifyCopy();
+
+	// Write the serialized blocks as plain text so that `usePasteStyles` can
+	// read them back from the clipboard with `navigator.clipboard.readText()`.
+	const ref = useCopyToClipboard(
+		() => serialize( getBlocksByClientId( clientIds ) ),
+		() => {
+			onCopy();
+			notifyCopy( 'copyStyles', clientIds );
+		}
+	);
+
+	return <MenuItem ref={ ref }>{ label }</MenuItem>;
 }
 
 export function BlockSettingsDropdown( {
@@ -397,11 +383,10 @@ export function BlockSettingsDropdown( {
 								</MenuGroup>
 								{ canCopyStyles && ! isContentOnly && (
 									<MenuGroup>
-										<CopyMenuItem
+										<CopyStylesMenuItem
 											clientIds={ clientIds }
 											onCopy={ onCopy }
 											label={ __( 'Copy styles' ) }
-											eventType="copyStyles"
 										/>
 										{ canEdit && (
 											<MenuItem onClick={ onPasteStyles }>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -7,7 +7,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { chevronDown, chevronUp, moreVertical } from '@wordpress/icons';
 import { Children, cloneElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,6 +26,7 @@ import BlockParentSelectorMenuItem from './block-parent-selector-menu-item';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
+import { setClipboardBlocks } from '../writing-flow/utils';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -40,30 +41,67 @@ function CopyMenuItem( {
 	eventType = 'copy',
 	__experimentalUpdateSelection: updateSelection = false,
 } ) {
+	const registry = useRegistry();
 	const { getBlocksByClientId } = useSelect( blockEditorStore );
 	const { removeBlocks } = useDispatch( blockEditorStore );
 	const notifyCopy = useNotifyCopy();
+
+	function onSuccess() {
+		switch ( eventType ) {
+			case 'copy':
+			case 'copyStyles':
+				onCopy();
+				notifyCopy( eventType, clientIds );
+				break;
+			case 'cut':
+				notifyCopy( eventType, clientIds );
+				removeBlocks( clientIds, updateSelection );
+				break;
+			default:
+				break;
+		}
+	}
+
+	// "Copy styles" writes the serialized blocks as plain text so that
+	// `usePasteStyles` can read them back from the clipboard.
 	const ref = useCopyToClipboard(
 		() => serialize( getBlocksByClientId( clientIds ) ),
-		() => {
-			switch ( eventType ) {
-				case 'copy':
-				case 'copyStyles':
-					onCopy();
-					notifyCopy( eventType, clientIds );
-					break;
-				case 'cut':
-					notifyCopy( eventType, clientIds );
-					removeBlocks( clientIds, updateSelection );
-					break;
-				default:
-					break;
-			}
-		}
+		onSuccess
 	);
+
+	// "Copy" and "Cut" set the same `text/plain` and `text/html` clipboard
+	// data as the keyboard shortcuts do, so that pasting behaves consistently
+	// no matter how the blocks were copied.
+	function onClick( event ) {
+		const { ownerDocument } = event.currentTarget;
+		const blocks = getBlocksByClientId( clientIds );
+
+		function onCopyEvent( copyEvent ) {
+			setClipboardBlocks( copyEvent, blocks, registry );
+			copyEvent.preventDefault();
+		}
+
+		ownerDocument.addEventListener( 'copy', onCopyEvent, true );
+		let hasCopied = false;
+		try {
+			hasCopied = ownerDocument.execCommand( 'copy' );
+		} finally {
+			ownerDocument.removeEventListener( 'copy', onCopyEvent, true );
+		}
+
+		if ( hasCopied ) {
+			onSuccess();
+		}
+	}
+
+	const isCopyStyles = eventType === 'copyStyles';
 	const copyMenuItemLabel = label ? label : __( 'Copy' );
 	return (
-		<MenuItem ref={ ref } shortcut={ shortcut }>
+		<MenuItem
+			ref={ isCopyStyles ? ref : undefined }
+			onClick={ isCopyStyles ? undefined : onClick }
+			shortcut={ shortcut }
+		>
 			{ copyMenuItemLabel }
 		</MenuItem>
 	);

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -63,6 +63,57 @@ export function setClipboardBlocks( event, blocks, registry ) {
 }
 
 /**
+ * Copies the given blocks to the clipboard with the same `text/plain` and
+ * `text/html` data as `setClipboardBlocks()` writes for the keyboard
+ * shortcuts, by triggering a native copy event and populating its clipboard
+ * data. Unlike `setClipboardBlocks()` it can be called outside a clipboard
+ * event handler, e.g. from a menu item click.
+ *
+ * @param {Document}  ownerDocument Document of the element that triggered the
+ *                                  copy.
+ * @param {WPBlock[]} blocks        Blocks to copy.
+ * @param {Object}    registry      The registry to select from.
+ *
+ * @return {boolean} Whether the blocks were written to the clipboard.
+ */
+export function copyBlocksToClipboard( ownerDocument, blocks, registry ) {
+	let didSetData = false;
+
+	function onCopy( event ) {
+		setClipboardBlocks( event, blocks, registry );
+		event.preventDefault();
+		didSetData = true;
+	}
+
+	// WebKit before Safari 18.4 only dispatches the copy event when there is
+	// a selection (https://bugs.webkit.org/show_bug.cgi?id=156529), so select
+	// a hidden textarea holding the serialized blocks. Engines that ignore
+	// the clipboard data set in the listener then still copy the markup as
+	// plain text.
+	const { activeElement } = ownerDocument;
+	const textarea = ownerDocument.createElement( 'textarea' );
+	textarea.value = serialize( blocks );
+	textarea.setAttribute( 'readonly', '' );
+	textarea.style.position = 'fixed';
+	textarea.style.left = '-9999px';
+	textarea.style.top = '-9999px';
+	ownerDocument.body.appendChild( textarea );
+	textarea.select();
+
+	ownerDocument.addEventListener( 'copy', onCopy, true );
+	let hasCopied = false;
+	try {
+		hasCopied = ownerDocument.execCommand( 'copy' );
+	} finally {
+		ownerDocument.removeEventListener( 'copy', onCopy, true );
+		textarea.remove();
+		activeElement?.focus();
+	}
+
+	return hasCopied && didSetData;
+}
+
+/**
  * Returns the blocks to be pasted from the clipboard event.
  *
  * @param {ClipboardEvent} event                    The clipboard event.

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -864,4 +864,84 @@ test.describe( 'Copy/cut/paste', () => {
 			},
 		] );
 	} );
+
+	// See https://github.com/WordPress/gutenberg/issues/68941.
+	test( 'should copy blocks via the options menu with the same clipboard data as the keyboard shortcut', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'Copy ' );
+		await pageUtils.pressKeys( 'primary+b' );
+		await page.keyboard.type( 'bold' );
+
+		// Record the clipboard data written by the keyboard shortcut. The
+		// bubble phase listener runs after the editor's copy handler, so it
+		// can read the data the editor set.
+		await editor.canvas.locator( ':root' ).evaluate( () => {
+			document.addEventListener( 'copy', ( event ) => {
+				window.__copiedFlavors = {
+					plainText: event.clipboardData.getData( 'text/plain' ),
+					html: event.clipboardData.getData( 'text/html' ),
+				};
+			} );
+		} );
+		await pageUtils.pressKeys( 'primary+c' );
+		const keyboardCopyData = await editor.canvas
+			.locator( ':root' )
+			.evaluate( () => window.__copiedFlavors );
+		expect( keyboardCopyData.html ).toContain( '<!-- wp:paragraph -->' );
+
+		// The options menu lives in the top-level document, where its copy
+		// event is dispatched.
+		await page.evaluate( () => {
+			document.addEventListener( 'copy', ( event ) => {
+				window.__copiedFlavors = {
+					plainText: event.clipboardData.getData( 'text/plain' ),
+					html: event.clipboardData.getData( 'text/html' ),
+				};
+			} );
+		} );
+		await editor.clickBlockToolbarButton( 'Options' );
+		await page
+			.getByRole( 'menu', { name: 'Options' } )
+			.getByRole( 'menuitem', { name: /^Copy(?! styles)/ } )
+			.click();
+		await expect
+			.poll( () =>
+				page.evaluate( () => Boolean( window.__copiedFlavors ) )
+			)
+			.toBe( true );
+		const menuCopyData = await page.evaluate(
+			() => window.__copiedFlavors
+		);
+
+		// Both copy methods must write the same `text/plain` and `text/html`
+		// clipboard data.
+		expect( menuCopyData ).toEqual( keyboardCopyData );
+
+		// Pasting the copied data back recreates the same block.
+		await page.keyboard.press( 'Escape' );
+		pageUtils.setClipboardData( {
+			plainText: menuCopyData.plainText,
+			html: menuCopyData.html,
+		} );
+		await editor.canvas.locator( 'text=Copy bold' ).click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.press( 'Enter' );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Copy <strong>bold</strong>' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Copy <strong>bold</strong>' },
+			},
+		] );
+	} );
 } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -905,22 +905,21 @@ test.describe( 'Copy/cut/paste', () => {
 				};
 			} );
 		} );
-		await editor.clickBlockToolbarButton( 'Options' );
-		await page
-			.getByRole( 'menu', { name: 'Options' } )
-			.getByRole( 'menuitem', { name: /^Copy(?! styles)/ } )
-			.click();
-		await expect
-			.poll( () =>
-				page.evaluate( () => Boolean( window.__copiedFlavors ) )
-			)
-			.toBe( true );
-		const menuCopyData = await page.evaluate(
-			() => window.__copiedFlavors
-		);
+		// The name matcher must exclude the "Copy styles" item; role name
+		// matching is substring based.
+		await editor.clickBlockOptionsMenuItem( /^Copy(?! styles)/ );
+
+		// The success snackbar pins that `execCommand( 'copy' )` actually
+		// succeeded, not just that the copy event carried the right data.
+		await expect(
+			page.locator( '.components-snackbar-list' )
+		).toContainText( 'Copied "Paragraph" to clipboard.' );
 
 		// Both copy methods must write the same `text/plain` and `text/html`
 		// clipboard data.
+		const menuCopyData = await page.evaluate(
+			() => window.__copiedFlavors
+		);
 		expect( menuCopyData ).toEqual( keyboardCopyData );
 
 		// Pasting the copied data back recreates the same block.
@@ -941,6 +940,72 @@ test.describe( 'Copy/cut/paste', () => {
 			{
 				name: 'core/paragraph',
 				attributes: { content: 'Copy <strong>bold</strong>' },
+			},
+		] );
+	} );
+
+	// See https://github.com/WordPress/gutenberg/issues/68941.
+	test( 'should cut blocks via the options menu, removing them and writing the same clipboard data as the keyboard shortcut', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'First' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Cut ' );
+		await pageUtils.pressKeys( 'primary+b' );
+		await page.keyboard.type( 'bold' );
+
+		// The options menu lives in the top-level document, where its copy
+		// event is dispatched.
+		await page.evaluate( () => {
+			document.addEventListener( 'copy', ( event ) => {
+				window.__copiedFlavors = {
+					plainText: event.clipboardData.getData( 'text/plain' ),
+					html: event.clipboardData.getData( 'text/html' ),
+				};
+			} );
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Cut' );
+
+		// The success snackbar pins that `execCommand( 'copy' )` actually
+		// succeeded; the blocks must only be removed after a successful copy.
+		await expect(
+			page.locator( '.components-snackbar-list' )
+		).toContainText( 'Moved "Paragraph" to clipboard.' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'First' },
+			},
+		] );
+
+		const menuCutData = await page.evaluate( () => window.__copiedFlavors );
+		expect( menuCutData.plainText ).toBe( 'Cut bold' );
+		expect( menuCutData.html ).toContain( '<!-- wp:paragraph -->' );
+		expect( menuCutData.html ).toContain( '<strong>bold</strong>' );
+
+		// Pasting the cut data back recreates the same block.
+		await page.keyboard.press( 'Escape' );
+		pageUtils.setClipboardData( {
+			plainText: menuCutData.plainText,
+			html: menuCutData.html,
+		} );
+		await editor.canvas.locator( 'text=First' ).click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.press( 'Enter' );
+		await pageUtils.pressKeys( 'primary+v' );
+		expect( await editor.getBlocks() ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'First' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Cut <strong>bold</strong>' },
 			},
 		] );
 	} );


### PR DESCRIPTION
## What?

Fixes #68941.

- The block options menu `Copy` and `Cut` items now write the same `text/plain` + `text/html` clipboard data as the keyboard shortcuts, via a new `copyBlocksToClipboard()` helper that wraps the writing flow's `setClipboardBlocks()`.
- `Cut` only removes the blocks after the clipboard write is confirmed.
- `Copy styles` is unchanged behavior-wise: it still writes the serialized blocks as plain text (now in a dedicated `CopyStylesMenuItem`), which `usePasteStyles` reads back with `navigator.clipboard.readText()`.

## Why?

The menu items used `useCopyToClipboard`, which writes only `text/plain` containing the raw serialized block markup, while the keyboard shortcuts write readable plain text plus the block markup as `text/html`. Blocks copied from the menu therefore pasted as raw `<!-- wp:... -->` markup in rich text targets, and the two copy paths produced different clipboard contents for the same blocks.

## How?

On click, the menu item calls `copyBlocksToClipboard( ownerDocument, blocks, registry )`, a new helper in `writing-flow/utils.js` next to `setClipboardBlocks()`:

- It registers a one-shot capture-phase `copy` listener that populates the event via `setClipboardBlocks()` and calls `preventDefault()`, then triggers `document.execCommand( 'copy' )`.
- Before invoking the command it selects a hidden textarea holding the serialized blocks: WebKit before Safari 18.4 only dispatches the copy event when a selection exists ([WebKit bug 156529](https://bugs.webkit.org/show_bug.cgi?id=156529)), and engines that ignore the listener's clipboard data still copy the markup as plain text.
- It returns `true` only when `execCommand()` succeeded *and* the listener actually wrote the data. Without the selection and this check, a selection-less `execCommand( 'copy' )` on pre-18.4 Safari returns `true` without firing the event, which would show a success notice — and, for Cut, remove the blocks — without anything reaching the clipboard.

`CopyMenuItem` now handles only `copy`/`cut` plus the success callbacks (flash, snackbar notice, block removal for Cut, all gated on a successful write), and `Copy styles` is split into `CopyStylesMenuItem`, so each menu item has exactly one clipboard mechanism.

Note: menu `Copy` followed by `Paste styles` no longer works, because the `text/plain` flavor is now readable text rather than markup. This matches the existing keyboard-copy behavior; `Copy styles` remains the supported path for that flow.

## Testing Instructions

### Automated

```bash
npm run test:e2e -- test/e2e/specs/editor/various/copy-cut-paste.spec.js
```

The two "options menu" tests cover Copy and Cut: flavor parity with the keyboard shortcut, the success snackbar (which pins that `execCommand()` really succeeded), block removal for Cut, and the paste round-trip.

To see the failure without the fix:

```bash
git checkout trunk -- packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
npm run build
npm run test:e2e -- test/e2e/specs/editor/various/copy-cut-paste.spec.js -g "options menu" # fails
git checkout HEAD -- packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
```

### Manual

1. Add a Paragraph block with some bold text, e.g. `Copy bold`.
2. Select the block, open the block toolbar options menu (⋮), and choose `Copy`.
3. Paste into a rich text target (Google Docs, Word, TextEdit in rich mode): on trunk it pastes raw `<!-- wp:paragraph -->` markup; with this branch it pastes the formatted content.
4. Paste back into the editor: the same paragraph block is recreated.
5. Repeat with the `Cut` menu item, and via the List View kebab menu `Copy`.
6. If available, repeat in Safari — especially 18.3 or older, where the copy event only fires when a selection exists.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
