### PR TITLE
Update Ariakit packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,29 +135,22 @@
 			}
 		},
 		"node_modules/@ariakit/components": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.5.tgz",
-			"integrity": "sha512-LnvU9bcOU2IkQS3jCFm2rxcULNtG55+M+fh66mFf4EEBHJnDoTdN7zNRtm1dyzcFn6hAn/AoLl3Hyg95RIGUOA==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.8.tgz",
+			"integrity": "sha512-Lwqh7wCjgQxNPYP8fU4mAXXtEVoN6Zv5jwd+sRYlPf61l7SUbFCEnrXy3+M2FJYOx/3QWUOp/co/OQrDVPid4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/store": "0.1.4",
-				"@ariakit/utils": "0.1.4"
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5"
 			}
 		},
-		"node_modules/@ariakit/core": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
-			"integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@ariakit/react": {
-			"version": "0.4.32",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.32.tgz",
-			"integrity": "sha512-ar5lyS/Pp/+p1TdAqsS8gHzL/E9df8uWXYmEsD/Olpv4hp9LVEtwM6FfOu57sn6qaycs2xWFN9GinmXkMd8LWA==",
+			"version": "0.4.35",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.35.tgz",
+			"integrity": "sha512-f/bCg+kw7YgBM5sElc5eHeACb8OxP54mN5w3igu6vg/JBFstDUBnhMeTWZU6NhOqMPUrZIgJYhry9i0Gl9TrVg==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-components": "0.3.1"
+				"@ariakit/react-components": "0.3.4"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -169,16 +162,16 @@
 			}
 		},
 		"node_modules/@ariakit/react-components": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.1.tgz",
-			"integrity": "sha512-SJ/xfL3vj20TX6p/Gx39wbQtfNKL66uQ8MtnW8yU7Mv3DnOr/riFUKZnTuVjl+rMfwCdiGoHK1DdYiFKSaHG5w==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.4.tgz",
+			"integrity": "sha512-jEfVkDQi99Zdv9SGnTRWGxfvhLXMHHuKXRw57D/uCA8ziKzMNH0+0ZhNDNKnskfPxBsZjbhtSsBXsCeMp1W1ag==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/components": "0.1.5",
-				"@ariakit/react-store": "0.1.5",
-				"@ariakit/react-utils": "0.2.0",
-				"@ariakit/store": "0.1.4",
-				"@ariakit/utils": "0.1.4",
+				"@ariakit/components": "0.1.8",
+				"@ariakit/react-store": "0.1.8",
+				"@ariakit/react-utils": "0.2.3",
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5",
 				"@floating-ui/dom": "^1.0.0"
 			},
 			"peerDependencies": {
@@ -187,14 +180,14 @@
 			}
 		},
 		"node_modules/@ariakit/react-store": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.5.tgz",
-			"integrity": "sha512-EMB7dG0aD+MqI/0M8dzmwPObGYoWx7lvJK4tKmTDDbuGIW+XwrKfG3n1dMkWgg/TEq5lDNE7S3WbpE8mRfXpPA==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.8.tgz",
+			"integrity": "sha512-VYZ1LTUVMrNUi4jP37Npvhe3mcAzKdznqnBSVeh1Jjsbcgw0JlN88oy6UpdoJPvLKWOZHVYr62Sqn7xE0GrsqQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-utils": "0.2.0",
-				"@ariakit/store": "0.1.4",
-				"@ariakit/utils": "0.1.4",
+				"@ariakit/react-utils": "0.2.3",
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
@@ -202,41 +195,41 @@
 			}
 		},
 		"node_modules/@ariakit/react-utils": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.0.tgz",
-			"integrity": "sha512-tyIx/qxYY5i8ntGSzDYZ5Olak7zZ58QeEYjbbMNSZEywgtrQlKhZXkVnXK72UkGXmCLg7OrrTsesv8Qh6Bx2LQ==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.3.tgz",
+			"integrity": "sha512-fDaheb/7QEusanZb2oRT7mO55GTpQUyBOdjvQF5RPh3/CM15lm0TejLKN5bl1obmU5HRuByvckQmQvSyr8n/dw==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/store": "0.1.4",
-				"@ariakit/utils": "0.1.4"
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@ariakit/store": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.4.tgz",
-			"integrity": "sha512-VQDtp5eq4MgIjxzo6M/6NN2sVx8WykiSs9HNMv2AnfAGntF1fMA6cxCuBIFFWkHekNMGWwe/utzbTt3J/mtuiA==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.7.tgz",
+			"integrity": "sha512-/GcxscA9QTo2F+IFbFPvoyj1N8hzXBnaYsQt9UxRiJgCFPQ2jIe4i6QgPXdOZEZUuqYdyuvjcQrg7MDm9vpvCA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/utils": "0.1.4"
+				"@ariakit/utils": "0.1.5"
 			}
 		},
 		"node_modules/@ariakit/test": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.4.13.tgz",
