### PR TITLE
Writing flow: mark shift+click as a multi-selection gesture

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -12,7 +12,6 @@ import {
  */
 import { isInsideRootBlock } from '../../../utils/dom';
 import { store as blockEditorStore } from '../../../store';
-import { isShiftClickInProgress } from '../../writing-flow/utils';
 import { unlock } from '../../../lock-unlock';
 
 const { subscribeDelegatedListener } = unlock( composePrivateApis );
@@ -23,7 +22,7 @@ const { subscribeDelegatedListener } = unlock( composePrivateApis );
  * @param {string} clientId Block client ID.
  */
 export function useFocusHandler( clientId ) {
-	const { isBlockSelected, isBlockMultiSelected } =
+	const { isBlockSelected, isBlockMultiSelected, isMultiSelecting } =
 		useSelect( blockEditorStore );
 	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 
@@ -48,12 +47,14 @@ export function useFocusHandler( clientId ) {
 					return;
 				}
 
-				// Never select on the focus fired by a shift+click: the
-				// browser can focus the common editable ancestor of the
-				// range (e.g. a group block), and any selection re-render
-				// mid gesture destroys the native selection being made. The
-				// selection observer builds the multi-selection on mouseup.
-				if ( isShiftClickInProgress() ) {
+				// Never select on the focus fired during a selection
+				// gesture (a shift+click, marked by the selection observer
+				// with startMultiSelect). The browser can focus the common
+				// editable ancestor of the range (e.g. a group block), and
+				// any selection re-render mid gesture destroys the native
+				// selection being made. The observer builds the
+				// multi-selection on mouseup.
+				if ( isMultiSelecting() ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -15,7 +15,7 @@ import { isSelectionForward } from '@wordpress/dom';
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
 import { canHostEditableRoot } from './use-editable-root';
-import { setContentEditableWrapper, setShiftClickInProgress } from './utils';
+import { setContentEditableWrapper } from './utils';
 import { unlock } from '../../lock-unlock';
 
 const { ownsSelection } = unlock( richTextPrivateApis );
@@ -102,8 +102,13 @@ function getRichTextElement( node ) {
  * Sets a multi-selection based on the native selection across blocks.
  */
 export default function useSelectionObserver() {
-	const { multiSelect, selectBlock, selectionChange } =
-		useDispatch( blockEditorStore );
+	const {
+		multiSelect,
+		selectBlock,
+		selectionChange,
+		startMultiSelect,
+		stopMultiSelect,
+	} = useDispatch( blockEditorStore );
 	const blockEditorSelectors = useSelect( blockEditorStore );
 	const {
 		getBlockParents,
@@ -122,12 +127,18 @@ export default function useSelectionObserver() {
 
 			function onMouseDown( event ) {
 				isTripleClick = event.detail === 3;
-				setShiftClickInProgress( event.shiftKey );
+				// A shift+click makes a multi-selection: mark the gesture as
+				// in progress so the clicked block's focus handler does not
+				// select it (collapsing the native range being made), and so
+				// use-multi-selection does not clear the native selection.
+				// The selection is built on mouseup.
+				if ( event.shiftKey ) {
+					startMultiSelect();
+				}
 			}
 
 			function onKeyDown() {
 				isTripleClick = false;
-				setShiftClickInProgress( false );
 			}
 
 			function onSelectionChange( event ) {
@@ -454,7 +465,7 @@ export default function useSelectionObserver() {
 			);
 			function onMouseUp( event ) {
 				onSelectionChange( event );
-				setShiftClickInProgress( false );
+				stopMultiSelect();
 			}
 
 			defaultView.addEventListener( 'mouseup', onMouseUp );

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -118,29 +118,6 @@ function toPlainText( html ) {
 	return plainText.replace( /\n\n+/g, '\n\n' );
 }
 
-let shiftClickInProgress = false;
-
-/**
- * Tracks whether a shift+click gesture is in progress, from the shift held
- * mousedown until its mouseup. Maintained by the selection observer; read by
- * the block focus handler, since the focus event fired between the two
- * carries no modifier keys.
- *
- * @param {boolean} value Whether a shift+click gesture is in progress.
- */
-export function setShiftClickInProgress( value ) {
-	shiftClickInProgress = value;
-}
-
-/**
- * Returns whether a shift+click gesture is in progress.
- *
- * @return {boolean} Whether a shift+click gesture is in progress.
- */
-export function isShiftClickInProgress() {
-	return shiftClickInProgress;
-}
-
 /**
  * Makes the wrapper element an editing host, or stops it from being one. The
  * ARIA attributes travel with the editability: while the wrapper is the


### PR DESCRIPTION
## What?
Cherry-picks #80286 into `wp/7.1` to verify that it fixes the e2e failure on the branch.

## Why?
Since the backport of #80687, the e2e job fails consistently on `wp/7.1`:

<details><summary>Details</summary>

```
 1) [webkit] › specs/editor/various/multi-block-selection.spec.js:1680:3 › Multi-block selection (@firefox, @webkit) › shift+click multi-selection › should grow and shrink a full selection with shift+arrow 

Error: expect(received).toMatchObject(expected)

    - Expected  -  0
    + Received  + 22

      Array [
        Object {
    +     "attributes": Object {
    +       "height": "100px",
    +     },
    +     "clientId": "842d183c-f6e5-4dee-8b7c-983801510802",
    +     "innerBlocks": Array [],
    +     "isValid": true,
          "name": "core/spacer",
        },
        Object {
    +     "attributes": Object {
    +       "height": "100px",
    +     },
    +     "clientId": "3184f1be-10d1-4029-ae26-c50f5c73584f",
    +     "innerBlocks": Array [],
    +     "isValid": true,
          "name": "core/spacer",
    +   },
    +   Object {
    +     "attributes": Object {
    +       "content": "a paragraph",
    +       "dropCap": false,
    +     },
    +     "clientId": "6702e1dc-9cda-408d-bd7b-3b263df5ea80",
    +     "innerBlocks": Array [],
    +     "isValid": true,
    +     "name": "core/paragraph",
        },
      ]

    Call Log:
    - Timeout 5000ms exceeded while waiting on the predicate

      1699 | 			await expect
      1700 | 				.poll( multiBlockSelectionUtils.getSelectedBlocks )
    > 1701 | 				.toMatchObject( [
           | 				 ^
      1702 | 					{ name: 'core/spacer' },
      1703 | 					{ name: 'core/spacer' },
      1704 | 				] );
        at /home/runner/work/gutenberg/gutenberg/test/e2e/specs/editor/various/multi-block-selection.spec.js:1701:6
```

</details> 

The selection grows to three blocks with Shift+ArrowDown, but Shift+ArrowUp does not shrink it back to two. The run before that commit was green.

#80286 is the only writing-flow related PR from the same series that was not backported — #80287, #80374, #80396, #80462, #80549 and #80651 are all on the branch. It was likely missed because it does not carry a backport label.

## Testing Instructions
If the analysis is correct, all CI checks on this PR should pass, in particular the e2e test above.

## Use of AI Tools
The regression was investigated with Claude Code. The PR contains no AI-authored code — it is an unmodified cherry-pick of an existing commit.
