### PR TITLE
Writing flow: grow keyboard selections block by block over blocks without text

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -181,6 +181,7 @@ export function getClosestTabbable(
 
 export default function useArrowNav() {
 	const {
+		getBlockName,
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
 		getNextBlockClientId,
@@ -319,6 +320,63 @@ export default function useArrowNav() {
 					event.preventDefault();
 				}
 				return;
+			}
+
+			// Extending into a block that does not support splitting (a
+			// spacer, a separator, a verse) covers it whole: a partial
+			// selection has no value within it, since it cannot merge, and
+			// the browser may have no text position to move the selection
+			// focus to anyway, skipping the block (e.g. a spacer after the
+			// line the caret is on). Record the block selection instead of
+			// letting the browser act.
+			if ( shiftKey ) {
+				const selection = defaultView.getSelection();
+				const focusClientId =
+					selection.rangeCount &&
+					selection.focusNode &&
+					getBlockClientId( selection.focusNode );
+
+				// Within the block the browser moves the selection line by
+				// line; only act at the block's edge in the key's direction.
+				// A selection focus at an element boundary has no rectangle
+				// to measure an edge from and is a block edge itself.
+				const focusElement =
+					focusClientId &&
+					( selection.focusNode.nodeType ===
+					selection.focusNode.ELEMENT_NODE
+						? selection.focusNode
+						: selection.focusNode.parentElement );
+				const focusRichText =
+					focusElement &&
+					focusElement.closest( '[data-wp-block-attribute-key]' );
+				const isFocusAtEdge =
+					focusClientId &&
+					( ! focusRichText ||
+						selection.focusNode.nodeType !==
+							selection.focusNode.TEXT_NODE ||
+						isNavEdge( focusRichText, isReverse ) );
+
+				if ( isFocusAtEdge ) {
+					const adjacentClientId = isReverse
+						? getPreviousBlockClientId( focusClientId )
+						: getNextBlockClientId( focusClientId );
+
+					if (
+						adjacentClientId &&
+						! hasBlockSupport(
+							getBlockName( adjacentClientId ),
+							'splitting',
+							false
+						)
+					) {
+						multiSelect(
+							getSelectionStart().clientId ?? focusClientId,
+							adjacentClientId
+						);
+						event.preventDefault();
+						return;
+					}
+				}
 			}
 
 			// Abort if our current target is not a candidate for navigation

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -14,6 +14,7 @@ import {
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
+import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -174,6 +175,7 @@ export function getClosestTabbable(
 
 export default function useArrowNav() {
 	const {
+		getBlockName,
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
 		getNextBlockClientId,
@@ -312,6 +314,63 @@ export default function useArrowNav() {
 					event.preventDefault();
 				}
 				return;
+			}
+
+			// Extending into a block that does not support splitting (a
+			// spacer, a separator, a verse) covers it whole: a partial
+			// selection has no value within it, since it cannot merge, and
+			// the browser may have no text position to move the selection
+			// focus to anyway, skipping the block (e.g. a spacer after the
+			// line the caret is on). Record the block selection instead of
+			// letting the browser act.
+			if ( shiftKey ) {
+				const selection = defaultView.getSelection();
+				const focusClientId =
+					selection.rangeCount &&
+					selection.focusNode &&
+					getBlockClientId( selection.focusNode );
+
+				// Within the block the browser moves the selection line by
+				// line; only act at the block's edge in the key's direction.
+				// A selection focus at an element boundary has no rectangle
+				// to measure an edge from and is a block edge itself.
+				const focusElement =
+					focusClientId &&
+					( selection.focusNode.nodeType ===
+					selection.focusNode.ELEMENT_NODE
+						? selection.focusNode
+						: selection.focusNode.parentElement );
+				const focusRichText =
+					focusElement &&
+					focusElement.closest( '[data-wp-block-attribute-key]' );
+				const isFocusAtEdge =
+					focusClientId &&
+					( ! focusRichText ||
+						selection.focusNode.nodeType !==
+							selection.focusNode.TEXT_NODE ||
+						isNavEdge( focusRichText, isReverse ) );
+
+				if ( isFocusAtEdge ) {
+					const adjacentClientId = isReverse
+						? getPreviousBlockClientId( focusClientId )
+						: getNextBlockClientId( focusClientId );
+
+					if (
+						adjacentClientId &&
+						! hasBlockSupport(
+							getBlockName( adjacentClientId ),
+							'splitting',
+							false
+						)
+					) {
+						multiSelect(
+							getSelectionStart().clientId ?? focusClientId,
+							adjacentClientId
+						);
+						event.preventDefault();
+						return;
+					}
+				}
 			}
 
 			// Abort if our current target is not a candidate for navigation

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -124,12 +124,9 @@ export default function useSelectionObserver() {
 			const { defaultView } = ownerDocument;
 
 			let isTripleClick = false;
-			let isKeyboardExtension = false;
-			let keyboardFocusClientId = null;
 
 			function onMouseDown( event ) {
 				isTripleClick = event.detail === 3;
-				isKeyboardExtension = false;
 				// A shift+click makes a multi-selection: mark the gesture as
 				// in progress so the clicked block's focus handler does not
 				// select it (collapsing the native range being made), and so
@@ -140,23 +137,8 @@ export default function useSelectionObserver() {
 				}
 			}
 
-			function onKeyDown( event ) {
+			function onKeyDown() {
 				isTripleClick = false;
-				isKeyboardExtension =
-					event.shiftKey &&
-					[
-						'ArrowDown',
-						'ArrowUp',
-						'ArrowLeft',
-						'ArrowRight',
-					].includes( event.key );
-				// Where the native selection focus is as the key goes down.
-				// The store cannot serve as the reference: its update is
-				// asynchronous, and the next press may arrive first. The
-				// native selection is always current.
-				keyboardFocusClientId = isKeyboardExtension
-					? getBlockClientId( defaultView.getSelection().focusNode )
-					: null;
 			}
 
 			function onSelectionChange( event ) {
@@ -247,66 +229,6 @@ export default function useSelectionObserver() {
 
 				let startClientId = getBlockClientId( startNode );
 				let endClientId = getBlockClientId( endNode );
-
-				// A keyboard extension moves the native focus to the nearest
-				// text position. A block without one (e.g. a spacer) is
-				// skipped: the native selection reaches into the block
-				// beyond it. The selection must grow block by block instead,
-				// so record a block selection up to the first skipped block.
-				// A block that could hold a partial text selection is never
-				// skipped (it has a text position to land in), so the
-				// skipped block is always fully covered. The overshot native
-				// selection is left alone here; use-multi-selection clears
-				// it while presenting the block selection, and further
-				// presses extend the block selection (use-arrow-nav).
-				if (
-					isKeyboardExtension &&
-					! selection.isCollapsed &&
-					startClientId &&
-					endClientId &&
-					keyboardFocusClientId &&
-					keyboardFocusClientId !== endClientId &&
-					startClientId !== endClientId
-				) {
-					const previousElement = ownerDocument.getElementById(
-						`block-${ keyboardFocusClientId }`
-					);
-					const endElement = ownerDocument.getElementById(
-						`block-${ endClientId }`
-					);
-
-					if (
-						previousElement &&
-						endElement &&
-						// Only among siblings: an extension across a nesting
-						// boundary is promoted to the common level instead
-						// (below).
-						previousElement.parentElement ===
-							endElement.parentElement
-					) {
-						const position =
-							previousElement.compareDocumentPosition(
-								endElement
-							);
-						const isForward = !! (
-							// eslint-disable-next-line no-bitwise
-							( position & node.DOCUMENT_POSITION_FOLLOWING )
-						);
-						const sibling = isForward
-							? previousElement.nextElementSibling
-							: previousElement.previousElementSibling;
-						const siblingClientId =
-							sibling && getBlockClientId( sibling );
-
-						if (
-							siblingClientId &&
-							siblingClientId !== endClientId
-						) {
-							multiSelect( startClientId, siblingClientId );
-							return;
-						}
-					}
-				}
 
 				// If the selection has changed and we had pressed `shift+click`,
 				// we need to check if in an element that doesn't support

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -124,9 +124,12 @@ export default function useSelectionObserver() {
 			const { defaultView } = ownerDocument;
 
 			let isTripleClick = false;
+			let isKeyboardExtension = false;
+			let keyboardFocusClientId = null;
 
 			function onMouseDown( event ) {
 				isTripleClick = event.detail === 3;
+				isKeyboardExtension = false;
 				// A shift+click makes a multi-selection: mark the gesture as
 				// in progress so the clicked block's focus handler does not
 				// select it (collapsing the native range being made), and so
@@ -137,8 +140,23 @@ export default function useSelectionObserver() {
 				}
 			}
 
-			function onKeyDown() {
+			function onKeyDown( event ) {
 				isTripleClick = false;
+				isKeyboardExtension =
+					event.shiftKey &&
+					[
+						'ArrowDown',
+						'ArrowUp',
+						'ArrowLeft',
+						'ArrowRight',
+					].includes( event.key );
+				// Where the native selection focus is as the key goes down.
+				// The store cannot serve as the reference: its update is
+				// asynchronous, and the next press may arrive first. The
+				// native selection is always current.
+				keyboardFocusClientId = isKeyboardExtension
+					? getBlockClientId( defaultView.getSelection().focusNode )
+					: null;
 			}
 
 			function onSelectionChange( event ) {
@@ -229,6 +247,66 @@ export default function useSelectionObserver() {
 
 				let startClientId = getBlockClientId( startNode );
 				let endClientId = getBlockClientId( endNode );
+
+				// A keyboard extension moves the native focus to the nearest
+				// text position. A block without one (e.g. a spacer) is
+				// skipped: the native selection reaches into the block
+				// beyond it. The selection must grow block by block instead,
+				// so record a block selection up to the first skipped block.
+				// A block that could hold a partial text selection is never
+				// skipped (it has a text position to land in), so the
+				// skipped block is always fully covered. The overshot native
+				// selection is left alone here; use-multi-selection clears
+				// it while presenting the block selection, and further
+				// presses extend the block selection (use-arrow-nav).
+				if (
+					isKeyboardExtension &&
+					! selection.isCollapsed &&
+					startClientId &&
+					endClientId &&
+					keyboardFocusClientId &&
+					keyboardFocusClientId !== endClientId &&
+					startClientId !== endClientId
+				) {
+					const previousElement = ownerDocument.getElementById(
+						`block-${ keyboardFocusClientId }`
+					);
+					const endElement = ownerDocument.getElementById(
+						`block-${ endClientId }`
+					);
+
+					if (
+						previousElement &&
+						endElement &&
+						// Only among siblings: an extension across a nesting
+						// boundary is promoted to the common level instead
+						// (below).
+						previousElement.parentElement ===
+							endElement.parentElement
+					) {
+						const position =
+							previousElement.compareDocumentPosition(
+								endElement
+							);
+						const isForward = !! (
+							// eslint-disable-next-line no-bitwise
+							( position & node.DOCUMENT_POSITION_FOLLOWING )
+						);
+						const sibling = isForward
+							? previousElement.nextElementSibling
+							: previousElement.previousElementSibling;
+						const siblingClientId =
+							sibling && getBlockClientId( sibling );
+
+						if (
+							siblingClientId &&
+							siblingClientId !== endClientId
+						) {
+							multiSelect( startClientId, siblingClientId );
+							return;
+						}
+					}
+				}
 
 				// If the selection has changed and we had pressed `shift+click`,
 				// we need to check if in an element that doesn't support

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:verse -->
+<pre class="wp-block-verse">verse</pre>
+<!-- /wp:verse -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:verse -->
-<pre class="wp-block-verse">verse</pre>
-<!-- /wp:verse -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B </p>
@@ -14,9 +14,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:verse -->
-<pre class="wp-block-verse">verse</pre>
-<!-- /wp:verse -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B </p>
@@ -14,9 +14,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:verse -->
-<pre class="wp-block-verse">verse</pre>
-<!-- /wp:verse -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-copy-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:verse -->
+<pre class="wp-block-verse">verse</pre>
+<!-- /wp:verse -->
 
 <!-- wp:paragraph -->
 <p>B </p>
@@ -14,9 +14,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:verse -->
+<pre class="wp-block-verse">verse</pre>
+<!-- /wp:verse -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:verse -->
+<pre class="wp-block-verse">verse</pre>
+<!-- /wp:verse -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-1-chromium.txt
@@ -2,9 +2,9 @@
 <p>A block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:verse -->
-<pre class="wp-block-verse">verse</pre>
-<!-- /wp:verse -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B block</p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B </p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:verse -->
+<pre class="wp-block-verse">verse</pre>
+<!-- /wp:verse -->
 
 <!-- wp:paragraph -->
 <p>B </p>

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-cut-paste-partial-selection-with-other-blocks-in-between-2-chromium.txt
@@ -2,9 +2,9 @@
 <p>block</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:verse -->
-<pre class="wp-block-verse">verse</pre>
-<!-- /wp:verse -->
+<!-- wp:paragraph -->
+<p>middle</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>B </p>

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -279,13 +279,37 @@ test.describe( 'Copy/cut/paste', () => {
 			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
-		await editor.insertBlock( { name: 'core/spacer' } );
-		await page.keyboard.press( 'Enter' );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'middle' },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		// Partial select from outer blocks.
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 5 } );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 2 );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 3 );
 		await pageUtils.pressKeys( 'primary+c' );
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
@@ -346,13 +370,37 @@ test.describe( 'Copy/cut/paste', () => {
 			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
-		await editor.insertBlock( { name: 'core/spacer' } );
-		await page.keyboard.press( 'Enter' );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'middle' },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		// Partial select from outer blocks.
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 5 } );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 2 );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 3 );
 		await pageUtils.pressKeys( 'primary+x' );
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -282,13 +282,37 @@ test.describe( 'Copy/cut/paste', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
-		await editor.insertBlock( { name: 'core/spacer' } );
-		await page.keyboard.press( 'Enter' );
+		await editor.insertBlock( {
+			name: 'core/verse',
+			attributes: { content: 'verse' },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		// Partial select from outer blocks.
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 5 } );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 2 );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 3 );
 		await pageUtils.pressKeys( 'primary+c' );
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.
@@ -349,13 +373,37 @@ test.describe( 'Copy/cut/paste', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
-		await editor.insertBlock( { name: 'core/spacer' } );
-		await page.keyboard.press( 'Enter' );
+		await editor.insertBlock( {
+			name: 'core/verse',
+			attributes: { content: 'verse' },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 		// Partial select from outer blocks.
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 5 } );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 2 );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlockClientIds().length
+				)
+			)
+			.toBe( 3 );
 		await pageUtils.pressKeys( 'primary+x' );
 		await pageUtils.pressKeys( 'primary+ArrowLeft' );
 		// Sometimes the caret has not moved to the correct position before pressing Enter.

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -283,8 +283,8 @@ test.describe( 'Copy/cut/paste', () => {
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( {
-			name: 'core/verse',
-			attributes: { content: 'verse' },
+			name: 'core/paragraph',
+			attributes: { content: 'middle' },
 		} );
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );
@@ -374,8 +374,8 @@ test.describe( 'Copy/cut/paste', () => {
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( {
-			name: 'core/verse',
-			attributes: { content: 'verse' },
+			name: 'core/paragraph',
+			attributes: { content: 'middle' },
 		} );
 		await editor.insertBlock( { name: 'core/paragraph' } );
 		await page.keyboard.type( 'B block' );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1756,6 +1756,110 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 				] );
 		} );
 
+		test( 'should extend the selection block by block over a block without text', async ( {
+			page,
+			editor,
+			multiBlockSelectionUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'first paragraph' },
+			} );
+			await editor.insertBlock( { name: 'core/spacer' } );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'second paragraph' },
+			} );
+
+			// Click within the text, not the (full row width) center.
+			await editor.canvas
+				.getByText( 'first paragraph', { exact: true } )
+				.click( { position: { x: 40, y: 8 } } );
+
+			// The nearest text position is in the second paragraph, but
+			// the selection must not reach past the spacer: it becomes a
+			// block selection up to the spacer.
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+				] );
+
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'second paragraph' },
+					},
+				] );
+
+			// The selection also shrinks block by block.
+			await page.keyboard.press( 'Shift+ArrowUp' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+				] );
+		} );
+
+		test( 'should select a block without splitting support as a block when extending into it', async ( {
+			page,
+			editor,
+			multiBlockSelectionUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'a paragraph' },
+			} );
+			await editor.insertBlock( {
+				name: 'core/verse',
+				attributes: { content: 'a verse' },
+			} );
+			// Deselect so the verse's block toolbar does not cover the
+			// paragraph.
+			await page.evaluate( () =>
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.clearSelectedBlock()
+			);
+
+			await editor.canvas
+				.getByText( 'a paragraph', { exact: true } )
+				.click( { position: { x: 40, y: 8 } } );
+
+			// The verse has text, but no value for a partial selection: it
+			// cannot split or merge, so it is selected as a block.
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'a paragraph' },
+					},
+					{
+						name: 'core/verse',
+						attributes: { content: 'a verse' },
+					},
+				] );
+		} );
+
 		test( 'should extend the selection from a block without a text selection', async ( {
 			page,
 			editor,

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1727,6 +1727,68 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 				] );
 		} );
 
