### PR TITLE
Make `useSelectionProps` hook layout agnostic

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiselect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
+-   DataViews: Model `useSelectionProps` with orthogonal semantic props (`selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. `selectionMode` distinguishes multi-selection from the two single-selection semantics (`'single-required'` keeps an item selected on re-click, `'single-clearable'` allows clearing it), so the `list` layout keeps its always-selected behavior while single-select pickers stay clearable. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiSelect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#00000](https://github.com/WordPress/gutenberg/pull/00000)
+-   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiselect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#00000](https://github.com/WordPress/gutenberg/pull/00000)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiselect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#00000](https://github.com/WordPress/gutenberg/pull/00000)
+-   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiselect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   DataViews: Model `useSelectionProps` with orthogonal semantic props (`isMultiSelect`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. No behavior change. [#00000](https://github.com/WordPress/gutenberg/pull/00000)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 

--- a/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
@@ -16,6 +16,7 @@ import { Stack } from '@wordpress/ui';
 import type { ViewGridProps } from '../../../types';
 import getDataByGroup from '../utils/get-data-by-group';
 import useSelectionProps from '../utils/use-selection-props';
+import { hasAPossibleBulkAction } from '../../dataviews-bulk-actions';
 import CompositeGrid from './composite-grid';
 import { useDelayedLoading } from '../../../hooks/use-delayed-loading';
 
@@ -50,10 +51,11 @@ function ViewGrid< Item >( {
 		: data;
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
-		actions,
 		getItemId,
 		selection,
 		onChangeSelection,
+		isMultiSelect: true,
+		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 	} );
 	if ( ! hasData ) {
 		return (

--- a/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
@@ -52,10 +52,10 @@ function ViewGrid< Item >( {
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
 		getItemId,
+		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 		selection,
 		onChangeSelection,
-		isMultiSelect: true,
-		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
+		isMultiselect: true,
 	} );
 	if ( ! hasData ) {
 		return (

--- a/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
@@ -55,7 +55,7 @@ function ViewGrid< Item >( {
 		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 		selection,
 		onChangeSelection,
-		isMultiselect: true,
+		selectionMode: 'multi',
 		shouldSelectOnClick: false,
 	} );
 	if ( ! hasData ) {

--- a/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/index.tsx
@@ -56,6 +56,7 @@ function ViewGrid< Item >( {
 		selection,
 		onChangeSelection,
 		isMultiselect: true,
+		shouldSelectOnClick: false,
 	} );
 	if ( ! hasData ) {
 		return (

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -416,7 +416,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiselect: false,
+		selectionMode: 'single-required',
 		shouldSelectOnClick: true,
 	} );
 

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -41,6 +41,8 @@ import type {
 	ActionModal as ActionModalType,
 } from '../../../types';
 import getDataByGroup from '../utils/get-data-by-group';
+import useSelectionProps from '../utils/use-selection-props';
+import type { SelectionProps } from '../utils/use-selection-props';
 
 interface ListViewItemProps< Item > {
 	view: ViewListType;
@@ -51,7 +53,7 @@ interface ListViewItemProps< Item > {
 	titleField?: NormalizedField< Item >;
 	mediaField?: NormalizedField< Item >;
 	descriptionField?: NormalizedField< Item >;
-	onSelect: ( item: Item ) => void;
+	selectionProps: SelectionProps;
 	otherFields: NormalizedField< Item >[];
 	onDropdownTriggerKeyDown: React.KeyboardEventHandler< HTMLButtonElement >;
 	posinset?: number;
@@ -147,7 +149,7 @@ function ListItem< Item >( {
 	titleField,
 	mediaField,
 	descriptionField,
-	onSelect,
+	selectionProps,
 	otherFields,
 	onDropdownTriggerKeyDown,
 	posinset,
@@ -311,7 +313,7 @@ function ListItem< Item >( {
 						aria-labelledby={ labelId }
 						aria-describedby={ descriptionId }
 						className="dataviews-view-list__item"
-						onClick={ () => onSelect( item ) }
+						{ ...selectionProps }
 					/>
 				</div>
 				<Stack
@@ -408,8 +410,15 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		.map( ( fieldId ) => fields.find( ( f ) => fieldId === f.id ) )
 		.filter( isDefined );
 
-	const onSelect = ( item: Item ) =>
-		onChangeSelection( [ getItemId( item ) ] );
+	const { getSelectionProps } = useSelectionProps( {
+		data,
+		getItemId,
+		selection,
+		onChangeSelection,
+		isMultiSelect: false,
+		shouldSelectOnClick: true,
+		isItemSelectable: () => true,
+	} );
 
 	const generateCompositeItemIdPrefix = useCallback(
 		( item: Item ) => `${ baseId }-${ getItemId( item ) }`,
@@ -600,7 +609,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 											actions={ actions }
 											item={ item }
 											isSelected={ item === selectedItem }
-											onSelect={ onSelect }
+											selectionProps={ getSelectionProps(
+												getItemId( item )
+											) }
 											mediaField={ mediaField }
 											titleField={ titleField }
 											descriptionField={
@@ -639,7 +650,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 							actions={ actions }
 							item={ item }
 							isSelected={ item === selectedItem }
-							onSelect={ onSelect }
+							selectionProps={ getSelectionProps(
+								getItemId( item )
+							) }
 							mediaField={ mediaField }
 							titleField={ titleField }
 							descriptionField={ descriptionField }

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -413,11 +413,11 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const { getSelectionProps } = useSelectionProps( {
 		data,
 		getItemId,
+		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiSelect: false,
+		isMultiselect: false,
 		shouldSelectOnClick: true,
-		isItemSelectable: () => true,
 	} );
 
 	const generateCompositeItemIdPrefix = useCallback(

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -266,11 +266,12 @@ export default function ViewPickerActivity< Item >( {
 		: data;
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
-		actions,
 		getItemId,
 		selection,
 		onChangeSelection,
-		pickerMultiselect: isMultiselect,
+		isMultiSelect: isMultiselect,
+		shouldSelectOnClick: true,
+		isItemSelectable: () => true,
 	} );
 
 	const renderItem = ( item: Item ) => (

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -267,11 +267,11 @@ export default function ViewPickerActivity< Item >( {
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
 		getItemId,
+		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiSelect: isMultiselect,
+		isMultiselect,
 		shouldSelectOnClick: true,
-		isItemSelectable: () => true,
 	} );
 
 	const renderItem = ( item: Item ) => (

--- a/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-activity/index.tsx
@@ -270,7 +270,7 @@ export default function ViewPickerActivity< Item >( {
 		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiselect,
+		selectionMode: isMultiselect ? 'multi' : 'single-clearable',
 		shouldSelectOnClick: true,
 	} );
 

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -329,11 +329,11 @@ function ViewPickerGrid< Item >( {
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
 		getItemId,
+		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiSelect: isMultiselect,
+		isMultiselect,
 		shouldSelectOnClick: true,
-		isItemSelectable: () => true,
 	} );
 
 	const currentPage = view?.page ?? 1;

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -332,7 +332,7 @@ function ViewPickerGrid< Item >( {
 		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiselect,
+		selectionMode: isMultiselect ? 'multi' : 'single-clearable',
 		shouldSelectOnClick: true,
 	} );
 

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -328,11 +328,12 @@ function ViewPickerGrid< Item >( {
 		: data;
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
-		actions,
 		getItemId,
 		selection,
 		onChangeSelection,
-		pickerMultiselect: isMultiselect,
+		isMultiSelect: isMultiselect,
+		shouldSelectOnClick: true,
+		isItemSelectable: () => true,
 	} );
 
 	const currentPage = view?.page ?? 1;

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -267,11 +267,12 @@ function ViewPickerTable< Item >( {
 		: data;
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
-		actions,
 		getItemId,
 		selection,
 		onChangeSelection,
-		pickerMultiselect: isMultiselect,
+		isMultiSelect: isMultiselect,
+		shouldSelectOnClick: true,
+		isItemSelectable: () => true,
 	} );
 
 	const tableNoticeId = useId();

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -268,11 +268,11 @@ function ViewPickerTable< Item >( {
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
 		getItemId,
+		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiSelect: isMultiselect,
+		isMultiselect,
 		shouldSelectOnClick: true,
-		isItemSelectable: () => true,
 	} );
 
 	const tableNoticeId = useId();

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -271,7 +271,7 @@ function ViewPickerTable< Item >( {
 		isItemSelectable: () => true,
 		selection,
 		onChangeSelection,
-		isMultiselect,
+		selectionMode: isMultiselect ? 'multi' : 'single-clearable',
 		shouldSelectOnClick: true,
 	} );
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -28,6 +28,7 @@ import { sortValues } from '../../../constants';
 import {
 	useSomeItemHasAPossibleBulkAction,
 	useHasAPossibleBulkAction,
+	hasAPossibleBulkAction,
 	BulkSelectionCheckbox,
 } from '../../dataviews-bulk-actions';
 import type {
@@ -290,10 +291,11 @@ function ViewTable< Item >( {
 		: data;
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
-		actions,
 		getItemId,
 		selection,
 		onChangeSelection,
+		isMultiSelect: true,
+		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 	} );
 	const headerMenuRefs = useRef<
 		Map< string, { node: HTMLButtonElement; fallback: string } >

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -292,10 +292,10 @@ function ViewTable< Item >( {
 	const { getSelectionProps } = useSelectionProps( {
 		data: orderedData,
 		getItemId,
+		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 		selection,
 		onChangeSelection,
-		isMultiSelect: true,
-		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
+		isMultiselect: true,
 	} );
 	const headerMenuRefs = useRef<
 		Map< string, { node: HTMLButtonElement; fallback: string } >

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -295,7 +295,7 @@ function ViewTable< Item >( {
 		isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item ),
 		selection,
 		onChangeSelection,
-		isMultiselect: true,
+		selectionMode: 'multi',
 		shouldSelectOnClick: false,
 	} );
 	const headerMenuRefs = useRef<

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -296,6 +296,7 @@ function ViewTable< Item >( {
 		selection,
 		onChangeSelection,
 		isMultiselect: true,
+		shouldSelectOnClick: false,
 	} );
 	const headerMenuRefs = useRef<
 		Map< string, { node: HTMLButtonElement; fallback: string } >

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -131,6 +131,10 @@ export function getClosestSelectedId( {
 	return closestId;
 }
 
+// How many items the selection can hold, and — for single selection — whether a
+// plain click on the selected item may clear it. See `useSelectionProps`.
+export type SelectionMode = 'multi' | 'single-required' | 'single-clearable';
+
 export interface SelectionProps {
 	onMouseDown: ( event: React.MouseEvent ) => void;
 	onClickCapture: ( event: React.MouseEvent ) => void;
@@ -147,12 +151,19 @@ export interface SelectionProps {
 // an `isItemSelectable` predicate; the hook derives the selectable items from
 // those. Spread `getSelectionProps( id )` on each item's container element.
 //
-// The selection semantics are described by three props. `multiselect` says
-// whether the selection can hold more than one item, which enables the range
-// gesture and makes modifier clicks add rather than replace. `selectOnClick`
-// says whether a plain click selects (and anchors the range) instead of opening
-// the item; when it does, the hook also returns the `onClick` that performs it.
-// `isItemSelectable` says which items can be selected.
+// The selection semantics are described by three props. `selectionMode` says
+// how many items the selection can hold and, for single selection, whether a
+// plain click on the selected item may clear it:
+//   - `'multi'`: the selection can hold more than one item, which enables the
+//     Shift+Click range gesture and makes modifier clicks add rather than
+//     replace. A plain click on a selected item removes it from the selection.
+//   - `'single-required'`: at most one item, and a plain click always leaves
+//     something selected — re-clicking the selected item keeps it (one-of-N).
+//   - `'single-clearable'`: at most one item, but a plain click on the selected
+//     item clears the selection (zero-or-one).
+// `selectOnClick` says whether a plain click selects (and anchors the range)
+// instead of opening the item; when it does, the hook also returns the `onClick`
+// that performs it. `isItemSelectable` says which items can be selected.
 //
 // The selection model is one-dimensional: a range is the contiguous run of
 // selectable items between the anchor and the target. Two-dimensional layouts
@@ -171,7 +182,7 @@ export default function useSelectionProps< Item >( {
 	isItemSelectable,
 	selection,
 	onChangeSelection,
-	isMultiselect,
+	selectionMode,
 	shouldSelectOnClick,
 }: {
 	data: Item[];
@@ -180,14 +191,22 @@ export default function useSelectionProps< Item >( {
 	isItemSelectable: ( item: Item ) => boolean;
 	selection: string[];
 	onChangeSelection: SetSelection;
-	// Whether the selection can hold more than one item. Enables the Shift+Click
-	// range gesture and makes modifier clicks add to the selection rather than
-	// replace it.
-	isMultiselect: boolean;
+	// How the selection behaves: `'multi'` allows more than one item (enabling
+	// the Shift+Click range gesture and making modifier clicks add rather than
+	// replace), while `'single-required'` and `'single-clearable'` cap it at one
+	// item and differ only in whether a plain click on the selected item clears
+	// the selection.
+	selectionMode: SelectionMode;
 	// Whether a plain click selects (and anchors the range) rather than opening
 	// the item. When it does, the hook returns the `onClick` that performs it.
 	shouldSelectOnClick: boolean;
 } ) {
+	// `multi` is the only mode holding more than one item, so it alone enables
+	// the range gesture and additive modifier clicks. Deselecting on a plain
+	// click is offered by every mode except `single-required`, which always
+	// keeps something selected.
+	const isMultiselect = selectionMode === 'multi';
+	const allowDeselect = selectionMode !== 'single-required';
 	// The Shift+Click range gesture in progress: the anchor ranges extend from
 	// — the last item whose selection was directly toggled — and the target of
 	// the last Shift+Click, which is the other end of the range currently
@@ -233,7 +252,7 @@ export default function useSelectionProps< Item >( {
 			// reach here: `onClickCapture` stops them.
 			...( shouldSelectOnClick && {
 				onClick: () => {
-					if ( selection.includes( id ) ) {
+					if ( allowDeselect && selection.includes( id ) ) {
 						onChangeSelection(
 							selection.filter( ( itemId ) => id !== itemId )
 						);

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -134,8 +134,7 @@ export function getClosestSelectedId( {
 export interface SelectionProps {
 	onMouseDown: ( event: React.MouseEvent ) => void;
 	onClickCapture: ( event: React.MouseEvent ) => void;
-	// Only returned when a plain click selects (`selectOnClick`).
-	onClick?: () => void;
+	// Only returned when a plain click selects (`shouldSelectOnClick`).
 }
 
 // Encapsulates the pointer gestures for multi-selection, shared by layouts:

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -171,8 +171,8 @@ export default function useSelectionProps< Item >( {
 	isItemSelectable,
 	selection,
 	onChangeSelection,
-	isMultiSelect: multiselect,
-	shouldSelectOnClick: selectOnClick,
+	isMultiselect,
+	shouldSelectOnClick,
 }: {
 	data: Item[];
 	getItemId: ( item: Item ) => string;
@@ -183,7 +183,7 @@ export default function useSelectionProps< Item >( {
 	// Whether the selection can hold more than one item. Enables the Shift+Click
 	// range gesture and makes modifier clicks add to the selection rather than
 	// replace it.
-	isMultiSelect: boolean;
+	isMultiselect: boolean;
 	// Whether a plain click selects (and anchors the range) rather than opening
 	// the item. When it does, the hook returns the `onClick` that performs it.
 	shouldSelectOnClick?: boolean;
@@ -223,7 +223,7 @@ export default function useSelectionProps< Item >( {
 	// A single-select view has no range to extend and no second item to add, so
 	// the modifier gestures have nothing to offer; plain clicks, when they
 	// select, are handled in `onClick` below.
-	const hasRangeGesture = hasSelectableItems && multiselect;
+	const hasRangeGesture = hasSelectableItems && isMultiselect;
 
 	const getSelectionProps = ( id: string ): SelectionProps => {
 		const isSelectable = selectableIdSet.has( id );
@@ -231,7 +231,7 @@ export default function useSelectionProps< Item >( {
 			// When a plain click selects, that click is also what anchors the
 			// range a following Shift+Click extends from. Modifier clicks never
 			// reach here: `onClickCapture` stops them.
-			...( selectOnClick && {
+			...( shouldSelectOnClick && {
 				onClick: () => {
 					if ( selection.includes( id ) ) {
 						onChangeSelection(
@@ -239,7 +239,7 @@ export default function useSelectionProps< Item >( {
 						);
 					} else {
 						onChangeSelection(
-							multiselect ? [ ...selection, id ] : [ id ]
+							isMultiselect ? [ ...selection, id ] : [ id ]
 						);
 					}
 					anchorTo( id );

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -135,6 +135,7 @@ export interface SelectionProps {
 	onMouseDown: ( event: React.MouseEvent ) => void;
 	onClickCapture: ( event: React.MouseEvent ) => void;
 	// Only returned when a plain click selects (`shouldSelectOnClick`).
+	onClick?: ( event: React.MouseEvent ) => void;
 }
 
 // Encapsulates the pointer gestures for multi-selection, shared by layouts:

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -8,8 +8,6 @@ import { isAppleOS } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { SELECTION_CHECKBOX_CLASS } from '../../dataviews-selection-checkbox';
-import { hasAPossibleBulkAction } from '../../dataviews-bulk-actions';
-import type { Action } from '../../../types';
 import type { SetSelection } from '../../../types/private';
 
 interface RangeSelectionArgs {
@@ -136,7 +134,7 @@ export function getClosestSelectedId( {
 export interface SelectionProps {
 	onMouseDown: ( event: React.MouseEvent ) => void;
 	onClickCapture: ( event: React.MouseEvent ) => void;
-	// Only returned to the picker layouts, whose plain clicks select.
+	// Only returned when a plain click selects (`selectOnClick`).
 	onClick?: () => void;
 }
 
@@ -145,15 +143,16 @@ export interface SelectionProps {
 // the anchor (the last item whose selection was directly toggled) and the
 // clicked item, leaving the selection outside the range untouched.
 //
-// Layouts pass `data` in the order they render it, along with `actions` and
-// `getItemId`; the hook derives the selectable items itself (those with a
-// possible bulk action) so every layout doesn't repeat that logic. Spread
-// `getSelectionProps( id )` on each item's container element.
+// Layouts pass `data` in the order they render it, along with `getItemId` and
+// an `isItemSelectable` predicate; the hook derives the selectable items from
+// those. Spread `getSelectionProps( id )` on each item's container element.
 //
-// The picker layouts select on a plain click instead, and set
-// `pickerMultiselect`; for them the hook also returns the `onClick` that
-// selects and anchors the range, and every rendered item is selectable rather
-// than only those with a bulk action.
+// The selection semantics are described by three props. `multiselect` says
+// whether the selection can hold more than one item, which enables the range
+// gesture and makes modifier clicks add rather than replace. `selectOnClick`
+// says whether a plain click selects (and anchors the range) instead of opening
+// the item; when it does, the hook also returns the `onClick` that performs it.
+// `isItemSelectable` says which items can be selected.
 //
 // The selection model is one-dimensional: a range is the contiguous run of
 // selectable items between the anchor and the target. Two-dimensional layouts
@@ -168,23 +167,26 @@ export interface SelectionProps {
 // layouts wrap the returned handlers to compose extra behavior ad-hoc.
 export default function useSelectionProps< Item >( {
 	data,
-	actions,
 	getItemId,
+	isItemSelectable,
 	selection,
 	onChangeSelection,
-	pickerMultiselect,
+	isMultiSelect: multiselect,
+	shouldSelectOnClick: selectOnClick,
 }: {
 	data: Item[];
-	actions: Action< Item >[];
 	getItemId: ( item: Item ) => string;
+	// The caller-supplied predicate for which items can be selected.
+	isItemSelectable: ( item: Item ) => boolean;
 	selection: string[];
 	onChangeSelection: SetSelection;
-	// Set by the picker layouts, where clicking an item is what selects it:
-	// `true` toggles the item into a multi-selection, `false` replaces the
-	// selection. Omitted by the other layouts, where a click opens the item and
-	// only the checkbox and modifier gestures select. `isEligible` is
-	// unsupported in a picker, so every rendered item is selectable there.
-	pickerMultiselect?: boolean;
+	// Whether the selection can hold more than one item. Enables the Shift+Click
+	// range gesture and makes modifier clicks add to the selection rather than
+	// replace it.
+	isMultiSelect: boolean;
+	// Whether a plain click selects (and anchors the range) rather than opening
+	// the item. When it does, the hook returns the `onClick` that performs it.
+	shouldSelectOnClick?: boolean;
 } ) {
 	// The Shift+Click range gesture in progress: the anchor ranges extend from
 	// — the last item whose selection was directly toggled — and the target of
@@ -214,30 +216,22 @@ export default function useSelectionProps< Item >( {
 	}, [] );
 
 	// The ids of all selectable items, in the order the layout renders them;
-	// ranges follow this order. A picker selects from every item it renders, so
-	// bulk actions don't gate it: `isEligible` is unsupported there, and reading
-	// `supportsBulk` with `some` would contradict the `every` that made the
-	// picker single-select in the first place.
-	const isPicker = pickerMultiselect !== undefined;
-	const selectableIds = (
-		isPicker
-			? data
-			: data.filter( ( item ) => hasAPossibleBulkAction( actions, item ) )
-	).map( getItemId );
+	// ranges follow this order.
+	const selectableIds = data.filter( isItemSelectable ).map( getItemId );
 	const selectableIdSet = new Set( selectableIds );
 	const hasSelectableItems = selectableIds.length > 0;
-	// A single-select picker has no range to extend and no second item to add,
-	// so the modifier gestures have nothing to offer; its plain clicks are
-	// handled in `onClick` below.
-	const hasRangeGesture = hasSelectableItems && pickerMultiselect !== false;
+	// A single-select view has no range to extend and no second item to add, so
+	// the modifier gestures have nothing to offer; plain clicks, when they
+	// select, are handled in `onClick` below.
+	const hasRangeGesture = hasSelectableItems && multiselect;
 
 	const getSelectionProps = ( id: string ): SelectionProps => {
 		const isSelectable = selectableIdSet.has( id );
 		return {
-			// A picker selects on a plain click, so that click is also what
-			// anchors the range a following Shift+Click extends from. Modifier
-			// clicks never reach here: `onClickCapture` stops them.
-			...( isPicker && {
+			// When a plain click selects, that click is also what anchors the
+			// range a following Shift+Click extends from. Modifier clicks never
+			// reach here: `onClickCapture` stops them.
+			...( selectOnClick && {
 				onClick: () => {
 					if ( selection.includes( id ) ) {
 						onChangeSelection(
@@ -245,7 +239,7 @@ export default function useSelectionProps< Item >( {
 						);
 					} else {
 						onChangeSelection(
-							pickerMultiselect ? [ ...selection, id ] : [ id ]
+							multiselect ? [ ...selection, id ] : [ id ]
 						);
 					}
 					anchorTo( id );

--- a/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/use-selection-props.ts
@@ -186,7 +186,7 @@ export default function useSelectionProps< Item >( {
 	isMultiselect: boolean;
 	// Whether a plain click selects (and anchors the range) rather than opening
 	// the item. When it does, the hook returns the `onClick` that performs it.
-	shouldSelectOnClick?: boolean;
+	shouldSelectOnClick: boolean;
 } ) {
 	// The Shift+Click range gesture in progress: the anchor ranges extend from
 	// — the last item whose selection was directly toggled — and the target of


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/80413

## What?

This refactors the DataViews `useSelectionProps` hook so it's no longer coupled to the picker layouts. The hook now describes selection behavior through orthogonal, semantic props — `selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable` predicate — instead of the picker-specific `pickerMultiselect` flag.

As a result, the `list` layout's selection is migrated onto the shared hook, so every layout now derives selection from the same place. No behavior change.

## Why?

So selection logic is shared across our bundled layouts, and so we can export this hook in the future for use by 3rd-party layouts. The old `pickerMultiselect` flag conflated several independent concerns (how many items, whether a click selects, which items are eligible) into one picker-shaped boolean, which is what blocked reuse.

## How?

Replaced the single `pickerMultiselect?: boolean` with three orthogonal props:

- **`selectionMode`** — how many items the selection can hold, and for single selection whether a plain click can clear it:
  - `'multi'`: more than one item; enables the Shift+Click range gesture and makes modifier clicks add rather than replace. A plain click on a selected item removes it.
  - `'single-required'`: at most one item, and a plain click always leaves something selected (re-clicking the selected item keeps it — one-of-N / radio semantics).
  - `'single-clearable'`: at most one item, but a plain click on the selected item clears the selection (zero-or-one / checkbox semantics).
- **`shouldSelectOnClick`** — whether a plain click selects (and anchors the range) rather than opening the item. When it does, the hook returns the `onClick` that performs it.
- **`isItemSelectable`** — a caller-supplied predicate for which items are eligible, replacing the removed `actions` parameter and the hook's internal `hasAPossibleBulkAction` filtering. Callers that need bulk-action gating now pass `isItemSelectable: ( item ) => hasAPossibleBulkAction( actions, item )` themselves.

Layout wiring after the change:

| Layout | `selectionMode` | `shouldSelectOnClick` | `isItemSelectable` |
|---|---|---|---|
| `table`, `grid` | `'multi'` | `false` | `hasAPossibleBulkAction( actions, item )` |
| `list` | `'single-required'` | `true` | `() => true` |
| picker `table` / `grid` / `activity` | `isMultiselect ? 'multi' : 'single-clearable'` | `true` | `() => true` |

Routed the `list` layout through the shared hook, replacing its local `onSelect` (`onChangeSelection( [ getItemId( item ) ] )`). Because that old handler always replaced the selection with the clicked item and never cleared it, `'single-required'` reproduces it exactly — the list keeps its always-selected behavior while single-select pickers stay clearable.

## Testing Instructions

There's no change in behavior, this is simply an internal refactor.

1. Open a DataViews-backed screen (Pages/Templates admin, or a media/pattern picker).
2. **List layout**: click an item → it selects as before; re-clicking the selected item keeps it selected (never clears).
3. **Table/grid**: only bulk-actionable items are selectable; the checkbox toggles selection; Shift+Click selects a contiguous range.
4. **Picker layouts (table, grid, activity)**: clicking a row/card selects it; Shift+Click extends the range in multi-select; in single-select, clicking the selected item clears it.
5. Confirm no selection regressions across layouts — this change is behavior-neutral.

## Use of AI Tools

The author used Claude Code to prepare the PR and the PR description. All changes are human-reviewed and sanctioned.
