### PR TITLE
Core Data: Document CRDT synchronization invariant

### DIFF
--- a/packages/core-data/AGENTS.md
+++ b/packages/core-data/AGENTS.md
@@ -1,0 +1,3 @@
+## Synchronization
+
+`SyncConfig.getChangesFromCRDTDoc` implementations must compare CRDT values with the edited entity record and return only properties that actually changed. Returning a whole deserialized record, or fresh object values that are equal to the current values, creates spurious edits and can leave the entity permanently dirty.


### PR DESCRIPTION
## What?

Add focused synchronization guidance for the `core-data` package based on Gutenberg 23.5.1.

## Why?

CRDT deserialization can produce fresh object instances even when their values did not change. Reporting those values as edits leaves entities dirty after synchronization. Future sync configurations need to compare against the edited record and return only genuine changes.

Evidence:

-   WordPress/gutenberg#79908 — the fix and review involving @adamsilverstein, @adamziel, and @alecgeatches.
-   WordPress/gutenberg#79907 — the linked bug report and reproduction discussed by @adamsilverstein and @adamziel.

## Discussion

This is a release-learning proposal, and the new package-level instruction is intentionally open for review. Please challenge the conclusion, scope, or placement if it would not consistently help future work. It is also fine to close this PR if the guidance is not useful—the discussion here will help us tune the release-knowledge skill before it becomes part of the release process.