+		test( 'should extend the selection block by block over a block without text', async ( {
+			page,
+			editor,
+			multiBlockSelectionUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'first paragraph' },
+			} );
+			await editor.insertBlock( { name: 'core/spacer' } );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'second paragraph' },
+			} );
+
+			// Click within the text, not the (full row width) center.
+			await editor.canvas
+				.getByText( 'first paragraph', { exact: true } )
+				.click( { position: { x: 40, y: 8 } } );
+
+			// The nearest text position is in the second paragraph, but
+			// the selection must not reach past the spacer: it becomes a
+			// block selection up to the spacer.
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+				] );
+
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'second paragraph' },
+					},
+				] );
+
+			// The selection also shrinks block by block.
+			await page.keyboard.press( 'Shift+ArrowUp' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'first paragraph' },
+					},
+					{ name: 'core/spacer' },
+				] );
+		} );
+
 		test( 'should extend the selection from a block without a text selection', async ( {
 			page,
 			editor,

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1789,6 +1789,48 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 				] );
 		} );
 
+		test( 'should select a block without splitting support as a block when extending into it', async ( {
+			page,
+			editor,
+			multiBlockSelectionUtils,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'a paragraph' },
+			} );
+			await editor.insertBlock( {
+				name: 'core/verse',
+				attributes: { content: 'a verse' },
+			} );
+			// Deselect so the verse's block toolbar does not cover the
+			// paragraph.
+			await page.evaluate( () =>
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.clearSelectedBlock()
+			);
+
+			await editor.canvas
+				.getByText( 'a paragraph', { exact: true } )
+				.click( { position: { x: 40, y: 8 } } );
+
+			// The verse has text, but no value for a partial selection: it
+			// cannot split or merge, so it is selected as a block.
+			await page.keyboard.press( 'Shift+ArrowDown' );
+			await expect
+				.poll( multiBlockSelectionUtils.getSelectedBlocks )
+				.toMatchObject( [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'a paragraph' },
+					},
+					{
+						name: 'core/verse',
+						attributes: { content: 'a verse' },
+					},
+				] );
+		} );
+
 		test( 'should extend the selection from a block without a text selection', async ( {
 			page,
 			editor,


### PR DESCRIPTION
## What?
Fixes #53674. Extending a selection with shift+arrow into a block that does not support splitting (a spacer, a separator, a verse) selects that block as a block, instead of overshooting into the block beyond it. The selection grows and shrinks block by block.

## Why?
A shift+arrow press moves the native focus to the nearest text position. A spacer has none, so the browser lands in the paragraph beyond it, and the observer faithfully recorded a three-block selection where two were expected. More generally, a partial selection has no value within a block that cannot split or merge: deleting such a selection removes the block whole anyway.

## How?
In `use-arrow-nav`, at keydown: when the selection focus is at its block's edge in the key's direction and the adjacent block does not support splitting, select up to that block as a block and prevent the browser from acting. The store updates synchronously, so a fast next press cannot race it, and no overshot native selection ever exists. Mid-block presses and adjacent blocks that support splitting are left entirely to the browser, including its column memory. Further presses grow or shrink the block selection one block at a time (#63259 machinery).

The trade-off: the keyboard no longer produces a partial text selection ending inside a non-splitting block. Partial selections with a block in between remain possible when the blocks support splitting, and via mouse selection; the copy and cut tests for that case use a paragraph in the middle.

## Testing Instructions
1. Insert a paragraph, a spacer, and a paragraph. Put the caret in the middle of the first paragraph.
2. Press Shift+ArrowDown: the first paragraph and the spacer are selected (previously all three blocks).
3. Press Shift+ArrowDown again: all three blocks are selected. Shift+ArrowUp shrinks back to two.
4. Replace the spacer with a verse: Shift+ArrowDown from the paragraph selects the paragraph and the whole verse.

Covered by e2e tests asserting each step in all three engines; they fail on trunk.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.