### PR TITLE
Input: Hide native spin controls for `type="number"`

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `Input`: Hide native browser spin controls for `type="number"` inputs by default. Consumers can compose custom stepper buttons via the `prefix`/`suffix` slots ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).
+-   `Input`: Hide native browser spin controls for `type="number"` inputs by default ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).
 -   Add `Autocomplete.Row` primitive ([#80490](https://github.com/WordPress/gutenberg/pull/80490)).
 -   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `Input`: Hide native browser spin controls for `type="number"` inputs by default. Consumers can compose custom stepper buttons via the `prefix`/`suffix` slots ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).
 -   Add `Autocomplete.Row` primitive ([#80490](https://github.com/WordPress/gutenberg/pull/80490)).
 -   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -119,44 +119,31 @@ export const NumberWithSteppers: Story = {
 		const [ value, setValue ] = useState( 0 );
 
 		return (
-			<>
-				<style>
-					{ `
-					  .my-number-with-steppers input[type='number'] {
-							-moz-appearance: textfield;
-					  }
-						.my-number-with-steppers ::-webkit-inner-spin-button {
-							appearance: none;
-						}
-					` }
-				</style>
-				<InputControl
-					{ ...args }
-					value={ value }
-					onValueChange={ ( v ) => setValue( parseInt( v, 10 ) ) }
-					className="my-number-with-steppers"
-					suffix={
-						<InputLayout.Slot padding="minimal">
-							<Stack direction="row" gap="xs">
-								<IconButton
-									label="Increment"
-									icon={ plus }
-									onClick={ () => setValue( value + 1 ) }
-									size="small"
-									variant="minimal"
-								/>
-								<IconButton
-									label="Decrement"
-									icon={ reset }
-									onClick={ () => setValue( value - 1 ) }
-									size="small"
-									variant="minimal"
-								/>
-							</Stack>
-						</InputLayout.Slot>
-					}
-				/>
-			</>
+			<InputControl
+				{ ...args }
+				value={ value }
+				onValueChange={ ( v ) => setValue( parseInt( v, 10 ) ) }
+				suffix={
+					<InputLayout.Slot padding="minimal">
+						<Stack direction="row" gap="xs">
+							<IconButton
+								label="Increment"
+								icon={ plus }
+								onClick={ () => setValue( value + 1 ) }
+								size="small"
+								variant="minimal"
+							/>
+							<IconButton
+								label="Decrement"
+								icon={ reset }
+								onClick={ () => setValue( value - 1 ) }
+								size="small"
+								variant="minimal"
+							/>
+						</Stack>
+					</InputLayout.Slot>
+				}
+			/>
 		);
 	},
 	args: {

--- a/packages/ui/src/form/primitives/input/style.module.css
+++ b/packages/ui/src/form/primitives/input/style.module.css
@@ -35,6 +35,16 @@
 			&[type="url"] {
 				direction: ltr; /* maintain LTR in RTL languages */
 			}
+
+			&[type="number"] {
+				-moz-appearance: textfield;
+
+				&::-webkit-outer-spin-button,
+				&::-webkit-inner-spin-button {
+					-webkit-appearance: none;
+					margin: 0;
+				}
+			}
 		}
 	}
 }

--- a/packages/ui/src/form/primitives/input/style.module.css
+++ b/packages/ui/src/form/primitives/input/style.module.css
@@ -41,7 +41,7 @@
 
 				&::-webkit-outer-spin-button,
 				&::-webkit-inner-spin-button {
-					-webkit-appearance: none;
+					appearance: none;
 					margin: 0;
 				}
 			}

--- a/packages/ui/src/form/primitives/input/style.module.css
+++ b/packages/ui/src/form/primitives/input/style.module.css
@@ -37,7 +37,7 @@
 			}
 
 			&[type="number"] {
-				-moz-appearance: textfield;
+				appearance: textfield;
 
 				&::-webkit-outer-spin-button,
 				&::-webkit-inner-spin-button {


### PR DESCRIPTION
## What?

Hide native browser spin controls on `@wordpress/ui` `Input` when `type="number"`.

## Why?

As discussed in https://github.com/WordPress/gutenberg/issues/78335#issuecomment-5039497858, the design system direction for number fields is to use a plain `InputControl type="number"` with native spin controls hidden by default. Consumers who want steppers can compose their own via the `prefix`/`suffix` slots, as demonstrated in the existing `NumberWithSteppers` Storybook example.

This avoids introducing a dedicated `NumberControl` with `spinControls` options in `@wordpress/ui`, and keeps custom stepper UI in consumer territory.

I want to start with this simple setup, because looking at usage patterns of `NumberControl` in Gutenberg:

1. Only three instances elect to show the custom spin buttons.
2. Many instances elect to hide the spin buttons entirely.

Given the questionable usefulness of the native browser spin buttons (not to mention touch devices), we can probably first simplify this decision to two options, which is "custom spin buttons vs. no spin buttons". Then, we see that only three instances have even thought to include useful spin buttons explicitly. The vast majority of cases either didn't bother, or thought spin buttons were clearly inappropriate.

## How?

Adds CSS to the `Input` primitive stylesheet to hide `::-webkit-inner/outer-spin-button` and set `-moz-appearance: textfield` for `type="number"`.

Removes the inline CSS workaround from the `NumberWithSteppers` story, since the behavior is now built in.

## Testing Instructions

1. Run Storybook and open **Design System / Components / Form / InputControl**.
3. Check the **Number** story: native browser steppers should not appear.
4. Check the **NumberWithSteppers** story: custom increment/decrement buttons should still work, without native steppers visible behind them.

Should work in all three major browsers.