### PR TITLE
Dark/light mode support for themes on theme.json 

### DIFF
--- a/docs/how-to-guides/themes/theme-json-dark-scheme.md
+++ b/docs/how-to-guides/themes/theme-json-dark-scheme.md
@@ -1,0 +1,132 @@
+# Color schemes (experimental)
+
+> **Status:** experimental prototype, opened for discussion. The shape of these
+> keys may change. See the tracking discussion linked from the pull request.
+
+A theme can provide alternate light and/or dark variants of its color presets,
+mirroring the CSS [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+model: the theme's base palette is the default, and `settings.color.light` /
+`settings.color.dark` override the *other* scheme. So a light-by-default theme adds
+a `dark` override, and a **dark-by-default theme adds a `light` override**. The
+feature is **fully opt-in**: without the keys below, output is unchanged.
+
+## How it works
+
+Color and gradient presets are already emitted as CSS custom properties
+(`--wp--preset--color--{slug}`, `--wp--preset--gradient--{slug}`). A scheme override
+**redefines those same custom properties** under the matching
+`prefers-color-scheme` media query. Anything that references a preset — theme
+styles, block styles, user selections made through the palette — flips
+automatically. Nothing that uses raw, non-preset color values is changed.
+
+Presets are matched by `slug`. A base preset with no override keeps its single
+value in every scheme. A scheme section overrides the base presets rather than
+adding to them, so an entry whose `slug` has no base preset is ignored.
+
+## Overriding the automatic scheme (`data-scheme`)
+
+The dark overrides respond to a `data-scheme` attribute on the root (`<html>`)
+element, so a visitor's choice can override the operating system:
+
+| `data-scheme` | Behavior |
+| --- | --- |
+| _absent_ or `system` | Follow the OS via `prefers-color-scheme` (the default). |
+| `light` | Never apply the dark values — stay light even if the OS is dark. |
+| `dark` | Always apply the dark values, regardless of the OS. |
+
+`data-scheme` is intended to be set **in memory only** — the automatic
+`prefers-color-scheme` behavior is always the default. It is not persisted (no
+`localStorage`, `sessionStorage`, or cookies), so the page returns to the system
+preference after navigation or reload. Core ships no UI to set it; you can exercise
+the mechanism by setting `document.documentElement.dataset.scheme = 'dark'` (or
+`'light'`, or removing it to return to the system default) in the browser console.
+
+## Authoring — inline light/dark presets
+
+```json
+{
+	"version": 3,
+	"settings": {
+		"color": {
+			"palette": [
+				{ "slug": "base", "name": "Base", "color": "#ffffff" },
+				{ "slug": "contrast", "name": "Contrast", "color": "#111111" }
+			],
+			"dark": {
+				"palette": [
+					{ "slug": "base", "color": "#111111" },
+					{ "slug": "contrast", "color": "#ffffff" }
+				]
+			}
+		}
+	}
+}
+```
+
+This emits, roughly (the `data-scheme` rules let a visitor control override the OS):
+
+```css
+:root {
+	--wp--preset--color--base: #ffffff;
+	--wp--preset--color--contrast: #111111;
+}
+@media (prefers-color-scheme: dark) {
+	:root:not([data-scheme="light"]) {
+		--wp--preset--color--base: #111111;
+		--wp--preset--color--contrast: #ffffff;
+	}
+}
+:root[data-scheme="dark"] {
+	--wp--preset--color--base: #111111;
+	--wp--preset--color--contrast: #ffffff;
+}
+```
+
+`dark` (and `light`) may contain `palette` and `gradients`.
+
+### Dark by default (a `light` override)
+
+For a theme whose base palette is dark, add a `light` override instead — it is
+emitted under `prefers-color-scheme: light`, so visitors whose OS is in light mode
+(or who opt into light) get the light values:
+
+```json
+{
+	"version": 3,
+	"settings": {
+		"color": {
+			"palette": [
+				{ "slug": "base", "name": "Base", "color": "#111111" },
+				{ "slug": "contrast", "name": "Contrast", "color": "#ffffff" }
+			],
+			"light": {
+				"palette": [
+					{ "slug": "base", "color": "#ffffff" },
+					{ "slug": "contrast", "color": "#111111" }
+				]
+			}
+		}
+	}
+}
+```
+
+A theme may define `light`, `dark`, or both. When both are set, the base palette is
+the fallback for visitors whose OS expresses no preference.
+
+## Backward compatibility
+
+`color.light` and `color.dark` are additive, optional keys under the current
+`theme.json` version — there is **no new version**. Older WordPress releases that
+don't recognize them simply strip them during sanitization, so the theme renders
+with its base palette. A single `theme.json` works on old and new WordPress.
+
+## Not covered (yet)
+
+- Persisting a visitor's `data-scheme` choice across page loads. If ever added, it
+  would be a dedicated visitor-preferences feature with its own privacy review, not
+  a default.
+- Dark duotone variants.
+- Automatic generation of dark values — the theme must define them; the system
+  never derives colors automatically.
+- Raw (non-preset) colors, per-block fixed colors, images/logos, and nested light/dark
+  surfaces. These remain the theme's responsibility.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -312,6 +312,12 @@
 		"parent": "themes"
 	},
 	{
+		"title": "Color schemes (experimental)",
+		"slug": "theme-json-dark-scheme",
+		"markdown_source": "../docs/how-to-guides/themes/theme-json-dark-scheme.md",
+		"parent": "themes"
+	},
+	{
 		"title": "Client-Side Media Processing",
 		"slug": "client-side-media",
 		"markdown_source": "../docs/how-to-guides/client-side-media.md",

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -99,6 +99,8 @@ Settings related to colors.
 | custom | Allow users to select custom colors. | `boolean` | `true` |
 | customDuotone | Allow users to create custom duotone filters. | `boolean` | `true` |
 | customGradient | Allow users to create custom gradients. | `boolean` | `true` |
+| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme="dark"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged. | `{ palette, gradients }` |  |
+| light | Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme="light"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in. | `{ palette, gradients }` |  |
 | defaultDuotone | Allow users to choose filters from the default duotone filter presets. | `boolean` | `true` |
 | defaultGradients | Allow users to choose colors from the default gradients. | `boolean` | `true` |
 | defaultPalette | Allow users to choose colors from the default palette. | `boolean` | `true` |

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -133,7 +133,10 @@
 					{
 						"docs/how-to-guides/themes/global-settings-and-styles.md": []
 					},
-					{ "docs/how-to-guides/themes/theme-support.md": [] }
+					{ "docs/how-to-guides/themes/theme-support.md": [] },
+					{
+						"docs/how-to-guides/themes/theme-json-dark-scheme.md": []
+					}
 				]
 			},
 			{ "docs/how-to-guides/client-side-media.md": [] },

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -418,6 +418,8 @@ class WP_Theme_JSON_Gutenberg {
 			'custom'           => null,
 			'customDuotone'    => null,
 			'customGradient'   => null,
+			'dark'             => null,
+			'light'            => null,
 			'defaultDuotone'   => null,
 			'defaultGradients' => null,
 			'defaultPalette'   => null,
@@ -2524,9 +2526,158 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $vars_by_selector as $rule_selector => $declarations ) {
 				$stylesheet .= static::to_ruleset( $rule_selector, $declarations );
 			}
