### PR TITLE
Dark mode: data-scheme runtime + pre-paint bootstrap (Phase 2a, stacked on #80698)

### DIFF
--- a/docs/how-to-guides/themes/theme-json-dark-scheme.md
+++ b/docs/how-to-guides/themes/theme-json-dark-scheme.md
@@ -20,6 +20,27 @@ non-preset color values is changed.
 Presets are matched by `slug`. A base preset with no dark counterpart keeps its
 single value in both schemes.
 
+## Overriding the automatic scheme (`data-scheme`)
+
+The dark overrides respond to a `data-scheme` attribute on the root (`<html>`)
+element, so a visitor's choice can override the operating system:
+
+| `data-scheme` | Behavior |
+| --- | --- |
+| _absent_ or `system` | Follow the OS via `prefers-color-scheme` (the default). |
+| `light` | Never apply the dark values — stay light even if the OS is dark. |
+| `dark` | Always apply the dark values, regardless of the OS. |
+
+The preference is persisted in `localStorage` under the `wp-color-scheme` key and
+applied to the root element **before first paint** by a small inline bootstrap
+script, so a saved choice never flashes the wrong scheme on load. The bootstrap is
+only emitted on the front end when the active theme provides a dark scheme.
+
+> A visitor-facing **toggle block** that writes this preference is added in a
+> follow-up change. Until then you can exercise the mechanism by setting
+> `localStorage.setItem( 'wp-color-scheme', 'dark' )` (or `'light'`) in the browser
+> console and reloading.
+
 ## Authoring source A — inline `settings.color.dark`
 
 ```json
@@ -88,8 +109,9 @@ its light scheme. A single `theme.json` works on old and new WordPress.
 
 ## Not covered (yet)
 
-- A visitor-facing toggle to override the automatic scheme, and a site-wide setting
-  to disable automatic switching. These are planned as a follow-up.
+- A visitor-facing toggle **block** that writes the `wp-color-scheme` preference,
+  and a site-wide setting to disable automatic switching. The `data-scheme` runtime
+  above is in place; the block UI is the next follow-up.
 - Dark duotone variants.
 - Automatic generation of dark values — the theme must define them; the system
   never derives colors automatically.

--- a/docs/how-to-guides/themes/theme-json-dark-scheme.md
+++ b/docs/how-to-guides/themes/theme-json-dark-scheme.md
@@ -1,0 +1,97 @@
+# Dark color scheme (experimental)
+
+> **Status:** experimental prototype, opened for discussion. The shape of these
+> keys may change. See the tracking discussion linked from the pull request.
+
+A theme can provide a dark variant of its color presets. When the visitor's
+operating system prefers a dark color scheme, the dark preset values are applied
+automatically. The feature is **fully opt-in**: without the keys below, output is
+unchanged and the site stays light.
+
+## How it works
+
+Color and gradient presets are already emitted as CSS custom properties
+(`--wp--preset--color--{slug}`, `--wp--preset--gradient--{slug}`). The dark scheme
+**redefines those same custom properties** under a `prefers-color-scheme: dark`
+media query. Anything that references a preset — theme styles, block styles, user
+selections made through the palette — flips automatically. Nothing that uses raw,
+non-preset color values is changed.
+
+Presets are matched by `slug`. A base preset with no dark counterpart keeps its
+single value in both schemes.
+
+## Authoring source A — inline `settings.color.dark`
+
+```json
+{
+	"version": 3,
+	"settings": {
+		"color": {
+			"palette": [
+				{ "slug": "base", "name": "Base", "color": "#ffffff" },
+				{ "slug": "contrast", "name": "Contrast", "color": "#111111" }
+			],
+			"dark": {
+				"palette": [
+					{ "slug": "base", "color": "#111111" },
+					{ "slug": "contrast", "color": "#ffffff" }
+				]
+			}
+		}
+	}
+}
+```
+
+This emits, roughly:
+
+```css
+:root {
+	--wp--preset--color--base: #ffffff;
+	--wp--preset--color--contrast: #111111;
+}
+@media (prefers-color-scheme: dark) {
+	:root {
+		--wp--preset--color--base: #111111;
+		--wp--preset--color--contrast: #ffffff;
+	}
+}
+```
+
+`dark` may contain `palette` and `gradients`. (Duotone is not yet supported.)
+
+## Authoring source B — reference a style variation
+
+If your theme already ships a dark style variation in its `styles/` directory, you
+can point at it by title instead of duplicating the palette:
+
+```json
+{
+	"version": 3,
+	"settings": {
+		"color": {
+			"darkScheme": "Midnight"
+		}
+	}
+}
+```
+
+Only the variation's color palette and gradients are used as the dark scheme; its
+other styles are ignored. If both `dark` and `darkScheme` are present, the inline
+`dark` takes precedence.
+
+## Backward compatibility
+
+`color.dark` and `color.darkScheme` are additive, optional keys under the current
+`theme.json` version — there is **no new version**. Older WordPress releases that
+don't recognize them simply strip them during sanitization, so the theme renders in
+its light scheme. A single `theme.json` works on old and new WordPress.
+
+## Not covered (yet)
+
+- A visitor-facing toggle to override the automatic scheme, and a site-wide setting
+  to disable automatic switching. These are planned as a follow-up.
+- Dark duotone variants.
+- Automatic generation of dark values — the theme must define them; the system
+  never derives colors automatically.
+- Raw (non-preset) colors, per-block fixed colors, images/logos, and nested light/dark
+  surfaces. These remain the theme's responsibility.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -312,6 +312,12 @@
 		"parent": "themes"
 	},
 	{
+		"title": "Dark color scheme (experimental)",
+		"slug": "theme-json-dark-scheme",
+		"markdown_source": "../docs/how-to-guides/themes/theme-json-dark-scheme.md",
+		"parent": "themes"
+	},
+	{
 		"title": "Client-Side Media Processing",
 		"slug": "client-side-media",
 		"markdown_source": "../docs/how-to-guides/client-side-media.md",

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -99,6 +99,8 @@ Settings related to colors.
 | custom | Allow users to select custom colors. | `boolean` | `true` |
 | customDuotone | Allow users to create custom duotone filters. | `boolean` | `true` |
 | customGradient | Allow users to create custom gradients. | `boolean` | `true` |
+| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here. | `{ palette, gradients }` |  |
+| darkScheme | Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the dark scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `dark` is also set, `dark` takes precedence. | `string` |  |
 | defaultDuotone | Allow users to choose filters from the default duotone filter presets. | `boolean` | `true` |
 | defaultGradients | Allow users to choose colors from the default gradients. | `boolean` | `true` |
 | defaultPalette | Allow users to choose colors from the default palette. | `boolean` | `true` |

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -133,7 +133,10 @@
 					{
 						"docs/how-to-guides/themes/global-settings-and-styles.md": []
 					},
-					{ "docs/how-to-guides/themes/theme-support.md": [] }
+					{ "docs/how-to-guides/themes/theme-support.md": [] },
+					{
+						"docs/how-to-guides/themes/theme-json-dark-scheme.md": []
+					}
 				]
 			},
 			{ "docs/how-to-guides/client-side-media.md": [] },

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2528,19 +2528,47 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			/*
-			 * Emit theme-authored dark-scheme preset overrides (palette, gradients)
-			 * under a `prefers-color-scheme: dark` gate. Because these override the
-			 * existing `--wp--preset--*` custom properties, any value referencing a
-			 * preset flips automatically. The gate is authored so a future opt-out
-			 * layer (a root `data-scheme` attribute) can be layered on top.
+			 * Emit theme-authored dark-scheme preset overrides (palette, gradients).
+			 * Because these override the existing `--wp--preset--*` custom properties,
+			 * any value referencing a preset flips automatically.
+			 *
+			 * The overrides respond to a root `data-scheme` attribute so a visitor
+			 * control can override the automatic behavior:
+			 *   - no attribute / `system`: follow the OS via `prefers-color-scheme`,
+			 *   - `light`: never apply the dark values (opt out),
+			 *   - `dark`: always apply the dark values.
 			 */
 			$dark_declarations = static::compute_dark_preset_vars( $node );
 			if ( ! empty( $dark_declarations ) ) {
-				$stylesheet .= '@media (prefers-color-scheme: dark){' . static::to_ruleset( $selector, $dark_declarations ) . '}';
+				$auto_selector   = static::get_scheme_scoped_selector( $selector, ':not([data-scheme="light"])' );
+				$forced_selector = static::get_scheme_scoped_selector( $selector, '[data-scheme="dark"]' );
+				$stylesheet     .= '@media (prefers-color-scheme: dark){' . static::to_ruleset( $auto_selector, $dark_declarations ) . '}';
+				$stylesheet     .= static::to_ruleset( $forced_selector, $dark_declarations );
 			}
 		}
 
 		return $stylesheet;
+	}
+
+	/**
+	 * Attaches a `data-scheme` condition to the root element of a selector so
+	 * dark-scheme overrides can respond to a visitor's chosen color scheme.
+	 *
+	 * The `data-scheme` attribute lives on the root (`<html>`) element, so the
+	 * condition is inserted directly after the leading `:root` token. Selectors
+	 * that do not start with `:root` are scoped under an `html` root carrying the
+	 * condition.
+	 *
+	 * @param string $selector  The base selector (e.g. `:root` or `:root :where(...)`).
+	 * @param string $condition The attribute condition (e.g. `[data-scheme="dark"]`).
+	 * @return string The scheme-scoped selector.
+	 */
+	protected static function get_scheme_scoped_selector( $selector, $condition ) {
+		$root = static::ROOT_CSS_PROPERTIES_SELECTOR; // ':root'.
+		if ( 0 === strpos( $selector, $root ) ) {
+			return $root . $condition . substr( $selector, strlen( $root ) );
+		}
+		return 'html' . $condition . ' ' . $selector;
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -418,6 +418,8 @@ class WP_Theme_JSON_Gutenberg {
 			'custom'           => null,
 			'customDuotone'    => null,
 			'customGradient'   => null,
+			'dark'             => null,
+			'darkScheme'       => null,
 			'defaultDuotone'   => null,
 			'defaultGradients' => null,
 			'defaultPalette'   => null,
@@ -2524,9 +2526,89 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $vars_by_selector as $rule_selector => $declarations ) {
 				$stylesheet .= static::to_ruleset( $rule_selector, $declarations );
 			}
+
+			/*
+			 * Emit theme-authored dark-scheme preset overrides (palette, gradients)
+			 * under a `prefers-color-scheme: dark` gate. Because these override the
+			 * existing `--wp--preset--*` custom properties, any value referencing a
+			 * preset flips automatically. The gate is authored so a future opt-out
+			 * layer (a root `data-scheme` attribute) can be layered on top.
+			 */
+			$dark_declarations = static::compute_dark_preset_vars( $node );
+			if ( ! empty( $dark_declarations ) ) {
+				$stylesheet .= '@media (prefers-color-scheme: dark){' . static::to_ruleset( $selector, $dark_declarations ) . '}';
+			}
 		}
 
 		return $stylesheet;
+	}
+
+	/**
+	 * Given a settings node, extracts theme-authored dark-scheme preset
+	 * overrides and returns them as CSS Custom Property declarations.
+	 *
+	 * Reads `color.dark.palette` and `color.dark.gradients`, which the resolver
+	 * also populates from a `color.darkScheme` variation reference. The dark
+	 * presets are matched by slug to the base presets they override, so only
+	 * overridden slugs emit a value; slugs without a dark counterpart keep their
+	 * single value in both schemes. This is fully opt-in: absent `color.dark`,
+	 * no declarations are produced and output is unchanged.
+	 *
+	 * @param array $node Settings node (global or block-level).
+	 * @return array List of `array( 'name' => ..., 'value' => ... )` declarations.
+	 */
+	protected static function compute_dark_preset_vars( $node ) {
+		$dark = $node['color']['dark'] ?? array();
+		if ( empty( $dark ) || ! is_array( $dark ) ) {
+			return array();
+		}
+
+		$preset_css_vars = array(
+			'palette'   => array(
+				'css_var'   => '--wp--preset--color--$slug',
+				'value_key' => 'color',
+			),
+			'gradients' => array(
+				'css_var'   => '--wp--preset--gradient--$slug',
+				'value_key' => 'gradient',
+			),
+		);
+
+		$declarations = array();
+		foreach ( $preset_css_vars as $preset_key => $meta ) {
+			if ( empty( $dark[ $preset_key ] ) || ! is_array( $dark[ $preset_key ] ) ) {
+				continue;
+			}
+
+			/*
+			 * Accept both a flat list of presets (as authored inline in
+			 * `settings.color.dark`) and an origin-keyed structure (as it may
+			 * arrive when sourced from a `darkScheme` style variation).
+			 */
+			$presets = $dark[ $preset_key ];
+			if ( ! wp_is_numeric_array( $presets ) ) {
+				$flattened = array();
+				foreach ( static::VALID_ORIGINS as $origin ) {
+					if ( ! empty( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
+						$flattened = array_merge( $flattened, $presets[ $origin ] );
+					}
+				}
+				$presets = $flattened;
+			}
+
+			foreach ( $presets as $preset ) {
+				if ( ! isset( $preset['slug'], $preset[ $meta['value_key'] ] ) ) {
+					continue;
+				}
+				$slug           = _wp_to_kebab_case( $preset['slug'] );
+				$declarations[] = array(
+					'name'  => static::replace_slug_in_string( $meta['css_var'], $slug ),
+					'value' => $preset[ $meta['value_key'] ],
+				);
+			}
+		}
+
+		return $declarations;
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -271,6 +271,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$theme_json_data = static::inject_variations_from_block_style_variation_files( $theme_json_data, $variations );
 			$theme_json_data = static::inject_variations_from_block_styles_registry( $theme_json_data );
 
+			// Resolve a `settings.color.darkScheme` variation reference into `settings.color.dark`.
+			$theme_json_data = static::resolve_dark_scheme_variation( $theme_json_data );
+
 			/**
 			 * Filters the data provided by the theme for global styles and settings.
 			 *
@@ -757,6 +760,53 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 */
 	public static function get_style_variations( $scope = 'theme' ) {
 		return static::get_style_variations_from_directory( get_stylesheet_directory(), $scope );
+	}
+
+	/**
+	 * Resolves a `settings.color.darkScheme` variation reference into
+	 * `settings.color.dark`.
+	 *
+	 * When a theme sets `settings.color.darkScheme` to the title of a style
+	 * variation, this copies that variation's color palette and gradients into
+	 * `settings.color.dark` so they are emitted as the dark scheme. Only the
+	 * variation's color presets are used; its other styles are ignored. An
+	 * inline `settings.color.dark` takes precedence and is left untouched.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param array $theme_json_data Raw theme.json data.
+	 * @return array The theme.json data, with `settings.color.dark` populated when applicable.
+	 */
+	protected static function resolve_dark_scheme_variation( $theme_json_data ) {
+		$color       = $theme_json_data['settings']['color'] ?? array();
+		$dark_scheme = $color['darkScheme'] ?? null;
+
+		// Nothing to resolve, or an inline `dark` is present and wins.
+		if ( empty( $dark_scheme ) || ! empty( $color['dark'] ) ) {
+			return $theme_json_data;
+		}
+
+		foreach ( static::get_style_variations( 'theme' ) as $variation ) {
+			if ( ! isset( $variation['title'] ) || $variation['title'] !== $dark_scheme ) {
+				continue;
+			}
+
+			$variation_color = $variation['settings']['color'] ?? array();
+			$dark            = array();
+			if ( ! empty( $variation_color['palette'] ) ) {
+				$dark['palette'] = $variation_color['palette'];
+			}
+			if ( ! empty( $variation_color['gradients'] ) ) {
+				$dark['gradients'] = $variation_color['gradients'];
+			}
+
+			if ( ! empty( $dark ) ) {
+				$theme_json_data['settings']['color']['dark'] = $dark;
+			}
+			break;
+		}
+
+		return $theme_json_data;
 	}
 
 	/**

--- a/lib/compat/wordpress-7.1/color-scheme.php
+++ b/lib/compat/wordpress-7.1/color-scheme.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Visitor color scheme (dark mode) runtime.
+ *
+ * Front-end support for the opt-in dark color scheme data model. Themes provide
+ * dark presets via `settings.color.dark` / `settings.color.darkScheme`, which are
+ * emitted as CSS custom properties gated on a root `data-scheme` attribute:
+ *
+ *   - no attribute / `system`: follow the OS via `prefers-color-scheme`,
+ *   - `light`: never apply the dark values (opt out),
+ *   - `dark`: always apply the dark values.
+ *
+ * This file applies a visitor's stored preference before first paint, so a saved
+ * choice does not flash the wrong scheme on load. The preference is persisted in
+ * `localStorage` under `wp-color-scheme` (written by the color scheme toggle,
+ * added in a follow-up change).
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Whether the active theme provides a dark color scheme.
+ *
+ * True when the merged theme.json defines inline dark presets
+ * (`settings.color.dark`) or references a dark style variation
+ * (`settings.color.darkScheme`).
+ *
+ * @return bool
+ */
+function gutenberg_theme_supports_color_scheme() {
+	$color = gutenberg_get_global_settings( array( 'color' ) );
+	return ! empty( $color['dark'] ) || ! empty( $color['darkScheme'] );
+}
+
+/**
+ * Prints the pre-paint color scheme bootstrap script.
+ *
+ * Reads the visitor's stored `data-scheme` preference from localStorage and
+ * applies it to the root element synchronously in the document head, before the
+ * page paints. Only emitted on the front end when the theme supports a dark
+ * scheme, so themes without dark presets are entirely unaffected.
+ *
+ * @return void
+ */
+function gutenberg_print_color_scheme_bootstrap() {
+	if ( is_admin() || ! gutenberg_theme_supports_color_scheme() ) {
+		return;
+	}
+
+	// Keep this tiny and dependency-free: it must run before first paint.
+	$script = "(function(){try{var s=window.localStorage.getItem('wp-color-scheme');" .
+		"if(s==='light'||s==='dark'||s==='system'){" .
+		"document.documentElement.setAttribute('data-scheme',s);}}catch(e){}})();";
+
+	wp_print_inline_script_tag( $script, array( 'id' => 'wp-color-scheme-bootstrap' ) );
+}
+// Priority 0 so the attribute is set before stylesheets are parsed/applied.
+add_action( 'wp_head', 'gutenberg_print_color_scheme_bootstrap', 0 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -75,6 +75,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.1/class-wp-rest-icon-collections-controller.php';
 	require __DIR__ . '/compat/wordpress-7.1/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.1/block-bindings.php';
+	require __DIR__ . '/compat/wordpress-7.1/color-scheme.php';
 	require __DIR__ . '/compat/wordpress-7.1/query-block.php';
 	require __DIR__ . '/compat/wordpress-7.1/block-comments.php';
 

--- a/phpunit/theme-json-dark-scheme-test.php
+++ b/phpunit/theme-json-dark-scheme-test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for the opt-in dark-scheme color data model in theme.json.
+ *
+ * Covers `settings.color.dark` (inline dark presets) emission, the single-value
+ * fallback, and backward-compatible/opt-in behavior. See
+ * sdd/dark-mode-site-editor/spec.md.
+ *
+ * @package Gutenberg
+ */
+
+class Theme_JSON_Dark_Scheme_Test extends WP_UnitTestCase {
+
+	/**
+	 * Builds a theme.json with a base palette and an optional dark override,
+	 * then returns the generated CSS variables split around the dark gate.
+	 *
+	 * @param array $color The `settings.color` array to use.
+	 * @return array {
+	 *     @type string $full  The full variables stylesheet.
+	 *     @type string $light Everything before the dark media query.
+	 *     @type string $dark  Everything inside/after the dark media query ('' if none).
+	 * }
+	 */
+	private function get_variables_split( $color ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array( 'color' => $color ),
+			)
+		);
+
+		$full  = $theme_json->get_stylesheet( array( 'variables' ) );
+		$parts = explode( '@media (prefers-color-scheme: dark)', $full, 2 );
+
+		return array(
+			'full'  => $full,
+			'light' => $parts[0],
+			'dark'  => $parts[1] ?? '',
+		);
+	}
+
+	public function test_inline_dark_palette_emits_gated_override() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'primary',
+						'name'  => 'Primary',
+						'color' => '#111111',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#eeeeee',
+						),
+					),
+				),
+			)
+		);
+
+		// A dark gate is emitted.
+		$this->assertStringContainsString( '@media (prefers-color-scheme: dark)', $result['full'] );
+		// Base (light) value is emitted at the root, not inside the gate.
+		$this->assertStringContainsString( '#111111', $result['light'] );
+		// Dark value is emitted only inside the gate.
+		$this->assertStringContainsString( '#eeeeee', $result['dark'] );
+		$this->assertStringNotContainsString( '#eeeeee', $result['light'] );
+		// The override targets the existing preset custom property.
+		$this->assertStringContainsString( '--wp--preset--color--primary', $result['dark'] );
+	}
+
+	public function test_inline_dark_gradient_emits_gated_override() {
+		$result = $this->get_variables_split(
+			array(
+				'gradients' => array(
+					array(
+						'slug'     => 'pop',
+						'name'     => 'Pop',
+						'gradient' => 'linear-gradient(#000, #111)',
+					),
+				),
+				'dark'      => array(
+					'gradients' => array(
+						array(
+							'slug'     => 'pop',
+							'name'     => 'Pop',
+							'gradient' => 'linear-gradient(#fff, #eee)',
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '--wp--preset--gradient--pop', $result['dark'] );
+		$this->assertStringContainsString( 'linear-gradient(#fff, #eee)', $result['dark'] );
+	}
+
+	public function test_single_value_slug_has_no_dark_override() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'primary',
+						'name'  => 'Primary',
+						'color' => '#111111',
+					),
+					array(
+						'slug'  => 'secondary',
+						'name'  => 'Secondary',
+						'color' => '#222222',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'primary',
+							'name'  => 'Primary',
+							'color' => '#eeeeee',
+						),
+					),
+				),
+			)
+		);
+
+		// Overridden slug appears in the dark gate; unoverridden slug does not.
+		$this->assertStringContainsString( '--wp--preset--color--primary', $result['dark'] );
+		$this->assertStringNotContainsString( '--wp--preset--color--secondary', $result['dark'] );
+	}
+
+	public function test_no_dark_key_emits_no_gate_and_is_unchanged() {
+		$base_only = array(
+			'palette' => array(
+				array(
+					'slug'  => 'primary',
+					'name'  => 'Primary',
+					'color' => '#111111',
+				),
+			),
+		);
+
+		// An absent dark section must not alter output at all (fully opt-in).
+		$result = $this->get_variables_split( $base_only );
+
+		$this->assertStringNotContainsString( '@media (prefers-color-scheme: dark)', $result['full'] );
+		$this->assertStringContainsString( '#111111', $result['full'] );
+	}
+}

--- a/phpunit/theme-json-dark-scheme-test.php
+++ b/phpunit/theme-json-dark-scheme-test.php
@@ -131,6 +131,36 @@ class Theme_JSON_Dark_Scheme_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '--wp--preset--color--secondary', $result['dark'] );
 	}
 
+	public function test_dark_overrides_respond_to_data_scheme_attribute() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#ffffff',
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#111111',
+						),
+					),
+				),
+			)
+		);
+
+		// Automatic dark (OS) applies unless the visitor opted out to light.
+		$this->assertStringContainsString( ':root:not([data-scheme="light"])', $result['full'] );
+		// An explicit dark choice forces the dark values regardless of OS.
+		$this->assertStringContainsString( ':root[data-scheme="dark"]', $result['full'] );
+		// Both scheme-scoped rules carry the dark value.
+		$this->assertStringContainsString( '#111111', $result['dark'] );
+	}
+
 	public function test_no_dark_key_emits_no_gate_and_is_unchanged() {
 		$base_only = array(
 			'palette' => array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -152,6 +152,63 @@
 							"type": "boolean",
 							"default": true
 						},
+						"dark": {
+							"description": "Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here.",
+							"type": "object",
+							"properties": {
+								"palette": {
+									"description": "Dark-scheme color palette. Slugs override matching entries in `palette`; unmatched base slugs keep their single value in both schemes.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the color preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base palette slug.",
+												"type": "string"
+											},
+											"color": {
+												"description": "CSS hex or rgb(a) string for the dark scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "color" ],
+										"additionalProperties": false
+									}
+								},
+								"gradients": {
+									"description": "Dark-scheme gradient presets. Slugs override matching entries in `gradients`.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the gradient preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base gradient slug.",
+												"type": "string"
+											},
+											"gradient": {
+												"description": "CSS gradient string for the dark scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "gradient" ],
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"darkScheme": {
+							"description": "Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the dark scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `dark` is also set, `dark` takes precedence.",
+							"type": "string"
+						},
 						"defaultDuotone": {
 							"description": "Allow users to choose filters from the default duotone filter presets.",
 							"type": "boolean",


### PR DESCRIPTION
## What / Why

**Prototype — stacked on #80698 (please review that first).** Second step toward visitor-facing dark mode: it makes the opt-in dark color scheme **overridable by the visitor** via a root `data-scheme` attribute, and applies a stored preference before first paint.

> ⚠️ **Base branch is `try/theme-json-color-schemes` (#80698), not `trunk`.** Review only the diff on top of that PR.

## What this adds

1. **`data-scheme`-aware CSS gate.** The dark preset overrides from #80698 are now emitted so they respond to a root `data-scheme` attribute:

   | `data-scheme` | Behavior |
   | --- | --- |
   | _absent_ / `system` | Follow the OS via `prefers-color-scheme` (default) |
   | `light` | Never apply dark values — opt out |
   | `dark` | Always apply dark values, regardless of OS |

   Concretely, the overrides are emitted under both `:root:not([data-scheme="light"])` (inside the `prefers-color-scheme: dark` media query) and `:root[data-scheme="dark"]`.

2. **Pre-paint bootstrap.** A tiny inline script (front end only, and only when the theme provides a dark scheme) reads a `wp-color-scheme` preference from `localStorage` and sets `data-scheme` on `<html>` **before first paint**, so a saved choice never flashes the wrong scheme. Added in `lib/compat/wordpress-7.1/color-scheme.php`.

## Testing

### Automated

`Theme_JSON_Dark_Scheme_Test` now covers the `data-scheme` gating — **5 tests / 14 assertions passing**:

```
npm run wp-env-test start
npx wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' \
  wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter Theme_JSON_Dark_Scheme_Test
```

### Manual (verified)

With a dark-capable theme (add `settings.color.dark` to Twenty Twenty-Four's `theme.json` overriding the `base`/`contrast` slugs — see #80698):

1. Load the front end — confirmed the page includes the `wp-color-scheme-bootstrap` inline script and the gated CSS (`:root[data-scheme="dark"]`, `@media (prefers-color-scheme: dark)`).
2. In the console: `localStorage.setItem('wp-color-scheme','dark')` → reload → site is dark regardless of OS. `'light'` → stays light even with OS in dark. `'system'` (or clear the key) → follows the OS.
3. No flash of the wrong scheme on reload (bootstrap runs before paint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)