### PR TITLE
Build Plugin ZIP: don't abort when changelog can't be generated

### DIFF
--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -425,7 +425,7 @@ You must also ensure that all PRs being included are assigned to the GitHub Mile
 
 For example, if you are releasing version `12.5.4`, then all PRs picked for that release must be unassigned from the `12.6` Milestone and instead assigned to the `12.5` Milestone.
 
-If release-note generation reports that the milestone has no unreleased pull requests, verify that every cherry-picked PR is assigned to the release milestone before rerunning the workflow. Do not generate the notes from a different milestone.
+If the milestone has no unreleased pull requests, the workflow still publishes the release draft, but its notes are replaced by a placeholder explaining how to write them by hand. Verify that every cherry-picked PR is assigned to the release milestone, then generate the changelog locally and paste it into the draft. Do not generate the notes from a different milestone.
 
 Once cherry picking is complete, you can also remove the `Backport to Gutenberg Minor Release` label from the PRs.
 
@@ -463,13 +463,21 @@ The process is identical to the one documented above when an RC is already out: 
 
 ### Troubleshooting
 
-> Release-note generation failed because no unreleased pull requests were found
+> The release draft says that the changelog could not be generated automatically
 
-The workflow fails before creating a release draft. Verify that every cherry-picked PR is assigned to the release milestone, then rerun the workflow. Do not manually create the release notes or use a different milestone.
+No unreleased pull requests were found in the release milestone, so there was nothing to pre-populate the notes with. The workflow does not fail: the version bump, the plugin ZIP, and the release draft are created as usual, and only the notes are missing, so there is no need to rerun it.
 
-If the milestone has been closed, you may reopen it for the release.
+This is expected when the release genuinely contains no pull requests, such as a security release whose commits were pushed straight to the release branch, or a re-release of a version that is already published. Write the release notes by hand, replacing the placeholder.
 
-After rerunning the workflow, manually verify that the PRs shown in the changelog match those cherry-picked to the release branch.
+If pull requests were expected, they are probably still assigned to another milestone:
+
+1. Verify that every cherry-picked PR is assigned to the release milestone. If the milestone has been closed, you may reopen it for the release.
+2. Generate the changelog locally with `npm run other:changelog -- --milestone="Gutenberg X.Y" --unreleased`.
+3. Replace the placeholder text in the draft with the output, and curate it as usual.
+
+Do not use a different milestone. Before publishing, manually verify that the PRs shown in the changelog match those cherry-picked to the release branch.
+
+Always replace the placeholder before publishing the release: whatever the release notes contain is committed to `changelog.txt` and shipped to WordPress.org.
 
 > The draft release only contains 1 asset file. Other releases have x3.
 

--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const Octokit = require( '@octokit/rest' );
+const { Octokit } = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
 const semver = require( 'semver' );
 
@@ -13,7 +13,7 @@ const {
 	getMilestoneByTitle,
 	getIssuesByMilestone,
 } = require( '../lib/milestone' );
-const { log, formats } = require( '../lib/logger' );
+const { log, warn, formats } = require( '../lib/logger' );
 const config = require( '../config' );
 // @ts-ignore
 const manifest = require( '../../../package.json' );
