### PR TITLE
DataForm: Stop card and details validation from hijacking focus

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug Fixes
 
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
+-   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#76832](https://github.com/WordPress/gutenberg/issues/76832)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `Autocomplete`: Omit `aria-activedescendant` while no suggestion is highlighted, instead of returning `null` for it ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Bug Fixes
 
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
--   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#76832](https://github.com/WordPress/gutenberg/issues/76832)).
+-   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#80685](https://github.com/WordPress/gutenberg/pull/80685)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `Autocomplete`: Omit `aria-activedescendant` while no suggestion is highlighted, instead of returning `null` for it ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,11 +14,11 @@
 
 -   `GradientPicker`: Add `selectedSlug` prop for slug-based selection and pass the selected preset's slug to `onChange`, so two presets sharing a gradient keep their identity ([#80554](https://github.com/WordPress/gutenberg/pull/80554)).
 -   `SandBox`: Add `allowPopups` prop to opt into `allow-popups` in the iframe's sandbox attribute ([#69617](https://github.com/WordPress/gutenberg/pull/69617)).
+-   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#80685](https://github.com/WordPress/gutenberg/pull/80685)).
 
 ### Bug Fixes
 
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
--   Validated form controls: Only move focus to the invalid control for trusted `invalid` events (form submission, `reportValidity()`). Consumers can now dispatch a synthetic `invalid` event to reveal a control's error message without disturbing the user's place in the form ([#80685](https://github.com/WordPress/gutenberg/pull/80685)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `Autocomplete`: Omit `aria-activedescendant` while no suggestion is highlighted, instead of returning `null` for it ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).

--- a/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.story.tsx
@@ -366,6 +366,57 @@ export const ShowingErrorsAtArbitraryTimes: StoryObj<
 };
 
 /**
+ * A synthetic `invalid` event can be dispatched to reveal an existing error
+ * without moving focus.
+ */
+export const ShowingErrorsWithoutMovingFocus: StoryObj<
+	typeof ValidatedInputControl
+> = {
+	args: {
+		label: 'Text',
+		required: true,
+		help: 'The word "error" will trigger an error.',
+	},
+	decorators: [],
+	render: function Template( { ...args } ) {
+		const [ text, setText ] = useState< string | undefined >( 'error' );
+		const ref = useRef< HTMLInputElement >( null );
+
+		return (
+			<VStack spacing={ 4 } alignment="left">
+				<ValidatedInputControl
+					ref={ ref }
+					{ ...args }
+					value={ text }
+					onChange={ setText }
+					customValidity={
+						text === 'error'
+							? {
+									type: 'invalid',
+									message: 'The word "error" is not allowed.',
+							  }
+							: undefined
+					}
+				/>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ () =>
+						ref.current?.dispatchEvent(
+							new Event( 'invalid', {
+								cancelable: true,
+							} )
+						)
+					}
+				>
+					Show errors
+				</Button>
+			</VStack>
+		);
+	},
+};
+
+/**
  * A `form` wrapper and `type="submit"` button can be used to force validation when
  * the user tries to commit their changes, while still allowing the modal to be closed by canceling.
  * Optionally, the `shouldCloseOnClickOutside`, `isDismissible`, and `shouldCloseOnEsc` props

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -124,10 +124,11 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		const suppressNativePopover = ( event: Event ) => {
 			event.preventDefault();
 
-			// Synthetic `invalid` events are dispatched programmatically to
-			// reveal error messages without interrupting the user, so they
-			// must not move focus. Only trusted events (a form submission or
-			// a `reportValidity()` call) mirror the native focus behavior.
+			// Only trusted `invalid` events (a form submission or a
+			// `reportValidity()` call) mirror the native focus behavior.
+			// Consumers may dispatch a synthetic `invalid` event to reveal
+			// this control's error message without disturbing the user's
+			// place in the form, so it must not move focus.
 			if ( ! event.isTrusted ) {
 				return;
 			}

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -124,6 +124,14 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		const suppressNativePopover = ( event: Event ) => {
 			event.preventDefault();
 
+			// Synthetic `invalid` events are dispatched programmatically to
+			// reveal error messages without interrupting the user, so they
+			// must not move focus. Only trusted events (a form submission or
+			// a `reportValidity()` call) mirror the native focus behavior.
+			if ( ! event.isTrusted ) {
+				return;
+			}
+
 			const target = event.target as ValidityTarget;
 			const firstErrorInForm = Array.from(
 				target.form?.elements ?? []

--- a/packages/components/src/validated-form-controls/test/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/test/control-with-error.tsx
@@ -542,5 +542,47 @@ describe( 'ControlWithError', () => {
 				).toHaveFocus();
 			} );
 		} );
+
+		it( 'should show the error message without moving focus on a synthetic `invalid` event', async () => {
+			const user = userEvent.setup();
+			function ValidatedInputControlWithRef(
+				props: React.ComponentProps< typeof ValidatedInputControl >
+			) {
+				const ref = useRef< HTMLInputElement >( null );
+				return (
+					<>
+						<ValidatedInputControl ref={ ref } { ...props } />
+						<button
+							type="button"
+							onClick={ () =>
+								ref.current?.dispatchEvent(
+									new Event( 'invalid', {
+										cancelable: true,
+									} )
+								)
+							}
+						>
+							Show errors
+						</button>
+					</>
+				);
+			}
+
+			render( <ValidatedInputControlWithRef label="Text" required /> );
+
+			const button = screen.getByRole( 'button', {
+				name: 'Show errors',
+			} );
+			await user.click( button );
+
+			// The error message is revealed...
+			await waitFor( () => {
+				expect(
+					screen.getByText( 'Constraints not satisfied' )
+				).toBeVisible();
+			} );
+			// ...but focus is not moved to the invalid field.
+			expect( button ).toHaveFocus();
+		} );
 	} );
 } );

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fix
 
+-   DataForms: Stop the `card` and `details` layouts from hijacking focus when they reveal validation errors. Errors for every field in the container are now shown once focus leaves it, instead of on each internal blur, and revealing them no longer moves focus, so the natural tab sequence is preserved. [#76832](https://github.com/WordPress/gutenberg/issues/76832)
 -   DataForms: Complete the `richtext` control's autocomplete semantics by associating the textbox with its suggestions list for assistive technology. [#80403](https://github.com/WordPress/gutenberg/pull/80403)
 -   DataViews: Fix the `list` layout ignoring the density setting, the refreshing state, and the loading state when `groupBy` is set. [#80255](https://github.com/WordPress/gutenberg/pull/80255)
 -   Fix Dataviews popover hover text color readability issue on WordPress 7.0. [#80105](https://github.com/WordPress/gutenberg/pull/80105)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fix
 
--   DataForms: Stop the `card` and `details` layouts from hijacking focus when they reveal validation errors. Errors for every field in the container are now shown once focus leaves it, instead of on each internal blur, and revealing them no longer moves focus, so the natural tab sequence is preserved. [#76832](https://github.com/WordPress/gutenberg/issues/76832)
+-   DataForms: Stop the `card` and `details` layouts from hijacking focus when they reveal validation errors. Errors for every field in the container are now shown once focus leaves it, instead of on each internal blur, and revealing them no longer moves focus, so the natural tab sequence is preserved. [#80685](https://github.com/WordPress/gutenberg/pull/80685)
 -   DataForms: Complete the `richtext` control's autocomplete semantics by associating the textbox with its suggestions list for assistive technology. [#80403](https://github.com/WordPress/gutenberg/pull/80403)
 -   DataViews: Fix the `list` layout ignoring the density setting, the refreshing state, and the loading state when `groupBy` is set. [#80255](https://github.com/WordPress/gutenberg/pull/80255)
 -   Fix Dataviews popover hover text color readability issue on WordPress 7.0. [#80105](https://github.com/WordPress/gutenberg/pull/80105)

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -211,7 +211,8 @@ function ValidatedDateControl< Item >( {
 		}
 	}, [ inputRefs, isValid, validity ] );
 
-	// Listen for 'invalid' events (e.g., from reportValidity() on card re-expand).
+	// Listen for 'invalid' events (e.g., dispatched by layouts when a card
+	// re-expands or loses focus).
 	useEffect( () => {
 		const refs = Array.isArray( inputRefs ) ? inputRefs : [ inputRefs ];
 		const handleInvalid = ( event: Event ) => {

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -251,11 +251,13 @@ export default function FormCardField< Item >( {
 			return;
 		}
 		setTouched( true );
-		reportValidity();
 		// The errors appear without moving focus, so announce them: their
-		// arrival is otherwise imperceptible to assistive technology.
+		// arrival is otherwise imperceptible to assistive technology. A
+		// collapsed card reveals nothing, and its header already describes
+		// the badge, so it stays silent.
+		const reportedCount = reportValidity();
 		const message = getValidationMessage( validity );
-		if ( message ) {
+		if ( reportedCount > 0 && message ) {
 			speak( message, 'polite' );
 		}
 	}, [ reportValidity, validity ] );

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -29,7 +29,7 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import getValidationMessage from '../get-validation-message';
 import { getSummaryFields } from '../get-summary-fields';
-import useReportValidity from '../../../hooks/use-report-validity';
+import useRevealValidity from '../../../hooks/use-reveal-validity';
 import ValidationBadge from '../validation-badge';
 
 function isSummaryFieldVisible< Item >(
@@ -231,7 +231,7 @@ export default function FormCardField< Item >( {
 
 	// When the card is expanded after being touched (collapsed with errors),
 	// reveal the field-level errors.
-	const reportValidity = useReportValidity(
+	const revealValidity = useRevealValidity(
 		contentRef,
 		( isCollapsible ? isOpen : true ) && touched
 	);
@@ -260,12 +260,12 @@ export default function FormCardField< Item >( {
 		}
 		// The errors appear without moving focus, so announce them: their
 		// arrival is otherwise imperceptible to assistive technology.
-		const reportedCount = reportValidity();
+		const revealedCount = revealValidity();
 		const message = getValidationMessage( validity );
-		if ( reportedCount > 0 && message ) {
+		if ( revealedCount > 0 && message ) {
 			speak( message, 'polite' );
 		}
-	}, [ isCollapsible, isOpen, reportValidity, validity ] );
+	}, [ isCollapsible, isOpen, revealValidity, validity ] );
 
 	const focusOutsideProps = useFocusOutside( handleFocusOutside );
 

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -9,6 +9,8 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 
 /**
@@ -25,6 +27,7 @@ import type {
 } from '../../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
+import getValidationMessage from '../get-validation-message';
 import { getSummaryFields } from '../get-summary-fields';
 import useReportValidity from '../../../hooks/use-report-validity';
 import ValidationBadge from '../validation-badge';
@@ -198,6 +201,7 @@ export default function FormCardField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const layout = field.layout as NormalizedCardLayout;
 	const contentRef = useRef< HTMLDivElement >( null );
+	const hasFocusedContentRef = useRef( false );
 
 	const form: NormalizedForm = useMemo(
 		() => ( {
@@ -225,18 +229,38 @@ export default function FormCardField< Item >( {
 		setIsOpen( open );
 	}, [] );
 
-	// Mark the card as touched when any field inside it is blurred.
-	// This aligns with how validated controls show errors on blur.
-	const handleBlur = useCallback( () => {
-		setTouched( true );
-	}, [] );
-
 	// When the card is expanded after being touched (collapsed with errors),
-	// trigger reportValidity to show field-level errors.
-	useReportValidity(
+	// reveal the field-level errors.
+	const reportValidity = useReportValidity(
 		contentRef,
 		( isCollapsible ? isOpen : true ) && touched
 	);
+
+	const handleContentFocus = useCallback( () => {
+		hasFocusedContentRef.current = true;
+	}, [] );
+
+	// Reveal the errors of every field in the card once focus leaves the card,
+	// replicating at the card level how validated controls show errors on
+	// their first blur. Moving focus between fields within the card doesn't
+	// count, so the natural tab sequence is preserved.
+	const handleFocusOutside = useCallback( () => {
+		// Leaving without ever entering the fields — for instance tabbing past
+		// the header of a collapsed card — isn't an interaction to report on.
+		if ( ! hasFocusedContentRef.current ) {
+			return;
+		}
+		setTouched( true );
+		reportValidity();
+		// The errors appear without moving focus, so announce them: their
+		// arrival is otherwise imperceptible to assistive technology.
+		const message = getValidationMessage( validity );
+		if ( message ) {
+			speak( message, 'polite' );
+		}
+	}, [ reportValidity, validity ] );
+
+	const focusOutsideProps = useFocusOutside( handleFocusOutside );
 
 	let label = field.label;
 	let withHeader: boolean;
@@ -287,13 +311,14 @@ export default function FormCardField< Item >( {
 				className="dataforms-layouts-card__field"
 				open={ isOpen }
 				onOpenChange={ handleOpenChange }
+				{ ...focusOutsideProps }
 			>
 				<CollapsibleCard.Header>
 					{ headerContent }
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content
 					ref={ contentRef }
-					onBlur={ handleBlur }
+					onFocus={ handleContentFocus }
 				>
 					{ bodyContent }
 				</CollapsibleCard.Content>
@@ -302,9 +327,12 @@ export default function FormCardField< Item >( {
 	}
 
 	return (
-		<Card.Root className="dataforms-layouts-card__field">
+		<Card.Root
+			className="dataforms-layouts-card__field"
+			{ ...focusOutsideProps }
+		>
 			{ withHeader && <Card.Header>{ headerContent }</Card.Header> }
-			<Card.Content ref={ contentRef } onBlur={ handleBlur }>
+			<Card.Content ref={ contentRef } onFocus={ handleContentFocus }>
 				{ bodyContent }
 			</Card.Content>
 		</Card.Root>

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -251,16 +251,21 @@ export default function FormCardField< Item >( {
 			return;
 		}
 		setTouched( true );
+		// A collapsed card reveals nothing: its content is hidden but still
+		// in the DOM, so the reveal would count the invalid fields and
+		// announce them. The header badge already conveys them, and expanding
+		// the card reveals the errors through the effect above.
+		if ( isCollapsible && ! isOpen ) {
+			return;
+		}
 		// The errors appear without moving focus, so announce them: their
-		// arrival is otherwise imperceptible to assistive technology. A
-		// collapsed card reveals nothing, and its header already describes
-		// the badge, so it stays silent.
+		// arrival is otherwise imperceptible to assistive technology.
 		const reportedCount = reportValidity();
 		const message = getValidationMessage( validity );
 		if ( reportedCount > 0 && message ) {
 			speak( message, 'polite' );
 		}
-	}, [ reportValidity, validity ] );
+	}, [ isCollapsible, isOpen, reportValidity, validity ] );
 
 	const focusOutsideProps = useFocusOutside( handleFocusOutside );
 

--- a/packages/dataviews/src/components/dataform-layouts/details/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/details/index.tsx
@@ -26,7 +26,7 @@ import DataFormContext from '../../dataform-context';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import getValidationMessage from '../get-validation-message';
-import useReportValidity from '../../../hooks/use-report-validity';
+import useRevealValidity from '../../../hooks/use-reveal-validity';
 import ValidationBadge from '../validation-badge';
 
 export default function FormDetailsField< Item >( {
@@ -73,7 +73,7 @@ export default function FormDetailsField< Item >( {
 	}, [] );
 
 	// When expanded after being touched, reveal the field-level errors.
-	const reportValidity = useReportValidity( contentRef, isOpen && touched );
+	const revealValidity = useRevealValidity( contentRef, isOpen && touched );
 
 	const handleContentFocus = useCallback( () => {
 		hasFocusedContentRef.current = true;
@@ -101,12 +101,12 @@ export default function FormDetailsField< Item >( {
 		}
 		// The errors appear without moving focus, so announce them: their
 		// arrival is otherwise imperceptible to assistive technology.
-		const reportedCount = reportValidity();
+		const revealedCount = revealValidity();
 		const message = getValidationMessage( validity );
-		if ( reportedCount > 0 && message ) {
+		if ( revealedCount > 0 && message ) {
 			speak( message, 'polite' );
 		}
-	}, [ reportValidity, validity ] );
+	}, [ revealValidity, validity ] );
 
 	const focusOutsideProps = useFocusOutside( handleFocusOutside );
 

--- a/packages/dataviews/src/components/dataform-layouts/details/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/details/index.tsx
@@ -10,6 +10,8 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -23,6 +25,7 @@ import type {
 import DataFormContext from '../../dataform-context';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
+import getValidationMessage from '../get-validation-message';
 import useReportValidity from '../../../hooks/use-report-validity';
 import ValidationBadge from '../validation-badge';
 
@@ -35,6 +38,7 @@ export default function FormDetailsField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const detailsRef = useRef< HTMLDetailsElement >( null );
 	const contentRef = useRef< HTMLDivElement >( null );
+	const hasFocusedContentRef = useRef( false );
 	const [ touched, setTouched ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -68,14 +72,34 @@ export default function FormDetailsField< Item >( {
 		};
 	}, [] );
 
-	// When expanded after being touched, trigger reportValidity to show
-	// field-level errors.
-	useReportValidity( contentRef, isOpen && touched );
+	// When expanded after being touched, reveal the field-level errors.
+	const reportValidity = useReportValidity( contentRef, isOpen && touched );
 
-	// Mark as touched when any field inside is blurred.
-	const handleBlur = useCallback( () => {
-		setTouched( true );
+	const handleContentFocus = useCallback( () => {
+		hasFocusedContentRef.current = true;
 	}, [] );
+
+	// Reveal the errors of every field once focus leaves the details element,
+	// replicating at the container level how validated controls show errors on
+	// their first blur. Moving focus between fields within it doesn't count,
+	// so the natural tab sequence is preserved.
+	const handleFocusOutside = useCallback( () => {
+		// Leaving without ever entering the fields — for instance tabbing past
+		// the summary while collapsed — isn't an interaction to report on.
+		if ( ! hasFocusedContentRef.current ) {
+			return;
+		}
+		setTouched( true );
+		reportValidity();
+		// The errors appear without moving focus, so announce them: their
+		// arrival is otherwise imperceptible to assistive technology.
+		const message = getValidationMessage( validity );
+		if ( message ) {
+			speak( message, 'polite' );
+		}
+	}, [ reportValidity, validity ] );
+
+	const focusOutsideProps = useFocusOutside( handleFocusOutside );
 
 	if ( ! field.children ) {
 		return null;
@@ -104,6 +128,7 @@ export default function FormDetailsField< Item >( {
 		<details
 			ref={ detailsRef }
 			className="dataforms-layouts-details__details"
+			{ ...focusOutsideProps }
 		>
 			<summary className="dataforms-layouts-details__summary">
 				<Stack
@@ -119,7 +144,7 @@ export default function FormDetailsField< Item >( {
 			<div
 				ref={ contentRef }
 				className="dataforms-layouts-details__content"
-				onBlur={ handleBlur }
+				onFocus={ handleContentFocus }
 			>
 				<DataFormLayout
 					data={ data }

--- a/packages/dataviews/src/components/dataform-layouts/details/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/details/index.tsx
@@ -90,11 +90,12 @@ export default function FormDetailsField< Item >( {
 			return;
 		}
 		setTouched( true );
-		reportValidity();
 		// The errors appear without moving focus, so announce them: their
-		// arrival is otherwise imperceptible to assistive technology.
+		// arrival is otherwise imperceptible to assistive technology. A
+		// collapsed element reveals nothing, so it stays silent.
+		const reportedCount = reportValidity();
 		const message = getValidationMessage( validity );
-		if ( message ) {
+		if ( reportedCount > 0 && message ) {
 			speak( message, 'polite' );
 		}
 	}, [ reportValidity, validity ] );

--- a/packages/dataviews/src/components/dataform-layouts/details/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/details/index.tsx
@@ -90,9 +90,17 @@ export default function FormDetailsField< Item >( {
 			return;
 		}
 		setTouched( true );
+		// A closed details element reveals nothing: its content is hidden but
+		// still in the DOM, so the reveal would count the invalid fields and
+		// announce them. The summary badge already conveys them, and
+		// reopening the element reveals the errors through the effect above.
+		// The DOM is read directly because the `isOpen` state trails it while
+		// the `toggle` event is still in flight.
+		if ( ! detailsRef.current?.open ) {
+			return;
+		}
 		// The errors appear without moving focus, so announce them: their
-		// arrival is otherwise imperceptible to assistive technology. A
-		// collapsed element reveals nothing, so it stays silent.
+		// arrival is otherwise imperceptible to assistive technology.
 		const reportedCount = reportValidity();
 		const message = getValidationMessage( validity );
 		if ( reportedCount > 0 && message ) {

--- a/packages/dataviews/src/components/dataform-layouts/get-validation-message.ts
+++ b/packages/dataviews/src/components/dataform-layouts/get-validation-message.ts
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { FieldValidity } from '../../types';
+
+function countInvalidFields( validity: FieldValidity | undefined ): number {
+	if ( ! validity ) {
+		return 0;
+	}
+
+	let count = 0;
+	const validityRules = Object.keys( validity ).filter(
+		( key ) => key !== 'children'
+	);
+
+	for ( const key of validityRules ) {
+		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
+		if ( rule?.type === 'invalid' ) {
+			count++;
+		}
+	}
+
+	// Count children recursively
+	if ( validity.children ) {
+		for ( const childValidity of Object.values( validity.children ) ) {
+			count += countInvalidFields( childValidity );
+		}
+	}
+
+	return count;
+}
+
+/**
+ * Summarizes how many fields need attention, or `undefined` when they are
+ * all valid. Used both as the visible badge text and as the message announced
+ * to assistive technology when a layout reveals its errors.
+ *
+ * @param validity The validity of the layout's field and its children.
+ */
+export default function getValidationMessage(
+	validity: FieldValidity | undefined
+): string | undefined {
+	const invalidCount = countInvalidFields( validity );
+
+	if ( invalidCount === 0 ) {
+		return undefined;
+	}
+
+	return sprintf(
+		/* translators: %d: Number of fields that need attention */
+		_n(
+			'%d field needs attention',
+			'%d fields need attention',
+			invalidCount
+		),
+		invalidCount
+	);
+}

