### PR TITLE
Document non-JSON API fetch bodies

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -79,10 +79,7 @@ Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the par
 
 #### `data` (`object`)
 
-Sent on `POST` or `PUT` requests only. Shorthand to be used in place of
-`body`, accepts an object value to be stringified to JSON. To send another
-format, use the standard `body` and `headers` fetch options and set the
-appropriate `Content-Type`.
+Sent on `POST` or `PUT` requests only. Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON. To send another format, use the standard `body` and `headers` fetch options and set the appropriate `Content-Type`.
 
 ### Aborting a request
 

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -46,6 +46,19 @@ apiFetch( {
 } );
 ```
 
+### Sending a non-JSON body
+
+```js
+apiFetch( {
+	path: '/my-plugin/v1/resource',
+	method: 'PUT',
+	body: 'Plain text content',
+	headers: {
+		'Content-Type': 'text/plain',
+	},
+} );
+```
+
 ### Options
 
 `apiFetch` supports and passes through all [options of the `fetch` global](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch).
@@ -66,7 +79,10 @@ Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the par
 
 #### `data` (`object`)
 
-Sent on `POST` or `PUT` requests only. Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
+Sent on `POST` or `PUT` requests only. Shorthand to be used in place of
+`body`, accepts an object value to be stringified to JSON. To send another
+format, use the standard `body` and `headers` fetch options and set the
+appropriate `Content-Type`.
 
 ### Aborting a request
 


### PR DESCRIPTION
## What?

Document how to send a non-JSON request body with `@wordpress/api-fetch`.

## Why?

Gutenberg 22.8 fixed custom `Content-Type` handling for tunneled REST requests in [#76285](https://github.com/WordPress/gutenberg/pull/76285), after @chubes4 reported the raw-body failure in [#76284](https://github.com/WordPress/gutenberg/issues/76284). @Mamaduka confirmed that preserving the caller's content type was the missing behavior.

## Discussion

This is a release-learning proposal, not a settled conclusion. Please challenge the evidence, scope, wording, or destination. Closing this PR is a useful outcome if the guidance is not durable or correct. Discussion here will be used to improve this skill.
