### PR TITLE
Used `@link` for url in inline documentation

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1470,7 +1470,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * there should be no way for a comma to mean anything other than a
 		 * comma token. The exception are syntax errors, which are not handled here.
 		 *
-		 * @see https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
+		 * @link https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
 		 */
 		if ( strlen( $selector ) === strcspn( $selector, '/\'"(<\\' ) ) {
 			return str_replace( ',', $to_append . ',', $selector ) . $to_append;
@@ -1519,7 +1519,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * there should be no way for a comma to mean anything other than a
 		 * comma token. The exception are syntax errors, which are not handled here.
 		 *
-		 * @see https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
+		 * @link https://www.w3.org/TR/css-syntax-3/#parse-comma-separated-list-of-component-values
 		 */
 		if ( strlen( $selector ) === strcspn( $selector, '/\'"(<\\' ) ) {
 			return $to_prepend . str_replace( ',', ',' . $to_prepend, $selector );
@@ -1565,8 +1565,8 @@ class WP_Theme_JSON_Gutenberg {
 	 *     // Comments stay with the selector they follow.
 	 *     array( '.a /* a, the first *\/', '.b' ) === self::split_selector_list( '.a /* a, the first *\/,.b' );
 	 *
-	 * @see https://www.w3.org/TR/selectors/#parse-selector
-	 * @see https://www.w3.org/TR/css-syntax-3/
+	 * @link https://www.w3.org/TR/selectors/#parse-selector
+	 * @link https://www.w3.org/TR/css-syntax-3/
 	 *
 	 * @param string $selector CSS selector list.
 	 * @return string[] Selectors.
@@ -1671,8 +1671,8 @@ class WP_Theme_JSON_Gutenberg {
 				 * > not included in this definition, as they are converted
 				 * > to U+000A LINE FEED during preprocessing.
 				 *
-				 * @see https://www.w3.org/TR/css-syntax/#whitespace
-				 * @see https://www.w3.org/TR/css-syntax/#newline
+				 * @link https://www.w3.org/TR/css-syntax/#whitespace
+				 * @link https://www.w3.org/TR/css-syntax/#newline
 				 */
 				$selectors[] = trim( substr( $selector, $was_at, $next_at - $was_at ), " \t\n" );
 				$at          = $next_at + 1;

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -15,7 +15,7 @@
  * consumer code might still be referencing them. In order to not break the Site Editor
  * flows, we don't fully remove the old routes, but redirect them to the core's one.
  *
- * @see https://github.com/WordPress/gutenberg/pull/41306
+ * @link https://github.com/WordPress/gutenberg/pull/41306
  *
  * @package gutenberg
  */

--- a/lib/compat/plugin/fonts.php
+++ b/lib/compat/plugin/fonts.php
@@ -2,7 +2,7 @@
 /**
  * A special compat layer for legacy font files upload directory.
  *
- * @see https://github.com/WordPress/gutenberg/pull/57688#issuecomment-2259037546
+ * @link https://github.com/WordPress/gutenberg/pull/57688#issuecomment-2259037546
  *
  * @package gutenberg
  */

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -27,7 +27,7 @@
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @global WP_Customize_Manager $wp_customize
  *
@@ -82,7 +82,7 @@ add_action( 'wp_update_nav_menu_item', 'gutenberg_update_nav_menu_item_content',
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param object $menu_item The menu item object.
  *
@@ -115,7 +115,7 @@ add_filter( 'wp_setup_nav_menu_item', 'gutenberg_setup_block_nav_menu_item' );
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param string   $item_output The menu item's starting HTML output.
  * @param WP_Post  $item        Menu item data object.
@@ -147,7 +147,7 @@ add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_block_nav_menu_item', 
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param array $menu_items The menu items, sorted by each menu item's menu order.
  *
@@ -155,7 +155,7 @@ add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_block_nav_menu_item', 
  */
 function gutenberg_remove_block_nav_menu_items( $menu_items ) {
 	// We should uncomment the line below when the block-nav-menus feature becomes stable.
-	// @see https://github.com/WordPress/gutenberg/issues/34265.
+	// @link https://github.com/WordPress/gutenberg/issues/34265.
 	/*if ( current_theme_supports( 'block-nav-menus' ) ) {*/
 	if ( false ) {
 		return $menu_items;
@@ -241,7 +241,7 @@ function gutenberg_convert_menu_items_to_blocks(
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param string|null $output Nav menu output to short-circuit with. Default null.
  * @param stdClass    $args   An object containing wp_nav_menu() arguments.
@@ -250,7 +250,7 @@ function gutenberg_convert_menu_items_to_blocks(
  */
 function gutenberg_output_block_nav_menu( $output, $args ) {
 	// We should uncomment the line below when the block-nav-menus feature becomes stable.
-	// @see https://github.com/WordPress/gutenberg/issues/34265.
+	// @link https://github.com/WordPress/gutenberg/issues/34265.
 	/*if ( ! current_theme_supports( 'block-nav-menus' ) ) {*/
 	if ( true ) {
 		return null;
@@ -331,7 +331,7 @@ add_filter( 'pre_wp_nav_menu', 'gutenberg_output_block_nav_menu', 10, 2 );
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param int     $item_id Menu item ID.
  * @param WP_Post $item    Menu item data object.
@@ -358,7 +358,7 @@ add_action( 'wp_nav_menu_item_custom_fields', 'gutenberg_output_block_menu_item_
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see https://core.trac.wordpress.org/ticket/50544
+ * @link https://core.trac.wordpress.org/ticket/50544
  *
  * @param string $hook The current admin page.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR replaces incorrect `@see` tags pointing to external URLs with `@link`, the correct `PHPDoc` tag for external references, across the following files:

- `lib/compact/plugin/font.php`
- `experimental/navigation-theme-opt-in.php`
- `lib/class-wp-theme-json-gutenberg.php`
- `lib/compact/plugin/edit-site-routes-backwards-compat.php`

<!-- In a few words, what is the PR actually doing? -->

## Why?
As Per [WordPress Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/):

- `@see` should reference internal code elements - functions, methods, classes, or hooks.
- `@link` should be used for external URLs - e.g. Trac tickets, GitHub issues or PRs, or Documentation pages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Used `@link` for external references, including Trac tickets, GitHub PRs, GitHub issues, and documentation pages.
- No functional / runtime code was modified - this is a documentation-only change.

## Testing Instructions
- Open the mentioned files and review the updated inline documentation.
- Confirm URLs use @link, and @see is used only for code references (functions/methods/classes).

## Use of AI Tools
- Yes 
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
