### PR TITLE
Editor: Avoid unnecessary term re-fetches in FlatTermSelector

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -87,7 +87,10 @@ export function FlatTermSelector( { slug } ) {
 
 			const query = {
 				...DEFAULT_QUERY,
-				include: _termIds?.join( ',' ),
+				// Sort ids so reordering alone doesn't produce a new query key and re-fetch.
+				include: _termIds?.length
+					? [ ..._termIds ].sort( ( a, b ) => a - b ).join( ',' )
+					: undefined,
 				per_page: -1,
 			};
 
@@ -206,6 +209,7 @@ export function FlatTermSelector( { slug } ) {
 		// Optimistically update term values.
 		// The selector will always re-fetch terms later.
 		setValues( uniqueTerms );
+		setSearch( '' );
 
 		if ( newTermNames.length === 0 ) {
 			onUpdateTerms( termNamesToIds( uniqueTerms, availableTerms ) );


### PR DESCRIPTION
## What?
PR makes two small optimizations to the flat term selector's `getEntityRecords` queries:

- **Sort included term IDs** in the query key, so reordering the same set of terms no longer produces a new query and an unnecessary re-fetch.
- **Clear search on change** (`setSearch('')`), so a stale search value doesn't trigger an extra search request after selecting/creating a term.
- No behavior change.

Note: There's one more unwanted query for stale `termIds`, but it requires too much bookkeeping to fix.

## Testing Instructions
1. Open a post.
2. Assign a tag and save.
3. Try creating a new tag by typing a non-existing name and pressing <kbd>Enter</kbd>.
4. Save again.
5. Observe network requests.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
<img width="1182" height="361" alt="CleanShot 2026-07-23 at 14 19 57" src="https://github.com/user-attachments/assets/949398ad-8c8f-4066-aa14-0a68cfce16f4" />|<img width="1184" height="292" alt="CleanShot 2026-07-23 at 14 16 27" src="https://github.com/user-attachments/assets/9bad9c46-4afe-42a9-a523-ecf77a04a366" />|


## Use of AI Tools

None.