### PR TITLE
Notes: Cancel in-flight hover highlight when focus leaves a note thread

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -103,6 +103,8 @@ export function NoteThread( {
 
 		// Drop the highlight, unless another note (possibly on the same block) now owns it.
 		if ( ! isNoteFocused ) {
+			// Discard a hover toggle still in flight so it can't re-highlight afterwards.
+			debouncedToggleBlockHighlight.cancel();
 			toggleBlockHighlight( note.blockClientId, false );
 		}
 
@@ -127,6 +129,7 @@ export function NoteThread( {
 	function onFocus( event ) {
 		// Cancel any pending deselect and highlight the related block.
 		focusOutside.onFocus( event );
+		debouncedToggleBlockHighlight.cancel();
 		toggleBlockHighlight( note.blockClientId, true );
 	}
 

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -681,10 +681,7 @@ test.describe( 'Block Notes', () => {
 			await thread.click();
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
 			await expect( block ).toHaveClass( /is-highlighted/ );
-			// @todo: restore, which became flaky - await page.keyboard.press( 'Shift+Tab' );
-			await editor.canvas
-				.getByRole( 'textbox', { name: 'Add title' } )
-				.focus();
+			await page.keyboard.press( 'Shift+Tab' );
 			await expect( thread ).not.toBeFocused();
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
 			await expect( block ).not.toHaveClass( /is-highlighted/ );


### PR DESCRIPTION
## What?
Fixes a minor race condition that is unnoticeable to users but causes an e2e test to fail from time to time.

A note thread highlights its related block from two places: hover (debounced 50ms) and focus/blur (immediate). A hover toggle scheduled but not yet fired could land *after* the blur handler had already cleared the highlight, re-highlighting the
block. Nothing undoes it until the pointer moves, so the block stays stuck in the highlighted state.

This also made the `should collapse a note when the focus moves outside the note` e2e test flaky (~3 in 8 locally): whether it failed depended purely on whether the test's remaining steps finished inside that 50ms window.

I originally swapped `Shift+Tab` for a direct `.focus()` call, but that didn't fix it.

## How

`debouncedToggleBlockHighlight.cancel()` before each immediate write, so a focus-driven toggle always supersedes a pending hover one.

## Testing Instructions
This is hard to reproduce manually. Running the mentioned tests multiple times on the trunk will fail.

## Use of AI Tools

Assisted by Claude.
