### PR TITLE
URLInput: Simplify keyboard handling and fix arrow keys with a text selection

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
+-   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
+-   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -276,14 +276,20 @@ export default function URLInput( props ) {
 		// Unless the list can consume them, the keys must reach the editor for
 		// block navigation, so they mustn't be prevented.
 		if ( ! showSuggestions || ! suggestions.length || isLoading ) {
-			if ( event.keyCode === UP || event.keyCode === DOWN ) {
+			// Holding Shift extends the selection, which the browser handles.
+			if (
+				! event.shiftKey &&
+				( event.keyCode === UP || event.keyCode === DOWN )
+			) {
 				// Firefox on Windows leaves the caret in place, trapping focus,
 				// since the editor only navigates away from an edge.
 				// See: https://github.com/WordPress/gutenberg/issues/5693#issuecomment-436684747
 				const caret =
 					event.keyCode === UP ? 0 : event.target.value.length;
 
-				// Yield only once the caret is collapsed at that edge.
+				// UP moves the caret to the start of the text, DOWN to the end.
+				// Once it is already there, with nothing selected, the key is
+				// left to the editor to navigate out of the field.
 				if (
 					event.target.selectionStart !== caret ||
 					event.target.selectionEnd !== caret

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -273,96 +273,63 @@ export default function URLInput( props ) {
 	function handleKeyDown( event ) {
 		onKeyDown?.( event );
 
-		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
-		// We shouldn't preventDefault to allow block arrow keys navigation.
+		// Unless the list can consume them, the keys must reach the editor for
+		// block navigation, so they mustn't be prevented.
 		if ( ! showSuggestions || ! suggestions.length || isLoading ) {
-			// In the Windows version of Firefox the up and down arrows don't move the caret
-			// within an input field like they do for Mac Firefox/Chrome/Safari. This causes
-			// a form of focus trapping that is disruptive to the user experience. This disruption
-			// only happens if the caret is not in the first or last position in the text input.
-			// See: https://github.com/WordPress/gutenberg/issues/5693#issuecomment-436684747
-			switch ( event.keyCode ) {
-				// When UP is pressed, if the caret is at the start of the text, move it to the 0
-				// position.
-				case UP: {
-					if ( 0 !== event.target.selectionStart ) {
-						event.preventDefault();
+			if ( event.keyCode === UP || event.keyCode === DOWN ) {
+				// Firefox on Windows leaves the caret in place, trapping focus,
+				// since the editor only navigates away from an edge.
+				// See: https://github.com/WordPress/gutenberg/issues/5693#issuecomment-436684747
+				const caret =
+					event.keyCode === UP ? 0 : event.target.value.length;
 
-						// Set the input caret to position 0.
-						event.target.setSelectionRange( 0, 0 );
-					}
-					break;
+				// Yield only once the caret is collapsed at that edge.
+				if (
+					event.target.selectionStart !== caret ||
+					event.target.selectionEnd !== caret
+				) {
+					event.preventDefault();
+					event.target.setSelectionRange( caret, caret );
 				}
-				// When DOWN is pressed, if the caret is not at the end of the text, move it to the
-				// last position.
-				case DOWN: {
-					if ( value.length !== event.target.selectionStart ) {
-						event.preventDefault();
-
-						// Set the input caret to the last position.
-						event.target.setSelectionRange(
-							value.length,
-							value.length
-						);
-					}
-					break;
-				}
-
-				// Submitting while loading should trigger onSubmit.
-				case ENTER: {
-					if ( onSubmit ) {
-						event.preventDefault();
-						onSubmit( null, event );
-					}
-					break;
-				}
+			} else if ( event.keyCode === ENTER && onSubmit ) {
+				event.preventDefault();
+				onSubmit( null, event );
 			}
 
 			return;
 		}
 
-		const suggestion = suggestions[ selectedSuggestion ];
+		const suggestion = suggestions[ selectedSuggestion ] ?? null;
 
 		switch ( event.keyCode ) {
-			case UP: {
-				event.preventDefault();
-				setSelectedSuggestion(
-					! selectedSuggestion
-						? suggestions.length - 1
-						: selectedSuggestion - 1
-				);
-				break;
-			}
+			case UP:
 			case DOWN: {
 				event.preventDefault();
+
+				const offset = event.keyCode === UP ? -1 : 1;
+				// An unselected list is entered from the end nearest the key,
+				// and the ends wrap into each other.
+				const from = selectedSuggestion ?? ( offset === -1 ? 0 : -1 );
+
 				setSelectedSuggestion(
-					selectedSuggestion === null ||
-						selectedSuggestion === suggestions.length - 1
-						? 0
-						: selectedSuggestion + 1
+					( from + offset + suggestions.length ) % suggestions.length
 				);
 				break;
 			}
 			case TAB: {
-				if ( selectedSuggestion !== null ) {
+				if ( suggestion ) {
 					selectLink( suggestion );
-					// Announce a link has been selected when tabbing away from the input field.
 					speak( __( 'Link selected.' ) );
 				}
 				break;
 			}
 			case ENTER: {
 				event.preventDefault();
-				if ( selectedSuggestion !== null ) {
+				if ( suggestion ) {
 					selectLink( suggestion );
-
-					if ( onSubmit ) {
-						onSubmit( suggestion, event );
-					}
-				} else if ( onSubmit ) {
-					onSubmit( null, event );
 				}
 
+				onSubmit?.( suggestion, event );
 				break;
 			}
 		}

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -503,6 +503,23 @@ describe( 'URLInput', () => {
 			fireEvent.keyDown( input, KEY_EVENTS.up );
 			expect( input.selectionEnd ).toBe( 0 );
 		} );
+
+		it( 'should leave a selection being extended with the shift key alone', async () => {
+			const { user, input } = renderURLInput( {
+				disableSuggestions: true,
+			} );
+
+			await user.type( input, 'hello' );
+			input.setSelectionRange( 0, 5 );
+
+			fireEvent.keyDown( input, {
+				...KEY_EVENTS.up,
+				shiftKey: true,
+			} );
+
+			expect( input.selectionStart ).toBe( 0 );
+			expect( input.selectionEnd ).toBe( 5 );
+		} );
 	} );
 
 	describe( 'suggestion selection', () => {

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -415,6 +415,13 @@ describe( 'URLInput', () => {
 				'aria-activedescendant',
 				firstOption.id
 			);
+
+			fireEvent.keyDown( input, KEY_EVENTS.up );
+
+			expect( input ).toHaveAttribute(
+				'aria-activedescendant',
+				secondOption.id
+			);
 		} );
 
 		it( 'should select and submit the active suggestion when pressing Enter', async () => {
@@ -490,6 +497,11 @@ describe( 'URLInput', () => {
 
 			fireEvent.keyDown( input, KEY_EVENTS.down );
 			expect( input.selectionStart ).toBe( 5 );
+
+			// A selection reaching an end is collapsed to it first.
+			input.setSelectionRange( 0, 5 );
+			fireEvent.keyDown( input, KEY_EVENTS.up );
+			expect( input.selectionEnd ).toBe( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
## What?
This is a follow-up to #80721.

A minor refactoring of `handleKeyDown` was out of scope for #80721, so it was extracted into a separate branch.

-   Combine the two switches in `handleKeyDown` that both handled `UP`/`DOWN`/`ENTER`: one caret target for the arrow keys, one offset-plus-wrap for suggestion navigation, one `onSubmit` call for `ENTER`.
-   Fix ArrowUp with text selected back to the start of the field. `selectionStart` was already `0`, so nothing was prevented, and the event reached writing flow, which read a caret at the edge and navigated out of the input instead of collapsing the selection. The guard now requires the selection to be *collapsed* at the edge. ArrowDown was unaffected.

## Testing Instructions
Behavior should be covered by unit and e2e tests.

## Use of AI Tools

Assisted by Claude.
