### PR TITLE
Gallery: update action labels for conversion from dynamic variation

### DIFF
--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -77,23 +77,21 @@ function OrderControl( { orderby, order, onChange } ) {
 /**
  * The Gallery block's "Source" inspector panel.
  *
- * In dynamic mode it shows the resolved source, a control to convert the
- * gallery to a static one, and the source ordering. In static mode it offers
- * the entry point into dynamic mode — and, since switching discards any
- * hand-added images, owns the confirmation dialog for that one-way change.
- * Rendered inside the block's `InspectorControls`, alongside the Settings panel.
+ * In dynamic mode it shows the resolved source, a control to convert back to
+ * individual images, and the source ordering. In static mode it offers the
+ * entry point into dynamic mode — and, since switching discards any hand-added
+ * images, owns the confirmation dialog for that one-way change. Rendered inside
+ * the block's `InspectorControls`, alongside the Settings panel.
  *
- * @param {Object}   props
- * @param {Object}   props.dynamic                The `useDynamicGallery` result.
- * @param {Object}   props.dropdownMenuProps      Shared ToolsPanel dropdown menu props.
- * @param {boolean}  props.hasImages              Whether the gallery has manually-added images.
- * @param {Function} props.requestConvertToStatic Opens the shared confirm dialog for converting to a static gallery.
+ * @param {Object}  props
+ * @param {Object}  props.dynamic           The `useDynamicGallery` result.
+ * @param {Object}  props.dropdownMenuProps Shared ToolsPanel dropdown menu props.
+ * @param {boolean} props.hasImages         Whether the gallery has manually-added images.
  */
 export function GallerySourcePanel( {
 	dynamic,
 	dropdownMenuProps,
 	hasImages,
-	requestConvertToStatic,
 } ) {
 	const {
 		dynamicContent,
@@ -102,6 +100,7 @@ export function GallerySourcePanel( {
 		sourceOrderby,
 		sourceOrder,
 		setSourceOrder,
+		convertToStatic,
 		enableDynamicMode,
 		resetSource,
 		isResolvingDynamic,
@@ -137,7 +136,7 @@ export function GallerySourcePanel( {
 					<Button
 						__next40pxDefaultSize
 						variant="secondary"
-						onClick={ requestConvertToStatic }
+						onClick={ convertToStatic }
 						// Guard the race where the media is still resolving:
 						// converting now would map over an incomplete (or empty)
 						// list and produce a gallery missing images.
@@ -267,7 +266,7 @@ function GalleryImagesPreview( { imageBlocks } ) {
 /**
  * Renders a dynamic-mode gallery on the canvas:
  *
- * - a block-toolbar control to convert the gallery to a static one;
+ * - a block-toolbar control to convert back to individual images;
  * - the gallery `<figure>` wrapper holding a non-editable preview of the
  *   resolved media (or a placeholder while resolving / when nothing is found),
  *   with the gallery's provided context so the previewed images inherit
@@ -278,16 +277,15 @@ function GalleryImagesPreview( { imageBlocks } ) {
  *   List View).
  *
  * @param {Object}   props
- * @param {Object}   props.dynamic                The `useDynamicGallery` result.
- * @param {Object}   props.blockProps             The gallery's `useBlockProps()` result.
- * @param {Object}   props.innerBlocksProps       The gallery's `useInnerBlocksProps()` result.
- * @param {Object}   props.attributes             The gallery block attributes.
- * @param {Function} props.setAttributes          The block's `setAttributes`.
- * @param {boolean}  props.isSelected             Whether the gallery block is selected.
- * @param {Function} props.insertBlocksAfter      Inserts blocks after the gallery.
- * @param {boolean}  props.isContentLocked        Whether the gallery is content-locked.
- * @param {boolean}  props.multiGallerySelection  Whether multiple galleries are selected.
- * @param {Function} props.requestConvertToStatic Opens the shared confirm dialog for converting to a static gallery.
+ * @param {Object}   props.dynamic               The `useDynamicGallery` result.
+ * @param {Object}   props.blockProps            The gallery's `useBlockProps()` result.
+ * @param {Object}   props.innerBlocksProps      The gallery's `useInnerBlocksProps()` result.
+ * @param {Object}   props.attributes            The gallery block attributes.
+ * @param {Function} props.setAttributes         The block's `setAttributes`.
+ * @param {boolean}  props.isSelected            Whether the gallery block is selected.
+ * @param {Function} props.insertBlocksAfter     Inserts blocks after the gallery.
+ * @param {boolean}  props.isContentLocked       Whether the gallery is content-locked.
+ * @param {boolean}  props.multiGallerySelection Whether multiple galleries are selected.
  */
 export function GalleryDynamicView( {
 	dynamic,
@@ -299,13 +297,13 @@ export function GalleryDynamicView( {
 	insertBlocksAfter,
 	isContentLocked,
 	multiGallerySelection,
-	requestConvertToStatic,
 } ) {
 	const {
 		sourceDescriptor,
 		dynamicImageBlocks,
 		galleryContext,
 		isResolvingDynamic,
+		convertToStatic,
 	} = dynamic;
 
 	// Converting to a static gallery materializes editable inner blocks, which
@@ -330,11 +328,10 @@ export function GalleryDynamicView( {
 			{ blockEditingMode === 'default' && (
 				<BlockControls group="other">
 					<ToolbarButton
-						onClick={ requestConvertToStatic }
+						onClick={ convertToStatic }
 						// Same guard as the inspector's "Convert to static
-						// gallery": both open the confirm dialog, whose confirm
-						// runs `convertToStatic`, which would otherwise map over a
-						// still-resolving (or empty) media list. (`ToolbarButton`
+						// gallery": both call `convertToStatic`, which would map over
+						// a still-resolving (or empty) media list. (`ToolbarButton`
 						// stays focusable when disabled by default.)
 						disabled={ isResolvingDynamic }
 					>

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -77,21 +77,23 @@ function OrderControl( { orderby, order, onChange } ) {
 /**
  * The Gallery block's "Source" inspector panel.
  *
- * In dynamic mode it shows the resolved source, a control to convert back to
- * individual images, and the source ordering. In static mode it offers the
- * entry point into dynamic mode — and, since switching discards any hand-added
- * images, owns the confirmation dialog for that one-way change. Rendered inside
- * the block's `InspectorControls`, alongside the Settings panel.
+ * In dynamic mode it shows the resolved source, a control to convert the
+ * gallery to a static one, and the source ordering. In static mode it offers
+ * the entry point into dynamic mode — and, since switching discards any
+ * hand-added images, owns the confirmation dialog for that one-way change.
+ * Rendered inside the block's `InspectorControls`, alongside the Settings panel.
  *
- * @param {Object}  props
- * @param {Object}  props.dynamic           The `useDynamicGallery` result.
- * @param {Object}  props.dropdownMenuProps Shared ToolsPanel dropdown menu props.
- * @param {boolean} props.hasImages         Whether the gallery has manually-added images.
+ * @param {Object}   props
+ * @param {Object}   props.dynamic                The `useDynamicGallery` result.
+ * @param {Object}   props.dropdownMenuProps      Shared ToolsPanel dropdown menu props.
+ * @param {boolean}  props.hasImages              Whether the gallery has manually-added images.
+ * @param {Function} props.requestConvertToStatic Opens the shared confirm dialog for converting to a static gallery.
  */
 export function GallerySourcePanel( {
 	dynamic,
 	dropdownMenuProps,
 	hasImages,
+	requestConvertToStatic,
 } ) {
 	const {
 		dynamicContent,
@@ -100,7 +102,6 @@ export function GallerySourcePanel( {
 		sourceOrderby,
 		sourceOrder,
 		setSourceOrder,
-		convertToStatic,
 		enableDynamicMode,
 		resetSource,
 		isResolvingDynamic,
@@ -136,14 +137,14 @@ export function GallerySourcePanel( {
 					<Button
 						__next40pxDefaultSize
 						variant="secondary"
-						onClick={ convertToStatic }
+						onClick={ requestConvertToStatic }
 						// Guard the race where the media is still resolving:
 						// converting now would map over an incomplete (or empty)
 						// list and produce a gallery missing images.
 						disabled={ isResolvingDynamic }
 						accessibleWhenDisabled
 					>
-						{ __( 'Convert to individual images' ) }
+						{ __( 'Convert to static gallery' ) }
 					</Button>
 				</div>
 				{ hasMoreImagesThanCap && (
@@ -266,7 +267,7 @@ function GalleryImagesPreview( { imageBlocks } ) {
 /**
  * Renders a dynamic-mode gallery on the canvas:
  *
- * - a block-toolbar control to convert back to individual images;
+ * - a block-toolbar control to convert the gallery to a static one;
  * - the gallery `<figure>` wrapper holding a non-editable preview of the
  *   resolved media (or a placeholder while resolving / when nothing is found),
  *   with the gallery's provided context so the previewed images inherit
@@ -277,15 +278,16 @@ function GalleryImagesPreview( { imageBlocks } ) {
  *   List View).
  *
  * @param {Object}   props
- * @param {Object}   props.dynamic               The `useDynamicGallery` result.
- * @param {Object}   props.blockProps            The gallery's `useBlockProps()` result.
- * @param {Object}   props.innerBlocksProps      The gallery's `useInnerBlocksProps()` result.
- * @param {Object}   props.attributes            The gallery block attributes.
- * @param {Function} props.setAttributes         The block's `setAttributes`.
- * @param {boolean}  props.isSelected            Whether the gallery block is selected.
- * @param {Function} props.insertBlocksAfter     Inserts blocks after the gallery.
- * @param {boolean}  props.isContentLocked       Whether the gallery is content-locked.
- * @param {boolean}  props.multiGallerySelection Whether multiple galleries are selected.
+ * @param {Object}   props.dynamic                The `useDynamicGallery` result.
+ * @param {Object}   props.blockProps             The gallery's `useBlockProps()` result.
+ * @param {Object}   props.innerBlocksProps       The gallery's `useInnerBlocksProps()` result.
+ * @param {Object}   props.attributes             The gallery block attributes.
+ * @param {Function} props.setAttributes          The block's `setAttributes`.
+ * @param {boolean}  props.isSelected             Whether the gallery block is selected.
+ * @param {Function} props.insertBlocksAfter      Inserts blocks after the gallery.
+ * @param {boolean}  props.isContentLocked        Whether the gallery is content-locked.
+ * @param {boolean}  props.multiGallerySelection  Whether multiple galleries are selected.
+ * @param {Function} props.requestConvertToStatic Opens the shared confirm dialog for converting to a static gallery.
  */
 export function GalleryDynamicView( {
 	dynamic,
@@ -297,13 +299,13 @@ export function GalleryDynamicView( {
 	insertBlocksAfter,
 	isContentLocked,
 	multiGallerySelection,
+	requestConvertToStatic,
 } ) {
 	const {
 		sourceDescriptor,
 		dynamicImageBlocks,
 		galleryContext,
 		isResolvingDynamic,
-		convertToStatic,
 	} = dynamic;
 
 	// Converting to a static gallery materializes editable inner blocks, which
@@ -328,14 +330,15 @@ export function GalleryDynamicView( {
 			{ blockEditingMode === 'default' && (
 				<BlockControls group="other">
 					<ToolbarButton
-						onClick={ convertToStatic }
-						// Same guard as the inspector's "Convert to individual
-						// images": both call `convertToStatic`, which would map over
-						// a still-resolving (or empty) media list. (`ToolbarButton`
+						onClick={ requestConvertToStatic }
+						// Same guard as the inspector's "Convert to static
+						// gallery": both open the confirm dialog, whose confirm
+						// runs `convertToStatic`, which would otherwise map over a
+						// still-resolving (or empty) media list. (`ToolbarButton`
 						// stays focusable when disabled by default.)
 						disabled={ isResolvingDynamic }
 					>
-						{ __( 'Convert to images' ) }
+						{ __( 'Convert to static gallery' ) }
 					</ToolbarButton>
 				</BlockControls>
 			) }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -18,6 +18,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToolbarDropdownMenu,
 	Button,
+	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import {
 	store as blockEditorStore,
@@ -30,7 +31,7 @@ import {
 	MediaReplaceFlow,
 	useSettings,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -236,6 +237,12 @@ export default function GalleryEdit( props ) {
 		postId,
 		postType,
 	} );
+
+	// Converting a dynamic gallery to a static one is a one-way change: the
+	// gallery stops resolving from its source and keeps whatever it shows now.
+	// Both the toolbar and inspector controls open this shared confirm dialog
+	// (rendered once below) so the consequence is spelled out before the switch.
+	const [ isConvertingToStatic, setIsConvertingToStatic ] = useState( false );
 
 	// State that drives counts/size options should reflect the dynamic media
 	// when the gallery is in dynamic mode.
@@ -716,6 +723,9 @@ export default function GalleryEdit( props ) {
 					dynamic={ dynamic }
 					dropdownMenuProps={ dropdownMenuProps }
 					hasImages={ hasImages }
+					requestConvertToStatic={ () =>
+						setIsConvertingToStatic( true )
+					}
 				/>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
@@ -953,6 +963,9 @@ export default function GalleryEdit( props ) {
 					blockProps={ blockProps }
 					innerBlocksProps={ innerBlocksProps }
 					multiGallerySelection={ multiGallerySelection }
+					requestConvertToStatic={ () =>
+						setIsConvertingToStatic( true )
+					}
 				/>
 			) : (
 				<Gallery
@@ -963,6 +976,24 @@ export default function GalleryEdit( props ) {
 					insertBlocksAfter={ insertBlocksAfter }
 					multiGallerySelection={ multiGallerySelection }
 				/>
+			) }
+			{ isConvertingToStatic && (
+				<ConfirmDialog
+					isOpen
+					title={ __( 'Convert to a static gallery?' ) }
+					__experimentalHideHeader={ false }
+					confirmButtonText={ __( 'Convert to static' ) }
+					onConfirm={ () => {
+						dynamic.convertToStatic();
+						setIsConvertingToStatic( false );
+					} }
+					onCancel={ () => setIsConvertingToStatic( false ) }
+					size="medium"
+				>
+					{ __(
+						'This gallery will stop updating automatically and keep the images it shows now. You can edit them like any manual gallery.'
+					) }
+				</ConfirmDialog>
 			) }
 		</>
 	);

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -18,7 +18,6 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToolbarDropdownMenu,
 	Button,
-	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import {
 	store as blockEditorStore,
@@ -31,7 +30,7 @@ import {
 	MediaReplaceFlow,
 	useSettings,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -237,12 +236,6 @@ export default function GalleryEdit( props ) {
 		postId,
 		postType,
 	} );
-
-	// Converting a dynamic gallery to a static one is a one-way change: the
-	// gallery stops resolving from its source and keeps whatever it shows now.
-	// Both the toolbar and inspector controls open this shared confirm dialog
-	// (rendered once below) so the consequence is spelled out before the switch.
-	const [ isConvertingToStatic, setIsConvertingToStatic ] = useState( false );
 
 	// State that drives counts/size options should reflect the dynamic media
 	// when the gallery is in dynamic mode.
@@ -723,9 +716,6 @@ export default function GalleryEdit( props ) {
 					dynamic={ dynamic }
 					dropdownMenuProps={ dropdownMenuProps }
 					hasImages={ hasImages }
-					requestConvertToStatic={ () =>
-						setIsConvertingToStatic( true )
-					}
 				/>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
@@ -963,9 +953,6 @@ export default function GalleryEdit( props ) {
 					blockProps={ blockProps }
 					innerBlocksProps={ innerBlocksProps }
 					multiGallerySelection={ multiGallerySelection }
-					requestConvertToStatic={ () =>
-						setIsConvertingToStatic( true )
-					}
 				/>
 			) : (
 				<Gallery
@@ -976,24 +963,6 @@ export default function GalleryEdit( props ) {
 					insertBlocksAfter={ insertBlocksAfter }
 					multiGallerySelection={ multiGallerySelection }
 				/>
-			) }
-			{ isConvertingToStatic && (
-				<ConfirmDialog
-					isOpen
-					title={ __( 'Convert to a static gallery?' ) }
-					__experimentalHideHeader={ false }
-					confirmButtonText={ __( 'Convert to static' ) }
-					onConfirm={ () => {
-						dynamic.convertToStatic();
-						setIsConvertingToStatic( false );
-					} }
-					onCancel={ () => setIsConvertingToStatic( false ) }
-					size="medium"
-				>
-					{ __(
-						'This gallery will stop updating automatically and keep the images it shows now. You can edit them like any manual gallery.'
-					) }
-				</ConfirmDialog>
 			) }
 		</>
 	);


### PR DESCRIPTION
## What? How?

> [!NOTE]
> Take or leave this change. It's low priority.

Addresses the "label semantics" part of #80613.

**Controls (toolbar + inspector):** `Convert to static gallery` (was "Convert to images" / "Convert to individual images")



## Why?

The Gallery block's dynamic variation offered a `convertToStatic` action under two different  labels: 

- "Convert to images" (toolbar) and 
- "Convert to individual images" (inspector). 

Read in a certain way, they could be construed as unwrapping the gallery into individual Image blocks, when in fact they switch the gallery from its dynamic source to a plain, manually-editable gallery.


## Testing Instructions

1. Add a Gallery block in the post editor and, from its Source panel, choose "Use images attached to the post" to enter dynamic mode.
2. Confirm the block toolbar and the Source inspector panel now both read **"Convert to static gallery"** (not "Convert to images" / "Convert to individual images").
3. Click either control → the gallery becomes a static gallery holding the currently-shown images, editable like any manual gallery.

<img width="1096" height="523" alt="Screenshot 2026-07-24 at 3 30 51 pm" src="https://github.com/user-attachments/assets/64c04e23-3974-43c2-8935-4542c86d1964" />

