### PR TITLE
Notes: Report save success consistently from note actions

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -403,9 +403,14 @@ export function useNoteActions() {
 					},
 				};
 
-				await saveEntityRecord( 'root', 'comment', newNoteData, {
-					throwOnError: true,
-				} );
+				const savedRecord = await saveEntityRecord(
+					'root',
+					'comment',
+					newNoteData,
+					{
+						throwOnError: true,
+					}
+				);
 
 				// Resolving a note drops its inline highlight: strip the marker
 				// so the note falls back to a block-level note in the content.
@@ -425,22 +430,31 @@ export function useNoteActions() {
 						? __( 'Note marked as resolved.' )
 						: __( 'Note reopened.' )
 				);
-			} else {
-				const updateData = {
-					id,
-					content,
-					status,
-				};
 
-				await saveEntityRecord( 'root', 'comment', updateData, {
-					throwOnError: true,
-				} );
-
-				createNotice( 'snackbar', __( 'Note updated.' ), {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
+				return savedRecord;
 			}
+
+			const updateData = {
+				id,
+				content,
+				status,
+			};
+
+			const savedRecord = await saveEntityRecord(
+				'root',
+				'comment',
+				updateData,
+				{
+					throwOnError: true,
+				}
+			);
+
+			createNotice( 'snackbar', __( 'Note updated.' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+
+			return savedRecord;
 		} catch ( error ) {
 			onError( error );
 		}
@@ -448,17 +462,18 @@ export function useNoteActions() {
 
 	const onDelete = async ( note ) => {
 		try {
+			// Capture the target block *before* the async delete: selection may
+			// shift during the round-trip, pointing the attribute cleanup at the
+			// wrong block.
+			const clientId = ! note.parent
+				? note.blockClientId || getSelectedBlockClientId()
+				: null;
+
 			await deleteEntityRecord( 'root', 'comment', note.id, undefined, {
 				throwOnError: true,
 			} );
 
-			if ( ! note.parent ) {
-				// Use blockClientId if available, otherwise fall back to selected block.
-				const clientId =
-					note.blockClientId || getSelectedBlockClientId();
-				if ( ! clientId ) {
-					return;
-				}
+			if ( clientId ) {
 				const attributes = getBlockAttributes( clientId );
 				const newAttributes = {
 					metadata: cleanEmptyObject(
@@ -488,6 +503,8 @@ export function useNoteActions() {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
+
+			return true;
 		} catch ( error ) {
 			onError( error );
 		}

--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -61,28 +61,25 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 		}
 		setIsSubmitting( true );
 		const submitted = inputComment;
-		try {
+
+		/*
+		 * The note actions resolve with the saved record on success and
+		 * `undefined` on failure (they surface their own error notice),
+		 * so only discard the draft once the save actually succeeded.
+		 */
+		const result = await onSubmit( submitted );
+		if ( result ) {
 			/*
-			 * The note actions resolve with the saved record on success and
-			 * `undefined` on failure (they surface their own error notice),
-			 * so only discard the draft once the save actually succeeded.
+			 * The field stays editable while the request is in flight, so
+			 * keep anything typed since; clearing unconditionally would
+			 * discard it.
 			 */
-			const result = await onSubmit( submitted );
-			if ( result !== undefined ) {
-				/*
-				 * The field stays editable while the request is in flight, so
-				 * keep anything typed since; clearing unconditionally would
-				 * discard it.
-				 */
-				setInputComment( ( current ) =>
-					current === submitted ? '' : current
-				);
-			}
-		} catch {
-			// Keep the draft so the user can retry.
-		} finally {
-			setIsSubmitting( false );
+			setInputComment( ( current ) =>
+				current === submitted ? '' : current
+			);
 		}
+
+		setIsSubmitting( false );
 	}
 
 	return (

--- a/packages/editor/src/components/collab-sidebar/note.js
+++ b/packages/editor/src/components/collab-sidebar/note.js
@@ -138,10 +138,16 @@ export function Note( {
 	if ( actionState === 'edit' ) {
 		body = (
 			<NoteForm
-				onSubmit={ ( value ) => {
-					onEditNote( { id: note.id, content: value } );
-					setActionState( null );
-					actionButtonRef.current?.focus();
+				onSubmit={ async ( value ) => {
+					const saved = await onEditNote( {
+						id: note.id,
+						content: value,
+					} );
+					// Keep the form open on failure so the edit isn't lost.
+					if ( saved ) {
+						handleCancel();
+					}
+					return saved;
 				} }
 				onCancel={ handleCancel }
 				note={ note }

--- a/packages/editor/src/components/collab-sidebar/notes.js
+++ b/packages/editor/src/components/collab-sidebar/notes.js
@@ -106,7 +106,11 @@ export function Notes( { notes, sidebarRef, isFloating = false, styles } ) {
 		const nextThread = threads[ currentIndex + 1 ];
 		const prevThread = threads[ currentIndex - 1 ];
 
-		await onDelete( note );
+		const deleted = await onDelete( note );
+		// Leave the selection alone when the delete failed; the note is still there.
+		if ( ! deleted ) {
+			return;
+		}
 
 		if ( note.parent !== 0 ) {
 			// Move focus to the parent thread when a reply was deleted.


### PR DESCRIPTION
## What?
Closes #80736.

Makes every action in `useNoteActions` resolve to a truthy value on success and `undefined` on failure, and updates the `NoteForm` call sites to act on it. This allows `NoteForm` to properly catch failures and avoid potential content loss.

## Why?
Two bugs fall out of the inconsistency:

- **Reopen & Reply** saved fine but never cleared the reply out of the form, because `onEdit` resolved `undefined` on success.
- **Editing a note** closed the form synchronously, before the save settled. On failure, you got an error notice, and your edit was already gone.

Also fixes two things in the same area:

- Deleting a note moved the selection and focus to an adjacent thread even when the delete failed, and the note was still on screen.
- `onDelete` read `getSelectedBlockClientId()` *after* the await, so a selection change mid-request could point the block-attribute cleanup at the wrong block. Now captured up front, matching `onCreate`.

## Testing Instructions
1. Add a note to a block, then edit it - the form should close, and the content should be updated.
2. Go offline, edit a note and submit - error notice appears and **the form stays open with your text**.
3. Resolve a note, then reply to it via **Reopen & Reply** -  the reply posts and the field clears.
4. Go offline and delete a note - error notice appears, selection stays put.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f2c8e973-48d4-4d8c-8a10-30bc3865890d

## Use of AI Tools

Assisted by Claude.