### PR TITLE
Docs: Clarify getBlock behavior with inner block controllers

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -168,7 +168,16 @@ _Returns_
 
 Returns a block given its client ID. This is a parsed copy of the block, containing its `blockName`, `clientId`, and current `attributes` state. This is not the block's registration settings, which must be retrieved from the blocks module registration store.
 
-getBlock recurses through its inner blocks until all its children blocks have been retrieved. Note that getBlock will not return the child inner blocks of an inner block controller. This is because an inner block controller syncs itself with its own entity, and should therefore not be included with the blocks of a different entity. For example, say you call `getBlocks( TP )` to get the blocks of a template part. If another template part is a child of TP, then the nested template part's child blocks will not be returned. This way, the template block itself is considered part of the parent, but the children are not.
+getBlock recurses through its inner blocks until all its children blocks have been retrieved, with one exception: the children of an "inner block controller" are not part of its tree, so `innerBlocks` usually comes back empty even though the block clearly has children in the editor. Never rely on a controller's `innerBlocks`; ask for its children directly:
+
+```js
+getBlock( syncedPatternClientId ).innerBlocks; // Usually [].
+getBlocks( syncedPatternClientId ); // The pattern's blocks.
+```
+
+A block is an inner block controller when its children belong to, and are synced with, an entity other than the one being edited. Synced patterns (`core/block`) and template parts (`core/template-part`) are the usual examples: each owns its own blocks, and editing them saves to that pattern or template part, not to the post or template it sits in. Leaving their children out of the tree is what keeps the two entities separate, so walking a template's blocks stops at a template part placed inside it.
+
+`areInnerBlocksControlled( clientId )` tells whether a block is such a controller.
 
 _Parameters_
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -149,14 +149,26 @@ export function getBlockAttributes( state, clientId ) {
  * blocks module registration store.
  *
  * getBlock recurses through its inner blocks until all its children blocks have
- * been retrieved. Note that getBlock will not return the child inner blocks of
- * an inner block controller. This is because an inner block controller syncs
- * itself with its own entity, and should therefore not be included with the
- * blocks of a different entity. For example, say you call `getBlocks( TP )` to
- * get the blocks of a template part. If another template part is a child of TP,
- * then the nested template part's child blocks will not be returned. This way,
- * the template block itself is considered part of the parent, but the children
- * are not.
+ * been retrieved, with one exception: the children of an "inner block
+ * controller" are not part of its tree, so `innerBlocks` usually comes back
+ * empty even though the block clearly has children in the editor. Never rely on
+ * a controller's `innerBlocks`; ask for its children directly:
+ *
+ * ```js
+ * getBlock( syncedPatternClientId ).innerBlocks; // Usually [].
+ * getBlocks( syncedPatternClientId ); // The pattern's blocks.
+ * ```
+ *
+ * A block is an inner block controller when its children belong to, and are
+ * synced with, an entity other than the one being edited. Synced patterns
+ * (`core/block`) and template parts (`core/template-part`) are the usual
+ * examples: each owns its own blocks, and editing them saves to that pattern or
+ * template part, not to the post or template it sits in. Leaving their children
+ * out of the tree is what keeps the two entities separate, so walking a
+ * template's blocks stops at a template part placed inside it.
+ *
+ * `areInnerBlocksControlled( clientId )` tells whether a block is such a
+ * controller.
  *
  * @param {Object} state    Editor state.
  * @param {string} clientId Block client ID.


### PR DESCRIPTION
## What?
PR attempts to clarify the `getBlock` selector's JSDoc and the "inner block controller" concept it mentions. I have to link this doc every once in a while, and I thought more clarity would help.

## Testing Instructions
None. Confirm the updated doc makes sense.

## Use of AI Tools

Assisted by Claude.