### PR TITLE
Apply Global Styles block spacing to inner blocks of flow and constrained containers

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -479,6 +479,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	$rules_group             = $options['rules_group'] ?? null;
 	$has_block_gap_override  = ! empty( $options['has_block_gap_override'] );
 	$should_output_block_gap = null === $viewport_overrides || $has_block_gap_override;
+
+	$should_apply_fallback_gap = ! empty( $options['apply_fallback_gap'] ) && null === $viewport_overrides;
+	$resolved_fallback_gap     = is_array( $fallback_gap_value )
+		? ( $fallback_gap_value['top'] ?? reset( $fallback_gap_value ) )
+		: $fallback_gap_value;
 	// Viewport styles only store changed fields. If a field is present with null,
 	// the user cleared a value inherited from the default viewport, so check
 	// whether the key exists rather than whether the value is truthy.
@@ -491,6 +496,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support && $should_output_block_gap ) {
 			if ( is_array( $gap_value ) ) {
 				$gap_value = $gap_value['top'] ?? null;
+			}
+			if ( null === $gap_value && $should_apply_fallback_gap ) {
+				$gap_value = $resolved_fallback_gap;
 			}
 			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
 				// Get spacing CSS variable from preset value if provided.
@@ -643,6 +651,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support && $should_output_block_gap ) {
 			if ( is_array( $gap_value ) ) {
 				$gap_value = $gap_value['top'] ?? null;
+			}
+			if ( null === $gap_value && $should_apply_fallback_gap ) {
+				$gap_value = $resolved_fallback_gap;
 			}
 			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
 				// Get spacing CSS variable from preset value if provided.
@@ -928,6 +939,30 @@ function gutenberg_incremental_id_per_prefix( $prefix = '' ) {
 }
 
 /**
+ * Returns the list of container blocks whose inner block gap should follow the
+ * site-wide block spacing (Global Styles > Layout > Block spacing) instead of a
+ * theme-defined per-block blockGap value.
+ *
+ * These blocks wrap arbitrary inner content and users expect the spacing between
+ * that content to match the rest of the site. See
+ * https://github.com/WordPress/gutenberg/issues/49777.
+ *
+ * @return string[] Array of block names.
+ */
+function gutenberg_blocks_using_site_block_gap() {
+	/**
+	 * Filters the list of blocks whose inner block gap follows the site-wide
+	 * block spacing rather than a theme-defined per-block blockGap value.
+	 *
+	 * @param string[] $block_names Array of block names.
+	 */
+	return apply_filters(
+		'gutenberg_blocks_using_site_block_gap',
+		array( 'core/quote', 'core/details' )
+	);
+}
+
+/**
  * Generates a unique ID based on the structure and values of a given array.
  *
  * This function serializes the array into a JSON string and generates a hash
@@ -1171,7 +1206,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			}
 		}
 
-		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+		$blocks_using_site_block_gap = gutenberg_blocks_using_site_block_gap();
+		if ( in_array( $block_name, $blocks_using_site_block_gap, true ) ) {
+			$global_block_gap_value = $global_styles['spacing']['blockGap'] ?? null;
+		} else {
+			$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+		}
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;
@@ -1227,7 +1267,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			$gap_value,
 			$should_skip_gap_serialization,
 			$fallback_gap_value,
-			$block_spacing
+			$block_spacing,
+			array( 'apply_fallback_gap' => null !== $global_block_gap_value )
 		);
 
 		// Only add container class and enqueue block support styles if unique styles were generated.

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   Flow and constrained layouts now fall back to the Global Styles block gap when a block does not define its own, so inner blocks of containers such as Group inherit the site's spacing instead of the browser's default margin. Container blocks that wrap arbitrary content (Quote, Details) follow the site-wide block spacing rather than a theme's per-block blockGap, so the Global Styles > Layout > Block spacing setting is reflected inside them ([#49777](https://github.com/WordPress/gutenberg/issues/49777)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 
 ## 16.0.0 (2026-07-14)

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -49,6 +49,8 @@ import {
 
 const VARIATION_PREFIX = 'is-style-';
 
+const BLOCKS_USING_SITE_BLOCK_GAP = [ 'core/quote', 'core/details' ];
+
 const layoutBlockSupportKey = 'layout';
 const CHILD_LAYOUT_KEYS = [
 	'selfStretch',
@@ -771,9 +773,12 @@ export const withLayoutStyles = createHigherOrderComponent(
 					}
 
 					const globalBlockGapValue =
-						variationBlockGapValue ??
-						globalStyles?.blocks?.[ name ]?.spacing?.blockGap ??
-						globalStyles?.spacing?.blockGap;
+						BLOCKS_USING_SITE_BLOCK_GAP.includes( name )
+							? globalStyles?.spacing?.blockGap
+							: variationBlockGapValue ??
+							  globalStyles?.blocks?.[ name ]?.spacing
+									?.blockGap ??
+							  globalStyles?.spacing?.blockGap;
 
 					return {
 						blockGapSupport,

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -245,6 +245,7 @@ export default {
 		style,
 		blockName,
 		hasBlockGapSupport,
+		globalBlockGapValue,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
 		const hasViewportOverrides = viewportOverrides !== undefined;
@@ -271,6 +272,14 @@ export default {
 				blockGapValue = getGapCSSValue( blockGapStyleValue?.top );
 			} else if ( typeof blockGapStyleValue === 'string' ) {
 				blockGapValue = getGapCSSValue( blockGapStyleValue );
+			}
+
+			if (
+				! blockGapValue &&
+				globalBlockGapValue &&
+				! hasViewportOverrides
+			) {
+				blockGapValue = getGapCSSValue( globalBlockGapValue );
 			}
 		}
 

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -25,6 +25,8 @@ export default {
 		style,
 		blockName,
 		hasBlockGapSupport,
+		globalBlockGapValue,
+		viewportOverrides,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
 		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
@@ -38,6 +40,14 @@ export default {
 				blockGapValue = getGapCSSValue( blockGapStyleValue?.top );
 			} else if ( typeof blockGapStyleValue === 'string' ) {
 				blockGapValue = getGapCSSValue( blockGapStyleValue );
+			}
+
+			if (
+				! blockGapValue &&
+				globalBlockGapValue &&
+				viewportOverrides === undefined
+			) {
+				blockGapValue = getGapCSSValue( globalBlockGapValue );
 			}
 		}
 

--- a/packages/block-editor/src/layouts/test/constrained.js
+++ b/packages/block-editor/src/layouts/test/constrained.js
@@ -46,6 +46,51 @@ describe( 'getLayoutStyle', () => {
 		expect( result ).toBe( expected );
 	} );
 
+	it( 'should fall back to the global block gap when the block has no explicit blockGap', () => {
+		const result = constrained.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { type: 'constrained' },
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+		} );
+
+		expect( result ).toContain(
+			'.my-container > * { margin-block-start: var(--wp--preset--spacing--30); margin-block-end: 0; }'
+		);
+	} );
+
+	it( 'should prefer an explicit blockGap over the global block gap fallback', () => {
+		const result = constrained.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { type: 'constrained' },
+			style: { spacing: { blockGap: '10px' } },
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+		} );
+
+		expect( result ).toContain(
+			'.my-container > * { margin-block-start: 10px; margin-block-end: 0; }'
+		);
+		expect( result ).not.toContain( 'var(--wp--preset--spacing--30)' );
+	} );
+
+	it( 'should not apply the global block gap fallback for viewport overrides', () => {
+		const result = constrained.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { type: 'constrained' },
+			viewportOverrides: { justifyContent: 'left' },
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+		} );
+
+		expect( result ).not.toContain( 'var(--wp--preset--spacing--30)' );
+	} );
+
 	it( 'should reset constrained sizes when content width is unset in a viewport', () => {
 		const result = constrained.getLayoutStyle( {
 			selector: '.my-container',

--- a/packages/block-editor/src/layouts/test/flow.js
+++ b/packages/block-editor/src/layouts/test/flow.js
@@ -18,4 +18,49 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
+
+	it( 'should fall back to the global block gap when the block has no explicit blockGap', () => {
+		const result = flow.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {},
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+		} );
+
+		expect( result ).toContain(
+			'.my-container > * { margin-block-start: var(--wp--preset--spacing--30); margin-block-end: 0; }'
+		);
+	} );
+
+	it( 'should prefer an explicit blockGap over the global block gap fallback', () => {
+		const result = flow.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {},
+			style: { spacing: { blockGap: '10px' } },
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+		} );
+
+		expect( result ).toContain(
+			'.my-container > * { margin-block-start: 10px; margin-block-end: 0; }'
+		);
+		expect( result ).not.toContain( 'var(--wp--preset--spacing--30)' );
+	} );
+
+	it( 'should not apply the global block gap fallback for viewport overrides', () => {
+		const result = flow.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {},
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			globalBlockGapValue: 'var(--wp--preset--spacing--30)',
+			viewportOverrides: {},
+		} );
+
+		expect( result ).toBe( '' );
+	} );
 } );

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -73,6 +73,32 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::gutenberg_blocks_using_site_block_gap
+	 */
+	public function test_blocks_using_site_block_gap_defaults() {
+		$this->assertSame(
+			array( 'core/quote', 'core/details' ),
+			gutenberg_blocks_using_site_block_gap()
+		);
+	}
+
+	/**
+	 * @covers ::gutenberg_blocks_using_site_block_gap
+	 */
+	public function test_blocks_using_site_block_gap_is_filterable() {
+		$callback = static function ( $blocks ) {
+			$blocks[] = 'core/group';
+			return $blocks;
+		};
+		add_filter( 'gutenberg_blocks_using_site_block_gap', $callback );
+		$blocks = gutenberg_blocks_using_site_block_gap();
+		remove_filter( 'gutenberg_blocks_using_site_block_gap', $callback );
+
+		$this->assertContains( 'core/group', $blocks );
+		$this->assertContains( 'core/quote', $blocks );
+	}
+
+	/**
 	 * @covers ::gutenberg_sanitize_block_gap_value
 	 */
 	public function test_sanitize_block_gap_value_rejects_nested_array_values() {
@@ -237,6 +263,66 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					'has_block_gap_support'         => true,
 					'gap_value'                     => '1em',
 					'should_skip_gap_serialization' => true,
+				),
+				'expected_output' => '',
+			),
+			'default layout falls back to global block gap when no block gap value is set' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => null,
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--30)',
+					'options'               => array(
+						'apply_fallback_gap' => true,
+					),
+				),
+				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout > * + *{margin-block-start:var(--wp--preset--spacing--30);margin-block-end:0;}',
+			),
+			'default layout prefers explicit block gap over the global fallback' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => '1em',
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--30)',
+					'options'               => array(
+						'apply_fallback_gap' => true,
+					),
+				),
+				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout > * + *{margin-block-start:1em;margin-block-end:0;}',
+			),
+			'default layout does not fall back when apply_fallback_gap is not set' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => null,
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--30)',
+				),
+				'expected_output' => '',
+			),
+			'constrained layout falls back to global block gap when no block gap value is set' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array( 'type' => 'constrained' ),
+					'has_block_gap_support' => true,
+					'gap_value'             => null,
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--30)',
+					'options'               => array(
+						'apply_fallback_gap' => true,
+					),
+				),
+				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout > * + *{margin-block-start:var(--wp--preset--spacing--30);margin-block-end:0;}',
+			),
+			'default layout does not apply the global fallback to viewport overrides' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => null,
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--30)',
+					'options'               => array(
+						'apply_fallback_gap'     => true,
+						'viewport_overrides'     => array(),
+						'has_block_gap_override' => true,
+					),
 				),
 				'expected_output' => '',
 			),