@@ -712,16 +712,14 @@ async function fetchAllPullRequests( octokit, settings ) {
 
 	const pullRequests = issues.filter( ( issue ) => issue.pull_request );
 
-	if ( ! pullRequests.length ) {
-		if ( settings.unreleased ) {
-			throw new Error(
-				`There are no unreleased pull requests associated with milestone "${ milestoneTitle }". Release coordinator: verify that every cherry-picked pull request is assigned to this milestone before rerunning the release.`
-			);
-		} else {
-			throw new Error(
-				`There are no pull requests associated with milestone "${ milestoneTitle }".`
-			);
-		}
+	// When only unreleased pull requests are requested, an empty list is a
+	// legitimate outcome: nothing needs to have been cherry-picked since the
+	// previous release in the series. Callers report it to the release
+	// coordinator instead of failing.
+	if ( ! pullRequests.length && ! unreleased ) {
+		throw new Error(
+			`There are no pull requests associated with milestone "${ milestoneTitle }".`
+		);
 	}
 
 	return pullRequests;
@@ -1006,6 +1004,28 @@ function getContributorsList( pullRequests ) {
 }
 
 /**
+ * Returns the release notes placeholder used when a milestone has no unreleased
+ * pull requests, telling the release coordinator how to fill the notes in.
+ *
+ * @param {string} milestoneTitle Milestone title.
+ *
+ * @return {string} Release notes placeholder.
+ */
+function getManualChangelogInstructions( milestoneTitle ) {
+	return [
+		'**⚠️ The changelog could not be generated automatically. The release notes have to be filled in by hand before publishing this release.**',
+		'',
+		`No unreleased pull requests were found in the "${ milestoneTitle }" milestone. That is expected for a release that contains no pull requests, such as a security release or a re-release of an already published version.`,
+		'',
+		`If pull requests were expected, they are probably still assigned to another milestone. Assign each of them to the "${ milestoneTitle }" milestone, then regenerate the notes locally and paste the output here:`,
+		'',
+		'```sh',
+		`npm run other:changelog -- --milestone="${ milestoneTitle }" --unreleased`,
+		'```',
+	].join( '\n' );
+}
+
+/**
  * Generates and logs changelog for a milestone.
  *
  * @param {WPChangelogSettings} settings Changelog settings.
@@ -1022,6 +1042,16 @@ async function createChangelog( settings ) {
 	} );
 
 	const pullRequests = await fetchAllPullRequests( octokit, settings );
+
+	if ( ! pullRequests.length ) {
+		warn(
+			formats.warning(
+				`No unreleased pull requests were found in milestone "${ settings.milestone }". The release notes need to be filled in by hand.`
+			)
+		);
+		log( getManualChangelogInstructions( settings.milestone ) );
+		return;
+	}
 
 	const changelog = getChangelog( pullRequests );
 	const contributorProps = getContributorProps( pullRequests );
@@ -1081,4 +1111,5 @@ module.exports = {
 	mapLabelsToFeatures,
 	createChangelog,
 	fetchAllPullRequests,
+	getManualChangelogInstructions,
 };

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -5,9 +5,11 @@ jest.mock( '@octokit/rest' );
 jest.mock( '../../lib/milestone' );
 jest.mock( '../../lib/logger', () => ( {
 	log: jest.fn(),
+	warn: jest.fn(),
 	formats: {
 		title: jest.fn( ( message ) => message ),
 		error: jest.fn( ( message ) => message ),
+		warning: jest.fn( ( message ) => message ),
 	},
 } ) );
 
@@ -32,16 +34,17 @@ import {
 	mapLabelsToFeatures,
 	createChangelog,
 	fetchAllPullRequests,
+	getManualChangelogInstructions,
 } from '../changelog';
 import _pullRequests from './fixtures/pull-requests.json';
 import botPullRequestFixture from './fixtures/bot-pull-requests.json';
 
-const Octokit = require( '@octokit/rest' );
+const { Octokit } = require( '@octokit/rest' );
 const {
 	getMilestoneByTitle,
 	getIssuesByMilestone,
 } = require( '../../lib/milestone' );
-const { log } = require( '../../lib/logger' );
+const { log, warn } = require( '../../lib/logger' );
 
 /**
  * pull-requests.json is a static snapshot of real data from the GitHub API.
@@ -51,6 +54,29 @@ const { log } = require( '../../lib/logger' );
  * See: https://github.com/WordPress/gutenberg/pull/38777#discussion_r808992346.
  */
 const pullRequests = _pullRequests.concat( botPullRequestFixture );
+
+/**
+ * Returns an Octokit stub for a repository without any release, so that
+ * `--unreleased` runs find no previous release in the series.
+ *
+ * @return {Object} Octokit stub.
+ */
+const createOctokitWithoutReleases = () => ( {
+	repos: {
+		listReleases: {
+			endpoint: {
+				merge: jest.fn().mockReturnValue( {} ),
+			},
+		},
+	},
+	paginate: {
+		iterator: jest.fn().mockReturnValue(
+			( async function* () {
+				yield { data: [] };
+			} )()
+		),
+	},
+} );
 
 describe( 'createChangelog', () => {
 	const settings = {
@@ -93,27 +119,38 @@ describe( 'createChangelog', () => {
 		);
 		expect( log ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'explains how to fill the notes in by hand when there are no unreleased pull requests', async () => {
+		Octokit.mockImplementation( createOctokitWithoutReleases );
+		getMilestoneByTitle.mockResolvedValue( {
+			number: 235,
+			title: settings.milestone,
+		} );
+		// An issue that is not a pull request, so no pull request is found.
+		getIssuesByMilestone.mockResolvedValue( [ { number: 123 } ] );
+
+		await createChangelog( { ...settings, unreleased: true } );
+
+		expect( warn ).toHaveBeenCalledTimes( 1 );
+		expect( log ).toHaveBeenCalledTimes( 2 );
+		expect( log ).toHaveBeenNthCalledWith(
+			2,
+			getManualChangelogInstructions( settings.milestone )
+		);
+	} );
+} );
+
+describe( 'getManualChangelogInstructions', () => {
+	it( 'includes the command that regenerates the notes for the milestone', () => {
+		expect( getManualChangelogInstructions( 'Gutenberg 23.5' ) ).toContain(
+			'npm run other:changelog -- --milestone="Gutenberg 23.5" --unreleased'
+		);
+	} );
 } );
 
 describe( 'fetchAllPullRequests', () => {
-	it( 'explains how to recover when a milestone has no unreleased pull requests', async () => {
+	it( 'resolves to an empty list when a milestone has no unreleased pull requests', async () => {
 		const milestone = 'Gutenberg 23.5';
-		const octokit = {
-			repos: {
-				listReleases: {
-					endpoint: {
-						merge: jest.fn().mockReturnValue( {} ),
-					},
-				},
-			},
-			paginate: {
-				iterator: jest.fn().mockReturnValue(
-					( async function* () {
-						yield { data: [] };
-					} )()
-				),
-			},
-		};
 
 		getMilestoneByTitle.mockResolvedValue( {
 			number: 235,
@@ -122,14 +159,37 @@ describe( 'fetchAllPullRequests', () => {
 		getIssuesByMilestone.mockResolvedValue( [ { number: 123 } ] );
 
 		await expect(
-			fetchAllPullRequests( octokit, {
+			fetchAllPullRequests( createOctokitWithoutReleases(), {
 				owner: 'WordPress',
 				repo: 'gutenberg',
 				milestone,
 				unreleased: true,
 			} )
+		).resolves.toEqual( [] );
+	} );
+
+	it( 'fails when a milestone has no pull requests at all', async () => {
+		const milestone = 'Gutenberg 23.5';
+
+		getMilestoneByTitle.mockResolvedValue( {
+			number: 235,
+			title: milestone,
+		} );
+		getIssuesByMilestone.mockResolvedValue( [ { number: 123 } ] );
+
+		await expect(
+			// Without `unreleased`, no release is looked up.
+			fetchAllPullRequests(
+				{},
+				{
+					owner: 'WordPress',
+					repo: 'gutenberg',
+					milestone,
+					unreleased: false,
+				}
+			)
 		).rejects.toThrow(
-			'There are no unreleased pull requests associated with milestone "Gutenberg 23.5". Release coordinator: verify that every cherry-picked pull request is assigned to this milestone before rerunning the release.'
+			'There are no pull requests associated with milestone "Gutenberg 23.5".'
 		);
 	} );
 } );

--- a/tools/release/lib/logger.js
+++ b/tools/release/lib/logger.js
@@ -11,8 +11,13 @@ const success = chalk.bold.green;
 
 const log = console.log;
 
+// Warnings go to stderr so that they stay out of command output that callers
+// redirect and reuse, such as generated release notes.
+const warn = console.warn;
+
 module.exports = {
 	log,
+	warn,
 	formats: {
 		title,
 		error,


### PR DESCRIPTION
Followup to #80175 that relaxes the checks that lead to build failure when changelog can't be generated.

When there are no unreleased PRs on GitHub correctly marked with the right milestone, the `build-plugin-zip.yml` script can't generate the `release-notes.txt` artifact that is used to populate the GitHub release draft. The current behavior is that the build is completely aborted, and the version bump commits that were already pushed to `trunk` and the `release/*` branches are reverted.

That's too harsh. There are releases that have no "official" PRs, like a security release. And if I forget to assign a milestone, it's easy to fix manually when I'm curating the release draft. Then I can re-generate the changelog locally with `npm run other:changelog` and just copy&paste the markdown. And the built `gutenberg.zip` archive is perfectly fine, there is nothing wrong with it.

This PR changes the behavior so that the generated `release-notes.txt` contains info that you need to edit the changelog manually. The "curate the changelog" step is part of the release checklist and you're always going to do it.

Note that the `release-notes.txt` artifact is only used to populate the release draft and nothing else. When uploading plugin info to WP.org, the changelog is generated from the published GitHub release info, after curation.