### PR TITLE
Docs: Document published dependency constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 ## Common pitfalls
 
 -   Do not add dependencies to the root `package.json`. Add them to the workspace that uses them, or create a new workspace under `tools/` (or `test/` for test infrastructure). See [Workspace Development](docs/contributors/code/workspace-development.md).
+-   Published package runtime files and emitted type declarations must resolve through the package's declared dependency surface; never rely on root hoisting or workspace links. Prefer fixing accidentally leaked public types over adding an unrelated heavy dependency, and run `npm run lint:published-deps` when changing package dependencies or exported types.
 -   PHP features in `lib/compat/` MUST target a specific `wordpress-X.Y/` subdirectory.
 -   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.


### PR DESCRIPTION
## What?

Add a repository instruction about the dependency surface of published packages, based on Gutenberg 23.5.0.

## Why?

Published runtime files and type declarations must work for npm consumers without relying on this monorepo's hoisting or workspace links. The release discussion also established that a leaked type is sometimes better fixed at the public boundary than by adding a large unrelated dependency.

Evidence:

-   WordPress/gutenberg#79095 — the release fix and resolved review discussion involving @manzoorwanijk and @aduth.
-   WordPress/gutenberg#78882 — the linked predecessor that exposed the same root-hoisting failure mode.
-   WordPress/gutenberg#74310 and WordPress/gutenberg#74655 — earlier examples of missing published dependencies and unavailable generated types.

The PR discussion included a concrete disagreement about adding Storybook as a runtime dependency. That concern was resolved by removing the dependency and fixing the leaked type separately, which is why the instruction preserves both sides of the decision instead of treating every audit finding as a request to add a dependency.

## Discussion

This is a release-learning proposal, and the instruction is intentionally open for review. Please challenge the conclusion or suggest a narrower formulation if it would not consistently help future package work. It is also fine to close this PR if the guidance is not useful—the discussion here will help us tune the release-knowledge skill before it becomes part of the release process.
