### PR TITLE
Add text alignment options to the Details block summary

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -313,7 +313,7 @@ Hide and show additional content.
 -	**Name:** [core/details](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-details/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
 -	**Supports:** align (full, wide), allowedBlocks, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** name, placeholder, showContent, summary
+-	**Attributes:** name, placeholder, showContent, summary, summaryAlign
 
 ## Embed
 

--- a/packages/block-library/src/details/README.md
+++ b/packages/block-library/src/details/README.md
@@ -19,6 +19,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `summary` | `rich-text` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `rich-text`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `summary`. [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `name` | `string` | — | [Source](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `attribute`. [Selector](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source): `.wp-block-details`. [HTML attr](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#attribute-source): `name` |
 | `placeholder` | `string` | — | — |
+| `summaryAlign` | `string` | — | — |
 
 ## Supports
 

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -26,6 +26,9 @@
 		},
 		"placeholder": {
 			"type": "string"
+		},
+		"summaryAlign": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -7,6 +7,8 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	store as blockEditorStore,
+	BlockControls,
+	AlignmentControl,
 } from '@wordpress/block-editor';
 import {
 	TextControl,
@@ -37,8 +39,14 @@ const TEMPLATE = [
 ];
 
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
-	const { name, showContent, summary, allowedBlocks, placeholder } =
-		attributes;
+	const {
+		name,
+		showContent,
+		summary,
+		allowedBlocks,
+		placeholder,
+		summaryAlign,
+	} = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -71,6 +79,14 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 
 	return (
 		<>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ summaryAlign }
+					onChange={ ( newAlign ) =>
+						setAttributes( { summaryAlign: newAlign } )
+					}
+				/>
+			</BlockControls>
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
@@ -122,6 +138,11 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 				name={ name || '' }
 			>
 				<summary
+					className={
+						summaryAlign
+							? `has-text-align-${ summaryAlign }`
+							: undefined
+					}
 					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
 					onKeyUp={ handleSummaryKeyUp }
 				>

--- a/packages/block-library/src/details/save.js
+++ b/packages/block-library/src/details/save.js
@@ -4,7 +4,7 @@
 import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { name, showContent } = attributes;
+	const { name, showContent, summaryAlign } = attributes;
 	const summary = attributes.summary ? attributes.summary : 'Details';
 	const blockProps = useBlockProps.save();
 
@@ -14,7 +14,13 @@ export default function save( { attributes } ) {
 			name={ name || undefined }
 			open={ showContent }
 		>
-			<summary>
+			<summary
+				className={
+					summaryAlign
+						? `has-text-align-${ summaryAlign }`
+						: undefined
+				}
+			>
 				<RichText.Content value={ summary } />
 			</summary>
 			<InnerBlocks.Content />


### PR DESCRIPTION
## What?
Closes #80411

This PR adds a text alignment control specifically for the Summary title of the Details block.

## Why?
Currently, users cannot align the title of the Details block. This is especially pain point for RTL (Right-to-Left) languages or multilingual websites where a user might want a specific title alignment. If we simply enable the standard block-wide typography alignment support, the alignment class gets applied to the root `<details>` wrapper, which unintentionally breaks the alignment of all the hidden child blocks inside the body.

## How?
This implementation is entirely based on the excellent proof of concept provided by @prasadkarmalkar in the original issue.

Instead of using the standard block supports, we introduce a dedicated `summaryAlign` attribute in `block.json`. We then manually wire up an `AlignmentControl` in the block toolbar and apply the generated `has-text-align-{value}` class exclusively to the `<summary>` HTML element. This safely aligns the title without forcing that alignment onto the inner blocks.

## Testing Instructions

1. Open a post or page and insert a Details block.
2. Type a title into the summary.
3. Use the new alignment controls in the block toolbar to align the title to the left, center, and right.
4. Expand the Details block and insert some text inside.
5. Confirm that the inner blocks do not inherit the summary title's alignment and can be aligned independently.
6. Save the post and view it on the frontend to ensure the alignment renders correctly.

<!-- ## Screenshots or screencast if applicable -->

