### PR TITLE
Use configured tablet viewport breakpoints for Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -138,3 +138,33 @@ function register_block_core_media_text() {
 	);
 }
 add_action( 'init', 'register_block_core_media_text' );
+
+/**
+ * Enqueues dynamic stacking styles for the Media & Text block.
+ * 
+ * @since 23.4.0
+ */
+function enqueue_block_core_media_text_dynamic_styles() {
+	$tablet_breakpoint = wp_get_global_settings( array( 'viewport', 'tablet' ) );
+	$breakpoint        = $tablet_breakpoint ? $tablet_breakpoint : '600px';
+
+	$css = sprintf(
+		'@media (max-width: %s) {
+			.wp-block-media-text.is-stacked-on-mobile {
+				grid-template-columns: 100%% !important;
+			}
+			.wp-block-media-text.is-stacked-on-mobile > .wp-block-media-text__media {
+				grid-column: 1;
+				grid-row: 1;
+			}
+			.wp-block-media-text.is-stacked-on-mobile > .wp-block-media-text__content {
+				grid-column: 1;
+				grid-row: 2;
+			}
+		}',
+		$breakpoint
+	);
+
+	wp_add_inline_style( 'wp-block-media-text', wp_strip_all_tags( $css ) );
+}
+add_action( 'enqueue_block_assets', 'enqueue_block_core_media_text_dynamic_styles' );

--- a/packages/block-library/src/media-text/index.php
+++ b/packages/block-library/src/media-text/index.php
@@ -141,10 +141,10 @@ add_action( 'init', 'register_block_core_media_text' );
 
 /**
  * Enqueues dynamic stacking styles for the Media & Text block.
- * 
+ *
  * @since 23.4.0
  */
-function enqueue_block_core_media_text_dynamic_styles() {
+function register_block_core_media_text_dynamic_styles() {
 	$tablet_breakpoint = wp_get_global_settings( array( 'viewport', 'tablet' ) );
 	$breakpoint        = $tablet_breakpoint ? $tablet_breakpoint : '600px';
 
@@ -167,4 +167,4 @@ function enqueue_block_core_media_text_dynamic_styles() {
 
 	wp_add_inline_style( 'wp-block-media-text', wp_strip_all_tags( $css ) );
 }
-add_action( 'enqueue_block_assets', 'enqueue_block_core_media_text_dynamic_styles' );
+add_action( 'enqueue_block_assets', 'register_block_core_media_text_dynamic_styles' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #80717

This updates the Media & Text block to use the active theme's tablet viewport breakpoint for its "Stack on mobile" behavior, replacing the hardcoded 600px value.

## Why?
The block currently forces a stack at 600px. This can be too late for some layouts, causing squished text, awkward button wrapping, and tiny images on tablet screens. Since configurable viewports were recently introduced in #79104, themes can now define their own breakpoints in theme.json. The Media & Text block needs to respect these dynamic settings to keep responsive layouts consistent across the site.

## How?
A PHP function is hooked into `enqueue_block_assets` in the block's render file. This function fetches the tablet viewport setting using `wp_get_global_settings`. It then dynamically generates the media query and injects the stacking CSS using `wp_add_inline_style` on the block's native stylesheet handle. If a theme does not define a custom tablet breakpoint, it safely falls back to the default 600px.

## Testing Instructions

1. Activate a block theme and edit its theme.json to include a custom tablet viewport (e.g., `"settings": { "viewport": { "tablet": "800px"` } }).
2. Create a new post and insert a Media & Text block.
3. Add an image and some text.
4. Ensure the "Stack on mobile" toggle is enabled in the block settings.
5. Resize your browser window or use the editor's device preview.
6. Verify that the block stacks when the screen width drops below 800px.
7. Remove the viewport setting from theme.json and verify the block falls back to stacking at 600px.
