### PR TITLE
Components: Update Floating UI to 2.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,31 +3475,31 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.11"
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+			"integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.5",
-				"@floating-ui/utils": "^0.2.11"
+				"@floating-ui/core": "^1.8.0",
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.6"
+				"@floating-ui/dom": "^1.8.0"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -3507,9 +3507,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+			"integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -49306,7 +49306,7 @@
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/styled": "^11.14.1",
 				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "^2.0.8",
+				"@floating-ui/react-dom": "^2.1.9",
 				"@types/gradient-parser": "^1.1.0",
 				"@types/highlight-words-core": "^1.2.1",
 				"@use-gesture/react": "^10.3.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -37,6 +37,7 @@
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 -   Update `@ariakit/react` to 0.4.35 and `@ariakit/test` to 0.7.2 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).
+-   Update `@floating-ui/react-dom` to 2.1.9 ([#80761](https://github.com/WordPress/gutenberg/pull/80761)).
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
 -   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,7 @@
 		"@emotion/serialize": "^1.3.3",
 		"@emotion/styled": "^11.14.1",
 		"@emotion/utils": "^1.4.2",
-		"@floating-ui/react-dom": "^2.0.8",
+		"@floating-ui/react-dom": "^2.1.9",
 		"@types/gradient-parser": "^1.1.0",
 		"@types/highlight-words-core": "^1.2.1",
 		"@use-gesture/react": "^10.3.1",


### PR DESCRIPTION
Release span: [`@floating-ui/react-dom` 2.1.9](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui/react-dom%402.1.9)

## What?

Updates the Components package from `@floating-ui/react-dom` 2.1.8 to 2.1.9, together with its compatible Floating UI dependency chain.

## Why?

The release supports explicit `undefined` values when TypeScript's `exactOptionalPropertyTypes` option is enabled.

## Notable upstream changes

- **Optional properties accept explicit `undefined`.** This improves compatibility for TypeScript consumers using `exactOptionalPropertyTypes`; it does not change Gutenberg's runtime Popover or Tooltip behavior.
- **The compatible `@floating-ui/dom` dependency moves to 1.8.0.** Gutenberg receives the matching internal Floating UI chain through the lockfile, with no source or public API migration required.

## How?

Updates the Components manifest and changelog, then regenerates the shared lockfile.

## Testing Instructions

1. Open the Components Storybook at **Components → Overlays → Popover → All Placements**.
2. Resize and scroll the preview. Confirm each popover stays anchored and adjusts when it reaches a viewport edge.
3. Open **Components → Overlays → Tooltip → Default**. Hover and focus the button, then move away. Confirm the tooltip appears in the expected position and dismisses normally.

<details>
<summary>Automated verification</summary>

Dependency and lockfile validation passed. The focused Popover and Tooltip tests passed 116 tests, with 4 existing skips.

</details>

### Testing Instructions for Keyboard

In the Popover story, Tab to the trigger, press Enter to open it, and press Escape to close it. Confirm focus returns to the trigger. In the Tooltip story, Tab to the button and confirm the tooltip appears without moving focus.

## Screenshots or screencast

Not applicable; no visual change is intended.

## Use of AI Tools

Codex selected and implemented the dependency update, reviewed the upstream release and peer constraints, ran the verification above, and updated this description.
