### PR TITLE
Block Library: Don't pass post_id to server-side renders for posts the user can't edit

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
+-   Breadcrumbs, auto-registered PHP-only blocks: Don't pass `post_id` to the block-renderer endpoint when the current user can't edit the post referenced by the `postId` block context, which made the request fail with a 403 error; render without post context instead ([#80604](https://github.com/WordPress/gutenberg/pull/80604)).
 
 ### Internal
 

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -40,6 +40,7 @@ export default function BreadcrumbEdit( {
 	} = attributes;
 	const {
 		post,
+		canEditPost,
 		isPostTypeHierarchical,
 		postTypeHasTaxonomies,
 		hasTermsAssigned,
@@ -54,6 +55,13 @@ export default function BreadcrumbEdit( {
 				postType,
 				postId
 			);
+			const _canEditPost = postId
+				? select( coreStore ).canUser( 'update', {
+						kind: 'postType',
+						name: postType,
+						id: postId,
+				  } )
+				: undefined;
 			const postTypeObject = select( coreStore ).getPostType( postType );
 			const _postTypeHasTaxonomies =
 				postTypeObject && postTypeObject.taxonomies.length;
@@ -66,6 +74,7 @@ export default function BreadcrumbEdit( {
 			}
 			return {
 				post: _post,
+				canEditPost: _canEditPost,
 				isPostTypeHierarchical: postTypeObject?.hierarchical,
 				postTypeHasTaxonomies: _postTypeHasTaxonomies,
 				hasTermsAssigned:
@@ -78,7 +87,12 @@ export default function BreadcrumbEdit( {
 							return !! _post[ taxonomy.rest_base ]?.length;
 						} ),
 				isLoading:
-					( postId && ! _post ) ||
+					// When the user can't edit the post, its record may not be
+					// readable either (the REST request can fail), so don't
+					// wait for it: the placeholder is shown instead.
+					( postId &&
+						_canEditPost !== false &&
+						( ! _post || _canEditPost === undefined ) ) ||
 					! postTypeObject ||
 					( _postTypeHasTaxonomies && ! taxonomies ),
 			};
@@ -107,7 +121,15 @@ export default function BreadcrumbEdit( {
 		attributes,
 		skipBlockSupportAttributes: true,
 		block: name,
-		urlQueryArgs: { post_id: postId, invalidationKey },
+		urlQueryArgs: {
+			// The block-renderer endpoint requires `edit_post` permissions
+			// for the post referenced by `post_id`, and the `postId` block
+			// context can reference a post the current user can't edit (e.g.
+			// another author's post in a query-like block), so only forward
+			// it when the user can edit it, to avoid a 403 error.
+			post_id: canEditPost ? postId : undefined,
+			invalidationKey,
+		},
 	} );
 	const prevContentRef = useRef( '' );
 	useEffect( () => {
@@ -158,6 +180,9 @@ export default function BreadcrumbEdit( {
 	const showPlaceholder =
 		! postId ||
 		! postType ||
+		// Without `post_id`, the server can't render the real breadcrumbs,
+		// so show the placeholder for posts the user can't edit.
+		canEditPost === false ||
 		// When `templateSlug` is set only show placeholder if the post type is not.
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -19,6 +19,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import HtmlRenderer from './utils/html-renderer';
+import { useCanEditEntity } from './utils/hooks';
 
 /**
  * Internal dependencies
@@ -352,16 +353,31 @@ export const registerCoreBlocks = (
 					new Set( [
 						...( bootstrappedBlockType?.usesContext ?? [] ),
 						'postId',
+						'postType',
 					] )
 				),
 				// Inspector controls are rendered by the auto-register hook in block-editor
 				edit: function Edit( { attributes, context } ) {
 					const disabledRef = useDisabled();
 					const blockProps = useBlockProps( { ref: disabledRef } );
+					const canEditPost = useCanEditEntity(
+						'postType',
+						context?.postType,
+						context?.postId
+					);
 					const { content, status, error } = useServerSideRender( {
 						block: blockName,
 						attributes,
-						urlQueryArgs: { post_id: context?.postId },
+						urlQueryArgs: {
+							// The block-renderer endpoint requires `edit_post`
+							// permissions for the post referenced by
+							// `post_id`, and the `postId` block context can
+							// reference a post the current user can't edit
+							// (e.g. another author's post in a query-like
+							// block), so only forward it when the user can
+							// edit it, to avoid a 403 error.
+							post_id: canEditPost ? context?.postId : undefined,
+						},
 					} );
 
 					if ( status === 'loading' ) {

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -87,6 +87,30 @@ add_action(
 			)
 		);
 
+		// Context provider block that provides the `postId`/`postType` block
+		// context from its attributes, simulating query-like blocks whose
+		// items can reference posts the current user can't edit.
+		register_block_type(
+			'test/post-context-provider',
+			array(
+				'attributes'            => array(
+					'postId'   => array(
+						'type'    => 'number',
+						'default' => 0,
+					),
+					'postType' => array(
+						'type'    => 'string',
+						'default' => 'post',
+					),
+				),
+				'provides_context'      => array(
+					'postId'   => 'postId',
+					'postType' => 'postType',
+				),
+				'editor_script_handles' => array( 'server-side-rendered-block' ),
+			)
+		);
+
 		// Add binding support for the auto-register-with-controls block.
 		add_filter(
 			'block_bindings_supported_attributes_test/auto-register-with-controls',

--- a/packages/e2e-tests/plugins/server-side-rendered-block/editor.js
+++ b/packages/e2e-tests/plugins/server-side-rendered-block/editor.js
@@ -1,7 +1,12 @@
 ( function () {
 	const { createElement: el, Fragment } = wp.element;
 	const { registerBlockType } = wp.blocks;
-	const { InspectorControls, useBlockProps } = wp.blockEditor;
+	const {
+		InnerBlocks,
+		InspectorControls,
+		useBlockProps,
+		useInnerBlocksProps,
+	} = wp.blockEditor;
 	const ServerSideRender = wp.serverSideRender;
 	const { PanelBody, __experimentalNumberControl: NumberControl } =
 		wp.components;
@@ -43,6 +48,43 @@
 					} )
 				)
 			);
+		},
+	} );
+
+	registerBlockType( 'test/post-context-provider', {
+		apiVersion: 3,
+		title: 'Test Post Context Provider',
+		icon: 'list-view',
+		category: 'text',
+
+		// Redundant with the server-side registration, but required since it
+		// is not picked up in `get_block_editor_server_block_settings`.
+		providesContext: {
+			postId: 'postId',
+			postType: 'postType',
+		},
+
+		edit: function Edit( { attributes, setAttributes } ) {
+			const blockProps = useBlockProps();
+			const innerBlocksProps = useInnerBlocksProps( blockProps );
+			return el(
+				'div',
+				innerBlocksProps,
+				el( 'input', {
+					'aria-label': 'Context post ID',
+					value: attributes.postId,
+					onChange( event ) {
+						setAttributes( {
+							postId: Number( event.currentTarget.value ),
+						} );
+					},
+				} ),
+				innerBlocksProps.children
+			);
+		},
+
+		save() {
+			return el( InnerBlocks.Content );
 		},
 	} );
 } )();

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	test,
+	expect,
+	Editor,
+} = require( '@wordpress/e2e-test-utils-playwright' );
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
 
 const ENDPOINT = [
 	'/wp/v2/block-renderer',
@@ -331,5 +337,104 @@ test.describe( 'PHP-only auto-register blocks', () => {
 			await expect( page.getByLabel( 'Spacing' ) ).toHaveValue( '0.5' );
 			await expect( page.getByLabel( 'Show Emojis' ) ).toBeChecked();
 		} );
+	} );
+} );
+
+test.describe( 'Server-side render with a non-editable post_id', () => {
+	const AUTHOR = {
+		username: 'ssrpermissionauthor',
+		password: 'ssrpermissionauthorpassword',
+	};
+	let adminPostId;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.createUser( {
+			username: AUTHOR.username,
+			email: 'ssrpermissionauthor@example.com',
+			roles: [ 'author' ],
+			password: AUTHOR.password,
+		} );
+		const post = await requestUtils.createPost( {
+			title: 'Admin owned post',
+			status: 'publish',
+		} );
+		adminPostId = post.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-server-side-rendered-block'
+		);
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllUsers();
+	} );
+
+	// The block-renderer endpoint requires `edit_post` permissions for the
+	// post referenced by `post_id`, so server-side rendered previews used to
+	// fail when the `postId` block context referenced a post the current
+	// user can't edit. See https://github.com/WordPress/gutenberg/issues/79949.
+	test( 'renders without post context instead of erroring when the user cannot edit the post', async ( {
+		browser,
+	} ) => {
+		// Log in as an author: the bug only reproduces for users who can't
+		// edit the post referenced by the `postId` context.
+		const context = await browser.newContext( { baseURL: BASE_URL } );
+		const page = await context.newPage();
+		await page.goto( '/wp-login.php' );
+		await page.locator( '#user_login' ).fill( AUTHOR.username );
+		await page.locator( '#user_pass' ).fill( AUTHOR.password );
+		await page.getByRole( 'button', { name: 'Log In' } ).click();
+		await page.waitForURL( '**/wp-admin/**' );
+
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => window?.wp?.data && window?.wp?.blocks
+		);
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'welcomeGuide', false );
+		} );
+
+		const editor = new Editor( { page } );
+
+		// Wait until the editor is initialized before inserting blocks, so
+		// they aren't wiped out by the initial content reset.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.waitFor( { timeout: 15000 } );
+
+		await editor.insertBlock( {
+			name: 'test/post-context-provider',
+			attributes: { postId: adminPostId, postType: 'post' },
+			innerBlocks: [
+				{ name: 'test/auto-register-block' },
+				{ name: 'core/breadcrumbs' },
+			],
+		} );
+
+		// The auto-registered PHP-only block renders without post context
+		// instead of showing "Error loading block: Sorry, you are not
+		// allowed to read blocks of this post."
+		await expect(
+			editor.canvas.getByText( 'Auto-register block content' )
+		).toBeVisible();
+
+		// The Breadcrumbs block falls back to its placeholder instead of
+		// loading indefinitely or showing an error.
+		await expect(
+			editor.canvas
+				.locator( '[data-type="core/breadcrumbs"]' )
+				.locator( 'ol' )
+		).toBeVisible();
+
+		await expect(
+			editor.canvas.getByText( /Error loading block/ )
+		).toHaveCount( 0 );
+
+		await context.close();
 	} );
 } );


### PR DESCRIPTION
Fixes #79949

Fixes the Breadcrumbs block and auto-registered PHP-only blocks failing to preview in the editor when the `postId` block context references a post the current user can't edit.

The block-renderer REST endpoint requires `edit_post` permissions for the post referenced by `post_id`, and these blocks forwarded the context `postId` unchecked. Core alone never triggers this, the posts list used by the Query Loop preview excludes posts the user can't edit, but providing a `postId` context is exactly the pattern third-party query-like blocks (related posts, custom loops) are built on, and those don't go through that filter. Inside one of them, Breadcrumbs stays on its loading state forever (its post record request also fails) and PHP-only blocks show "Error loading block: …", while the front end renders fine.

To fix this we only forward `post_id` when `canUser( 'update', … )` allows it: Breadcrumbs stops waiting for the inaccessible post record and falls back to its placeholder, and PHP-only blocks render without post context. Permissions usually resolve from the `targetHints` already sent with entity records, so no extra requests are made for editable posts. A minimal `test/post-context-provider` block is added to the SSR e2e test plugin to stand in for third-party providers, with an e2e test for the permission scenario.

## Before
<img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/79949-ssr-post-id/before.png" width="380">

## After
<img src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/79949-ssr-post-id/after.png" width="380">

## Testing Instructions

```bash
npm run test:e2e -- test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
```

Manual, on any site running this branch (no plugin needed):

1. Create an Author user and log in with it. Create a new post.
2. Paste this in the browser console; it registers a throwaway block that provides the `postId` context, standing in for a third-party query-like block:

   ```js
   wp.blocks.registerBlockType( 'repro/post-context-provider', {
   	title: 'Post context provider (repro)',
   	category: 'text',
   	attributes: { postId: { type: 'number' } },
   	providesContext: { postId: 'postId' },
   	edit: ( { attributes, setAttributes } ) => {
   		const el = wp.element.createElement;
   		const blockProps = wp.blockEditor.useBlockProps( {
   			style: { border: '1px dashed currentColor', padding: '12px' },
   		} );
   		const innerBlocksProps = wp.blockEditor.useInnerBlocksProps();
   		return el(
   			'div',
   			blockProps,
   			el( wp.components.TextControl, {
   				label: 'Context post ID',
   				type: 'number',
   				value: attributes.postId ?? '',
   				onChange: ( value ) =>
   					setAttributes( { postId: Number( value ) || undefined } ),
   			} ),
   			el( 'div', innerBlocksProps )
   		);
   	},
   	save: () => wp.element.createElement( wp.blockEditor.InnerBlocks.Content ),
   } );
   ```

3. Insert the "Post context provider (repro)" block and type `1` in its "Context post ID" input (the admin-owned "Hello world!" post — any post the Author can't edit works).
4. Insert Breadcrumbs inside it. Without this branch it stays on its loading state forever and the network tab shows the block-renderer and post record requests failing with 403; with this branch it renders its placeholder and `post_id` is not sent.
5. Change the ID to a post the Author owns and verify real breadcrumbs render (`post_id` is still sent). As admin, verify Breadcrumbs in a plain post and inside a Query Loop's Post Template are unchanged.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Server-rendered blocks now render successfully when the current user cannot edit the contextual post.
  - Inaccessible post context is no longer sent to the rendering service, preventing authorization errors.
  - Breadcrumbs display the appropriate placeholder when the related post cannot be edited.
  - Valid post context continues to be preserved when permissions and post types match.

- **Tests**
  - Added end-to-end coverage for restricted post permissions, contextual rendering, and mismatched post types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->