-			"integrity": "sha512-Kk0FDiHgvPnQw0HrU6B+XHTherTgvpAeI9kXBwCMcZXfLgYO9dh4BUrn1p0vT6EcMDJePEd9nrwZdAfnBFl0cg==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.7.2.tgz",
+			"integrity": "sha512-TSL9DKKuhVmSjU65TeP1hQ3dkxdPcx9R82hxntbkAbNRFmGgUItvrWr6NtlVoqjASSG/9nX4T6SEarLPjYKBBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.18",
+				"@ariakit/utils": "0.1.5",
 				"@testing-library/dom": "^8.0.0 || ^9.0.0 || ^10.0.0"
 			},
 			"peerDependencies": {
 				"@playwright/test": "^1.27.0",
-				"@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+				"@testing-library/react": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+				"react": "^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@playwright/test": {
@@ -251,9 +244,9 @@
 			}
 		},
 		"node_modules/@ariakit/utils": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.4.tgz",
-			"integrity": "sha512-gIC/FR/gcOtp2FQQDOnRPfxizJjqp4PSQWS7fH2tNr6O6iTwwW8CPao7VUpu8Y8xKeMXrvzHvkOHhBhfBf4OrA==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.5.tgz",
+			"integrity": "sha512-BQebYH9nV1VZttZwoq/fsxcxIJjc8oW2bNV6yJDHLZ8OF8UtM15drFN0JOL8Jwn7jeeD7Ev+tIC8pUijJEditQ==",
 			"license": "MIT"
 		},
 		"node_modules/@arraypress/waveform-player": {
@@ -49022,7 +49015,7 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
-				"@ariakit/test": "^0.4.13",
+				"@ariakit/test": "^0.7.2",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -49305,7 +49298,7 @@
 			"version": "37.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.32",
+				"@ariakit/react": "^0.4.35",
 				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.14.0",
 				"@emotion/css": "^11.13.5",
@@ -49357,7 +49350,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
-				"@ariakit/test": "^0.4.13",
+				"@ariakit/test": "^0.7.2",
 				"@storybook/addon-docs": "^10.4.3",
 				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
@@ -49843,7 +49836,7 @@
 			"version": "17.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.32",
+				"@ariakit/react": "^0.4.35",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/components": "file:../components",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -112,7 +112,7 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
-		"@ariakit/test": "^0.4.13",
+		"@ariakit/test": "^0.7.2",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
+-   Update `@ariakit/react` to 0.4.35 and `@ariakit/test` to 0.7.2.
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
 -   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,7 +36,7 @@
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
--   Update `@ariakit/react` to 0.4.35 and `@ariakit/test` to 0.7.2.
+-   Update `@ariakit/react` to 0.4.35 and `@ariakit/test` to 0.7.2 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).
 -   `ConfirmDialog`: Migrate styles from Emotion to an SCSS Module ([#80394](https://github.com/WordPress/gutenberg/pull/80394)).
 -   `ExternalLink`: Use the shared `outset-ring__focus` mixin for the focus ring ([#80573](https://github.com/WordPress/gutenberg/pull/80573)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@ariakit/react": "^0.4.32",
+		"@ariakit/react": "^0.4.35",
 		"@date-fns/utc": "^2.1.1",
 		"@emotion/cache": "^11.14.0",
 		"@emotion/css": "^11.13.5",
@@ -102,7 +102,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
-		"@ariakit/test": "^0.4.13",
+		"@ariakit/test": "^0.7.2",
 		"@storybook/addon-docs": "^10.4.3",
 		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
--   Update `@ariakit/react` to 0.4.35.
+-   Update `@ariakit/react` to 0.4.35 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).
 -   DataViews: Model `useSelectionProps` with orthogonal semantic props (`selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. `selectionMode` distinguishes multi-selection from the two single-selection semantics (`'single-required'` keeps an item selected on re-click, `'single-clearable'` allows clearing it), so the `list` layout keeps its always-selected behavior while single-select pickers stay clearable. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
+-   Update `@ariakit/react` to 0.4.35.
 -   DataViews: Model `useSelectionProps` with orthogonal semantic props (`selectionMode`, `shouldSelectOnClick`, and a caller-supplied `isItemSelectable`) instead of a picker-specific flag, and route the `list` layout's selection through the shared hook. `selectionMode` distinguishes multi-selection from the two single-selection semantics (`'single-required'` keeps an item selected on re-click, `'single-clearable'` allows clearing it), so the `list` layout keeps its always-selected behavior while single-select pickers stay clearable. No behavior change. [#80677](https://github.com/WordPress/gutenberg/pull/80677)
 -   DataForms: Track the `richtext` control's selection with a single React-tree focus boundary (`useFocusOutside`) instead of document-level focus bookkeeping, and drop the field-owned `Popover.Slot` so format popovers use the default Popover container. No behavior change. [#80324](https://github.com/WordPress/gutenberg/pull/80324)
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -51,7 +51,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@ariakit/react": "^0.4.32",
+		"@ariakit/react": "^0.4.35",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/components": "file:../components",

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -129,6 +129,14 @@ if ( typeof window !== 'undefined' ) {
 		global.HTMLElement.prototype.getAnimations = () => [];
 	}
 
+	// jsdom lacks CSS.supports (needed by Ariakit's modal scroll locking).
+	if ( ! global.CSS ) {
+		global.CSS = {};
+	}
+	if ( ! global.CSS.supports ) {
+		global.CSS.supports = jest.fn( () => false );
+	}
+
 	/**
 	 * The following mock is for block integration tests that might render
 	 * components leveraging DOMRect. For example, the Cover block which now renders

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -36,6 +36,13 @@ process.env.TZ = 'UTC';
 module.exports = {
 	rootDir: '../../',
 	moduleNameMapper: {
+		// Jest resolves dependencies from CommonJS and cannot select import-only
+		// package exports. Map Ariakit's ESM test helpers explicitly.
+		'^@ariakit/test$': '<rootDir>/node_modules/@ariakit/test/dist/index.js',
+		'^@ariakit/test/react$':
+			'<rootDir>/node_modules/@ariakit/test/dist/react.js',
+		'^@ariakit/utils$':
+			'<rootDir>/node_modules/@ariakit/utils/dist/index.js',
 		// Mock @wordpress/vips/worker before the general pattern so it doesn't try to load the real file.
 		// The worker-code.ts file is auto-generated during full builds and is gitignored.
 		'@wordpress/vips/worker':
@@ -80,7 +87,7 @@ module.exports = {
 		'^.+\\.m?[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
 	transformIgnorePatterns: [
-		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid|marked)/)',
+		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid|marked|@ariakit/(test|utils))/)',
 		'\\.pnp\\.[^\\/]+$',
 	],
 	snapshotSerializers: [


### PR DESCRIPTION
Complete release span:

- `@ariakit/react`: [0.4.33](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Freact%400.4.33), [0.4.34](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Freact%400.4.34), and [0.4.35](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Freact%400.4.35)
- `@ariakit/test`: [0.4.14](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.4.14), [0.4.15](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.4.15), [0.5.0](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.5.0), [0.5.1](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.5.1), [0.6.0](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.6.0), [0.6.1](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.6.1), [0.7.0](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.7.0), [0.7.1](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.7.1), and [0.7.2](https://github.com/ariakit/ariakit/releases/tag/%40ariakit%2Ftest%400.7.2)

## What?

Updates the Ariakit group: `@ariakit/react` from 0.4.32 to 0.4.35 and `@ariakit/test` from 0.4.13 to 0.7.2.

## Why?

The React update includes interaction and performance fixes. The test-package update keeps Gutenberg on the supported Ariakit test API, but is a potentially breaking 0.x minor update.

## Notable upstream changes

- **React 0.4.33 changes modal scroll locking to use `scrollbar-gutter` and improves component/store performance.** Gutenberg's Ariakit-backed overlays benefit directly; jsdom needed the added `CSS.supports` shim to exercise this path.
- **React 0.4.34 restores build output omitted from the published package.** This is a packaging correction with no Gutenberg API change.
- **React 0.4.35 improves hidden-popover performance, nested Escape handling, dialogs, typeahead, and virtual focus.** These changes are relevant to Gutenberg's Menu, Popover, Tooltip, Select, Composite, and Tabs consumers, but require no source migration.
- **Test 0.5.0 becomes ESM-only.** This affected Gutenberg's Jest environment, which now maps and transpiles the package's import-only exports.
- **Test 0.6.0 drops React 17 and Testing Library React 12.** Gutenberg already uses React 18 and Testing Library React 16, so its supported versions are unaffected.
- **Test 0.7.0 renames `includesHidden`, removes most helper subpaths, applies browser shims globally, and speeds up interactions.** Gutenberg does not use `includesHidden` or removed subpaths; its imports stay on the supported root and `/react` entry points.
- **The remaining test releases update dependencies, Playwright query behavior, environment checks, provenance, and interaction helpers.** None require Gutenberg source changes; the focused test consumers pass with the updated package.

## How?

Updates all direct declarations and the lockfile. The Jest setup now resolves and transpiles Ariakit's ESM-only test helpers, and jsdom supplies the `CSS.supports` API used by Ariakit's modal scroll locking.

## Testing Instructions

1. Open Storybook at **Components → Actions → Menu**. Open a menu, move through its items, open any submenu, and dismiss it. Confirm positioning, focus, and dismissal behave normally.
2. Open **Components → Containers → Tabs**. Move between tabs and confirm the matching panel is shown.
3. Open **CustomSelectControl** and **Tooltip** stories. Select an option and show or dismiss the tooltip, confirming there are no focus jumps or interaction errors.

<details>
<summary>Automated verification</summary>

Dependency and lockfile validation passed. All 25 focused suites passed, covering 632 tests and 5 snapshots across the affected Ariakit-backed components and test helpers.

</details>

### Testing Instructions for Keyboard

Use Tab to reach each control, Enter or Space to open it, the arrow keys to move through items or tabs, and Escape to dismiss overlays. Confirm focus remains visible and returns to the trigger after dismissal.

## Screenshots or screencast

Not applicable; no visual change is intended.

## Use of AI Tools

Codex selected and implemented the dependency update, reviewed the intervening releases and compatibility constraints, ran the verification above, and updated this description.
