### PR TITLE
Writing flow: fix shift+click selection between list items in Safari

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-click-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-click-selection.js
@@ -82,6 +82,53 @@ export default function useClickSelection() {
 								isForward ? 0 : blockElement.childNodes.length
 							);
 						}
+
+						// Safari does not extend the selection to a
+						// clicked position within an element with a
+						// tabIndex, or within a block whose wrapper has
+						// one (a list item): the mousedown default action
+						// focuses the element instead, discarding the
+						// selection. Remove the tabIndex for the duration
+						// of the click. Restoring it any earlier (e.g. in
+						// a microtask, which runs before the default
+						// action) puts it back in time for Safari to
+						// focus it.
+						const stripped = [];
+						let element = event.target;
+						while ( element && element !== node ) {
+							if (
+								element.hasAttribute?.( 'tabindex' ) &&
+								element.contentEditable !== 'true'
+							) {
+								stripped.push( [
+									element,
+									element.getAttribute( 'tabindex' ),
+								] );
+								element.removeAttribute( 'tabindex' );
+							}
+							element = element.parentElement;
+						}
+						if ( stripped.length ) {
+							const { defaultView } = ownerDocument;
+							const restore = () => {
+								defaultView.removeEventListener(
+									'mouseup',
+									restore
+								);
+								defaultView.removeEventListener(
+									'dragend',
+									restore
+								);
+								for ( const [ el, value ] of stripped ) {
+									el.setAttribute( 'tabindex', value );
+								}
+							};
+							// The press normally ends with a mouseup, but
+							// with a dragend instead when a native drag
+							// starts mid-press.
+							defaultView.addEventListener( 'mouseup', restore );
+							defaultView.addEventListener( 'dragend', restore );
+						}
 					}
 				} else if ( hasMultiSelection() ) {
 					// Allow user to escape out of a multi-selection to a


### PR DESCRIPTION
## What?
Fixes #80661. In Safari, shift+clicking from one list item to another extends the text selection again instead of just moving the caret.

## Why?
Safari's mousedown default action focuses the nearest click-focusable element on the click path, and once it focuses something it treats the click as caret placement, ignoring Shift and discarding the selection being extended. #80651 removed the `tabIndex` from rich text elements, which fixed blocks whose wrapper is the rich text element (paragraphs, headings). A list item's wrapper (the `li`) is a separate element and keeps `tabindex="0"`, so Safari still captures focus there. This is pre-existing behavior, not a regression.

## How?
On a cross-block shift+mousedown, remove the `tabindex` from non-editable elements along the clicked path and restore it when the press ends (mouseup, or dragend when a native drag starts mid-press). Restoring earlier does not work: a microtask runs before the mousedown default action, so Safari would still see the `tabindex` when it captures focus (verified in real Safari). React re-renders do not resurrect the attribute mid-gesture because the rendered value is unchanged, so nothing rewrites it until the restore.

## Testing Instructions
1. In Safari, add a list with two items containing some text.
2. Click in the middle of the first item's text, then shift+click in the middle of the second item's text.
3. The selection extends between the two points. Before, the caret just moved to the second item.

Playwright's engines do not reproduce Safari's focus-capture behavior (the existing list item e2e test passes either way), so the fix is verified against real Safari via safaridriver, alongside the existing shift+click e2e suite in all three engines.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.