### PR TITLE
ToolsPanel: fix panel header heading rendering at the wrong size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `ContentEditableControl`: Associate the label with the `contentEditable` field via `aria-labelledby` instead of an invalid `label[for]`, which triggered Chrome console errors ([#80344](https://github.com/WordPress/gutenberg/pull/80344)).
 -   `SearchControl`: Render suffix only if there is one. ([#80356](https://github.com/WordPress/gutenberg/pull/80356), [#80406](https://github.com/WordPress/gutenberg/pull/80406)).
 -   `ColorPicker`: Keep the visual picker in native HSVA so gradient/controlled HSLA echoes no longer jitter the saturation pointer, and preserve the black-edge saturation coordinate without leaving white at a chromatic position ([#80205](https://github.com/WordPress/gutenberg/pull/80205)).
+-   `ToolsPanelHeader`: Fix the heading rendering at the wrong `font-size` and `line-height` depending on style insertion order, by setting both via `Heading` props ([#80729](https://github.com/WordPress/gutenberg/pull/80729)).
 
 ### TypeScript
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -100,9 +100,7 @@ export const ToolsPanelHeader = css`
 `;
 
 export const ToolsPanelHeading = css`
-	font-size: inherit;
 	font-weight: ${ CONFIG.fontWeightEmphasis };
-	line-height: normal;
 
 	/* Required to meet specificity requirements to ensure zero margin */
 	&& {

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -189,7 +189,12 @@ const ToolsPanelHeader = (
 
 	return (
 		<HStack { ...headerProps } ref={ forwardedRef }>
-			<Heading level={ headingLevel } className={ headingClassName }>
+			<Heading
+				level={ headingLevel }
+				size="inherit"
+				lineHeight="normal"
+				className={ headingClassName }
+			>
 				{ labelText }
 			</Heading>
 			{ hasMenuItems && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

The ToolsPanel header sometimes renders much bigger than it should. Right now it's visible if you go to Global Styles > Layout and you see the "Dimensions" title

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`ToolsPanelHeading` is setting `font-size: inherit` to override the size heading sets on itself. Those two end up as separate emotion classes with the same specificity, and they don't get merged. So whichever one is inserted into the stylesheet last wins. The order isn't guaranteed, so you could get 13px or 25px depending on that.

I also noticed `line-height: normal` in the same block has exactly the same problem, and it was already losing to `line-height: 1.4` from `Text`. So that one was silently broken too. Left `font-weight` alone since it wasn't part of the problem, but we could also do it with it for consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Setting the values through props rather than trying to win the specificity.

## Testing Instructions

1. Go to Site Editor > Styles > Layout
2. The "Dimensions" header should be the same size as the other panel headers.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
 | <img width="2940" height="1562" alt="Screenshot 2026-07-27 at 10-22-21 Blog Home ‹ Template ‹ Stories® ‹ Editor — WordPress" src="https://github.com/user-attachments/assets/b323828b-ad15-4eae-8641-02a19b9f190d" /> | <img width="2940" height="1562" alt="Screenshot 2026-07-27 at 10-12-38 Blog Home ‹ Template ‹ Stories® ‹ Editor — WordPress" src="https://github.com/user-attachments/assets/8e63128d-74ca-41a7-ac64-a439ab6f5d32" /> |




