### PR TITLE
Storybook e2e: add small, compact and icon examples to button matrix

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Internal
 
+-   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 -   `TextControl`, `ComboboxControl`, `FormTokenField`, `ContentEditableControl`: Replace `--wp-components-color-accent` with `--wp-admin-theme-color` for focus ring color ([#80595](https://github.com/WordPress/gutenberg/pull/80595)).

--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -93,10 +93,10 @@ export const VariantStates: StoryFn< typeof Button > = (
 			<tbody>
 				<VariantsRow name="(default)" />
 				<VariantsRow
-					name="isCompact"
+					name="compact"
 					buttonProps={ { size: 'compact' } }
 				/>
-				<VariantsRow name="isSmall" buttonProps={ { size: 'small' } } />
+				<VariantsRow name="small" buttonProps={ { size: 'small' } } />
 				<VariantsRow
 					name="disabled"
 					buttonProps={ { disabled: true } }

--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -150,6 +150,10 @@ export const VariantStates: StoryFn< typeof Button > = (
 						disabled: true,
 					} }
 				/>
+				<VariantsRow
+					name="with icon"
+					buttonProps={ { icon: wordpress } }
+				/>
 			</tbody>
 		</table>
 	);

--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -51,7 +51,13 @@ export const VariantStates: StoryFn< typeof Button > = (
 					{ name }
 				</th>
 				{ variants.map( ( variant ) => (
-					<td key={ variant ?? 'undefined' } style={ { padding: 4 } }>
+					<td
+						key={ variant ?? 'undefined' }
+						style={ {
+							padding: 4,
+							textAlign: 'center',
+						} }
+					>
 						<Button
 							__next40pxDefaultSize
 							{ ...props }
@@ -86,6 +92,11 @@ export const VariantStates: StoryFn< typeof Button > = (
 			</thead>
 			<tbody>
 				<VariantsRow name="(default)" />
+				<VariantsRow
+					name="isCompact"
+					buttonProps={ { size: 'compact' } }
+				/>
+				<VariantsRow name="isSmall" buttonProps={ { size: 'small' } } />
 				<VariantsRow
 					name="disabled"
 					buttonProps={ { disabled: true } }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Internal
 
+-   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Use keyed children arrays instead of Fragments in Storybook stories so Show code examples omit `Fragment` wrappers ([#80352](https://github.com/WordPress/gutenberg/pull/80352)).
 

--- a/packages/ui/src/button/stories/e2e/index.story.tsx
+++ b/packages/ui/src/button/stories/e2e/index.story.tsx
@@ -74,10 +74,10 @@ export const VariantStates: StoryFn< typeof Button > = (
 			<tbody>
 				<VariantsRow name="(default)" />
 				<VariantsRow
-					name="isCompact"
+					name="compact"
 					buttonProps={ { size: 'compact' } }
 				/>
-				<VariantsRow name="isSmall" buttonProps={ { size: 'small' } } />
+				<VariantsRow name="small" buttonProps={ { size: 'small' } } />
 				<VariantsRow
 					name="disabled"
 					buttonProps={ { disabled: true } }

--- a/packages/ui/src/button/stories/e2e/index.story.tsx
+++ b/packages/ui/src/button/stories/e2e/index.story.tsx
@@ -40,7 +40,13 @@ export const VariantStates: StoryFn< typeof Button > = (
 					{ name }
 				</th>
 				{ variants.map( ( variant ) => (
-					<td key={ variant } style={ { padding: 4 } }>
+					<td
+						key={ variant }
+						style={ {
+							padding: 4,
+							textAlign: 'center',
+						} }
+					>
 						<Button
 							{ ...props }
 							variant={ variant }
@@ -66,6 +72,11 @@ export const VariantStates: StoryFn< typeof Button > = (
 			</thead>
 			<tbody>
 				<VariantsRow name="(default)" />
+				<VariantsRow
+					name="isCompact"
+					buttonProps={ { size: 'compact' } }
+				/>
+				<VariantsRow name="isSmall" buttonProps={ { size: 'small' } } />
 				<VariantsRow
 					name="disabled"
 					buttonProps={ { disabled: true } }

--- a/packages/ui/src/button/stories/e2e/index.story.tsx
+++ b/packages/ui/src/button/stories/e2e/index.story.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { wordpress } from '@wordpress/icons';
 import { Button } from '../..';
 import type { ButtonProps } from '../../types';
 
@@ -120,6 +121,15 @@ export const VariantStates: StoryFn< typeof Button > = (
 						tone: 'neutral',
 						'aria-pressed': true,
 						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="with icon"
+					buttonProps={ {
+						children: [
+							<Button.Icon icon={ wordpress } key="icon" />,
+							'Code is poetry',
+						],
 					} }
 				/>
 			</tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Expands button matrix with "small", "compact" and "with icon" examples.

Also center-aligns buttons in row so that it's easier to compare now that they're different sizes.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on https://github.com/WordPress/gutenberg/pull/79993, I've found manually adding these anyway to observe changes so might as well add here.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Run `npm run storybook:e2e:dev`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### UI Button
<img width="786" height="602" alt="Screenshot 2026-07-28 at 17 24 43" src="https://github.com/user-attachments/assets/410dd3da-4238-4ccc-838a-ff8542a81771" />

### Components Button
<img width="935" height="658" alt="Screenshot 2026-07-28 at 17 24 51" src="https://github.com/user-attachments/assets/b1cde3e6-e808-471d-8bbe-97d4b6bda568" />

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
