### PR TITLE
Query: guard non-scalar queryId to avoid fatal in enhanced pagination

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -19,7 +19,8 @@
 function render_block_core_query( $attributes, $content, $block ) {
 	$is_interactive = isset( $attributes['enhancedPagination'] )
 		&& true === $attributes['enhancedPagination']
-		&& isset( $attributes['queryId'] );
+		&& isset( $attributes['queryId'] )
+		&& is_scalar( $attributes['queryId'] );
 
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
@@ -88,7 +89,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 
 	$block_name              = $parsed_block['blockName'];
 	$block_type              = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-	$has_enhanced_pagination = isset( $parsed_block['attrs']['enhancedPagination'] ) && true === $parsed_block['attrs']['enhancedPagination'] && isset( $parsed_block['attrs']['queryId'] );
+	$has_enhanced_pagination = isset( $parsed_block['attrs']['enhancedPagination'] ) && true === $parsed_block['attrs']['enhancedPagination'] && isset( $parsed_block['attrs']['queryId'] ) && is_scalar( $parsed_block['attrs']['queryId'] );
 	/*
 	 * Client side navigation can be true in two states:
 	 *  - supports.interactivity = true;
@@ -112,7 +113,7 @@ function block_core_query_disable_enhanced_pagination( $parsed_block ) {
 			 * @return string Returns the modified output of the query block.
 			 */
 			$render_query_callback = static function ( $content, $block ) use ( &$enhanced_query_stack, &$dirty_enhanced_queries, &$render_query_callback ) {
-				$has_enhanced_pagination = isset( $block['attrs']['enhancedPagination'] ) && true === $block['attrs']['enhancedPagination'] && isset( $block['attrs']['queryId'] );
+				$has_enhanced_pagination = isset( $block['attrs']['enhancedPagination'] ) && true === $block['attrs']['enhancedPagination'] && isset( $block['attrs']['queryId'] ) && is_scalar( $block['attrs']['queryId'] );
 
 				if ( ! $has_enhanced_pagination ) {
 					return $content;

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -303,4 +303,36 @@ HTML;
 		$router_config = wp_interactivity_config( 'core/router' );
 		$this->assertArrayNotHasKey( 'clientNavigationDisabled', $router_config );
 	}
+
+	/**
+	 * Tests that a non-scalar `queryId` (e.g. from hand-edited, imported, or
+	 * AI-generated content) does not cause a fatal error and falls back to
+	 * non-enhanced rendering.
+	 */
+	public function test_rendering_query_with_non_scalar_query_id_does_not_error() {
+		global $wp_query, $wp_the_query;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":["0"],"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		$wp_query     = new WP_Query( array( 'posts_per_page' => 1 ) );
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$this->assertIsString( $output, 'A non-scalar queryId must not cause a fatal error.' );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertNull(
+			$p->get_attribute( 'data-wp-router-region' ),
+			'Enhanced pagination should not be applied when queryId is non-scalar.'
+		);
+	}
 }

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -303,36 +303,4 @@ HTML;
 		$router_config = wp_interactivity_config( 'core/router' );
 		$this->assertArrayNotHasKey( 'clientNavigationDisabled', $router_config );
 	}
-
-	/**
-	 * Tests that a non-scalar `queryId` (e.g. from hand-edited, imported, or
-	 * AI-generated content) does not cause a fatal error and falls back to
-	 * non-enhanced rendering.
-	 */
-	public function test_rendering_query_with_non_scalar_query_id_does_not_error() {
-		global $wp_query, $wp_the_query;
-
-		$content = <<<HTML
-		<!-- wp:query {"queryId":["0"],"query":{"inherit":true},"enhancedPagination":true} -->
-		<div class="wp-block-query">
-			<!-- wp:post-template {"align":"wide"} -->
-			<!-- /wp:post-template -->
-		</div>
-		<!-- /wp:query -->
-HTML;
-
-		$wp_query     = new WP_Query( array( 'posts_per_page' => 1 ) );
-		$wp_the_query = $wp_query;
-
-		$output = do_blocks( $content );
-
-		$this->assertIsString( $output, 'A non-scalar queryId must not cause a fatal error.' );
-
-		$p = new WP_HTML_Tag_Processor( $output );
-		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
-		$this->assertNull(
-			$p->get_attribute( 'data-wp-router-region' ),
-			'Enhanced pagination should not be applied when queryId is non-scalar.'
-		);
-	}
 }


