### PR TITLE
Block Editor: Refactor 'URLInput' to function component

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,12 +11,12 @@
 ### Internal
 
 -   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#80555](https://github.com/WordPress/gutenberg/pull/80555)).
--   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to.
+-   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
--   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set.
+-   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 
 -   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#80555](https://github.com/WordPress/gutenberg/pull/80555)).
+-   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to.
 
 ### Bug Fixes
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
+-   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set.
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -952,9 +952,15 @@ Ensures that the text selection keeps the same vertical distance from the viewpo
 
 ### URLInput
 
+Text field for entering a URL, with an autocomplete list of matching posts, pages and other link suggestions.
+
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/url-input/README.md>
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
 
 ### URLInputButton
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -6,25 +6,20 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import {
 	BaseControl,
 	Button,
 	__experimentalInputControl as InputControl,
 	Spinner,
-	withSpokenMessages,
 	Popover,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import {
-	compose,
-	debounce,
-	withInstanceId,
-	withSafeTimeout,
-} from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useDebounce, useEvent, useInstanceId } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 
 /**
@@ -45,99 +40,75 @@ function isFunction( maybeFunc ) {
 	return typeof maybeFunc === 'function';
 }
 
-class URLInput extends Component {
-	constructor( props ) {
-		super( props );
+/**
+ * Text field for entering a URL, with an autocomplete list of matching posts,
+ * pages and other link suggestions.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/url-input/README.md
+ *
+ * @param {Object} props Component props.
+ */
+export default function URLInput( props ) {
+	const {
+		__experimentalFetchLinkSuggestions: fetchLinkSuggestionsProp,
+		__experimentalHandleURLSuggestions: handleURLSuggestions,
+		__experimentalRenderControl: renderControl,
+		__experimentalRenderSuggestions: renderSuggestions,
+		__experimentalShowInitialSuggestions: showInitialSuggestions = false,
+		autocompleteRef,
+		className,
+		customValidity,
+		disableSuggestions,
+		disabled = false,
+		help = null,
+		hideLabelFromVision = false,
+		inputRef,
+		isFullWidth,
+		label = null,
+		markWhenOptional,
+		onChange,
+		onKeyDown,
+		onSubmit,
+		placeholder = __( 'Paste URL or type to search' ),
+		required = true,
+		suffix,
+		value = '',
+	} = props;
 
-		this.onChange = this.onChange.bind( this );
-		this.onFocus = this.onFocus.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
-		this.selectLink = this.selectLink.bind( this );
-		this.handleOnClick = this.handleOnClick.bind( this );
-		this.bindSuggestionNode = this.bindSuggestionNode.bind( this );
-		this.autocompleteRef = props.autocompleteRef || createRef();
-		this.inputRef = props.inputRef || createRef();
-		this.hasRenderedValidation = { current: false };
-		this.updateSuggestions = debounce(
-			this.updateSuggestions.bind( this ),
-			200
-		);
+	const instanceId = useInstanceId( URLInput );
+	const { getSettings } = useSelect( blockEditorStore );
+	const debouncedSpeak = useDebounce( speak, 500 );
 
-		this.suggestionNodes = [];
+	const [ suggestions, setSuggestions ] = useState( [] );
+	const [ suggestionsValue, setSuggestionsValue ] = useState( null );
+	const [ selectedSuggestion, setSelectedSuggestion ] = useState( null );
+	const [ isSuggestionsListOpen, setIsSuggestionsListOpen ] =
+		useState( false );
+	const [ isLoading, setIsLoading ] = useState( false );
 
-		this.suggestionsRequest = null;
+	const fallbackInputRef = useRef();
+	const suggestionNodesRef = useRef( [] );
+	// A fetch Promise can't be aborted. It's mimicked by holding on to the
+	// pending request so that responses of superseded requests can be ignored.
+	const suggestionsRequestRef = useRef( null );
 
-		this.state = {
-			suggestions: [],
-			showSuggestions: false,
-			suggestionsValue: null,
-			selectedSuggestion: null,
-			suggestionsListboxId: '',
-			suggestionOptionIdPrefix: '',
-		};
-	}
+	const controlInputRef = inputRef ?? fallbackInputRef;
 
