### PR TITLE
Docs: Document page stability convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
 -   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
+-   Pages and routes are stable by default. Mark experimental pages with `"experimental": true` in `wpPlugin.pages`; WordPress Core builds exclude those pages and routes used only by experimental pages. Do not introduce separate `stable` or `core` flags for this distinction.
 -   Never invoke WordPress's forked or local CLIs through `npx` (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` can resolve to an unrelated third-party package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
 
 ## PR instructions


### PR DESCRIPTION
## What?

Add a repository instruction for declaring experimental pages and routes, based on Gutenberg 23.4.0.

## Why?

The release fixed WordPress Core builds so they exclude experimental pages and routes that belong only to those pages. Future page work needs to preserve the convention agreed in review: pages are stable by default, and experiments use the existing opt-out flag.

Evidence:

-   WordPress/gutenberg#76715 — the implementation and design discussion involving @desrosj, @youknowriad, @aaronjorbin, and @tyxla.

The discussion considered explicit `stable` and `core` flags. It ultimately resolved on the existing `"experimental": true` convention so Gutenberg features remain stable by default and plugin authors do not need a new opt-in flag.

## Discussion

This is a release-learning proposal, and the instruction is intentionally open for review. Please challenge the conclusion or suggest a narrower formulation if the discussion supports one. It is also fine to close this PR if the guidance is not useful—the discussion here will help us tune the release-knowledge skill before it becomes part of the release process.
