### PR TITLE
Block Editor: Fix floated blocks overlapping sticky blocks

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `outset-ring__focus`: Allow overriding the focus ring color via the `--focus-color` custom property ([#80587](https://github.com/WordPress/gutenberg/pull/80587)).
 
+### Bug Fixes
+
+-   Lower the editor z-index of left/right aligned blocks below sticky and fixed position blocks, so floated blocks no longer cover stuck blocks while scrolling ([#80749](https://github.com/WordPress/gutenberg/pull/80749)).
+
 ### Internal
 
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -25,8 +25,11 @@ $z-layers: (
 	".components-drop-zone": 40,
 	".components-drop-zone__content": 50,
 
-	// The floated blocks should be above the other blocks to allow selection.
-	"{core/image aligned left or right} .wp-block": 21,
+	// The floated blocks should be above adjacent blocks (`z-index: auto`) to
+	// allow selection, and above in-block UI like resize handles (2), but below
+	// sticky/fixed blocks (10) so they don't cover them when scrolling, as
+	// happens on the front end where floated blocks have no z-index.
+	"{core/image aligned left or right} .wp-block": 9,
 
 	// Needs to be below media library that has a z-index of 160000.
 	"{core/video track editor popover}": 160000 - 10,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/62774

In the editor, blocks aligned left or right get `z-index: 21` so they stay clickable above the adjacent blocks the text wraps around. Sticky and fixed blocks get `z-index: 10` from the position block support, so a floated block paints on top of a stuck block while scrolling the canvas. On the front end floated blocks have no z-index at all and sticky blocks correctly render above them, so the editor was showing the opposite of what the site renders.

To fix this we lower the editor value to 9. Floated blocks still paint above adjacent blocks (`z-index: auto`) and above in-block UI like resize handles (`z-index: 2`), so selection is unaffected, but they now go below sticky and fixed blocks (`z-index: 10`), matching the front end.

## Videos

### Before

![The floated image paints over the sticky group while scrolling](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/fix-62774-float-sticky/before-62774.gif)

[Download the MP4](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/fix-62774-float-sticky/before-62774.mp4)

### After

![The sticky group stays above the floated image while scrolling](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/fix-62774-float-sticky/after-62774.gif)

[Download the MP4](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/fix-62774-float-sticky/after-62774.mp4)

## Testing Instructions

1. In a post, add a Group with a Heading inside, give it a background color, and set Position to Sticky in the group's settings.
2. Below the group add an image, align it left, and add a few long paragraphs after it.
3. Scroll the editor canvas.
4. Verify the sticky group stays above the floated image while the content scrolls under it (on trunk the image paints over the group).
5. Verify the floated image can still be selected by clicking it, including where the paragraph text wraps around it.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