+
+			/*
+			 * Emit theme-authored per-scheme preset overrides (palette, gradients),
+			 * mirroring the CSS `prefers-color-scheme` model: the base presets are
+			 * the default, and `color.light` / `color.dark` override the other
+			 * scheme. A theme can therefore be light by default with a dark override,
+			 * or dark by default with a light override. Because these override the
+			 * existing `--wp--preset--*` custom properties, any value referencing a
+			 * preset flips automatically.
+			 *
+			 * The overrides respond to a root `data-scheme` attribute so a visitor
+			 * control can override the automatic behavior. For each scheme:
+			 *   - no attribute / `system`: follow the OS via `prefers-color-scheme`,
+			 *     unless the visitor forced the opposite scheme,
+			 *   - `data-scheme="<scheme>"`: always apply that scheme's values.
+			 */
+			foreach ( array( 'light', 'dark' ) as $scheme ) {
+				$scheme_declarations = static::compute_scheme_preset_vars( $node, $scheme );
+				if ( empty( $scheme_declarations ) ) {
+					continue;
+				}
+				$opposite        = 'dark' === $scheme ? 'light' : 'dark';
+				$auto_selector   = static::get_scheme_scoped_selector( $selector, ':not([data-scheme="' . $opposite . '"])' );
+				$forced_selector = static::get_scheme_scoped_selector( $selector, '[data-scheme="' . $scheme . '"]' );
+				$stylesheet     .= '@media (prefers-color-scheme: ' . $scheme . '){' . static::to_ruleset( $auto_selector, $scheme_declarations ) . '}';
+				$stylesheet     .= static::to_ruleset( $forced_selector, $scheme_declarations );
+			}
 		}
 
 		return $stylesheet;
