### PR TITLE
Docs: Clarify agent guidance discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 ## Common pitfalls
 
 -   Do not add dependencies to the root `package.json`. Add them to the workspace that uses them, or create a new workspace under `tools/` (or `test/` for test infrastructure). See [Workspace Development](docs/contributors/code/workspace-development.md).
--   PHP features in `lib/compat/` MUST target a specific `wordpress-X.Y/` subdirectory.
+-   PHP features in `lib/compat/` MUST target the `wordpress-X.Y/` directory for the intended WordPress release; inspect the available compatibility directories before choosing a target.
 -   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ Read only what your task needs, when it needs it:
 -   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests).
 -   **Directory guides**: some directories carry their own `AGENTS.md` and `README.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
 
+## Testing
+
+For writing, running, or debugging JavaScript, PHP, or E2E tests, read [`skills/testing/SKILL.md`](skills/testing/SKILL.md) before choosing a command.
+
 ## Code quality
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,6 @@ Read only what your task needs, when it needs it:
 -   **Task procedures (skills)**: before starting a matching task, read the relevant `skills/<domain>/SKILL.md` (e.g. `skills/testing/SKILL.md` for writing, running, or debugging tests).
 -   **Directory guides**: some directories carry their own `AGENTS.md` and `README.md` with rules for working there (e.g. `packages/components/AGENTS.md`) — read it before changing files in that directory.
 
-## Testing
-
-For writing, running, or debugging JavaScript, PHP, or E2E tests, read [`skills/testing/SKILL.md`](skills/testing/SKILL.md) before choosing a command.
-
 ## Code quality
 
 ```bash
@@ -63,7 +59,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 ## Common pitfalls
 
 -   Do not add dependencies to the root `package.json`. Add them to the workspace that uses them, or create a new workspace under `tools/` (or `test/` for test infrastructure). See [Workspace Development](docs/contributors/code/workspace-development.md).
--   PHP features in `lib/compat/` MUST target the `wordpress-X.Y/` directory for the intended WordPress release; inspect the available compatibility directories before choosing a target.
+-   PHP features in `lib/compat/` MUST go in the `wordpress-X.Y/` directory for their intended WordPress release. Inspect the available compatibility directories first; do not assume the newest one is right.
 -   Avoid using private APIs in bundled packages (packages without `wpScript` or `wpModuleExports`). Private APIs are intended for Core usage; bundled packages may also be imported via npm into plugin scripts, causing incompatibilities.
 -   Avoid adding new APIs prefixed with `__experimental` or `__unstable`. This pattern is now not used. Instead use private APIs or in bundled packages regular exports.
 -   `block-editor` is a WordPress-agnostic package. NEVER add `core-data` dependencies or direct REST API calls to it.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -4,7 +4,7 @@ This package contains UI components that are intended to be used anywhere in a g
 
 We are currently in the process of rewriting the global components to be in the new `@wordpress/ui` package. Refer to the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for guidance on which components to use.
 
-For components not explicitly listed in the `use-recommended-components` rule, locate the component's `*.stories.*` file under `packages/components/src/` and check its status documentation for up-to-date usage guidance. The component status given in the Storybook file should be considered the most accurate signal, above the `experimental` tag or component prefix.
+For components not explicitly listed in the `use-recommended-components` rule, locate the component's Storybook source within this package and use its status guidance. This guidance is more authoritative than the `experimental` tag or component prefix.
 
 ## Forms
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -4,7 +4,7 @@ This package contains UI components that are intended to be used anywhere in a g
 
 We are currently in the process of rewriting the global components to be in the new `@wordpress/ui` package. Refer to the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for guidance on which components to use.
 
-For components not explicitly listed in the `use-recommended-components` rule, check the component status documentation in each Storybook file for up-to-date usage guidance on each component. The component status given in the Storybook file should be considered the most accurate signal, above the `experimental` tag or component prefix.
+For components not explicitly listed in the `use-recommended-components` rule, locate the component's `*.stories.*` file under `packages/components/src/` and check its status documentation for up-to-date usage guidance. The component status given in the Storybook file should be considered the most accurate signal, above the `experimental` tag or component prefix.
 
 ## Forms
 
@@ -14,4 +14,4 @@ For adding validation, consider using the [Validated Form Components](./src/vali
 
 ## Storybook
 
-Don't forget to check a components's Storybook documentation for additional usage guidance. The Storybook links ([public base URL](https://wordpress.github.io/gutenberg/)) are also useful to present to a human when they are asking for help with a component.
+Don't forget to check a component's Storybook documentation for additional usage guidance. The Storybook links ([public base URL](https://wordpress.github.io/gutenberg/)) are also useful to present to a human when they are asking for help with a component.


### PR DESCRIPTION
## What?

Clarifies compatibility targeting and component-status discovery guidance for agents.

## Why?

Contributors need a release-targeted compatibility rule and a direct, durable way to locate authoritative Storybook status guidance.

## How?

- States that compatibility code belongs in the directory for its intended WordPress release and must not default to the newest directory.
- Directs component work to its Storybook source within the package, without relying on a filename convention, and corrects a wording typo.

## Testing Instructions

1. Read the updated Common pitfalls entry in `AGENTS.md`.
2. Confirm the components guide directs readers to the component’s Storybook source without naming a file pattern.
3. Confirm root and `packages/components/` `CLAUDE.md` remain import-only shims.

### Testing Instructions for Keyboard

Not applicable; documentation-only change.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex assisted with the documentation wording and static verification.