### PR TITLE
Notes: detach core's mention kses filter in the baseline strip test

### DIFF
--- a/phpunit/tests/notes-mention-kses-test.php
+++ b/phpunit/tests/notes-mention-kses-test.php
@@ -32,7 +32,10 @@ class Tests_Notes_Mention_Kses extends WP_UnitTestCase {
 	public function test_comment_kses_strips_mention_span_by_default() {
 		// Baseline proving the allowance is required at all: without the
 		// notes filter, the comment kses context strips `span` entirely.
+		// WordPress trunk ships the allowance natively (see r62832), hooked
+		// as `_wp_kses_allow_note_mention_span`, so detach that one too.
 		remove_filter( 'wp_kses_allowed_html', 'gutenberg_notes_allow_mention_span' );
+		remove_filter( 'wp_kses_allowed_html', '_wp_kses_allow_note_mention_span' );
 
 		$stripped = wp_kses( self::MENTION_CONTENT, 'pre_comment_content' );
 


### PR DESCRIPTION
## What?

Fixes the `Tests_Notes_Mention_Kses::test_comment_kses_strips_mention_span_by_default` failure that started showing up on trunk CI runs against WordPress trunk.

## Why?

WordPress trunk now ships the note mention span allowance natively - see https://core.trac.wordpress.org/changeset/62832 (the core backport of #80528). The baseline test proves the allowance is required by removing the notes filter and asserting the chip gets stripped, but it only removes Gutenberg's `gutenberg_notes_allow_mention_span` callback. On WP trunk, core's own `_wp_kses_allow_note_mention_span` is still hooked, so the span survives and the assertion fails. Every Gutenberg PR is currently red on the PHP unit test jobs because of this.

Worth noting the plugin code itself coexists fine with the core change - `lib/compat/wordpress-7.1/block-comments.php` already guards with `function_exists( '_wp_kses_allow_note_mention_span' )`, which is why only this one baseline test fails.

## How?

Detach core's filter alongside Gutenberg's before running the baseline assertion. Removing a filter that isn't hooked is a no-op, so no version gating is needed, and `WP_UnitTestCase` restores hooks after each test.

## Testing Instructions

The failure only reproduces against WordPress trunk, eg. the trunk unit test run https://github.com/WordPress/gutenberg/actions/runs/30034562918. The PHP unit test jobs on this PR should go green, including the WP trunk variant.

To check locally against the default test environment (where this change is a no-op):

1. `npm run wp-env-test start`
2. `vendor/bin/phpunit phpunit/tests/notes-mention-kses-test.php`

Related: https://github.com/WordPress/gutenberg/pull/80528