### PR TITLE
Edit Site: Replace Theme usage in canvas loader with CSS

### DIFF
--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -28,14 +28,7 @@ export default function CanvasLoader( { id } ) {
 	return (
 		<div
 			className="edit-site-canvas-loader"
-			style={
-				textColor
-					? {
-							'--wp-edit-site-canvas-loader-foreground':
-								textColor,
-					  }
-					: undefined
-			}
+			style={ textColor ? { '--color': textColor } : undefined }
 		>
 			<ProgressBar id={ id } max={ total } value={ elapsed } />
 		</div>

--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	privateApis as componentsPrivateApis,
-	ProgressBar,
-} from '@wordpress/components';
+import { ProgressBar } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
@@ -14,12 +11,10 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { Theme } = unlock( componentsPrivateApis );
 const { useStyle } = unlock( editorPrivateApis );
 
 export default function CanvasLoader( { id } ) {
 	const textColor = useStyle( 'color.text' );
-	const backgroundColor = useStyle( 'color.background' );
 	const { elapsed, total } = useSelect( ( select ) => {
 		const selectorsByStatus = select( coreStore ).countSelectorsByStatus();
 		const resolving = selectorsByStatus.resolving ?? 0;
@@ -31,10 +26,18 @@ export default function CanvasLoader( { id } ) {
 	}, [] );
 
 	return (
-		<div className="edit-site-canvas-loader">
-			<Theme accent={ textColor } background={ backgroundColor }>
-				<ProgressBar id={ id } max={ total } value={ elapsed } />
-			</Theme>
+		<div
+			className="edit-site-canvas-loader"
+			style={
+				textColor
+					? {
+							'--wp-edit-site-canvas-loader-foreground':
+								textColor,
+					  }
+					: undefined
+			}
+		>
+			<ProgressBar id={ id } max={ total } value={ elapsed } />
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -8,14 +8,11 @@
 	opacity: 0;
 	align-items: center;
 	justify-content: center;
+	--wp-components-color-foreground: var(--wp-edit-site-canvas-loader-foreground, var(--wpds-color-foreground-content-neutral));
 
 	@media not (prefers-reduced-motion) {
 		animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;
 		animation-fill-mode: forwards;
-	}
-
-	& > div {
-		width: 160px;
 	}
 }
 

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -1,4 +1,7 @@
 .edit-site-canvas-loader {
+	// TODO: Use design tokens with ThemeProvider.
+	--wp-components-color-foreground: var(--color);
+
 	width: 100%;
 	height: 100%;
 	display: flex;
@@ -8,7 +11,6 @@
 	opacity: 0;
 	align-items: center;
 	justify-content: center;
-	--wp-components-color-foreground: var(--wp-edit-site-canvas-loader-foreground, var(--wpds-color-foreground-content-neutral));
 
 	@media not (prefers-reduced-motion) {
 		animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;


### PR DESCRIPTION
## What?

Removes the private `Theme` wrapper from `CanvasLoader` and themes the progress bar with (temporary) CSS custom properties instead.

## Why?

This is the only production `Theme` usage in Gutenberg. This is a step towards formally deprecating the `Theme` component.

## How?

- Pass the global styles text color from `useStyle( 'color.text' )` as a `--color` custom property on the loader wrapper.
- Map that to `--wp-components-color-foreground` in SCSS so `ProgressBar` picks up the themed color through its existing token chain.
- Drop the intermediate `Theme` wrapper and its associated layout rule.

This is temporary, and we'll want to switch to proper theme tokens once the Emotion refactor is done.

## Testing Instructions

1. Apply the debug code.
1. Open the Site Editor (`/wp-admin/site-editor.php`).
2. Confirm the progress bar appears over the canvas.
3. In **Styles → Colors → Text**, change the text color.
4. Confirm the progress bar color follows the updated text color.

<details><summary>Debug code to render the ProgressBar</summary>
<p>

```diff
diff --git a/packages/edit-site/src/components/canvas-loader/index.js b/packages/edit-site/src/components/canvas-loader/index.js
index a7a2b0027fa..57a49bcc997 100644
--- a/packages/edit-site/src/components/canvas-loader/index.js
+++ b/packages/edit-site/src/components/canvas-loader/index.js
@@ -13,6 +13,9 @@ import { unlock } from '../../lock-unlock';
 
 const { useStyle } = unlock( editorPrivateApis );
 
+// TODO: Remove before committing — keeps loader visible for theming debug.
+const DEBUG_CANVAS_LOADER = true;
+
 export default function CanvasLoader( { id } ) {
 	const textColor = useStyle( 'color.text' );
 	const { elapsed, total } = useSelect( ( select ) => {
@@ -25,12 +28,19 @@ export default function CanvasLoader( { id } ) {
 		};
 	}, [] );
 
+	const progressMax = DEBUG_CANVAS_LOADER ? 100 : total;
+	const progressValue = DEBUG_CANVAS_LOADER ? 60 : elapsed;
+
 	return (
 		<div
 			className="edit-site-canvas-loader"
 			style={ textColor ? { '--color': textColor } : undefined }
 		>
-			<ProgressBar id={ id } max={ total } value={ elapsed } />
+			<ProgressBar
+				id={ id }
+				max={ progressMax }
+				value={ progressValue }
+			/>
 		</div>
 	);
 }
diff --git a/packages/edit-site/src/components/canvas-loader/style.scss b/packages/edit-site/src/components/canvas-loader/style.scss
index e24b8aedafb..33097b2c6e4 100644
--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -8,7 +8,6 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	opacity: 0;
 	align-items: center;
 	justify-content: center;
 
@@ -16,6 +15,12 @@
 		animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;
 		animation-fill-mode: forwards;
 	}
+
+	// TODO: Remove before committing — keeps loader visible for theming debug.
+	opacity: 1;
+	animation: none;
+	pointer-events: none;
+	z-index: 100000;
 }
 
 @keyframes edit-site-canvas-loader__fade-in-animation {
diff --git a/packages/edit-site/src/components/editor/index.js b/packages/edit-site/src/components/editor/index.js
index 08789b97ba0..446b1fd1e02 100644
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -169,19 +169,24 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 
 	const isReady = ! isLoading;
 
+	// TODO: Remove before committing — keeps canvas loader visible for theming debug.
+	const debugKeepCanvasLoaderVisible = true;
+
 	return ! isBlockBasedTheme && isHomeRoute ? (
 		<SitePreview />
 	) : (
 		<>
 			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }
-			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
+			{ ! isReady || debugKeepCanvasLoaderVisible ? (
+				<CanvasLoader id={ loadingProgressId } />
+			) : null }
 			{ isEditMode && isReady && (
 				<WelcomeGuide
 					postType={ postWithTemplate ? context.postType : postType }
 				/>
 			) }
-			{ isReady && (
+			{ isReady || debugKeepCanvasLoaderVisible ? (
 				<Editor
 					postType={ postWithTemplate ? context.postType : postType }
 					postId={ postWithTemplate ? context.postId : postId }
@@ -236,7 +241,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 					) }
 					<SiteEditorMoreMenu />
 				</Editor>
-			) }
+			) : null }
 		</>
 	);
 }
```


</p>
</details> 

## Screenshots or screencast


https://github.com/user-attachments/assets/1792afef-e9c7-4ec8-bb46-0968289959db