--- a/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/dropdown.tsx
@@ -24,7 +24,7 @@ import type {
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
-import useReportValidity from '../../../hooks/use-report-validity';
+import useRevealValidity from '../../../hooks/use-reveal-validity';
 import useFieldFromFormField from './utils/use-field-from-form-field';
 
 function DropdownHeader( {
@@ -68,7 +68,7 @@ function DropdownContentWithValidation( {
 	children: React.ReactNode;
 } ) {
 	const ref = useRef< HTMLDivElement >( null );
-	useReportValidity( ref, touched );
+	useRevealValidity( ref, touched );
 	return <div ref={ ref }>{ children }</div>;
 }
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/modal.tsx
@@ -31,7 +31,7 @@ import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 import SummaryButton from './summary-button';
 import useFormValidity from '../../../hooks/use-form-validity';
-import useReportValidity from '../../../hooks/use-report-validity';
+import useRevealValidity from '../../../hooks/use-reveal-validity';
 import DataFormContext from '../../dataform-context';
 import useFieldFromFormField from './utils/use-field-from-form-field';
 
@@ -104,8 +104,8 @@ function ModalContent< Item >( {
 	const mergedRef = useMergeRefs( [ focusOnMountRef, contentRef ] );
 
 	// When the modal is opened after being previously closed (touched),
-	// trigger reportValidity to show field-level errors.
-	useReportValidity( contentRef, touched );
+	// reveal the field-level errors.
+	useRevealValidity( contentRef, touched );
 
 	return (
 		<Modal

--- a/packages/dataviews/src/components/dataform-layouts/validation-badge.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/validation-badge.tsx
@@ -2,62 +2,23 @@
  * WordPress dependencies
  */
 import { Badge } from '@wordpress/ui';
-import { sprintf, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { FieldValidity } from '../../types';
-
-function countInvalidFields( validity: FieldValidity | undefined ): number {
-	if ( ! validity ) {
-		return 0;
-	}
-
-	let count = 0;
-	const validityRules = Object.keys( validity ).filter(
-		( key ) => key !== 'children'
-	);
-
-	for ( const key of validityRules ) {
-		const rule = validity[ key as keyof Omit< FieldValidity, 'children' > ];
-		if ( rule?.type === 'invalid' ) {
-			count++;
-		}
-	}
-
-	// Count children recursively
-	if ( validity.children ) {
-		for ( const childValidity of Object.values( validity.children ) ) {
-			count += countInvalidFields( childValidity );
-		}
-	}
-
-	return count;
-}
+import getValidationMessage from './get-validation-message';
 
 export default function ValidationBadge( {
 	validity,
 }: {
 	validity: FieldValidity | undefined;
 } ) {
-	const invalidCount = countInvalidFields( validity );
+	const message = getValidationMessage( validity );
 
-	if ( invalidCount === 0 ) {
+	if ( ! message ) {
 		return null;
 	}
 
-	return (
-		<Badge intent="high">
-			{ sprintf(
-				/* translators: %d: Number of fields that need attention */
-				_n(
-					'%d field needs attention',
-					'%d fields need attention',
-					invalidCount
-				),
-				invalidCount
-			) }
-		</Badge>
-	);
+	return <Badge intent="high">{ message }</Badge>;
 }

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -748,6 +748,47 @@ describe( 'DataForm component', () => {
 			);
 		} );
 
+		it( 'should not announce when focus leaves the card while it is collapsed', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ formCardMode }
+						data={ { ...data, title: '' } }
+						validity={ {
+							mainCard: {
+								children: {
+									title: {
+										required: {
+											type: 'invalid' as const,
+											message: 'Title is required.',
+										},
+									},
+								},
+							},
+						} }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			// Focus a field inside the card, then collapse it. The toggle is
+			// inside the card, so focus hasn't left it yet.
+			await user.click( fieldsSelector.order.edit() );
+			await user.click(
+				screen.getByRole( 'button', { name: /main card/i } )
+			);
+			jest.mocked( speak ).mockClear();
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			);
+
+			expect( speak ).not.toHaveBeenCalled();
+		} );
+
 		it( 'should show errors for invalid fields after the card is collapsed and expanded', async () => {
 			const user = userEvent.setup();
 			render(
@@ -825,6 +866,57 @@ describe( 'DataForm component', () => {
 			expect(
 				screen.getByRole( 'button', { name: 'Outside' } )
 			).toHaveFocus();
+		} );
+
+		it( 'should not announce when focus leaves it while collapsed', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ formDetailsMode }
+						data={ { ...data, title: '' } }
+						validity={ {
+							moreDetails: {
+								children: {
+									title: {
+										required: {
+											type: 'invalid' as const,
+											message: 'Title is required.',
+										},
+									},
+								},
+							},
+						} }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			// Expand the disclosure and focus a field inside it.
+			const summary = screen.getByText( 'More details' );
+			await user.click( summary );
+			await waitFor( () =>
+				expect( fieldsSelector.order.edit() ).toBeVisible()
+			);
+			await user.click( fieldsSelector.order.edit() );
+
+			// Close it while focus is still inside, as when the summary is
+			// clicked in a browser, where it receives focus. jsdom leaves
+			// focus where it was, so close programmatically instead.
+			// eslint-disable-next-line testing-library/no-node-access
+			const details = summary.closest( 'details' );
+			await act( async () => {
+				details!.open = false;
+			} );
+			jest.mocked( speak ).mockClear();
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			);
+
+			expect( speak ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -772,6 +772,59 @@ describe( 'DataForm component', () => {
 			expect(
 				await screen.findByText( 'Constraints not satisfied' )
 			).toBeVisible();
+		} );
+	} );
+
+	describe( 'in details mode', () => {
+		const fieldsWithRequiredTitle = fields.map( ( field ) =>
+			field.id === 'title'
+				? { ...field, isValid: { required: true } }
+				: field
+		);
+
+		const formDetailsMode = {
+			layout: { type: 'details' as const },
+			fields: [
+				{
+					id: 'moreDetails',
+					label: 'More details',
+					children: [ 'title', 'order' ],
+				},
+			],
+		};
+
+		it( 'should show errors for invalid fields once focus leaves it', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ formDetailsMode }
+						data={ { ...data, title: '' } }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			// Expand the disclosure so its fields, and any error they show,
+			// are visible.
+			await user.click( screen.getByText( 'More details' ) );
+			await waitFor( () =>
+				expect( fieldsSelector.order.edit() ).toBeVisible()
+			);
+			await user.click( fieldsSelector.order.edit() );
+
+			// Leave by keyboard: a click would re-assign focus afterwards and
+			// mask a focus steal.
+			await user.tab();
+
+			expect(
+				await screen.findByText( 'Constraints not satisfied' )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			).toHaveFocus();
 		} );
 	} );
 } );

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -8,12 +8,15 @@ import userEvent from '@testing-library/user-event';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import Dataform from '../index';
 import useFormValidity from '../../hooks/use-form-validity';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 const noop = () => {};
 
@@ -706,6 +709,43 @@ describe( 'DataForm component', () => {
 			await user.click( outsideButton );
 
 			expect( await screen.findByText( errorText ) ).toBeVisible();
+		} );
+
+		it( 'should announce how many fields need attention when focus leaves the card', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ formCardMode }
+						data={ { ...data, title: '' } }
+						validity={ {
+							mainCard: {
+								children: {
+									title: {
+										required: {
+											type: 'invalid' as const,
+											message: 'Title is required.',
+										},
+									},
+								},
+							},
+						} }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			await user.click( fieldsSelector.order.edit() );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			);
+
+			expect( speak ).toHaveBeenCalledWith(
+				'1 field needs attention',
+				'polite'
+			);
 		} );
 
 		it( 'should show errors for invalid fields after the card is collapsed and expanded', async () => {

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -5,9 +5,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Dataform from '../index';
+import useFormValidity from '../../hooks/use-form-validity';
 
 const noop = () => {};
 
@@ -518,6 +524,214 @@ describe( 'DataForm component', () => {
 				'This is the Title Field'
 			);
 			expect( titleEditField ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'in card mode', () => {
+		const fieldsWithRequiredTitle = fields.map( ( field ) =>
+			field.id === 'title'
+				? { ...field, isValid: { required: true } }
+				: field
+		);
+
+		const formCardMode = {
+			layout: { type: 'card' } as const,
+			fields: [
+				{
+					id: 'mainCard',
+					label: 'Main card',
+					children: [ 'title', 'order', 'author' ],
+				},
+			],
+		};
+
+		it( 'should preserve the natural tab order when a field inside the card is blurred', async () => {
+			const user = userEvent.setup();
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithRequiredTitle }
+					form={ formCardMode }
+					// Empty title makes the required field invalid.
+					data={ { ...data, title: '' } }
+				/>
+			);
+
+			const titleInput = screen.getByRole( 'textbox', {
+				name: /title/i,
+			} );
+			const orderInput = fieldsSelector.order.edit();
+			await user.click( orderInput );
+			await user.tab();
+
+			// Focus is not hijacked by the invalid field...
+			expect( titleInput ).not.toHaveFocus();
+			// ...and moving focus within the card doesn't show errors
+			// for fields the user hasn't interacted with.
+			expect(
+				screen.queryByText( 'Constraints not satisfied' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should show errors for invalid fields when focus leaves the card, without moving focus', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ formCardMode }
+						data={ { ...data, title: '' } }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			const orderInput = fieldsSelector.order.edit();
+			await user.click( orderInput );
+
+			const outsideButton = screen.getByRole( 'button', {
+				name: 'Outside',
+			} );
+			await user.click( outsideButton );
+
+			// The required error for the untouched title field is shown...
+			expect(
+				await screen.findByText( 'Constraints not satisfied' )
+			).toBeVisible();
+			// ...but focus is not moved back into the card.
+			expect( outsideButton ).toHaveFocus();
+		} );
+
+		it( 'should not show errors when tabbing past the header of a collapsed card', async () => {
+			const user = userEvent.setup();
+			render(
+				<>
+					<Dataform
+						onChange={ noop }
+						fields={ fieldsWithRequiredTitle }
+						form={ {
+							...formCardMode,
+							fields: [
+								{
+									...formCardMode.fields[ 0 ],
+									layout: {
+										type: 'card' as const,
+										isOpened: false,
+									},
+								},
+							],
+						} }
+						data={ { ...data, title: '' } }
+					/>
+					<button type="button">Outside</button>
+				</>
+			);
+
+			// Tab to the collapse toggle, then past it, without ever
+			// expanding the card.
+			await user.tab();
+			expect(
+				screen.getByRole( 'button', { name: /main card/i } )
+			).toHaveFocus();
+			await user.tab();
+
+			expect(
+				screen.getByRole( 'button', { name: 'Outside' } )
+			).toHaveFocus();
+			expect(
+				screen.queryByText( /needs? attention/ )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should show errors for fields that become invalid after focus already left the card once', async () => {
+			const user = userEvent.setup();
+
+			// The title is only valid while the order is 1, so it can become
+			// invalid without the user ever focusing it.
+			const fieldsWithCrossFieldRule = fields.map( ( field ) =>
+				field.id === 'title'
+					? {
+							...field,
+							isValid: {
+								custom: ( item: typeof data ) =>
+									item.order === 1
+										? null
+										: 'Title is not allowed for this order.',
+							},
+					  }
+					: field
+			);
+
+			function ControlledForm() {
+				const [ item, setItem ] = useState( data );
+				const { validity } = useFormValidity(
+					item,
+					fieldsWithCrossFieldRule,
+					formCardMode
+				);
+				return (
+					<>
+						<Dataform
+							onChange={ ( edits ) =>
+								setItem( ( prev ) => ( {
+									...prev,
+									...edits,
+								} ) )
+							}
+							fields={ fieldsWithCrossFieldRule }
+							form={ formCardMode }
+							data={ item }
+							validity={ validity }
+						/>
+						<button type="button">Outside</button>
+					</>
+				);
+			}
+
+			render( <ControlledForm /> );
+
+			const outsideButton = screen.getByRole( 'button', {
+				name: 'Outside',
+			} );
+			const errorText = 'Title is not allowed for this order.';
+
+			// Leave the card once while every field is still valid.
+			await user.click( fieldsSelector.order.edit() );
+			await user.click( outsideButton );
+			expect( screen.queryByText( errorText ) ).not.toBeInTheDocument();
+
+			// Invalidate the never-focused title field, then leave again.
+			await user.type( fieldsSelector.order.edit(), '2' );
+			await user.click( outsideButton );
+
+			expect( await screen.findByText( errorText ) ).toBeVisible();
+		} );
+
+		it( 'should show errors for invalid fields after the card is collapsed and expanded', async () => {
+			const user = userEvent.setup();
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithRequiredTitle }
+					form={ formCardMode }
+					data={ { ...data, title: '' } }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Constraints not satisfied' )
+			).not.toBeInTheDocument();
+
+			const toggle = screen.getByRole( 'button', {
+				name: /main card/i,
+			} );
+			await user.click( toggle );
+			await user.click( toggle );
+
+			expect(
+				await screen.findByText( 'Constraints not satisfied' )
+			).toBeVisible();
 		} );
 	} );
 } );

