### PR TITLE
Storybook: Use SelectControl in Motion tokens story

### DIFF
--- a/storybook/stories/design-system/tokens/motion.story.tsx
+++ b/storybook/stories/design-system/tokens/motion.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState, useCallback, useId } from '@wordpress/element';
-import { Button, Field, InputControl, Select, Stack } from '@wordpress/ui';
+import { useState, useCallback } from '@wordpress/element';
+import { Button, InputControl, SelectControl, Stack } from '@wordpress/ui';
 
 const EASING_TOKENS = [
 	{
@@ -138,7 +138,6 @@ function AnimationRow( {
 }
 
 function MotionDemo() {
-	const durationSelectId = useId();
 	const [ animKey, setAnimKey ] = useState( 0 );
 	const replay = useCallback( () => setAnimKey( ( k ) => k + 1 ), [] );
 	const [ selectedDuration, setSelectedDuration ] = useState(
@@ -163,33 +162,25 @@ function MotionDemo() {
 			<Stack direction="column" gap="lg">
 				<h3>Easing curves</h3>
 				<Stack align="end" gap="md" wrap="wrap">
-					<Field.Root style={ { minWidth: '180px' } }>
-						<Field.Label htmlFor={ durationSelectId }>
-							Duration
-						</Field.Label>
-						<Select.Root
-							value={ selectedDuration }
-							onValueChange={ ( value ) => {
-								if ( typeof value !== 'string' ) {
+					<div style={ { minWidth: '180px' } }>
+						<SelectControl
+							label="Duration"
+							items={ DURATION_OPTIONS }
+							value={ DURATION_OPTIONS.find(
+								( opt ) => opt.value === selectedDuration
+							) }
+							onValueChange={ ( item ) => {
+								if (
+									! item ||
+									typeof item.value !== 'string'
+								) {
 									return;
 								}
-								setSelectedDuration( value );
+								setSelectedDuration( item.value );
 								setAnimKey( ( k ) => k + 1 );
 							} }
-						>
-							<Select.Trigger id={ durationSelectId } />
-							<Select.Popup>
-								{ DURATION_OPTIONS.map( ( opt ) => (
-									<Select.Item
-										key={ opt.value }
-										value={ opt.value }
-									>
-										{ opt.label }
-									</Select.Item>
-								) ) }
-							</Select.Popup>
-						</Select.Root>
-					</Field.Root>
+						/>
+					</div>
 					{ selectedDuration === 'custom' && (
 						<InputControl
 							label="Value (ms)"

--- a/storybook/stories/design-system/tokens/motion.story.tsx
+++ b/storybook/stories/design-system/tokens/motion.story.tsx
@@ -52,12 +52,11 @@ const DURATION_TOKENS = [
 ];
 
 const DURATION_OPTIONS = [
-	{ label: 'xs', value: 'var(--wpds-motion-duration-xs)' },
-	{ label: 'sm', value: 'var(--wpds-motion-duration-sm)' },
-	{ label: 'md', value: 'var(--wpds-motion-duration-md)' },
-	{ label: 'lg', value: 'var(--wpds-motion-duration-lg)' },
-	{ label: 'xl', value: 'var(--wpds-motion-duration-xl)' },
-	{ label: 'Custom', value: 'custom' },
+	...DURATION_TOKENS.map( ( token ) => ( {
+		label: token.name,
+		value: token.variable,
+	} ) ),
+	{ label: 'custom', value: 'custom' },
 ];
 
 const DEFAULT_DURATION_OPTION = DURATION_OPTIONS[ 4 ];
@@ -169,6 +168,7 @@ function MotionDemo() {
 							label="Duration"
 							items={ DURATION_OPTIONS }
 							defaultValue={ DEFAULT_DURATION_OPTION }
+							triggerContent={ ( item ) => item.value }
 							onValueChange={ ( item ) => {
 								if (
 									! item ||

--- a/storybook/stories/design-system/tokens/motion.story.tsx
+++ b/storybook/stories/design-system/tokens/motion.story.tsx
@@ -60,6 +60,8 @@ const DURATION_OPTIONS = [
 	{ label: 'Custom', value: 'custom' },
 ];
 
+const DEFAULT_DURATION_OPTION = DURATION_OPTIONS[ 4 ];
+
 const labelStyle = {
 	fontFamily: 'var(--wpds-typography-font-family-mono)',
 	fontSize: 'var(--wpds-typography-font-size-sm)',
@@ -141,7 +143,7 @@ function MotionDemo() {
 	const [ animKey, setAnimKey ] = useState( 0 );
 	const replay = useCallback( () => setAnimKey( ( k ) => k + 1 ), [] );
 	const [ selectedDuration, setSelectedDuration ] = useState(
-		'var(--wpds-motion-duration-xl)'
+		DEFAULT_DURATION_OPTION.value
 	);
 	const [ customDuration, setCustomDuration ] = useState( '600' );
 
@@ -166,9 +168,7 @@ function MotionDemo() {
 						<SelectControl
 							label="Duration"
 							items={ DURATION_OPTIONS }
-							value={ DURATION_OPTIONS.find(
-								( opt ) => opt.value === selectedDuration
-							) }
+							defaultValue={ DEFAULT_DURATION_OPTION }
 							onValueChange={ ( item ) => {
 								if (
 									! item ||


### PR DESCRIPTION
## What?

Replaces the low-level `Select` primitive usage in the Motion tokens Storybook story with `SelectControl`.

## Why?

This prepares the story for an upcoming breaking change in the `Select` primitives. `SelectControl` will absorb that change, so stories using it should not need updates.

## How?

Swap the manual `Field` + `Select` composition for `SelectControl` in the duration picker on the Motion tokens demo page.

## Testing Instructions

1. Run Storybook and open **Design System / Tokens / Motion**.
2. Confirm the **Duration** select still works: choose each preset duration and **Custom**.
3. With **Custom** selected, confirm the number input still updates the animation duration.
4. Click **Replay animations** and confirm the easing curves still animate with the selected duration.