### PR TITLE
Playlist: Shorten track toolbar button label

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Playlist: Shorten the track toolbar button label from "Add track" to "Add".
+
 ### Bug Fixes
 
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -166,7 +166,7 @@ const PlaylistTrackEdit = ( {
 			{ !! addTracks && (
 				<BlockControls group="block">
 					<MediaReplaceFlow
-						name={ __( 'Add track' ) }
+						name={ __( 'Add' ) }
 						onSelect={ addTracks }
 						accept="audio/*"
 						multiple

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -199,7 +199,7 @@ describe( 'PlaylistTrackEdit', () => {
 		const addTracks = jest.fn();
 		renderEdit( { addTracks } );
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Add track' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
 
 		expect( addTracks ).toHaveBeenCalledWith( {} );
 	} );
@@ -216,7 +216,7 @@ describe( 'PlaylistTrackEdit', () => {
 		expect(
 			within( screen.getByTestId( 'block-controls-block' ) ).getByRole(
 				'button',
-				{ name: 'Add track' }
+				{ name: 'Add' }
 			)
 		).toBeInTheDocument();
 	} );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -485,7 +485,7 @@ const PlaylistEdit = ( {
 		<>
 			<BlockControls group="other">
 				<MediaReplaceFlow
-					name={ __( 'Add track' ) }
+					name={ __( 'Add' ) }
 					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple


### PR DESCRIPTION
## What?

Follow-up to [#80368](https://github.com/WordPress/gutenberg/pull/80368).

Shortens the Playlist and Playlist Track toolbar button label from "Add track" to "Add".

This change was [suggested by Joen (`@jasmussen`)](https://github.com/WordPress/gutenberg/pull/80368#issuecomment-5020760055).

## Why?

The shorter label uses less space in the block toolbar and is consistent with the "Add" label used by Gallery and elsewhere in the editor.

## How?

Updates the `MediaReplaceFlow` label in both the Playlist and Playlist Track edit components, updates the existing Playlist Track test assertions, and records the enhancement in the Block Library changelog.

## Testing Instructions

1. Open the editor and insert a Playlist block.
2. Add one or more audio tracks.
3. Select the Playlist block and confirm its toolbar button is labeled "Add".
4. Select an individual Playlist Track block and confirm its toolbar includes "Add" and "Replace" controls.
5. Confirm the "Add" button still opens the media flow and can add another track.

The focused Playlist and Playlist Track Jest suites also pass (3 suites, 20 tests).

### Testing Instructions for Keyboard

1. Select a Playlist or Playlist Track block using the keyboard.
2. Navigate to the block toolbar.
3. Tab to the "Add" button and confirm its accessible name is "Add".
4. Press Enter and confirm the media flow opens.

## Screenshots or screencast

Not applicable; this is a text-only toolbar label change.

## Use of AI Tools

OpenAI Codex was used to implement the label and test updates, run focused validation, and draft this PR description. The changes were reviewed by the contributor.