### PR TITLE
Components: Update react-day-picker to 9.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,9 +2463,10 @@
 			}
 		},
 		"node_modules/@date-fns/tz": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
-			"integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+			"integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+			"license": "MIT"
 		},
 		"node_modules/@date-fns/utc": {
 			"version": "2.1.1",
@@ -14221,6 +14222,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@tabby_ai/hijri-converter": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+			"integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -22996,9 +23006,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -41152,12 +41162,14 @@
 			}
 		},
 		"node_modules/react-day-picker": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.7.0.tgz",
-			"integrity": "sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==",
+			"version": "9.14.0",
+			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+			"integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+			"license": "MIT",
 			"dependencies": {
-				"@date-fns/tz": "1.2.0",
-				"date-fns": "4.1.0",
+				"@date-fns/tz": "^1.4.1",
+				"@tabby_ai/hijri-converter": "1.0.5",
+				"date-fns": "^4.1.0",
 				"date-fns-jalali": "4.1.0-0"
 			},
 			"engines": {
@@ -49345,7 +49357,7 @@
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
+				"react-day-picker": "^9.14.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^14.0.0"
 			},
@@ -49391,16 +49403,6 @@
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/sheet": "^1.4.0",
 				"@emotion/utils": "^1.4.2"
-			}
-		},
-		"packages/components/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/components/node_modules/framer-motion": {
@@ -49887,16 +49889,6 @@
 				}
 			}
 		},
-		"packages/dataviews/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"packages/date": {
 			"name": "@wordpress/date",
 			"version": "5.51.0",
@@ -50341,16 +50333,6 @@
 				"@types/react": {
 					"optional": true
 				}
