### PR TITLE
Add style runtime compatibility guidance

### DIFF
--- a/packages/style-runtime/AGENTS.md
+++ b/packages/style-runtime/AGENTS.md
@@ -1,7 +1,4 @@
 # Style runtime compatibility
 
--   Treat the shape of `globalThis.__wpStyleRuntime` as a backward-compatibility
-    contract. Separately bundled versions of `@wordpress/style-runtime` can run
-    on the same page and must be able to share that registry.
--   Keep consumers on the package's public APIs. Do not make application code
-    read or write the reserved global directly.
+-   Treat the shape of `globalThis.__wpStyleRuntime` as a backward-compatibility contract. Separately bundled versions of `@wordpress/style-runtime` can run on the same page and must be able to share that registry.
+-   Keep consumers on the package's public APIs. Do not make application code read or write the reserved global directly.

--- a/packages/style-runtime/AGENTS.md
+++ b/packages/style-runtime/AGENTS.md
@@ -1,0 +1,7 @@
+# Style runtime compatibility
+
+-   Treat the shape of `globalThis.__wpStyleRuntime` as a backward-compatibility
+    contract. Separately bundled versions of `@wordpress/style-runtime` can run
+    on the same page and must be able to share that registry.
+-   Keep consumers on the package's public APIs. Do not make application code
+    read or write the reserved global directly.


### PR DESCRIPTION
## What?

Add package-scoped guidance that treats the shared style runtime registry as a backward-compatibility contract.

## Why?

Gutenberg 23.1.1 introduced `@wordpress/style-runtime` in [#77965](https://github.com/WordPress/gutenberg/pull/77965). During review, @ciampo identified the shape of `globalThis.__wpStyleRuntime` as a compatibility boundary between separately bundled versions, while @mirka and @youknowriad worked through how old and new consumers can coexist.

## Discussion

This is a release-learning proposal, not a settled conclusion. Please challenge the evidence, scope, wording, or destination. Closing this PR is a useful outcome if the guidance is not durable or correct. Discussion here will be used to improve this skill.
