### PR TITLE
Add progressive-discovery pattern for agent instructions and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,6 @@
 npm install && composer install
 npm run wp-env status      # Always check status first.
 npm run wp-env start       # Only start if not already running.
-npm run wp-env-test status # Status of test environment. Always check first.
-npm run wp-env-test start  # Start the test env, only start if not already running.
 
 # Development
 npm start     # Development with watch
@@ -28,28 +26,17 @@ npm run build # Production build
     -   `/docs/how-to-guides/` - Implementation tutorials
     -   `/docs/reference-guides/` - API documentation
 
-## Testing instructions
+## Progressive discovery
 
-> **Note**: PHP/E2E tests require `wp-env-test` running.
+Read only what your task needs, when it needs it:
+
+-   **Contributor docs**: before starting a task, check `docs/contributors/code/` for the guide covering that kind of work (coding guidelines, backward compatibility, workspaces, releases, and so on) and read the relevant one.
+-   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests). See `skills/README.md`.
+-   **Directory guides**: some directories carry their own `AGENTS.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
+
+## Code quality
 
 ```bash
-# JavaScript
-npm test                   # All JS tests
-npm run test:unit         # Unit tests
-npm run test:unit -- --testNamePattern="<TestName>"  # Specific test
-npm run test:unit <path_to_test_directory>
-
-# PHP (requires wp-env-test)
-composer test             # All PHP tests
-vendor/bin/phpunit <path_to_test_file.php>  # Specific file
-vendor/bin/phpunit <path_to_test_directory>/              # Directory
-
-# E2E (requires wp-env-test)
-npm run test:e2e
-npm run test:e2e -- <path_to_test_file.spec.js>  # Specific test file
-npm run test:e2e -- --headed                   # Run with browser visible
-
-# Code Quality
 npm run format            # Fix JS formatting
 npm run lint:js          # Check JS linting
 vendor/bin/phpcbf        # Fix PHP standards
@@ -78,6 +65,8 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.
 -   `@wordpress/build` (`packages/wp-build`) is a generic build tool used both in Gutenberg and by plugins targeting WordPress Core directly. Avoid Gutenberg-specific changes in it.
 -   Never invoke WordPress's forked or local CLIs through `npx` (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` can resolve to an unrelated third-party package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
+-   PHP function and class names are renamed at build time (`gutenberg_*` prefix, `*_Gutenberg` suffix) to avoid conflicts with WordPress Core — the built names, not the source names, are what runs (and what tests must call). See `docs/contributors/code/build-system-function-prefixing.md`.
+-   Production code changes in a package require an entry in that package's `CHANGELOG.md`. See `docs/contributors/code/managing-packages.md`.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ npm run build # Production build
 Read only what your task needs, when it needs it:
 
 -   **Contributor docs**: before starting a task, check `docs/contributors/code/` for the guide covering that kind of work (coding guidelines, backward compatibility, workspaces, releases, and so on) and read the relevant one.
--   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests). See `skills/README.md`.
--   **Directory guides**: some directories carry their own `AGENTS.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
+-   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests).
+-   **Directory guides**: some directories carry their own `AGENTS.md` and `README.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
 
 ## Code quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ npm run build # Production build
 
 Read only what your task needs, when it needs it:
 
