### PR TITLE
Docs: Require view config filter callbacks to return the container

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -85,7 +85,7 @@ DataViews-powered screens (such as the Pages list and its Quick Edit form) build
 
 The configuration has four top-level keys: `default_view`, `default_layouts`, `view_list` (the saved views shown in the list), and `form` (the DataForm used by consumers like Quick Edit).
 
-The filter receives a `Gutenberg_View_Config_Data` object holding the entity's view configuration. Change the configuration by calling its methods and **return the object** (a callback that returns anything else is ignored and the unfiltered configuration is used). Only the four documented top-level keys are accepted; a patch that names any other key, or that declares an unsupported `$version`, is rejected with a `_doing_it_wrong()` notice.
+The filter receives a `Gutenberg_View_Config_Data` object holding the entity's view configuration. Change the configuration by calling its methods and **return the object**: as with any filter, the return value is passed to the next callback as `$data`, so a callback that returns anything else hands that value to callbacks hooked at a later priority. Only the four documented top-level keys are accepted; a patch that names any other key, or that declares an unsupported `$version`, is rejected with a `_doing_it_wrong()` notice.
 
 ### Merging a patch
 

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -161,10 +161,12 @@ class Gutenberg_View_Config_Data {
 		 *   individual list members.
 		 *
 		 * A change that declares an unsupported schema version is rejected and does
-		 * not alter anything. Callbacks mutate the container in place, so there is no
-		 * need to return it; any returned value is ignored. Callbacks must not replace
-		 * the container with a different value, as later callbacks receive whatever the
-		 * previous one returned.
+		 * not alter anything. As with any filter, each callback's return value is
+		 * passed to the next callback as `$data`, so callbacks must return the
+		 * container they received: a callback that returns nothing, or any other
+		 * value, hands that result to every callback hooked at a later priority
+		 * instead of the container. Since the write methods return the container,
+		 * a callback can end with `return $data->merge( $patch, $version );`.
 		 *
 		 * @param Gutenberg_View_Config_Data $data   The view configuration container
 		 *                                           for the entity, exposing the


### PR DESCRIPTION
## What?

- Syncs the `get_entity_view_config_{$kind}_{$name}` filter docblock correction from core PR https://github.com/WordPress/wordpress-develop/pull/12641 into the Gutenberg compat copy: callbacks must return the container they receive.
- Fixes the same wrong rationale in the curating-the-editor-experience guide, which claimed a callback returning anything else "is ignored and the unfiltered configuration is used".

## Why?

The docblock told callbacks the container is mutated in place, so there is "no need to return it; any returned value is ignored". Only the final return is discarded: as with any filter, each callback's return value is passed to the next callback as `$data`, so a callback that follows that advice hands `null` to every callback hooked at a later priority, which fatals the moment it calls a method on it (`Call to a member function merge() on null`).

Docs-only; the dispatch is unchanged. All existing callbacks (the internal `_gutenberg_get_entity_view_config_post_type_*` ones, the PHPUnit filter tests, and the `view-config-extensibility` e2e plugin) already return the container.

## Testing

- Docs-only change; CI passing is sufficient.
- `vendor/bin/phpcs lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php`

AI usage disclosure: change and description drafted with AI assistance and reviewed by me.
