### PR TITLE
Fix flaky theme activation tests

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
@@ -5,12 +5,49 @@ import type { RequestUtils } from './index';
 import { WP_BASE_URL } from '../config';
 
 const THEMES_URL = new URL( 'wp-admin/themes.php', WP_BASE_URL ).href;
+const MAX_THEME_ACTIVATION_ATTEMPTS = 3;
+const TRANSIENT_THEME_ACTIVATION_ERROR =
+	/socket hang up|ECONNRESET|ETIMEDOUT|ERR_HTTP|timeout|\b5\d{2}\b/i;
 
 async function activateTheme(
 	this: RequestUtils,
 	themeSlug: string
 ): Promise< void > {
+	for (
+		let attempt = 1;
+		attempt <= MAX_THEME_ACTIVATION_ATTEMPTS;
+		attempt++
+	) {
+		try {
+			await activateThemeOnce.call( this, themeSlug );
+			await verifyThemeActive.call( this, themeSlug );
+			return;
+		} catch ( error ) {
+			if (
+				! isTransientThemeActivationError( error ) ||
+				attempt === MAX_THEME_ACTIVATION_ATTEMPTS
+			) {
+				throw error;
+			}
+
+			await new Promise( ( resolve ) =>
+				setTimeout( resolve, 500 * attempt )
+			);
+		}
+	}
+}
+
+async function activateThemeOnce(
+	this: RequestUtils,
+	themeSlug: string
+): Promise< void > {
 	let response = await this.request.get( THEMES_URL );
+	if ( ! response.ok() ) {
+		const status = response.status();
+		await response.dispose();
+		throw new Error( `Failed to load themes page. Status: ${ status }` );
+	}
+
 	const html = await response.text();
 	const optionalFolder = '([a-z0-9-]+%2F)?';
 
@@ -46,8 +83,45 @@ async function activateTheme(
 		THEMES_URL + `?${ activateQuery }`.replace( /&amp;/g, '&' );
 
 	response = await this.request.get( activateLink );
+	if ( ! response.ok() ) {
+		const status = response.status();
+		await response.dispose();
+		throw new Error( `Failed to activate theme. Status: ${ status }` );
+	}
 
 	await response.dispose();
+}
+
+async function verifyThemeActive(
+	this: RequestUtils,
+	themeSlug: string
+): Promise< void > {
+	type ThemeItem = {
+		stylesheet: string;
+		status: string;
+	};
+
+	const themes = await this.rest< ThemeItem[] >( {
+		path: '/wp/v2/themes',
+	} );
+
+	const activeTheme = themes.find( ( { status } ) => status === 'active' );
+	const activeStylesheet = activeTheme?.stylesheet;
+	const isActive =
+		activeStylesheet === themeSlug ||
+		activeStylesheet?.endsWith( `/${ themeSlug }` );
+
+	if ( ! isActive ) {
+		throw new Error(
+			`Theme activation failed. Expected "${ themeSlug }", got "${ activeStylesheet }".`
+		);
+	}
+}
+
+function isTransientThemeActivationError( error: unknown ) {
+	const message = error instanceof Error ? error.message : String( error );
+
+	return TRANSIENT_THEME_ACTIVATION_ERROR.test( message );
 }
 
 // https://developer.wordpress.org/rest-api/reference/themes/#definition

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -3,32 +3,6 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-/**
- * Activates a theme, retrying on the transient "socket hang up"
- * (ECONNRESET) connection error that intermittently occurs in CI.
- *
- * See https://github.com/WordPress/gutenberg/issues/74483.
- *
- * @param {Object} requestUtils Playwright request utils.
- * @param {string} themeSlug    Theme slug to activate.
- */
-async function activateThemeWithRetry( requestUtils, themeSlug ) {
-	const maxAttempts = 3;
-	for ( let attempt = 1; attempt <= maxAttempts; attempt++ ) {
-		try {
-			await requestUtils.activateTheme( themeSlug );
-			return;
-		} catch ( error ) {
-			const isTransient = /socket hang up|ECONNRESET/i.test(
-				error?.message ?? ''
-			);
-			if ( ! isTransient || attempt === maxAttempts ) {
-				throw error;
-			}
-		}
-	}
-}
-
 async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
 	await page.getByRole( 'button', { name: 'Add page' } ).click();
@@ -95,7 +69,7 @@ async function addPageContent( editor, page ) {
 
 test.describe( 'Pages', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await activateThemeWithRetry( requestUtils, 'emptytheme' );
+		await requestUtils.activateTheme( 'emptytheme' );
 		await Promise.all( [
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllPages(),
@@ -111,7 +85,7 @@ test.describe( 'Pages', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await activateThemeWithRetry( requestUtils, 'twentytwentyone' );
+		await requestUtils.activateTheme( 'twentytwentyone' );
 		await Promise.all( [
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllPages(),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #74483.

Centralizes retry handling for flaky Playwright theme activation in `requestUtils.activateTheme()`.

## Why?
Theme activation can intermittently fail in CI with transient HTTP connection errors, and one site editor spec had a local retry workaround for that behavior.

## How?
`activateTheme()` now retries transient activation failures, verifies HTTP responses, and confirms the requested theme is active via the REST themes endpoint before returning. The Pages e2e spec now calls the shared helper directly instead of carrying its own retry wrapper.

## Testing Instructions
1. Run `npm run format -- packages/e2e-test-utils-playwright/src/request-utils/themes.ts test/e2e/specs/site-editor/pages.spec.js`.
2. Run `npm run lint:js -- packages/e2e-test-utils-playwright/src/request-utils/themes.ts test/e2e/specs/site-editor/pages.spec.js`.
3. Run `git diff --check`.
4. Optionally run `npm run test:e2e -- test/e2e/specs/site-editor/pages.spec.js` with `wp-env-test` running.

### Testing Instructions for Keyboard
Not applicable; this changes e2e test utilities only.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
This PR was implemented with assistance from OpenAI Codex, with human review expected before merge.