--- a/packages/dataviews/src/hooks/use-report-validity.ts
+++ b/packages/dataviews/src/hooks/use-report-validity.ts
@@ -19,7 +19,8 @@ import { useCallback, useEffect } from '@wordpress/element';
  *                     open/visible state.
  *
  * @return A callback that reveals the errors on demand, for layouts that also
- *         need to report on a recurring event such as losing focus.
+ *         need to report on a recurring event such as losing focus. It returns
+ *         how many inputs it revealed an error for.
  */
 export default function useReportValidity(
 	ref: React.RefObject< HTMLElement | null >,
@@ -29,13 +30,16 @@ export default function useReportValidity(
 		const inputs = ref.current?.querySelectorAll<
 			HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
 		>( 'input, textarea, select' );
+		let reportedCount = 0;
 		inputs?.forEach( ( input ) => {
 			if ( input.willValidate && ! input.validity.valid ) {
+				reportedCount++;
 				input.dispatchEvent(
 					new Event( 'invalid', { cancelable: true } )
 				);
 			}
 		} );
+		return reportedCount;
 	}, [ ref ] );
 
 	useEffect( () => {

--- a/packages/dataviews/src/hooks/use-report-validity.ts
+++ b/packages/dataviews/src/hooks/use-report-validity.ts
@@ -1,32 +1,48 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
- * Triggers `reportValidity()` on all form inputs within a container element.
- * This fires the browser's `invalid` event on each input, which validated
- * controls listen to in order to display their error states.
+ * Shows validation errors for all invalid form inputs within a container
+ * element, without moving focus. It fires a synthetic `invalid` event on each
+ * invalid input, which validated controls listen to in order to display their
+ * error states. Unlike `reportValidity()`, it never focuses the invalid
+ * input, so the natural tab sequence is preserved.
  *
  * Used by panel and card layouts to show validation errors
  * immediately when their content becomes visible after prior interaction.
  *
  * @param ref          A ref to the container element.
- * @param shouldReport Whether to trigger reportValidity. Typically
- *                     derived from `touched` state and open/visible state.
+ * @param shouldReport Whether to trigger the invalid events when it becomes
+ *                     `true`. Typically derived from `touched` state and
+ *                     open/visible state.
+ *
+ * @return A callback that reveals the errors on demand, for layouts that also
+ *         need to report on a recurring event such as losing focus.
  */
 export default function useReportValidity(
 	ref: React.RefObject< HTMLElement | null >,
 	shouldReport: boolean
 ) {
+	const reportValidity = useCallback( () => {
+		const inputs = ref.current?.querySelectorAll<
+			HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+		>( 'input, textarea, select' );
+		inputs?.forEach( ( input ) => {
+			if ( input.willValidate && ! input.validity.valid ) {
+				input.dispatchEvent(
+					new Event( 'invalid', { cancelable: true } )
+				);
+			}
+		} );
+	}, [ ref ] );
+
 	useEffect( () => {
-		if ( shouldReport && ref.current ) {
-			const inputs = ref.current.querySelectorAll(
-				'input, textarea, select'
-			);
-			inputs.forEach( ( input ) => {
-				( input as HTMLInputElement ).reportValidity();
-			} );
+		if ( shouldReport ) {
+			reportValidity();
 		}
-	}, [ shouldReport, ref ] );
+	}, [ shouldReport, reportValidity ] );
+
+	return reportValidity;
 }

--- a/packages/dataviews/src/hooks/use-reveal-validity.ts
+++ b/packages/dataviews/src/hooks/use-reveal-validity.ts
@@ -10,43 +10,43 @@ import { useCallback, useEffect } from '@wordpress/element';
  * error states. Unlike `reportValidity()`, it never focuses the invalid
  * input, so the natural tab sequence is preserved.
  *
- * Used by panel and card layouts to show validation errors
+ * Used by panel, card, and details layouts to show validation errors
  * immediately when their content becomes visible after prior interaction.
  *
  * @param ref          A ref to the container element.
- * @param shouldReport Whether to trigger the invalid events when it becomes
+ * @param shouldReveal Whether to trigger the invalid events when it becomes
  *                     `true`. Typically derived from `touched` state and
  *                     open/visible state.
  *
  * @return A callback that reveals the errors on demand, for layouts that also
- *         need to report on a recurring event such as losing focus. It returns
+ *         need to reveal on a recurring event such as losing focus. It returns
  *         how many inputs it revealed an error for.
  */
-export default function useReportValidity(
+export default function useRevealValidity(
 	ref: React.RefObject< HTMLElement | null >,
-	shouldReport: boolean
+	shouldReveal: boolean
 ) {
-	const reportValidity = useCallback( () => {
+	const revealValidity = useCallback( () => {
 		const inputs = ref.current?.querySelectorAll<
 			HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
 		>( 'input, textarea, select' );
-		let reportedCount = 0;
+		let revealedCount = 0;
 		inputs?.forEach( ( input ) => {
 			if ( input.willValidate && ! input.validity.valid ) {
-				reportedCount++;
+				revealedCount++;
 				input.dispatchEvent(
 					new Event( 'invalid', { cancelable: true } )
 				);
 			}
 		} );
-		return reportedCount;
+		return revealedCount;
 	}, [ ref ] );
 
 	useEffect( () => {
-		if ( shouldReport ) {
-			reportValidity();
+		if ( shouldReveal ) {
+			revealValidity();
 		}
-	}, [ shouldReport, reportValidity ] );
+	}, [ shouldReveal, revealValidity ] );
 
-	return reportValidity;
+	return revealValidity;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/76832

On the card layout, validation runs on every blur inside the card, and `reportValidity()` moves focus to the first invalid field. So tabbing from one field to the next sends focus back to an unrelated field, breaking the natural tab sequence.

Following the discussion on the issue, this PR shows the errors of all the fields of a card when the card loses focus, instead of on each blur inside it. The errors are shown by dispatching a synthetic `invalid` event, so focus is never moved. Validated controls only replicate the native focus behavior for trusted events, so submitting a form still focuses the first error. The details layout gets the same treatment, and both announce how many fields need attention, given the errors now appear without moving focus.

The panel layout shares the same hook, so reopening a touched panel also shows its errors without moving focus.

## Videos

Both videos run the same steps on the left and on the right. The title bar, the caption and the red ring around the focused field were added for the recording only.

DataForm Validation story, card layout — focus the Text field and press TAB without editing anything. Before, focus jumps to Password, the first field with errors. After, it goes to the Textarea, as expected.

![DataForm Validation story, before and after](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/dataform-card-validation/storybook-before-after.gif)

<sub>[Download the MP4](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/dataform-card-validation/storybook-before-after.mp4)</sub>

Settings > Content Types > Add post type — click the Singular label and press TAB. Before, focus jumps back to Plural label and the whole card turns red. After, focus moves on to Post type key, and only the field that was left shows its error.

![Content Types Add post type, before and after](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/dataform-card-validation/wordpress-before-after.gif)

<sub>[Download the MP4](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/dataform-card-validation/wordpress-before-after.mp4)</sub>

## Testing Instructions

Go to http://localhost:50240/?path=/story/dataviews-dataform--validation and set the layout to `card-collapsible`.
Focus the Text field, press TAB, and verify focus moves to the Textarea instead of to the first field with errors.
Click outside the card and verify every invalid field shows its error and focus stays where you put it.
Collapse the card and verify the badge appears, expand it and verify the errors are still shown.

Then, with the Content Types experiment enabled, go to Settings > Content Types and click "Add post type".
Click the Singular label, press TAB, and verify focus moves to Post type key instead of back to Plural label.
Click outside the card and verify the fields you left show their errors without pulling focus back.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
