### PR TITLE
Navigation Overlay Close: Inherit typography and color from the overlay

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Bug Fixes
 
+-   Navigation Overlay Close: Inherit typography and color from the overlay, so the button follows the theme font instead of the browser default button styles ([#80751](https://github.com/WordPress/gutenberg/pull/80751)).
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
 -   Post Content: Restrict the wrapper tag to the supported values offered in the editor.
 -   Post Date: Escape date values and link URLs before rendering the block.

--- a/packages/block-library/src/navigation-overlay-close/style.scss
+++ b/packages/block-library/src/navigation-overlay-close/style.scss
@@ -1,3 +1,17 @@
+// The button element's user agent styles set `font` and `color`, which breaks
+// inheritance, so both are explicitly inherited from the overlay. Specificity is
+// lowered so that theme.json and Global Styles block level values still win.
+:where(.wp-block-navigation-overlay-close) {
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	font-style: inherit;
+	font-weight: inherit;
+	letter-spacing: inherit;
+	line-height: inherit;
+	text-transform: inherit;
+}
+
 .wp-block-navigation-overlay-close {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
Fixes #80742

Fixes the Navigation Overlay Close block rendering with the browser default font instead of the font supplied by the theme.

The Close block renders a `button` element, and the browser user agent stylesheet applies a `font` shorthand and a `color` to buttons. Both break inheritance, so on Twenty Twenty-Five the Close button rendered in Arial at 13px while the menu items right next to it rendered in Manrope. The typography panel showed "Default", which was misleading, since the default turned out to be the browser font and not the theme font. The color has the same problem: a Close block with no explicit text color renders black even inside a white on black overlay.

To fix this we explicitly inherit the typography properties and the color, the same button reset already used by the legacy navigation overlay close button, the Accordion Heading block and the Tab List block. The declarations are wrapped in `:where()` so the rule carries no specificity and any value coming from theme.json, Global Styles or the block typography controls keeps winning.

## Video

Before and after, with the computed `font-family` of a menu item and of the Close button read live from the page. The title bar, the readout and the highlight rings were added for the recording.

![Overlay Close button typography before and after the fix](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/80742-overlay-close-typography/overlay-close-font.gif)

[Download the MP4](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/80742-overlay-close-typography/overlay-close-font.mp4) for a sharper version.

## Testing Instructions

1. Activate Twenty Twenty-Five.
2. In the Site Editor open the Header template part, select the Navigation block, and under Settings set the overlay menu to "Always" and click "Create overlay".
3. In the overlay, select the Close block, set its Display Mode to "Text", and save.
4. Visit the front end and click the menu button to open the overlay.
5. Verify the word "Close" renders in Manrope, matching the menu items beside it, instead of the browser default font.
6. Back in the editor, select the Close block, set a font family and a font size on it, and verify both still apply.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
