### PR TITLE
wp-build: Document rolling deployment safety

### DIFF
--- a/packages/wp-build/AGENTS.md
+++ b/packages/wp-build/AGENTS.md
@@ -1,0 +1,3 @@
+## Generated PHP
+
+Generated PHP loaders must remain safe during rolling deployments, when an entry point can become available before a referenced file. Before adding a `require` or `require_once` for a generated artifact, check that the file exists and skip the include or return instead of causing a fatal error.


### PR DESCRIPTION
## What?

Add focused guidance for generated PHP loaders in the `wp-build` package, based on Gutenberg 23.2.0.

## Why?

During rolling deployments, a generated entry point can become available before one of the files it loads. Generated PHP should treat that window as a temporary missing artifact instead of causing a fatal error.

Evidence:

-   WordPress/gutenberg#78110 — the deployment-race fix authored by @mikachan and reviewed by @scruffian.

## Discussion

This is a release-learning proposal, and the new package-level instruction is intentionally open for review. Please challenge the conclusion, scope, or placement if it would not consistently help future build work. It is also fine to close this PR if the guidance is not useful—the discussion here will help us tune the release-knowledge skill before it becomes part of the release process.
