### PR TITLE
Components: Clarify AGENTS.md scope

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -1,5 +1,7 @@
 ## Status
 
+This file supplements the repository-root `AGENTS.md`; its setup, quality, and verification guidance still applies.
+
 This package contains UI components that are intended to be used anywhere in a general way (global), or specifically in the block editor.
 
 We are currently in the process of rewriting the global components to be in the new `@wordpress/ui` package. Refer to the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for guidance on which components to use.


### PR DESCRIPTION
## What?

Clarifies that `packages/components/AGENTS.md` supplements the repository-root instructions.

## Why?

Package-specific guidance should not imply that repository setup, quality, and verification guidance no longer applies.

## How?

Adds the requested sentence under the package guidance’s existing Status section.

## Testing Instructions

Documentation-only change. `git diff --check` passes.

`npm run lint:md:docs -- packages/components/AGENTS.md` still reports MD041 because the unchanged base file begins with `## Status` rather than a top-level heading.

## Use of AI Tools

Codex was used to draft and validate this documentation change; the resulting diff was reviewed before submission.