### PR TITLE
Docs: Update iframe guidance for Gutenberg 23.6

### DIFF
--- a/docs/how-to-guides/enqueueing-assets-in-the-editor.md
+++ b/docs/how-to-guides/enqueueing-assets-in-the-editor.md
@@ -2,7 +2,7 @@
 
 This guide is designed to be the definitive reference for enqueueing assets (scripts and styles) in the Editor. The approaches outlined here represent the recommended practices but keep in mind that this resource will evolve as WordPress does. Updates are encouraged.
 
-As of WordPress 6.3, the Post Editor is iframed if all registered blocks have a [`Block API version 3`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) or higher and no traditional metaboxes are registered. The Site Editor has always been iframed. This guide assumes you are looking to enqueue assets for the iframed Editor, but refer to the backward compatibility section below for additional considerations.
+The Site Editor always uses an iframe. Gutenberg 23.6 and WordPress 7.1 also always use an iframe for the Post Editor, regardless of the [`Block API version`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of blocks in the post content. WordPress 7.0 retains a conditional fallback to a non-iframe Post Editor. This guide assumes you are targeting the iframed Editor; refer to the backward compatibility section below when supporting older WordPress versions.
 
 For more information about why the Editor is iframed, please revisit the post [Blocks in an iframed (template) editor](https://make.wordpress.org/core/2021/06/29/blocks-in-an-iframed-template-editor/).
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -355,7 +355,7 @@ remove_theme_support( 'core-block-patterns' );
 
 The block editor supports the theme's [editor styles](https://codex.wordpress.org/Editor_Style), however it works a little differently than in the classic editor.
 
-In the classic editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. The block editor, however, doesn't use iframes. To make sure your styles are applied only to the content of the editor, we automatically transform your editor styles by selectively rewriting or adjusting certain CSS selectors. This also allows the block editor to leverage your editor style in block variation previews.
+In the classic editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. The block editor uses an iframe for the Site Editor and, in Gutenberg 23.6, for the Post Editor. WordPress Core versions before 7.1 can still fall back to a non-iframe Post Editor in some configurations. To keep editor styles scoped to the content across these contexts, WordPress selectively rewrites or adjusts certain CSS selectors. This also allows the block editor to use your editor style in block variation previews.
 
 For example, if you write `body { ... }` in your editor style, this is rewritten to `.editor-styles-wrapper { ... }`. This also means that you should _not_ target any of the editor class names directly.
 

--- a/docs/reference-guides/block-api/block-api-versions/README.md
+++ b/docs/reference-guides/block-api/block-api-versions/README.md
@@ -3,9 +3,12 @@
 This document lists the changes made between the different API versions.
 
 ## Version 3 (>= WordPress 6.3)
-- The post editor will be iframed if all registered blocks have a Block API version 3 or higher. Adding version 3 support means that the block should work inside an iframe, though the block may still be rendered outside the iframe if not all blocks support version 3.
-- **In WordPress 7.0, the post editor is planned to always work as an iframe, regardless of the `apiVersion` of registered blocks**.
- Please refer to [this migration guide](/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md) to test your blocks in the iframe editor beforehand.
+
+-   WordPress 6.3 introduced the iframed post editor when all registered blocks use Block API version 3 or higher and no traditional meta boxes are present.
+-   WordPress 7.0 evaluates the blocks in the post content instead of all registered blocks when deciding whether to use the iframe.
+-   Gutenberg 23.6 and WordPress 7.1 always use the iframe for the post editor, regardless of the `apiVersion` of the blocks in the post content.
+
+Adding version 3 support means that a block should work inside an iframe. Refer to the [iframe editor migration guide](/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md) for testing and migration guidance.
 
 ## Version 2 (>= WordPress 5.6)
 

--- a/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md
+++ b/docs/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The iframe integration is part of an ongoing effort to modernize the editing experience. WordPress is moving toward running the post editor inside an iframe, building upon the original iframe migration in the template editor.
+The iframe integration is part of an ongoing effort to modernize the editing experience. The Gutenberg plugin always runs the post editor inside an iframe, building upon the original iframe migration in the template editor. WordPress Core is moving toward the same behavior.
 
 This guide encourages migration of blocks to API version 3 in preparation for the planned iframe integration of the post editor. It helps verify in advance that blocks work in the iframe editor and assists in updating blocks so they work correctly in the iframe environment.
 
@@ -22,16 +22,16 @@ The iframed post editor will make life easier for block and theme authors by red
 
 ### When does the post editor work as an iframe?
 
-While most editors, including the template editor, already work as iframes, for backward compatibility, the current post editor only works as an iframe when the following conditions are met (determined by [the useShouldIframe hook](https://github.com/WordPress/gutenberg/blob/cd4fae71551e0ebf27472da1d7bbdfce91a131ec/packages/edit-post/src/components/layout/use-should-iframe.js#L16)):
+While most editors, including the template editor, already work as iframes, WordPress 7.0 retains a conditional fallback for backward compatibility (determined by [the useShouldIframe hook](https://github.com/WordPress/gutenberg/blob/cd4fae71551e0ebf27472da1d7bbdfce91a131ec/packages/edit-post/src/components/layout/use-should-iframe.js#L16)):
 
-- **If the Gutenberg plugin is enabled:** The editor always works as an iframe.
-- **If the Gutenberg plugin is not enabled:** The editor always works as an iframe when any of the following is true: the device type is not `Desktop` (e.g., tablet or mobile previews), the current post type is `wp_template` or `wp_block`, zoom-out mode is active, or all blocks present in the post content have `apiVersion` 3 or higher.
+-   **If the Gutenberg plugin is enabled:** The editor always works as an iframe.
+-   **If the Gutenberg plugin is not enabled:** The editor works as an iframe when any of the following is true: the device type is not `Desktop` (for example, tablet or mobile previews), the current post type is `wp_template` or `wp_block`, zoom-out mode is active, or all blocks present in the post content have `apiVersion` 3 or higher.
 
-In summary, if you haven't been able to fully test your blocks in the iframe editor yet, by maintaining `apiVersion` 2, you can prevent the post editor from working as an iframe in most cases. Once you've confirmed that your blocks work in the iframe editor, you can then migrate to `apiVersion` 3.
+In WordPress 7.0 without the Gutenberg plugin, keeping a block at `apiVersion` 2 can trigger the non-iframe fallback when that block is present in the post. This is only a temporary compatibility path: it does not apply when the Gutenberg plugin is enabled and is planned for removal in WordPress 7.1. Blocks should migrate to `apiVersion` 3 after they have been tested in the iframe editor.
 
 ### When will the post editor work as an iframe?
 
-**In WordPress 7.1, the post editor always works as an iframe, regardless of the `apiVersion` of the blocks in the post content.** The conditional fallback to a non-iframe editor is removed, so blocks with `apiVersion` 2 or lower always run inside the iframe.
+**In Gutenberg 23.6 and WordPress 7.1, the post editor always works as an iframe, regardless of the `apiVersion` of the blocks in the post content.** The conditional fallback to a non-iframe editor is removed, so blocks with `apiVersion` 2 or lower always run inside the iframe.
 
 Ahead of this, to encourage developers to test in the iframe editor, WordPress 6.9 introduces a browser console warning when blocks are registered with `apiVersion` 2 or lower, and updates the [block.json schema](https://github.com/WordPress/gutenberg/blob/trunk/schemas/json/block.json) to only allow `apiVersion: 3`. For details, see [Preparing the post editor for full iframe integration](https://make.wordpress.org/core/2025/11/12/preparing-the-post-editor-for-full-iframe-integration/).
 
@@ -39,9 +39,9 @@ In WordPress 7.0, the iframe condition is evaluated against the `apiVersion` of 
 
 ## How to test your blocks in the iframe post editor
 
-All core blocks are already using `apiVersion` 3, so simply changing your `apiVersion` to 3 should allow your blocks to work in the iframe post editor.
+All core blocks already use `apiVersion` 3. After testing your block in the iframe editor, update it to `apiVersion` 3.
 
-However, make sure that no other third-party blocks registered with version 2 or lower are present. If blocks with version 2 or lower are registered, the post editor may not work as an iframe editor.
+The simplest way to test is with Gutenberg 23.6 or later, where the post editor always uses the iframe. In WordPress 7.0 without the Gutenberg plugin, the editor may fall back to a non-iframe editor when the post contains a block using `apiVersion` 2 or lower.
 
 ## Technical considerations for the iframe editor
 


### PR DESCRIPTION
## What?

Update the iframe editor documentation for the behavior shipped in Gutenberg 23.6 and WordPress 7.1.

## Why?

Gutenberg now always uses the iframe for the post editor. The existing guides still described the older conditional fallback, which could send block and theme developers toward obsolete compatibility work.

Evidence:

-   WordPress/gutenberg#74042 — implementation and discussion involving @ellatrix, @t-hamano, @Mamaduka, @annezazu, and @joedolson.
-   WordPress/gutenberg#54095 — developer confusion caused by the conditional iframe behavior.
-   WordPress/gutenberg#65172 — a concrete CSS nesting failure in the non-iframe fallback.

## Discussion

This is a release-learning proposal, and the wording is intentionally open for review. Please challenge the conclusion or suggest a smaller change if the release discussion points elsewhere. It is also fine to close this PR if the guidance is not useful—the discussion here will help us tune the release-knowledge skill before it becomes part of the release process.
