### PR TITLE
Block Editor: Prevent inner block template from re-inserting when a block is moved via drag and drop

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Prevent inner block template from re-inserting when a block is moved via drag and drop ([#80679](https://github.com/WordPress/gutenberg/pull/80679)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 
 ## 16.0.0 (2026-07-14)

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -56,10 +56,8 @@ export default function useInnerBlockTemplateSync(
 			getSelectedBlocksInitialCaretPosition,
 			isBlockSelected,
 		} = registry.select( blockEditorStore );
-		const {
-			replaceInnerBlocks,
-			__unstableMarkNextChangeAsNotPersistent,
-		} = registry.dispatch( blockEditorStore );
+		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+			registry.dispatch( blockEditorStore );
 
 		// Access private store APIs for the template-sync flag.
 		const { wasTemplateSyncApplied } = unlock(

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -14,6 +14,7 @@ import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * This hook makes sure that a block's inner blocks stay in sync with the given
@@ -55,8 +56,18 @@ export default function useInnerBlockTemplateSync(
 			getSelectedBlocksInitialCaretPosition,
 			isBlockSelected,
 		} = registry.select( blockEditorStore );
-		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-			registry.dispatch( blockEditorStore );
+		const {
+			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = registry.dispatch( blockEditorStore );
+
+		// Access private store APIs for the template-sync flag.
+		const { wasTemplateSyncApplied } = unlock(
+			registry.select( blockEditorStore )
+		);
+		const { markTemplateSyncApplied } = unlock(
+			registry.dispatch( blockEditorStore )
+		);
 
 		// There's an implicit dependency between useInnerBlockTemplateSync and useNestedSettingsUpdate
 		// The former needs to happen after the latter and since the latter is using microtasks to batch updates (performance optimization),
@@ -70,8 +81,20 @@ export default function useInnerBlockTemplateSync(
 			// Only synchronize innerBlocks with template if innerBlocks are empty
 			// or a locking "all" or "contentOnly" exists directly on the block.
 			const currentInnerBlocks = getBlocks( clientId );
+
+			// When there is no templateLock the template only serves as an
+			// initial default. Once we have successfully applied the template
+			// for this clientId (recorded in the store), we must NOT re-apply
+			// it on subsequent mounts (e.g. after a drag-and-drop remount),
+			// even if inner blocks are currently empty because the user deleted
+			// them intentionally.
+			const isUnlocked =
+				templateLock !== 'all' && templateLock !== 'contentOnly';
+			const alreadyApplied =
+				isUnlocked && wasTemplateSyncApplied( clientId );
+
 			const shouldApplyTemplate =
-				currentInnerBlocks.length === 0 ||
+				( currentInnerBlocks.length === 0 && ! alreadyApplied ) ||
 				templateLock === 'all' ||
 				templateLock === 'contentOnly';
 
@@ -107,6 +130,14 @@ export default function useInnerBlockTemplateSync(
 					// This ensures for instance that the focus stays in the inserter when inserting the "buttons" block.
 					getSelectedBlocksInitialCaretPosition()
 				);
+			}
+
+			// Persist the fact that this template has been applied for this
+			// clientId. The flag lives in the block-editor store and survives
+			// React remounts (e.g. drag-and-drop), unlike a useRef which is
+			// reset every time the component is destroyed and recreated.
+			if ( isUnlocked ) {
+				markTemplateSyncApplied( clientId );
 			}
 		} );
 

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -589,3 +589,21 @@ export function setResponsiveEditing( enabled ) {
 		enabled,
 	};
 }
+
+/**
+ * Marks that the inner-block template for a given block client ID has been
+ * applied at least once. This flag is stored in the block-editor store so it
+ * survives React component remounts (e.g. when a block is moved via
+ * drag-and-drop), preventing the template from being unexpectedly re-inserted
+ * into blocks that the user has intentionally modified.
+ *
+ * @param {string} clientId The client ID of the block whose template has been applied.
+ *
+ * @return {Object} Action object.
+ */
+export function markTemplateSyncApplied( clientId ) {
+	return {
+		type: 'MARK_TEMPLATE_SYNC_APPLIED',
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -85,6 +85,21 @@ export function getBlockWithoutAttributes( state, clientId ) {
 }
 
 /**
+ * Returns true if the inner-block template for the given block client ID has
+ * already been applied (i.e. `markTemplateSyncApplied` was dispatched for it).
+ * Returns false for blocks where the template has never been applied, so the
+ * initial template insertion still happens correctly.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The client ID of the block to check.
+ *
+ * @return {boolean} Whether the block's template has previously been applied.
+ */
+export function wasTemplateSyncApplied( state, clientId ) {
+	return state.syncedTemplateClientIds.has( clientId );
+}
+
+/**
  * Returns true if all of the descendants of a block with the given client ID
  * have an editing mode of 'disabled', or false otherwise.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1881,6 +1881,62 @@ export const blockListSettings = ( state = new Map(), action ) => {
 };
 
 /**
+ * Reducer tracking which block client IDs have had their inner-block template
+ * applied at least once. Stored as a Set so lookups are O(1).
+ *
+ * The flag is intentionally preserved across MOVE_BLOCKS_TO_POSITION so that
+ * dragging a block to a new parent does not cause the template to be
+ * re-applied when the Edit component remounts.
+ *
+ * @param {Set}    state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Set} Updated state.
+ */
+export const syncedTemplateClientIds = ( state = new Set(), action ) => {
+	switch ( action.type ) {
+		case 'MARK_TEMPLATE_SYNC_APPLIED': {
+			if ( state.has( action.clientId ) ) {
+				return state;
+			}
+			const newState = new Set( state );
+			newState.add( action.clientId );
+			return newState;
+		}
+		case 'REPLACE_BLOCKS': {
+			// Collect every clientId present in the replacement blocks (including
+			// descendants) so that reused block instances keep their flag.
+			const replacementIds = new Set();
+			const stack = [ ...action.blocks ];
+			while ( stack.length ) {
+				const block = stack.shift();
+				replacementIds.add( block.clientId );
+				stack.push( ...block.innerBlocks );
+			}
+			const newState = new Set( state );
+			for ( const clientId of action.clientIds ) {
+				if ( ! replacementIds.has( clientId ) ) {
+					newState.delete( clientId );
+				}
+			}
+			return newState.size === state.size ? state : newState;
+		}
+		case 'REMOVE_BLOCKS': {
+			const newState = new Set( state );
+			for ( const clientId of action.clientIds ) {
+				newState.delete( clientId );
+			}
+			return newState.size === state.size ? state : newState;
+		}
+		case 'RESET_BLOCKS': {
+			// Full post load / reset — all flags are stale.
+			return new Set();
+		}
+	}
+	return state;
+};
+
+/**
  * Reducer return an updated state representing the most recent block attribute
  * update. The state is structured as an object where the keys represent the
  * client IDs of blocks, the values a subset of attributes from the most recent
@@ -2435,6 +2491,7 @@ const combinedReducers = combineReducers( {
 	initialPosition,
 	blocksMode,
 	blockListSettings,
+	syncedTemplateClientIds,
 	insertionPoint,
 	insertionCue,
 	template,


### PR DESCRIPTION
## What?

Closes #70495 

This PR fixes a bug where inner blocks that the user deliberately removed are unexpectedly re-inserted when the parent block (e.g. **Details**, **Quote**, **Media & Text**) is moved via drag and drop. After moving the block, inner blocks reappear as if the user never deleted them.

## Why?

`useInnerBlockTemplateSync` relies on a `useRef(null)` to track whether the template has already been applied. Since `useRef` is tied to the React component instance, it resets to `null` every time the component is destroyed and recreated, which is exactly what happens during a drag-and-drop move.

On remount, two conditions happen to be true simultaneously:

- `currentInnerBlocks.length === 0` , because the user already deleted the inner blocks
- `hasTemplateChanged` is `true` , because `existingTemplateRef.current` is `null` again after the remount

Both guards pass, `replaceInnerBlocks` is called, and the deleted blocks come back. This affects any block that uses `useInnerBlocksProps` with a `template` but without a `templateLock` , confirmed on Details, Quote, and Media & Text blocks.

## How?

We followed the existing pattern already used by [useNestedSettingsUpdate](https://github.com/WordPress/gutenberg/blob/8b2bcdd53676f0e1ebd98696db19cb4a877e05af/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js) + [blockListSettings](https://github.com/WordPress/gutenberg/blob/8b2bcdd53676f0e1ebd98696db19cb4a877e05af/packages/block-editor/src/store/reducer.js#L1812) in the block-editor store: state that must survive React component remounts should live in the Redux store keyed by `clientId`, not in a `useRef`.

- Added a `syncedTemplateClientIds` reducer (a `Set<string>`) to the block-editor store. It tracks which block clientIds have had their template applied at least once. The key design decision is that the reducer intentionally ignores `MOVE_BLOCKS_TO_POSITION` , so the flag survives a drag-and-drop but cleans up on `REMOVE_BLOCKS`, `REPLACE_BLOCKS`, and `RESET_BLOCKS`.
- Added a private action `markTemplateSyncApplied( clientId )` dispatched after the first successful template application.
- Added a private selector `wasTemplateSyncApplied( state, clientId )` to read from the Set.
- Updated `useInnerBlockTemplateSync` to read the store flag and skip re-applying the template when the block is unlocked and the flag is already set, preventing the unexpected re-insertion on remount.

The fix is scoped only to unlocked templates (`templateLock` is not `'all'` or `'contentOnly'`), so locked template behaviour is completely unchanged.

## Testing Instructions

1. Create a post and add a **Group** block.
2. Inside the Group, add a **Details** block (or Quote / Media & Text).
3. Inside the Details block, confirm the default **Paragraph** inner block is present.
4. Delete the Paragraph inner block.
5. Drag the Details block outside the Group block.
6. Confirm the Paragraph block does **not** reappear after the move. 
7. Also verify that inserting a fresh Details block still correctly populates the default Paragraph on first insert.

## Screenshots or screencast

### Before Fix : 

https://github.com/user-attachments/assets/11085918-393e-4ca3-ac01-be3bfc5ea7b4

### After Fix : 

https://github.com/user-attachments/assets/864bbc50-0ac2-48e9-a78b-f28839e2a430

## Use of AI Tools

Claude was used to investigate the issue, figure out existing pattern, implement the fix, and documentation. The changes were reviewed and validated.