### PR TITLE
UI: Update Notice spoken message default to plaintext title and description

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Notice`: Constrain `Title` and `Description` children and `spokenMessage` to plain strings. The default screen reader announcement is now the combined title and description text, instead of serializing the full compound tree (which could include action labels and other controls) ([#80706](https://github.com/WordPress/gutenberg/pull/80706)).
+
 ### Enhancements
 
 -   `Input`: Hide native browser spin controls for `type="number"` inputs by default ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).

--- a/packages/ui/src/notice/context.tsx
+++ b/packages/ui/src/notice/context.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from '@wordpress/element';
+
+type NoticeContextValue = {
+	setTitle: ( title: string | undefined ) => void;
+	setDescription: ( description: string | undefined ) => void;
+};
+
+const NoticeContext = createContext< NoticeContextValue >( {
+	setTitle: () => {},
+	setDescription: () => {},
+} );
+
+export function useNoticeContext() {
+	return useContext( NoticeContext );
+}
+
+export { NoticeContext };

--- a/packages/ui/src/notice/description.tsx
+++ b/packages/ui/src/notice/description.tsx
@@ -1,21 +1,31 @@
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import type { DescriptionProps } from './types';
 import { Text } from '../text';
+import { useNoticeContext } from './context';
 import styles from './style.module.css';
 
 /**
  * The description text for a notice.
  */
 export const Description = forwardRef< HTMLSpanElement, DescriptionProps >(
-	function NoticeDescription( { className, ...props }, ref ) {
+	function NoticeDescription( { className, children, ...props }, ref ) {
+		const { setDescription } = useNoticeContext();
+
+		useEffect( () => {
+			setDescription( children );
+			return () => setDescription( undefined );
+		}, [ children, setDescription ] );
+
 		return (
 			<Text
 				ref={ ref }
 				variant="body-md"
 				className={ clsx( styles.description, className ) }
 				{ ...props }
-			/>
+			>
+				{ children }
+			</Text>
 		);
 	}
 );

--- a/packages/ui/src/notice/root.tsx
+++ b/packages/ui/src/notice/root.tsx
@@ -1,10 +1,17 @@
 import { speak } from '@wordpress/a11y';
-import { forwardRef, renderToString, useEffect } from '@wordpress/element';
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { info, published, error, caution } from '@wordpress/icons';
 import { useRender, mergeProps } from '@base-ui/react';
 import clsx from 'clsx';
 import { Icon } from '../icon';
 import resetStyles from '../utils/css/resets.module.css';
+import { NoticeContext } from './context';
 import type { NoticeIntent, RootProps } from './types';
 import type { IconProps } from '../icon/types';
 import styles from './style.module.css';
@@ -26,39 +33,26 @@ function getDefaultPoliteness( intent: NoticeIntent ): 'polite' | 'assertive' {
 }
 
 /**
- * Safely converts a message to a string for screen reader announcement.
- * Returns undefined if the message can't be safely serialized.
+ * Builds the default spoken message from registered title and description text.
  */
-function safeRenderToString( message: RootProps[ 'spokenMessage' ] ) {
-	if ( ! message ) {
-		return undefined;
-	}
-	if ( typeof message === 'string' ) {
-		return message;
-	}
-	try {
-		return renderToString( message );
-	} catch {
-		// If renderToString fails (e.g., due to complex components like Tooltip),
-		// return undefined and skip the announcement
-		return undefined;
-	}
-}
+const getDefaultSpokenMessage = (
+	title: string | undefined,
+	description: string | undefined
+): string | undefined =>
+	[ title, description ].filter( Boolean ).join( '. ' ) || undefined;
 
 /**
  * Custom hook which announces the message with the given politeness.
  */
 function useSpokenMessage(
-	message: RootProps[ 'spokenMessage' ],
+	message: string | undefined,
 	politeness: 'polite' | 'assertive'
 ) {
-	const spokenMessage = safeRenderToString( message );
-
 	useEffect( () => {
-		if ( spokenMessage ) {
-			speak( spokenMessage, politeness );
+		if ( message ) {
+			speak( message, politeness );
 		}
-	}, [ spokenMessage, politeness ] );
+	}, [ message, politeness ] );
 }
 
 /**
@@ -86,16 +80,36 @@ export const Root = forwardRef< HTMLDivElement, RootProps >( function Notice(
 		intent = 'neutral',
 		children,
 		icon,
-		spokenMessage = children,
+		spokenMessage,
 		politeness = getDefaultPoliteness( intent ),
 		render,
 		...restProps
 	},
 	ref
 ) {
+	const [ title, setTitleState ] = useState< string | undefined >();
+	const [ description, setDescriptionState ] = useState<
+		string | undefined
+	>();
+
+	const setTitle = useCallback( ( value: string | undefined ) => {
+		setTitleState( value );
+	}, [] );
+	const setDescription = useCallback( ( value: string | undefined ) => {
+		setDescriptionState( value );
+	}, [] );
+
+	const contextValue = useMemo(
+		() => ( { setTitle, setDescription } ),
+		[ setTitle, setDescription ]
+	);
+
+	const resolvedSpokenMessage =
+		spokenMessage ?? getDefaultSpokenMessage( title, description );
+
 	// Announce to screen readers via speak() API - no role attribute needed
 	// as it would cause double announcements
-	useSpokenMessage( spokenMessage, politeness );
+	useSpokenMessage( resolvedSpokenMessage, politeness );
 
 	const iconElement = icon === null ? null : icon ?? icons[ intent ];
 
@@ -128,5 +142,9 @@ export const Root = forwardRef< HTMLDivElement, RootProps >( function Notice(
 		),
 	} );
 
-	return element;
+	return (
+		<NoticeContext.Provider value={ contextValue }>
+			{ element }
+		</NoticeContext.Provider>
+	);
 } );

--- a/packages/ui/src/notice/test/index.test.tsx
+++ b/packages/ui/src/notice/test/index.test.tsx
@@ -202,5 +202,65 @@ describe( 'Notice', () => {
 				} )
 			).toBeInTheDocument();
 		} );
+
+		it( 'announces the combined title and description by default', () => {
+			render(
+				<Notice.Root intent="info">
+					<Notice.Title>Update available</Notice.Title>
+					<Notice.Description>
+						A new version is ready to install.
+					</Notice.Description>
+				</Notice.Root>
+			);
+			expect(
+				screen.getByText(
+					'Update available. A new version is ready to install.',
+					{ selector: '[aria-live="polite"]' }
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'announces an explicit spokenMessage instead of title and description', () => {
+			render(
+				<Notice.Root intent="info" spokenMessage="Custom announcement">
+					<Notice.Title>Update available</Notice.Title>
+					<Notice.Description>
+						A new version is ready to install.
+					</Notice.Description>
+				</Notice.Root>
+			);
+			expect(
+				screen.getByText( 'Custom announcement', {
+					selector: '[aria-live="polite"]',
+				} )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(
+					'Update available. A new version is ready to install.',
+					{ selector: '[aria-live="polite"]' }
+				)
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'does not include action labels in the default announcement', () => {
+			render(
+				<Notice.Root intent="info">
+					<Notice.Description>Notice with actions</Notice.Description>
+					<Notice.Actions>
+						<Notice.ActionButton>Retry</Notice.ActionButton>
+					</Notice.Actions>
+				</Notice.Root>
+			);
+			expect(
+				screen.getByText( 'Notice with actions', {
+					selector: '[aria-live="polite"]',
+				} )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText( /Retry/, {
+					selector: '[aria-live="polite"]',
+				} )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/ui/src/notice/title.tsx
+++ b/packages/ui/src/notice/title.tsx
@@ -1,21 +1,31 @@
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import type { TitleProps } from './types';
 import { Text } from '../text';
+import { useNoticeContext } from './context';
 import styles from './style.module.css';
 
 /**
  * A short heading that communicates the main message of the notice.
  */
 export const Title = forwardRef< HTMLSpanElement, TitleProps >(
-	function NoticeTitle( { className, ...props }, ref ) {
+	function NoticeTitle( { className, children, ...props }, ref ) {
+		const { setTitle } = useNoticeContext();
+
+		useEffect( () => {
+			setTitle( children );
+			return () => setTitle( undefined );
+		}, [ children, setTitle ] );
+
 		return (
 			<Text
 				ref={ ref }
 				variant="heading-md"
 				className={ clsx( styles.title, className ) }
 				{ ...props }
-			/>
+			>
+				{ children }
+			</Text>
 		);
 	}
 );

--- a/packages/ui/src/notice/types.ts
+++ b/packages/ui/src/notice/types.ts
@@ -24,15 +24,18 @@ export interface RootProps extends Omit< ComponentProps< 'div' >, 'title' > {
 	icon?: IconProps[ 'icon' ] | null;
 
 	/**
-	 * The content to be rendered inside the notice.
+	 * The content to be rendered inside the notice. Compose with `Title`,
+	 * `Description`, `Actions`, and `CloseIcon`.
 	 */
 	children?: ReactNode;
 
 	/**
-	 * The message to be announced to screen readers. Defaults to the children content.
-	 * Used by the `speak()` function from `@wordpress/a11y`.
+	 * The message announced to screen readers via `speak()` from `@wordpress/a11y`.
+	 *
+	 * Defaults to the combined `Title` and `Description` text. Provide an
+	 * explicit string when the announcement should differ from the visible copy.
 	 */
-	spokenMessage?: ReactNode;
+	spokenMessage?: string;
 
 	/**
 	 * The politeness level for screen reader announcements.
@@ -44,15 +47,21 @@ export interface RootProps extends Omit< ComponentProps< 'div' >, 'title' > {
 export interface TitleProps extends ComponentProps< 'span' > {
 	/**
 	 * The title text of the notice.
+	 *
+	 * For screen reader accessibility, this should only contain plain text,
+	 * and no semantics such as links. Put links in `Notice.ActionLink`.
 	 */
-	children?: ReactNode;
+	children?: string;
 }
 
 export interface DescriptionProps extends ComponentProps< 'span' > {
 	/**
 	 * The description text of the notice.
+	 *
+	 * For screen reader accessibility, this should only contain plain text,
+	 * and no semantics such as links. Put links in `Notice.ActionLink`.
 	 */
-	children?: ReactNode;
+	children?: string;
 }
 
 export interface ActionsProps extends ComponentProps< 'div' > {


### PR DESCRIPTION
## What?

Updates the `@wordpress/ui` `Notice` component implementation of the default spoken message to use the title and description text (and enforce them as plaintext), instead of its stripped-tags HTML structure.

## Why?

- Technical: This removes a dependency on `renderToString` from `@wordpress/element`. I'm hoping we can update the `@wordpress/ui` package to use `react` directly instead of `@wordpress/element`, consistent with a previous decision in #54074, and in order to help compatibility within projects that "bring their own React 19" as highlighted by @SirLouen in #80053. `renderToString` does not have a direct parallel in `react` without bringing in the `react-dom/server` server-side rendering package.
- Accessibility: The previous naive approach of just rendered the tags-stripped copy of whatever HTML produced is not ideal, as it does not have any punctuation to abbreviate the content, and includes full set of actions and whatever other HTML might be present in the notice. For example, if it was working correctly, the spoken message for the [default Notice Storybook story](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-notice--docs) would be "Notice Title Description text with details about this notification. Primary button Secondary button Link".
- Bug: Notice I said "If it was working correctly" 😅 In practice, nothing is actually spoken, because there's an error in rendering the components: `Uncaught Error: Base UI error #82; visit https://base-ui.com/production-error?code=82 for the full message.` which is absorbed by [`safeRenderToString`](https://github.com/WordPress/gutenberg/blob/c6c8e71cfef82fe01b189ad58b00af4ea921f743/packages/ui/src/notice/root.tsx#L28-L46).

## How?

- Updates `Title` and `Description` to only accept string children.
- Updates default spoken message to use the title and description, joined by a `.` period to pause between the title and description. Consumers can still pass their own `spokenMessage` to override.

I'm open to feedback on whether it would be useful to include additional context about what actions might exist in the alert.

## Testing Instructions

Verify the spoken message in Storybook:

1. Run `npm run storybook:dev`
2. Visit http://localhost:50240/iframe.html?id=design-system-components-notice--default&viewMode=story
3. Inspect the page in DevTools
4. Find element with ID `a11y-speak-polite`
5. Observe its content is "Notice Title. Description text with details about this notification."

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to research and implement, with review and some manual iterations myself.