### PR TITLE
ESLint plugin: Fix no-unused-vars-before-return false positive for JSX in nested functions

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `no-unused-vars-before-return`: no longer reports a false positive when a variable is only referenced by JSX nested inside a local function ([#55552](https://github.com/WordPress/gutenberg/issues/55552)).
+
 ## 25.7.0 (2026-07-14)
 
 ## 25.6.0 (2026-07-01)

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -62,6 +62,26 @@ function MyComponent() {
 	return <Foo />;
 }`,
 		},
+		{
+			code: `
+function lazyEdit( load ) {
+	const Load = lazy( load );
+	return function LoadEdit( props ) {
+		return (
+			<Suspense fallback={ null }>
+				<Load { ...props } />
+			</Suspense>
+		);
+	};
+}`,
+		},
+		{
+			code: `
+function createComponent() {
+	const Foo = getSomeComponent();
+	return () => <Foo />;
+}`,
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -28,6 +28,29 @@ function getClosestFunctionScope( context, node ) {
 	return functionScope;
 }
 
+/**
+ * Returns all function scopes enclosing the given node, ordered from the
+ * closest outwards.
+ *
+ * @param {ESLintRuleContext} context ESLint context object.
+ * @param {ESTreeNode}        node    Current AST node.
+ *
+ * @return {ESLintScope[]} Enclosing function scopes.
+ */
+function getEnclosingFunctionScopes( context, node ) {
+	const functionScopes = [];
+
+	let scope = context.sourceCode.getScope( node );
+	while ( scope ) {
+		if ( scope.type === 'function' ) {
+			functionScopes.push( scope );
+		}
+		scope = scope.upper;
+	}
+
+	return functionScopes;
+}
+
 module.exports = /** @type {import('eslint').Rule} */ ( {
 	meta: {
 		type: 'problem',
@@ -70,23 +93,32 @@ module.exports = /** @type {import('eslint').Rule} */ ( {
 
 		return {
 			JSXIdentifier( node ) {
-				// Currently, a scope's variable references does not include JSX
-				// identifiers. Account for this by visiting JSX identifiers
-				// first, and tracking them in a map per function scope, which
-				// is later merged with the known variable references.
-				const functionScope = getClosestFunctionScope( context, node );
-				if ( ! functionScope ) {
-					return;
-				}
+				// Depending on the ESLint version in use, a scope's variable
+				// references may not include JSX identifiers. Account for this
+				// by visiting JSX identifiers first, and tracking them in a map
+				// per function scope, which is later merged with the known
+				// variable references.
+				//
+				// The identifier is tracked for every enclosing function scope,
+				// not only the closest one, since JSX nested in a local
+				// function can still reference a variable of an outer scope.
+				for ( const functionScope of getEnclosingFunctionScopes(
+					context,
+					node
+				) ) {
+					if (
+						! FUNCTION_SCOPE_JSX_IDENTIFIERS.has( functionScope )
+					) {
+						FUNCTION_SCOPE_JSX_IDENTIFIERS.set(
+							functionScope,
+							new Set()
+						);
+					}
 
-				if ( ! FUNCTION_SCOPE_JSX_IDENTIFIERS.has( functionScope ) ) {
-					FUNCTION_SCOPE_JSX_IDENTIFIERS.set(
-						functionScope,
-						new Set()
+					FUNCTION_SCOPE_JSX_IDENTIFIERS.get( functionScope ).add(
+						node
 					);
 				}
-
-				FUNCTION_SCOPE_JSX_IDENTIFIERS.get( functionScope ).add( node );
 			},
 			'ReturnStatement:exit'( node ) {
 				const functionScope = getClosestFunctionScope( context, node );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #55552

Fixes a false positive in the `@wordpress/no-unused-vars-before-return` ESLint rule, which reported a variable as unused when its only reference was JSX nested inside a local function.

## Why?
The code from the issue is flagged incorrectly:

```jsx
function lazyEdit( load ) {
	const Load = lazy( load );
	return function LoadEdit( props ) {
		return (
			<Suspense fallback={ null }>
				<Load { ...props } />
			</Suspense>
		);
	};
}
```

`Load` *is* used, as a JSX component type inside `LoadEdit`, but the rule reports "Variables should not be assigned until just prior its first reference."

Two notes on scope, since they affect how you'll want to verify this:

1. **The issue does not reproduce on `trunk` as-is.** Scope analysis in `eslint-scope` gained native JSX reference resolution in **8.3.0** (shipped with ESLint ~9.22), so on the ESLint version Gutenberg currently uses the rule's JSX workaround is bypassed entirely and `Load` resolves as a genuine reference.
2. **The bug is still live for plugin consumers.** `@wordpress/eslint-plugin` declares `eslint: ^9.0.0 || ^10.0.0` as a peer dependency, and ESLint 9.0–9.21 bundle `eslint-scope` < 8.3, where the workaround is the only thing running and the false positive is real.

So this fixes the rule for the ESLint versions we still support, and removes a latent correctness bug from the workaround regardless.

## Testing Instructions
This is a lint-rule change with no runtime or UI impact.

```
npm run test:unit packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
```

The two new `valid` cases cover the reported code and the arrow-function variant.

Because current ESLint resolves JSX references natively (see "Why?" above), those tests pass with or without the rule change on `trunk`. To exercise the code path this PR actually fixes, the rule has to be run against a scope manager that does not resolve JSX identifiers — i.e. the same analyzer with the `jsx` scope option off, which is what ESLint 9.0–9.21 do. Under that setup:

| Case | Before | After |
|-|-|-|
| Issue #55552 (JSX in nested `function`) | ❌ false positive | ✅ clean |
| JSX in nested arrow function | ❌ false positive | ✅ clean |
| JSX in the same scope | ✅ clean | ✅ clean |
| Declared before an early return (true positive) | ✅ reported | ✅ reported |

The last row matters most: the fix must not silence genuine findings, and it doesn't.

The equivalent real-world check is to install ESLint 9.21 or earlier alongside the plugin and lint the snippet from the issue.

## Use of AI Tools

This PR was developed with the assistance of Claude Opus 4.8, used to diagnose the root cause, identify the `eslint-scope` version boundary where JSX reference resolution was introduced, implement the fix, and write the regression tests.