### PR TITLE
Fix/visual revisions autosave diff 80455

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   Visual revisions now compare autosaves against the saved post, preventing unchanged blocks from being highlighted as additions ([#80455](https://github.com/WordPress/gutenberg/issues/80455)).
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 
 ## 14.51.0 (2026-07-14)

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -593,6 +593,20 @@ export const getPreviousRevision = createRegistrySelector(
 		const currentIndex = revisions.findIndex(
 			( r ) => r[ revisionKey ] === currentRevisionId
 		);
+		const currentRevision = revisions[ currentIndex ];
+
+		// Autosaves are changes against the currently saved post, not the
+		// preceding revision. This also provides a baseline when the autosave is
+		// the post's only revision.
+		if ( currentRevision?.slug === `${ postId }-autosave-v1` ) {
+			return (
+				select( coreStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				) ?? null
+			);
+		}
 
 		// Return the previous revision (older one) if it exists.
 		if ( currentIndex >= 0 && currentIndex < revisions.length - 1 ) {

--- a/packages/editor/src/store/test/private-selectors.js
+++ b/packages/editor/src/store/test/private-selectors.js
@@ -12,8 +12,10 @@ import {
 	getCanvasHeight,
 	getDefaultRenderingMode,
 	getPostBlocksByName,
+	getPreviousRevision,
 	isCollaborationEnabledForCurrentPost,
 } from '../private-selectors';
+import { getCurrentPost } from '../selectors';
 import { lock } from '../../lock-unlock';
 
 describe( 'getPostBlocksByName', () => {
@@ -87,6 +89,84 @@ describe( 'getPostBlocksByName', () => {
 			'core/heading',
 		] );
 		expect( result ).toEqual( [ 'block1', 'block2', 'block3' ] );
+	} );
+} );
+
+describe( 'getPreviousRevision', () => {
+	const postId = 123;
+	const savedPost = {
+		id: postId,
+		type: 'post',
+		content: {
+			raw: '<!-- wp:paragraph --><p>Saved</p><!-- /wp:paragraph -->',
+		},
+		title: { raw: 'Saved title' },
+		meta: { footnotes: '' },
+	};
+	const state = {
+		postId,
+		postType: 'post',
+		revisionId: 3,
+		revisionPage: 1,
+	};
+
+	function setupRegistry( revisions, parentPost = savedPost ) {
+		const getEntityRecord = jest.fn( () => parentPost );
+		const registry = {
+			select: ( store ) => {
+				if ( store === coreStore ) {
+					return {
+						getRawEntityRecord: () => ( {
+							id: postId,
+							type: 'post',
+							_links: {
+								'version-history': [
+									{ count: revisions.length },
+								],
+							},
+						} ),
+						getEntityConfig: () => ( { revisionKey: 'id' } ),
+						getEntityRecord,
+						getRevisions: () => revisions,
+					};
+				}
+			},
+		};
+		getCurrentPost.registry = registry;
+		getPreviousRevision.registry = registry;
+		return getEntityRecord;
+	}
+
+	it( 'returns the saved post as the autosave baseline', () => {
+		const revisions = [
+			{ id: 3, slug: `${ postId }-autosave-v1` },
+			{ id: 2, slug: `${ postId }-revision-v1` },
+		];
+		const getEntityRecord = setupRegistry( revisions );
+
+		expect( getPreviousRevision( state ) ).toBe( savedPost );
+		expect( getEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			postId
+		);
+	} );
+
+	it( 'returns null while the saved post is unavailable', () => {
+		setupRegistry( [ { id: 3, slug: `${ postId }-autosave-v1` } ], null );
+
+		expect( getPreviousRevision( state ) ).toBeNull();
+	} );
+
+	it( 'returns the preceding revision for a regular revision', () => {
+		const previousRevision = { id: 2, slug: `${ postId }-revision-v1` };
+		const getEntityRecord = setupRegistry( [
+			{ id: 3, slug: `${ postId }-revision-v2` },
+			previousRevision,
+		] );
+
+		expect( getPreviousRevision( state ) ).toBe( previousRevision );
+		expect( getEntityRecord ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -346,12 +346,13 @@ test.describe( 'Autosave', () => {
 		await page.keyboard.type( 'before save' );
 		await editor.publishPost();
 
-		const paragraph = editor.canvas.getByRole( 'document', {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		const paragraphs = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
-		await paragraph.click();
+		await paragraphs.nth( 1 ).click();
 		// Type slowly so the autosave happens more than 1s after publish.
-		await page.keyboard.type( ' after save', { delay: 100 } );
+		await page.keyboard.type( 'after save', { delay: 100 } );
 
 		// Trigger a server-side autosave newer than the saved version.
 		await page.evaluate( () =>
@@ -390,6 +391,19 @@ test.describe( 'Autosave', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Exit' } )
 		).toBeVisible();
+		await expect
+			.poll( async () => {
+				const blocks = await editor.getBlocks();
+				return blocks.map( ( block ) => ( {
+					content: block.attributes.content,
+					status:
+						block.attributes.__revisionDiffStatus?.status ?? null,
+				} ) );
+			} )
+			.toEqual( [
+				{ content: 'before save', status: null },
+				{ content: 'after save', status: 'added' },
+			] );
 
 		// Restoring the autosave dismisses the notice.
 		await page.getByRole( 'button', { name: 'Restore' } ).click();


### PR DESCRIPTION
## What?

Closes 80455

Fixes Visual Revisions incorrectly highlighting unchanged blocks as additions when viewing an autosave.

## Why?

Autosaves without an older revision were compared against empty content, causing every block to appear newly added.

## How?

Autosaves are now compared against the currently saved post. The existing E2E test now verifies that only newly added content receives addition highlighting.

## Testing Instructions

1. Publish a post containing a paragraph.
2. Add a second paragraph without changing the original.
3. Run `wp.data.dispatch( 'core/editor' ).autosave()` in the browser console.
4. Reload and click **View the autosave**.
5. Confirm only the new paragraph is highlighted as added.
6. Restore the autosave and confirm the notice disappears.

### Testing Instructions for Keyboard

Follow the instructions above using Tab, Shift+Tab, Enter, and standard editor keyboard controls. Confirm the Visual Revisions controls remain keyboard accessible.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

OpenAI Codex was used to investigate the issue, implement the fix, and draft tests and documentation. The changes were reviewed and validated by the contributor.