+	}
+
+	/**
+	 * Attaches a `data-scheme` condition to the root element of a selector so
+	 * dark-scheme overrides can respond to a visitor's chosen color scheme.
+	 *
+	 * The `data-scheme` attribute lives on the root (`<html>`) element, so the
+	 * condition is inserted directly after the leading `:root` token. Selectors
+	 * that do not start with `:root` are scoped under an `html` root carrying the
+	 * condition.
+	 *
+	 * @param string $selector  The base selector (e.g. `:root` or `:root :where(...)`).
+	 * @param string $condition The attribute condition (e.g. `[data-scheme="dark"]`).
+	 * @return string The scheme-scoped selector.
+	 */
+	protected static function get_scheme_scoped_selector( $selector, $condition ) {
+		$root = static::ROOT_CSS_PROPERTIES_SELECTOR; // ':root'.
+		if ( 0 === strpos( $selector, $root ) ) {
+			return $root . $condition . substr( $selector, strlen( $root ) );
+		}
+		return 'html' . $condition . ' ' . $selector;
+	}
+
+	/**
+	 * Given a settings node, extracts theme-authored per-scheme preset overrides
+	 * and returns them as CSS Custom Property declarations.
+	 *
+	 * Reads `color.<scheme>.palette` and `color.<scheme>.gradients`, where
+	 * `<scheme>` is `light` or `dark`. The overrides are matched by slug to the
+	 * base presets, so only overridden slugs emit a value; base slugs without a
+	 * counterpart keep their single value in every scheme, and a scheme preset
+	 * whose slug has no base preset is ignored. This is fully opt-in: absent the
+	 * key, no declarations are produced and output is unchanged.
+	 *
+	 * @param array  $node   Settings node (global or block-level).
+	 * @param string $scheme The scheme to read: `light` or `dark`.
+	 * @return array List of `array( 'name' => ..., 'value' => ... )` declarations.
+	 */
+	protected static function compute_scheme_preset_vars( $node, $scheme ) {
+		$overrides = $node['color'][ $scheme ] ?? array();
+		if ( empty( $overrides ) || ! is_array( $overrides ) ) {
+			return array();
+		}
+
+		$preset_css_vars = array(
+			'palette'   => array(
+				'css_var'   => '--wp--preset--color--$slug',
+				'value_key' => 'color',
+			),
+			'gradients' => array(
+				'css_var'   => '--wp--preset--gradient--$slug',
+				'value_key' => 'gradient',
+			),
+		);
+
+		$declarations = array();
+		foreach ( $preset_css_vars as $preset_key => $meta ) {
+			if ( empty( $overrides[ $preset_key ] ) || ! is_array( $overrides[ $preset_key ] ) ) {
+				continue;
+			}
+
+			/*
+			 * A scheme section overrides the base presets; it does not introduce
+			 * new ones. A slug with no base preset has no class, no editor entry
+			 * and nothing referencing its custom property, so emitting a value for
+			 * it would only produce a declaration that exists in one scheme.
+			 */
+			$base_slugs = array();
+			if ( ! empty( $node['color'][ $preset_key ] ) && is_array( $node['color'][ $preset_key ] ) ) {
+				foreach ( static::flatten_scheme_presets( $node['color'][ $preset_key ] ) as $base_preset ) {
+					if ( isset( $base_preset['slug'] ) ) {
+						$base_slugs[ _wp_to_kebab_case( $base_preset['slug'] ) ] = true;
+					}
+				}
+			}
+			if ( empty( $base_slugs ) ) {
+				continue;
+			}
+
+			foreach ( static::flatten_scheme_presets( $overrides[ $preset_key ] ) as $preset ) {
+				if ( ! isset( $preset['slug'], $preset[ $meta['value_key'] ] ) ) {
+					continue;
+				}
+				$slug = _wp_to_kebab_case( $preset['slug'] );
+				if ( ! isset( $base_slugs[ $slug ] ) ) {
+					continue;
+				}
+				$declarations[] = array(
+					'name'  => static::replace_slug_in_string( $meta['css_var'], $slug ),
+					'value' => $preset[ $meta['value_key'] ],
+				);
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Normalizes a preset list to a flat, numerically indexed array.
+	 *
+	 * Accepts both a flat list (as a scheme section is authored inline in
+	 * `settings.color.<scheme>`) and the origin-keyed structure the base presets
+	 * use once they have been merged per origin.
+	 *
+	 * @param array $presets A flat or origin-keyed list of presets.
+	 * @return array A flat list of presets.
+	 */
+	protected static function flatten_scheme_presets( $presets ) {
+		if ( ! is_array( $presets ) ) {
+			return array();
+		}
+		if ( wp_is_numeric_array( $presets ) ) {
+			return $presets;
+		}
+
+		$flattened = array();
+		foreach ( static::VALID_ORIGINS as $origin ) {
+			if ( ! empty( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
+				$flattened = array_merge( $flattened, $presets[ $origin ] );
+			}
+		}
+		return $flattened;
 	}
 
 	/**

--- a/phpunit/theme-json-dark-scheme-test.php
+++ b/phpunit/theme-json-dark-scheme-test.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Tests for the opt-in dark-scheme color data model in theme.json.
+ *
+ * Covers `settings.color.dark` (inline dark presets) emission, the single-value
+ * fallback, and backward-compatible/opt-in behavior.
+ *
+ * @package Gutenberg
+ */
+
+class Theme_JSON_Dark_Scheme_Test extends WP_UnitTestCase {
+
+	/**
+	 * Builds a theme.json with a base palette and an optional dark override,
+	 * then returns the generated CSS variables split around the dark gate.
+	 *
+	 * @param array $color The `settings.color` array to use.
+	 * @return array {
+	 *     @type string $full  The full variables stylesheet.
+	 *     @type string $light Everything before the dark media query.
+	 *     @type string $dark  Everything inside/after the dark media query ('' if none).
+	 * }
+	 */
+	private function get_variables_split( $color ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array( 'color' => $color ),
+			)
+		);
+
+		$full  = $theme_json->get_stylesheet( array( 'variables' ) );
+		$parts = explode( '@media (prefers-color-scheme: dark)', $full, 2 );
+
+		return array(
+			'full'  => $full,
+			'light' => $parts[0],
+			'dark'  => $parts[1] ?? '',
+		);
+	}
+
+	public function test_inline_dark_palette_emits_gated_override() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'primary',
+						'name'  => 'Primary',
+						'color' => '#111111',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#eeeeee',
+						),
+					),
+				),
+			)
+		);
+
+		// A dark gate is emitted.
+		$this->assertStringContainsString( '@media (prefers-color-scheme: dark)', $result['full'] );
+		// Base (light) value is emitted at the root, not inside the gate.
+		$this->assertStringContainsString( '#111111', $result['light'] );
+		// Dark value is emitted only inside the gate.
+		$this->assertStringContainsString( '#eeeeee', $result['dark'] );
+		$this->assertStringNotContainsString( '#eeeeee', $result['light'] );
+		// The override targets the existing preset custom property.
+		$this->assertStringContainsString( '--wp--preset--color--primary', $result['dark'] );
+	}
+
+	public function test_inline_dark_gradient_emits_gated_override() {
+		$result = $this->get_variables_split(
+			array(
+				'gradients' => array(
+					array(
+						'slug'     => 'pop',
+						'name'     => 'Pop',
+						'gradient' => 'linear-gradient(#000, #111)',
+					),
+				),
+				'dark'      => array(
+					'gradients' => array(
+						array(
+							'slug'     => 'pop',
+							'name'     => 'Pop',
+							'gradient' => 'linear-gradient(#fff, #eee)',
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '--wp--preset--gradient--pop', $result['dark'] );
+		$this->assertStringContainsString( 'linear-gradient(#fff, #eee)', $result['dark'] );
+	}
+
+	public function test_single_value_slug_has_no_dark_override() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'primary',
+						'name'  => 'Primary',
+						'color' => '#111111',
+					),
+					array(
+						'slug'  => 'secondary',
+						'name'  => 'Secondary',
+						'color' => '#222222',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#eeeeee',
+						),
+					),
+				),
+			)
+		);
+
+		// Overridden slug appears in the dark gate; unoverridden slug does not.
+		$this->assertStringContainsString( '--wp--preset--color--primary', $result['dark'] );
+		$this->assertStringNotContainsString( '--wp--preset--color--secondary', $result['dark'] );
+	}
+
+	public function test_dark_only_slug_is_ignored() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'primary',
+						'name'  => 'Primary',
+						'color' => '#111111',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#eeeeee',
+						),
+						array(
+							'slug'  => 'midnight',
+							'name'  => 'Midnight',
+							'color' => '#000033',
+						),
+					),
+				),
+			)
+		);
+
+		/*
+		 * A scheme section overrides base presets rather than introducing new
+		 * ones, so a slug with no base preset emits nothing in either scheme.
+		 */
+		$this->assertStringContainsString( '--wp--preset--color--primary', $result['dark'] );
+		$this->assertStringNotContainsString( '--wp--preset--color--midnight', $result['full'] );
+	}
+
+	public function test_dark_overrides_respond_to_data_scheme_attribute() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#ffffff',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#111111',
+						),
+					),
+				),
+			)
+		);
+
+		// Automatic dark (OS) applies unless the visitor opted out to light.
+		$this->assertStringContainsString( ':root:not([data-scheme="light"])', $result['full'] );
+		// An explicit dark choice forces the dark values regardless of OS.
+		$this->assertStringContainsString( ':root[data-scheme="dark"]', $result['full'] );
+		// Both scheme-scoped rules carry the dark value.
+		$this->assertStringContainsString( '#111111', $result['dark'] );
+	}
+
+	public function test_light_scheme_emits_gated_override() {
+		// A dark-by-default theme: base palette is dark, `light` is the override.
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#111111',
+					),
+				),
+				'light'   => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#ffffff',
+						),
+					),
+				),
+			)
+		);
+		$full   = $result['full'];
+
+		// Light override is gated on `prefers-color-scheme: light`, applied unless forced dark.
+		$this->assertStringContainsString( '@media (prefers-color-scheme: light)', $full );
+		$this->assertStringContainsString( ':root:not([data-scheme="dark"])', $full );
+		// A forced-light choice re-asserts the light values.
+		$this->assertStringContainsString( ':root[data-scheme="light"]', $full );
+		$this->assertStringContainsString( '#ffffff', $full );
+		// No dark gate is emitted when only `light` is defined.
+		$this->assertStringNotContainsString( 'prefers-color-scheme: dark', $full );
+	}
+
+	public function test_light_and_dark_can_coexist() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#888888',
+					),
+				),
+				'light'   => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#ffffff',
+						),
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#000000',
+						),
+					),
+				),
+			)
+		);
+		$full   = $result['full'];
+
+		$this->assertStringContainsString( '@media (prefers-color-scheme: light)', $full );
+		$this->assertStringContainsString( '@media (prefers-color-scheme: dark)', $full );
+		$this->assertStringContainsString( ':root[data-scheme="light"]', $full );
+		$this->assertStringContainsString( ':root[data-scheme="dark"]', $full );
+	}
+
+	public function test_no_dark_key_emits_no_gate_and_is_unchanged() {
+		$base_only = array(
+			'palette' => array(
+				array(
+					'slug'  => 'primary',
+					'name'  => 'Primary',
+					'color' => '#111111',
+				),
+			),
+		);
+
+		// An absent dark section must not alter output at all (fully opt-in).
+		$result = $this->get_variables_split( $base_only );
+
+		$this->assertStringNotContainsString( '@media (prefers-color-scheme: dark)', $result['full'] );
+		$this->assertStringContainsString( '#111111', $result['full'] );
+	}
+}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -152,6 +152,112 @@
 							"type": "boolean",
 							"default": true
 						},
