### PR TITLE
Block Style Variations: Remove variation styles when a dynamic block renders no markup

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -231,7 +231,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
  * @return string                Filtered block content.
  */
 function gutenberg_render_block_style_variation_class_name( $block_content, $block ) {
-	if ( ! $block_content || empty( $block['attrs']['className'] ) ) {
+	if ( empty( $block['attrs']['className'] ) ) {
 		return $block_content;
 	}
 
@@ -250,18 +250,77 @@ function gutenberg_render_block_style_variation_class_name( $block_content, $blo
 		return $block_content;
 	}
 
-	$tags = new WP_HTML_Tag_Processor( $block_content );
+	$tags = $block_content ? new WP_HTML_Tag_Processor( $block_content ) : null;
 
-	if ( $tags->next_tag() ) {
+	if ( $tags && $tags->next_tag() ) {
 		/*
 		 * Ensure the variation instance class name set in the
 		 * `render_block_data` filter is applied in markup.
 		 * See `gutenberg_render_block_style_variation_support_styles`.
 		 */
 		$tags->add_class( $matches[0] );
+
+		return $tags->get_updated_html();
 	}
 
-	return $tags->get_updated_html();
+	/*
+	 * The block produced no markup, for example a dynamic block such as
+	 * `core/post-terms` that rendered nothing. The variation styles are
+	 * enqueued optimistically on the `render_block_data` filter, before the
+	 * block's render callback runs, so remove them now to avoid emitting CSS
+	 * for a block instance that isn't present in the markup.
+	 *
+	 * See https://github.com/WordPress/gutenberg/issues/80718.
+	 */
+	gutenberg_remove_block_style_variation_styles( $matches[0] );
+
+	return $block_content;
+}
+
+/**
+ * Removes previously enqueued inline styles for a block style variation instance.
+ *
+ * Block style variation styles are enqueued on the `render_block_data` filter,
+ * which runs before dynamic blocks render. When such a block produces no markup
+ * its styles must be removed so CSS isn't emitted for a block instance that
+ * isn't present on the page.
+ *
+ * Each variation instance's styles are scoped by its unique
+ * `.is-style-<instance>` selector, so only that instance's inline style is
+ * removed and the relative order of the remaining variation styles, on which
+ * descendant-over-ancestor priority depends, is preserved.
+ *
+ * @since 7.1.0
+ *
+ * @access private
+ *
+ * @see gutenberg_render_block_style_variation_support_styles
+ *
+ * @param string $instance_class_name Variation instance class name, e.g.
+ *                                    `is-style-my-variation--1`.
+ */
+function gutenberg_remove_block_style_variation_styles( $instance_class_name ) {
+	$styles = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+
+	if ( empty( $styles ) || ! is_array( $styles ) ) {
+		return;
+	}
+
+	/*
+	 * Match the variation's scope selector while avoiding a longer instance
+	 * number that merely shares the same prefix, for example `--1` vs `--10`.
+	 */
+	$pattern  = '/\.' . preg_quote( $instance_class_name, '/' ) . '(?![\w-])/';
+	$filtered = array();
+
+	foreach ( $styles as $style ) {
+		if ( is_string( $style ) && preg_match( $pattern, $style ) ) {
+			continue;
+		}
+		$filtered[] = $style;
+	}
+
+	wp_styles()->add_data( 'block-style-variation-styles', 'after', $filtered );
 }
 
 /**

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -389,4 +389,190 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 			gutenberg_render_block_style_variation_class_name( $block_content, $block )
 		);
 	}
+
+	/**
+	 * Tests that a block style variation's styles are removed when the block
+	 * renders no markup, for example a dynamic block such as `core/post-terms`
+	 * with nothing to output.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/issues/80718
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_class_name
+	 * @covers ::gutenberg_remove_block_style_variation_styles
+	 */
+	public function test_block_style_variation_styles_removed_for_empty_block_markup() {
+		switch_theme( 'block-theme' );
+
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'empty-removal',
+				'style_data' => array(
+					'color' => array( 'background' => 'hotpink' ),
+				),
+			)
+		);
+
+		try {
+			$parsed_block = array(
+				'blockName' => 'core/group',
+				'attrs'     => array(
+					'className' => 'wp-block-group is-style-empty-removal',
+				),
+			);
+
+			// The `render_block_data` filter enqueues the variation styles up front.
+			$parsed_block = gutenberg_render_block_style_variation_support_styles( $parsed_block );
+
+			$enqueued = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$this->assertNotEmpty(
+				$enqueued,
+				'Variation styles should be enqueued on the render_block_data filter.'
+			);
+
+			// The block renders no markup, so its styles should be removed.
+			$result = gutenberg_render_block_style_variation_class_name( '', $parsed_block );
+
+			$this->assertSame(
+				'',
+				$result,
+				'Empty block content should be returned unchanged.'
+			);
+
+			$after     = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$remaining = is_array( $after ) ? implode( '', $after ) : (string) $after;
+
+			$this->assertStringNotContainsString(
+				'is-style-empty-removal--',
+				$remaining,
+				'Variation styles should be removed when the block renders no markup.'
+			);
+		} finally {
+			unregister_block_style( 'core/group', 'empty-removal' );
+			wp_deregister_style( 'block-style-variation-styles' );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that a block style variation's styles are retained, and the instance
+	 * class is applied to markup, when the block does render markup.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/issues/80718
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_class_name
+	 */
+	public function test_block_style_variation_styles_retained_for_rendered_markup() {
+		switch_theme( 'block-theme' );
+
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'retained',
+				'style_data' => array(
+					'color' => array( 'background' => 'rebeccapurple' ),
+				),
+			)
+		);
+
+		try {
+			$parsed_block = array(
+				'blockName' => 'core/group',
+				'attrs'     => array(
+					'className' => 'wp-block-group is-style-retained',
+				),
+			);
+
+			$parsed_block = gutenberg_render_block_style_variation_support_styles( $parsed_block );
+
+			$result = gutenberg_render_block_style_variation_class_name(
+				"<div class=\"wp-block-group\">Content</div>\n",
+				$parsed_block
+			);
+
+			$this->assertMatchesRegularExpression(
+				'/is-style-retained--\d+/',
+				$result,
+				'The variation instance class should be applied to the rendered markup.'
+			);
+
+			$after     = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$remaining = is_array( $after ) ? implode( '', $after ) : (string) $after;
+
+			$this->assertStringContainsString(
+				'is-style-retained--',
+				$remaining,
+				'Variation styles should be retained when the block renders markup.'
+			);
+		} finally {
+			unregister_block_style( 'core/group', 'retained' );
+			wp_deregister_style( 'block-style-variation-styles' );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that removing one empty block instance's variation styles leaves a
+	 * sibling instance's styles intact, so unrelated variations aren't dropped.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/issues/80718
+	 *
+	 * @covers ::gutenberg_remove_block_style_variation_styles
+	 */
+	public function test_block_style_variation_styles_removal_is_scoped_to_instance() {
+		switch_theme( 'block-theme' );
+
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'sibling',
+				'style_data' => array(
+					'color' => array( 'background' => 'seagreen' ),
+				),
+			)
+		);
+
+		try {
+			// First instance renders markup and should be retained.
+			$kept_block = gutenberg_render_block_style_variation_support_styles(
+				array(
+					'blockName' => 'core/group',
+					'attrs'     => array( 'className' => 'wp-block-group is-style-sibling' ),
+				)
+			);
+			gutenberg_render_block_style_variation_class_name(
+				"<div class=\"wp-block-group\">Kept</div>\n",
+				$kept_block
+			);
+			preg_match( '/is-style-(sibling--\d+)/', $kept_block['attrs']['className'], $kept_matches );
+
+			// Second instance renders nothing and should be removed.
+			$empty_block = gutenberg_render_block_style_variation_support_styles(
+				array(
+					'blockName' => 'core/group',
+					'attrs'     => array( 'className' => 'wp-block-group is-style-sibling' ),
+				)
+			);
+			gutenberg_render_block_style_variation_class_name( '', $empty_block );
+			preg_match( '/is-style-(sibling--\d+)/', $empty_block['attrs']['className'], $empty_matches );
+
+			$after     = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$remaining = is_array( $after ) ? implode( '', $after ) : (string) $after;
+
+			$this->assertStringContainsString(
+				$kept_matches[1],
+				$remaining,
+				'Styles for the instance that rendered markup should be retained.'
+			);
+			$this->assertStringNotContainsString(
+				$empty_matches[1],
+				$remaining,
+				'Styles for the instance that rendered no markup should be removed.'
+			);
+		} finally {
+			unregister_block_style( 'core/group', 'sibling' );
+			wp_deregister_style( 'block-style-variation-styles' );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+	}
 }

