### PR TITLE
Dynamic Gallery: Rename toolbar button to Detach and add a modal explaining what will happen

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Playlist: Shorten the track toolbar button label from "Add track" to "Add".
+-   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery keeps its current images but stops following the post's attachments ([#80613](https://github.com/WordPress/gutenberg/issues/80613)).
 
 ### Bug Fixes
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Playlist: Shorten the track toolbar button label from "Add track" to "Add".
--   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery keeps its current images but stops following the post's attachments ([#80613](https://github.com/WordPress/gutenberg/issues/80613)).
+-   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
 
 ### Bug Fixes
 

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -90,7 +90,7 @@ function DetachGalleryDialog( { onConfirm, onCancel } ) {
 	return (
 		<ConfirmDialog
 			isOpen
-			title={ __( 'Detach gallery?' ) }
+			title={ __( 'Detach Gallery' ) }
 			__experimentalHideHeader={ false }
 			confirmButtonText={ __( 'Detach' ) }
 			onConfirm={ onConfirm }
@@ -98,7 +98,7 @@ function DetachGalleryDialog( { onConfirm, onCancel } ) {
 			size="medium"
 		>
 			{ __(
-				'The gallery displays the images attached to the post. Detaching it will enable you to add, delete, or reorder images. However, newly attached images will no longer be added automatically.'
+				'The gallery displays the images attached to the post. Detaching will enable you to add, delete, or reorder images. However, new attachments will no longer be added automatically.'
 			) }
 		</ConfirmDialog>
 	);
@@ -175,7 +175,7 @@ export function GallerySourcePanel( {
 							disabled={ isResolvingDynamic }
 							accessibleWhenDisabled
 						>
-							{ __( 'Detach gallery' ) }
+							{ __( 'Detach Gallery' ) }
 						</Button>
 					</div>
 					{ hasMoreImagesThanCap && (
@@ -377,7 +377,7 @@ export function GalleryDynamicView( {
 					<BlockControls group="other">
 						<ToolbarButton
 							onClick={ () => setIsConfirmingDetach( true ) }
-							// Same guard as the inspector's "Detach gallery": both end in
+							// Same guard as the inspector's "Detach Gallery": both end in
 							// `convertToStatic`, which would map over a
 							// still-resolving (or empty) media list.
 							// (`ToolbarButton` stays focusable when disabled by

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -98,7 +98,7 @@ function DetachGalleryDialog( { onConfirm, onCancel } ) {
 			size="medium"
 		>
 			{ __(
-				'The gallery will keep the images it currently shows, but will no longer update when the images attached to the post change.'
+				'The gallery displays the images attached to the post. Detaching it will enable you to add, delete, or reorder images. However, newly attached images will no longer be added automatically.'
 			) }
 		</ConfirmDialog>
 	);
@@ -376,17 +376,6 @@ export function GalleryDynamicView( {
 				<>
 					<BlockControls group="other">
 						<ToolbarButton
-							// `label` matches the visible text so it stays the
-							// accessible name, while `description` carries the
-							// longer explanation — as the tooltip, and as the
-							// button's accessible description. A button with text
-							// children only shows a tooltip when `showTooltip` is
-							// set alongside a `label`.
-							label={ __( 'Detach' ) }
-							showTooltip
-							description={ __(
-								'Stop the gallery updating from the images attached to the post'
-							) }
 							onClick={ () => setIsConfirmingDetach( true ) }
 							// Same guard as the inspector's "Detach gallery": both end in
 							// `convertToStatic`, which would map over a

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -387,10 +387,6 @@ export function GalleryDynamicView( {
 							{ __( 'Detach' ) }
 						</ToolbarButton>
 					</BlockControls>
-					{ /*
-					 * Rendered outside `BlockControls` — that's a slot fill for
-					 * toolbar controls, and the dialog isn't one.
-					 */ }
 					{ isConfirmingDetach && (
 						<DetachGalleryDialog
 							onConfirm={ () => {

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -75,13 +75,43 @@ function OrderControl( { orderby, order, onChange } ) {
 }
 
 /**
+ * Confirmation for leaving dynamic mode, shown from both the block toolbar and
+ * the Source panel so the two entry points explain the change identically.
+ *
+ * Detaching keeps the images the gallery currently shows but breaks the link to
+ * its source, so it's worth confirming — mirroring the dialog `GallerySourcePanel`
+ * shows for the opposite direction.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onConfirm Called when the user confirms detaching.
+ * @param {Function} props.onCancel  Called when the user dismisses the dialog.
+ */
+function DetachGalleryDialog( { onConfirm, onCancel } ) {
+	return (
+		<ConfirmDialog
+			isOpen
+			title={ __( 'Detach gallery?' ) }
+			__experimentalHideHeader={ false }
+			confirmButtonText={ __( 'Detach' ) }
+			onConfirm={ onConfirm }
+			onCancel={ onCancel }
+			size="medium"
+		>
+			{ __(
+				'The gallery will keep the images it currently shows, but will no longer update when the images attached to the post change.'
+			) }
+		</ConfirmDialog>
+	);
+}
+
+/**
  * The Gallery block's "Source" inspector panel.
  *
- * In dynamic mode it shows the resolved source, a control to convert back to
- * individual images, and the source ordering. In static mode it offers the
- * entry point into dynamic mode — and, since switching discards any hand-added
- * images, owns the confirmation dialog for that one-way change. Rendered inside
- * the block's `InspectorControls`, alongside the Settings panel.
+ * In dynamic mode it shows the resolved source, a control to detach the gallery
+ * from it, and the source ordering. In static mode it offers the entry point
+ * into dynamic mode. Either direction is a one-way change, so both are behind a
+ * confirmation dialog this panel owns. Rendered inside the block's
+ * `InspectorControls`, alongside the Settings panel.
  *
  * @param {Object}  props
  * @param {Object}  props.dynamic           The `useDynamicGallery` result.
@@ -110,6 +140,7 @@ export function GallerySourcePanel( {
 	const isDynamic = !! dynamicContent;
 
 	const [ isConfirming, setIsConfirming ] = useState( false );
+	const [ isConfirmingDetach, setIsConfirmingDetach ] = useState( false );
 
 	// Entering dynamic mode discards any hand-added images, so confirm first
 	// when there are images to lose; otherwise switch straight away.
@@ -123,63 +154,76 @@ export function GallerySourcePanel( {
 
 	if ( isDynamic ) {
 		return (
-			<ToolsPanel
-				label={ __( 'Source' ) }
-				resetAll={ resetSource }
-				dropdownMenuProps={ dropdownMenuProps }
-			>
-				<div className="wp-block-gallery__source-settings">
-					<p className="wp-block-gallery__source-description">
-						{ sourceDescriptor?.description ??
-							__( 'Dynamic images.' ) }
-					</p>
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ convertToStatic }
-						// Guard the race where the media is still resolving:
-						// converting now would map over an incomplete (or empty)
-						// list and produce a gallery missing images.
-						disabled={ isResolvingDynamic }
-						accessibleWhenDisabled
-					>
-						{ __( 'Convert to individual images' ) }
-					</Button>
-				</div>
-				{ hasMoreImagesThanCap && (
-					<Notice
-						className="wp-block-gallery__source-notice"
-						status="warning"
-						isDismissible={ false }
-					>
-						{ sprintf(
-							/* translators: 1: number of images shown. 2: total number of matching images. */
-							__(
-								'Only the first %1$d of %2$d images will be displayed.'
-							),
-							MAX_IMAGES,
-							dynamicMediaTotal
-						) }
-					</Notice>
-				) }
-				<ToolsPanelItem
-					isShownByDefault
-					label={ __( 'Order by' ) }
-					hasValue={ () =>
-						sourceOrderby !== DEFAULT_ORDERBY ||
-						sourceOrder !== DEFAULT_ORDER
-					}
-					onDeselect={ () => setSourceOrder( undefined, undefined ) }
+			<>
+				<ToolsPanel
+					label={ __( 'Source' ) }
+					resetAll={ resetSource }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
-					<OrderControl
-						orderby={ sourceOrderby }
-						order={ sourceOrder }
-						onChange={ ( { orderby, order } ) =>
-							setSourceOrder( orderby, order )
+					<div className="wp-block-gallery__source-settings">
+						<p className="wp-block-gallery__source-description">
+							{ sourceDescriptor?.description ??
+								__( 'Dynamic images.' ) }
+						</p>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsConfirmingDetach( true ) }
+							// Guard the race where the media is still resolving:
+							// detaching now would map over an incomplete (or
+							// empty) list and produce a gallery missing images.
+							disabled={ isResolvingDynamic }
+							accessibleWhenDisabled
+						>
+							{ __( 'Detach gallery' ) }
+						</Button>
+					</div>
+					{ hasMoreImagesThanCap && (
+						<Notice
+							className="wp-block-gallery__source-notice"
+							status="warning"
+							isDismissible={ false }
+						>
+							{ sprintf(
+								/* translators: 1: number of images shown. 2: total number of matching images. */
+								__(
+									'Only the first %1$d of %2$d images will be displayed.'
+								),
+								MAX_IMAGES,
+								dynamicMediaTotal
+							) }
+						</Notice>
+					) }
+					<ToolsPanelItem
+						isShownByDefault
+						label={ __( 'Order by' ) }
+						hasValue={ () =>
+							sourceOrderby !== DEFAULT_ORDERBY ||
+							sourceOrder !== DEFAULT_ORDER
 						}
+						onDeselect={ () =>
+							setSourceOrder( undefined, undefined )
+						}
+					>
+						<OrderControl
+							orderby={ sourceOrderby }
+							order={ sourceOrder }
+							onChange={ ( { orderby, order } ) =>
+								setSourceOrder( orderby, order )
+							}
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				{ isConfirmingDetach && (
+					<DetachGalleryDialog
+						onConfirm={ () => {
+							convertToStatic();
+							setIsConfirmingDetach( false );
+						} }
+						onCancel={ () => setIsConfirmingDetach( false ) }
 					/>
-				</ToolsPanelItem>
-			</ToolsPanel>
+				) }
+			</>
 		);
 	}
 
@@ -266,7 +310,8 @@ function GalleryImagesPreview( { imageBlocks } ) {
 /**
  * Renders a dynamic-mode gallery on the canvas:
  *
- * - a block-toolbar control to convert back to individual images;
+ * - a block-toolbar control to detach the gallery from its source, confirmed in
+ *   a dialog;
  * - the gallery `<figure>` wrapper holding a non-editable preview of the
  *   resolved media (or a placeholder while resolving / when nothing is found),
  *   with the gallery's provided context so the previewed images inherit
@@ -306,12 +351,14 @@ export function GalleryDynamicView( {
 		convertToStatic,
 	} = dynamic;
 
-	// Converting to a static gallery materializes editable inner blocks, which
-	// is a structural change. Only offer it when the block is fully editable:
+	// Detaching the gallery materializes editable inner blocks, which is a
+	// structural change. Only offer it when the block is fully editable:
 	// under a content lock (e.g. inside a `contentOnly` group) the editing mode
 	// is `'contentOnly'`/`'disabled'`, where structural toolbar controls are
 	// hidden and the conversion shouldn't be possible.
 	const blockEditingMode = useBlockEditingMode();
+
+	const [ isConfirmingDetach, setIsConfirmingDetach ] = useState( false );
 
 	// Empty-state copy for the preview. Framed as forward-looking ("… will appear
 	// here") rather than as an error, since the same empty result covers both a
@@ -326,18 +373,45 @@ export function GalleryDynamicView( {
 	return (
 		<>
 			{ blockEditingMode === 'default' && (
-				<BlockControls group="other">
-					<ToolbarButton
-						onClick={ convertToStatic }
-						// Same guard as the inspector's "Convert to individual
-						// images": both call `convertToStatic`, which would map over
-						// a still-resolving (or empty) media list. (`ToolbarButton`
-						// stays focusable when disabled by default.)
-						disabled={ isResolvingDynamic }
-					>
-						{ __( 'Convert to images' ) }
-					</ToolbarButton>
-				</BlockControls>
+				<>
+					<BlockControls group="other">
+						<ToolbarButton
+							// `label` matches the visible text so it stays the
+							// accessible name, while `description` carries the
+							// longer explanation — as the tooltip, and as the
+							// button's accessible description. A button with text
+							// children only shows a tooltip when `showTooltip` is
+							// set alongside a `label`.
+							label={ __( 'Detach' ) }
+							showTooltip
+							description={ __(
+								'Stop the gallery updating from the images attached to the post'
+							) }
+							onClick={ () => setIsConfirmingDetach( true ) }
+							// Same guard as the inspector's "Detach gallery": both end in
+							// `convertToStatic`, which would map over a
+							// still-resolving (or empty) media list.
+							// (`ToolbarButton` stays focusable when disabled by
+							// default.)
+							disabled={ isResolvingDynamic }
+						>
+							{ __( 'Detach' ) }
+						</ToolbarButton>
+					</BlockControls>
+					{ /*
+					 * Rendered outside `BlockControls` — that's a slot fill for
+					 * toolbar controls, and the dialog isn't one.
+					 */ }
+					{ isConfirmingDetach && (
+						<DetachGalleryDialog
+							onConfirm={ () => {
+								convertToStatic();
+								setIsConfirmingDetach( false );
+							} }
+							onCancel={ () => setIsConfirmingDetach( false ) }
+						/>
+					) }
+				</>
 			) }
 			<figure { ...blockProps }>
 				{ dynamicImageBlocks.length ? (


### PR DESCRIPTION
## What?

Fixes #80613 

The Dynamic mode of the gallery block (the Dynamic Gallery variation) has an ambiguous "Convert to images" button in the block toolbar. As discussed in #80613 this can be confusing to users, and it also doesn't accurately reflect what's really going to happen.

This PR tries out ideas discussed in that issue: let's try renaming the button to `Detach` and add a confirm dialog that helps explain what will happen.

Very happy for feedback and ideas on the wording! Right now I've borrowed from @ramonjd's mockups. 

## Why?

The block can operate in two modes: dynamic mode connected to a source, and a static mode where the block isn't attached to a source and is made up of editable inner blocks. The two modes provide powerful behaviour (at least I think so), but it's also difficult to understand.

Hopefully, the button and modal can help users learn how to interact with the gallery block in each of its states, and also with this change, we hopefully reduce some confusion.

## How?

* Add an additional confirm dialog and state to the dynamic mode of the gallery block
* When a user clicks "Detach" trigger the modal instead of immediately switching to a static version of the gallery block

## Testing Instructions

* Upload a bunch of images to a post or page (or attach them manually via the media library)
* Insert a Gallery block to the page and select "Use attached images" to switch to the dynamic mode
* Try out the "Detach" button in the block toolbar or the "Detach gallery" button in the inspector sidebar
* How does the text read / look / feel? Does it make sense?
* Click to confirm the detach. And make sure it otherwise works as on trunk.

## Screenshots or screencast <!-- if applicable -->

This screenshot includes the three changes:

* Block toolbar button copy change (it now says Detach)
* Inspector controls button copy change (it now says Detach gallery)
* The new modal

<img width="1242" height="746" alt="image" src="https://github.com/user-attachments/assets/68e9e9a1-7d70-41a0-8a5f-4d3dcd5e67fc" />

## Use of AI Tools

Claude Code (Opus 5) for making the initial change, with testing and a little tweaking by me.