+						"dark": {
+							"description": "Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme=\"dark\"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged.",
+							"type": "object",
+							"properties": {
+								"palette": {
+									"description": "Dark-scheme color palette. Slugs override matching entries in `palette`; unmatched base slugs keep their single value in both schemes.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the color preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base palette slug.",
+												"type": "string"
+											},
+											"color": {
+												"description": "CSS hex or rgb(a) string for the dark scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "color" ],
+										"additionalProperties": false
+									}
+								},
+								"gradients": {
+									"description": "Dark-scheme gradient presets. Slugs override matching entries in `gradients`.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the gradient preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base gradient slug.",
+												"type": "string"
+											},
+											"gradient": {
+												"description": "CSS gradient string for the dark scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "gradient" ],
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"light": {
+							"description": "Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme=\"light\"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in.",
+							"type": "object",
+							"properties": {
+								"palette": {
+									"description": "Light-scheme color palette. Slugs override matching entries in `palette`; unmatched base slugs keep their single value in every scheme.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the color preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base palette slug.",
+												"type": "string"
+											},
+											"color": {
+												"description": "CSS hex or rgb(a) string for the light scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "color" ],
+										"additionalProperties": false
+									}
+								},
+								"gradients": {
+									"description": "Light-scheme gradient presets. Slugs override matching entries in `gradients`.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the gradient preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base gradient slug.",
+												"type": "string"
+											},
+											"gradient": {
+												"description": "CSS gradient string for the light scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "gradient" ],
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
+						},
 						"defaultDuotone": {
 							"description": "Allow users to choose filters from the default duotone filter presets.",
 							"type": "boolean",


### PR DESCRIPTION
## What / Why

**Technical prototype for discussion — not ready to merge.** Adds an opt-in color scheme data model to `theme.json`. Themes can provide light or dark variants of color and gradient presets; the front end and editor canvas follow `prefers-color-scheme`, while `data-scheme` can force a value.

This PR is limited to the data model discussed in #24368, #42828, and #39372.

## Stack

| PR | Base | Adds |
| --- | --- | --- |
| **#80698** | `trunk` | Palette and gradient scheme overrides |
| **#80746** | #80698 | Duotone scheme overrides |
| **#80805** | #80746 | Global Styles controls |
| **#80809** | #80805 | Contextual editor previews and complete alternative palettes |

## How it works

Scheme presets match base presets by `slug` and redefine the existing `--wp--preset--*` custom properties. Presets without an override keep their base value.

A light-first theme adds `settings.color.dark`; a dark-first theme adds `settings.color.light`:

```jsonc
"settings": { "color": {
  "palette": [ { "slug": "base", "name": "Base", "color": "#fff" } ],
  "dark": { "palette": [ { "slug": "base", "color": "#111" } ] }
} }
```

Without `data-scheme`, the page follows the OS. `light` and `dark` force that scheme; removing the attribute returns to the system preference. The override is intentionally not persisted.

## Testing

### Automated

```bash
npm run wp-env-test start
npm run wp-env-test -- run --env-cwd=wp-content/plugins/gutenberg \
  wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter Theme_JSON_Dark_Scheme_Test
```

### Manual

Use the two fixtures in [WordPress/community-themes#266](https://github.com/WordPress/community-themes/pull/266) with a Gutenberg build containing this PR and #80746.

1. Activate `light-theme`. Use **System**, **Citrus Daylight**, and **Electric Dusk**; confirm the background, text, primary card, and Signal gradient switch together without a reload.
2. Confirm the Fixed accent badge does not change, because it has no override.
3. Repeat with `dark-theme` to test a dark-first theme with a light override.
4. Repeat the system appearance check in the Site Editor canvas.
5. Remove the scheme keys and confirm no scheme media block is emitted.

### Screenshots

<table>
<tr><th colspan="2"><code>light-theme</code></th></tr>
<tr><th>Light: Citrus Daylight</th><th>Dark: Electric Dusk</th></tr>
<tr>
<td><img alt="Light theme using Citrus Daylight" src="https://github.com/user-attachments/assets/c35dba09-744c-42b0-a473-a2ed65c3b4ef"></td>
<td><img alt="Light theme using Electric Dusk" src="https://github.com/user-attachments/assets/dbadbe97-a0ec-4e8f-89f5-f895b4e913e2"></td>
</tr>
<tr><th colspan="2"><code>dark-theme</code></th></tr>
<tr><th>Dark: Midnight Terminal</th><th>Light: Paper Morning</th></tr>
<tr>
<td><img alt="Dark theme using Midnight Terminal" src="https://github.com/user-attachments/assets/916a2839-8742-47ac-b2e9-abcfe5ee4b96"></td>
<td><img alt="Dark theme using Paper Morning" src="https://github.com/user-attachments/assets/8b4ac66e-5a86-43dc-a663-01b284e406cc"></td>
</tr>
</table>

See `docs/how-to-guides/themes/theme-json-dark-scheme.md`.