### PR TITLE
Theme: Update Color.js to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48527,7 +48527,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/style-runtime": "file:../style-runtime",
-				"colorjs.io": "^0.7.0",
+				"colorjs.io": "^0.7.1",
 				"memize": "^2.1.0"
 			},
 			"devDependencies": {
@@ -48580,9 +48580,9 @@
 			}
 		},
 		"packages/theme/node_modules/colorjs.io": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.0.tgz",
-			"integrity": "sha512-JfLy3aZW1Xp2iwSFzGlLn0XSMnIdItH3BmzsXtwHVFEWwVUJIwKBWNzjQq2Tgf3998OY7qW2R6klrlYo8vmEGg==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+			"integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Code Quality
 
--   Update `colorjs.io` to 0.7.1.
+-   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).
 -   Update `colorjs.io` dependency to remove need for colorspace registration workaround ([#80272](https://github.com/WordPress/gutenberg/pull/80272)).
 -   Regenerate design token styles using the shared CSS/SCSS Prettier configuration ([#80422](https://github.com/WordPress/gutenberg/pull/80422)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Code Quality
 
+-   Update `colorjs.io` to 0.7.1.
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).
 -   Update `colorjs.io` dependency to remove need for colorspace registration workaround ([#80272](https://github.com/WordPress/gutenberg/pull/80272)).
 -   Regenerate design token styles using the shared CSS/SCSS Prettier configuration ([#80422](https://github.com/WordPress/gutenberg/pull/80422)).

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -83,7 +83,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/style-runtime": "file:../style-runtime",
-		"colorjs.io": "^0.7.0",
+		"colorjs.io": "^0.7.1",
 		"memize": "^2.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Release span: [Color.js 0.7.1](https://github.com/color-js/color.js/releases/tag/v0.7.1)

## What?

Updates the Theme package from `colorjs.io` 0.7.0 to 0.7.1.

## Why?

The release fixes property-style color-space accessors in bundlers and makes `deltaEMethod` handling consistent in color steps.

## Notable upstream changes

- **Property-style color-space accessors work correctly in bundlers again.** Gutenberg imports the functional `colorjs.io/fn` API instead, so the regression did not affect the current Theme implementation.
- **Color steps now apply `deltaEMethod` consistently.** Gutenberg does not call Color.js's `steps` API, so no direct behavior change is expected.
- **No transitive dependencies move.** The update is isolated to the Color.js lockfile entry.

## How?

Updates the Theme manifest and changelog, then refreshes the isolated lockfile entry. No transitive package versions change.

## Testing Instructions

1. Open Storybook at **Design System → Theme → Theme Provider → Color Scales**.
2. Change the background and primary color controls across several light and dark values. Confirm every ramp updates and the story either reports that accessibility targets are met or clearly lists any unmet combination.
3. Open **Brand Color Fallbacks** and change the admin theme color. Confirm the actual and fallback swatches update together without missing or invalid colors.

<details>
<summary>Automated verification</summary>

Dependency and lockfile validation passed. All 71 focused tests and 2 snapshots passed, and the Theme build produced no unexpected generated changes.

</details>

### Testing Instructions for Keyboard

Not applicable; this dependency update does not change keyboard interaction.

## Screenshots or screencast

Not applicable; no visual change is intended.

## Use of AI Tools

Codex selected and implemented the dependency update, reviewed the upstream release and direct usage, ran the verification above, and updated this description.
