### PR TITLE
Inserter: fix synced pattern insertion under allowed_block_types_all

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
--   Inserter: gate synced pattern insertion on the `core/block` reference that is actually inserted, so a synced pattern made up of otherwise-allowed blocks is no longer silently dropped (leaving only a misleading success notice) when `allowed_block_types_all` restricts the block list ([#PRNUMBER](https://github.com/WordPress/gutenberg/pull/PRNUMBER)).
+-   Inserter: gate synced pattern insertion on the `core/block` reference that is actually inserted, so a synced pattern made up of otherwise-allowed blocks is no longer silently dropped (leaving only a misleading success notice) when `allowed_block_types_all` restricts the block list ([#80681](https://github.com/WordPress/gutenberg/pull/80681)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
+-   Inserter: gate synced pattern insertion on the `core/block` reference that is actually inserted, so a synced pattern made up of otherwise-allowed blocks is no longer silently dropped (leaving only a misleading success notice) when `allowed_block_types_all` restricts the block list ([#PRNUMBER](https://github.com/WordPress/gutenberg/pull/PRNUMBER)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -914,8 +914,6 @@ export function getClosestAllowedInsertionPointForPattern(
 	pattern,
 	clientId
 ) {
-	const { allowedBlockTypes } = getSettings( state );
-
 	// A synced pattern is inserted as a `core/block` reference rather than its
 	// parsed grammar. The wrapper block — not the pattern's inner blocks —
 	// therefore determines whether the pattern can be inserted. Checking the
@@ -930,6 +928,7 @@ export function getClosestAllowedInsertionPointForPattern(
 		return getClosestAllowedInsertionPoint( state, 'core/block', clientId );
 	}
 
+	const { allowedBlockTypes } = getSettings( state );
 	const isAllowed = checkAllowListRecursive(
 		getGrammar( pattern ),
 		allowedBlockTypes

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -41,6 +41,7 @@ import {
 	isIsolatedEditorKey,
 } from './private-keys';
 import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/constants';
+import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
 const { getViewportBreakpoints } = unlock( globalStylesEnginePrivateApis );
@@ -914,6 +915,21 @@ export function getClosestAllowedInsertionPointForPattern(
 	clientId
 ) {
 	const { allowedBlockTypes } = getSettings( state );
+
+	// A synced pattern is inserted as a `core/block` reference rather than its
+	// parsed grammar. The wrapper block — not the pattern's inner blocks —
+	// therefore determines whether the pattern can be inserted. Checking the
+	// grammar here would wrongly allow the insertion (e.g. an allow-list of
+	// `[ 'core/paragraph' ]` passes the inner check) while the `core/block`
+	// wrapper is silently dropped, leaving a success notice but no content.
+	// See https://core.trac.wordpress.org/ticket/65701.
+	const isSyncedPattern =
+		pattern.type === INSERTER_PATTERN_TYPES.user &&
+		pattern.syncStatus !== 'unsynced';
+	if ( isSyncedPattern ) {
+		return getClosestAllowedInsertionPoint( state, 'core/block', clientId );
+	}
+
 	const isAllowed = checkAllowListRecursive(
 		getGrammar( pattern ),
 		allowedBlockTypes

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -33,7 +33,9 @@ import {
 	getClosestAllowedInsertionPointForPattern,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
-import { store } from '../';
+// Import for its side effect: registers the block-editor store so the registry
+// selectors used below (e.g. canInsertBlockType) resolve.
+import '../';
 import { deviceTypeKey } from '../private-keys';
 
 describe( 'private selectors', () => {
@@ -2623,8 +2625,7 @@ describe( 'private selectors', () => {
 			const pattern = {
 				type: 'theme',
 				syncStatus: 'unsynced',
-				content:
-					'<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->',
+				content: '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->',
 			};
 			expect(
 				getClosestAllowedInsertionPointForPattern( state, pattern, '' )

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -30,8 +30,10 @@ import {
 	isSelectedBlockStyleStateShownOnCanvas,
 	shouldRenderBlockListView,
 	getStyleOverrides,
+	getClosestAllowedInsertionPointForPattern,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
+import { store } from '../';
 import { deviceTypeKey } from '../private-keys';
 
 describe( 'private selectors', () => {
@@ -2548,6 +2550,85 @@ describe( 'private selectors', () => {
 			expect( getParentSectionBlock( state, 'inner-block' ) ).toBe(
 				'pattern-a'
 			);
+		} );
+	} );
+
+	describe( 'getClosestAllowedInsertionPointForPattern', () => {
+		beforeAll( () => {
+			registerBlockType( 'core/paragraph', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'Paragraph',
+				attributes: {},
+			} );
+			registerBlockType( 'core/block', {
+				apiVersion: 3,
+				save: () => null,
+				category: 'text',
+				title: 'Pattern',
+				attributes: { ref: { type: 'number' } },
+			} );
+		} );
+
+		afterAll( () => {
+			unregisterBlockType( 'core/paragraph' );
+			unregisterBlockType( 'core/block' );
+		} );
+
+		const emptyBlocksState = {
+			blocks: {
+				byClientId: new Map(),
+				attributes: new Map(),
+				order: new Map(),
+				parents: new Map(),
+				blockEditingModes: new Map(),
+			},
+			blockListSettings: new Map(),
+		};
+
+		// Regression tests for https://core.trac.wordpress.org/ticket/65701.
+		// A synced pattern is inserted as a `core/block` reference, so it must be
+		// gated on `core/block` — not the pattern's inner grammar — otherwise the
+		// wrapper is silently dropped while a success notice still fires.
+		it( 'returns null for a synced pattern when core/block is not allowed', () => {
+			const state = {
+				...emptyBlocksState,
+				settings: { allowedBlockTypes: [ 'core/paragraph' ] },
+			};
+			const pattern = { type: 'user', syncStatus: 'fully', id: 1 };
+			expect(
+				getClosestAllowedInsertionPointForPattern( state, pattern, '' )
+			).toBe( null );
+		} );
+
+		it( 'returns an insertion point for a synced pattern when core/block is allowed', () => {
+			const state = {
+				...emptyBlocksState,
+				settings: {
+					allowedBlockTypes: [ 'core/paragraph', 'core/block' ],
+				},
+			};
+			const pattern = { type: 'user', syncStatus: 'fully', id: 1 };
+			expect(
+				getClosestAllowedInsertionPointForPattern( state, pattern, '' )
+			).toBe( '' );
+		} );
+
+		it( 'still validates the inner grammar for unsynced patterns', () => {
+			const state = {
+				...emptyBlocksState,
+				settings: { allowedBlockTypes: [ 'core/paragraph' ] },
+			};
+			const pattern = {
+				type: 'theme',
+				syncStatus: 'unsynced',
+				content:
+					'<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->',
+			};
+			expect(
+				getClosestAllowedInsertionPointForPattern( state, pattern, '' )
+			).toBe( '' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Draft: e2e coverage and a design decision (see "Open questions") are still outstanding. -->

## What?

Fixes a bug where a **synced** block pattern made up only of allowed blocks cannot be inserted when `allowed_block_types_all` restricts the editor's block list: the editor shows a "Pattern inserted" success notice but no content is added.

Trac: https://core.trac.wordpress.org/ticket/65701

## Why?

A pattern created via Appearance → Editor → Patterns is **synced**, so it is inserted as a `core/block` *reference* wrapper (`createBlock( 'core/block', { ref } )`) rather than its raw grammar.

`getClosestAllowedInsertionPointForPattern` validated the pattern's **inner grammar** (`getGrammar( pattern )`) against `allowedBlockTypes`. With, say, `allowed_block_types_all` returning `[ 'core/paragraph' ]`, the inner check passes — but the block actually inserted is `core/block`, which is never checked and is dropped by `insertBlocks`. `onClickPattern` then fires its success notice unconditionally, so the user sees "inserted" with nothing on the canvas.

## How?

In `getClosestAllowedInsertionPointForPattern`, detect a synced user pattern and gate on the `core/block` wrapper that is actually inserted, instead of the pattern's inner grammar:

```js
const isSyncedPattern =
    pattern.type === INSERTER_PATTERN_TYPES.user &&
    pattern.syncStatus !== 'unsynced';
if ( isSyncedPattern ) {
    return getClosestAllowedInsertionPoint( state, 'core/block', clientId );
}
```

When `core/block` isn't insertable the selector returns `null`, and `onClickPattern`'s existing `if ( destinationRootClientId === null ) return;` guard suppresses both the insert and the misleading notice. When it is allowed, the pattern inserts normally. Unsynced patterns are unchanged (still validated by inner grammar).

## Testing Instructions

1. Default Twenty Twenty-Five theme.
2. Add to a plugin / `functions.php`:
   ```php
   add_filter( 'allowed_block_types_all', function ( $allowed, $context ) {
       return array( 'core/paragraph' );
   }, 10, 2 );
   ```
3. Create a **synced** pattern containing a single Paragraph.
4. Edit a page/post and insert that pattern.
   - **Before:** "Pattern inserted" notice, nothing added.
   - **After:** the pattern inserts. (Restricting to `[ 'core/paragraph' ]` and *not* allowing reusable blocks now cleanly refuses insertion with no false notice — see the open question below.)

### Automated tests

Unit tests added to `packages/block-editor/src/store/test/private-selectors.js` (synced + `core/block` disallowed → `null`; synced + allowed → valid point; unsynced → inner grammar still checked). The file passes (117 tests). RED verified: reverting the fix makes the disallowed case fail.

## Open questions

- **Design choice:** this PR *gates honestly* — a synced pattern whose `core/block` wrapper isn't allowed becomes non-insertable. The alternative is to *implicitly allow* `core/block` whenever a synced pattern's inner blocks are all allowed. That's friendlier but overrides a site owner who intentionally excluded reusable blocks. Feedback welcome.
- **Quick inserter:** `onClickPattern` bypasses this selector when `isQuick` (`isQuick ? rootClientId : …`), so the same drop can occur there. Should the quick inserter get the same gate?
- **E2E:** not yet added; happy to add a spec covering the repro once the design direction is confirmed.
