### PR TITLE
Packages: Update date-fns to 4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44390,7 +44390,7 @@
 				"clsx": "^2.1.1",
 				"colord": "^2.9.3",
 				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
+				"date-fns": "^4.4.0",
 				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -44447,6 +44447,16 @@
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/sheet": "^1.4.0",
 				"@emotion/utils": "^1.4.2"
+			}
+		},
+		"packages/components/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/components/node_modules/framer-motion": {
@@ -45437,7 +45447,7 @@
 				"@wordpress/warning": "file:../warning",
 				"clsx": "^2.1.1",
 				"colord": "^2.9.3",
-				"date-fns": "^4.1.0",
+				"date-fns": "^4.4.0",
 				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"
@@ -45467,6 +45477,16 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"packages/dataviews/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/date": {
@@ -45886,7 +45906,7 @@
 				"client-zip": "^2.4.5",
 				"clsx": "^2.1.1",
 				"colord": "^2.9.3",
-				"date-fns": "^4.1.0",
+				"date-fns": "^4.4.0",
 				"diff": "^8.0.3",
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
@@ -45916,6 +45936,16 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"packages/editor/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/element": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Internal
 
+-   Update `date-fns` to 4.4.0.
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
 -   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Internal
 
--   Update `date-fns` to 4.4.0.
+-   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
 -   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -86,7 +86,7 @@
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",
 		"csstype": "^3.2.3",
-		"date-fns": "^4.1.0",
+		"date-fns": "^4.4.0",
 		"deepmerge": "^4.3.1",
 		"fast-deep-equal": "^3.1.3",
 		"framer-motion": "^11.15.0",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   Update `date-fns` to 4.4.0.
 -   DataViews: Model `useSelectionProps` with orthogonal semantic props (`selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. `selectionMode` distinguishes multi-selection from the two single-selection semantics (`'single-required'` keeps an item selected on re-click, `'single-clearable'` allows clearing it), so the `list` layout keeps its always-selected behavior while single-select pickers stay clearable. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   Update `date-fns` to 4.4.0.
+-   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   DataViews: Model `useSelectionProps` with orthogonal semantic props (`selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. `selectionMode` distinguishes multi-selection from the two single-selection semantics (`'single-required'` keeps an item selected on re-click, `'single-clearable'` allows clearing it), so the `list` layout keeps its always-selected behavior while single-select pickers stay clearable. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -70,7 +70,7 @@
 		"@wordpress/warning": "file:../warning",
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",
-		"date-fns": "^4.1.0",
+		"date-fns": "^4.4.0",
 		"deepmerge": "^4.3.1",
 		"fast-deep-equal": "^3.1.3",
 		"remove-accents": "^0.5.0"

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 
+### Internal
+
+-   Update `date-fns` to 4.4.0.
+
 ## 14.51.0 (2026-07-14)
 
 ### New Features

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internal
 
--   Update `date-fns` to 4.4.0.
+-   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 
 ## 14.51.0 (2026-07-14)
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -108,7 +108,7 @@
 		"client-zip": "^2.4.5",
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",
-		"date-fns": "^4.1.0",
+		"date-fns": "^4.4.0",
 		"diff": "^8.0.3",
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",


### PR DESCRIPTION
Complete release span: [4.2.0](https://github.com/date-fns/date-fns/releases/tag/v4.2.0), [4.2.1](https://github.com/date-fns/date-fns/releases/tag/v4.2.1), [4.3.0](https://github.com/date-fns/date-fns/releases/tag/v4.3.0), and [4.4.0](https://github.com/date-fns/date-fns/releases/tag/v4.4.0)

## What?

Updates every direct `date-fns` dependency in Components, DataViews, and Editor from 4.1.0 to 4.4.0.

## Why?

There are no breaking changes in this update. It restores missing type definitions, improves modularized optimization and locale handling, and reduces the published package size.

## Notable upstream changes

- **4.2.0 adds documentation only.** It has no runtime effect on Gutenberg.
- **4.2.1 restores type definitions missing from 4.2.0.** This avoids exposing broken typings to the Components, DataViews, and Editor packages.
- **4.3.0 fixes modularized optimization and Portuguese and Chinese locale behavior.** Gutenberg uses module imports and exposes these locales in its calendar components, so the fixes are relevant without requiring an API migration.
- **4.4.0 deprecates date-fns CDN scripts and reduces the package size.** Gutenberg imports date-fns from npm rather than a CDN, so the deprecation does not apply; it only benefits from the smaller package artifact.

## How?

Updates the three package manifests and changelogs, then regenerates the shared lockfile. Existing consumers that still require 4.1.0 remain isolated.

## Testing Instructions

1. Open Storybook at **Components → Selection & Input → Time & Date → DateTimePicker → Default**. Choose a different date and time and confirm the selection updates correctly.
2. Open **DateRangeCalendar → Default**. Select a range, then change the locale and time-zone controls. Confirm the selected range and calendar labels remain correct.
3. In the post editor, change the scheduled publish date and time, close the picker, and reopen it. Confirm the chosen value is preserved and displayed correctly.

<details>
<summary>Automated verification</summary>

Dependency and lockfile validation passed. All 12 focused suites passed, covering 324 tests across Components, DataViews, and Editor.

</details>

### Testing Instructions for Keyboard

Repeat the calendar checks using Tab, the arrow keys, and Enter or Space. Confirm focus remains visible and the selected date or range updates as expected.

## Screenshots or screencast

Not applicable; no visual change is intended.

## Use of AI Tools

Codex selected and implemented the dependency update, reviewed the intervening releases and direct consumers, ran the verification above, and updated this description.
