### PR TITLE
RTC: Compact during serialization

### DIFF
--- a/packages/sync/src/test/utils.ts
+++ b/packages/sync/src/test/utils.ts
@@ -145,6 +145,65 @@ describe( 'utils', () => {
 			expect( typeof parsed.document ).toBe( 'string' );
 			expect( parsed.document.length ).toBeGreaterThan( 0 );
 		} );
+
+		it( 'garbage-collects undo-pinned deleted content when serializing', () => {
+			const ytext = testDoc.getText( 'content' );
+			const origin = 'test-local-origin';
+			const undoManager = new Y.UndoManager( ytext, {
+				captureTimeout: 0,
+				trackedOrigins: new Set( [ origin ] ),
+			} );
+			const largeText = 'x'.repeat( 100000 );
+
+			// Insert and delete in separate tracked transactions. The undo
+			// manager flags the deleted content with `keep`, blocking garbage
+			// collection in the live doc.
+			testDoc.transact( () => ytext.insert( 0, largeText ), origin );
+			testDoc.transact(
+				() => ytext.delete( 0, largeText.length ),
+				origin
+			);
+
+			const liveDocSize = Y.encodeStateAsUpdateV2( testDoc ).byteLength;
+			const serialized = serializeCrdtDoc( testDoc );
+			const compactedSize = buffer.fromBase64(
+				JSON.parse( serialized ).document
+			).byteLength;
+
+			// The live doc still carries the deleted content for undo; the
+			// serialized snapshot must not.
+			expect( liveDocSize ).toBeGreaterThan( largeText.length );
+			expect( compactedSize ).toBeLessThan( 1000 );
+
+			// The snapshot deserializes to the current (post-delete) state.
+			const deserialized = deserializeCrdtDoc( serialized );
+			expect( deserialized!.getText( 'content' ).toString() ).toBe( '' );
+
+			undoManager.destroy();
+		} );
+
+		it( 'does not affect undo history on the live doc', () => {
+			const ytext = testDoc.getText( 'content' );
+			const origin = 'test-local-origin';
+			const undoManager = new Y.UndoManager( ytext, {
+				captureTimeout: 0,
+				trackedOrigins: new Set( [ origin ] ),
+			} );
+
+			testDoc.transact(
+				() => ytext.insert( 0, 'Hello, world!' ),
+				origin
+			);
+			testDoc.transact( () => ytext.delete( 0, 13 ), origin );
+
+			serializeCrdtDoc( testDoc );
+
+			// Undo the delete: the content must still be restorable.
+			undoManager.undo();
+			expect( ytext.toString() ).toBe( 'Hello, world!' );
+
+			undoManager.destroy();
+		} );
 	} );
 
 	describe( 'deserializeCrdtDoc', () => {

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -68,8 +68,21 @@ function pseudoRandomID(): number {
 }
 
 export function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {
+	// Encode a compacted copy of the doc rather than the doc itself. The live
+	// doc can be much larger than its current content: Y.UndoManager flags
+	// items deleted by tracked transactions with `keep`, which blocks garbage
+	// collection while they sit on the undo stack, so the encoded state would
+	// include the full content of everything deleted during the session. The
+	// `keep` flag is not serialized, so applying the state to a temporary doc
+	// garbage-collects that content. Struct identities are preserved, meaning
+	// peers merge the compacted state exactly as they would the original.
+	const tempDoc = createYjsDoc();
+	Y.applyUpdateV2( tempDoc, Y.encodeStateAsUpdateV2( crdtDoc ) );
+	const compactedUpdate = Y.encodeStateAsUpdateV2( tempDoc );
+	tempDoc.destroy();
+
 	return JSON.stringify( {
-		document: buffer.toBase64( Y.encodeStateAsUpdateV2( crdtDoc ) ),
+		document: buffer.toBase64( compactedUpdate ),
 		updateId: pseudoRandomID(), // helps with debugging
 	} );
 }


### PR DESCRIPTION
## What?

Compact CRDT document state before serializing.

## Why?

CRDT garbage collection is disabled in order to preserve the undo stack. As a result, `encodeStateAsUpdateV2` of the live document contains the full text of everything ever typed, deleted, pasted, reformatted, etc., during the session. The document's size is proportional to total bytes ever written, not the post's current content.

On save, the serialized CRDT document is persisted to post meta with all updates intact, leading to large post meta values. For heavily edited posts, the size of this post meta can affect performance and reduce the effectiveness of object caching.

This behavior is partially self-healing in certain workflows: `deserializeCrdtDoc` applies the persisted document to a fresh doc and deleted content collapses to tiny GC tombstones. But this compacted version only reaches the database if the user saves after a fresh load.

## How?

Compact the document by applying the current state to a temporary document with garbage collection enabled.

## Testing Instructions

1. Enable Real-time Collaboration (Settings → Writing → Collaboration, if not already on).
1. Create a new post and add a few paragraphs of filler text (~5–10 KB — e.g. paste several lorem ipsum paragraphs). Save.
1. Check the persisted snapshot size:
   ```
   npm run wp-env run cli -- wp eval 'echo strlen( get_post_meta( <POST_ID>, "_crdt_document", true ) ) . PHP_EOL;'
   ```
   - Alternatively, use DevTools → Network to inspect the `meta._crdt_document` string length in the POST payload of the save request.
1. Note the baseline size.
1. Without reloading the editor, select all content, delete it, paste the filler text back, and repeat this delete/paste cycle ~5 times. Save (Update) after the last cycle.
1. Re-run the command from step 3.


On `trunk`: the size grows by roughly the size of everything deleted — after 5 cycles, expect a multiple of the baseline. On this branch: the size stays close to the baseline regardless of how many delete/paste cycles preceded the save.

### Verify undo is unaffected

1. In the same session, after saving, press <kbd>Cmd/Ctrl+Z</kbd> repeatedly.
2. Deleted content is restored normally. Serialization must not strip undo history from the live document, only from the persisted snapshot.

### Verify collaboration continuity

1. Open the same post in two browser tabs and type in one. Edits appear in the other.
2. Save in one tab, reload the other, and continue editing from both. Edits still sync in both directions. The compacted snapshot preserves CRDT struct identity, so peers merge it exactly like the uncompacted one.


## Use of AI Tools

This PR was created with the assistance of Claude Fable 5.
