### PR TITLE
Notes: hide menu actions the current user can't actually perform

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   Notes: Hide the Edit/Reopen and Delete actions in a note's menu when the current user isn't allowed to perform them, instead of showing options that fail with a permissions error when clicked.
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 
 ## 14.51.0 (2026-07-14)

--- a/packages/editor/src/components/collab-sidebar/note.js
+++ b/packages/editor/src/components/collab-sidebar/note.js
@@ -16,6 +16,8 @@ import {
 import { Button as UIButton } from '@wordpress/ui';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { moreVertical, published } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -97,23 +99,38 @@ export function Note( {
 		( note.meta._wp_note_status === 'resolved' ||
 			note.meta._wp_note_status === 'reopen' );
 
+	// Notes can only be edited or deleted by their author or by users who
+	// can moderate comments, so check the actual REST permission for this
+	// note rather than assuming every menu action is available.
+	const { canEdit, canDelete } = useSelect(
+		( select ) => {
+			const { canUser } = select( coreStore );
+			const resource = { kind: 'root', name: 'comment', id: note.id };
+			return {
+				canEdit: canUser( 'update', resource ),
+				canDelete: canUser( 'delete', resource ),
+			};
+		},
+		[ note.id ]
+	);
+
 	const menuItems = [
 		{
 			id: 'edit',
 			title: __( 'Edit' ),
-			isEligible: ( { status } ) => status !== 'approved',
+			isEligible: ( { status } ) => status !== 'approved' && canEdit,
 			onClick: () => setActionState( 'edit' ),
 		},
 		{
 			id: 'reopen',
 			title: _x( 'Reopen', 'Reopen note' ),
-			isEligible: ( { status } ) => status === 'approved',
+			isEligible: ( { status } ) => status === 'approved' && canEdit,
 			onClick: () => onEditNote( { id: note.id, status: 'hold' } ),
 		},
 		{
 			id: 'delete',
 			title: __( 'Delete' ),
-			isEligible: () => true,
+			isEligible: () => canDelete,
 			onClick: () => setActionState( 'delete' ),
 		},
 	];

--- a/packages/editor/src/components/collab-sidebar/test/note.js
+++ b/packages/editor/src/components/collab-sidebar/test/note.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { Note } from '../note';
+
+function seedNotePermissions( noteId, { canEdit, canDelete } ) {
+	dispatch( coreStore ).receiveUserPermissions( {
+		[ `update/root/comment/${ noteId }` ]: canEdit,
+		[ `delete/root/comment/${ noteId }` ]: canDelete,
+	} );
+}
+
+function makeNote( overrides = {} ) {
+	return {
+		id: 1,
+		parent: 0,
+		status: 'hold',
+		author: 1,
+		author_name: 'Admin',
+		content: {
+			raw: 'Please change this to something else.',
+			rendered: '<p>Please change this to something else.</p>',
+		},
+		...overrides,
+	};
+}
+
+async function openActionsMenu() {
+	const user = userEvent.setup();
+	const trigger = screen.getByRole( 'button', { name: 'Actions' } );
+	expect( trigger ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	await user.click( trigger );
+}
+
+describe( 'Note', () => {
+	it( 'disables the actions menu when the user can neither edit nor delete the note', () => {
+		const note = makeNote( { id: 101 } );
+		seedNotePermissions( note.id, { canEdit: false, canDelete: false } );
+
+		render( <Note note={ note } isSelected /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Actions' } )
+		).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'shows only Edit when the user can edit but not delete', async () => {
+		const note = makeNote( { id: 102 } );
+		seedNotePermissions( note.id, { canEdit: true, canDelete: false } );
+
+		render( <Note note={ note } isSelected /> );
+
+		await openActionsMenu();
+
+		expect( screen.getByText( 'Edit' ) ).toBeVisible();
+		expect( screen.queryByText( 'Delete' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows only Delete when the user can delete but not edit', async () => {
+		const note = makeNote( { id: 103 } );
+		seedNotePermissions( note.id, { canEdit: false, canDelete: true } );
+
+		render( <Note note={ note } isSelected /> );
+
+		await openActionsMenu();
+
+		expect( screen.queryByText( 'Edit' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Delete' ) ).toBeVisible();
+	} );
+
+	it( 'shows both Edit and Delete when the user can do both', async () => {
+		const note = makeNote( { id: 104 } );
+		seedNotePermissions( note.id, { canEdit: true, canDelete: true } );
+
+		render( <Note note={ note } isSelected /> );
+
+		await openActionsMenu();
+
+		expect( screen.getByText( 'Edit' ) ).toBeVisible();
+		expect( screen.getByText( 'Delete' ) ).toBeVisible();
+	} );
+
+	it( 'shows Reopen instead of Edit for an approved note when the user can edit', async () => {
+		const note = makeNote( { id: 105, status: 'approved' } );
+		seedNotePermissions( note.id, { canEdit: true, canDelete: true } );
+
+		render( <Note note={ note } isSelected /> );
+
+		await openActionsMenu();
+
+		expect( screen.getByText( 'Reopen' ) ).toBeVisible();
+		expect( screen.queryByText( 'Edit' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
## What

Follow-up to Trac #64779. That ticket restricted note editing/deletion server-side to the note's author or a comment moderator, but the note's action menu in the editor still showed Edit/Reopen and Delete to everyone regardless. Testers on the Trac ticket flagged this: the options are visible but clicking them just fails with a permissions error.

## Why

The menu's eligibility check only looked at the note's status (approved vs not), never at who was actually viewing it:

```js
{
    id: 'edit',
    title: __( 'Edit' ),
    isEligible: ( { status } ) => status !== 'approved',
    ...
},
```

## How

Added a check for the actual per-note REST permission, using the same `canUser` mechanism already used elsewhere in this component (`note-byline.js`) for a similar purpose. It does a real permission check against the note's REST endpoint rather than guessing client-side:

```js
const { canEdit, canDelete } = useSelect(
    ( select ) => {
        const { canUser } = select( coreStore );
        const resource = { kind: 'root', name: 'comment', id: note.id };
        return {
            canEdit: canUser( 'update', resource ),
            canDelete: canUser( 'delete', resource ),
        };
    },
    [ note.id ]
);
```

Edit/Reopen and Delete are now only shown when `canEdit`/`canDelete` are true. If neither is available, the "..." Actions button itself is disabled (it already disables when there are zero eligible items).

## Testing Instructions

1. Apply the PHP patch from Trac #64779 (PR 11191) to a WordPress core checkout, so the server actually enforces the author-or-moderator restriction on notes.
2. As an Administrator, leave a note on a Contributor's own draft post.
3. As the Contributor, open the note in the editor and check its "..." menu — Edit/Reopen and Delete should not appear (and the "..." button itself should be disabled if that's the only note).
4. As the Contributor, add your own note and confirm you can still edit/delete it.
5. As the Administrator, confirm you can still edit/delete any note.

Also added unit tests covering all four menu-visibility combinations (no permissions, edit-only, delete-only, both) plus the existing approved/reopen behavior, to avoid needing the full permission plumbing in the test itself.