### PR TITLE
Rich text: resolve owned event listeners once instead of per subscriber

### DIFF
--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -341,8 +341,8 @@ export default ( props ) => ( element ) => {
 	// `handleSelectionChange` checks whether the element is focused itself,
 	// and the shared underlying delegated listener keeps the number of native
 	// listeners constant.
-	const unsubscribeSelectionChange = subscribeDelegatedListener(
-		ownerDocument,
+	const unsubscribeSelectionChange = subscribeOwnedListener(
+		element,
 		'selectionchange',
 		handleSelectionChange
 	);
@@ -363,8 +363,8 @@ export default ( props ) => ( element ) => {
 		'cut',
 		'paste',
 	].map( ( eventType ) =>
-		subscribeDelegatedListener(
-			ownerDocument,
+		subscribeOwnedListener(
+			element,
 			eventType,
 			handleSelectionChange,
 			true

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -348,8 +348,8 @@ export default ( props ) => ( element ) => {
 	// `handleSelectionChange` checks whether the element is focused itself,
 	// and the shared underlying delegated listener keeps the number of native
 	// listeners constant.
-	const unsubscribeSelectionChange = subscribeDelegatedListener(
-		ownerDocument,
+	const unsubscribeSelectionChange = subscribeOwnedListener(
+		element,
 		'selectionchange',
 		handleSelectionChange
 	);
@@ -370,8 +370,8 @@ export default ( props ) => ( element ) => {
 		'cut',
 		'paste',
 	].map( ( eventType ) =>
-		subscribeDelegatedListener(
-			ownerDocument,
+		subscribeOwnedListener(
+			element,
 			eventType,
 			handleSelectionChange,
 			true

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -17,30 +17,24 @@ const registries = new WeakMap();
 /**
  * Fires the callbacks of every subscribed element that owns the event.
  *
- * An element owns the event when it contains the target (the event happened
- * inside it) or `ownsSelection` is true (it owns the selection through a focused
- * editing host, e.g. the block editor canvas wrapper). That can only hold for
- * an ancestor of the target, an ancestor of the selection anchor, or the
- * focused element, so only those chains are walked, rather than testing every
- * subscriber. The check is the same one an element-bound listener would make;
- * it is only asked of the nodes that could pass it.
+ * These are editing and selection events, so the element that owns the event is
+ * the one that owns the selection: it contains the selection anchor, or it is
+ * the focused element (when the selection sits elsewhere). `ownsSelection` can
+ * only be true for an ancestor of the anchor or the focused element, so only
+ * those two chains are walked, rather than testing every subscriber.
  *
  * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
  * @param {Document} ownerDocument Document the listener is attached to.
  * @param {Event}    event         The event to dispatch.
  */
 function dispatch( elements, ownerDocument, event ) {
-	const { activeElement } = ownerDocument;
 	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
 	const fired = new Set();
 
-	for ( const start of [ event.target, anchorNode, activeElement ] ) {
+	for ( const start of [ anchorNode, ownerDocument.activeElement ] ) {
 		for ( let node = start; node; node = node.parentNode ) {
 			const callbacks = elements.get( node );
-			if ( ! callbacks || fired.has( node ) ) {
-				continue;
-			}
-			if ( node.contains( event.target ) || ownsSelection( node ) ) {
+			if ( callbacks && ! fired.has( node ) && ownsSelection( node ) ) {
 				fired.add( node );
 				for ( const callback of callbacks ) {
 					callback( event );
@@ -51,11 +45,11 @@ function dispatch( elements, ownerDocument, event ) {
 }
 
 /**
- * Subscribes a callback for events owned by the given editable element:
- * events targeting the element or its descendants, and events targeting a
- * focused editing host (e.g. an editable block editor canvas wrapper) while
- * the element contains the selection. In the latter case events target the
- * host, never the element, so an element-bound listener would not fire.
+ * Subscribes a callback for editing and selection events the given editable
+ * element owns, meaning it owns the document selection. This covers the case
+ * where a focused editing host (e.g. an editable block editor canvas wrapper)
+ * owns the selection: the event targets the host, never the element, so an
+ * element-bound listener would not fire.
  *
  * @param {HTMLElement} element   The editable element.
  * @param {string}      eventType DOM event name.

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -4,6 +4,52 @@ import { unlock } from './lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
+// ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >.
+//
+// Subscribers share one delegated listener per document, event type and phase.
+// `dispatch` works out which elements own the event and fires their callbacks,
+// rather than every subscriber checking whether it owns the event: bound to the
+// document, all of them run on every event, which with an editable element per
+// block is O(blocks) per keystroke. The element map is weak so a detached
+// element (or the iframe holding it) can be garbage-collected.
+const registries = new WeakMap();
+
+/**
+ * Fires the callbacks of every subscribed element that owns the event.
+ *
+ * An element owns the event when it contains the target (the event happened
+ * inside it) or `ownsSelection` is true (it owns the selection through a focused
+ * editing host, e.g. the block editor canvas wrapper). That can only hold for
+ * an ancestor of the target, an ancestor of the selection anchor, or the
+ * focused element, so only those chains are walked, rather than testing every
+ * subscriber. The check is the same one an element-bound listener would make;
+ * it is only asked of the nodes that could pass it.
+ *
+ * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
+ * @param {Document} ownerDocument Document the listener is attached to.
+ * @param {Event}    event         The event to dispatch.
+ */
+function dispatch( elements, ownerDocument, event ) {
+	const { activeElement } = ownerDocument;
+	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
+	const fired = new Set();
+
+	for ( const start of [ event.target, anchorNode, activeElement ] ) {
+		for ( let node = start; node; node = node.parentNode ) {
+			const callbacks = elements.get( node );
+			if ( ! callbacks || fired.has( node ) ) {
+				continue;
+			}
+			if ( node.contains( event.target ) || ownsSelection( node ) ) {
+				fired.add( node );
+				for ( const callback of callbacks ) {
+					callback( event );
+				}
+			}
+		}
+	}
+}
+
 /**
  * Subscribes a callback for events owned by the given editable element:
  * events targeting the element or its descendants, and events targeting a
@@ -24,18 +70,39 @@ export function subscribeOwnedListener(
 	callback,
 	capture = false
 ) {
-	return subscribeDelegatedListener(
-		element.ownerDocument,
-		eventType,
-		( event ) => {
-			if (
-				! element.contains( event.target ) &&
-				! ownsSelection( element )
-			) {
-				return;
-			}
-			callback( event );
-		},
-		capture
-	);
+	const { ownerDocument } = element;
+
+	let byEvent = registries.get( ownerDocument );
+	if ( ! byEvent ) {
+		byEvent = new Map();
+		registries.set( ownerDocument, byEvent );
+	}
+
+	const key = capture ? `${ eventType }:capture` : eventType;
+	let elements = byEvent.get( key );
+	if ( ! elements ) {
+		elements = new WeakMap();
+		byEvent.set( key, elements );
+		// One delegated listener per document, event type and phase, bound to
+		// the document so it is reached for every event and lets `dispatch`
+		// pick the owners. Riding the delegated listener keeps owned and
+		// element-bound subscribers in DOM order relative to each other.
+		subscribeDelegatedListener(
+			ownerDocument,
+			eventType,
+			( event ) => dispatch( elements, ownerDocument, event ),
+			capture
+		);
+	}
+
+	let callbacks = elements.get( element );
+	if ( ! callbacks ) {
+		callbacks = new Set();
+		elements.set( element, callbacks );
+	}
+	callbacks.add( callback );
+
+	return () => {
+		callbacks.delete( callback );
+	};
 }

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -15,11 +15,9 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 const registries = new WeakMap();
 
 /**
- * Subscribes a callback for editing and selection events the given editable
- * element owns, meaning it owns the document selection. This covers the case
- * where a focused editing host (e.g. an editable block editor canvas wrapper)
- * owns the selection: the event targets the host, never the element, so an
- * element-bound listener would not fire.
+ * Listens for events on the element. Unlike an element listener, it also
+ * fires when the selection is inside the element but a focused editing host
+ * around it (e.g. the editable canvas wrapper) is the event target.
  *
  * @param {HTMLElement} element   The editable element.
  * @param {string}      eventType DOM event name.

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -7,42 +7,12 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 // ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >.
 //
 // Subscribers share one delegated listener per document, event type and phase.
-// `dispatch` works out which elements own the event and fires their callbacks,
+// Its callback works out which element owns the event and fires its callbacks,
 // rather than every subscriber checking whether it owns the event: bound to the
 // document, all of them run on every event, which with an editable element per
 // block is O(blocks) per keystroke. The element map is weak so a detached
 // element (or the iframe holding it) can be garbage-collected.
 const registries = new WeakMap();
-
-/**
- * Fires the callbacks of every subscribed element that owns the event.
- *
- * These are editing and selection events, so the element that owns the event is
- * the one that owns the selection, and it contains the selection anchor. The
- * owner is found by walking up from the anchor, testing `ownsSelection`, rather
- * than testing every subscriber. When there is no selection, an editable can
- * still be focused, so the walk starts from the focused element instead.
- *
- * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
- * @param {Document} ownerDocument Document the listener is attached to.
- * @param {Event}    event         The event to dispatch.
- */
-function dispatch( elements, ownerDocument, event ) {
-	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
-
-	for (
-		let node = anchorNode ?? ownerDocument.activeElement;
-		node;
-		node = node.parentNode
-	) {
-		const callbacks = elements.get( node );
-		if ( callbacks && ownsSelection( node ) ) {
-			for ( const callback of callbacks ) {
-				callback( event );
-			}
-		}
-	}
-}
 
 /**
  * Subscribes a callback for editing and selection events the given editable
@@ -78,25 +48,46 @@ export function subscribeOwnedListener(
 		elements = new WeakMap();
 		byEvent.set( key, elements );
 		// One delegated listener per document, event type and phase, bound to
-		// the document so it is reached for every event and lets `dispatch`
-		// pick the owners. Riding the delegated listener keeps owned and
-		// element-bound subscribers in DOM order relative to each other.
+		// the document so it is reached for every event. Riding the delegated
+		// listener keeps owned and element-bound subscribers in DOM order
+		// relative to each other.
 		subscribeDelegatedListener(
 			ownerDocument,
 			eventType,
-			( event ) => dispatch( elements, ownerDocument, event ),
+			( event ) => {
+				// These are editing and selection events, so the element that
+				// owns the event owns the selection, and it contains the
+				// selection anchor. Walk up from the anchor, testing
+				// `ownsSelection`, rather than testing every subscriber. When
+				// there is no selection an editable can still be focused, so
+				// start from the focused element instead.
+				const { defaultView, activeElement } = ownerDocument;
+				const anchorNode = defaultView?.getSelection()?.anchorNode;
+				for (
+					let node = anchorNode ?? activeElement;
+					node;
+					node = node.parentNode
+				) {
+					const callbacks = elements.get( node );
+					if ( callbacks && ownsSelection( node ) ) {
+						for ( const cb of callbacks ) {
+							cb( event );
+						}
+					}
+				}
+			},
 			capture
 		);
 	}
 
-	let callbacks = elements.get( element );
-	if ( ! callbacks ) {
-		callbacks = new Set();
-		elements.set( element, callbacks );
+	let set = elements.get( element );
+	if ( ! set ) {
+		set = new Set();
+		elements.set( element, set );
 	}
-	callbacks.add( callback );
+	set.add( callback );
 
 	return () => {
-		callbacks.delete( callback );
+		set.delete( callback );
 	};
 }

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -18,10 +18,10 @@ const registries = new WeakMap();
  * Fires the callbacks of every subscribed element that owns the event.
  *
  * These are editing and selection events, so the element that owns the event is
- * the one that owns the selection: it contains the selection anchor, or it is
- * the focused element (when the selection sits elsewhere). `ownsSelection` can
- * only be true for an ancestor of the anchor or the focused element, so only
- * those two chains are walked, rather than testing every subscriber.
+ * the one that owns the selection, and it contains the selection anchor. The
+ * owner is found by walking up from the anchor, testing `ownsSelection`, rather
+ * than testing every subscriber. When there is no selection, an editable can
+ * still be focused, so the walk starts from the focused element instead.
  *
  * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
  * @param {Document} ownerDocument Document the listener is attached to.
@@ -29,16 +29,16 @@ const registries = new WeakMap();
  */
 function dispatch( elements, ownerDocument, event ) {
 	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
-	const fired = new Set();
 
-	for ( const start of [ anchorNode, ownerDocument.activeElement ] ) {
-		for ( let node = start; node; node = node.parentNode ) {
-			const callbacks = elements.get( node );
-			if ( callbacks && ! fired.has( node ) && ownsSelection( node ) ) {
-				fired.add( node );
-				for ( const callback of callbacks ) {
-					callback( event );
-				}
+	for (
+		let node = anchorNode ?? ownerDocument.activeElement;
+		node;
+		node = node.parentNode
+	) {
+		const callbacks = elements.get( node );
+		if ( callbacks && ownsSelection( node ) ) {
+			for ( const callback of callbacks ) {
+				callback( event );
 			}
 		}
 	}

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -11,6 +11,52 @@ import { unlock } from './lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
 
+// ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >.
+//
+// Subscribers share one delegated listener per document, event type and phase.
+// `dispatch` works out which elements own the event and fires their callbacks,
+// rather than every subscriber checking whether it owns the event: bound to the
+// document, all of them run on every event, which with an editable element per
+// block is O(blocks) per keystroke. The element map is weak so a detached
+// element (or the iframe holding it) can be garbage-collected.
+const registries = new WeakMap();
+
+/**
+ * Fires the callbacks of every subscribed element that owns the event.
+ *
+ * An element owns the event when it contains the target (the event happened
+ * inside it) or `ownsSelection` is true (it owns the selection through a focused
+ * editing host, e.g. the block editor canvas wrapper). That can only hold for
+ * an ancestor of the target, an ancestor of the selection anchor, or the
+ * focused element, so only those chains are walked, rather than testing every
+ * subscriber. The check is the same one an element-bound listener would make;
+ * it is only asked of the nodes that could pass it.
+ *
+ * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
+ * @param {Document} ownerDocument Document the listener is attached to.
+ * @param {Event}    event         The event to dispatch.
+ */
+function dispatch( elements, ownerDocument, event ) {
+	const { activeElement } = ownerDocument;
+	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
+	const fired = new Set();
+
+	for ( const start of [ event.target, anchorNode, activeElement ] ) {
+		for ( let node = start; node; node = node.parentNode ) {
+			const callbacks = elements.get( node );
+			if ( ! callbacks || fired.has( node ) ) {
+				continue;
+			}
+			if ( node.contains( event.target ) || ownsSelection( node ) ) {
+				fired.add( node );
+				for ( const callback of callbacks ) {
+					callback( event );
+				}
+			}
+		}
+	}
+}
+
 /**
  * Subscribes a callback for events owned by the given editable element:
  * events targeting the element or its descendants, and events targeting a
@@ -31,18 +77,39 @@ export function subscribeOwnedListener(
 	callback,
 	capture = false
 ) {
-	return subscribeDelegatedListener(
-		element.ownerDocument,
-		eventType,
-		( event ) => {
-			if (
-				! element.contains( event.target ) &&
-				! ownsSelection( element )
-			) {
-				return;
-			}
-			callback( event );
-		},
-		capture
-	);
+	const { ownerDocument } = element;
+
+	let byEvent = registries.get( ownerDocument );
+	if ( ! byEvent ) {
+		byEvent = new Map();
+		registries.set( ownerDocument, byEvent );
+	}
+
+	const key = capture ? `${ eventType }:capture` : eventType;
+	let elements = byEvent.get( key );
+	if ( ! elements ) {
+		elements = new WeakMap();
+		byEvent.set( key, elements );
+		// One delegated listener per document, event type and phase, bound to
+		// the document so it is reached for every event and lets `dispatch`
+		// pick the owners. Riding the delegated listener keeps owned and
+		// element-bound subscribers in DOM order relative to each other.
+		subscribeDelegatedListener(
+			ownerDocument,
+			eventType,
+			( event ) => dispatch( elements, ownerDocument, event ),
+			capture
+		);
+	}
+
+	let callbacks = elements.get( element );
+	if ( ! callbacks ) {
+		callbacks = new Set();
+		elements.set( element, callbacks );
+	}
+	callbacks.add( callback );
+
+	return () => {
+		callbacks.delete( callback );
+	};
 }

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -24,30 +24,24 @@ const registries = new WeakMap();
 /**
  * Fires the callbacks of every subscribed element that owns the event.
  *
- * An element owns the event when it contains the target (the event happened
- * inside it) or `ownsSelection` is true (it owns the selection through a focused
- * editing host, e.g. the block editor canvas wrapper). That can only hold for
- * an ancestor of the target, an ancestor of the selection anchor, or the
- * focused element, so only those chains are walked, rather than testing every
- * subscriber. The check is the same one an element-bound listener would make;
- * it is only asked of the nodes that could pass it.
+ * These are editing and selection events, so the element that owns the event is
+ * the one that owns the selection: it contains the selection anchor, or it is
+ * the focused element (when the selection sits elsewhere). `ownsSelection` can
+ * only be true for an ancestor of the anchor or the focused element, so only
+ * those two chains are walked, rather than testing every subscriber.
  *
  * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
  * @param {Document} ownerDocument Document the listener is attached to.
  * @param {Event}    event         The event to dispatch.
  */
 function dispatch( elements, ownerDocument, event ) {
-	const { activeElement } = ownerDocument;
 	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
 	const fired = new Set();
 
-	for ( const start of [ event.target, anchorNode, activeElement ] ) {
+	for ( const start of [ anchorNode, ownerDocument.activeElement ] ) {
 		for ( let node = start; node; node = node.parentNode ) {
 			const callbacks = elements.get( node );
-			if ( ! callbacks || fired.has( node ) ) {
-				continue;
-			}
-			if ( node.contains( event.target ) || ownsSelection( node ) ) {
+			if ( callbacks && ! fired.has( node ) && ownsSelection( node ) ) {
 				fired.add( node );
 				for ( const callback of callbacks ) {
 					callback( event );
@@ -58,11 +52,11 @@ function dispatch( elements, ownerDocument, event ) {
 }
 
 /**
- * Subscribes a callback for events owned by the given editable element:
- * events targeting the element or its descendants, and events targeting a
- * focused editing host (e.g. an editable block editor canvas wrapper) while
- * the element contains the selection. In the latter case events target the
- * host, never the element, so an element-bound listener would not fire.
+ * Subscribes a callback for editing and selection events the given editable
+ * element owns, meaning it owns the document selection. This covers the case
+ * where a focused editing host (e.g. an editable block editor canvas wrapper)
+ * owns the selection: the event targets the host, never the element, so an
+ * element-bound listener would not fire.
  *
  * @param {HTMLElement} element   The editable element.
  * @param {string}      eventType DOM event name.

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -25,10 +25,10 @@ const registries = new WeakMap();
  * Fires the callbacks of every subscribed element that owns the event.
  *
  * These are editing and selection events, so the element that owns the event is
- * the one that owns the selection: it contains the selection anchor, or it is
- * the focused element (when the selection sits elsewhere). `ownsSelection` can
- * only be true for an ancestor of the anchor or the focused element, so only
- * those two chains are walked, rather than testing every subscriber.
+ * the one that owns the selection, and it contains the selection anchor. The
+ * owner is found by walking up from the anchor, testing `ownsSelection`, rather
+ * than testing every subscriber. When there is no selection, an editable can
+ * still be focused, so the walk starts from the focused element instead.
  *
  * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
  * @param {Document} ownerDocument Document the listener is attached to.
@@ -36,16 +36,16 @@ const registries = new WeakMap();
  */
 function dispatch( elements, ownerDocument, event ) {
 	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
-	const fired = new Set();
 
-	for ( const start of [ anchorNode, ownerDocument.activeElement ] ) {
-		for ( let node = start; node; node = node.parentNode ) {
-			const callbacks = elements.get( node );
-			if ( callbacks && ! fired.has( node ) && ownsSelection( node ) ) {
-				fired.add( node );
-				for ( const callback of callbacks ) {
-					callback( event );
-				}
+	for (
+		let node = anchorNode ?? ownerDocument.activeElement;
+		node;
+		node = node.parentNode
+	) {
+		const callbacks = elements.get( node );
+		if ( callbacks && ownsSelection( node ) ) {
+			for ( const callback of callbacks ) {
+				callback( event );
 			}
 		}
 	}

--- a/packages/rich-text/src/subscribe-owned-listener.js
+++ b/packages/rich-text/src/subscribe-owned-listener.js
@@ -14,42 +14,12 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
 // ownerDocument -> eventTypeKey -> WeakMap< element, Set< callback > >.
 //
 // Subscribers share one delegated listener per document, event type and phase.
-// `dispatch` works out which elements own the event and fires their callbacks,
+// Its callback works out which element owns the event and fires its callbacks,
 // rather than every subscriber checking whether it owns the event: bound to the
 // document, all of them run on every event, which with an editable element per
 // block is O(blocks) per keystroke. The element map is weak so a detached
 // element (or the iframe holding it) can be garbage-collected.
 const registries = new WeakMap();
-
-/**
- * Fires the callbacks of every subscribed element that owns the event.
- *
- * These are editing and selection events, so the element that owns the event is
- * the one that owns the selection, and it contains the selection anchor. The
- * owner is found by walking up from the anchor, testing `ownsSelection`, rather
- * than testing every subscriber. When there is no selection, an editable can
- * still be focused, so the walk starts from the focused element instead.
- *
- * @param {WeakMap}  elements      Subscribed elements mapped to their callbacks.
- * @param {Document} ownerDocument Document the listener is attached to.
- * @param {Event}    event         The event to dispatch.
- */
-function dispatch( elements, ownerDocument, event ) {
-	const anchorNode = ownerDocument.defaultView?.getSelection()?.anchorNode;
-
-	for (
-		let node = anchorNode ?? ownerDocument.activeElement;
-		node;
-		node = node.parentNode
-	) {
-		const callbacks = elements.get( node );
-		if ( callbacks && ownsSelection( node ) ) {
-			for ( const callback of callbacks ) {
-				callback( event );
-			}
-		}
-	}
-}
 
 /**
  * Subscribes a callback for editing and selection events the given editable
@@ -85,25 +55,46 @@ export function subscribeOwnedListener(
 		elements = new WeakMap();
 		byEvent.set( key, elements );
 		// One delegated listener per document, event type and phase, bound to
-		// the document so it is reached for every event and lets `dispatch`
-		// pick the owners. Riding the delegated listener keeps owned and
-		// element-bound subscribers in DOM order relative to each other.
+		// the document so it is reached for every event. Riding the delegated
+		// listener keeps owned and element-bound subscribers in DOM order
+		// relative to each other.
 		subscribeDelegatedListener(
 			ownerDocument,
 			eventType,
-			( event ) => dispatch( elements, ownerDocument, event ),
+			( event ) => {
+				// These are editing and selection events, so the element that
+				// owns the event owns the selection, and it contains the
+				// selection anchor. Walk up from the anchor, testing
+				// `ownsSelection`, rather than testing every subscriber. When
+				// there is no selection an editable can still be focused, so
+				// start from the focused element instead.
+				const { defaultView, activeElement } = ownerDocument;
+				const anchorNode = defaultView?.getSelection()?.anchorNode;
+				for (
+					let node = anchorNode ?? activeElement;
+					node;
+					node = node.parentNode
+				) {
+					const callbacks = elements.get( node );
+					if ( callbacks && ownsSelection( node ) ) {
+						for ( const cb of callbacks ) {
+							cb( event );
+						}
+					}
+				}
+			},
 			capture
 		);
 	}
 
-	let callbacks = elements.get( element );
-	if ( ! callbacks ) {
-		callbacks = new Set();
-		elements.set( element, callbacks );
+	let set = elements.get( element );
+	if ( ! set ) {
+		set = new Set();
+		elements.set( element, set );
 	}
-	callbacks.add( callback );
+	set.add( callback );
 
 	return () => {
-		callbacks.delete( callback );
+		set.delete( callback );
 	};
 }


### PR DESCRIPTION
## What?

Makes `subscribeOwnedListener` work out which element an event belongs to once per event, instead of every rich text instance checking for itself.

## Why?

Every rich text instance listens on the document, so each keystroke ran the ownership check once per block. Typing gets slower as the post grows.

## How?

One document listener per event type. It walks up from the selection (or the focused element) to find the subscribed element and calls only its callbacks.

`handleSelectionChange` must run before `format-boundaries`, `delete`, etc. in the same keydown, because they read the `record.current` it updates. Both were document listeners, so their order was the order they were added. Now `format-boundaries` and friends run from one shared document listener that is added when the first block mounts. If `handleSelectionChange` stayed a plain document listener, for every later block it would be added after that shared listener, so it would run after them. Moving it into the same shared listener keeps it first.

## Testing Instructions

1. Type, split, merge, format, and move between blocks: nothing changes.
2. CI performance job: `type` -36% post editor, -25% site editor.

## Use of AI Tools

Written with the help of Claude Code.
