### PR TITLE
Editor: leave undo to the browser in fields that handle their own undo

### DIFF
--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -83,6 +83,9 @@ function BlockHTML( { clientId } ) {
 			value={ html }
 			onBlur={ onChange }
 			onChange={ ( event ) => setHtml( event.target.value ) }
+			// The edits are local state until committed on blur, so undo
+			// and redo must remain the browser's own within the field.
+			data-editor-undo="false"
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -85,7 +85,7 @@ function BlockHTML( { clientId } ) {
 			onChange={ ( event ) => setHtml( event.target.value ) }
 			// The edits are local state until committed on blur, so undo
 			// and redo must remain the browser's own within the field.
-			data-editor-undo="false"
+			data-wp-native-undo
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -20,9 +20,11 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { useNativeUndo } from '../../utils/native-undo';
 
 function BlockHTML( { clientId } ) {
 	const [ html, setHtml ] = useState( '' );
+	const nativeUndoRef = useNativeUndo();
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
@@ -85,7 +87,7 @@ function BlockHTML( { clientId } ) {
 			onChange={ ( event ) => setHtml( event.target.value ) }
 			// The edits are local state until committed on blur, so undo
 			// and redo must remain the browser's own within the field.
-			data-wp-native-undo
+			ref={ nativeUndoRef }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -653,6 +653,10 @@ function LinkControl( {
 			tabIndex={ -1 }
 			ref={ wrapperNode }
 			className="block-editor-link-control"
+			// The dialog holds local state that is only committed when the
+			// link is applied, so undo and redo within it must remain the
+			// browser's own.
+			data-editor-undo="false"
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -656,7 +656,7 @@ function LinkControl( {
 			// The dialog holds local state that is only committed when the
 			// link is applied, so undo and redo within it must remain the
 			// browser's own.
-			data-editor-undo="false"
+			data-wp-native-undo
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState, useEffect, useMemo } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
@@ -29,6 +29,7 @@ import { isURL, prependHTTPS } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import { useNativeUndo } from '../../utils/native-undo';
 import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
 import LinkPreview from './link-preview';
@@ -227,6 +228,7 @@ function LinkControl( {
 
 	const isMountingRef = useRef( true );
 	const wrapperNode = useRef();
+	const wrapperRef = useMergeRefs( [ wrapperNode, useNativeUndo() ] );
 	const textInputRef = useRef();
 	const searchInputRef = useRef();
 	// TODO: Remove entityUrlFallbackRef and previewValue in favor of value prop after taxonomy entity binding
@@ -651,12 +653,11 @@ function LinkControl( {
 	return (
 		<div
 			tabIndex={ -1 }
-			ref={ wrapperNode }
-			className="block-editor-link-control"
 			// The dialog holds local state that is only committed when the
 			// link is applied, so undo and redo within it must remain the
 			// browser's own.
-			data-wp-native-undo
+			ref={ wrapperRef }
+			className="block-editor-link-control"
 		>
 			{ isCreatingPage && (
 				<div className="block-editor-link-control__loading">

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -83,6 +83,7 @@ import useRemoteUrlData from './components/link-control/use-rich-url-data';
 import { PrivateBlockContext } from './components/block-list/private-block-context';
 import useListViewPanelState from './components/use-list-view-panel-state';
 import InnerContent from './components/inner-content';
+import { useNativeUndo, usesNativeUndo } from './utils/native-undo';
 import {
 	isHashLink,
 	isRelativePath,
@@ -163,4 +164,6 @@ lock( privateApis, {
 	isHashLink,
 	isRelativePath,
 	InnerContent,
+	useNativeUndo,
+	usesNativeUndo,
 } );

--- a/packages/block-editor/src/utils/native-undo.js
+++ b/packages/block-editor/src/utils/native-undo.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Elements whose content the browser's own undo acts on (a dialog input, an
+ * HTML editing field, a search field), registered through `useNativeUndo`.
+ * The editor history must not act on events originating within them.
+ */
+const nativeUndoNodes = new WeakSet();
+
+/**
+ * Returns a ref that marks an element (and its descendants) as relying on
+ * the browser's own undo, so the editor history leaves the undo and redo
+ * shortcuts alone within it.
+ *
+ * @return {Function} Ref callback.
+ */
+export function useNativeUndo() {
+	return useRefEffect( ( node ) => {
+		nativeUndoNodes.add( node );
+		return () => {
+			nativeUndoNodes.delete( node );
+		};
+	}, [] );
+}
+
+/**
+ * Returns true when the event originates from an element registered through
+ * `useNativeUndo`.
+ *
+ * Events coming from the editor canvas are re-dispatched on the iframe
+ * element, so the real target is resolved through the frame's focused
+ * element.
+ *
+ * @param {KeyboardEvent} event Keyboard event.
+ *
+ * @return {boolean} Whether the element relies on the browser's own undo.
+ */
+export function usesNativeUndo( event ) {
+	let { target } = event;
+
+	if ( target?.nodeName === 'IFRAME' ) {
+		target = target.contentDocument?.activeElement;
+	}
+
+	while ( target ) {
+		if ( nativeUndoNodes.has( target ) ) {
+			return true;
+		}
+		target = target.parentElement;
+	}
+
+	return false;
+}

--- a/packages/block-library/src/html/modal.js
+++ b/packages/block-library/src/html/modal.js
@@ -13,7 +13,11 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { PlainText, store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	PlainText,
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { fullscreen, square } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 
@@ -25,6 +29,7 @@ import Preview from './preview';
 import { parseContent, serializeContent } from './utils';
 
 const { Tabs } = unlock( componentsPrivateApis );
+const { useNativeUndo } = unlock( blockEditorPrivateApis );
 
 export default function HTMLEditModal( { onRequestClose, content, onUpdate } ) {
 	// Parse content into separate sections and use as initial state
@@ -33,6 +38,9 @@ export default function HTMLEditModal( { onRequestClose, content, onUpdate } ) {
 	const [ editedCss, setEditedCss ] = useState( css );
 	const [ editedJs, setEditedJs ] = useState( js );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
+	// The fields hold local state that is only committed when the dialog is
+	// saved, so undo and redo within them must remain the browser's own.
+	const nativeUndoRef = useNativeUndo();
 
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 
@@ -132,7 +140,10 @@ export default function HTMLEditModal( { onRequestClose, content, onUpdate } ) {
 							align="stretch"
 							gap={ 8 }
 						>
-							<div className="block-library-html__modal-content">
+							<div
+								ref={ nativeUndoRef }
+								className="block-library-html__modal-content"
+							>
 								<Tabs.TabPanel
 									tabId="html"
 									focusable={ false }

--- a/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcuts/index.js
@@ -9,14 +9,28 @@ import {
 import { isAppleOS } from '@wordpress/keycodes';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { usesNativeUndo } = unlock( blockEditorPrivateApis );
 
 function KeyboardShortcuts( { undo, redo, save } ) {
 	useShortcut( 'core/customize-widgets/undo', ( event ) => {
+		if ( usesNativeUndo( event ) ) {
+			return;
+		}
 		undo();
 		event.preventDefault();
 	} );
 
 	useShortcut( 'core/customize-widgets/redo', ( event ) => {
+		if ( usesNativeUndo( event ) ) {
+			return;
+		}
 		redo();
 		event.preventDefault();
 	} );

--- a/packages/e2e-tests/plugins/meta-box.php
+++ b/packages/e2e-tests/plugins/meta-box.php
@@ -12,6 +12,8 @@
  */
 function gutenberg_test_meta_box_render_meta_box() {
 	echo 'Hello World';
+	echo '<label for="gutenberg_test_meta_box_input">Test meta box field</label>';
+	echo '<input type="text" id="gutenberg_test_meta_box_input" name="gutenberg_test_meta_box_input" />';
 }
 
 /**

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/index.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/index.js
@@ -9,11 +9,15 @@ import clsx from 'clsx';
 import { useRef, useEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
+
+const { useNativeUndo } = unlock( blockEditorPrivateApis );
 
 /**
  * Render metabox area.
@@ -52,8 +56,12 @@ function MetaBoxesArea( { location } ) {
 		'is-loading': isSaving,
 	} );
 
+	// Meta box fields are not part of the editor history, so undo and redo
+	// within them must remain the browser's own.
+	const nativeUndoRef = useNativeUndo();
+
 	return (
-		<div className={ classes }>
+		<div className={ classes } ref={ nativeUndoRef }>
 			{ isSaving && (
 				<Spinner className="edit-post-meta-boxes-area__spinner" />
 			) }

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -10,22 +10,32 @@ import { isAppleOS } from '@wordpress/keycodes';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editWidgetsStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { usesNativeUndo } = unlock( blockEditorPrivateApis );
 
 function KeyboardShortcuts() {
 	const { redo, undo } = useDispatch( coreStore );
 	const { saveEditedWidgetAreas } = useDispatch( editWidgetsStore );
 
 	useShortcut( 'core/edit-widgets/undo', ( event ) => {
+		if ( usesNativeUndo( event ) ) {
+			return;
+		}
 		undo();
 		event.preventDefault();
 	} );
 
 	useShortcut( 'core/edit-widgets/redo', ( event ) => {
+		if ( usesNativeUndo( event ) ) {
+			return;
+		}
 		redo();
 		event.preventDefault();
 	} );

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -12,6 +12,31 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 
 /**
+ * Returns true when the event originates from an element that handles undo
+ * and redo itself, marked with `data-editor-undo="false"`. Such elements hold
+ * local state that is not yet committed to the editor (a dialog input, an
+ * HTML editing field), so the browser's own undo must be left to act on them
+ * instead of the editor history.
+ *
+ * Events coming from the editor canvas are re-dispatched on the iframe
+ * element, so the real target is resolved through the frame's focused
+ * element.
+ *
+ * @param {KeyboardEvent} event Keyboard event.
+ *
+ * @return {boolean} Whether the element handles its own undo.
+ */
+function hasSelfContainedUndo( event ) {
+	let { target } = event;
+
+	while ( target?.nodeName === 'IFRAME' ) {
+		target = target.contentDocument?.activeElement;
+	}
+
+	return !! target?.closest?.( '[data-editor-undo="false"]' );
+}
+
+/**
  * Handles the keyboard shortcuts for the editor.
  *
  * It provides functionality for various keyboard shortcuts such as toggling editor mode,
@@ -61,11 +86,17 @@ export default function EditorKeyboardShortcuts() {
 	} );
 
 	useShortcut( 'core/editor/undo', ( event ) => {
+		if ( hasSelfContainedUndo( event ) ) {
+			return;
+		}
 		undo();
 		event.preventDefault();
 	} );
 
 	useShortcut( 'core/editor/redo', ( event ) => {
+		if ( hasSelfContainedUndo( event ) ) {
+			return;
+		}
 		redo();
 		event.preventDefault();
 	} );

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -12,11 +12,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 
 /**
- * Returns true when the event originates from an element that handles undo
- * and redo itself, marked with `data-editor-undo="false"`. Such elements hold
- * local state that is not yet committed to the editor (a dialog input, an
- * HTML editing field), so the browser's own undo must be left to act on them
- * instead of the editor history.
+ * Returns true when the event originates from an element marked with
+ * `data-wp-native-undo`: the browser's own undo acts on its content (a
+ * dialog input, an HTML editing field, a search field), so the editor
+ * history must not.
  *
  * Events coming from the editor canvas are re-dispatched on the iframe
  * element, so the real target is resolved through the frame's focused
@@ -24,16 +23,16 @@ import { store as editorStore } from '../../store';
  *
  * @param {KeyboardEvent} event Keyboard event.
  *
- * @return {boolean} Whether the element handles its own undo.
+ * @return {boolean} Whether the element relies on the browser's own undo.
  */
-function hasSelfContainedUndo( event ) {
+function usesNativeUndo( event ) {
 	let { target } = event;
 
 	while ( target?.nodeName === 'IFRAME' ) {
 		target = target.contentDocument?.activeElement;
 	}
 
-	return !! target?.closest?.( '[data-editor-undo="false"]' );
+	return !! target?.closest?.( '[data-wp-native-undo]' );
 }
 
 /**
@@ -86,7 +85,7 @@ export default function EditorKeyboardShortcuts() {
 	} );
 
 	useShortcut( 'core/editor/undo', ( event ) => {
-		if ( hasSelfContainedUndo( event ) ) {
+		if ( usesNativeUndo( event ) ) {
 			return;
 		}
 		undo();
@@ -94,7 +93,7 @@ export default function EditorKeyboardShortcuts() {
 	} );
 
 	useShortcut( 'core/editor/redo', ( event ) => {
-		if ( hasSelfContainedUndo( event ) ) {
+		if ( usesNativeUndo( event ) ) {
 			return;
 		}
 		redo();

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -4,36 +4,18 @@
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
-/**
- * Returns true when the event originates from an element marked with
- * `data-wp-native-undo`: the browser's own undo acts on its content (a
- * dialog input, an HTML editing field, a search field), so the editor
- * history must not.
- *
- * Events coming from the editor canvas are re-dispatched on the iframe
- * element, so the real target is resolved through the frame's focused
- * element.
- *
- * @param {KeyboardEvent} event Keyboard event.
- *
- * @return {boolean} Whether the element relies on the browser's own undo.
- */
-function usesNativeUndo( event ) {
-	let { target } = event;
-
-	if ( target?.nodeName === 'IFRAME' ) {
-		target = target.contentDocument?.activeElement;
-	}
-
-	return !! target?.closest?.( '[data-wp-native-undo]' );
-}
+const { usesNativeUndo } = unlock( blockEditorPrivateApis );
 
 /**
  * Handles the keyboard shortcuts for the editor.

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -28,7 +28,7 @@ import { store as editorStore } from '../../store';
 function usesNativeUndo( event ) {
 	let { target } = event;
 
-	while ( target?.nodeName === 'IFRAME' ) {
+	if ( target?.nodeName === 'IFRAME' ) {
 		target = target.contentDocument?.activeElement;
 	}
 

--- a/test/e2e/specs/editor/plugins/meta-boxes.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-boxes.spec.js
@@ -38,6 +38,44 @@ test.describe( 'Meta boxes', () => {
 		await expect( saveDraft ).toBeEnabled();
 	} );
 
+	test( 'should leave undo to the browser inside meta box fields', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'canvas text' );
+
+		// Click near the label, away from the resize handle overlaying the
+		// center of the toggle.
+		await page
+			.getByRole( 'button', { name: 'Meta Boxes', exact: true } )
+			.click( { position: { x: 40, y: 10 } } );
+		const field = page.getByRole( 'textbox', {
+			name: 'Test meta box field',
+		} );
+		await field.click();
+		await page.keyboard.type( 'META' );
+		await expect( field ).toHaveValue( 'META' );
+
+		await pageUtils.pressKeys( 'primary+z', { times: 4 } );
+
+		// The browser undoes the typing within the field. The canvas is
+		// untouched, and redo restores the typing.
+		await expect( field ).toHaveValue( '' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'canvas text' },
+			},
+		] );
+
+		await pageUtils.pressKeys( 'primaryShift+z', { times: 4 } );
+		await expect( field ).toHaveValue( 'META' );
+	} );
+
 	test( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async ( {
 		admin,
 		editor,

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -650,6 +650,49 @@ test.describe( 'undo', () => {
 		await pageUtils.pressKeys( 'primaryShift+z', { times: 4 } );
 		await expect( textarea ).toHaveValue( '<p>second</p>EDIT' );
 	} );
+
+	test( 'should leave undo to the browser inside the Custom HTML dialog', async ( {
+		page,
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'a paragraph' );
+		await editor.insertBlock( {
+			name: 'core/html',
+			attributes: { content: '<p>markup</p>' },
+		} );
+		await editor.clickBlockToolbarButton( 'Edit code' );
+
+		const field = page.getByRole( 'dialog' ).getByRole( 'textbox' );
+		await field.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( 'EDIT' );
+		await expect( field ).toHaveValue( '<p>markup</p>EDIT' );
+
+		await pageUtils.pressKeys( 'primary+z', { times: 4 } );
+
+		// The browser undoes the typing within the field. The dialog stays
+		// open and the content behind it is untouched.
+		await expect( field ).toHaveValue( '<p>markup</p>' );
+		await expect.poll( editor.getEditedPostContent )
+			.toBe( `<!-- wp:paragraph -->
+<p>a paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:html -->
+<p>markup</p>
+<!-- /wp:html -->` );
+
+		// Redo restores the typing. This distinguishes the browser's own
+		// undo from the editor history remounting the dialog: a remount
+		// resets the field to the same committed value, but destroys the
+		// browser's redo stack with it.
+		await pageUtils.pressKeys( 'primaryShift+z', { times: 4 } );
+		await expect( field ).toHaveValue( '<p>markup</p>EDIT' );
+	} );
 } );
 
 class UndoUtils {

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -570,6 +570,86 @@ test.describe( 'undo', () => {
 			isCollaborationEnabled ? 'false' : 'true'
 		);
 	} );
+
+	test( 'should leave undo to the browser inside the link dialog', async ( {
+		page,
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'some linked text here' );
+		// Select the word "linked".
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 10 } );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 6 } );
+		await pageUtils.pressKeys( 'primary+k' );
+
+		const urlInput = page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+		await expect( urlInput ).toBeFocused();
+
+		await page.keyboard.type( 'exampl' );
+		await expect( urlInput ).toHaveValue( 'exampl' );
+
+		await pageUtils.pressKeys( 'primary+z' );
+
+		// The browser undoes the typing within the field. The dialog stays
+		// open and the canvas content is untouched.
+		await expect( urlInput ).toHaveValue( '' );
+		await expect( urlInput ).toBeFocused();
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'some linked text here' },
+			},
+		] );
+	} );
+
+	test( 'should leave undo to the browser when editing a block as HTML', async ( {
+		page,
+		pageUtils,
+		editor,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'first' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'third' );
+
+		await editor.canvas.getByText( 'second', { exact: true } ).click();
+		await editor.clickBlockOptionsMenuItem( 'Edit as HTML' );
+
+		const textarea = editor.canvas.locator(
+			'textarea.block-editor-block-list__block-html-textarea'
+		);
+		await textarea.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( 'EDIT' );
+		await expect( textarea ).toHaveValue( '<p>second</p>EDIT' );
+
+		// Undo granularity within the field is the browser's own; press
+		// once per typed character. Excess presses are harmless no-ops in
+		// browsers that group the typing into a single undo unit, since the
+		// editor history must not act while the field is focused.
+		await pageUtils.pressKeys( 'primary+z', { times: 4 } );
+
+		// The browser undoes the typing within the field. The other blocks
+		// are untouched, and redo restores the typing.
+		await expect( textarea ).toHaveValue( '<p>second</p>' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'first' } },
+			{ name: 'core/paragraph', attributes: { content: 'second' } },
+			{ name: 'core/paragraph', attributes: { content: 'third' } },
+		] );
+
+		await pageUtils.pressKeys( 'primaryShift+z', { times: 4 } );
+		await expect( textarea ).toHaveValue( '<p>second</p>EDIT' );
+	} );
 } );
 
 class UndoUtils {


### PR DESCRIPTION
## What?
Fixes #80541. Fixes #38731. Fixes the link dialog and "Edit as HTML" problems reported in [this comment on #44238](https://github.com/WordPress/gutenberg/issues/44238#issuecomment-3247110087); the scroll jump that issue originally reports could not be reproduced and remains open. Cmd+Z inside the link dialog, a block's "Edit as HTML" view, the Custom HTML block's editing dialog, or a classic meta box field no longer rewinds the editor history. The browser's own undo acts on the field instead.

## Why?
The undo and redo shortcuts are global, so they fire from any focused element. Fields whose text is not in the editor history (the link dialog commits on Apply, the HTML view on blur) cannot be undone by it, so undo there rewound an earlier, unrelated change: the dialog closed, other blocks lost content, and redo could not always restore it.

## How?
An element that relies on the browser's own undo registers itself through a private `useNativeUndo` ref hook, and the global handlers leave the shortcut alone within it (checked via the paired `usesNativeUndo( event )`). The registry is a module-private WeakSet, deliberately invisible in the DOM so the mechanism is not adoptable as a de facto public API and can change later. The link dialog, the "Edit as HTML" textarea, the Custom HTML block's editing dialog, and the meta box areas register. Meta box contents are plugin-rendered classic form fields whose values are never part of the editor history, so the whole area registers as one. Since canvas keyboard events are re-dispatched on the iframe element, the real target is resolved through the frame's focused element. Everything else is unchanged, including plugin fields synced to block attributes.

Alternatives considered:

- **Attaching the handlers to editor surfaces** (canvas, list view, header) or one root node with popovers mounted outside: the surface is a proxy for the real criterion (is this text in the editor history?) and misses in both directions. It is overinclusive (the HTML editing textarea lives in the canvas, so it stays hijacked) and underinclusive (plugin panels whose fields sync to block attributes lose undo).
- **`stopPropagation()` in the field**: every such field must know an ancestor is listening, and it silences all other listeners.
- **`event.defaultPrevented` as the signal**: unavailable, because rich text prevents the default of these keys to suppress the browser's content editable undo, expecting the editor history to take over.
- **Skipping `input`/`textarea` targets**: changes undo in fields synced per keystroke to block attributes (e.g. PlainText blocks), where editor undo is correct.
- **A `data-` attribute as the marker**: works identically, but a readable attribute is a public API the moment it ships; hiding it behind the hook keeps the mechanism replaceable.

This deliberately does not close #18755, the umbrella issue. Remaining for that:

- Register the remaining core local-state fields (block rename modal, create-pattern modal, inline image size popover, and similar).
- Consider a blanket rule for modals: registering the `Modal` component covers them all, but requires moving the registry below `block-editor` (e.g. `@wordpress/compose`) so `components` can use it.
- Document that fields synced to block attributes or post fields intentionally keep editor undo.
- A public opt-in for plugin fields; the mechanism is private until proven.

## Testing Instructions
1. Select a word, press Cmd+K, type in the URL field, press Cmd+Z: the typing reverts, the dialog stays open, the canvas is untouched.
2. Switch a block to Edit as HTML, type in the textarea, press Cmd+Z: the typing reverts, other blocks stay intact, Cmd+Shift+Z restores it.

Covered by four regression tests (three in the undo suite, one in the meta boxes suite); all fail on trunk. The Custom HTML one asserts redo restores the typing, which distinguishes the browser's own undo from the editor history remounting the dialog: the remount resets the field to the same committed value, but destroys the browser's redo stack with it.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.
