### PR TITLE
Storybook: Remove Emotion as JSX import source

### DIFF
--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -126,7 +126,6 @@ const config: StorybookConfig = {
 			plugins: [
 				dsTokenFallbacksJs(),
 				react( {
-					jsxImportSource: '@emotion/react',
 					babel: {
 						plugins: [ getAbsolutePath( '@emotion/babel-plugin' ) ],
 					},


### PR DESCRIPTION
## What?

Updates Storybook configuration to remove the `jsxImportSource` override to `@emotion/react`.

Follow-up to #80426 and specifically https://github.com/WordPress/gutenberg/pull/80426#discussion_r3612729105.

## Why?

1. Fixes the issue described in https://github.com/WordPress/gutenberg/pull/80426#discussion_r3612729105 where assigning `jsxImportSource` causes the import source to be injected into packages that don't necessarily define the dependency themselves, which will break under isolated npm install being explored in #75814.
2. It's not necessary: As I understand, the `@emotion/react` JSX import source is primarily necessary to support `css` prop assignment to components, but the last instance of this was removed in #79443.

## How?

Removes the explicit `jsxImportSource` override in the Storybook configuration so that it falls back to the default (`react`).

`@emotion/react` still needs to be a dependency in `storybook/package.json` because [it is a peer dependency of `@emotion/styled`](https://app.unpkg.com/@emotion/styled@11.14.0/files/package.json#L22), which is still used in the `@wordpress/storybook` tool package.

## Testing Instructions

Repeating Testing Instructions from #79443.

It's also worth testing that the live Storybook (via both `npm run storybook:dev` and `npm run storybook:build` build output) is unaffected, since this configuration is common to all Storybook builds:

1. Run `npm run storybook:build && cd storybook/build && php -S localhost:8000`
2. Go to http://localhost:8000
3. Observe that stories load as expected with no errors in browser console

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to explore the initial proposal at https://github.com/WordPress/gutenberg/pull/80426#discussion_r3612729105 and understand the viability of removing the override. Manually reviewed.