### PR TITLE
UI: add dialog vs drawer design guidance

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).
 -   `Popover`: Default the popup's portal container to the `@wordpress/ui` compat overlay slot when present, so popovers stack reliably above other overlays in mixed-library compositions. A caller-supplied `Popover.Portal` `container` prop continues to take precedence ([#80278](https://github.com/WordPress/gutenberg/pull/80278)).
 -   `Button`: Add Storybook example demonstrating manual keyboard shortcut composition with `Tooltip`, `aria-keyshortcuts`, and an accessible description ([#80353](https://github.com/WordPress/gutenberg/pull/80353)).
+-   `Dialog`: Add Storybook usage guidelines for choosing between `Dialog` and `Drawer` ([#80783](https://github.com/WordPress/gutenberg/pull/80783)).
 
 ### Bug Fixes
 

--- a/packages/ui/src/dialog/stories/usage-guidelines.mdx
+++ b/packages/ui/src/dialog/stories/usage-guidelines.mdx
@@ -1,0 +1,66 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as UsageGuidelinesStories from './usage-guidelines.story';
+
+<Meta of={ UsageGuidelinesStories } />
+
+# Dialog usage guidelines
+
+**When should something be shown in a [Dialog](?path=/docs/design-system-components-dialog--docs) vs. a [Drawer](?path=/docs/design-system-components-drawer--docs)?**
+
+Both patterns interrupt the primary workflow, but they signal different expectations about context, scope, and how long the user will stay in the overlay.
+
+## Use a `Dialog` (or `AlertDialog`) when
+
+### The task can be opened from multiple places
+
+Choose a `Dialog` when the same flow is reachable from several entry points and the user does not need much of the surrounding page to complete it.
+
+Examples in WordPress:
+
+-   **Draft a page** — the same flow can open from a navigation menu block, the Pages list, or other surfaces.
+-   **Command palette** — global, context-light navigation and actions.
+-   **Media Library** when adding an image — a reusable picker that does not depend on one specific screen.
+
+<Canvas of={ UsageGuidelinesStories.DialogForFocusedTask } />
+
+### The overlay is a deliberate interruption
+
+A `Dialog` is appropriate for focused, specific tasks that pause the current workflow and require the user to make a decision or acknowledge critical information.
+
+For destructive or irreversible actions, prefer [AlertDialog](?path=/docs/design-system-components-alertdialog--docs) so dismissal behavior and button emphasis match the severity of the action.
+
+<Canvas of={ UsageGuidelinesStories.AlertDialogForDeliberateInterruption } />
+
+### There is one decision or one primary action
+
+A `Dialog` works best when the user can answer a single question or complete one focused task:
+
+-   Add a tax rate
+-   Add an image
+-   Remove a customer
+
+Include a prominent and clear call to action so the expected next step is obvious.
+
+### Content is short enough to scan without scrolling
+
+In most cases, `Dialog` content should fit comfortably in the viewport. Longer flows with many fields, sections, or drill-down steps are usually better suited to a `Drawer`.
+
+### Do not nest dialogs
+
+Avoid launching one `Dialog` from another. If a flow needs additional steps, prefer a single `Dialog` with clearer content, or move the longer flow into a `Drawer`.
+
+## Use a `Drawer` when
+
+### The user is editing something on the current page
+
+A `Drawer` fits contextual work where it helps to keep the underlying page visible — or at least mentally available — while editing details of an item already on screen.
+
+<Canvas of={ UsageGuidelinesStories.DrawerForContextualEditing } />
+
+### There are multiple fields or sections
+
+When the overlay becomes a small parallel workspace with several inputs, tabs, or collapsible sections, a `Drawer` usually scales better than a `Dialog`.
+
+### The flow may drill down
+
+A `Drawer` can grow into multi-step or multi-section experiences without feeling cramped. Collapsible sections, tabs, and nested panels are common `Drawer` patterns.

--- a/packages/ui/src/dialog/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/dialog/stories/usage-guidelines.story.tsx
@@ -11,7 +11,7 @@ const meta: Meta = {
 	parameters: {
 		controls: { disable: true },
 	},
-	tags: [ '!dev' ],
+	tags: [ '!dev' /* Hide individual story pages from sidebar */ ],
 };
 export default meta;
 

--- a/packages/ui/src/dialog/stories/usage-guidelines.story.tsx
+++ b/packages/ui/src/dialog/stories/usage-guidelines.story.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as AlertDialog from '../../alert-dialog';
+import * as Drawer from '../../drawer';
+import { InputControl } from '../../form/input-control';
+import { Field, Textarea } from '../../form/primitives';
+import { Stack } from '../../stack';
+import * as Dialog from '../index';
+
+const meta: Meta = {
+	title: 'Design System/Components/Dialog/Usage Guidelines',
+	parameters: {
+		controls: { disable: true },
+	},
+	tags: [ '!dev' ],
+};
+export default meta;
+
+type Story = StoryObj;
+
+/**
+ * Dialog works well for a focused task with one primary action that can be
+ * opened from many places without needing surrounding page context.
+ */
+export const DialogForFocusedTask: Story = {
+	render: () => (
+		<Dialog.Root>
+			<Dialog.Trigger>Add tax rate</Dialog.Trigger>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					<Dialog.Title>Add tax rate</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Content>
+					<Stack direction="column" gap="sm">
+						<Dialog.Description>
+							Enter a name and percentage for the new tax rate.
+						</Dialog.Description>
+						<InputControl
+							label="Name"
+							defaultValue="Standard rate"
+						/>
+						<InputControl
+							label="Rate (%)"
+							type="number"
+							defaultValue="8.5"
+						/>
+					</Stack>
+				</Dialog.Content>
+				<Dialog.Footer>
+					<Dialog.Action variant="outline">Cancel</Dialog.Action>
+					<Dialog.Action>Add tax rate</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	),
+};
+
+/**
+ * AlertDialog is appropriate when the overlay is a deliberate interruption,
+ * such as confirming a destructive action.
+ */
+export const AlertDialogForDeliberateInterruption: Story = {
+	render: () => (
+		<AlertDialog.Root>
+			<AlertDialog.Trigger>Remove customer</AlertDialog.Trigger>
+			<AlertDialog.Popup
+				intent="irreversible"
+				title="Remove customer?"
+				description="This customer will lose access to their account. This action cannot be undone."
+				confirmButtonText="Remove customer"
+			/>
+		</AlertDialog.Root>
+	),
+};
+
+/**
+ * Drawer fits contextual editing where the user benefits from keeping the
+ * underlying page visible while working through multiple fields or sections.
+ */
+export const DrawerForContextualEditing: Story = {
+	render: () => (
+		<Drawer.Root modal={ false } swipeDirection="right">
+			<Drawer.Trigger>Edit order details</Drawer.Trigger>
+			<Drawer.Popup size="medium">
+				<Drawer.Header>
+					<Drawer.Title>Order details</Drawer.Title>
+					<Drawer.CloseIcon />
+				</Drawer.Header>
+				<Drawer.Content>
+					<Stack direction="column" gap="md">
+						<InputControl
+							label="Customer name"
+							defaultValue="Alex Rivera"
+						/>
+						<Field.Root>
+							<Field.Label>Shipping address</Field.Label>
+							<Textarea
+								defaultValue={
+									'123 Market Street\nSan Francisco, CA 94103'
+								}
+								rows={ 3 }
+							/>
+						</Field.Root>
+						<Field.Root>
+							<Field.Label>Internal note</Field.Label>
+							<Textarea
+								defaultValue="Gift wrap requested."
+								rows={ 2 }
+							/>
+						</Field.Root>
+					</Stack>
+				</Drawer.Content>
+				<Drawer.Footer>
+					<Drawer.Action variant="outline">Cancel</Drawer.Action>
+					<Drawer.Action>Save changes</Drawer.Action>
+				</Drawer.Footer>
+			</Drawer.Popup>
+		</Drawer.Root>
+	),
+};

--- a/packages/ui/src/drawer/root.tsx
+++ b/packages/ui/src/drawer/root.tsx
@@ -18,6 +18,9 @@ import type { RootProps } from './types';
  * and expected. For drawers requiring explicit user choice (especially
  * destructive actions), omit the close icon and rely on footer action buttons
  * like "Cancel" and "Confirm" instead.
+ *
+ * See the [Usage Guidelines](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-dialog-usage-guidelines--docs)
+ * for when to use `Dialog` or `Drawer`.
  */
 function Root( {
 	modal = true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Props @j111q and @jasmussen for the original guide, which I've adopted here.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adds design guidance for choosing between Dialog and Drawer components.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Help designers and developers to create cohesive UIs by using components consistently; educate on differences between the two similar "modal" /  "overlay" components.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds Storybook Dialog "Usage guidelines" doc, and links it from Drawer.

<img width="1528" height="1248" alt="Screenshot 2026-07-28 at 15 34 29" src="https://github.com/user-attachments/assets/a9c2ed8b-41ec-4e74-af99-fdcbd9e79472" />


An alternative doc location could be in the "Patterns" folder:

<img width="292" height="146" alt="Screenshot 2026-07-28 at 14 42 17" src="https://github.com/user-attachments/assets/28f07d91-b412-40da-870f-b9d87c89f34b" />



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run storybook:dev`
Open http://localhost:50240/?path=/docs/design-system-components-dialog-usage-guidelines--docs

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
### Screenshots
#### Sections:
<img width="1155" height="1233" alt="Screenshot 2026-07-28 at 15 35 23" src="https://github.com/user-attachments/assets/f20fe7ef-22e0-4cc7-8d61-1756a814565b" />
<img width="1155" height="578" alt="Screenshot 2026-07-28 at 15 35 16" src="https://github.com/user-attachments/assets/1dd620cd-311f-43fc-bb58-eb104a0d6246" />

#### Examples:

<img width="1158" height="797" alt="Screenshot 2026-07-28 at 15 35 49" src="https://github.com/user-attachments/assets/25395847-2245-4025-be9f-e3a1875f2bee" />
<img width="1171" height="787" alt="Screenshot 2026-07-28 at 15 35 41" src="https://github.com/user-attachments/assets/74ba3e2c-8604-4cae-bc25-931f3f4307a4" />
<img width="1531" height="1250" alt="Screenshot 2026-07-28 at 15 34 48" src="https://github.com/user-attachments/assets/c8d8d3a3-53c0-4481-9ede-8ec9d161fc45" />



## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