### PR DESCRIPTION
## What?
Closes #49777

Inner blocks of flow and constrained layout containers now inherit the Global Styles block gap instead of falling back to the browser's default margin. Additionally, container blocks that wrap arbitrary content (Quote, Details) follow the **site-wide** block spacing, so `Styles → Layout → Block spacing` is reflected inside them.

## Why?
Blocks inside `core/quote` (and `core/details`) were spaced using the browser's default paragraph margin rather than the site's `blockGap`, producing inconsistent spacing compared to blocks outside the container.

The root cause is in the layout system rather than the Quote block itself. For the `flow` (`default`) and `constrained` layouts, block gap CSS was only emitted when an **explicit** `blockGap` value existed, either set on the block instance, or defined per-block-type in `theme.json`. The site-level `styles.spacing.blockGap` value is only applied at the root (`.wp-site-blocks > *`) and never cascaded into nested flow/constrained containers. As a result, any such container without an explicit value fell back to browser margins.

This affects every flow/constrained container (Group, Details, Quote, Columns…), not just Quote. Some themes work around it by pinning a per-block value, for example, Twenty Twenty-Five sets `styles.blocks.core/quote.spacing.blockGap`, which masks the bug for that one block in that one theme.

Note: `core/media-text` (mentioned in the issue) does **not** use the layout block support, it manages its own grid, so it is out of scope here and would need a separate fix.

## Testing Instructions
1. Go to **Appearance → Editor → Styles → Layout** and set **Block spacing** to a large, obvious value (e.g. `10rem`). Save.
2. Create a new post. Insert a **Group** block containing two Paragraphs.
3. Confirm the spacing between the two paragraphs in the editor matches the site block spacing. On `trunk` this is the browser default (~1em).
4. Insert a **Quote** block with two Paragraphs inside. Confirm the spacing between them also matches the site block spacing. On `trunk` this is the browser default (or the theme's pinned value in Twenty Twenty-Five).
5. Repeat with a **Details** block.
6. Publish and view the post on the front end, the spacing should match what the editor shows.
7. Change **Block spacing** to a different value and confirm both the editor and the front end update.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/db493c05-1a33-470c-b6b1-6c0a9aad91ff

## Use of AI Tools
This pull request was authored with the assistance of AI tooling, Claude. AI was used to investigate the root cause, implement the changes across the PHP and JavaScript layout code.