### PR TITLE
Clarify icon name requirements

### DIFF
--- a/lib/compat/wordpress-7.1/icons.php
+++ b/lib/compat/wordpress-7.1/icons.php
@@ -40,10 +40,12 @@ if ( ! function_exists( 'wp_register_icon' ) ) {
 	 * Registers a new icon.
 	 *
 	 * @param string $icon_name Namespaced icon name in the form "collection/icon-name"
-	 *                          (e.g. "my-plugin/arrow-left"). The "core" collection is
-	 *                          reserved for WordPress core icons; third-party code should
-	 *                          register icons under its own collection rather than the
-	 *                          "core" collection.
+	 *                          (e.g. "my-plugin/arrow-left"). The unqualified name must
+	 *                          start and end with a lowercase letter or digit and contain
+	 *                          only lowercase letters, digits, hyphens, and underscores.
+	 *                          The "core" collection is reserved for WordPress core icons;
+	 *                          third-party code should register icons under its own
+	 *                          collection rather than the "core" collection.
 	 * @param array  $args {
 	 *     List of properties for the icon.
 	 *
@@ -65,7 +67,9 @@ if ( ! function_exists( 'wp_unregister_icon' ) ) {
 	 * Unregisters an icon.
 	 *
 	 * @param string $icon_name Namespaced icon name in the form "collection/icon-name"
-	 *                          (e.g. "core/arrow-left").
+	 *                          (e.g. "core/arrow-left"). The unqualified name must
+	 *                          start and end with a lowercase letter or digit and contain
+	 *                          only lowercase letters, digits, hyphens, and underscores.
 	 * @return bool True if the icon was unregistered successfully, else false.
 	 */
 	function wp_unregister_icon( $icon_name ) {


### PR DESCRIPTION
## What?

Clarify the accepted format for icon names in the public Icons API PHPDoc.

## Why?

Gutenberg 22.9 tightened icon-name validation in [#76079](https://github.com/WordPress/gutenberg/pull/76079), following an API-review gap recorded in [#72215](https://github.com/WordPress/gutenberg/pull/72215). @im3dabasia implemented the validation, while @mcsf and @t-hamano refined the public naming contract and its WordPress 7.1 compatibility boundary.

## Discussion

This is a release-learning proposal, not a settled conclusion. Please challenge the evidence, scope, wording, or destination. Closing this PR is a useful outcome if the guidance is not durable or correct. Discussion here will be used to improve this skill.
