### PR TITLE
Document RTC-compatible meta boxes

### DIFF
--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -199,6 +199,30 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 
 WordPress won't show the meta box but a message saying that it isn't compatible with the block editor, including a link to the Classic Editor plugin. By default, `__block_editor_compatible_meta_box` is `true`.
 
+Real-time collaboration is disabled when the editor contains a legacy meta box
+that has not been marked as compatible. This protects against data loss because
+the meta box may edit state that is not synchronized between collaborators.
+After verifying that a meta box does not edit unsynchronized state, plugin
+authors can opt it in through the callback arguments:
+
+```php
+add_meta_box(
+	'my-meta-box',
+	'My Meta Box',
+	'my_meta_box_callback',
+	null,
+	'normal',
+	'high',
+	array(
+		'__rtc_compatible_meta_box' => true,
+	)
+);
+```
+
+Site owners can apply the same flag to a third-party meta box with the
+`filter_block_editor_meta_boxes` filter, but should do so only after checking
+the meta box's behavior.
+
 After a meta box is converted to a block, it can be declared as existing for backward compatibility:
 
 ```php

--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -199,11 +199,7 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 
 WordPress won't show the meta box but a message saying that it isn't compatible with the block editor, including a link to the Classic Editor plugin. By default, `__block_editor_compatible_meta_box` is `true`.
 
-Real-time collaboration is disabled when the editor contains a legacy meta box
-that has not been marked as compatible. This protects against data loss because
-the meta box may edit state that is not synchronized between collaborators.
-After verifying that a meta box does not edit unsynchronized state, plugin
-authors can opt it in through the callback arguments:
+Real-time collaboration is disabled when the editor contains a legacy meta box that has not been marked as compatible. This protects against data loss because the meta box may edit state that is not synchronized between collaborators. After verifying that a meta box does not edit unsynchronized state, plugin authors can opt it in through the callback arguments:
 
 ```php
 add_meta_box(
@@ -219,9 +215,7 @@ add_meta_box(
 );
 ```
 
-Site owners can apply the same flag to a third-party meta box with the
-`filter_block_editor_meta_boxes` filter, but should do so only after checking
-the meta box's behavior.
+Site owners can apply the same flag to a third-party meta box with the `filter_block_editor_meta_boxes` filter, but should do so only after checking the meta box's behavior.
 
 After a meta box is converted to a block, it can be declared as existing for backward compatibility:
 


### PR DESCRIPTION
## What?

Document how legacy meta boxes can declare compatibility with real-time collaboration.

## Why?

Gutenberg 23.0 added the compatibility flag in [#76939](https://github.com/WordPress/gutenberg/pull/76939), following the data-loss concern reported by @maxschmeling in [#76940](https://github.com/WordPress/gutenberg/issues/76940). @alecgeatches implemented the opt-in, @sc0ttkclark proposed carrying it through `add_meta_box()` arguments, and @Mamaduka helped keep the implementation on the existing meta-box data path rather than introducing another public store action.

## Discussion

This is a release-learning proposal, not a settled conclusion. Please challenge the evidence, scope, wording, or destination. Closing this PR is a useful outcome if the guidance is not durable or correct. Discussion here will be used to improve this skill.
