### PR TITLE
Font library: Fix navigation page select font size to match DataViews

### DIFF
--- a/packages/global-styles-ui/src/font-library/style.scss
+++ b/packages/global-styles-ui/src/font-library/style.scss
@@ -85,7 +85,7 @@ $footer-height: 90px;
 	text-transform: uppercase;
 
 	@include mixins.break-small() {
-		.font-library__page-selection-trigger {
+		.components-select-control__input {
 			font-size: 11px !important;
 			font-weight: var(--wpds-typography-font-weight-emphasis);
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

The page selector in the Font Library footer was rendering at 13px instead of the intended 11px. Updated the `.font-library__page-selection` styles to target `.components-select-control__input`, the class actually used by `SelectControl`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The styles still pointed at `.font-library__page-selection-trigger`, which no longer exists in the markup. DataViews pagination already styles the select this way and renders correctly at 11px.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Aligned the font library selector with the DataViews pagination

## Testing Instructions

1. Go to Appearance > Fonts
2. Visit "Install fonts", authorize google fonts if necessary.
3. Confirm the page select at the bottom looks in line with the other texts there and DataViews (11px)e admin

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="2940" height="1562" alt="Screenshot 2026-07-27 at 10-27-34 Fonts ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/eead56da-f062-4b7b-8193-142595114993" /> | <img width="2940" height="1562" alt="Screenshot 2026-07-23 at 11-05-46 Fonts ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/f3016cec-5807-44a2-bef6-2a9601f8a71c" /> |