--- a/test/e2e/specs/editor/various/post-terms-block-style-variation.spec.js
+++ b/test/e2e/specs/editor/various/post-terms-block-style-variation.spec.js
@@ -1,0 +1,178 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Builds a page whose content is a Query Loop, filtered to a single taxonomy
+ * term, that renders a Post Terms block with the `post-terms-variation` block
+ * style variation applied.
+ *
+ * The Post Terms block is set to the `post_tag` taxonomy so that whether it
+ * renders any markup depends entirely on whether the queried post has tags.
+ *
+ * @param {Object} filter Query taxonomy filter, e.g. `{ tagIds: [ 1 ] }`.
+ * @return {string} Serialized block markup.
+ */
+function queryLoopWithPostTerms( filter ) {
+	const query = {
+		perPage: 10,
+		pages: 0,
+		offset: 0,
+		postType: 'post',
+		order: 'desc',
+		orderBy: 'date',
+		inherit: false,
+		...filter,
+	};
+
+	return `<!-- wp:query {"queryId":0,"query":${ JSON.stringify( query ) }} -->
+<div class="wp-block-query">
+<!-- wp:post-template -->
+<!-- wp:post-terms {"term":"post_tag","className":"is-style-post-terms-variation"} /-->
+<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->`;
+}
+
+/**
+ * Creates a taxonomy term, first removing any existing term with the same name
+ * so an interrupted previous run doesn't cause a `term_exists` error.
+ *
+ * @param {Object} requestUtils Playwright request utils.
+ * @param {string} restBase     Taxonomy REST base, e.g. `categories` or `tags`.
+ * @param {string} name         Term name.
+ * @return {Promise<number>} The created term's id.
+ */
+async function createUniqueTerm( requestUtils, restBase, name ) {
+	const existing = await requestUtils.rest( {
+		path: `/wp/v2/${ restBase }`,
+		params: { search: name, per_page: 100 },
+	} );
+
+	await Promise.all(
+		existing
+			.filter( ( term ) => term.name === name )
+			.map( ( term ) =>
+				requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/${ restBase }/${ term.id }`,
+					params: { force: true },
+				} )
+			)
+	);
+
+	const term = await requestUtils.createRecord( restBase, { name } );
+	return term.id;
+}
+
+test.describe( 'Post Terms block style variation styles', () => {
+	let controlPageId;
+	let emptyPageId;
+	let categoryId;
+	let tagId;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme(
+			'gutenberg-test-themes/style-variations'
+		);
+
+		// Terms aren't removed by `deleteAll*`, so clear any left over from a
+		// previously interrupted run to avoid a `term_exists` error.
+		categoryId = await createUniqueTerm(
+			requestUtils,
+			'categories',
+			'Post terms variation category'
+		);
+		tagId = await createUniqueTerm(
+			requestUtils,
+			'tags',
+			'Post terms variation tag'
+		);
+
+		// A post with the tag: the Post Terms block renders the tag markup.
+		await requestUtils.createPost( {
+			title: 'Post with a tag',
+			status: 'publish',
+			tags: [ tagId ],
+		} );
+
+		// A post with a category but no tags: the Post Terms block (set to
+		// `post_tag`) renders no markup for it.
+		await requestUtils.createPost( {
+			title: 'Post without tags',
+			status: 'publish',
+			categories: [ categoryId ],
+		} );
+
+		// Container pages are `page` post type so they don't match the
+		// `post`-type Query Loops they hold.
+		const controlPage = await requestUtils.createPage( {
+			title: 'Post terms variation control',
+			status: 'publish',
+			content: queryLoopWithPostTerms( { tagIds: [ tagId ] } ),
+		} );
+		controlPageId = controlPage.id;
+
+		const emptyPage = await requestUtils.createPage( {
+			title: 'Post terms variation empty',
+			status: 'publish',
+			content: queryLoopWithPostTerms( { categoryIds: [ categoryId ] } ),
+		} );
+		emptyPageId = emptyPage.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllPages(),
+		] );
+		await Promise.all( [
+			requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/categories/${ categoryId }`,
+				params: { force: true },
+			} ),
+			requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/tags/${ tagId }`,
+				params: { force: true },
+			} ),
+		] );
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'are emitted and applied when the block renders markup', async ( {
+		page,
+	} ) => {
+		await page.goto( `/?page_id=${ controlPageId }` );
+
+		const postTerms = page.locator( '.wp-block-post-terms' );
+
+		// The block rendered markup, so its variation styles should apply.
+		await expect( postTerms ).toBeVisible();
+		await expect( postTerms ).toHaveCSS( 'color', 'rgb(255, 0, 128)' );
+
+		// The instance-scoped variation stylesheet should be present in the page.
+		expect( await page.content() ).toContain(
+			'is-style-post-terms-variation--'
+		);
+	} );
+
+	test( 'are not emitted when the block renders no markup', async ( {
+		page,
+	} ) => {
+		await page.goto( `/?page_id=${ emptyPageId }` );
+
+		// The Query Loop found a post, but the Post Terms block rendered
+		// nothing because the post has no tags.
+		await expect( page.locator( '.wp-block-post-terms' ) ).toHaveCount( 0 );
+
+		// The variation's instance-scoped stylesheet must not be emitted for a
+		// block instance that isn't present in the markup.
+		// See https://github.com/WordPress/gutenberg/issues/80718.
+		expect( await page.content() ).not.toContain(
+			'is-style-post-terms-variation--'
+		);
+	} );
+} );

--- a/test/gutenberg-test-themes/style-variations/styles/post-terms-variation.json
+++ b/test/gutenberg-test-themes/style-variations/styles/post-terms-variation.json
@@ -1,0 +1,11 @@
+{
+	"version": 3,
+	"title": "Post Terms Variation",
+	"slug": "post-terms-variation",
+	"blockTypes": [ "core/post-terms" ],
+	"styles": {
+		"color": {
+			"text": "rgb(255, 0, 128)"
+		}
+	}
+}


### PR DESCRIPTION


## What?
Closes https://github.com/WordPress/gutenberg/issues/80718

Block style variation CSS was still emitted for a block instance even when a dynamic block (e.g. `core/post-terms`) rendered no markup. This removes that orphaned CSS.

## Why?

Variation styles are generated and enqueued on the `render_block_data` filter, which runs before a dynamic block's render callback. So when the block ultimately outputs nothing, its instance stylesheet is left behind on the page with no matching markup, dead CSS.



## How?
Since a block's output is only known after it renders, we reconcile in the `render_block` filter: if the block produced no HTML tag, we remove that one instance's styles. Each instance is scoped by a unique `.is-style-<slug>--<n> `selector, so only its stylesheet is dropped, the order of every other variation's styles (which descendant-over-ancestor priority relies on) is preserved.

## Testing Instructions

1. Activate a block theme with a core/post-terms block style variation partial in /styles.
2. In a template, add a Query Loop → Post Template → Post Terms block (set to Tags) with the variation applied.
3. View a post that has no tags.
4. Confirm the Post Terms block renders nothing and the variation's instance CSS (.is-style-<slug>--<n>) is no longer present in the page source.
5. View a post with tags and confirm the block renders and the variation styles are applied.

Automated coverage: `phpunit/block-supports/block-style-variations-test.php` and `test/e2e/specs/editor/various/post-terms-block-style-variation.spec.js`.

## Use of AI Tools

Claude
