### PR TITLE
Upload Media: Fail the item when the /finalize request fails

### DIFF
--- a/packages/upload-media/CHANGELOG.md
+++ b/packages/upload-media/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+-   A failed `/finalize` request is no longer reported as a successful upload. Finalize is the server's commit point for the attachment metadata (responsive sub-sizes and the final `-scaled` file reference); when it fails, the item is now cancelled and the error surfaced instead of showing "upload complete" and keeping an attachment that is missing its registered sizes ([#80673](https://github.com/WordPress/gutenberg/issues/80673)).
 -   `cancelItem` no longer awaits the best-effort worker cancellation calls. A busy vips worker is synchronously blocked inside a wasm call and cannot answer the cancellation RPC until every operation already queued in the worker finishes, which for a large animated GIF left cancelled items stuck in the queue - and the parent attachment unfinalized - for minutes ([#80376](https://github.com/WordPress/gutenberg/issues/80376)).
 -   Pass `isTransportOnly: true` to the `mediaUpload` setting when the queue uploads a file, so consumers that manage the upload lifecycle themselves (progress tracking, save locking) don't handle the same file twice ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 

--- a/packages/upload-media/src/error-messages.ts
+++ b/packages/upload-media/src/error-messages.ts
@@ -111,6 +111,15 @@ export function getErrorMessage(
 			),
 			action: __( 'The file may be corrupted. Try a different file.' ),
 		},
+		[ ErrorCode.MEDIA_FINALIZE_ERROR ]: {
+			title: __( 'Upload failed' ),
+			description: sprintf(
+				/* translators: %s: file name */
+				__( 'Could not finalize the upload of "%s".' ),
+				fileName
+			),
+			action: __( 'Please try again.' ),
+		},
 		[ ErrorCode.GENERAL ]: {
 			title: __( 'Upload failed' ),
 			description: sprintf(

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1928,6 +1928,13 @@ export function finalizeItem( id: QueueItemId ) {
 					updates.attachment = updatedAttachment;
 				}
 			} catch ( error ) {
+				// Log the underlying failure so it is visible in every
+				// environment; `apiFetch` may reject with a plain object
+				// rather than an Error, and the user-facing notice below is
+				// deliberately generic.
+				// eslint-disable-next-line no-console
+				console.warn( 'Media finalization failed:', error );
+
 				// Finalize is the server's commit point: it writes the
 				// attachment metadata (responsive sub-sizes and the final
 				// `-scaled` file reference). If it fails, none of that was
@@ -1943,7 +1950,6 @@ export function finalizeItem( id: QueueItemId ) {
 						code: ErrorCode.MEDIA_FINALIZE_ERROR,
 						message: __( 'Could not finalize the upload.' ),
 						file: item.file,
-						cause: error instanceof Error ? error : undefined,
 					} )
 				);
 				return;

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1928,9 +1928,25 @@ export function finalizeItem( id: QueueItemId ) {
 					updates.attachment = updatedAttachment;
 				}
 			} catch ( error ) {
-				// Log but don't fail the upload if finalization fails.
-				// eslint-disable-next-line no-console
-				console.warn( 'Media finalization failed:', error );
+				// Finalize is the server's commit point: it writes the
+				// attachment metadata (responsive sub-sizes and the final
+				// `-scaled` file reference). If it fails, none of that was
+				// saved, so the upload is NOT complete. Reporting success
+				// would let the editor keep — and autosave — a block whose
+				// attachment is missing its registered sizes (so the front
+				// end cannot build a srcset) and whose file references are
+				// inconsistent. Fail the item instead so the error surfaces
+				// to the user rather than showing "upload complete".
+				dispatch.cancelItem(
+					id,
+					new UploadError( {
+						code: ErrorCode.MEDIA_FINALIZE_ERROR,
+						message: __( 'Could not finalize the upload.' ),
+						file: item.file,
+						cause: error instanceof Error ? error : undefined,
+					} )
+				);
+				return;
 			}
 		}
 

--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -23,6 +23,7 @@ import {
 	uploadItem,
 } from '../private-actions';
 import { OperationType, Type } from '../types';
+import { ErrorCode } from '../../upload-error';
 import {
 	vipsHasTransparency,
 	vipsGetUltraHdrInfo,
@@ -448,33 +449,41 @@ describe( 'private actions', () => {
 			} );
 		} );
 