-	componentDidUpdate( prevProps ) {
-		const { showSuggestions, selectedSuggestion } = this.state;
-		const { value, __experimentalShowInitialSuggestions = false } =
-			this.props;
+	const inputId = `url-input-control-${ instanceId }`;
+	const suggestionsListboxId = `block-editor-url-input-suggestions-${ instanceId }`;
+	const suggestionOptionIdPrefix = `block-editor-url-input-suggestion-${ instanceId }`;
 
-		// Only have to worry about scrolling selected suggestion into view
-		// when already expanded.
-		if (
-			showSuggestions &&
-			selectedSuggestion !== null &&
-			this.suggestionNodes[ selectedSuggestion ]
-		) {
-			this.suggestionNodes[ selectedSuggestion ].scrollIntoView( {
-				behavior: 'instant',
-				block: 'nearest',
-				inline: 'nearest',
-			} );
-		}
+	// The suggestions are hidden rather than discarded, so that returning focus
+	// to a field that already has results doesn't trigger a new search.
+	const showSuggestions =
+		isSuggestionsListOpen &&
+		disableSuggestions !== true &&
+		( showInitialSuggestions || !! value?.length );
 
-		// Update suggestions when the value changes.
-		if ( prevProps.value !== value && ! this.props.disableSuggestions ) {
-			if ( value?.length ) {
-				// If the new value is not empty we need to update with suggestions for it.
-				this.updateSuggestions( value );
-			} else if ( __experimentalShowInitialSuggestions ) {
-				// If the new value is empty and we can show initial suggestions, then show initial suggestions.
-				this.updateSuggestions();
-			}
-		}
-	}
-
-	componentDidMount() {
-		if ( this.shouldShowInitialSuggestions() ) {
-			this.updateSuggestions();
-		}
-	}
-
-	componentWillUnmount() {
-		this.suggestionsRequest?.cancel?.();
-		this.suggestionsRequest = null;
-	}
-
-	bindSuggestionNode( index ) {
-		return ( ref ) => {
-			this.suggestionNodes[ index ] = ref;
-		};
-	}
-
-	shouldShowInitialSuggestions() {
-		const { __experimentalShowInitialSuggestions = false, value } =
-			this.props;
-		return (
-			__experimentalShowInitialSuggestions && ! ( value && value.length )
-		);
-	}
-
-	updateSuggestions( value = '' ) {
-		const {
-			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
-			__experimentalHandleURLSuggestions: handleURLSuggestions,
-		} = this.props;
+	const updateSuggestions = useEvent( ( searchValue = '' ) => {
+		const fetchLinkSuggestions = isFunction( fetchLinkSuggestionsProp )
+			? fetchLinkSuggestionsProp
+			: getSettings().__experimentalFetchLinkSuggestions;
 
 		if ( ! fetchLinkSuggestions ) {
 			return;
@@ -145,11 +116,11 @@ class URLInput extends Component {
 
 		// Initial suggestions may only show if there is no value
 		// (note: this includes whitespace).
-		const isInitialSuggestions = ! value?.length;
+		const isInitialSuggestions = ! searchValue?.length;
 
 		// Trim only now we've determined whether or not it originally had a "length"
 		// (even if that value was all whitespace).
-		value = value.trim();
+		const search = searchValue.trim();
 
 		// Allow a suggestions request if:
 		// - there are at least 2 characters in the search input (except manual searches where
@@ -157,119 +128,166 @@ class URLInput extends Component {
 		// - this is a direct entry (eg: a URL)
 		if (
 			! isInitialSuggestions &&
-			( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) )
+			( search.length < 2 ||
+				( ! handleURLSuggestions && isURL( search ) ) )
 		) {
-			this.suggestionsRequest?.cancel?.();
-			this.suggestionsRequest = null;
+			suggestionsRequestRef.current?.cancel?.();
+			suggestionsRequestRef.current = null;
 
-			this.setState( {
-				suggestions: [],
-				showSuggestions: false,
-				suggestionsValue: value,
-				selectedSuggestion: null,
-				loading: false,
-			} );
+			setSuggestions( [] );
+			setIsSuggestionsListOpen( false );
+			setSuggestionsValue( search );
+			setSelectedSuggestion( null );
+			setIsLoading( false );
 
 			return;
 		}
 
-		this.setState( {
-			selectedSuggestion: null,
-			loading: true,
-		} );
+		setSelectedSuggestion( null );
+		setIsLoading( true );
 
-		const request = fetchLinkSuggestions( value, {
+		const request = fetchLinkSuggestions( search, {
 			isInitialSuggestions,
 		} );
+		suggestionsRequestRef.current = request;
 
 		request
-			.then( ( suggestions ) => {
-				// A fetch Promise doesn't have an abort option. It's mimicked by
-				// comparing the request reference in on the instance, which is
-				// reset or deleted on subsequent requests or unmounting.
-				if ( this.suggestionsRequest !== request ) {
+			.then( ( nextSuggestions ) => {
+				if ( suggestionsRequestRef.current !== request ) {
 					return;
 				}
 
-				this.setState( {
-					suggestions,
-					suggestionsValue: value,
-					loading: false,
-					showSuggestions: !! suggestions.length,
-				} );
+				setSuggestions( nextSuggestions );
+				setSuggestionsValue( search );
+				setIsLoading( false );
+				setIsSuggestionsListOpen( !! nextSuggestions.length );
 
-				if ( !! suggestions.length ) {
-					this.props.debouncedSpeak(
+				if ( nextSuggestions.length ) {
+					debouncedSpeak(
 						sprintf(
 							/* translators: %d: number of results. */
 							_n(
 								'%d result found, use up and down arrow keys to navigate.',
 								'%d results found, use up and down arrow keys to navigate.',
-								suggestions.length
+								nextSuggestions.length
 							),
-							suggestions.length
+							nextSuggestions.length
 						),
 						'assertive'
 					);
 				} else {
-					this.props.debouncedSpeak(
-						__( 'No results.' ),
-						'assertive'
-					);
+					debouncedSpeak( __( 'No results.' ), 'assertive' );
 				}
 			} )
 			.catch( () => {
-				if ( this.suggestionsRequest !== request ) {
+				if ( suggestionsRequestRef.current !== request ) {
 					return;
 				}
 
-				this.setState( {
-					loading: false,
-				} );
+				setIsLoading( false );
 			} )
 			.finally( () => {
-				// If this is the current promise then reset the reference
-				// to allow for checking if a new request is made.
-				if ( this.suggestionsRequest === request ) {
-					this.suggestionsRequest = null;
+				if ( suggestionsRequestRef.current === request ) {
+					suggestionsRequestRef.current = null;
 				}
 			} );
+	} );
 
-		// Note that this assignment is handled *before* the async search request
-		// as a Promise always resolves on the next tick of the event loop.
-		this.suggestionsRequest = request;
+	const debouncedUpdateSuggestions = useDebounce( updateSuggestions, 200 );
+
+	// The value that suggestions were last requested for. Seeded with the value
+	// the field is mounted with, so that a pre-filled field doesn't search until
+	// the value is edited.
+	const requestedValueRef = useRef( value );
+
+	useEffect( () => {
+		if ( requestedValueRef.current === value ) {
+			return;
+		}
+
+		requestedValueRef.current = value;
+
+		if ( disableSuggestions ) {
+			return;
+		}
+
+		if ( value?.length ) {
+			debouncedUpdateSuggestions( value );
+		} else if ( showInitialSuggestions ) {
+			debouncedUpdateSuggestions();
+		}
+	}, [
+		value,
+		disableSuggestions,
+		showInitialSuggestions,
+		debouncedUpdateSuggestions,
+	] );
+
+	useEffect( () => {
+		if ( showInitialSuggestions && ! value?.length ) {
+			debouncedUpdateSuggestions();
+		}
+		// Initial suggestions are only loaded for a field that mounts empty.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Persist the hidden state, so that the list can't reappear with stale
+	// results once the value or the props allow suggestions again.
+	useEffect( () => {
+		if ( ! showSuggestions ) {
+			setIsSuggestionsListOpen( false );
+		}
+	}, [ showSuggestions ] );
+
+	useEffect( () => {
+		if ( showSuggestions && selectedSuggestion !== null ) {
+			suggestionNodesRef.current[ selectedSuggestion ]?.scrollIntoView( {
+				behavior: 'instant',
+				block: 'nearest',
+				inline: 'nearest',
+			} );
+		}
+	}, [ showSuggestions, selectedSuggestion ] );
+
+	useEffect( () => {
+		return () => {
+			suggestionsRequestRef.current?.cancel?.();
+			suggestionsRequestRef.current = null;
+		};
+	}, [] );
+
+	function selectLink( suggestion ) {
+		onChange( suggestion.url, suggestion );
+		setSelectedSuggestion( null );
+		setIsSuggestionsListOpen( false );
 	}
 
-	onChange( newValue ) {
-		this.props.onChange( newValue );
+	function handleSuggestionClick( suggestion ) {
+		selectLink( suggestion );
+		// Move focus to the input field when a link suggestion is clicked.
+		controlInputRef.current.focus();
 	}
 
-	onFocus() {
-		const { suggestions } = this.state;
-		const { disableSuggestions, value } = this.props;
-
+	function handleFocus() {
 		// When opening the link editor, if there's a value present, we want to load the suggestions pane with the results for this input search value
 		// Don't re-run the suggestions on focus if there are already suggestions present (prevents searching again when tabbing between the input and buttons)
 		// or there is already a request in progress.
 		if (
 			value &&
 			! disableSuggestions &&
-			! ( suggestions && suggestions.length ) &&
-			this.suggestionsRequest === null
+			! suggestions.length &&
+			suggestionsRequestRef.current === null
 		) {
-			// Ensure the suggestions are updated with the current input value.
-			this.updateSuggestions( value );
+			debouncedUpdateSuggestions( value );
 		}
 	}
 
-	onKeyDown( event ) {
-		this.props.onKeyDown?.( event );
-		const { showSuggestions, selectedSuggestion, suggestions, loading } =
-			this.state;
+	function handleKeyDown( event ) {
+		onKeyDown?.( event );
 
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation.
-		if ( ! showSuggestions || ! suggestions.length || loading ) {
+		if ( ! showSuggestions || ! suggestions.length || isLoading ) {
 			// In the Windows version of Firefox the up and down arrows don't move the caret
 			// within an input field like they do for Mac Firefox/Chrome/Safari. This causes
 			// a form of focus trapping that is disruptive to the user experience. This disruption
@@ -290,15 +308,13 @@ class URLInput extends Component {
 				// When DOWN is pressed, if the caret is not at the end of the text, move it to the
 				// last position.
 				case DOWN: {
-					if (
-						this.props.value.length !== event.target.selectionStart
-					) {
+					if ( value.length !== event.target.selectionStart ) {
 						event.preventDefault();
 
 						// Set the input caret to the last position.
 						event.target.setSelectionRange(
-							this.props.value.length,
-							this.props.value.length
+							value.length,
+							value.length
 						);
 					}
 					break;
@@ -306,9 +322,9 @@ class URLInput extends Component {
 
 				// Submitting while loading should trigger onSubmit.
 				case ENTER: {
-					if ( this.props.onSubmit ) {
+					if ( onSubmit ) {
 						event.preventDefault();
-						this.props.onSubmit( null, event );
+						onSubmit( null, event );
 					}
 					break;
 				}
@@ -317,50 +333,46 @@ class URLInput extends Component {
 			return;
 		}
 
-		const suggestion =
-			this.state.suggestions[ this.state.selectedSuggestion ];
+		const suggestion = suggestions[ selectedSuggestion ];
 
 		switch ( event.keyCode ) {
 			case UP: {
 				event.preventDefault();
-				const previousIndex = ! selectedSuggestion
-					? suggestions.length - 1
-					: selectedSuggestion - 1;
-				this.setState( {
-					selectedSuggestion: previousIndex,
-				} );
+				setSelectedSuggestion(
+					! selectedSuggestion
+						? suggestions.length - 1
+						: selectedSuggestion - 1
+				);
 				break;
 			}
 			case DOWN: {
 				event.preventDefault();
-				const nextIndex =
+				setSelectedSuggestion(
 					selectedSuggestion === null ||
-					selectedSuggestion === suggestions.length - 1
+						selectedSuggestion === suggestions.length - 1
 						? 0
-						: selectedSuggestion + 1;
-				this.setState( {
-					selectedSuggestion: nextIndex,
-				} );
+						: selectedSuggestion + 1
+				);
 				break;
 			}
 			case TAB: {
-				if ( this.state.selectedSuggestion !== null ) {
-					this.selectLink( suggestion );
+				if ( selectedSuggestion !== null ) {
+					selectLink( suggestion );
 					// Announce a link has been selected when tabbing away from the input field.
-					this.props.speak( __( 'Link selected.' ) );
+					speak( __( 'Link selected.' ) );
 				}
 				break;
 			}
 			case ENTER: {
 				event.preventDefault();
-				if ( this.state.selectedSuggestion !== null ) {
-					this.selectLink( suggestion );
+				if ( selectedSuggestion !== null ) {
+					selectLink( suggestion );
 
-					if ( this.props.onSubmit ) {
-						this.props.onSubmit( suggestion, event );
+					if ( onSubmit ) {
+						onSubmit( suggestion, event );
 					}
-				} else if ( this.props.onSubmit ) {
-					this.props.onSubmit( null, event );
+				} else if ( onSubmit ) {
+					onSubmit( null, event );
 				}
 
 				break;
@@ -368,251 +380,184 @@ class URLInput extends Component {
 		}
 	}
 
-	selectLink( suggestion ) {
-		this.props.onChange( suggestion.url, suggestion );
-		this.setState( {
-			selectedSuggestion: null,
-			showSuggestions: false,
+	const controlProps = {
+		id: inputId, // Passes attribute to label for the for attribute
+		label,
+		className: clsx( 'block-editor-url-input', className, {
+			'is-full-width': isFullWidth,
+		} ),
+		hideLabelFromVision,
+	};
+
+	const inputProps = {
+		id: inputId,
+		value,
+		required,
+		type: 'text',
+		name: inputId,
+		autoComplete: 'off',
+		onChange: disabled ? () => {} : ( newValue ) => onChange( newValue ), // Disable onChange when disabled
+		onFocus: disabled ? () => {} : handleFocus, // Disable onFocus when disabled
+		placeholder,
+		onKeyDown: disabled ? () => {} : handleKeyDown, // Disable onKeyDown when disabled
+		role: 'combobox',
+		'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
+		'aria-expanded': showSuggestions,
+		'aria-autocomplete': 'list',
+		'aria-owns': suggestionsListboxId,
+		'aria-activedescendant':
+			selectedSuggestion !== null
+				? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
+				: undefined,
+		ref: controlInputRef,
+		disabled,
+		suffix,
+		help,
+	};
+
+	return (
+		<>
+			<Control
+				controlProps={ controlProps }
+				inputProps={ inputProps }
+				isLoading={ isLoading }
+				customValidity={ customValidity }
+				markWhenOptional={ markWhenOptional }
+				renderControl={ renderControl }
+			/>
+			{ showSuggestions && suggestions.length > 0 && (
+				<Suggestions
+					autocompleteRef={ autocompleteRef }
+					className={ className }
+					handleSuggestionClick={ handleSuggestionClick }
+					isLoading={ isLoading }
+					renderSuggestions={ renderSuggestions }
+					selectedSuggestion={ selectedSuggestion }
+					suggestionNodesRef={ suggestionNodesRef }
+					suggestionOptionIdPrefix={ suggestionOptionIdPrefix }
+					suggestions={ suggestions }
+					suggestionsListboxId={ suggestionsListboxId }
+					suggestionsValue={ suggestionsValue }
+				/>
+			) }
+		</>
+	);
+}
+
+function Control( {
+	controlProps,
+	inputProps,
+	isLoading,
+	customValidity,
+	markWhenOptional,
+	renderControl,
+} ) {
+	// Once a validity has been reported, keep using the validated control, so
+	// that clearing the validity doesn't remount (and blur) the input.
+	const [ isValidated, setIsValidated ] = useState(
+		customValidity !== undefined
+	);
+
+	if ( customValidity !== undefined && ! isValidated ) {
+		setIsValidated( true );
+	}
+
+	if ( renderControl ) {
+		return renderControl( controlProps, inputProps, isLoading );
+	}
+
+	const MaybeValidatedInputControl = isValidated
+		? ValidatedInputControl
+		: InputControl;
+
+	return (
+		<BaseControl { ...controlProps }>
+			<MaybeValidatedInputControl
+				{ ...inputProps }
+				{ ...( isValidated && {
+					customValidity,
+					// Suppress the "(Required)" indicator in the label.
+					// The field is still required for validation, but the indicator
+					// can be hidden when markWhenOptional is set to true.
+					...( markWhenOptional !== undefined && {
+						markWhenOptional,
+					} ),
+				} ) }
+			/>
+			{ isLoading && <Spinner /> }
+		</BaseControl>
+	);
+}
+
+function Suggestions( {
+	autocompleteRef,
+	className,
+	handleSuggestionClick,
+	isLoading,
+	renderSuggestions,
+	selectedSuggestion,
+	suggestionNodesRef,
+	suggestionOptionIdPrefix,
+	suggestions,
+	suggestionsListboxId,
+	suggestionsValue,
+} ) {
+	const suggestionsListProps = {
+		id: suggestionsListboxId,
+		ref: autocompleteRef,
+		role: 'listbox',
+	};
+
+	const buildSuggestionItemProps = ( suggestion, index ) => {
+		return {
+			role: 'option',
+			tabIndex: '-1',
+			id: `${ suggestionOptionIdPrefix }-${ index }`,
+			ref: ( node ) => {
+				suggestionNodesRef.current[ index ] = node;
+			},
+			'aria-selected': index === selectedSuggestion ? true : undefined,
+		};
+	};
+
+	if ( isFunction( renderSuggestions ) ) {
+		return renderSuggestions( {
+			suggestions,
+			selectedSuggestion,
+			suggestionsListProps,
+			buildSuggestionItemProps,
+			isLoading,
+			handleSuggestionClick,
+			isInitialSuggestions: ! suggestionsValue?.length,
+			currentInputValue: suggestionsValue,
 		} );
 	}
 
-	handleOnClick( suggestion ) {
-		this.selectLink( suggestion );
-		// Move focus to the input field when a link suggestion is clicked.
-		this.inputRef.current.focus();
-	}
-
-	static getDerivedStateFromProps(
-		{
-			value,
-			instanceId,
-			disableSuggestions,
-			__experimentalShowInitialSuggestions = false,
-		},
-		{ showSuggestions }
-	) {
-		let shouldShowSuggestions = showSuggestions;
-
-		const hasValue = value && value.length;
-
-		if ( ! __experimentalShowInitialSuggestions && ! hasValue ) {
-			shouldShowSuggestions = false;
-		}
-
-		if ( disableSuggestions === true ) {
-			shouldShowSuggestions = false;
-		}
-
-		return {
-			showSuggestions: shouldShowSuggestions,
-			suggestionsListboxId: `block-editor-url-input-suggestions-${ instanceId }`,
-			suggestionOptionIdPrefix: `block-editor-url-input-suggestion-${ instanceId }`,
-		};
-	}
-
-	render() {
-		return (
-			<>
-				{ this.renderControl() }
-				{ this.renderSuggestions() }
-			</>
-		);
-	}
-
-	renderControl() {
-		const {
-			label = null,
-			className,
-			isFullWidth,
-			instanceId,
-			placeholder = __( 'Paste URL or type to search' ),
-			__experimentalRenderControl: renderControl,
-			value = '',
-			hideLabelFromVision = false,
-			help = null,
-			disabled = false,
-			customValidity,
-			markWhenOptional,
-		} = this.props;
-
-		const {
-			loading,
-			showSuggestions,
-			selectedSuggestion,
-			suggestionsListboxId,
-			suggestionOptionIdPrefix,
-		} = this.state;
-
-		const inputId = `url-input-control-${ instanceId }`;
-
-		const controlProps = {
-			id: inputId, // Passes attribute to label for the for attribute
-			label,
-			className: clsx( 'block-editor-url-input', className, {
-				'is-full-width': isFullWidth,
-			} ),
-			hideLabelFromVision,
-		};
-
-		const inputProps = {
-			id: inputId,
-			value,
-			required: this.props.required ?? true,
-			type: 'text',
-			name: inputId,
-			autoComplete: 'off',
-			onChange: disabled ? () => {} : this.onChange, // Disable onChange when disabled
-			onFocus: disabled ? () => {} : this.onFocus, // Disable onFocus when disabled
-			placeholder,
-			onKeyDown: disabled ? () => {} : this.onKeyDown, // Disable onKeyDown when disabled
-			role: 'combobox',
-			'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
-			'aria-expanded': showSuggestions,
-			'aria-autocomplete': 'list',
-			'aria-owns': suggestionsListboxId,
-			'aria-activedescendant':
-				selectedSuggestion !== null
-					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
-					: undefined,
-			ref: this.inputRef,
-			disabled,
-			suffix: this.props.suffix,
-			help,
-		};
-
-		const validationProps = {
-			customValidity,
-			// Suppress the "(Required)" indicator in the label.
-			// The field is still required for validation, but the indicator
-			// can be hidden when markWhenOptional is set to true.
-			...( markWhenOptional !== undefined && {
-				markWhenOptional,
-			} ),
-		};
-
-		if ( renderControl ) {
-			return renderControl( controlProps, inputProps, loading );
-		}
-
-		// Use ValidatedInputControl if customValidity has ever had a non-undefined value.
-		if ( customValidity !== undefined ) {
-			this.hasRenderedValidation.current = true;
-		}
-
-		const MaybeValidatedInputControl = this.hasRenderedValidation.current
-			? ValidatedInputControl
-			: InputControl;
-
-		return (
-			<BaseControl { ...controlProps }>
-				<MaybeValidatedInputControl
-					{ ...inputProps }
-					{ ...( this.hasRenderedValidation.current
-						? validationProps
-						: {} ) }
-				/>
-				{ loading && <Spinner /> }
-			</BaseControl>
-		);
-	}
-
-	renderSuggestions() {
-		const {
-			className,
-			__experimentalRenderSuggestions: renderSuggestions,
-		} = this.props;
-
-		const {
-			showSuggestions,
-			suggestions,
-			suggestionsValue,
-			selectedSuggestion,
-			suggestionsListboxId,
-			suggestionOptionIdPrefix,
-			loading,
-		} = this.state;
-
-		if ( ! showSuggestions || suggestions.length === 0 ) {
-			return null;
-		}
-
-		const suggestionsListProps = {
-			id: suggestionsListboxId,
-			ref: this.autocompleteRef,
-			role: 'listbox',
-		};
-
-		const buildSuggestionItemProps = ( suggestion, index ) => {
-			return {
-				role: 'option',
-				tabIndex: '-1',
-				id: `${ suggestionOptionIdPrefix }-${ index }`,
-				ref: this.bindSuggestionNode( index ),
-				'aria-selected':
-					index === selectedSuggestion ? true : undefined,
-			};
-		};
-
-		if ( isFunction( renderSuggestions ) ) {
-			return renderSuggestions( {
-				suggestions,
-				selectedSuggestion,
-				suggestionsListProps,
-				buildSuggestionItemProps,
-				isLoading: loading,
-				handleSuggestionClick: this.handleOnClick,
-				isInitialSuggestions: ! suggestionsValue?.length,
-				currentInputValue: suggestionsValue,
-			} );
-		}
-
-		return (
-			<Popover placement="bottom" focusOnMount={ false }>
-				<div
-					{ ...suggestionsListProps }
-					className={ clsx( 'block-editor-url-input__suggestions', {
-						[ `${ className }__suggestions` ]: className,
-					} ) }
-				>
-					{ suggestions.map( ( suggestion, index ) => (
-						<Button
-							__next40pxDefaultSize
-							{ ...buildSuggestionItemProps( suggestion, index ) }
-							key={ suggestion.id }
-							className={ clsx(
-								'block-editor-url-input__suggestion',
-								{
-									'is-selected': index === selectedSuggestion,
-								}
-							) }
-							onClick={ () => this.handleOnClick( suggestion ) }
-						>
-							{ suggestion.title }
-						</Button>
-					) ) }
-				</div>
-			</Popover>
-		);
-	}
+	return (
+		<Popover placement="bottom" focusOnMount={ false }>
+			<div
+				{ ...suggestionsListProps }
+				className={ clsx( 'block-editor-url-input__suggestions', {
+					[ `${ className }__suggestions` ]: className,
+				} ) }
+			>
+				{ suggestions.map( ( suggestion, index ) => (
+					<Button
+						__next40pxDefaultSize
+						{ ...buildSuggestionItemProps( suggestion, index ) }
+						key={ suggestion.id }
+						className={ clsx(
+							'block-editor-url-input__suggestion',
+							{
+								'is-selected': index === selectedSuggestion,
+							}
+						) }
+						onClick={ () => handleSuggestionClick( suggestion ) }
+					>
+						{ suggestion.title }
+					</Button>
+				) ) }
+			</div>
+		</Popover>
+	);
 }
-
-/**
- * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/url-input/README.md
- */
-export default compose(
-	withSafeTimeout,
-	withSpokenMessages,
-	withInstanceId,
-	withSelect( ( select, props ) => {
-		// If a link suggestions handler is already provided then
-		// bail.
-		if ( isFunction( props.__experimentalFetchLinkSuggestions ) ) {
-			return;
-		}
-		const { getSettings } = select( blockEditorStore );
-		return {
-			__experimentalFetchLinkSuggestions:
-				getSettings().__experimentalFetchLinkSuggestions,
-		};
-	} )
-)( URLInput );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -195,26 +195,14 @@ export default function URLInput( props ) {
 
 	const debouncedUpdateSuggestions = useDebounce( updateSuggestions, 200 );
 
-	// The value that suggestions were last requested for. Seeded with the value
-	// the field is mounted with, so that a pre-filled field doesn't search until
-	// the value is edited.
-	const requestedValueRef = useRef( value );
-
+	// Keep the suggestions in sync with the value being searched for. An empty
+	// value requests the initial suggestions, when those are enabled.
 	useEffect( () => {
-		if ( requestedValueRef.current === value ) {
-			return;
-		}
-
-		requestedValueRef.current = value;
-
-		if ( disableSuggestions ) {
-			return;
-		}
-
-		if ( value?.length ) {
-			debouncedUpdateSuggestions( value );
-		} else if ( showInitialSuggestions ) {
-			debouncedUpdateSuggestions();
+		if (
+			! disableSuggestions &&
+			( value?.length || showInitialSuggestions )
+		) {
+			debouncedUpdateSuggestions( value ?? '' );
 		}
 	}, [
 		value,
@@ -222,14 +210,6 @@ export default function URLInput( props ) {
 		showInitialSuggestions,
 		debouncedUpdateSuggestions,
 	] );
-
-	useEffect( () => {
-		if ( showInitialSuggestions && ! value?.length ) {
-			debouncedUpdateSuggestions();
-		}
-		// Initial suggestions are only loaded for a field that mounts empty.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	// Persist the hidden state, so that the list can't reappear with stale
 	// results once the value or the props allow suggestions again.

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -103,7 +103,7 @@ export default function URLInput( props ) {
 	const showSuggestions =
 		isSuggestionsListOpen &&
 		disableSuggestions !== true &&
-		( showInitialSuggestions || !! value?.length );
+		( showInitialSuggestions || !! value.length );
 
 	const updateSuggestions = useEvent( ( searchValue = '' ) => {
 		const fetchLinkSuggestions = isFunction( fetchLinkSuggestionsProp )
@@ -200,9 +200,9 @@ export default function URLInput( props ) {
 	useEffect( () => {
 		if (
 			! disableSuggestions &&
-			( value?.length || showInitialSuggestions )
+			( value.length || showInitialSuggestions )
 		) {
-			debouncedUpdateSuggestions( value ?? '' );
+			debouncedUpdateSuggestions( value );
 		}
 	}, [
 		value,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -30,6 +30,8 @@ import { unlock } from '../../lock-unlock';
 
 const { ValidatedInputControl } = unlock( componentsPrivateApis );
 
+const noop = () => {};
+
 /**
  * Whether the argument is a function.
  *
@@ -248,6 +250,12 @@ export default function URLInput( props ) {
 		controlInputRef.current.focus();
 	}
 
+	function handleChange( newValue ) {
+		// `InputControl` passes an `{ event }` object as its second argument,
+		// which callers would mistake for a selected suggestion.
+		onChange( newValue );
+	}
+
 	function handleFocus() {
 		// When opening the link editor, if there's a value present, we want to load the suggestions pane with the results for this input search value
 		// Don't re-run the suggestions on focus if there are already suggestions present (prevents searching again when tabbing between the input and buttons)
@@ -376,10 +384,10 @@ export default function URLInput( props ) {
 		type: 'text',
 		name: inputId,
 		autoComplete: 'off',
-		onChange: disabled ? () => {} : ( newValue ) => onChange( newValue ), // Disable onChange when disabled
-		onFocus: disabled ? () => {} : handleFocus, // Disable onFocus when disabled
+		onChange: disabled ? noop : handleChange,
+		onFocus: disabled ? noop : handleFocus,
+		onKeyDown: disabled ? noop : handleKeyDown,
 		placeholder,
-		onKeyDown: disabled ? () => {} : handleKeyDown, // Disable onKeyDown when disabled
 		role: 'combobox',
 		'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
 		'aria-expanded': showSuggestions,

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -284,8 +284,14 @@ describe( 'URLInput', () => {
 
 		it( 'should fetch suggestions on focus when the previous search returned no results', async () => {
 			const user = userEvent.setup();
+			let resolveMountRequest;
 			fetchLinkSuggestions
-				.mockResolvedValueOnce( [] )
+				.mockImplementationOnce(
+					() =>
+						new Promise( ( resolve ) => {
+							resolveMountRequest = resolve;
+						} )
+				)
 				.mockResolvedValue( SUGGESTIONS );
 
 			render(
@@ -295,10 +301,19 @@ describe( 'URLInput', () => {
 				/>
 			);
 
-			// Let the request made on mount settle without results.
 			await waitFor( () =>
 				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
 			);
+
+			// The request made on mount returns no results. The spinner is only
+			// removed once it has settled.
+			resolveMountRequest( [] );
+			await waitFor( () =>
+				expect(
+					screen.queryByRole( 'presentation' )
+				).not.toBeInTheDocument()
+			);
+
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'combobox' ) );

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -1,0 +1,854 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+import { useState } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
+import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import URLInput from '../';
+import { store as blockEditorStore } from '../../../store';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+const SUGGESTIONS = [
+	{
+		id: 1,
+		title: 'Hello world',
+		type: 'post',
+		url: 'https://example.com/hello-world',
+	},
+	{
+		id: 2,
+		title: 'Sample page',
+		type: 'page',
+		url: 'https://example.com/sample-page',
+	},
+];
+
+/**
+ * Waits long enough for the suggestions request debounce to elapse, so that
+ * assertions about a request _not_ being made are meaningful.
+ */
+function flushDebounce() {
+	return new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+}
+
+/**
+ * `URLInput` is a controlled component, so most interactions require an owner
+ * that holds on to the value.
+ *
+ * @param {Object} props Props passed through to `URLInput`, with `value` used
+ *                       as the initial value.
+ */
+function ControlledURLInput( props ) {
+	const { onChange, value: initialValue = '', ...restProps } = props;
+	const [ value, setValue ] = useState( initialValue );
+
+	return (
+		<URLInput
+			{ ...restProps }
+			value={ value }
+			onChange={ ( newValue, suggestion ) => {
+				setValue( newValue );
+				onChange?.( newValue, suggestion );
+			} }
+		/>
+	);
+}
+
+describe( 'URLInput', () => {
+	let fetchLinkSuggestions;
+
+	beforeEach( () => {
+		fetchLinkSuggestions = jest.fn().mockResolvedValue( SUGGESTIONS );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'rendering', () => {
+		it( 'should render a combobox with a generic accessible name when no label is provided', () => {
+			render( <URLInput value="" onChange={ () => {} } /> );
+
+			const input = screen.getByRole( 'combobox', { name: 'URL' } );
+
+			expect( input ).toBeVisible();
+			expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( input ).toHaveAttribute( 'aria-autocomplete', 'list' );
+		} );
+
+		it( 'should use the provided label as the accessible name', () => {
+			render( <URLInput label="Link" value="" onChange={ () => {} } /> );
+
+			expect(
+				screen.getByRole( 'combobox', { name: /Link/ } )
+			).toBeVisible();
+		} );
+
+		it( 'should render the provided value', () => {
+			render(
+				<URLInput value="https://example.com" onChange={ () => {} } />
+			);
+
+			expect( screen.getByRole( 'combobox' ) ).toHaveValue(
+				'https://example.com'
+			);
+		} );
+
+		it( 'should render a disabled input when `disabled` is set', () => {
+			render( <URLInput value="" onChange={ () => {} } disabled /> );
+
+			expect( screen.getByRole( 'combobox' ) ).toBeDisabled();
+		} );
+
+		it( 'should call `onChange` for each character typed', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render( <ControlledURLInput onChange={ onChange } /> );
+
+			await user.type( screen.getByRole( 'combobox' ), 'abc' );
+
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
+
+	describe( 'fetching suggestions', () => {
+		it( 'should display suggestions for the typed value', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 2 );
+			expect(
+				screen.getByRole( 'option', { name: 'Hello world' } )
+			).toBeVisible();
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
+				isInitialSuggestions: false,
+			} );
+			expect( screen.getByRole( 'combobox' ) ).toHaveAttribute(
+				'aria-expanded',
+				'true'
+			);
+		} );
+
+		it( 'should debounce requests while the user is typing', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			await screen.findByRole( 'listbox' );
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not fetch suggestions for fewer than two characters', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'h' );
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should not fetch suggestions for a direct URL entry', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type(
+				screen.getByRole( 'combobox' ),
+				'https://example.com'
+			);
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should fetch suggestions for a direct URL entry when `__experimentalHandleURLSuggestions` is set', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					__experimentalHandleURLSuggestions
+				/>
+			);
+
+			await user.type(
+				screen.getByRole( 'combobox' ),
+				'https://example.com'
+			);
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
+				'https://example.com',
+				{ isInitialSuggestions: false }
+			);
+		} );
+
+		it( 'should fetch initial suggestions on mount when `__experimentalShowInitialSuggestions` is set', async () => {
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					__experimentalShowInitialSuggestions
+				/>
+			);
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( '', {
+				isInitialSuggestions: true,
+			} );
+		} );
+
+		it( 'should not fetch initial suggestions on mount when a value is already present', async () => {
+			render(
+				<ControlledURLInput
+					value="https://example.com"
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					__experimentalShowInitialSuggestions
+				/>
+			);
+
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should still request initial suggestions on mount when `disableSuggestions` is set', async () => {
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					__experimentalShowInitialSuggestions
+					disableSuggestions
+				/>
+			);
+
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalledWith( '', {
+					isInitialSuggestions: true,
+				} )
+			);
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should not fetch suggestions when `disableSuggestions` is set', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					disableSuggestions
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should fetch suggestions on focus when a value is already present', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					value="hello"
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.click( screen.getByRole( 'combobox' ) );
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
+				isInitialSuggestions: false,
+			} );
+		} );
+
+		it( 'should not fetch suggestions again on refocus when suggestions are already displayed', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					value="hello"
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.click( input );
+			await screen.findByRole( 'listbox' );
+
+			await user.tab();
+			await user.click( input );
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should hide the suggestions when the value is cleared', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.type( input, 'hello' );
+			await screen.findByRole( 'listbox' );
+
+			await user.clear( input );
+
+			await waitFor( () =>
+				expect(
+					screen.queryByRole( 'listbox' )
+				).not.toBeInTheDocument()
+			);
+		} );
+
+		it( 'should display a spinner while suggestions are loading', async () => {
+			const user = userEvent.setup();
+			let resolveRequest;
+			fetchLinkSuggestions.mockImplementation(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveRequest = resolve;
+					} )
+			);
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalled()
+			);
+			expect( screen.getByRole( 'presentation' ) ).toBeVisible();
+
+			resolveRequest( SUGGESTIONS );
+
+			await waitFor( () =>
+				expect(
+					screen.queryByRole( 'presentation' )
+				).not.toBeInTheDocument()
+			);
+		} );
+
+		it( 'should ignore the response of a superseded request', async () => {
+			const user = userEvent.setup();
+			const staleSuggestions = [
+				{
+					id: 3,
+					title: 'Stale result',
+					type: 'post',
+					url: 'https://example.com/stale',
+				},
+			];
+			let resolveStaleRequest;
+			fetchLinkSuggestions
+				.mockImplementationOnce(
+					() =>
+						new Promise( ( resolve ) => {
+							resolveStaleRequest = resolve;
+						} )
+				)
+				.mockResolvedValue( SUGGESTIONS );
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+
+			await user.type( input, 'hello' );
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
+			);
+
+			await user.type( input, ' world' );
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 2 )
+			);
+
+			resolveStaleRequest( staleSuggestions );
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect(
+				screen.queryByRole( 'option', { name: 'Stale result' } )
+			).not.toBeInTheDocument();
+			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should fall back to the fetch handler from the block editor settings', async () => {
+			const user = userEvent.setup();
+
+			dispatch( blockEditorStore ).updateSettings( {
+				__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
+			} );
+
+			try {
+				render( <ControlledURLInput /> );
+
+				await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+				expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+				expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
+					isInitialSuggestions: false,
+				} );
+			} finally {
+				dispatch( blockEditorStore ).updateSettings( {
+					__experimentalFetchLinkSuggestions: undefined,
+				} );
+			}
+		} );
+	} );
+
+	describe( 'announcements', () => {
+		it( 'should announce the number of results', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			await waitFor( () =>
+				expect( speak ).toHaveBeenCalledWith(
+					'2 results found, use up and down arrow keys to navigate.',
+					'assertive'
+				)
+			);
+		} );
+
+		it( 'should announce when there are no results', async () => {
+			const user = userEvent.setup();
+			fetchLinkSuggestions.mockResolvedValue( [] );
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			await waitFor( () =>
+				expect( speak ).toHaveBeenCalledWith(
+					'No results.',
+					'assertive'
+				)
+			);
+		} );
+	} );
+
+	describe( 'keyboard interaction', () => {
+		// `@wordpress/keycodes` matches on `event.keyCode`, which `userEvent`
+		// does not set.
+		const KEY_EVENTS = {
+			up: { key: 'ArrowUp', keyCode: UP },
+			down: { key: 'ArrowDown', keyCode: DOWN },
+			enter: { key: 'Enter', keyCode: ENTER },
+			tab: { key: 'Tab', keyCode: TAB },
+		};
+
+		async function renderWithSuggestions( props = {} ) {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+			const fetch = jest.fn().mockResolvedValue( SUGGESTIONS );
+
+			render(
+				<ControlledURLInput
+					onChange={ onChange }
+					__experimentalFetchLinkSuggestions={ fetch }
+					{ ...props }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.type( input, 'hello' );
+			await screen.findByRole( 'listbox' );
+
+			return { user, input, onChange };
+		}
+
+		it( 'should move the active suggestion with the down arrow key', async () => {
+			const { input } = await renderWithSuggestions();
+
+			expect( input ).not.toHaveAttribute( 'aria-activedescendant' );
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+
+			const [ firstOption, secondOption ] =
+				screen.getAllByRole( 'option' );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				firstOption.id
+			);
+			expect( firstOption ).toHaveAttribute( 'aria-selected', 'true' );
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				secondOption.id
+			);
+
+			// Wraps back around to the first suggestion.
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				firstOption.id
+			);
+		} );
+
+		it( 'should move the active suggestion with the up arrow key', async () => {
+			const { input } = await renderWithSuggestions();
+
+			// Wraps around to the last suggestion.
+			fireEvent.keyDown( input, KEY_EVENTS.up );
+
+			const [ firstOption, secondOption ] =
+				screen.getAllByRole( 'option' );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				secondOption.id
+			);
+
+			fireEvent.keyDown( input, KEY_EVENTS.up );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				firstOption.id
+			);
+		} );
+
+		it( 'should select the active suggestion when pressing Enter', async () => {
+			const { input, onChange } = await renderWithSuggestions();
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+			fireEvent.keyDown( input, KEY_EVENTS.enter );
+
+			expect( onChange ).toHaveBeenLastCalledWith(
+				SUGGESTIONS[ 0 ].url,
+				SUGGESTIONS[ 0 ]
+			);
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should submit the active suggestion when pressing Enter', async () => {
+			const onSubmit = jest.fn();
+			const { input } = await renderWithSuggestions( { onSubmit } );
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+			fireEvent.keyDown( input, KEY_EVENTS.enter );
+
+			expect( onSubmit ).toHaveBeenCalledWith(
+				SUGGESTIONS[ 0 ],
+				expect.anything()
+			);
+		} );
+
+		it( 'should submit without a suggestion when pressing Enter with no active suggestion', async () => {
+			const onSubmit = jest.fn();
+			const { input } = await renderWithSuggestions( { onSubmit } );
+
+			fireEvent.keyDown( input, KEY_EVENTS.enter );
+
+			expect( onSubmit ).toHaveBeenCalledWith( null, expect.anything() );
+		} );
+
+		it( 'should submit without a suggestion when pressing Enter and there are no suggestions', async () => {
+			const user = userEvent.setup();
+			const onSubmit = jest.fn();
+
+			render(
+				<ControlledURLInput
+					onSubmit={ onSubmit }
+					disableSuggestions
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.type( input, 'hello' );
+			fireEvent.keyDown( input, KEY_EVENTS.enter );
+
+			expect( onSubmit ).toHaveBeenCalledWith( null, expect.anything() );
+		} );
+
+		it( 'should select and announce the active suggestion when pressing Tab', async () => {
+			const { input, onChange } = await renderWithSuggestions();
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+			fireEvent.keyDown( input, KEY_EVENTS.tab );
+
+			expect( onChange ).toHaveBeenLastCalledWith(
+				SUGGESTIONS[ 0 ].url,
+				SUGGESTIONS[ 0 ]
+			);
+			expect( speak ).toHaveBeenCalledWith( 'Link selected.' );
+		} );
+
+		it( 'should move the caret to the start of the input when pressing the up arrow key with no suggestions', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					disableSuggestions
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.type( input, 'hello' );
+
+			expect( input.selectionStart ).toBe( 5 );
+
+			fireEvent.keyDown( input, KEY_EVENTS.up );
+
+			expect( input.selectionStart ).toBe( 0 );
+		} );
+
+		it( 'should move the caret to the end of the input when pressing the down arrow key with no suggestions', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<ControlledURLInput
+					disableSuggestions
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.type( input, 'hello' );
+			input.setSelectionRange( 0, 0 );
+
+			fireEvent.keyDown( input, KEY_EVENTS.down );
+
+			expect( input.selectionStart ).toBe( 5 );
+		} );
+
+		it( 'should call the `onKeyDown` prop', async () => {
+			const user = userEvent.setup();
+			const onKeyDown = jest.fn();
+
+			render(
+				<ControlledURLInput
+					onKeyDown={ onKeyDown }
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'a' );
+
+			expect( onKeyDown ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'suggestion selection', () => {
+		it( 'should select a suggestion on click and return focus to the input', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<ControlledURLInput
+					onChange={ onChange }
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.type( input, 'hello' );
+			await screen.findByRole( 'listbox' );
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Sample page' } )
+			);
+
+			expect( onChange ).toHaveBeenLastCalledWith(
+				SUGGESTIONS[ 1 ].url,
+				SUGGESTIONS[ 1 ]
+			);
+			expect( input ).toHaveFocus();
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'custom rendering', () => {
+		it( 'should render the control via `__experimentalRenderControl`', () => {
+			const renderControl = jest
+				.fn()
+				.mockReturnValue( <div>Custom control</div> );
+
+			render(
+				<URLInput
+					value=""
+					onChange={ () => {} }
+					__experimentalRenderControl={ renderControl }
+				/>
+			);
+
+			expect( screen.getByText( 'Custom control' ) ).toBeVisible();
+			expect( renderControl ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					className: expect.stringContaining(
+						'block-editor-url-input'
+					),
+				} ),
+				expect.objectContaining( { role: 'combobox', value: '' } ),
+				false
+			);
+		} );
+
+		it( 'should render suggestions via `__experimentalRenderSuggestions`', async () => {
+			const user = userEvent.setup();
+			const renderSuggestions = jest.fn( ( { suggestions } ) => (
+				<ul>
+					{ suggestions.map( ( suggestion ) => (
+						<li key={ suggestion.id }>{ suggestion.title }</li>
+					) ) }
+				</ul>
+			) );
+
+			render(
+				<ControlledURLInput
+					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+					__experimentalRenderSuggestions={ renderSuggestions }
+				/>
+			);
+
+			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+
+			expect(
+				await screen.findByText( 'Hello world' )
+			).toBeInTheDocument();
+			expect( renderSuggestions ).toHaveBeenLastCalledWith(
+				expect.objectContaining( {
+					suggestions: SUGGESTIONS,
+					selectedSuggestion: null,
+					isLoading: false,
+					isInitialSuggestions: false,
+					currentInputValue: 'hello',
+					handleSuggestionClick: expect.any( Function ),
+					suggestionsListProps: expect.objectContaining( {
+						role: 'listbox',
+					} ),
+					buildSuggestionItemProps: expect.any( Function ),
+				} )
+			);
+		} );
+	} );
+
+	describe( 'validation', () => {
+		it( 'should display a custom validity message once the field has been touched', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<URLInput
+					label="Link"
+					value="hello"
+					onChange={ () => {} }
+					customValidity={ {
+						type: 'invalid',
+						message: 'Invalid URL.',
+					} }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Invalid URL.' )
+			).not.toBeInTheDocument();
+
+			await user.click( screen.getByRole( 'combobox' ) );
+			await user.tab();
+
+			expect(
+				await screen.findByText( 'Invalid URL.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should not remount the input when a custom validity is cleared', async () => {
+			const user = userEvent.setup();
+
+			const { rerender } = render(
+				<URLInput
+					label="Link"
+					value="hello"
+					onChange={ () => {} }
+					customValidity={ {
+						type: 'invalid',
+						message: 'Invalid URL.',
+					} }
+				/>
+			);
+
+			const input = screen.getByRole( 'combobox' );
+			await user.click( input );
+
+			rerender(
+				<URLInput
+					label="Link"
+					value="hello"
+					onChange={ () => {} }
+					customValidity={ undefined }
+				/>
+			);
+
+			expect( screen.getByRole( 'combobox' ) ).toBe( input );
+			expect( input ).toHaveFocus();
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -35,6 +35,14 @@ const SUGGESTIONS = [
 	},
 ];
 
+// `@wordpress/keycodes` matches on `event.keyCode`, which `userEvent` does not set.
+const KEY_EVENTS = {
+	up: { key: 'ArrowUp', keyCode: UP },
+	down: { key: 'ArrowDown', keyCode: DOWN },
+	enter: { key: 'Enter', keyCode: ENTER },
+	tab: { key: 'Tab', keyCode: TAB },
+};
+
 /**
  * Waits long enough for the suggestions request debounce to elapse, so that
  * assertions about a request _not_ being made are meaningful.
@@ -77,105 +85,81 @@ describe( 'URLInput', () => {
 		jest.clearAllMocks();
 	} );
 
+	function renderURLInput( props = {} ) {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<ControlledURLInput
+				onChange={ onChange }
+				__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
+				{ ...props }
+			/>
+		);
+
+		return { user, onChange, input: screen.getByRole( 'combobox' ) };
+	}
+
+	// Mounting with a value requests suggestions for it, so the list is open
+	// by the time this resolves.
+	async function renderWithSuggestions( props = {} ) {
+		const utils = renderURLInput( { value: 'hello', ...props } );
+		await screen.findByRole( 'listbox' );
+		return utils;
+	}
+
 	describe( 'rendering', () => {
-		it( 'should render a combobox with a generic accessible name when no label is provided', () => {
-			render( <URLInput value="" onChange={ () => {} } /> );
+		it( 'should fall back to a generic accessible name when no label is provided', () => {
+			const { rerender } = render(
+				<URLInput value="" onChange={ () => {} } />
+			);
 
 			const input = screen.getByRole( 'combobox', { name: 'URL' } );
 
 			expect( input ).toBeVisible();
 			expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
-			expect( input ).toHaveAttribute( 'aria-autocomplete', 'list' );
-		} );
 
-		it( 'should use the provided label as the accessible name', () => {
-			render( <URLInput label="Link" value="" onChange={ () => {} } /> );
+			rerender(
+				<URLInput label="Link" value="" onChange={ () => {} } />
+			);
 
 			expect(
 				screen.getByRole( 'combobox', { name: /Link/ } )
 			).toBeVisible();
 		} );
 
-		it( 'should render the provided value', () => {
-			render(
-				<URLInput value="https://example.com" onChange={ () => {} } />
-			);
+		it( 'should call `onChange` with the new value only', async () => {
+			const { user, input, onChange } = renderURLInput();
 
-			expect( screen.getByRole( 'combobox' ) ).toHaveValue(
-				'https://example.com'
-			);
-		} );
-
-		it( 'should render a disabled input when `disabled` is set', () => {
-			render( <URLInput value="" onChange={ () => {} } disabled /> );
-
-			expect( screen.getByRole( 'combobox' ) ).toBeDisabled();
-		} );
-
-		it( 'should call `onChange` for each character typed', async () => {
-			const user = userEvent.setup();
-			const onChange = jest.fn();
-
-			render( <ControlledURLInput onChange={ onChange } /> );
-
-			await user.type( screen.getByRole( 'combobox' ), 'abc' );
+			await user.type( input, 'abc' );
 
 			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			// The second argument is reserved for a selected suggestion, so the
+			// `{ event }` object `InputControl` passes must not reach callers.
+			expect( onChange ).toHaveBeenLastCalledWith( 'abc', undefined );
 		} );
 	} );
 
 	describe( 'fetching suggestions', () => {
 		it( 'should display suggestions for the typed value', async () => {
-			const user = userEvent.setup();
+			const { user, input } = renderURLInput();
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+			await user.type( input, 'hello' );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 2 );
-			expect(
-				screen.getByRole( 'option', { name: 'Hello world' } )
-			).toBeVisible();
+			expect( input ).toHaveAttribute( 'aria-expanded', 'true' );
+			// Typing five characters is debounced into a single request.
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
 			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
 				isInitialSuggestions: false,
 			} );
-			expect( screen.getByRole( 'combobox' ) ).toHaveAttribute(
-				'aria-expanded',
-				'true'
-			);
-		} );
-
-		it( 'should debounce requests while the user is typing', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
-
-			await screen.findByRole( 'listbox' );
-
-			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should not fetch suggestions for fewer than two characters', async () => {
-			const user = userEvent.setup();
+			const { user, input } = renderURLInput();
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'h' );
+			await user.type( input, 'h' );
 			await flushDebounce();
 
 			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
@@ -183,37 +167,20 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should not fetch suggestions for a direct URL entry', async () => {
-			const user = userEvent.setup();
+			const { user, input } = renderURLInput();
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type(
-				screen.getByRole( 'combobox' ),
-				'https://example.com'
-			);
+			await user.type( input, 'https://example.com' );
 			await flushDebounce();
 
 			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should fetch suggestions for a direct URL entry when `__experimentalHandleURLSuggestions` is set', async () => {
-			const user = userEvent.setup();
+			const { user, input } = renderURLInput( {
+				__experimentalHandleURLSuggestions: true,
+			} );
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					__experimentalHandleURLSuggestions
-				/>
-			);
-
-			await user.type(
-				screen.getByRole( 'combobox' ),
-				'https://example.com'
-			);
+			await user.type( input, 'https://example.com' );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect( fetchLinkSuggestions ).toHaveBeenCalledWith(
@@ -223,12 +190,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should fetch initial suggestions on mount when `__experimentalShowInitialSuggestions` is set', async () => {
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					__experimentalShowInitialSuggestions
-				/>
-			);
+			renderURLInput( { __experimentalShowInitialSuggestions: true } );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( '', {
@@ -237,12 +199,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should fetch suggestions on mount for a value that is already present', async () => {
-			render(
-				<ControlledURLInput
-					value="hello"
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
+			renderURLInput( { value: 'hello' } );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
@@ -251,31 +208,11 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should not fetch initial suggestions on mount when `disableSuggestions` is set', async () => {
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					__experimentalShowInitialSuggestions
-					disableSuggestions
-				/>
-			);
+			renderURLInput( {
+				__experimentalShowInitialSuggestions: true,
+				disableSuggestions: true,
+			} );
 
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
-			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'should not fetch suggestions when `disableSuggestions` is set', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					disableSuggestions
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
 			await flushDebounce();
 
 			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
@@ -283,7 +220,6 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should fetch suggestions on focus when the previous search returned no results', async () => {
-			const user = userEvent.setup();
 			let resolveMountRequest;
 			fetchLinkSuggestions
 				.mockImplementationOnce(
@@ -294,12 +230,7 @@ describe( 'URLInput', () => {
 				)
 				.mockResolvedValue( SUGGESTIONS );
 
-			render(
-				<ControlledURLInput
-					value="hello"
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
+			const { user, input } = renderURLInput( { value: 'hello' } );
 
 			await waitFor( () =>
 				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
@@ -316,25 +247,14 @@ describe( 'URLInput', () => {
 
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 
-			await user.click( screen.getByRole( 'combobox' ) );
+			await user.click( input );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'should not fetch suggestions again on refocus when suggestions are already displayed', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					value="hello"
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await screen.findByRole( 'listbox' );
-
-			const input = screen.getByRole( 'combobox' );
+			const { user, input } = await renderWithSuggestions();
 
 			await user.click( input );
 			await user.tab();
@@ -345,18 +265,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should hide the suggestions when the value is cleared', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
-
-			await user.type( input, 'hello' );
-			await screen.findByRole( 'listbox' );
+			const { user, input } = await renderWithSuggestions();
 
 			await user.clear( input );
 
@@ -367,48 +276,7 @@ describe( 'URLInput', () => {
 			);
 		} );
 
-		it( 'should display a spinner while suggestions are loading', async () => {
-			const user = userEvent.setup();
-			let resolveRequest;
-			fetchLinkSuggestions.mockImplementation(
-				() =>
-					new Promise( ( resolve ) => {
-						resolveRequest = resolve;
-					} )
-			);
-
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
-
-			await waitFor( () =>
-				expect( fetchLinkSuggestions ).toHaveBeenCalled()
-			);
-			expect( screen.getByRole( 'presentation' ) ).toBeVisible();
-
-			resolveRequest( SUGGESTIONS );
-
-			await waitFor( () =>
-				expect(
-					screen.queryByRole( 'presentation' )
-				).not.toBeInTheDocument()
-			);
-		} );
-
 		it( 'should ignore the response of a superseded request', async () => {
-			const user = userEvent.setup();
-			const staleSuggestions = [
-				{
-					id: 3,
-					title: 'Stale result',
-					type: 'post',
-					url: 'https://example.com/stale',
-				},
-			];
 			let resolveStaleRequest;
 			fetchLinkSuggestions
 				.mockImplementationOnce(
@@ -419,15 +287,8 @@ describe( 'URLInput', () => {
 				)
 				.mockResolvedValue( SUGGESTIONS );
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
+			const { user, input } = renderURLInput( { value: 'hello' } );
 
-			const input = screen.getByRole( 'combobox' );
-
-			await user.type( input, 'hello' );
 			await waitFor( () =>
 				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
 			);
@@ -437,23 +298,28 @@ describe( 'URLInput', () => {
 				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 2 )
 			);
 
-			resolveStaleRequest( staleSuggestions );
+			resolveStaleRequest( [
+				{
+					id: 3,
+					title: 'Stale result',
+					type: 'post',
+					url: 'https://example.com/stale',
+				},
+			] );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
 			expect(
 				screen.queryByRole( 'option', { name: 'Stale result' } )
 			).not.toBeInTheDocument();
-			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 2 );
 		} );
 
 		it( 'should fall back to the fetch handler from the block editor settings', async () => {
-			const user = userEvent.setup();
-
 			dispatch( blockEditorStore ).updateSettings( {
 				__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			} );
 
 			try {
+				const user = userEvent.setup();
 				render( <ControlledURLInput /> );
 
 				await user.type( screen.getByRole( 'combobox' ), 'hello' );
@@ -472,15 +338,7 @@ describe( 'URLInput', () => {
 
 	describe( 'announcements', () => {
 		it( 'should announce the number of results', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+			await renderWithSuggestions();
 
 			await waitFor( () =>
 				expect( speak ).toHaveBeenCalledWith(
@@ -491,16 +349,9 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should announce when there are no results', async () => {
-			const user = userEvent.setup();
 			fetchLinkSuggestions.mockResolvedValue( [] );
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+			renderURLInput( { value: 'hello' } );
 
 			await waitFor( () =>
 				expect( speak ).toHaveBeenCalledWith(
@@ -512,35 +363,6 @@ describe( 'URLInput', () => {
 	} );
 
 	describe( 'keyboard interaction', () => {
-		// `@wordpress/keycodes` matches on `event.keyCode`, which `userEvent`
-		// does not set.
-		const KEY_EVENTS = {
-			up: { key: 'ArrowUp', keyCode: UP },
-			down: { key: 'ArrowDown', keyCode: DOWN },
-			enter: { key: 'Enter', keyCode: ENTER },
-			tab: { key: 'Tab', keyCode: TAB },
-		};
-
-		async function renderWithSuggestions( props = {} ) {
-			const user = userEvent.setup();
-			const onChange = jest.fn();
-			const fetch = jest.fn().mockResolvedValue( SUGGESTIONS );
-
-			render(
-				<ControlledURLInput
-					onChange={ onChange }
-					__experimentalFetchLinkSuggestions={ fetch }
-					{ ...props }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
-			await user.type( input, 'hello' );
-			await screen.findByRole( 'listbox' );
-
-			return { user, input, onChange };
-		}
-
 		it( 'should move the active suggestion with the down arrow key', async () => {
 			const { input } = await renderWithSuggestions();
 
@@ -595,8 +417,11 @@ describe( 'URLInput', () => {
 			);
 		} );
 
-		it( 'should select the active suggestion when pressing Enter', async () => {
-			const { input, onChange } = await renderWithSuggestions();
+		it( 'should select and submit the active suggestion when pressing Enter', async () => {
+			const onSubmit = jest.fn();
+			const { input, onChange } = await renderWithSuggestions( {
+				onSubmit,
+			} );
 
 			fireEvent.keyDown( input, KEY_EVENTS.down );
 			fireEvent.keyDown( input, KEY_EVENTS.enter );
@@ -605,20 +430,11 @@ describe( 'URLInput', () => {
 				SUGGESTIONS[ 0 ].url,
 				SUGGESTIONS[ 0 ]
 			);
-			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'should submit the active suggestion when pressing Enter', async () => {
-			const onSubmit = jest.fn();
-			const { input } = await renderWithSuggestions( { onSubmit } );
-
-			fireEvent.keyDown( input, KEY_EVENTS.down );
-			fireEvent.keyDown( input, KEY_EVENTS.enter );
-
 			expect( onSubmit ).toHaveBeenCalledWith(
 				SUGGESTIONS[ 0 ],
 				expect.anything()
 			);
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'should submit without a suggestion when pressing Enter with no active suggestion', async () => {
@@ -631,22 +447,19 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should submit without a suggestion when pressing Enter and there are no suggestions', async () => {
-			const user = userEvent.setup();
 			const onSubmit = jest.fn();
+			const onKeyDown = jest.fn();
+			const { input } = renderURLInput( {
+				value: 'hello',
+				disableSuggestions: true,
+				onSubmit,
+				onKeyDown,
+			} );
 
-			render(
-				<ControlledURLInput
-					onSubmit={ onSubmit }
-					disableSuggestions
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
-			await user.type( input, 'hello' );
 			fireEvent.keyDown( input, KEY_EVENTS.enter );
 
 			expect( onSubmit ).toHaveBeenCalledWith( null, expect.anything() );
+			expect( onKeyDown ).toHaveBeenCalled();
 		} );
 
 		it( 'should select and announce the active suggestion when pressing Tab', async () => {
@@ -662,77 +475,27 @@ describe( 'URLInput', () => {
 			expect( speak ).toHaveBeenCalledWith( 'Link selected.' );
 		} );
 
-		it( 'should move the caret to the start of the input when pressing the up arrow key with no suggestions', async () => {
-			const user = userEvent.setup();
+		// Works around Firefox on Windows not moving the caret with the arrow
+		// keys. See https://github.com/WordPress/gutenberg/issues/5693.
+		it( 'should move the caret to either end of the input when there are no suggestions', async () => {
+			const { user, input } = renderURLInput( {
+				disableSuggestions: true,
+			} );
 
-			render(
-				<ControlledURLInput
-					disableSuggestions
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
 			await user.type( input, 'hello' );
-
 			expect( input.selectionStart ).toBe( 5 );
 
 			fireEvent.keyDown( input, KEY_EVENTS.up );
-
 			expect( input.selectionStart ).toBe( 0 );
-		} );
-
-		it( 'should move the caret to the end of the input when pressing the down arrow key with no suggestions', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<ControlledURLInput
-					disableSuggestions
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
-			await user.type( input, 'hello' );
-			input.setSelectionRange( 0, 0 );
 
 			fireEvent.keyDown( input, KEY_EVENTS.down );
-
 			expect( input.selectionStart ).toBe( 5 );
-		} );
-
-		it( 'should call the `onKeyDown` prop', async () => {
-			const user = userEvent.setup();
-			const onKeyDown = jest.fn();
-
-			render(
-				<ControlledURLInput
-					onKeyDown={ onKeyDown }
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'a' );
-
-			expect( onKeyDown ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
 	describe( 'suggestion selection', () => {
 		it( 'should select a suggestion on click and return focus to the input', async () => {
-			const user = userEvent.setup();
-			const onChange = jest.fn();
-
-			render(
-				<ControlledURLInput
-					onChange={ onChange }
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-				/>
-			);
-
-			const input = screen.getByRole( 'combobox' );
-			await user.type( input, 'hello' );
-			await screen.findByRole( 'listbox' );
+			const { user, input, onChange } = await renderWithSuggestions();
 
 			await user.click(
 				screen.getByRole( 'option', { name: 'Sample page' } )
@@ -763,18 +526,13 @@ describe( 'URLInput', () => {
 
 			expect( screen.getByText( 'Custom control' ) ).toBeVisible();
 			expect( renderControl ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					className: expect.stringContaining(
-						'block-editor-url-input'
-					),
-				} ),
+				expect.objectContaining( { label: null } ),
 				expect.objectContaining( { role: 'combobox', value: '' } ),
 				false
 			);
 		} );
 
 		it( 'should render suggestions via `__experimentalRenderSuggestions`', async () => {
-			const user = userEvent.setup();
 			const renderSuggestions = jest.fn( ( { suggestions } ) => (
 				<ul>
 					{ suggestions.map( ( suggestion ) => (
@@ -783,14 +541,10 @@ describe( 'URLInput', () => {
 				</ul>
 			) );
 
-			render(
-				<ControlledURLInput
-					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					__experimentalRenderSuggestions={ renderSuggestions }
-				/>
-			);
-
-			await user.type( screen.getByRole( 'combobox' ), 'hello' );
+			renderURLInput( {
+				value: 'hello',
+				__experimentalRenderSuggestions: renderSuggestions,
+			} );
 
 			expect(
 				await screen.findByText( 'Hello world' )
@@ -802,52 +556,23 @@ describe( 'URLInput', () => {
 					isLoading: false,
 					isInitialSuggestions: false,
 					currentInputValue: 'hello',
-					handleSuggestionClick: expect.any( Function ),
-					suggestionsListProps: expect.objectContaining( {
-						role: 'listbox',
-					} ),
-					buildSuggestionItemProps: expect.any( Function ),
 				} )
 			);
 		} );
 	} );
 
 	describe( 'validation', () => {
-		it( 'should display a custom validity message once the field has been touched', async () => {
-			const user = userEvent.setup();
-
-			render(
-				<URLInput
-					label="Link"
-					value="hello"
-					onChange={ () => {} }
-					customValidity={ {
-						type: 'invalid',
-						message: 'Invalid URL.',
-					} }
-				/>
-			);
-
-			expect(
-				screen.queryByText( 'Invalid URL.' )
-			).not.toBeInTheDocument();
-
-			await user.click( screen.getByRole( 'combobox' ) );
-			await user.tab();
-
-			expect(
-				await screen.findByText( 'Invalid URL.' )
-			).toBeInTheDocument();
-		} );
-
 		it( 'should not remount the input when a custom validity is cleared', async () => {
 			const user = userEvent.setup();
+			const props = {
+				label: 'Link',
+				value: 'hello',
+				onChange: () => {},
+			};
 
 			const { rerender } = render(
 				<URLInput
-					label="Link"
-					value="hello"
-					onChange={ () => {} }
+					{ ...props }
 					customValidity={ {
 						type: 'invalid',
 						message: 'Invalid URL.',
@@ -858,14 +583,7 @@ describe( 'URLInput', () => {
 			const input = screen.getByRole( 'combobox' );
 			await user.click( input );
 
-			rerender(
-				<URLInput
-					label="Link"
-					value="hello"
-					onChange={ () => {} }
-					customValidity={ undefined }
-				/>
-			);
+			rerender( <URLInput { ...props } customValidity={ undefined } /> );
 
 			expect( screen.getByRole( 'combobox' ) ).toBe( input );
 			expect( input ).toHaveFocus();

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -236,21 +236,21 @@ describe( 'URLInput', () => {
 			} );
 		} );
 
-		it( 'should not fetch initial suggestions on mount when a value is already present', async () => {
+		it( 'should fetch suggestions on mount for a value that is already present', async () => {
 			render(
 				<ControlledURLInput
-					value="https://example.com"
+					value="hello"
 					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
-					__experimentalShowInitialSuggestions
 				/>
 			);
 
-			await flushDebounce();
-
-			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
+				isInitialSuggestions: false,
+			} );
 		} );
 
-		it( 'should still request initial suggestions on mount when `disableSuggestions` is set', async () => {
+		it( 'should not fetch initial suggestions on mount when `disableSuggestions` is set', async () => {
 			render(
 				<ControlledURLInput
 					__experimentalFetchLinkSuggestions={ fetchLinkSuggestions }
@@ -259,11 +259,9 @@ describe( 'URLInput', () => {
 				/>
 			);
 
-			await waitFor( () =>
-				expect( fetchLinkSuggestions ).toHaveBeenCalledWith( '', {
-					isInitialSuggestions: true,
-				} )
-			);
+			await flushDebounce();
+
+			expect( fetchLinkSuggestions ).not.toHaveBeenCalled();
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
@@ -284,8 +282,11 @@ describe( 'URLInput', () => {
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'should fetch suggestions on focus when a value is already present', async () => {
+		it( 'should fetch suggestions on focus when the previous search returned no results', async () => {
 			const user = userEvent.setup();
+			fetchLinkSuggestions
+				.mockResolvedValueOnce( [] )
+				.mockResolvedValue( SUGGESTIONS );
 
 			render(
 				<ControlledURLInput
@@ -294,12 +295,16 @@ describe( 'URLInput', () => {
 				/>
 			);
 
+			// Let the request made on mount settle without results.
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
+			);
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+
 			await user.click( screen.getByRole( 'combobox' ) );
 
 			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
-			expect( fetchLinkSuggestions ).toHaveBeenCalledWith( 'hello', {
-				isInitialSuggestions: false,
-			} );
+			expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'should not fetch suggestions again on refocus when suggestions are already displayed', async () => {
@@ -312,11 +317,11 @@ describe( 'URLInput', () => {
 				/>
 			);
 
+			await screen.findByRole( 'listbox' );
+
 			const input = screen.getByRole( 'combobox' );
 
 			await user.click( input );
-			await screen.findByRole( 'listbox' );
-
 			await user.tab();
 			await user.click( input );
 			await flushDebounce();


### PR DESCRIPTION
## What?
Part of #22890
This supersedes #70385, which converts the same component. Differences:

<details><summary>Show differences</summary>
<p>

- Removes all four HoCs; #70385 replaces only `withSelect`, keeping `withSafeTimeout` — which injects a `setTimeout` prop the component never uses.
- Net smaller. #70385 is +152 lines, mostly a `useReducer` with eight action types.
- Reads the block editor settings on demand rather than subscribing to the store, since the value is only needed inside the fetch callback.
- Keeps the validation control swap and the prop-driven hiding of suggestions in the render phase. #70385 defers both effects: it remounts the input and leaves suggestions visible, and it renders too long.
- Fixes two pre-existing bugs in a separate commit: a field mounted with a value never searched for it, and initial suggestions were requested even when `disableSuggestions` was set.

</p>
</details> 

PR converts `URLInput` from a class component wrapped in `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` to a function component with hooks, then fixes two behaviors the conversion made visible.

The class had separate mount and update paths for requesting suggestions, which caused two bugs. Collapsing them into one effect fixes both:

- A field mounted with a value never searched for it; only `onFocus` did, as a workaround. It now searches on the mount.
- Initial suggestions were requested on mount even when `disableSuggestions` was set. The guard now covers the mount, too.

P.S. I tried to keep new bug fixes for the component to a minimum. There's more room for improvement, and I will do that in follow-ups.

## Why?
One of the last remaining class components in the link editing UI. The HoC stack obscured the fact that one of the four HoCs was dead, and `withSelect` subscribed to block editor settings that are only ever read within a fetch callback.

## How?

- `withSafeTimeout` — **removed**; injected a `setTimeout` prop the class never used.
- `withSpokenMessages` → `speak` + `useDebounce( speak, 500 )`.
- `withInstanceId` → `useInstanceId`.
- `withSelect` → static `useSelect( blockEditorStore )`; settings are read on demand, so the component no longer re-renders on unrelated state changes.
- `getDerivedStateFromProps` → `showSuggestions` derived during render.
- `componentDidUpdate` prevProps diffing → an effect on `value`.
- `renderControl()` / `renderSuggestions()` methods → local `Control` / `Suggestions` components.

## Testing Instructions

```
npm run test:unit packages/block-editor/src/components/url-input
```

## Use of AI Tools

Assisted by Claude.
