### PR TITLE
Writing flow: stop the page scrolling on caret moves within blocks taller than the viewport

### DIFF
--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -103,17 +103,22 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	// which `scrollIfNoRange` scrolls the container's edge into view to
 	// measure, e.g. on every arrow press within a container taller than the
 	// viewport). When the edge is outside the viewport and the selection is
-	// within it, they are at least a viewport boundary apart, so the
-	// selection cannot be at the edge.
-	if (
-		( y < 0 ||
-			y > defaultView.innerHeight ||
-			x < 0 ||
-			x > defaultView.innerWidth ) &&
+	// within it, they are at least a viewport boundary apart along that
+	// axis, so the selection cannot be at the edge. Check each axis
+	// separately: the vertical check must not be short-circuited by a
+	// horizontally overflowing container, and vice versa.
+	const isFarFromVerticalEdge =
+		( y < 0 || y > defaultView.innerHeight ) &&
 		rangeRect.top >= 0 &&
-		rangeRect.bottom <= defaultView.innerHeight &&
+		rangeRect.bottom <= defaultView.innerHeight;
+	const isFarFromHorizontalEdge =
+		( x < 0 || x > defaultView.innerWidth ) &&
 		rangeRect.left >= 0 &&
-		rangeRect.right <= defaultView.innerWidth
+		rangeRect.right <= defaultView.innerWidth;
+
+	if (
+		isFarFromVerticalEdge ||
+		( ! onlyVertical && isFarFromHorizontalEdge )
 	) {
 		return false;
 	}

--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -97,6 +97,27 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	// pixels. `getComputedStyle` may return a value with different units.
 	const x = isReverseDir ? containerRect.left + 1 : containerRect.right - 1;
 	const y = isReverse ? containerRect.top + 1 : containerRect.bottom - 1;
+
+	// The test point can only be hit-tested when it is within the viewport
+	// (`caretRangeFromPoint` returns nothing for a point outside it, upon
+	// which `scrollIfNoRange` scrolls the container's edge into view to
+	// measure, e.g. on every arrow press within a container taller than the
+	// viewport). When the edge is outside the viewport and the selection is
+	// within it, they are at least a viewport boundary apart, so the
+	// selection cannot be at the edge.
+	if (
+		( y < 0 ||
+			y > defaultView.innerHeight ||
+			x < 0 ||
+			x > defaultView.innerWidth ) &&
+		rangeRect.top >= 0 &&
+		rangeRect.bottom <= defaultView.innerHeight &&
+		rangeRect.left >= 0 &&
+		rangeRect.right <= defaultView.innerWidth
+	) {
+		return false;
+	}
+
 	const testRange = scrollIfNoRange( container, isReverse, () =>
 		hiddenCaretRangeFromPoint( ownerDocument, x, y, container )
 	);

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1151,6 +1151,10 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 			);
 		const lineBefore = await getCaretLine();
 
+		// Without a caret the line reads are NaN and the final assertion
+		// would compare NaN to NaN, which passes.
+		expect( lineBefore ).toBeGreaterThan( 1 );
+
 		// Record every scroll movement for a second. Moving the caret
 		// within the block must not scroll the page: the caret stays
 		// within the viewport.

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1162,9 +1162,19 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 			() =>
 				new Promise( ( resolve ) => {
 					const positions = [];
-					document.addEventListener( 'scroll', () => {
-						positions.push( document.documentElement.scrollTop );
-					} );
+					// Capture phase so scrolls of nested containers are
+					// caught too, not only the document.
+					document.addEventListener(
+						'scroll',
+						( event ) => {
+							positions.push(
+								event.target === document
+									? document.documentElement.scrollTop
+									: event.target.scrollTop
+							);
+						},
+						true
+					);
 					setTimeout( () => resolve( positions ), 1000 );
 				} )
 		);

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1108,6 +1108,72 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		).toHaveText( /^\.a+$/ );
 	} );
 