--   **Contributor docs**: before starting a task, check `docs/contributors/code/` for the guide covering that kind of work (coding guidelines, backward compatibility, workspaces, releases, and so on) and read the relevant one.
+-   **Contributor docs**: before starting a task, check `docs/contributors/code/` for the guide covering that kind of work (coding guidelines, backward compatibility, workspaces, releases) and read the relevant one.
 -   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests).
 -   **Directory guides**: some directories carry their own `AGENTS.md` and `README.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
 

--- a/docs/contributors/code/README.md
+++ b/docs/contributors/code/README.md
@@ -23,4 +23,5 @@ Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find 
 -   [Accessibility Testing](/docs/contributors/accessibility-testing.md) documents the process of testing accessibility in Gutenberg.
 -   [Managing Packages](/docs/contributors/code/managing-packages.md) documents the process for managing the npm packages.
 -   [Workspace Development](/docs/contributors/code/workspace-development.md) explains how to create and work with internal workspaces under `tools/` and `test/`, and why dependencies belong in a workspace rather than at the repo root.
+-   [Agents and Skills](/docs/contributors/code/agents-and-skills.md) explains how instructions for AI coding agents (`AGENTS.md` files and `skills/`) are organized, and what to consider before adding more.
 -   [Gutenberg Release Process](/docs/contributors/code/release/README.md) - a checklist for the different types of releases for the Gutenberg project.

--- a/docs/contributors/code/agents-and-skills.md
+++ b/docs/contributors/code/agents-and-skills.md
@@ -1,0 +1,77 @@
+# Agents and Skills
+
+The Gutenberg repository ships instructions for AI coding agents: `AGENTS.md` files and a `skills/` directory. This document explains how they are organized and what to consider before adding more.
+
+## Guiding principle: improve the documentation first
+
+Before adding anything to an agent file, ask whether the information would help human contributors too. If it would, it belongs in the public documentation, and the agent files should point to it.
+
+Agent-only files are easy to let rot: missed details and stale information linger because nobody audits them, while public docs are continuously read and corrected by contributors. Duplicating documentation into agent files also means the two copies silently diverge. Agent files should route to canonical docs, never fork their content.
+
+## How agent instructions are organized
+
+Agent instructions follow **progressive discovery** — an agent reads only what its current task needs:
+
+-   **Root [`AGENTS.md`](https://github.com/WordPress/gutenberg/blob/trunk/AGENTS.md)** is loaded in every agent session. It stays lean and routes to everything else: "if working on X, read the docs for X at this path."
+-   **Directory `AGENTS.md`** files (for example [`packages/components/AGENTS.md`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/AGENTS.md)) are loaded when an agent works with files in that directory. They hold rules scoped to that directory only.
+-   **Skills** ([`skills/<domain>/SKILL.md`](https://github.com/WordPress/gutenberg/blob/trunk/skills/README.md)) are thin, task-scoped guidance — procedures, checklists, or decision trees. An agent reads one when its task matches the skill's description.
+-   **Linked docs and references** are read only when a procedure step points to them — they carry no cost until then, so depth belongs there.
+-   `CLAUDE.md` files are one-line `@AGENTS.md` redirects for tools that look for that filename; the content always lives in `AGENTS.md`.
+
+This structure controls context bloat. The root `AGENTS.md` is a fixed cost in every session, so keep it lean. Skill bodies are read when relevant, so keep them thin and procedural. Everything linked one hop away is effectively free.
+
+## Where does new guidance belong?
+
+Work down this list and stop at the first match:
+
+1. **Public documentation** — if the information helps humans too (it usually does), improve the docs and have agent files point there.
+2. **Root `AGENTS.md`** — only for facts nearly every task needs: environment setup, universal pitfalls, and the routing list itself.
+3. **A directory `AGENTS.md`** — for rules an agent must know when working in one specific directory.
+4. **A skill** — for guidance scoped to a kind of task rather than a location: a procedure, checklist, or decision tree an agent should follow when doing that work (running tests, releasing a package, scaffolding a block).
+
+## Skill conventions
+
+These conventions match [WordPress/agent-skills](https://github.com/WordPress/agent-skills), so contributors can work in both repositories with one mental model:
+
+-   One directory per domain: `skills/<domain>/`, lowercase kebab-case.
+-   `SKILL.md` starts with YAML frontmatter containing only `name` (matching the directory) and `description`. Phrase the description as a trigger: "Use when …".
+-   Keep the body short and procedural. Link to depth rather than inlining it, and keep every linked file one hop from `SKILL.md`.
+-   Do not restate what the root `AGENTS.md` already provides — agents have both loaded.
+-   An optional `skills/<domain>/references/` directory holds agent-specific depth that has no home in the public docs.
+
+The [testing skill](https://github.com/WordPress/gutenberg/blob/trunk/skills/testing/SKILL.md) and its [`references/` directory](https://github.com/WordPress/gutenberg/tree/trunk/skills/testing/references) are the live example of these conventions. In skeleton form, a skill looks like:
+
+```md
+---
+name: <domain>
+description: Use when <the tasks that should trigger reading this skill>.
+---
+
+# <Domain>
+
+<What the root AGENTS.md already covers is not repeated here.>
+
+## <Procedure step shared by every sub-area>
+
+…
+
+## By sub-area
+
+-   **<Sub-area>**: read [references/<sub-area>.md](references/<sub-area>.md).
+```
+
+Walking through how the live testing skill applies these conventions:
+
+-   The `description` is what an agent matches against when deciding whether to read the skill, so it names the tasks that should trigger it ("writing, running, or debugging tests…").
+-   The body routes rather than explains: one line per kind of work, each pointing at a `references/` file one hop away.
+-   A procedure step that applies to every sub-area (planning the test list with the author) lives once in the skill body, not repeated in each reference — each fact has one home, at the highest level where it applies everywhere below.
+-   Each reference file holds only the agent-specific rules for its area and links to the canonical docs for depth. For example, [`references/e2e.md`](https://github.com/WordPress/gutenberg/blob/trunk/skills/testing/references/e2e.md) says "stay headless; never use `--headed` or `--ui`" — modes the e2e guide rightly recommends to humans but which would hang an agent's session — and then links to that guide for authoring practices.
+-   Nothing restates the root `AGENTS.md` — every agent already has it loaded.
+-   This is progressive disclosure end to end: the description is always visible, the body is read when a testing task starts, and each reference is read only when the work is actually of that kind.
+
+## Checklist for adding a skill
+
+1. Confirm the public docs can't cover it — improve them first if they can.
+2. Create `skills/<domain>/SKILL.md` following the conventions above.
+3. Add a routing entry to the root `AGENTS.md`.
+4. Run `npm run lint:md:docs`.

--- a/docs/contributors/code/agents-and-skills.md
+++ b/docs/contributors/code/agents-and-skills.md
@@ -36,7 +36,7 @@ These conventions match [WordPress/agent-skills](https://github.com/WordPress/ag
 -   One directory per domain: `skills/<domain>/`, lowercase kebab-case.
 -   `SKILL.md` starts with YAML frontmatter containing only `name` (matching the directory) and `description`. Phrase the description as a trigger: "Use when …".
 -   Keep the body short and procedural. Link to depth rather than inlining it, and keep every linked file one hop from `SKILL.md`.
--   Do not restate what the root `AGENTS.md` already provides — agents have both loaded.
+-   Link a doc the agent **must** read as part of the procedure step that needs it ("read the [guide] before writing your first body"). In testing, if an agent finds a skill that matches its task, it will focus on that task rather than re-considering generalized "read the relevant docs" files from AGENTS.md.
 -   An optional `skills/<domain>/references/` directory holds agent-specific depth that has no home in the public docs.
 
 The [testing skill](https://github.com/WordPress/gutenberg/blob/trunk/skills/testing/SKILL.md) and its [`references/` directory](https://github.com/WordPress/gutenberg/tree/trunk/skills/testing/references) are the live example of these conventions. In skeleton form, a skill looks like:

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3228,6 +3228,12 @@
 		"parent": "code"
 	},
 	{
+		"title": "Agents and Skills",
+		"slug": "agents-and-skills",
+		"markdown_source": "../docs/contributors/code/agents-and-skills.md",
+		"parent": "code"
+	},
+	{
 		"title": "Gutenberg Release Process",
 		"slug": "release",
 		"markdown_source": "../docs/contributors/code/release/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -399,6 +399,7 @@
 					{ "docs/contributors/code/scripts.md": [] },
 					{ "docs/contributors/code/managing-packages.md": [] },
 					{ "docs/contributors/code/workspace-development.md": [] },
+					{ "docs/contributors/code/agents-and-skills.md": [] },
 					{
 						"docs/contributors/code/release/README.md": [
 							{

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,16 @@
+# Skills
+
+Task-scoped guidance ("skills") for AI coding agents working in this repository — procedures, checklists, or decision trees for a kind of task. Agents discover them through the root `AGENTS.md`, which routes to the skill matching the task at hand.
+
+## Layout
+
+```text
+skills/<domain>/SKILL.md      # Thin procedure with name/description frontmatter.
+skills/<domain>/references/   # Optional depth, read only when a step needs it.
+```
+
+## Before adding anything here
+
+**Prefer improving the public documentation and pointing to it over adding agent-only content.** Agent files are easy to let rot: missed details and stale information linger because nobody audits them, while public docs are continuously read and corrected by contributors. A skill should route to canonical docs, never fork their content. Add a `references/` file only for genuinely agent-specific depth that has no home in the docs.
+
+See [Agents and Skills](../docs/contributors/code/agents-and-skills.md) for the full guidance, conventions, and checklist.

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: testing
+description: Use when writing, running, or debugging tests in the Gutenberg repository — JavaScript unit tests (Jest), PHP tests (PHPUnit), or end-to-end tests (Playwright).
+---
+
+# Testing
+
+## Environment
+
+PHP and e2e tests require the wp-env test environment. Check `npm run wp-env-test status` first; run `npm run wp-env-test start` only if it is not already running.
+
+## Plan the tests with the author first
+
+Before writing any test bodies, draft the test names — behavior from the user's perspective, one behavior per case (see [Describing tests](../../docs/contributors/code/testing-overview.md#describing-tests)) — and confirm the list with the author. Every proposed case must trace to the behavior being added or changed; do not pad the list with adjacent or unrelated coverage. If working unattended, put the proposed list in your summary for review instead.
+
+## Never make a failing test pass by weakening it
+
+No loosened assertions, no added waits or timeouts, no skipped cases without saying so. Diagnose the root cause, or report the failure honestly.
+
+## By test type
+
+-   **JavaScript unit and integration tests (Jest)**: read [references/jest.md](references/jest.md).
+-   **PHP tests (PHPUnit)**: read [references/php.md](references/php.md).
+-   **E2e tests (Playwright)**: read [references/e2e.md](references/e2e.md).

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -13,6 +13,10 @@ Before writing any test bodies, draft the test names — behavior from the user'
 
 No loosened assertions, no added waits or timeouts, no skipped cases without saying so. Diagnose the root cause, or report the failure honestly.
 
+## Never make a failing test pass by changing the production code unless the production code is the source of a bug
+
+The e2e test passing is not the final task success criteria. The core goal is to verify that the production code works as expected.
+
 ## By test type
 
 -   **JavaScript unit and integration tests (Jest)**: read [references/jest.md](references/jest.md).

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -5,10 +5,6 @@ description: Use when writing, running, or debugging tests in the Gutenberg repo
 
 # Testing
 
-## Environment
-
-PHP and e2e tests require the wp-env test environment. Check `npm run wp-env-test status` first; run `npm run wp-env-test start` only if it is not already running.
-
 ## Plan the tests with the author first
 
 Before writing any test bodies, draft the test names — behavior from the user's perspective, one behavior per case (see [Describing tests](../../docs/contributors/code/testing-overview.md#describing-tests)) — and confirm the list with the author. Every proposed case must trace to the behavior being added or changed; do not pad the list with adjacent or unrelated coverage. If working unattended, put the proposed list in your summary for review instead.

--- a/skills/testing/references/e2e.md
+++ b/skills/testing/references/e2e.md
@@ -1,0 +1,21 @@
+# E2e tests: agent rules and routing
+
+Agent-specific guidance for Playwright e2e tests. Requires the wp-env test environment (see [SKILL.md](../SKILL.md)).
+
+## Procedure for writing tests
+
+Plan the test list with the author first — see "Plan the tests with the author first" in [SKILL.md](../SKILL.md). Then:
+
+1. **Check for an existing spec** in `test/e2e/specs/<area>/` that already covers the surface, and extend it rather than adding a parallel file.
+2. **Write the bodies for the confirmed list** — all of it. If a case proves infeasible, say so rather than silently omitting it.
+3. **Verify**: the spec passes scoped and headless, and is stable across repeats (`npm run test:e2e -- <path_to_spec> --repeat-each=3`).
+
+## Rules
+
+-   **Stay headless** (the default). Do not use `--headed`, `--ui`, or `--debug` — the human docs recommend them, but they open a GUI and block an agent session.
+-   **Run a scoped subset** (`npm run test:e2e -- <path_to_test_file.spec.js>`); the full suite is slow.
+
+## Routing
+
+-   **Authoring**: follow the [End-to-End Testing guide](../../../docs/contributors/code/e2e/README.md) — locators, Page Object Model, cross-browser tags.
+-   **Fixtures**: use [`@wordpress/e2e-test-utils-playwright`](../../../packages/e2e-test-utils-playwright/README.md) (`admin`, `editor`, `pageUtils`, `requestUtils`). The editor canvas is iframed — interact with it via `editor.canvas`.

--- a/skills/testing/references/e2e.md
+++ b/skills/testing/references/e2e.md
@@ -1,6 +1,6 @@
 # E2e tests: agent rules and routing
 
-Agent-specific guidance for Playwright e2e tests. Requires the wp-env test environment (see [SKILL.md](../SKILL.md)).
+Agent-specific guidance for Playwright e2e tests. They require the wp-env test environment: check `npm run wp-env-test status` first, and run `npm run wp-env-test start` only if it is not already running.
 
 ## Procedure for writing tests
 
@@ -13,7 +13,7 @@ Plan the test list with the author first — see "Plan the tests with the author
 ## Rules
 
 -   **Stay headless** (the default). Do not use `--headed`, `--ui`, or `--debug` — the human docs recommend them, but they open a GUI and block an agent session.
--   **Run a scoped subset** (`npm run test:e2e -- <path_to_test_file.spec.js>`); the full suite is slow.
+-   **Run a scoped subset** (`npm run test:e2e -- <path_to_test_file.spec.js>`), scoped to the specs affected by the change. The full suite takes a long time — if asked to run the e2e tests with no scope, confirm which specs matter before launching everything; when working unattended, scope to the affected areas and say so in your summary.
 
 ## Routing
 

--- a/skills/testing/references/e2e.md
+++ b/skills/testing/references/e2e.md
@@ -6,9 +6,10 @@ Agent-specific guidance for Playwright e2e tests. They require the wp-env test e
 
 Plan the test list with the author first — see "Plan the tests with the author first" in [SKILL.md](../SKILL.md). Then:
 
-1. **Check for an existing spec** in `test/e2e/specs/<area>/` that already covers the surface, and extend it rather than adding a parallel file.
-2. **Write the bodies for the confirmed list** — all of it. If a case proves infeasible, say so rather than silently omitting it.
-3. **Verify**: the spec passes scoped and headless, and is stable across repeats (`npm run test:e2e -- <path_to_spec> --repeat-each=3`).
+1. **Read the [End-to-End Testing guide](../../../docs/contributors/code/e2e/README.md) first** — locators, Page Object Model, assertions, cross-browser tags. Do not propose or write tests before reading it.
+2. **Check for an existing spec** in `test/e2e/specs/<area>/` that already covers the surface, and extend it rather than adding a parallel file.
+3. **Write the bodies for the confirmed list** — all of it. If a case proves infeasible, say so rather than silently omitting it.
+4. **Verify**: the spec passes scoped and headless, and is stable across repeats (`npm run test:e2e -- <path_to_spec> --repeat-each=3`).
 
 ## Rules
 
@@ -17,5 +18,4 @@ Plan the test list with the author first — see "Plan the tests with the author
 
 ## Routing
 
--   **Authoring**: follow the [End-to-End Testing guide](../../../docs/contributors/code/e2e/README.md) — locators, Page Object Model, cross-browser tags.
 -   **Fixtures**: use [`@wordpress/e2e-test-utils-playwright`](../../../packages/e2e-test-utils-playwright/README.md) (`admin`, `editor`, `pageUtils`, `requestUtils`). The editor canvas is iframed — interact with it via `editor.canvas`.

--- a/skills/testing/references/jest.md
+++ b/skills/testing/references/jest.md
@@ -1,0 +1,7 @@
+# Jest tests: agent rules and routing
+
+Agent-specific guidance for JavaScript unit and integration tests.
+
+-   **Run**: `npm run test:unit <path_to_test_directory>` or `npm run test:unit -- --testNamePattern="<TestName>"`; `npm test` runs all JS tests plus lint. No wp-env needed.
+-   **Prefer integration tests over e2e for block UI** — they render blocks in a real block editor instance and are faster and more reliable; see [Integration testing for block UI](../../../docs/contributors/code/testing-overview.md#integration-testing-for-block-ui).
+-   **Depth** (mocking, user interactions, snapshots): [Testing Overview](../../../docs/contributors/code/testing-overview.md).

--- a/skills/testing/references/php.md
+++ b/skills/testing/references/php.md
@@ -1,0 +1,6 @@
+# PHP tests: agent rules and routing
+
+Agent-specific guidance for PHPUnit tests. Requires the wp-env test environment (see [SKILL.md](../SKILL.md)).
+
+-   **Run**: `composer test` (all PHP tests), or `vendor/bin/phpunit <path_to_test_file.php>` (specific file or directory).
+-   **Depth**: [Testing Overview – PHP testing](../../../docs/contributors/code/testing-overview.md#php-testing), including [Testing prefixed functions](../../../docs/contributors/code/testing-overview.md#testing-prefixed-functions) — the prefixing rule itself is in the root `AGENTS.md` pitfalls.

--- a/skills/testing/references/php.md
+++ b/skills/testing/references/php.md
@@ -1,6 +1,6 @@
 # PHP tests: agent rules and routing
 
-Agent-specific guidance for PHPUnit tests. Requires the wp-env test environment (see [SKILL.md](../SKILL.md)).
+Agent-specific guidance for PHPUnit tests. They require the wp-env test environment: check `npm run wp-env-test status` first, and run `npm run wp-env-test start` only if it is not already running.
 
 -   **Run**: `composer test` (all PHP tests), or `vendor/bin/phpunit <path_to_test_file.php>` (specific file or directory).
 -   **Depth**: [Testing Overview – PHP testing](../../../docs/contributors/code/testing-overview.md#php-testing), including [Testing prefixed functions](../../../docs/contributors/code/testing-overview.md#testing-prefixed-functions) — the prefixing rule itself is in the root `AGENTS.md` pitfalls.


### PR DESCRIPTION
## What?

Establishes a documented pattern for how AI-agent instructions are organized in the Gutenberg repository, and lands the first skill (testing):

-   Root `AGENTS.md` becomes a lean router with a **Progressive discovery** section: contributor docs, skills, and directory guides are read only when the task needs them.
-   New top-level `skills/` directory: `skills/testing/SKILL.md` intro point with `references/` files for Jest, PHP, and e2e specifics.
-   New contributor guide at `docs/contributors/code/agents-and-skills.md`.

## Why?

Agent guidance in the repo is currently ad hoc (root `AGENTS.md`, one per-directory file in `packages/components/`), with no documented convention for contributors. By providing a general structure, we have a way to start contributing to improve agent success in coding in Gutenberg.

## How?

Follows conventions from [WordPress Agent Skills](https://github.com/WordPress/agent-skills/) to progressively disclose skills to prevent context bloat and confusing agents:

-   Content is placed by trigger: always-loaded (root `AGENTS.md`: env setup, code quality, pitfalls, router) / location-triggered (directory `AGENTS.md`) / task-triggered (`skills/`) / on-demand (docs and references). Each fact has one home, at the highest level where it applies to everything below it.
-   The testing command block moved from root `AGENTS.md` into the skill's per-type references; the shared wp-env-test requirement lives once in `SKILL.md`. Non-discoverable trap rules (PHP build-time function prefixing, per-package `CHANGELOG.md` entries) moved to **Common pitfalls**.
-   The guidance doc's example is a skeleton (not a copy of the live skill) so it cannot drift; the live example is linked instead.

## Testing Instructions

1. Start a fresh agent session with default configuration: claude (interactive), or for a captured run: `claude -p "Run the e2e tests for the paragraph block" --verbose --output-format stream-json > run.jsonl`.
2.  Run `grep -o '"file_path":"[^"]*"' run.jsonl` to list every file read.
3. Confirm the file-read list includes `skills/testing/SKILL.md` and `skills/testing/references/e2e.md`, and that those reads appear before the first test command.
3. Confirm the file-read list does NOT include `skills/testing/references/php.md` or `skills/testing/references/jest.md`
4. Run `grep -o '"command":"[^"]*"' run.jsonl` to list every shell command. 
4. Confirm the command list contains `npm run wp-env-test status` before any `wp-env-test start`.
5. Confirm it contains a spec path after `npm run test:e2e --` (e.g. editor/blocks/paragraph.spec.js) and does not contain `--headed`, `--ui`, or `--debug`. Cross-check: no browser window opened during the run.
6. Start a new agent session: ``claude -p 'Add an e2e test for the paragraph block that checks that the `&` key is not output as `&amp;` in the editor' --verbose --permission-mode acceptEdits --output-format stream-json > run.jsonl``
2.  Run `grep -o '"file_path":"[^"]*"' run.jsonl` to list every file read.
3. Confirm the file-read list includes the relevant docs and sklls, `docs/contributors/code/e2e/README.md`, `skills/testing/SKILL.md` and `skills/testing/references/e2e.md`, and that those reads appear before the first test command.

## Use of AI Tools

Authored with Claude Code (Claude Fable 5) in an interactive session, with structure and content directed and reviewed by the PR author. The comparison against WordPress/agent-skills conventions was also AI-assisted and human-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)