### PR TITLE
Block editor: place the caret in the next block on forward delete from an empty block

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1253,10 +1253,19 @@ export const mergeBlocks =
 		}
 
 		if ( isUnmodifiedDefaultBlock( blockA ) ) {
-			dispatch.removeBlock(
-				clientIdA,
-				select.isBlockSelected( clientIdA )
-			);
+			// The first block only holds the selection when it is being
+			// merged forward (forward delete from an empty block). The
+			// caret must end up at the start of the next block, not at
+			// the end of the previous one.
+			const wasSelected = select.isBlockSelected( clientIdA );
+
+			registry.batch( () => {
+				dispatch.removeBlock( clientIdA, false );
+
+				if ( wasSelected ) {
+					dispatch.selectBlock( clientIdB, 0 );
+				}
+			} );
 			return;
 		}
 

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -242,6 +242,41 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		);
 	} );
 
+	test( 'should place the caret in the next block on forward delete from an empty paragraph', async ( {
+		editor,
+		page,
+	} ) => {
+		for ( const content of [ 'first', '', '', 'last' ] ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content },
+			} );
+		}
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.first()
+			.click();
+
+		// Forward delete removes the empty block; the caret must move to
+		// the start of the next block, not the end of the previous one,
+		// so repeated presses keep deleting forward.
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.type( '|' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'first' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: '|last' },
+			},
+		] );
+	} );
+
 	test( 'should remove empty paragraph block on backspace', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Fixes #64235. Pressing forward delete in an empty block removes it and places the caret at the start of the next block, so repeated presses keep deleting forward. Previously the caret jumped backward to the end of the previous block.

## Why?
`mergeBlocks` removed the unmodified first block with select-previous semantics. That is the one branch where the removed block itself holds the selection (a forward merge from an empty block), so the selection fell back to the block before it, against the direction of the gesture.

## How?
When the removed first block was the selected one, select the second block at its start instead. The backward merge paths are untouched: there the removed block does not hold the selection, and their behavior is already correct.

## Testing Instructions
1. Add a paragraph with text, two empty paragraphs, and another paragraph with text.
2. Place the caret in the first empty paragraph and press forward delete (Fn+Backspace on macOS) twice.
3. The empty paragraphs are removed one by one and the caret ends at the start of the last paragraph. Previously the first press moved the caret to the end of the first paragraph.

Covered by an e2e test in all three engines; it fails on trunk.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.