+	test( 'should not scroll the page when moving the caret within a block taller than the viewport', async ( {
+		page,
+		editor,
+	} ) => {
+		const lines = Array.from(
+			{ length: 70 },
+			( _, i ) => `line ${ i + 1 }`
+		).join( '\n' );
+		await editor.insertBlock( {
+			name: 'core/code',
+			attributes: { content: lines },
+		} );
+
+		const frame = page.frame( { name: 'editor-canvas' } );
+
+		// Scroll the middle of the code block into view and click there.
+		await frame.evaluate( () => {
+			const code = document.querySelector( '[data-type="core/code"]' );
+			const rect = code.getBoundingClientRect();
+			const middle =
+				rect.top + document.documentElement.scrollTop + rect.height / 2;
+			document.documentElement.scrollTop =
+				middle - window.innerHeight / 2;
+		} );
+		const codeBox = await editor.canvas
+			.locator( '[data-type="core/code"] code' )
+			.boundingBox();
+		await page.mouse.click(
+			codeBox.x + 60,
+			codeBox.y + codeBox.height / 2
+		);
+
+		const getCaretLine = () =>
+			frame.evaluate( () =>
+				parseInt(
+					document
+						.getSelection()
+						.focusNode?.textContent.match( /line (\d+)/ )?.[ 1 ],
+					10
+				)
+			);
+		const lineBefore = await getCaretLine();
+
+		// Record every scroll movement for a second. Moving the caret
+		// within the block must not scroll the page: the caret stays
+		// within the viewport.
+		const scrollWatcher = frame.evaluate(
+			() =>
+				new Promise( ( resolve ) => {
+					const positions = [];
+					document.addEventListener( 'scroll', () => {
+						positions.push( document.documentElement.scrollTop );
+					} );
+					setTimeout( () => resolve( positions ), 1000 );
+				} )
+		);
+
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		// The caret moved down one line net (down, down, up).
+		await expect.poll( getCaretLine ).toBe( lineBefore + 1 );
+		expect( await scrollWatcher ).toEqual( [] );
+	} );
+
 	test( 'should vertically move the caret from corner to corner (-webkit)', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?
Fixes #73801. Closes #68492 (same cause). Moving the caret with the arrow keys inside a block taller than the viewport (a long code block, quote, or paragraph) no longer scrolls the page on every press.

## Why?
On every arrow press, writing flow asks whether the selection is at the block's edge. `isEdge` answers by hit-testing the caret position at the container's visual edge via `caretRangeFromPoint`, which only works for points within the viewport. For a block taller than the viewport, the edge is off screen, so `scrollIfNoRange` first scrolled the block's edge into view to measure: a scroll on every arrow press. The browser's caret reveal then pulled the view partly back, leaving the caret pinned at a fixed screen position while the page lurched, one line per press. In milder geometries this masquerades as a typewriter effect on arrow keys, which the actual typewriter component deliberately does not do.

## How?
Skip the probe when its outcome is already determined: if the edge point is outside the viewport (along the axis being checked) while the selection rect is within it, they are at least a viewport boundary apart, so the selection cannot be at that edge and `isEdge` returns false without measuring. A caret scrolled out of view still takes the probe path, including its scroll-to-measure fallback.

One narrow trade-off: the skip compares the container's outer edge with the viewport, while the caret sits on the edge line of text, which is higher by the block's bottom padding plus line spacing. When the outer edge is a few pixels off screen but the edge line is visible with the caret on it, the check now answers "not at the edge", so an arrow press does nothing until the page scrolls those few pixels. In that same strip, the previous behavior was a full-viewport jump on every press. The strip cannot be shrunk without measuring where the edge line is, which is exactly the probe being skipped. `placeCaretAtEdge`, the other consumer of the scrolling helper, is untouched: there the scroll is legitimate, since caret placement is about to reveal the container anyway.

## Testing Instructions
1. Insert a Code block and paste 60 or more lines, so the block is taller than the viewport.
2. Click a line in the middle of the block, with the caret mid-screen and the block extending off screen above and below.
3. Press ArrowDown or ArrowUp repeatedly: the page stays still while the caret walks the lines. Previously the content shifted on every press with the caret pinned in place.

Covered by an e2e test in all three engines asserting no scroll events fire across the presses and that the caret actually moved a line; it fails on trunk in all three.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.