### PR DESCRIPTION
## What?

Part of #80494

Guards `core/query` against a non-scalar `queryId`, which throws a fatal `TypeError` on the front end when enhanced pagination is enabled.

## Why?

`queryId` is declared `"type": "number"` in `block.json`, but nothing enforces that at render time. Hand-edited, imported, or AI-generated content can persist any JSON value, and it survives deserialization intact.

In `block_core_query_disable_enhanced_pagination()`, the value is used as an array key. An array reaches two separate fatal sites:

- `isset( $dirty_enhanced_queries[ $block['attrs']['queryId'] ] )` → `TypeError: Cannot access offset of type array in isset or empty`
- `$dirty_enhanced_queries[ $query_id ] = true;`, reached after the value is pushed onto `$enhanced_query_stack` → `TypeError: Cannot access offset of type array on array`

Either one takes down the front end.

## How?

Require `queryId` to be a scalar alongside the existing `isset()` before treating enhanced pagination as active, in all three places the check appears. A malformed value falls back to standard, non-enhanced rendering.

`is_scalar()` rather than `is_numeric()`: the defect is a non-scalar array offset, and `is_scalar()` rejects exactly arrays and objects. `is_numeric()` would additionally reject non-numeric strings, which are legal array keys, legal `data-wp-key` values, and render fine today — narrowing the guard would silently disable enhanced pagination on working content, which is a behaviour change beyond the fix. Neither guard affects floats, where `$arr[1.5]` raises a deprecation rather than a fatal.

## Testing Instructions

**The guard cannot be exercised from a Gutenberg plugin install.** Two copies of the filter end up registered on `render_block_data` at priority 10:

- core's `block_core_query_disable_enhanced_pagination()`, hooked at bootstrap via `wp-settings.php` → `blocks/index.php` → `require-dynamic-blocks.php`
- the plugin's build-prefixed `gutenberg_block_core_query_disable_enhanced_pagination()`, hooked later on `init` via `gutenberg_reregister_core_block_types()`

Core's is registered first, so it runs first and fatals before the patched copy is reached. The render-callback change in `render_block_core_query()` *is* live on the plugin — the block re-registers with the prefixed callback — but the fatal is in the filter, not the callback.

To exercise it, apply the same change to `src/wp-includes/blocks/query.php` in a `wordpress-develop` checkout and confirm the environment serves the tree you patched: `.wp-env.json` must point `core` at `src` when running `build:dev`/`dev`, or at `build` after a full build. Patching `src` while the env serves `build` is a silent no-op.

Note that the repro markup cannot be authored through the editor. [`query-content.js`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query/edit/query-content.js#L135-L138) normalises it away on load:

```js
if ( ! Number.isFinite( queryId ) ) {
	__unstableMarkNextChangeAsNotPersistent();
	setAttributes( { queryId: instanceId } );
}
```

An array is not a finite number, so the editor substitutes the instance ID and the next save persists that. The malformed value has to be written directly into a template file or `wp_posts` to survive.

Markup to use:

```
<!-- wp:query {"queryId":["0"],"query":{"inherit":true},"enhancedPagination":true} -->
<div class="wp-block-query">
	<!-- wp:post-template --><!-- /wp:post-template -->
</div>
<!-- /wp:query -->
```

Before the patch: fatal `TypeError` on the front end. After: the page renders, with enhanced pagination inactive for that block.

Props @im3dabasia for the `query-content.js` detail and for pushing on the verification path.