-			}
-		},
-		"packages/editor/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"packages/element": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Internal
 
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
+-   Update `react-day-picker` to 9.14.0 ([#80792](https://github.com/WordPress/gutenberg/pull/80792)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 -   Update `@ariakit/react` to 0.4.35 and `@ariakit/test` to 0.7.2 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -97,7 +97,7 @@
 		"path-to-regexp": "^6.2.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.6.1",
-		"react-day-picker": "^9.7.0",
+		"react-day-picker": "^9.14.0",
 		"remove-accents": "^0.5.0",
 		"uuid": "^14.0.0"
 	},

--- a/packages/components/src/calendar/stories/date-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-calendar.story.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { fn } from 'storybook/test';
 import {
 	enUS,
@@ -22,20 +19,21 @@ import {
 	sv,
 } from 'date-fns/locale';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-/**
- * WordPress dependencies
- */
 import { useState, useEffect } from '@wordpress/element';
-/**
- * Internal dependencies
- */
 import { DateCalendar, TZDate } from '..';
+
+// Storybook date controls pass a number, but react-day-picker expects a Date for `endMonth`.
+function toDate( value: Date | number | undefined ): Date | undefined {
+	return value === undefined ? undefined : new Date( value );
+}
 
 const meta: Meta< typeof DateCalendar > = {
 	title: 'Components/Selection & Input/Time & Date/DateCalendar',
 	component: DateCalendar,
 	tags: [ 'status-private' ],
+	render: ( { endMonth, ...args } ) => (
+		<DateCalendar { ...args } endMonth={ toDate( endMonth ) } />
+	),
 	argTypes: {
 		locale: {
 			options: [
@@ -174,7 +172,7 @@ export const WithOutsideDays: Story = {
  * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
  */
 export const WithTimeZone: Story = {
-	render: function DateCalendarWithTimeZone( args ) {
+	render: function DateCalendarWithTimeZone( { endMonth, ...args } ) {
 		const [ selected, setSelected ] = useState< TZDate | null >( null );
 
 		useEffect( () => {
@@ -191,6 +189,7 @@ export const WithTimeZone: Story = {
 			<>
 				<DateCalendar
 					{ ...args }
+					endMonth={ toDate( endMonth ) }
 					selected={ selected }
 					onSelect={ ( selectedDate, ...rest ) => {
 						setSelected(

--- a/packages/components/src/calendar/stories/date-range-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-range-calendar.story.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { fn } from 'storybook/test';
 import {
 	enUS,
@@ -22,19 +19,21 @@ import {
 	sv,
 } from 'date-fns/locale';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-/**
- * WordPress dependencies
- */
 import { useState, useEffect } from '@wordpress/element';
-/**
- * Internal dependencies
- */
 import { DateRangeCalendar, TZDate } from '..';
+
+// Storybook date controls pass a number, but react-day-picker expects a Date for `endMonth`.
+function toDate( value: Date | number | undefined ): Date | undefined {
+	return value === undefined ? undefined : new Date( value );
+}
 
 const meta: Meta< typeof DateRangeCalendar > = {
 	title: 'Components/Selection & Input/Time & Date/DateRangeCalendar',
 	component: DateRangeCalendar,
 	tags: [ 'status-private' ],
+	render: ( { endMonth, ...args } ) => (
+		<DateRangeCalendar { ...args } endMonth={ toDate( endMonth ) } />
+	),
 	argTypes: {
 		locale: {
 			options: [
@@ -177,7 +176,7 @@ export const WithOutsideDays: Story = {
  * When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
  */
 export const WithTimeZone: Story = {
-	render: function DateCalendarWithTimeZone( args ) {
+	render: function DateCalendarWithTimeZone( { endMonth, ...args } ) {
 		const [ range, setRange ] = useState< typeof args.selected | null >(
 			null
 		);
@@ -203,6 +202,7 @@ export const WithTimeZone: Story = {
 			<>
 				<DateRangeCalendar
 					{ ...args }
+					endMonth={ toDate( endMonth ) }
 					selected={ range }
 					onSelect={ ( selectedDate, ...rest ) => {
 						setRange(


### PR DESCRIPTION
Follows #80763.

Complete release span: [v9.8.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.8.0), [v9.8.1](https://github.com/gpbl/react-day-picker/releases/tag/v9.8.1), [v9.9.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.9.0), [v9.10.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.10.0), [v9.11.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.11.0), [v9.11.1](https://github.com/gpbl/react-day-picker/releases/tag/v9.11.1), [v9.11.2](https://github.com/gpbl/react-day-picker/releases/tag/v9.11.2), [v9.11.3](https://github.com/gpbl/react-day-picker/releases/tag/v9.11.3), [v9.12.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.12.0), [v9.13.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.13.0), [v9.13.1](https://github.com/gpbl/react-day-picker/releases/tag/v9.13.1), [v9.13.2](https://github.com/gpbl/react-day-picker/releases/tag/v9.13.2), and [v9.14.0](https://github.com/gpbl/react-day-picker/releases/tag/v9.14.0).

## What?

Updates the direct `react-day-picker` dependency in `@wordpress/components` from 9.7.0 to 9.14.0.

## Why?

Version 9.7.0 pinned `date-fns` to 4.1.0. After #80763 updated Gutenberg's direct `date-fns` dependencies to 4.4.0, that pin left a second resolved version in the shared lockfile. The newer release accepts `date-fns` 4.4.0, so Components, DataViews, Editor, and Day Picker now share one resolution.

## Notable upstream changes

- **9.8–9.11 improve keyboard navigation, time-zone handling, range selection, and locale formatting.** Gutenberg uses Day Picker's default calendar APIs, locale entry point, `TZDate`, and range helper, all of which remain compatible.
- **9.11.3 changes grid markup when `endMonth` is set.** The focused calendar suites cover Gutenberg's date and range calendars.
- **9.12–9.14 add locale labels and optional calendar entry points.** The lockfile includes the upstream Hijri converter used by the optional Hijri entry point; Gutenberg does not import that entry point.

## How?

Updates the Components manifest and regenerates the shared lockfile. `@date-fns/tz` resolves from 1.2.0 to 1.5.0, and the redundant workspace-local `date-fns` 4.4.0 copies introduced by #80763 are removed.

## Testing Instructions

1. Open the DateCalendar and DateRangeCalendar stories in Storybook.
2. Select dates and ranges, including with a non-default time zone.
3. Use Tab, arrow keys, and Enter or Space to confirm keyboard navigation and selection still work.

<details>
<summary>Automated verification</summary>

- `npm run build`
- `npm run lint:deps`
- `npm run lint:lockfile`
- `npm run lint:published-deps`
- `npm run test:unit packages/components/src/calendar/test/date-calendar.tsx packages/components/src/calendar/test/date-range-calendar.tsx`
- `npm audit --omit=dev --audit-level=critical` (no critical findings; existing workspace audit findings remain)

</details>
