### PR TITLE
Media REST API: Backport sideload from url path upload size check

### DIFF
--- a/backport-changelog/7.1/12670.md
+++ b/backport-changelog/7.1/12670.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12670
+
+* https://github.com/WordPress/gutenberg/pull/PENDING

--- a/backport-changelog/7.1/12670.md
+++ b/backport-changelog/7.1/12670.md
@@ -1,3 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/12670
 
-* https://github.com/WordPress/gutenberg/pull/PENDING
+* https://github.com/WordPress/gutenberg/pull/80659

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -704,6 +704,14 @@ class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controll
 			'tmp_name' => $tmp_file,
 		);
 
+		$size_check = self::check_upload_size( $file_array );
+		if ( is_wp_error( $size_check ) ) {
+			if ( file_exists( $tmp_file ) ) {
+				wp_delete_file( $tmp_file );
+			}
+			return $size_check;
+		}
+
 		$attachment_id = media_handle_sideload( $file_array, $post_id );
 
 		if ( is_wp_error( $attachment_id ) ) {

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-test.php
@@ -2401,6 +2401,64 @@ class Gutenberg_REST_Attachments_Controller_Test extends WP_Test_REST_Post_Type_
 	}
 
 	/**
+	 * Verifies that the URL sideload path enforces the multisite maximum file
+	 * size, for parity with the multipart and raw-body upload paths.
+	 *
+	 * @group multisite
+	 * @group ms-required
+	 *
+	 * @covers ::create_item_from_url
+	 * @covers WP_REST_Attachments_Controller::check_upload_size
+	 */
+	public function test_create_item_from_url_exceeds_multisite_max_filesize(): void {
+		wp_set_current_user( self::$admin_id );
+		update_site_option( 'fileupload_maxk', 1 );
+		update_site_option( 'upload_space_check_disabled', false );
+
+		// Ensure ample space is available so the file-size limit is what rejects it.
+		add_filter( 'pre_get_space_used', '__return_zero' );
+		add_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_param( 'url', 'https://example.com/too-big.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10 );
+
+		$this->assertErrorResponse( 'rest_upload_file_too_big', $response, 400 );
+	}
+
+	/**
+	 * Verifies that the URL sideload path enforces the multisite site upload
+	 * space quota, for parity with the multipart and raw-body upload paths.
+	 *
+	 * @group multisite
+	 * @group ms-required
+	 *
+	 * @covers ::create_item_from_url
+	 * @covers WP_REST_Attachments_Controller::check_upload_size
+	 */
+	public function test_create_item_from_url_exceeds_multisite_site_upload_space(): void {
+		wp_set_current_user( self::$admin_id );
+		add_filter( 'get_space_allowed', '__return_zero' );
+		update_site_option( 'upload_space_check_disabled', false );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_param( 'url', 'https://example.com/no-space.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10 );
+
+		$this->assertErrorResponse( 'rest_upload_limited_space', $response, 400 );
+	}
+
+	/**
 	 * Verifies that a URL with no usable path bails with a 400 before any
 	 * download is attempted, rather than handing an empty filename to the
 	 * sideload handler.


### PR DESCRIPTION
## What?

Backports https://github.com/WordPress/wordpress-develop/pull/12670 to Gutenberg.

This change adds a `check_upload_size` check to the media REST API endpoint's behaviour that allows an image to be uploaded via a `url` parameter instead of the browser having to first download the file and then perform a traditional POST request.

## Why?

The added check ensures parity with the other upload paths (e.g. the multipart and raw-body upload paths).

## How?

In `create_item_from_url` we now call `check_upload_size` on the file to be uploaded _before_ sideloading. This makes sure that it passes upload size checks in multisite environments before we allow the server to perform the sideload. If it doesn't pass the check, delete the temp file, just as we do further down the file if `media_handle_sideload` fails.

## Testing Instructions

Smoke test uploading an externally referenced media file in an image block. E.g. using the following markup, click on the "Upload to media library" button in the block toolbar and make sure it still works:

```html
<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://user-images.githubusercontent.com/1204802/100067796-fc3e8700-2e36-11eb-993b-6b80b4310b87.png" alt=""/></figure>
<!-- /wp:image -->
```

## Screenshots or screencast <!-- if applicable -->

For reference, this is the upload button we're looking at:

<img width="705" height="227" alt="image" src="https://github.com/user-attachments/assets/efd44446-8b14-4561-9827-b4b17aa1dc4b" />

## Use of AI Tools

Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Identifying the gap in upload paths; final implementation and tests were reviewed and edited by me.