### PR TITLE
Color schemes: symmetric light override / dark-by-default (stacked on #80700)

### DIFF
--- a/docs/how-to-guides/themes/theme-json-dark-scheme.md
+++ b/docs/how-to-guides/themes/theme-json-dark-scheme.md
@@ -1,24 +1,26 @@
-# Dark color scheme (experimental)
+# Color schemes (experimental)
 
 > **Status:** experimental prototype, opened for discussion. The shape of these
 > keys may change. See the tracking discussion linked from the pull request.
 
-A theme can provide a dark variant of its color presets. When the visitor's
-operating system prefers a dark color scheme, the dark preset values are applied
-automatically. The feature is **fully opt-in**: without the keys below, output is
-unchanged and the site stays light.
+A theme can provide alternate light and/or dark variants of its color presets,
+mirroring the CSS [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+model: the theme's base palette is the default, and `settings.color.light` /
+`settings.color.dark` override the *other* scheme. So a light-by-default theme adds
+a `dark` override, and a **dark-by-default theme adds a `light` override**. The
+feature is **fully opt-in**: without the keys below, output is unchanged.
 
 ## How it works
 
 Color and gradient presets are already emitted as CSS custom properties
-(`--wp--preset--color--{slug}`, `--wp--preset--gradient--{slug}`). The dark scheme
-**redefines those same custom properties** under a `prefers-color-scheme: dark`
-media query. Anything that references a preset — theme styles, block styles, user
-selections made through the palette — flips automatically. Nothing that uses raw,
-non-preset color values is changed.
+(`--wp--preset--color--{slug}`, `--wp--preset--gradient--{slug}`). A scheme override
+**redefines those same custom properties** under the matching
+`prefers-color-scheme` media query. Anything that references a preset — theme
+styles, block styles, user selections made through the palette — flips
+automatically. Nothing that uses raw, non-preset color values is changed.
 
-Presets are matched by `slug`. A base preset with no dark counterpart keeps its
-single value in both schemes.
+Presets are matched by `slug`. A base preset with no override keeps its single
+value in every scheme.
 
 ## Overriding the automatic scheme (`data-scheme`)
 
@@ -63,7 +65,7 @@ only emitted on the front end when the active theme provides a dark scheme.
 }
 ```
 
-This emits, roughly:
+This emits, roughly (the `data-scheme` rules let a visitor control override the OS):
 
 ```css
 :root {
@@ -71,14 +73,48 @@ This emits, roughly:
 	--wp--preset--color--contrast: #111111;
 }
 @media (prefers-color-scheme: dark) {
-	:root {
+	:root:not([data-scheme="light"]) {
 		--wp--preset--color--base: #111111;
 		--wp--preset--color--contrast: #ffffff;
 	}
 }
+:root[data-scheme="dark"] {
+	--wp--preset--color--base: #111111;
+	--wp--preset--color--contrast: #ffffff;
+}
 ```
 
-`dark` may contain `palette` and `gradients`. (Duotone is not yet supported.)
+`dark` (and `light`) may contain `palette` and `gradients`. (Duotone is not yet
+supported.)
+
+### Dark by default (a `light` override)
+
+For a theme whose base palette is dark, add a `light` override instead — it is
+emitted under `prefers-color-scheme: light`, so visitors whose OS is in light mode
+(or who opt into light) get the light values:
+
+```json
+{
+	"version": 3,
+	"settings": {
+		"color": {
+			"palette": [
+				{ "slug": "base", "name": "Base", "color": "#111111" },
+				{ "slug": "contrast", "name": "Contrast", "color": "#ffffff" }
+			],
+			"light": {
+				"palette": [
+					{ "slug": "base", "color": "#ffffff" },
+					{ "slug": "contrast", "color": "#111111" }
+				]
+			}
+		}
+	}
+}
+```
+
+A theme may define `light`, `dark`, or both. When both are set, the base palette is
+the fallback for visitors whose OS expresses no preference.
 
 ## Authoring source B — reference a style variation
 
@@ -98,14 +134,15 @@ can point at it by title instead of duplicating the palette:
 
 Only the variation's color palette and gradients are used as the dark scheme; its
 other styles are ignored. If both `dark` and `darkScheme` are present, the inline
-`dark` takes precedence.
+`dark` takes precedence. `lightScheme` works the same way for the light scheme.
 
 ## Backward compatibility
 
-`color.dark` and `color.darkScheme` are additive, optional keys under the current
-`theme.json` version — there is **no new version**. Older WordPress releases that
-don't recognize them simply strip them during sanitization, so the theme renders in
-its light scheme. A single `theme.json` works on old and new WordPress.
+`color.light`, `color.dark`, `color.lightScheme`, and `color.darkScheme` are
+additive, optional keys under the current `theme.json` version — there is **no new
+version**. Older WordPress releases that don't recognize them simply strip them
+during sanitization, so the theme renders with its base palette. A single
+`theme.json` works on old and new WordPress.
 
 ## Not covered (yet)
 

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -99,8 +99,10 @@ Settings related to colors.
 | custom | Allow users to select custom colors. | `boolean` | `true` |
 | customDuotone | Allow users to create custom duotone filters. | `boolean` | `true` |
 | customGradient | Allow users to create custom gradients. | `boolean` | `true` |
-| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here. | `{ palette, gradients }` |  |
+| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme="dark"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here. | `{ palette, gradients }` |  |
 | darkScheme | Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the dark scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `dark` is also set, `dark` takes precedence. | `string` |  |
+| light | Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme="light"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in. Duotone is not yet supported here. | `{ palette, gradients }` |  |
+| lightScheme | Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the light scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `light` is also set, `light` takes precedence. | `string` |  |
 | defaultDuotone | Allow users to choose filters from the default duotone filter presets. | `boolean` | `true` |
 | defaultGradients | Allow users to choose colors from the default gradients. | `boolean` | `true` |
 | defaultPalette | Allow users to choose colors from the default palette. | `boolean` | `true` |

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -420,6 +420,8 @@ class WP_Theme_JSON_Gutenberg {
 			'customGradient'   => null,
 			'dark'             => null,
 			'darkScheme'       => null,
+			'light'            => null,
+			'lightScheme'      => null,
 			'defaultDuotone'   => null,
 			'defaultGradients' => null,
 			'defaultPalette'   => null,
@@ -2528,22 +2530,30 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			/*
-			 * Emit theme-authored dark-scheme preset overrides (palette, gradients).
-			 * Because these override the existing `--wp--preset--*` custom properties,
-			 * any value referencing a preset flips automatically.
+			 * Emit theme-authored per-scheme preset overrides (palette, gradients),
+			 * mirroring the CSS `prefers-color-scheme` model: the base presets are
+			 * the default, and `color.light` / `color.dark` override the other
+			 * scheme. A theme can therefore be light by default with a dark override,
+			 * or dark by default with a light override. Because these override the
+			 * existing `--wp--preset--*` custom properties, any value referencing a
+			 * preset flips automatically.
 			 *
 			 * The overrides respond to a root `data-scheme` attribute so a visitor
-			 * control can override the automatic behavior:
+			 * control can override the automatic behavior. For each scheme:
 			 *   - no attribute / `system`: follow the OS via `prefers-color-scheme`,
-			 *   - `light`: never apply the dark values (opt out),
-			 *   - `dark`: always apply the dark values.
+			 *     unless the visitor forced the opposite scheme,
+			 *   - `data-scheme="<scheme>"`: always apply that scheme's values.
 			 */
-			$dark_declarations = static::compute_dark_preset_vars( $node );
-			if ( ! empty( $dark_declarations ) ) {
-				$auto_selector   = static::get_scheme_scoped_selector( $selector, ':not([data-scheme="light"])' );
-				$forced_selector = static::get_scheme_scoped_selector( $selector, '[data-scheme="dark"]' );
-				$stylesheet     .= '@media (prefers-color-scheme: dark){' . static::to_ruleset( $auto_selector, $dark_declarations ) . '}';
-				$stylesheet     .= static::to_ruleset( $forced_selector, $dark_declarations );
+			foreach ( array( 'light', 'dark' ) as $scheme ) {
+				$scheme_declarations = static::compute_scheme_preset_vars( $node, $scheme );
+				if ( empty( $scheme_declarations ) ) {
+					continue;
+				}
+				$opposite        = 'dark' === $scheme ? 'light' : 'dark';
+				$auto_selector   = static::get_scheme_scoped_selector( $selector, ':not([data-scheme="' . $opposite . '"])' );
+				$forced_selector = static::get_scheme_scoped_selector( $selector, '[data-scheme="' . $scheme . '"]' );
+				$stylesheet     .= '@media (prefers-color-scheme: ' . $scheme . '){' . static::to_ruleset( $auto_selector, $scheme_declarations ) . '}';
+				$stylesheet     .= static::to_ruleset( $forced_selector, $scheme_declarations );
 			}
 		}
 
@@ -2572,22 +2582,23 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Given a settings node, extracts theme-authored dark-scheme preset
-	 * overrides and returns them as CSS Custom Property declarations.
+	 * Given a settings node, extracts theme-authored per-scheme preset overrides
+	 * and returns them as CSS Custom Property declarations.
 	 *
-	 * Reads `color.dark.palette` and `color.dark.gradients`, which the resolver
-	 * also populates from a `color.darkScheme` variation reference. The dark
-	 * presets are matched by slug to the base presets they override, so only
-	 * overridden slugs emit a value; slugs without a dark counterpart keep their
-	 * single value in both schemes. This is fully opt-in: absent `color.dark`,
-	 * no declarations are produced and output is unchanged.
+	 * Reads `color.<scheme>.palette` and `color.<scheme>.gradients` (where
+	 * `<scheme>` is `light` or `dark`), which the resolver also populates from a
+	 * `color.<scheme>Scheme` variation reference. The overrides are matched by
+	 * slug to the base presets, so only overridden slugs emit a value; slugs
+	 * without a counterpart keep their single value in every scheme. This is fully
+	 * opt-in: absent the key, no declarations are produced and output is unchanged.
 	 *
-	 * @param array $node Settings node (global or block-level).
+	 * @param array  $node   Settings node (global or block-level).
+	 * @param string $scheme The scheme to read: `light` or `dark`.
 	 * @return array List of `array( 'name' => ..., 'value' => ... )` declarations.
 	 */
-	protected static function compute_dark_preset_vars( $node ) {
-		$dark = $node['color']['dark'] ?? array();
-		if ( empty( $dark ) || ! is_array( $dark ) ) {
+	protected static function compute_scheme_preset_vars( $node, $scheme ) {
+		$overrides = $node['color'][ $scheme ] ?? array();
+		if ( empty( $overrides ) || ! is_array( $overrides ) ) {
 			return array();
 		}
 
@@ -2604,16 +2615,16 @@ class WP_Theme_JSON_Gutenberg {
 
 		$declarations = array();
 		foreach ( $preset_css_vars as $preset_key => $meta ) {
-			if ( empty( $dark[ $preset_key ] ) || ! is_array( $dark[ $preset_key ] ) ) {
+			if ( empty( $overrides[ $preset_key ] ) || ! is_array( $overrides[ $preset_key ] ) ) {
 				continue;
 			}
 
 			/*
 			 * Accept both a flat list of presets (as authored inline in
-			 * `settings.color.dark`) and an origin-keyed structure (as it may
-			 * arrive when sourced from a `darkScheme` style variation).
+			 * `settings.color.<scheme>`) and an origin-keyed structure (as it may
+			 * arrive when sourced from a `color.<scheme>Scheme` style variation).
 			 */
-			$presets = $dark[ $preset_key ];
+			$presets = $overrides[ $preset_key ];
 			if ( ! wp_is_numeric_array( $presets ) ) {
 				$flattened = array();
 				foreach ( static::VALID_ORIGINS as $origin ) {

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -271,8 +271,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$theme_json_data = static::inject_variations_from_block_style_variation_files( $theme_json_data, $variations );
 			$theme_json_data = static::inject_variations_from_block_styles_registry( $theme_json_data );
 
-			// Resolve a `settings.color.darkScheme` variation reference into `settings.color.dark`.
-			$theme_json_data = static::resolve_dark_scheme_variation( $theme_json_data );
+			// Resolve `settings.color.<scheme>Scheme` variation references into `settings.color.<scheme>`.
+			$theme_json_data = static::resolve_scheme_variations( $theme_json_data );
 
 			/**
 			 * Filters the data provided by the theme for global styles and settings.
@@ -763,47 +763,50 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Resolves a `settings.color.darkScheme` variation reference into
-	 * `settings.color.dark`.
+	 * Resolves `settings.color.lightScheme` / `settings.color.darkScheme`
+	 * variation references into `settings.color.light` / `settings.color.dark`.
 	 *
-	 * When a theme sets `settings.color.darkScheme` to the title of a style
+	 * When a theme sets `settings.color.<scheme>Scheme` to the title of a style
 	 * variation, this copies that variation's color palette and gradients into
-	 * `settings.color.dark` so they are emitted as the dark scheme. Only the
-	 * variation's color presets are used; its other styles are ignored. An
-	 * inline `settings.color.dark` takes precedence and is left untouched.
+	 * `settings.color.<scheme>` so they are emitted as that scheme. Only the
+	 * variation's color presets are used; its other styles are ignored. An inline
+	 * `settings.color.<scheme>` takes precedence and is left untouched.
 	 *
 	 * @since 6.9.0
 	 *
 	 * @param array $theme_json_data Raw theme.json data.
-	 * @return array The theme.json data, with `settings.color.dark` populated when applicable.
+	 * @return array The theme.json data, with `settings.color.<scheme>` populated when applicable.
 	 */
-	protected static function resolve_dark_scheme_variation( $theme_json_data ) {
-		$color       = $theme_json_data['settings']['color'] ?? array();
-		$dark_scheme = $color['darkScheme'] ?? null;
+	protected static function resolve_scheme_variations( $theme_json_data ) {
+		$color = $theme_json_data['settings']['color'] ?? array();
 
-		// Nothing to resolve, or an inline `dark` is present and wins.
-		if ( empty( $dark_scheme ) || ! empty( $color['dark'] ) ) {
-			return $theme_json_data;
-		}
+		foreach ( array( 'light', 'dark' ) as $scheme ) {
+			$reference = $color[ $scheme . 'Scheme' ] ?? null;
 
-		foreach ( static::get_style_variations( 'theme' ) as $variation ) {
-			if ( ! isset( $variation['title'] ) || $variation['title'] !== $dark_scheme ) {
+			// Nothing to resolve, or an inline override is present and wins.
+			if ( empty( $reference ) || ! empty( $color[ $scheme ] ) ) {
 				continue;
 			}
 
-			$variation_color = $variation['settings']['color'] ?? array();
-			$dark            = array();
-			if ( ! empty( $variation_color['palette'] ) ) {
-				$dark['palette'] = $variation_color['palette'];
-			}
-			if ( ! empty( $variation_color['gradients'] ) ) {
-				$dark['gradients'] = $variation_color['gradients'];
-			}
+			foreach ( static::get_style_variations( 'theme' ) as $variation ) {
+				if ( ! isset( $variation['title'] ) || $variation['title'] !== $reference ) {
+					continue;
+				}
 
-			if ( ! empty( $dark ) ) {
-				$theme_json_data['settings']['color']['dark'] = $dark;
+				$variation_color = $variation['settings']['color'] ?? array();
+				$overrides       = array();
+				if ( ! empty( $variation_color['palette'] ) ) {
+					$overrides['palette'] = $variation_color['palette'];
+				}
+				if ( ! empty( $variation_color['gradients'] ) ) {
+					$overrides['gradients'] = $variation_color['gradients'];
+				}
+
+				if ( ! empty( $overrides ) ) {
+					$theme_json_data['settings']['color'][ $scheme ] = $overrides;
+				}
+				break;
 			}
-			break;
 		}
 
 		return $theme_json_data;

--- a/lib/compat/wordpress-7.1/color-scheme.php
+++ b/lib/compat/wordpress-7.1/color-scheme.php
@@ -19,17 +19,18 @@
  */
 
 /**
- * Whether the active theme provides a dark color scheme.
+ * Whether the active theme provides an alternate color scheme.
  *
- * True when the merged theme.json defines inline dark presets
- * (`settings.color.dark`) or references a dark style variation
- * (`settings.color.darkScheme`).
+ * True when the merged theme.json defines inline per-scheme presets
+ * (`settings.color.light` / `settings.color.dark`) or references a scheme style
+ * variation (`settings.color.lightScheme` / `settings.color.darkScheme`).
  *
  * @return bool
  */
 function gutenberg_theme_supports_color_scheme() {
 	$color = gutenberg_get_global_settings( array( 'color' ) );
-	return ! empty( $color['dark'] ) || ! empty( $color['darkScheme'] );
+	return ! empty( $color['light'] ) || ! empty( $color['lightScheme'] )
+		|| ! empty( $color['dark'] ) || ! empty( $color['darkScheme'] );
 }
 
 /**

--- a/phpunit/theme-json-dark-scheme-test.php
+++ b/phpunit/theme-json-dark-scheme-test.php
@@ -161,6 +161,78 @@ class Theme_JSON_Dark_Scheme_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '#111111', $result['dark'] );
 	}
 
+	public function test_light_scheme_emits_gated_override() {
+		// A dark-by-default theme: base palette is dark, `light` is the override.
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#111111',
+					),
+				),
+				'light'   => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#ffffff',
+						),
+					),
+				),
+			)
+		);
+		$full   = $result['full'];
+
+		// Light override is gated on `prefers-color-scheme: light`, applied unless forced dark.
+		$this->assertStringContainsString( '@media (prefers-color-scheme: light)', $full );
+		$this->assertStringContainsString( ':root:not([data-scheme="dark"])', $full );
+		// A forced-light choice re-asserts the light values.
+		$this->assertStringContainsString( ':root[data-scheme="light"]', $full );
+		$this->assertStringContainsString( '#ffffff', $full );
+		// No dark gate is emitted when only `light` is defined.
+		$this->assertStringNotContainsString( 'prefers-color-scheme: dark', $full );
+	}
+
+	public function test_light_and_dark_can_coexist() {
+		$result = $this->get_variables_split(
+			array(
+				'palette' => array(
+					array(
+						'slug'  => 'base',
+						'name'  => 'Base',
+						'color' => '#888888',
+					),
+				),
+				'light'   => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#ffffff',
+						),
+					),
+				),
+				'dark'    => array(
+					'palette' => array(
+						array(
+							'slug'  => 'base',
+							'name'  => 'Base',
+							'color' => '#000000',
+						),
+					),
+				),
+			)
+		);
+		$full   = $result['full'];
+
+		$this->assertStringContainsString( '@media (prefers-color-scheme: light)', $full );
+		$this->assertStringContainsString( '@media (prefers-color-scheme: dark)', $full );
+		$this->assertStringContainsString( ':root[data-scheme="light"]', $full );
+		$this->assertStringContainsString( ':root[data-scheme="dark"]', $full );
+	}
+
 	public function test_no_dark_key_emits_no_gate_and_is_unchanged() {
 		$base_only = array(
 			'palette' => array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -153,7 +153,7 @@
 							"default": true
 						},
 						"dark": {
-							"description": "Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here.",
+							"description": "Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme=\"dark\"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged. Duotone is not yet supported here.",
 							"type": "object",
 							"properties": {
 								"palette": {
@@ -207,6 +207,63 @@
 						},
 						"darkScheme": {
 							"description": "Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the dark scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `dark` is also set, `dark` takes precedence.",
+							"type": "string"
+						},
+						"light": {
+							"description": "Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme=\"light\"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in. Duotone is not yet supported here.",
+							"type": "object",
+							"properties": {
+								"palette": {
+									"description": "Light-scheme color palette. Slugs override matching entries in `palette`; unmatched base slugs keep their single value in every scheme.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the color preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base palette slug.",
+												"type": "string"
+											},
+											"color": {
+												"description": "CSS hex or rgb(a) string for the light scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "color" ],
+										"additionalProperties": false
+									}
+								},
+								"gradients": {
+									"description": "Light-scheme gradient presets. Slugs override matching entries in `gradients`.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the gradient preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base gradient slug.",
+												"type": "string"
+											},
+											"gradient": {
+												"description": "CSS gradient string for the light scheme.",
+												"type": "string"
+											}
+										},
+										"required": [ "slug", "gradient" ],
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
+						},
+						"lightScheme": {
+							"description": "Title of a theme style variation (from the theme's `styles/` directory) whose color presets are used as the light scheme. Only the variation's color palette/gradients are used; other styles are ignored. If `light` is also set, `light` takes precedence.",
 							"type": "string"
 						},
 						"defaultDuotone": {


### PR DESCRIPTION
## What / Why

**Prototype — stacked on #80700 (review that first).** Makes the color scheme model **symmetric**, mirroring the CSS [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) pattern (default in the base, override the *other* scheme). This enables **dark-by-default themes** to define a light alternative for visitors whose OS is in light mode — not just light-default themes with a dark override.

> ⚠️ **Base branch is `try/dark-mode-visitor-toggle` (#80700), not `trunk`.** Review only the diff on top of that PR.

## What this adds

- **`settings.color.light`** and **`settings.color.lightScheme`**, mirroring the existing `dark` / `darkScheme` keys (schema + sanitization + resolver).
- Preset emission and the resolver's variation resolution are generalized over both schemes. Each scheme is emitted under its own media query and responds to `data-scheme`:

  ```css
  @media (prefers-color-scheme: light) {
    :root:not([data-scheme="dark"]) { /* light overrides */ }
  }
  :root[data-scheme="light"] { /* light overrides */ }
  ```

- A theme may define `light`, `dark`, or both; with both, the base palette is the fallback when the OS expresses no preference.

This matches MDN's "Theme B" example: a dark base plus a `prefers-color-scheme: light` override.

## Testing

### Automated

`Theme_JSON_Dark_Scheme_Test` — **7 tests / 23 assertions passing** (adds light-scheme gating and light+dark coexistence):

```
npm run wp-env-test start
npx wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' \
  wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter Theme_JSON_Dark_Scheme_Test
```

### Manual (verified) — a dark-by-default theme

1. Activate **Twenty Twenty-Four** and give it a dark base + a light override in `theme.json`:
   ```jsonc
   "settings": { "color": {
     "palette": [ { "slug": "base", "name": "Base", "color": "#111111" },
                  { "slug": "contrast", "name": "Contrast", "color": "#ffffff" } ],
     "light":   { "palette": [ { "slug": "base", "color": "#ffffff" },
                               { "slug": "contrast", "color": "#111111" } ] }
   } }
   ```
2. Front end confirmed to include `@media (prefers-color-scheme: light)`, `:root[data-scheme="light"]`, and the `wp-color-scheme-bootstrap` script.
3. OS in **light** mode → light palette; OS in **dark** mode → the theme's dark base. `localStorage.setItem('wp-color-scheme','dark')` forces the dark base regardless of OS; `'light'` forces the light override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