-		it( 'should handle mediaFinalize errors gracefully', async () => {
-			const mediaFinalize = jest
-				.fn()
-				.mockRejectedValue( new Error( 'Network error' ) );
+		it( 'should cancel the item when mediaFinalize fails', async () => {
+			// Finalize is the server's commit point. When it fails the
+			// attachment metadata was never written, so the item must be
+			// cancelled (surfacing the error) rather than finished — which
+			// would falsely report "upload complete".
+			const cause = new Error( 'Network error' );
+			const mediaFinalize = jest.fn().mockRejectedValue( cause );
 			const finishOperation = jest.fn();
-			const warnSpy = jest
-				.spyOn( console, 'warn' )
-				.mockImplementation( () => {} );
+			const cancelItem = jest.fn();
+			const file = new File( [ 'foo' ], 'foo.jpg', {
+				type: 'image/jpeg',
+			} );
 			const select = {
 				getItem: () => ( {
+					file,
 					attachment: { id: 42 },
 					subSizes: mockSubSizes,
 				} ),
 				getSettings: () => ( { mediaFinalize } ),
 			};
-			const dispatch = { finishOperation };
+			const dispatch = { finishOperation, cancelItem };
 
 			const thunk = finalizeItem( 'test-id' );
 			await thunk( { select, dispatch } );
 
 			expect( mediaFinalize ).toHaveBeenCalledWith( 42, mockSubSizes );
-			expect( warnSpy ).toHaveBeenCalledWith(
-				'Media finalization failed:',
-				expect.any( Error )
+			expect( finishOperation ).not.toHaveBeenCalled();
+			expect( cancelItem ).toHaveBeenCalledWith(
+				'test-id',
+				expect.objectContaining( {
+					code: ErrorCode.MEDIA_FINALIZE_ERROR,
+					file,
+					cause,
+				} )
 			);
-			expect( finishOperation ).toHaveBeenCalledWith( 'test-id', {} );
-			warnSpy.mockRestore();
 		} );
 
 		it( 'should return early when item is not found', async () => {

--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -454,10 +454,15 @@ describe( 'private actions', () => {
 			// attachment metadata was never written, so the item must be
 			// cancelled (surfacing the error) rather than finished — which
 			// would falsely report "upload complete".
-			const cause = new Error( 'Network error' );
-			const mediaFinalize = jest.fn().mockRejectedValue( cause );
+			// apiFetch rejects a failed REST request with a plain object, not
+			// an Error instance, so reject with one here to mirror that.
+			const restError = { code: 'rest_error', message: 'Server error' };
+			const mediaFinalize = jest.fn().mockRejectedValue( restError );
 			const finishOperation = jest.fn();
 			const cancelItem = jest.fn();
+			const warnSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => {} );
 			const file = new File( [ 'foo' ], 'foo.jpg', {
 				type: 'image/jpeg',
 			} );
@@ -475,15 +480,19 @@ describe( 'private actions', () => {
 			await thunk( { select, dispatch } );
 
 			expect( mediaFinalize ).toHaveBeenCalledWith( 42, mockSubSizes );
+			expect( warnSpy ).toHaveBeenCalledWith(
+				'Media finalization failed:',
+				restError
+			);
 			expect( finishOperation ).not.toHaveBeenCalled();
 			expect( cancelItem ).toHaveBeenCalledWith(
 				'test-id',
 				expect.objectContaining( {
 					code: ErrorCode.MEDIA_FINALIZE_ERROR,
 					file,
-					cause,
 				} )
 			);
+			warnSpy.mockRestore();
 		} );
 
 		it( 'should return early when item is not found', async () => {

--- a/packages/upload-media/src/upload-error.ts
+++ b/packages/upload-media/src/upload-error.ts
@@ -18,6 +18,10 @@ export enum ErrorCode {
 	MEDIA_TRANSCODING_ERROR = 'MEDIA_TRANSCODING_ERROR',
 	GIF_TRANSCODING_ERROR = 'GIF_TRANSCODING_ERROR',
 
+	// Server-side commit error: the client-side files uploaded, but the
+	// server failed to finalize the attachment (write its metadata).
+	MEDIA_FINALIZE_ERROR = 'MEDIA_FINALIZE_ERROR',
+
 	// Generic fallback
 	GENERAL = 'GENERAL',
 }


### PR DESCRIPTION
## What?

Client-side media processing calls `POST /wp/v2/media/<id>/finalize` after every generated file has been uploaded. This PR makes a **failed** finalize request fail the upload instead of reporting it as a success.

Fixes #80673.

## Why?

Finalize is the server's commit point: it writes the attachment metadata (the responsive sub-sizes and the final `-scaled` file reference). Before this change, a failed finalize was caught and only logged, and the queue item finished normally. That fired `onSuccess`, so:

- the editor said **"Media upload complete,"**
- the Image block was kept and could be autosaved,
- but the attachment was missing its registered sizes, so the front end could not build a `srcset`, and the saved main-file references were left inconsistent (`…-scaled.jpg` in the block/metadata vs `…-scaled-1.jpg` in `source_url`).

In short, a 500 on the commit endpoint was reported to the user as a completed upload.

## How?

In `finalizeItem`, the `catch` now cancels the queue item rather than falling through to `finishOperation`:

- the error is wrapped in an `UploadError` (new `MEDIA_FINALIZE_ERROR` code + user-facing message) so it surfaces as a notice instead of a silent `console.warn`,
- `cancelItem`'s existing retry guard already skips retry once an attachment id exists (which is always the case at finalize), so this does not loop or re-upload,
- finalize only runs after all child sideloads have been removed, so cancelling the parent leaves no orphaned queue items.

## Testing Instructions

Automated:

```
npm run test:unit -- packages/upload-media/src/store/test/private-actions.js -t "finalizeItem"
```

Manual (from the issue): with client-side media processing active (`crossOriginIsolated` + `SharedArrayBuffer`), add an mu-plugin that forces `/wp/v2/media/<id>/finalize` to return a 500, then upload an image through an Image block.

- Before: editor shows "Media upload complete" and keeps the image.
- After: the finalize failure surfaces as an upload error notice; no false success.

## Known limitations / open questions for reviewers

1. This stops the false success but does **not** remove the image from the block. The `upload` step already fired `onChange` with the real attachment id/url before finalize, so the block committed those first. The main file is a valid attachment, but the missing sub-sizes / mismatched file references persist in the saved post. Fully reverting the block on finalize failure would be a larger, separate change.
2. No retry for a transient finalize 500 — the current retry mechanism re-runs the whole item (including re-upload), so it can't cleanly retry finalize alone. This PR fails fast instead.
