### PR TITLE
Notes: Capture the target block before saving a block-level note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -300,12 +300,14 @@ export function useNoteActions() {
 
 	const onCreate = async ( { content, parent } ) => {
 		try {
-			// Capture inline selection *before* the async save: focus may shift
-			// during the round-trip and the editor's stored selection can
-			// collapse if the user clicks elsewhere. The selection drives the
-			// in-content marker written below, which is the note's only anchor.
+			// Capture the target block and inline selection *before* the async
+			// save: selection may shift during the round-trip, attaching the
+			// note to the wrong block or collapsing its inline anchor.
 			const inlineSelection = ! parent
 				? readInlineSelection( getSelectionStart, getSelectionEnd )
+				: null;
+			const clientId = ! parent
+				? inlineSelection?.clientId || getSelectedBlockClientId()
 				: null;
 
 			const savedRecord = await saveEntityRecord(
@@ -329,12 +331,7 @@ export function useNoteActions() {
 			 * other id. Tracking issue:
 			 * https://github.com/WordPress/gutenberg/issues/74751.
 			 */
-			if ( ! parent && savedRecord?.id ) {
-				const clientId =
-					inlineSelection?.clientId || getSelectedBlockClientId();
-				if ( ! clientId ) {
-					return savedRecord;
-				}
+			if ( ! parent && savedRecord?.id && clientId ) {
 				const attributes = getBlockAttributes( clientId );
 				const metadata = attributes?.metadata;
 				const updatedMetadata = addNoteIdToMetadata(


### PR DESCRIPTION
## What?
Fixes #80675.

A block-level note now attaches to the block that was selected when the note was submitted, not whichever block happens to be selected when the REST create resolves.

## Why?

`onCreate` resolved the target `clientId` via `getSelectedBlockClientId()` *after* awaiting the save. On a slow connection, clicking a different block while the request was pending redirected the note to the wrong block.

## How?

- Capture `clientId` *before* the async save, alongside `inlineSelection`, using the same `inlineSelection?.clientId || getSelectedBlockClientId()` resolution.
- Drop the post-save re-resolution and fold the `clientId` guard into the block-update condition, so a note with no target block still fires the "Note added." snackbar.

## Testing Instructions

1. Create two paragraph blocks.
2. Enable Slow 3G throttling in DevTools.
3. Select the first paragraph and add a note.
4. While the POST is pending, click the second paragraph.
5. Confirm the note attaches to the **first** paragraph.


## Use of AI Tools

Assisted by Claude.
