### PR TITLE
Background image control: Remove duplicated focus ring

### DIFF
--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -58,10 +58,6 @@
 		&:hover {
 			color: var(--wp-admin-theme-color);
 		}
-
-		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
 	}
 
 	.block-editor-global-styles-background-panel__loading {


### PR DESCRIPTION
## What?

Part of #80138

Removes the custom `box-shadow` focus outline from the Image button in the Background panel.

## Why?

The `Button` component now renders its focus ring with `outline`, so the component's own focus ring and this custom `box-shadow` are both drawn, resulting in a double focus ring.

## Testing Instructions

1. Insert a Group block.
2. Open the Block Inspector > Background panel.
3. Focus the Image button and confirm only a single focus ring is rendered.

## Screenshots or screencast

Note that to compare the focus outline with other buttons, I am applying a focus state to the relevant buttons using the browser developer tools.

|Before|After|
|-|-|
| <img width="283" height="382" alt="before" src="https://github.com/user-attachments/assets/359a2018-f99d-461b-b172-dbdc84eb4546" /> | <img width="289" height="392" alt="after" src="https://github.com/user-attachments/assets/98baec91-06ff-4fd4-8c67-d2b1b758648f" /> |

## Use of AI Tools

Claude Code was used to create the commit and draft this pull request description. The code change itself was authored and verified manually.
