### PR TITLE
Page List: Use null coalescing operator for parentPageID attribute

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -258,7 +258,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
-	$parent_page_id_attr = isset( $attributes['parentPageID'] ) ? $attributes['parentPageID'] : null;
+	$parent_page_id_attr = $attributes['parentPageID'] ?? null;
 	$parent_page_id      = is_scalar( $parent_page_id_attr ) ? (int) $parent_page_id_attr : 0;
 	$is_nested           = ! empty( $block->context['core/isInsideSubmenu'] );
 


### PR DESCRIPTION
## What?

Simplifies reading the `parentPageID` attribute in the Page List block's by replacing the ternary `isset()` check
with the null coalescing operator (`??`).

## Why?

The `isset( $x ) ? $x : null` pattern is exactly what the `??` operator was introduced for. Using it makes the intent clearer and the line shorter, without changing behavior. This is a code quality / readability improvement only.

Follow-up to  #80558