### PR TITLE
Color schemes: per-scheme duotone overrides (prototype, stacked on #80698)

### DIFF
--- a/docs/how-to-guides/themes/theme-json-dark-scheme.md
+++ b/docs/how-to-guides/themes/theme-json-dark-scheme.md
@@ -82,7 +82,11 @@ This emits, roughly (the `data-scheme` rules let a visitor control override the 
 }
 ```
 
-`dark` (and `light`) may contain `palette` and `gradients`.
+`dark` (and `light`) may contain `palette`, `gradients`, and `duotone`. A duotone
+override supplies replacement `colors` for a matching base duotone slug; it emits an
+additional SVG filter and redefines `--wp--preset--duotone--{slug}` under the scheme
+gate, so duotone-filtered images (cover, image, media) recolor with the scheme
+instead of staying fixed.
 
 ### Dark by default (a `light` override)
 
@@ -125,8 +129,8 @@ with its base palette. A single `theme.json` works on old and new WordPress.
 - Persisting a visitor's `data-scheme` choice across page loads. If ever added, it
   would be a dedicated visitor-preferences feature with its own privacy review, not
   a default.
-- Dark duotone variants.
-- Automatic generation of dark values — the theme must define them; the system
+- Automatic generation of scheme values — the theme must define them; the system
   never derives colors automatically.
-- Raw (non-preset) colors, per-block fixed colors, images/logos, and nested light/dark
-  surfaces. These remain the theme's responsibility.
+- Raw (non-preset) colors, per-block fixed colors, custom (non-preset) duotones,
+  transparent logos, and nested light/dark surfaces. These remain the theme's
+  responsibility.

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -99,8 +99,8 @@ Settings related to colors.
 | custom | Allow users to select custom colors. | `boolean` | `true` |
 | customDuotone | Allow users to create custom duotone filters. | `boolean` | `true` |
 | customGradient | Allow users to create custom gradients. | `boolean` | `true` |
-| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme="dark"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged. | `{ palette, gradients }` |  |
-| light | Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme="light"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in. | `{ palette, gradients }` |  |
+| dark | Dark-scheme overrides for color presets. Presets are matched by slug to the base palette/gradients and emitted as `--wp--preset--*` custom properties under a `prefers-color-scheme: dark` gate (and a `data-scheme="dark"` override). Use for a light-by-default theme. Fully opt-in: omit to leave output unchanged. | `{ palette, gradients, duotone }` |  |
+| light | Light-scheme overrides for color presets. Mirrors `dark`, but emitted under a `prefers-color-scheme: light` gate (and a `data-scheme="light"` override). Use for a dark-by-default theme that wants a light alternative. Fully opt-in. | `{ palette, gradients, duotone }` |  |
 | defaultDuotone | Allow users to choose filters from the default duotone filter presets. | `boolean` | `true` |
 | defaultGradients | Allow users to choose colors from the default gradients. | `boolean` | `true` |
 | defaultPalette | Allow users to choose colors from the default palette. | `boolean` | `true` |

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -111,6 +111,24 @@ class WP_Duotone_Gutenberg {
 	private static $used_svg_filter_data = array();
 
 	/**
+	 * Per-scheme duotone overrides from theme.json (`settings.color.light.duotone`
+	 * and `settings.color.dark.duotone`), keyed by scheme then base preset slug.
+	 * Lazily built by get_scheme_duotone_overrides().
+	 *
+	 * @var array
+	 */
+	private static $scheme_duotone_overrides;
+
+	/**
+	 * Used per-scheme duotone variant presets, keyed by variant filter id. Each
+	 * entry records the scheme, the base preset slug, and the variant filter URL
+	 * so the gated CSS custom-property overrides can be emitted.
+	 *
+	 * @var array
+	 */
+	private static $used_scheme_duotone_presets = array();
+
+	/**
 	 * All of the block CSS declarations for styles on the page.
 	 *
 	 * Example:
@@ -644,6 +662,38 @@ class WP_Duotone_Gutenberg {
 	}
 
 	/**
+	 * Gets the gated CSS custom-property overrides for used per-scheme duotone
+	 * variants.
+	 *
+	 * Redefines `--wp--preset--duotone--<slug>` to point at the variant filter
+	 * under the matching `prefers-color-scheme` media query (unless the visitor
+	 * forced the opposite scheme) and under a `data-scheme="<scheme>"` override,
+	 * mirroring the palette/gradient scheme model. Because duotone is referenced
+	 * through this custom property, blocks flip automatically.
+	 *
+	 * @return string The CSS for the per-scheme duotone overrides ('' if none).
+	 */
+	private static function get_scheme_global_styles_presets() {
+		if ( empty( self::$used_scheme_duotone_presets ) ) {
+			return '';
+		}
+
+		$root = WP_Theme_JSON_Gutenberg::ROOT_CSS_PROPERTIES_SELECTOR;
+		$css  = '';
+		foreach ( self::$used_scheme_duotone_presets as $data ) {
+			$scheme      = $data['scheme'];
+			$opposite    = 'dark' === $scheme ? 'light' : 'dark';
+			$declaration = self::get_css_custom_property_name( $data['slug'] ) . ':' . $data['filter'] . ';';
+
+			$css .= '@media (prefers-color-scheme: ' . $scheme . '){' .
+				$root . ':not([data-scheme="' . $opposite . '"]){' . $declaration . '}}';
+			$css .= $root . '[data-scheme="' . $scheme . '"]{' . $declaration . '}';
+		}
+
+		return $css;
+	}
+
+	/**
 	 * Get the CSS selector for a block type.
 	 *
 	 * @param WP_Block_Type $block_type Block type to check for support.
@@ -745,6 +795,86 @@ class WP_Duotone_Gutenberg {
 		}
 		self::$used_global_styles_presets[ $filter_id ] = $global_styles_presets[ $filter_id ];
 		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $global_styles_presets[ $filter_id ] );
+		self::enqueue_scheme_duotone_variants( $global_styles_presets[ $filter_id ]['slug'] );
+	}
+
+	/**
+	 * Reads per-scheme duotone overrides from theme.json.
+	 *
+	 * Returns a map of scheme (`light`/`dark`) to a map of base preset slug to the
+	 * override colors, from `settings.color.<scheme>.duotone`. Fully opt-in: absent
+	 * the keys, the map is empty and duotone output is unchanged.
+	 *
+	 * @return array
+	 */
+	private static function get_scheme_duotone_overrides() {
+		if ( isset( self::$scheme_duotone_overrides ) ) {
+			return self::$scheme_duotone_overrides;
+		}
+
+		self::$scheme_duotone_overrides = array();
+		$settings                       = gutenberg_get_global_settings();
+
+		foreach ( array( 'light', 'dark' ) as $scheme ) {
+			$duotones = $settings['color'][ $scheme ]['duotone'] ?? array();
+			if ( empty( $duotones ) || ! is_array( $duotones ) ) {
+				continue;
+			}
+			// Accept a flat list, as authored inline, or an origin-keyed structure.
+			if ( ! wp_is_numeric_array( $duotones ) ) {
+				$flattened = array();
+				foreach ( $duotones as $by_origin ) {
+					if ( is_array( $by_origin ) ) {
+						$flattened = array_merge( $flattened, $by_origin );
+					}
+				}
+				$duotones = $flattened;
+			}
+			foreach ( $duotones as $preset ) {
+				if ( ! isset( $preset['slug'], $preset['colors'] ) ) {
+					continue;
+				}
+				$slug = _wp_to_kebab_case( $preset['slug'] );
+				self::$scheme_duotone_overrides[ $scheme ][ $slug ] = $preset['colors'];
+			}
+		}
+
+		return self::$scheme_duotone_overrides;
+	}
+
+	/**
+	 * Registers per-scheme variant filters for a used duotone preset.
+	 *
+	 * For each scheme that overrides the given preset slug, injects an additional
+	 * SVG filter built from the override colors (id `wp-duotone-<slug>--<scheme>`)
+	 * and records it so a gated custom-property override can be emitted.
+	 *
+	 * @param string $slug The base duotone preset slug.
+	 * @return void
+	 */
+	private static function enqueue_scheme_duotone_variants( $slug ) {
+		$slug      = _wp_to_kebab_case( $slug );
+		$overrides = self::get_scheme_duotone_overrides();
+
+		foreach ( array( 'light', 'dark' ) as $scheme ) {
+			if ( empty( $overrides[ $scheme ][ $slug ] ) ) {
+				continue;
+			}
+			$variant_filter_id = self::get_filter_id( $slug ) . '--' . $scheme;
+
+			// Inject the variant SVG filter alongside the base one.
+			self::$used_svg_filter_data[ $variant_filter_id ] = array(
+				'slug'   => $slug . '--' . $scheme,
+				'colors' => $overrides[ $scheme ][ $slug ],
+			);
+
+			// Record the variant so its gated custom-property override is emitted.
+			self::$used_scheme_duotone_presets[ $variant_filter_id ] = array(
+				'scheme' => $scheme,
+				'slug'   => $slug,
+				'filter' => self::get_filter_url( $variant_filter_id ),
+			);
+		}
 	}
 
 	/**
@@ -1025,6 +1155,10 @@ class WP_Duotone_Gutenberg {
 		if ( ! empty( self::$used_global_styles_presets ) ) {
 			wp_add_inline_style( 'global-styles', self::get_global_styles_presets( self::$used_global_styles_presets ) );
 		}
+		$scheme_css = self::get_scheme_global_styles_presets();
+		if ( '' !== $scheme_css ) {
+			wp_add_inline_style( 'global-styles', $scheme_css );
+		}
 	}
 
 	/**
@@ -1043,6 +1177,10 @@ class WP_Duotone_Gutenberg {
 			wp_register_style( $style_tag_id, false );
 			if ( ! empty( self::$used_global_styles_presets ) ) {
 				wp_add_inline_style( $style_tag_id, self::get_global_styles_presets( self::$used_global_styles_presets ) );
+			}
+			$scheme_css = self::get_scheme_global_styles_presets();
+			if ( '' !== $scheme_css ) {
+				wp_add_inline_style( $style_tag_id, $scheme_css );
 			}
 			if ( ! empty( self::$block_css_declarations ) ) {
 				wp_add_inline_style( $style_tag_id, gutenberg_style_engine_get_stylesheet_from_css_rules( self::$block_css_declarations ) );

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -201,6 +201,33 @@
 										"required": [ "slug", "gradient" ],
 										"additionalProperties": false
 									}
+								},
+								"duotone": {
+									"description": "Dark-scheme duotone presets. Slugs override matching entries in `duotone`. Each generates an additional SVG filter and a gated `--wp--preset--duotone--{slug}` override.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the duotone preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base duotone slug.",
+												"type": "string"
+											},
+											"colors": {
+												"description": "List of colors from dark to light for the dark scheme.",
+												"type": "array",
+												"items": {
+													"description": "CSS hex or rgb string.",
+													"type": "string"
+												}
+											}
+										},
+										"required": [ "slug", "colors" ],
+										"additionalProperties": false
+									}
 								}
 							},
 							"additionalProperties": false
@@ -252,6 +279,33 @@
 											}
 										},
 										"required": [ "slug", "gradient" ],
+										"additionalProperties": false
+									}
+								},
+								"duotone": {
+									"description": "Light-scheme duotone presets. Slugs override matching entries in `duotone`. Each generates an additional SVG filter and a gated `--wp--preset--duotone--{slug}` override.",
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"description": "Name of the duotone preset, translatable.",
+												"type": "string"
+											},
+											"slug": {
+												"description": "Kebab-case identifier matching a base duotone slug.",
+												"type": "string"
+											},
+											"colors": {
+												"description": "List of colors from dark to light for the light scheme.",
+												"type": "array",
+												"items": {
+													"description": "CSS hex or rgb string.",
+													"type": "string"
+												}
+											}
+										},
+										"required": [ "slug", "colors" ],
 										"additionalProperties": false
 									}
 								}


### PR DESCRIPTION
## What / Why

**Technical prototype for discussion — not ready to merge. Stacked on #80698.** Extends the color scheme data model to duotone presets, so filtered images switch with the rest of the palette.

## How it works

A scheme override in `settings.color.dark.duotone` or `settings.color.light.duotone`:

1. Injects `wp-duotone-{slug}--{scheme}` when the base preset is used.
2. Points `--wp--preset--duotone--{slug}` to that filter inside the same `prefers-color-scheme` and `data-scheme` gates as #80698.

Overrides match by slug. Custom per-block duotones remain fixed across schemes.

## Testing

### Automated

```bash
npm run wp-env-test start
npm run wp-env-test -- run --env-cwd=wp-content/plugins/gutenberg \
  wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter WP_Duotone_Gutenberg_Test
```

### Manual

Use either theme from [WordPress/community-themes#266](https://github.com/WordPress/community-themes/pull/266):

1. Switch between its light and dark controls.
2. Confirm the Portrait image recolors with the palette and Signal gradient.
3. In DevTools, confirm `--wp--preset--duotone--portrait` points to the matching scheme filter.
4. Repeat in the Site Editor canvas.

<table>
<tr><th>Citrus Daylight</th><th>Electric Dusk</th></tr>
<tr>
<td><img alt="Portrait duotone in the light scheme" src="https://github.com/user-attachments/assets/c35dba09-744c-42b0-a473-a2ed65c3b4ef"></td>
<td><img alt="Portrait duotone in the dark scheme" src="https://github.com/user-attachments/assets/dbadbe97-a0ec-4e8f-89f5-f895b4e913e2"></td>
</tr>
</table>

## Questions for reviewers

1. Is a per-scheme SVG filter the right mechanism, or should duotone move to CSS-native filters first?
2. Should custom per-block duotones remain out of scope?

See `docs/how-to-guides/themes/theme-json-dark-scheme.md`.