### PR TITLE
Document script module translations

### DIFF
--- a/docs/how-to-guides/internationalization.md
+++ b/docs/how-to-guides/internationalization.md
@@ -87,6 +87,19 @@ This is all you need to make your plugin JavaScript code translatable.
 
 When you set script translations for a handle WordPress will automatically figure out if a translations file exists on translate.wordpress.org, and if so ensure that it's loaded into `wp.i18n` before your script runs. With translate.wordpress.org, plugin authors also do not need to worry about setting up their own infrastructure for translations and can rely on a global community with dozens of active locales. Read more about [WordPress Translations](https://make.wordpress.org/meta/handbook/documentation/translations/).
 
+### Script modules
+
+Since WordPress 7.0, translations are detected automatically for enqueued script
+modules and their dependencies. Use
+[`wp_set_script_module_translations()`](https://developer.wordpress.org/reference/functions/wp_set_script_module_translations/)
+only when you need to override the default text domain or translation path.
+
+The Gutenberg plugin provides automatic detection on earlier supported
+WordPress versions, but it does not polyfill the override function. Script
+module translations also still use the classic `wp-i18n` runtime. Translation
+data for dynamically imported modules may therefore be loaded before those
+modules are needed.
+
 ## Provide your own translations
 
 You can create and ship your own translations with your plugin, if you have sufficient knowledge of the language(s) you can ensure the translations are available.

--- a/docs/how-to-guides/internationalization.md
+++ b/docs/how-to-guides/internationalization.md
@@ -89,16 +89,9 @@ When you set script translations for a handle WordPress will automatically figur
 
 ### Script modules
 
-Since WordPress 7.0, translations are detected automatically for enqueued script
-modules and their dependencies. Use
-[`wp_set_script_module_translations()`](https://developer.wordpress.org/reference/functions/wp_set_script_module_translations/)
-only when you need to override the default text domain or translation path.
+Since WordPress 7.0, translations are detected automatically for enqueued script modules and their dependencies. Use [`wp_set_script_module_translations()`](https://developer.wordpress.org/reference/functions/wp_set_script_module_translations/) only when you need to override the default text domain or translation path.
 
-The Gutenberg plugin provides automatic detection on earlier supported
-WordPress versions, but it does not polyfill the override function. Script
-module translations also still use the classic `wp-i18n` runtime. Translation
-data for dynamically imported modules may therefore be loaded before those
-modules are needed.
+The Gutenberg plugin provides automatic detection on earlier supported WordPress versions, but it does not polyfill the override function. Script module translations also still use the classic `wp-i18n` runtime. Translation data for dynamically imported modules may therefore be loaded before those modules are needed.
 
 ## Provide your own translations
 


### PR DESCRIPTION
## What?

Document how translations work for WordPress script modules.

## Why?

Gutenberg 23.1 added script-module translation support in [#77214](https://github.com/WordPress/gutenberg/pull/77214). @manzoorwanijk implemented the compatibility layer, while @jsnajdr and @westonruter clarified that automatic detection is available now but the implementation still relies on the classic i18n runtime and eagerly includes some translation data.

## Discussion

This is a release-learning proposal, not a settled conclusion. Please challenge the evidence, scope, wording, or destination. Closing this PR is a useful outcome if the guidance is not durable or correct. Discussion here will be used to improve this skill.
