### PR TITLE
Components: Update polymorphism types to allow all attributes when specifying `as`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,10 @@
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   `Autocomplete`: `__unstableUseAutocompleteProps` now narrows its returned ARIA props and no longer asks for a `contentRef` it never used, so callers can spread its return value onto an element without a placeholder ref, normalizing, or casting ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   Improved performance of TypeScript types for internal polymorphic `WordPressComponent` component type ([#80364](https://github.com/WordPress/gutenberg/pull/80364)).
+-   Further improved `WordPressComponent` typecheck performance: intrinsic `as` values use a shared attribute bag instead of remapping props per HTML tag ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
+-   `ConfirmDialog`: Type the `size` prop forwarded to `Modal` ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
+-   `ToggleGroupControl`: Type the `disabled` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
+-   `DropdownContentWrapper`: Type the `children` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 
 ### Internal
 

--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -28,7 +28,7 @@ function Example() {
 
 ### `as`
 
- - Type: `PolymorphicAs`
+ - Type: `keyof IntrinsicElements | JSXElementConstructor<any>`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -28,7 +28,7 @@ function Example() {
 
 ### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
+ - Type: `PolymorphicAs`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -30,10 +30,10 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 
 ### `as`
 
- - Type: `ElementType<any, keyof IntrinsicElements>`
+ - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
  - Required: Yes
 
-The HTML element or React component to render the component as.
+The HTML element to render the component as.
 
 ### `className`
 
@@ -107,7 +107,7 @@ const MyBaseControl = () => (
 
 ##### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
+ - Type: `PolymorphicAs`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -107,7 +107,7 @@ const MyBaseControl = () => (
 
 ##### `as`
 
- - Type: `PolymorphicAs`
+ - Type: `keyof IntrinsicElements | JSXElementConstructor<any>`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -91,6 +91,12 @@ type DialogInputEvent =
 
 An optional `title` for the dialog. Setting a title will render it in a title bar at the top of the dialog, making it a bit taller. The bar will also include an `x` close button at the top-right corner.
 
+### `size`: `'small' | 'medium' | 'large' | 'fill'`
+
+-   Required: No
+
+Size of the underlying [`Modal`](/packages/components/src/modal/README.md). See `Modal`'s `size` prop for details.
+
 ### `children`: `React.ReactNode`
 
 -   Required: Yes

--- a/packages/components/src/confirm-dialog/types.ts
+++ b/packages/components/src/confirm-dialog/types.ts
@@ -19,6 +19,10 @@ export type ConfirmDialogProps = {
 	 */
 	children: ReactNode;
 	/**
+	 * Size of the underlying Modal. See `Modal`'s `size` prop.
+	 */
+	size?: ModalProps[ 'size' ];
+	/**
 	 * The callback that's called when the user confirms.
 	 * A confirmation can happen when the `OK` button is clicked or when `Enter` is pressed.
 	 */

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -54,14 +54,26 @@ export type WordPressComponent<
 > = ( IsPolymorphic extends true
 	? {
 			/**
-			 * Polymorphic call signature. When `as` is provided, additional intrinsic
-			 * attributes are accepted via a flat attribute bag.
+			 * Intrinsic `as` (e.g. `as="label"`): accept a flat HTML/SVG attribute
+			 * bag instead of remapping to that tag's props.
 			 */
 			(
 				props: WordPressComponentProps< O, T, false > & {
-					/** The HTML element or React component to render the component as. */
-					as: PolymorphicAs;
+					/** The HTML element to render the component as. */
+					as: keyof React.JSX.IntrinsicElements;
 				} & Omit< PolymorphicIntrinsicProps, keyof O >
+			): React.ReactNode;
+			/**
+			 * Component `as` (e.g. `as={ Item }`): remap to that component's props.
+			 */
+			< C extends React.JSXElementConstructor< any > >(
+				props: WordPressComponentProps< O, T, false > & {
+					/** The React component to render the component as. */
+					as: C;
+				} & Omit<
+						React.ComponentPropsWithoutRef< C >,
+						'as' | keyof O | 'children'
+					>
 			): React.ReactNode;
 	  }
 	: unknown ) & {

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -14,14 +14,6 @@ type PolymorphicIntrinsicProps = Omit<
 	'as' | 'children'
 >;
 
-/**
- * Compatible with Emotion/`styled` `as` props and React's `ElementType`, without
- * using the default `React.ElementType` mapped type helper directly.
- */
-type PolymorphicAs =
-	| keyof React.JSX.IntrinsicElements
-	| React.JSXElementConstructor< any >;
-
 // Based on https://github.com/ariakit/ariakit/blob/reakit/packages/reakit-utils/src/types.ts
 export type WordPressComponentProps<
 	/** Prop types. */
@@ -43,7 +35,10 @@ export type WordPressComponentProps<
 	( IsPolymorphic extends true
 		? {
 				/** The HTML element or React component to render the component as. */
-				as?: T | PolymorphicAs;
+				as?:
+					| T
+					| keyof React.JSX.IntrinsicElements
+					| React.JSXElementConstructor< any >;
 		  }
 		: {} );
 

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -10,7 +10,7 @@ import type * as React from 'react';
  * contributed to high memory usage and slow compilation times.
  */
 type PolymorphicIntrinsicProps = Omit<
-	React.AllHTMLAttributes< any > & React.SVGAttributes< any >,
+	React.AllHTMLAttributes< Element > & React.SVGAttributes< Element >,
 	'as' | 'children'
 >;
 

--- a/packages/components/src/context/wordpress-component.ts
+++ b/packages/components/src/context/wordpress-component.ts
@@ -3,6 +3,25 @@
  */
 import type * as React from 'react';
 
+/**
+ * Loose intrinsic attribute bag used when a polymorphic component is rendered
+ * with an `as` prop. Previous implementations enabled precise typings for the
+ * given `as` element (e.g. `as="label"` unlocks `htmlFor`), but doing so
+ * contributed to high memory usage and slow compilation times.
+ */
+type PolymorphicIntrinsicProps = Omit<
+	React.AllHTMLAttributes< any > & React.SVGAttributes< any >,
+	'as' | 'children'
+>;
+
+/**
+ * Compatible with Emotion/`styled` `as` props and React's `ElementType`, without
+ * using the default `React.ElementType` mapped type helper directly.
+ */
+type PolymorphicAs =
+	| keyof React.JSX.IntrinsicElements
+	| React.JSXElementConstructor< any >;
+
 // Based on https://github.com/ariakit/ariakit/blob/reakit/packages/reakit-utils/src/types.ts
 export type WordPressComponentProps<
 	/** Prop types. */
@@ -24,7 +43,7 @@ export type WordPressComponentProps<
 	( IsPolymorphic extends true
 		? {
 				/** The HTML element or React component to render the component as. */
-				as?: T | keyof React.JSX.IntrinsicElements;
+				as?: T | PolymorphicAs;
 		  }
 		: {} );
 
@@ -32,16 +51,20 @@ export type WordPressComponent<
 	T extends React.ElementType | null,
 	O,
 	IsPolymorphic extends boolean,
-> = {
-	< TT extends React.ElementType >(
-		props: WordPressComponentProps< O, TT, false > &
-			( IsPolymorphic extends true
-				? {
-						/** The HTML element or React component to render the component as. */
-						as: TT;
-				  }
-				: {} )
-	): React.ReactNode;
+> = ( IsPolymorphic extends true
+	? {
+			/**
+			 * Polymorphic call signature. When `as` is provided, additional intrinsic
+			 * attributes are accepted via a flat attribute bag.
+			 */
+			(
+				props: WordPressComponentProps< O, T, false > & {
+					/** The HTML element or React component to render the component as. */
+					as: PolymorphicAs;
+				} & Omit< PolymorphicIntrinsicProps, keyof O >
+			): React.ReactNode;
+	  }
+	: unknown ) & {
 	( props: WordPressComponentProps< O, T, IsPolymorphic > ): React.ReactNode;
 	displayName?: string;
 	/**

--- a/packages/components/src/dropdown/types.ts
+++ b/packages/components/src/dropdown/types.ts
@@ -11,6 +11,10 @@ type CallbackProps = {
 
 export type DropdownContentWrapperProps = {
 	/**
+	 * The content to render inside the wrapper.
+	 */
+	children?: ReactNode;
+	/**
 	 * Amount of padding to apply on the dropdown content.
 	 *
 	 * @default 'small'

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -19,8 +19,8 @@ component, and the `Menu.Popover` component.
 
 ### `as`
 
- - Type: `ElementType<any, keyof IntrinsicElements>`
- - Required: Yes
+ - Type: `any`
+ - Required: No
 
 The HTML element or React component to render the component as.
 
@@ -64,7 +64,7 @@ A callback that gets called when the `open` state changes.
 
 ### `placement`
 
- - Type: `"top" | "bottom" | "left" | "right" | "top-start" | "bottom-start" | "left-start" | "right-start" | "top-end" | "bottom-end" | ...`
+ - Type: `"left" | "right" | "top" | "bottom" | "left-start" | "right-start" | "top-start" | "bottom-start" | "left-end" | "right-end" | ...`
  - Required: No
  - Default: `'bottom-start' for root-level menus, 'right-start' for submenus`
 
@@ -466,7 +466,7 @@ Renders a menu item's label text. It should be wrapped with `Menu.Item`,
 
 ##### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
+ - Type: `PolymorphicAs`
  - Required: No
 
 The HTML element or React component to render the component as.
@@ -480,7 +480,7 @@ Renders a menu item's help text. It should be wrapped with `Menu.Item`,
 
 ##### `as`
 
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
+ - Type: `PolymorphicAs`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -466,7 +466,7 @@ Renders a menu item's label text. It should be wrapped with `Menu.Item`,
 
 ##### `as`
 
- - Type: `PolymorphicAs`
+ - Type: `keyof IntrinsicElements | JSXElementConstructor<any>`
  - Required: No
 
 The HTML element or React component to render the component as.
@@ -480,7 +480,7 @@ Renders a menu item's help text. It should be wrapped with `Menu.Item`,
 
 ##### `as`
 
- - Type: `PolymorphicAs`
+ - Type: `keyof IntrinsicElements | JSXElementConstructor<any>`
  - Required: No
 
 The HTML element or React component to render the component as.

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -117,6 +117,10 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	children: ReactNode;
 	/**
+	 * Whether the control is disabled.
+	 */
+	disabled?: boolean;
+	/**
 	 * The size variant of the control.
 	 *
 	 * @deprecated This prop no longer has any effect.

--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internal
 
+-   Remove unused `isAction` prop from preferences modal tab buttons (`Item` has ignored it since it was replaced by `onClick`) ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).
 
 ## 4.51.0 (2026-07-14)

--- a/packages/preferences/src/components/preferences-modal-tabs/index.tsx
+++ b/packages/preferences/src/components/preferences-modal-tabs/index.tsx
@@ -113,9 +113,7 @@ export default function PreferencesModalTabs( {
 										<Navigator.Button
 											key={ tab.name }
 											path={ `/${ tab.name }` }
-											// @ts-expect-error: Navigator.Button is currently typed in a way that prevents Item from being passed in
 											as={ Item }
-											isAction
 										>
 											<HStack justify="space-between">
 												<FlexItem>


### PR DESCRIPTION
## What?

Updates the polymorphism types used in `@wordpress/components` to expose all possible HTML attributes when `as` is specified, rather than narrowing the types based on the tagName provided to `as`.

The performance impact on TypeScript builds is significant, **reducing memory usage by -47% (7.4GB to 4.0GB), TypeScript build time by -49% (13.7s to 7.0s), and internal instantiations by -54% (42.5M to 19.5M)**.

## Why?

- Significant performance improvement and reduced memory usage.
- Improves build stability.
   - Recently, builds have been crashing during TypeScript compilation ([example](https://github.com/WordPress/gutenberg/actions/runs/30043491965/job/89328840961?pr=80655)). This was [discussed in Slack](https://github.com/WordPress/gutenberg/actions/runs/30043491965/job/89328840961?pr=80655) and #80364 was aimed at improving this, but the issue persists. It was known with #80364 that the "peak memory usage" was not dramatically reduced, and so TypeScript builds could still consume more than 10GB of memory, likely exhausting the CI environment.

## How?

As described in #80655 , these polymorphism types are a major contributor to overall TypeScript build times and memory consumption. While #80655 tried to fully maintain the original intent of the polymorphism types, the changes here propose a more drastic change: If `as` is provided, all valid HTML attributes are accessible on that component. This means someone could do something like `<VisuallyHidden as="div" htmlFor="id" />` and TypeScript would consider it valid, which was not the case before now, as `htmlFor` is not a valid attribute for `div` elements.

This is meant to be a reasonable compromise given the circumstances, and how new development in `@wordpress/ui` leans on `render` props instead of `as` polymorphism. `render` props don't suffer from this problem because props which are relevant to the component passed to `render` are applied to the element directly.

This isn't all bad though, since:

- Those additional HTML attributes only become known if `as` is provided, and otherwise the component's own props are the only ones available.
- The attribute types are still accurately typed, so TypeScript validates that `htmlFor` is a `string`, for example.

## Testing Instructions

Verify type-checking passes:

```
npm run build
```

For bonus points, try some of the scenarios described under "How", like how you can't assign `htmlFor` unless specifying `as`, or that `htmlFor` can be used with `as="div"`, or how `htmlFor` can't be assigned to a type other than string.

Also check performance for yourself using snippets from #80364 "Testing Instructions":

> If you want to validate performance yourself, you can compare the following set of commands on this branch and trunk:
> 
> ```
> rm -f packages/components/tsconfig.tsbuildinfo
> /usr/bin/time -l npx tsc -p packages/components/tsconfig.json --extendedDiagnostics 2>&1 \
>   | grep -E '^(Symbols|Instantiations|Memory used|Memory allocs):|maximum resident'
> ```
> 
> Or full project timings and memory usage:
> 
> ```
> npx tsc --build --clean >/dev/null 2>&1
> rm -rf packages/*/build-types
> /usr/bin/time -l npx tsc --build 2>&1 | grep -E 'maximum resident|real'
> ```

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to research and implement, with manual iterations, particularly on the code comments.