### PR TITLE
Remove redundant @jest-environment jsdom pragma and lint against it

### DIFF
--- a/packages/block-library/src/navigation/test/view.js
+++ b/packages/block-library/src/navigation/test/view.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 let mockRegisteredStore;
 let mockCurrentContext;
 

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -486,6 +486,20 @@ export default dedupePlugins( [
 			'test/performance/**/*.[tj]s?(x)',
 			'test/storybook-playwright/**/*.[tj]s?(x)',
 		],
+		rules: {
+			...jestPlugin.configs[ 'flat/recommended' ].rules,
+			/*
+			 * `jsdom` is already the default test environment in `@wordpress/jest-preset-default`,
+			so the docblock pragma is redundant.
+			 */
+			'no-warning-comments': [
+				'error',
+				{
+					terms: [ '@jest-environment jsdom' ],
+					location: 'anywhere',
+				},
+			],
+		},
 	},
 
 	// Override: E2E test files (non-Playwright).

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -490,7 +490,7 @@ export default dedupePlugins( [
 			...jestPlugin.configs[ 'flat/recommended' ].rules,
 			/*
 			 * `jsdom` is already the default test environment in `@wordpress/jest-preset-default`,
-			so the docblock pragma is redundant.
+			 * so the docblock pragma is redundant.
 			 */
 			'no-warning-comments': [
 				'error',


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/77563#discussion_r3644656395

Removes the `@jest-environment jsdom` pragma that #77563 reintroduced, and adds an ESLint rule so it does not come back.

## Why?

#79672 removed these pragmas repo-wide. `jsdom` is already the default `testEnvironment` in `@wordpress/jest-preset-default`, so the pragma is a no-op, and it [breaks under the isolated node_modules layout](https://github.com/WordPress/gutenberg/actions/runs/30075930235/job/89426531546?pr=75814).

Since nothing prevented it from being added back, a lint rule is needed alongside the removal.

## How?

- Deleted the pragma docblock from `packages/block-library/src/navigation/test/view.js`.
- Added `no-warning-comments` with `@jest-environment jsdom` as a banned term to the existing Jest override block in `tools/eslint/config.mjs`. It is the only core ESLint rule that inspects comment text, so no custom rule is needed. The rule's `rules` object is re-spread from `eslint-plugin-jest`'s recommended config so the plugin's own rules stay active.

Scoped to `**/test/**` and `**/__tests__/**`, excluding e2e/performance/storybook-playwright. `@jest-environment node` pragmas are genuine overrides and remain untouched.

## Testing Instructions

1. `npm run lint:js -- packages/block-library/src/navigation/test/view.js` passes.
2. Re-add the pragma to any unit test file and confirm ESLint errors with `no-warning-comments`.
3. Confirm the `node` overrides still lint clean:
   ```
   npm run lint:js -- packages/compose/src/hooks/use-media-query/test/ssr.js packages/vips/src/test packages/theme/src/stylelint-plugins/test
   ```
4. `npm run test:unit -- packages/block-library/src/navigation/test/view.js` passes under the default jsdom environment.

### Testing Instructions for Keyboard

N/A — test and tooling only, no UI.

## Screenshots or screencast

N/A

## Use of AI Tools

This pull request was authored with assistance from Claude Code. All changes were reviewed by the contributor.
