### PR TITLE
Build: Normalize import extensions in ESM package type declarations

### DIFF
--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -150,6 +150,17 @@ async function build() {
 			const buildTime = Date.now() - tsStartTime;
 			console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
 
+			// Add explicit extensions to relative specifiers in ESM package
+			// declarations so they resolve under Node-style ESM (node16/nodenext),
+			// not just bundler resolution. See https://github.com/WordPress/gutenberg/issues/80206.
+			console.log( '\n🧩 Normalizing ESM declaration extensions...' );
+			await exec( 'node', [
+				path.join(
+					__dirname,
+					'packages/normalize-declaration-extensions.mjs'
+				),
+			] );
+
 			console.log( '\n✅ Checking type declaration files...' );
 			await exec( 'node', [
 				path.join(

--- a/tools/build-scripts/packages/normalize-declaration-extensions.mjs
+++ b/tools/build-scripts/packages/normalize-declaration-extensions.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Adds explicit file extensions to relative import/export specifiers in the
+ * compiled type declarations of `"type": "module"` packages.
+ *
+ * `tsc` emits declaration specifiers verbatim from source, and the shared
+ * config authors extensionless relative imports (valid under
+ * `moduleResolution: "bundler"`). Because these packages are ESM, Node-style
+ * resolution (`node16`/`nodenext`) rejects extensionless relative specifiers in
+ * the published `.d.ts` graph, which `@arethetypeswrong/cli` reports as an
+ * `InternalResolutionError`.
+ *
+ * This mirrors what esbuild already does for the runtime `build-module` output
+ * (which emits `./foo.mjs`), normalizing the declaration emit as a shared
+ * post-`tsc` step rather than a per-package workaround.
+ *
+ * A relative specifier is resolved against the emitted declaration graph and
+ * rewritten to point at the runtime counterpart of its target:
+ *   - `./foo`       -> `./foo.js`        (target `foo.d.ts`)
+ *   - `./foo`       -> `./foo.mjs`       (target `foo.d.mts`)
+ *   - `./foo`       -> `./foo.cjs`       (target `foo.d.cts`)
+ *   - `./dir`       -> `./dir/index.js`  (target `dir/index.d.ts`)
+ * TypeScript maps the `.js`/`.mjs`/`.cjs` specifier back to the sibling
+ * declaration during resolution, so this is valid for both bundler and
+ * Node-style ESM consumers.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/80206
+ */
+
+/**
+ * External dependencies
+ */
+import { readdir, readFile, writeFile, access } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
+const ROOT_DIR = path.resolve( __dirname, '../../..' );
+
+// The packages directory to scan. Defaults to the repo's `packages`; an
+// explicit path can be passed as the first argument (used by tests).
+const PACKAGES_DIR = process.argv[ 2 ]
+	? path.resolve( process.argv[ 2 ] )
+	: path.join( ROOT_DIR, 'packages' );
+
+// Declaration extension -> runtime extension the specifier should point at.
+const DECLARATION_TO_RUNTIME = [
+	[ '.d.mts', '.mjs' ],
+	[ '.d.cts', '.cjs' ],
+	[ '.d.ts', '.js' ],
+];
+
+// Specifiers already carrying one of these are left untouched.
+const KNOWN_EXTENSIONS = [
+	'.js',
+	'.mjs',
+	'.cjs',
+	'.jsx',
+	'.json',
+	'.css',
+	'.node',
+	'.wasm',
+];
+
+/**
+ * Matches the specifier of a relative `import`/`export ... from`, side-effect
+ * `import`, and (inline or dynamic) `import(...)`. Capture groups: prefix,
+ * quote, specifier, closing quote.
+ */
+const SPECIFIER_RE =
+	/(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(['"])(\.\.?\/[^'"]*)(['"])/g;
+
+/**
+ * Whether a filesystem path exists.
+ *
+ * @param {string} filePath Absolute path.
+ * @return {Promise<boolean>} Whether the path exists.
+ */
+async function exists( filePath ) {
+	try {
+		await access( filePath );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Resolves a relative specifier against the emitted declaration graph and
+ * returns the runtime extension (or `/index.*`) it should be rewritten with, or
+ * `null` when it should be left unchanged.
+ *
+ * @param {string} fromDir   Directory of the file containing the specifier.
+ * @param {string} specifier The relative specifier, e.g. `./foo`.
+ * @return {Promise<string|null>} The suffix to append, or `null`.
+ */
+async function resolveSuffix( fromDir, specifier ) {
+	// Already carries a meaningful extension.
+	if ( KNOWN_EXTENSIONS.some( ( ext ) => specifier.endsWith( ext ) ) ) {
+		return null;
+	}
+
+	const target = path.resolve( fromDir, specifier );
+
+	// Direct file match: `./foo` -> `./foo.<runtime>`.
+	for ( const [ decExt, runtimeExt ] of DECLARATION_TO_RUNTIME ) {
+		if ( await exists( target + decExt ) ) {
+			return runtimeExt;
+		}
+	}
+
+	// Directory match: `./dir` -> `./dir/index.<runtime>`.
+	for ( const [ decExt, runtimeExt ] of DECLARATION_TO_RUNTIME ) {
+		if ( await exists( path.join( target, `index${ decExt }` ) ) ) {
+			return `/index${ runtimeExt }`;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Rewrites the relative specifiers of a single declaration file in place.
+ *
+ * @param {string} file Absolute path to a declaration file.
+ * @return {Promise<number>} Number of specifiers rewritten.
+ */
+async function normalizeFile( file ) {
+	const source = await readFile( file, 'utf8' );
+	const fromDir = path.dirname( file );
+
+	// Collect matches first because the replacement is async.
+	const matches = [ ...source.matchAll( SPECIFIER_RE ) ];
+	const replacements = await Promise.all(
+		matches.map( async ( match ) => {
+			const [ , , , specifier ] = match;
+			return resolveSuffix( fromDir, specifier );
+		} )
+	);
+
+	let rewritten = 0;
+	let index = 0;
+	const output = source.replace(
+		SPECIFIER_RE,
+		( full, prefix, quote, specifier, closingQuote ) => {
+			const suffix = replacements[ index++ ];
+			if ( suffix === null ) {
+				return full;
+			}
+			rewritten++;
+			return `${ prefix }${ quote }${ specifier }${ suffix }${ closingQuote }`;
+		}
+	);
+
+	if ( rewritten > 0 ) {
+		await writeFile( file, output );
+	}
+	return rewritten;
+}
+
+/**
+ * Recursively collects declaration files under a directory.
+ *
+ * @param {string} dir Directory to walk.
+ * @return {Promise<string[]>} Absolute paths of declaration files.
+ */
+async function collectDeclarationFiles( dir ) {
+	const entries = await readdir( dir, { withFileTypes: true } );
+	const files = await Promise.all(
+		entries.map( async ( entry ) => {
+			const full = path.join( dir, entry.name );
+			if ( entry.isDirectory() ) {
+				return collectDeclarationFiles( full );
+			}
+			// Skip declaration maps; only rewrite declaration files.
+			return /\.d\.(ts|mts|cts)$/.test( entry.name ) ? [ full ] : [];
+		} )
+	);
+	return files.flat();
+}
+
+/**
+ * Whether a package publishes ESM declarations that need normalization, i.e. it
+ * declares `"type": "module"` and has a `build-types` directory.
+ *
+ * @param {string} packagePath Absolute path to the package.
+ * @return {Promise<boolean>} Whether the package needs normalization.
+ */
+async function packageNeedsNormalization( packagePath ) {
+	try {
+		const pkg = JSON.parse(
+			await readFile( path.join( packagePath, 'package.json' ), 'utf8' )
+		);
+		if ( pkg.type !== 'module' ) {
+			return false;
+		}
+	} catch {
+		return false;
+	}
+	return exists( path.join( packagePath, 'build-types' ) );
+}
+
+async function normalizeDeclarationExtensions() {
+	const packageDirs = (
+		await readdir( PACKAGES_DIR, { withFileTypes: true } )
+	)
+		.filter( ( dirent ) => dirent.isDirectory() )
+		.map( ( dirent ) => path.join( PACKAGES_DIR, dirent.name ) );
+
+	let totalRewritten = 0;
+	for ( const packageDir of packageDirs ) {
+		if ( ! ( await packageNeedsNormalization( packageDir ) ) ) {
+			continue;
+		}
+
+		const files = await collectDeclarationFiles(
+			path.join( packageDir, 'build-types' )
+		);
+		const counts = await Promise.all( files.map( normalizeFile ) );
+		const rewritten = counts.reduce( ( sum, count ) => sum + count, 0 );
+
+		if ( rewritten > 0 ) {
+			totalRewritten += rewritten;
+			console.log(
+				`   ✔ ${ path.basename(
+					packageDir
+				) }: normalized ${ rewritten } declaration specifier(s)`
+			);
+		}
+	}
+
+	if ( totalRewritten === 0 ) {
+		console.log(
+			'   ✔ No declaration specifiers required normalization.'
+		);
+	}
+}
+
+normalizeDeclarationExtensions().catch( ( error ) => {
+	console.error( error );
+	process.exit( 1 );
+} );

--- a/tools/build-scripts/packages/normalize-declaration-extensions.test.js
+++ b/tools/build-scripts/packages/normalize-declaration-extensions.test.js
@@ -1,0 +1,206 @@
+/* global afterEach, expect, test, describe */
+
+/**
+ * External dependencies
+ */
+const { spawnSync } = require( 'node:child_process' );
+const {
+	mkdtempSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+	readFileSync,
+} = require( 'node:fs' );
+const { tmpdir } = require( 'node:os' );
+const { dirname, join } = require( 'node:path' );
+
+const scriptPath = join( __dirname, 'normalize-declaration-extensions.mjs' );
+const temporaryRoots = [];
+
+afterEach( () => {
+	for ( const root of temporaryRoots.splice( 0 ) ) {
+		rmSync( root, { force: true, recursive: true } );
+	}
+} );
+
+/**
+ * Creates a temporary `packages` directory containing a single package.
+ *
+ * @param {Object} options               Options.
+ * @param {Object} options.files         Map of relative path -> file contents.
+ * @param {Object} [options.packageJson] Extra package.json fields.
+ * @return {{ packagesDir: string, read: (relativePath: string) => string }} Handles.
+ */
+function createPackagesDir( { files, packageJson = {} } ) {
+	const root = mkdtempSync( join( tmpdir(), 'normalize-declarations-' ) );
+	temporaryRoots.push( root );
+
+	const packageDir = join( root, 'packages', 'sample' );
+	mkdirSync( packageDir, { recursive: true } );
+
+	writeFileSync(
+		join( packageDir, 'package.json' ),
+		JSON.stringify(
+			{ name: '@wordpress/sample', version: '1.0.0', ...packageJson },
+			null,
+			'\t'
+		) + '\n'
+	);
+
+	for ( const [ path, contents ] of Object.entries( files ) ) {
+		const filePath = join( packageDir, path );
+		mkdirSync( dirname( filePath ), { recursive: true } );
+		writeFileSync( filePath, contents );
+	}
+
+	return {
+		packagesDir: join( root, 'packages' ),
+		read: ( relativePath ) =>
+			readFileSync( join( packageDir, relativePath ), 'utf8' ),
+	};
+}
+
+function run( packagesDir ) {
+	return spawnSync( 'node', [ scriptPath, packagesDir ], {
+		encoding: 'utf8',
+	} );
+}
+
+describe( 'normalize-declaration-extensions', () => {
+	test( 'appends .js to extensionless relative specifiers in ESM packages', () => {
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts':
+					"export { privateApis } from './private-apis';\n" +
+					"export type * from './types';\n",
+				'build-types/private-apis.d.ts':
+					'export declare const x: number;\n',
+				'build-types/types.d.ts': 'export type T = string;\n',
+			},
+		} );
+
+		const { status } = run( packagesDir );
+
+		expect( status ).toBe( 0 );
+		expect( read( 'build-types/index.d.ts' ) ).toBe(
+			"export { privateApis } from './private-apis.js';\n" +
+				"export type * from './types.js';\n"
+		);
+	} );
+
+	test( 'rewrites a directory specifier to /index.js', () => {
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts': "export * from './nested';\n",
+				'build-types/nested/index.d.ts': 'export type T = number;\n',
+			},
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe(
+			"export * from './nested/index.js';\n"
+		);
+	} );
+
+	test( 'matches the target declaration kind (.d.mts -> .mjs)', () => {
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts': "export * from './tokens';\n",
+				'build-types/tokens.d.mts': 'export declare const t: number;\n',
+			},
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe(
+			"export * from './tokens.mjs';\n"
+		);
+	} );
+
+	test( 'rewrites dynamic and inline import() specifiers', () => {
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts':
+					"export declare const c: import('./context').Ctx;\n",
+				'build-types/context.d.ts': 'export type Ctx = unknown;\n',
+			},
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe(
+			"export declare const c: import('./context.js').Ctx;\n"
+		);
+	} );
+
+	test( 'leaves specifiers with an existing extension untouched', () => {
+		const original =
+			"export { a } from './a.js';\n" +
+			"import './styles.css';\n" +
+			"export type { T } from './b.mjs';\n";
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts': original,
+				'build-types/a.d.ts': 'export declare const a: number;\n',
+				'build-types/b.d.mts': 'export type T = string;\n',
+			},
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe( original );
+	} );
+
+	test( 'does not touch bare (package) specifiers', () => {
+		const original =
+			"export { compose } from '@wordpress/compose';\n" +
+			"import { useState } from 'react';\n";
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: { 'build-types/index.d.ts': original },
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe( original );
+	} );
+
+	test( 'skips packages that are not "type": "module"', () => {
+		const original = "export { x } from './x';\n";
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: {},
+			files: {
+				'build-types/index.d.ts': original,
+				'build-types/x.d.ts': 'export declare const x: number;\n',
+			},
+		} );
+
+		run( packagesDir );
+
+		expect( read( 'build-types/index.d.ts' ) ).toBe( original );
+	} );
+
+	test( 'is idempotent', () => {
+		const { packagesDir, read } = createPackagesDir( {
+			packageJson: { type: 'module' },
+			files: {
+				'build-types/index.d.ts': "export { x } from './x';\n",
+				'build-types/x.d.ts': 'export declare const x: number;\n',
+			},
+		} );
+
+		run( packagesDir );
+		const afterFirst = read( 'build-types/index.d.ts' );
+		run( packagesDir );
+		const afterSecond = read( 'build-types/index.d.ts' );
+
+		expect( afterFirst ).toBe( "export { x } from './x.js';\n" );
+		expect( afterSecond ).toBe( afterFirst );
+	} );
+} );


### PR DESCRIPTION
## What?

Adds a shared post-`tsc` build step that appends explicit file extensions to the relative import/export specifiers in the compiled type declarations of `"type": "module"` packages, so the published `.d.ts` graph resolves under Node-style ESM (`node16`/`nodenext`) and not just `bundler`.

- #80206 

## Why?

`tsc` emits declaration specifiers verbatim from source, and the shared config authors extensionless relative imports (valid under `moduleResolution: "bundler"`). Because these packages are `"type": "module"`, Node interprets the emitted `.d.ts`
as ESM, where relative specifiers **require** file extensions. As reported in https://github.com/WordPress/gutenberg/issues/80206, `@arethetypeswrong/cli` (`attw`) flags this as an `InternalResolutionError` for `@wordpress/theme`, `@wordpress/design-system-mcp`, and `@wordpress/video-conversion` (and `@wordpress/vips`):

"@wordpress/theme"
node16 (from ESM): 🥴 Internal resolution error
bundler:           🟢

Notably, the **runtime half of the pipeline already handles this** — esbuild emits `./private-apis.mjs` in `build-module`. The defect is an asymmetry: the JS emit normalizes extensions, the declaration emit does not. This PR closes that gap in
shared tooling rather than per-package.

## How?

- New `tools/build-scripts/packages/normalize-declaration-extensions.mjs`, run  right after `tsc --build` in `build.mjs`.
- For each `"type": "module"` package with a `build-types/` directory, it resolves  every relative specifier against the emitted declaration graph and rewrites it to  the runtime counterpart of its target:
  - `./foo` → `./foo.js` (target `foo.d.ts`)
  - `./foo` → `./foo.mjs` / `.cjs` (target `foo.d.mts` / `foo.d.cts`)
  - `./dir` → `./dir/index.js` (directory targets)
- Handles `from`, side-effect `import`, and inline/dynamic `import(...)` specifiers;  skips bare (package) specifiers and specifiers that already carry an extension (idempotent).
- **Source is left untouched** — imports stay extensionless, so Jest, Storybook, webpack, and the bundler-based type check are unaffected. The rewrite only targets the generated (gitignored) `build-types` artifacts, mirroring esbuild's  existing `.mjs` handling.
- Unit tests in `normalize-declaration-extensions.test.js`.

### Design notes / trade-offs

- This is one of the tactical options from #80206. The alternative (explicit `.ts`/`.tsx` source extensions via `allowImportingTsExtensions`) is also viable and would make the change visible in source, but touches imports repo-wide. Both are compatible with — and superseded by — a future`tsdown`/`tsup` dual-build migration.
- Because the step runs last, a bare `tsc --build` on its own still emits extensionless declarations locally; the normalization is applied by `npm run build` (the published path). Only `tsc` writes `build-types`, so nothing after the step clobbers it.

## Testing Instructions

1. Build declarations for an affected package: `npx tsc --build packages/theme/tsconfig.json --force`
2. Confirm the raw output has extensionless specifiers (head -1 packages/theme/build-types/index.d.ts).
3. Run the normalizer:  `node tools/build-scripts/packages/normalize-declaration-extensions.mjs`
3. The specifiers now carry .js (e.g. from './private-apis.js').
4. Validate with attw — node16 (from ESM) should be green with 0 internal resolution errors: `npx -y @arethetypeswrong/cli@0.18.4 --pack packages/theme --profile esm-only`
4. Repeat for design-system-mcp, video-conversion, vips.
5. Run the unit tests: `npm run test:unit -- tools/build-scripts/packages/normalize-declaration-extensions.test.js`

Verified: a consumer importing @wordpress/theme type-checks cleanly under bundler, node16, and nodenext after normalization.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Claude Code: Opus 4.8
Investigate and 