### PR TITLE
Writing flow: keep the scroll position when a selection becomes a block multi-selection

### DIFF
--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -171,7 +171,10 @@ export function setContentEditableWrapper(
 	node.setAttribute( 'aria-label', __( 'Editor canvas' ) );
 
 	if ( focus ) {
-		node.focus();
+		// Without preventScroll, focusing the wrapper (or the browser
+		// moving focus to it on its own when it becomes the editing
+		// host) scrolls the viewport to the top of the wrapper.
+		node.focus( { preventScroll: true } );
 	}
 
 	return true;

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1504,6 +1504,81 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 					{ name: 'core/spacer' },
 				] );
 		} );
+
+		test( 'should not scroll the canvas when the selection spans a scrolled page', async ( {
+			editor,
+			page,
+			browserName,
+		} ) => {
+			test.fixme(
+				browserName === 'webkit',
+				'WebKit still scrolls through a different route: transient single selections during the gesture trigger the selected block scroll into view behavior. See #80608.'
+			);
+			await editor.insertBlock( { name: 'core/spacer' } );
+			for ( let i = 0; i < 30; i++ ) {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: { content: `${ i }` },
+				} );
+			}
+
+			const frame = page.frame( { name: 'editor-canvas' } );
+
+			// Select the spacer at the top of the document.
+			await frame.evaluate( () => {
+				document.documentElement.scrollTop = 0;
+			} );
+			await editor.canvas
+				.getByRole( 'document', { name: 'Block: Spacer' } )
+				.click();
+
+			// Scroll to the bottom of the document, and resolve after the
+			// scroll event settles so the watcher below only sees
+			// scrolling caused by the selection.
+			const before = await frame.evaluate(
+				() =>
+					new Promise( ( resolve ) => {
+						document.addEventListener(
+							'scroll',
+							() =>
+								window.requestAnimationFrame( () =>
+									resolve(
+										document.documentElement.scrollTop
+									)
+								),
+							{ once: true }
+						);
+						document.documentElement.scrollTop =
+							document.documentElement.scrollHeight;
+					} )
+			);
+			expect( before ).toBeGreaterThan( 0 );
+
+			// Record every scroll movement for a second. The page may
+			// scroll up and back down again, so the position cannot be
+			// asserted after the fact.
+			const scrollWatcher = frame.evaluate(
+				() =>
+					new Promise( ( resolve ) => {
+						const positions = [];
+						document.addEventListener( 'scroll', () => {
+							positions.push(
+								document.documentElement.scrollTop
+							);
+						} );
+						setTimeout( () => resolve( positions ), 1000 );
+					} )
+			);
+
+			// Extend the selection to a paragraph at the bottom. Focus
+			// moves to the editable wrapper, which must not scroll the
+			// page back to the top of the document.
+			await editor.canvas
+				.getByText( '28', { exact: true } )
+				.click( { modifiers: [ 'Shift' ] } );
+
+			expect( await scrollWatcher ).toEqual( [] );
+		} );
 	} );
 
 	test( 'should select by dragging into separator', async ( {


### PR DESCRIPTION
## What?
Selecting blocks across a scrolled page (e.g. shift+clicking a block far down while a block at the top is selected) no longer scrolls the viewport to the top of the document and back. See #72512.

## Why?
When a selection becomes a block multi-selection, the block list wrapper becomes the editing host and receives focus, either from the explicit focus call or from the browser moving focus there on its own. Focusing the wrapper scrolls it into view, and since it spans the whole document, that means jumping to the top.

## How?
The focus call passes `preventScroll: true`. Focus still moves; only the scrolling is suppressed. There is no case where scrolling to the top of the wrapper is wanted: anything that legitimately scrolls (caret placement, block focus) does so through its own element.

The new test records scroll events during the gesture, since asserting the position afterwards would miss the round trip. It is skipped on WebKit: transient single selections during the gesture separately trigger the selected block scroll-into-view behavior there, part of the selection races tracked in #80608.

## Testing Instructions
1. Insert a spacer followed by enough paragraphs to make the page scroll.
2. Click the spacer to select it, then scroll to the bottom.
3. Shift+click a paragraph near the bottom.
4. The viewport should not move. On trunk it snaps to the top of the document and animates back down.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.