### PR TITLE
Table of Contents: Reuse server rendering for the editor preview

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Playlist: Shorten the track toolbar button label from "Add track" to "Add".
 -   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
 -   Page List: Rename the "Edit" action to "Detach", and confirm it in a dialog explaining that the list will keep its current pages but stop adding new ones automatically, matching the Gallery block ([#80847](https://github.com/WordPress/gutenberg/pull/80847)).
+-   Table of Contents: Render the editor preview on the server to match the front end.
 
 ### Bug Fixes
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -13,6 +13,12 @@
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
 -   Paragraph, List, Heading, Preformatted, Columns, Group, Template Part: Read the default padding these blocks add when they have a background color from the `--wp--style--block-background-padding` custom property, so themes can change or remove it ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
+-   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
+-   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
+-   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
+-   Page List: Rename the "Edit" action to "Detach", and confirm it in a dialog explaining that the list will keep its current pages but stop adding new ones automatically, matching the Gallery block ([#80847](https://github.com/WordPress/gutenberg/pull/80847)).
+-   Tabs: Start new tabs with an empty label showing a "Tab title" placeholder instead of a generic "Tab" ([#81009](https://github.com/WordPress/gutenberg/pull/81009)).
+-   Table of Contents: Render the editor preview on the server to match the front end.
 
 ### Bug Fixes
 

--- a/packages/block-library/src/table-of-contents/README.md
+++ b/packages/block-library/src/table-of-contents/README.md
@@ -43,6 +43,15 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 
+## Context
+
+_Defined via the [`usesContext` and `providesContext`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/) properties in block.json._
+
+**Uses context:**
+
+- `postId`
+- `postType`
+
 ## Block Markup
 
 This is a [**hybrid block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). It saves static markup that the server may enhance during rendering.

--- a/packages/block-library/src/table-of-contents/README.md
+++ b/packages/block-library/src/table-of-contents/README.md
@@ -43,6 +43,15 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 
+## Context
+
+_Defined via the [`usesContext` and `providesContext`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/) properties in block.json._
+
+**Uses context:**
+
+- `postId`
+- `postType`
+
 ## Block Markup
 
 This is a [**dynamic block**](https://developer.wordpress.org/block-editor/getting-started/fundamentals/static-dynamic-rendering/). It is rendered on the server and does not save HTML in post content.

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -28,6 +28,7 @@
 			"default": true
 		}
 	},
+	"usesContext": [ "postId", "postType" ],
 	"supports": {
 		"anchor": true,
 		"ariaLabel": true,

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -29,6 +29,7 @@
 			"default": true
 		}
 	},
+	"usesContext": [ "postId", "postType" ],
 	"supports": {
 		"anchor": true,
 		"ariaLabel": true,

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -3,14 +3,13 @@
  */
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
-	Placeholder,
+	Spinner,
 	ToggleControl,
 	SelectControl,
 	ToolbarButton,
@@ -20,12 +19,12 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
-import { store as noticeStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { useEffect, useState } from '@wordpress/element';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { useDisabled } from '@wordpress/compose';
+import { useServerSideRender } from '@wordpress/server-side-render';
 import {
-	tableOfContents as icon,
 	formatListBullets,
 	formatListBulletsRTL,
 	formatListNumbered,
@@ -35,10 +34,10 @@ import {
 /**
  * Internal dependencies
  */
-import TableOfContentsList from './list';
 import { createListItemBlocks, linearToNestedHeadingList } from './utils';
 import { useObserveHeadings } from './hooks';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import HtmlRenderer from '../utils/html-renderer';
 
 /** @typedef {import('./utils').HeadingData} HeadingData */
 
@@ -123,34 +122,66 @@ function TableOfContentsToolbar( {
 	);
 }
 
-export default function TableOfContentsEdit( {
-	attributes: {
+/**
+ * Table of Contents block edit component.
+ *
+ * @param {Object}                       props                                   The props.
+ * @param {Object}                       props.attributes                        The block attributes.
+ * @param {HeadingData[]}                props.attributes.headings               The list of data for each heading in the post.
+ * @param {boolean}                      props.attributes.onlyIncludeCurrentPage Whether to only include headings from the current page (if the post is paginated).
+ * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or null to include all levels.
+ * @param {boolean}                      props.attributes.ordered                Whether to display as an ordered list (true) or unordered list (false).
+ * @param {string}                       props.clientId                          The client id.
+ * @param {string}                       props.name                              The block name.
+ * @param {Object}                       props.context                           The block context.
+ * @param {number}                       props.context.postId                    The post ID.
+ * @param {string}                       props.context.postType                  The post type.
+ * @param {(attributes: Object) => void} props.setAttributes                     The set attributes function.
+ *
+ * @return {Component} The component.
+ */
+export default function TableOfContentsEdit( props ) {
+	const {
+		attributes,
+		clientId,
+		name,
+		context: { postId, postType } = {},
+		setAttributes,
+	} = props;
+	const {
 		headings = [],
 		onlyIncludeCurrentPage,
 		maxLevel,
 		ordered = true,
-	},
-	clientId,
-	setAttributes,
-} ) {
+	} = attributes;
 	useObserveHeadings( clientId );
 
-	const blockProps = useBlockProps();
-	const instanceId = useInstanceId(
-		TableOfContentsEdit,
-		'table-of-contents'
+	const post = useSelect(
+		( select ) => {
+			if ( ! postId || ! postType ) {
+				return;
+			}
+
+			return select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+		},
+		[ postId, postType ]
 	);
+	const [ invalidationKey, setInvalidationKey ] = useState( 0 );
+	useEffect( () => {
+		setInvalidationKey( ( value ) => value + 1 );
+	}, [ post ] );
 
-	// If a user clicks to a link prevent redirection and show a warning.
-	const { createWarningNotice } = useDispatch( noticeStore );
-	const showRedirectionPreventedNotice = ( event ) => {
-		event.preventDefault();
-		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`,
-			type: 'snackbar',
-		} );
-	};
-
+	const { content, status, error } = useServerSideRender( {
+		attributes,
+		block: name,
+		urlQueryArgs: { post_id: postId, invalidationKey },
+	} );
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const headingTree = linearToNestedHeadingList( headings );
 
@@ -241,41 +272,28 @@ export default function TableOfContentsEdit( {
 		</InspectorControls>
 	);
 
-	// If there are no headings or the only heading is empty.
-	// Note that the toolbar controls are intentionally omitted since the
-	// "Detach" option is useless to the placeholder state.
-	if ( headings.length === 0 ) {
-		return (
-			<>
-				<div { ...blockProps }>
-					<Placeholder
-						icon={ <BlockIcon icon={ icon } /> }
-						label={ __( 'Table of Contents' ) }
-						instructions={ __(
-							'Start adding Heading blocks to create a table of contents. Headings with HTML anchors will be linked here.'
-						) }
-					/>
-				</div>
-				{ inspectorControls }
-			</>
-		);
-	}
-
-	const ListTag = ordered ? 'ol' : 'ul';
-
 	return (
 		<>
-			<nav { ...blockProps }>
-				<ListTag>
-					<TableOfContentsList
-						nestedHeadingList={ headingTree }
-						disableLinkActivation
-						onClick={ showRedirectionPreventedNotice }
-						ordered={ ordered }
-					/>
-				</ListTag>
-			</nav>
-			{ toolbarControls }
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
+			{ status === 'error' && (
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
+			) }
+			{ status === 'success' && (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
+			{ headings.length > 0 && toolbarControls }
 			{ inspectorControls }
 		</>
 	);

--- a/packages/block-library/src/table-of-contents/edit.jsx
+++ b/packages/block-library/src/table-of-contents/edit.jsx
@@ -1,13 +1,12 @@
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
-	Placeholder,
+	Spinner,
 	ToggleControl,
 	SelectControl,
 	ToolbarButton,
@@ -17,21 +16,25 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
-import { store as noticeStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { useEffect, useState } from '@wordpress/element';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { useDisabled } from '@wordpress/compose';
+import { useServerSideRender } from '@wordpress/server-side-render';
 import {
-	tableOfContents as icon,
 	formatListBullets,
 	formatListBulletsRTL,
 	formatListNumbered,
 	formatListNumberedRTL,
 } from '@wordpress/icons';
-import TableOfContentsList from './list';
+
+/**
+ * Internal dependencies
+ */
 import { createListItemBlocks, linearToNestedHeadingList } from './utils';
 import { useObserveHeadings } from './hooks';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import HtmlRenderer from '../utils/html-renderer';
 
 /** @typedef {import('./utils').HeadingData} HeadingData */
 
@@ -116,34 +119,66 @@ function TableOfContentsToolbar( {
 	);
 }
 
-export default function TableOfContentsEdit( {
-	attributes: {
+/**
+ * Table of Contents block edit component.
+ *
+ * @param {Object}                       props                                   The props.
+ * @param {Object}                       props.attributes                        The block attributes.
+ * @param {HeadingData[]}                props.attributes.headings               The list of data for each heading in the post.
+ * @param {boolean}                      props.attributes.onlyIncludeCurrentPage Whether to only include headings from the current page (if the post is paginated).
+ * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or null to include all levels.
+ * @param {boolean}                      props.attributes.ordered                Whether to display as an ordered list (true) or unordered list (false).
+ * @param {string}                       props.clientId                          The client id.
+ * @param {string}                       props.name                              The block name.
+ * @param {Object}                       props.context                           The block context.
+ * @param {number}                       props.context.postId                    The post ID.
+ * @param {string}                       props.context.postType                  The post type.
+ * @param {(attributes: Object) => void} props.setAttributes                     The set attributes function.
+ *
+ * @return {Component} The component.
+ */
+export default function TableOfContentsEdit( props ) {
+	const {
+		attributes,
+		clientId,
+		name,
+		context: { postId, postType } = {},
+		setAttributes,
+	} = props;
+	const {
 		headings = [],
 		onlyIncludeCurrentPage,
 		maxLevel,
 		ordered = true,
-	},
-	clientId,
-	setAttributes,
-} ) {
+	} = attributes;
 	useObserveHeadings( clientId );
 
-	const blockProps = useBlockProps();
-	const instanceId = useInstanceId(
-		TableOfContentsEdit,
-		'table-of-contents'
+	const post = useSelect(
+		( select ) => {
+			if ( ! postId || ! postType ) {
+				return;
+			}
+
+			return select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+		},
+		[ postId, postType ]
 	);
+	const [ invalidationKey, setInvalidationKey ] = useState( 0 );
+	useEffect( () => {
+		setInvalidationKey( ( value ) => value + 1 );
+	}, [ post ] );
 
-	// If a user clicks to a link prevent redirection and show a warning.
-	const { createWarningNotice } = useDispatch( noticeStore );
-	const showRedirectionPreventedNotice = ( event ) => {
-		event.preventDefault();
-		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`,
-			type: 'snackbar',
-		} );
-	};
-
+	const { content, status, error } = useServerSideRender( {
+		attributes,
+		block: name,
+		urlQueryArgs: { post_id: postId, invalidationKey },
+	} );
+	const disabledRef = useDisabled();
+	const blockProps = useBlockProps( { ref: disabledRef } );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const headingTree = linearToNestedHeadingList( headings );
 
@@ -234,41 +269,28 @@ export default function TableOfContentsEdit( {
 		</InspectorControls>
 	);
 
-	// If there are no headings or the only heading is empty.
-	// Note that the toolbar controls are intentionally omitted since the
-	// "Detach" option is useless to the placeholder state.
-	if ( headings.length === 0 ) {
-		return (
-			<>
-				<div { ...blockProps }>
-					<Placeholder
-						icon={ <BlockIcon icon={ icon } /> }
-						label={ __( 'Table of Contents' ) }
-						instructions={ __(
-							'Start adding Heading blocks to create a table of contents. Headings with HTML anchors will be linked here.'
-						) }
-					/>
-				</div>
-				{ inspectorControls }
-			</>
-		);
-	}
-
-	const ListTag = ordered ? 'ol' : 'ul';
-
 	return (
 		<>
-			<nav { ...blockProps }>
-				<ListTag>
-					<TableOfContentsList
-						nestedHeadingList={ headingTree }
-						disableLinkActivation
-						onClick={ showRedirectionPreventedNotice }
-						ordered={ ordered }
-					/>
-				</ListTag>
-			</nav>
-			{ toolbarControls }
+			{ status === 'loading' && (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			) }
+			{ status === 'error' && (
+				<div { ...blockProps }>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message returned when rendering the block. */
+							__( 'Error: %s' ),
+							error
+						) }
+					</p>
+				</div>
+			) }
+			{ status === 'success' && (
+				<HtmlRenderer wrapperProps={ blockProps } html={ content } />
+			) }
+			{ headings.length > 0 && toolbarControls }
 			{ inspectorControls }
 		</>
 	);

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -371,7 +371,13 @@ function block_core_table_of_contents_build_list_items( $nested_headings, $list_
 function block_core_table_of_contents_render( $attributes, $content ) {
 	global $wp_current_filter;
 
-	if ( ! is_array( $wp_current_filter ) || ! in_array( 'the_content', $wp_current_filter, true ) ) {
+	// The REST block renderer provides the edited post as the global post, so
+	// use the same dynamic output for its editor preview as on the front end.
+	$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
+	if (
+		( ! is_array( $wp_current_filter ) || ! in_array( 'the_content', $wp_current_filter, true ) ) &&
+		! $is_rest_request
+	) {
 		return block_core_table_of_contents_add_aria_label( $attributes, $content );
 	}
 

--- a/packages/block-library/src/table-of-contents/index.php
+++ b/packages/block-library/src/table-of-contents/index.php
@@ -383,8 +383,15 @@ function block_core_table_of_contents_render( $attributes, $content, $block = nu
 		return block_core_table_of_contents_add_aria_label( $attributes, $legacy_content );
 	}
 
+	// The REST block renderer provides the edited post as the global post, so
+	// use the same dynamic output for its editor preview as on the front end.
+	$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
+
 	// Outside post content rendering, there is no reliable current post to scan.
-	if ( ! is_array( $wp_current_filter ) || ! in_array( 'the_content', $wp_current_filter, true ) ) {
+	if (
+		( ! is_array( $wp_current_filter ) || ! in_array( 'the_content', $wp_current_filter, true ) ) &&
+		! $is_rest_request
+	) {
 		return block_core_table_of_contents_add_aria_label( $attributes, $content );
 	}
 

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -125,7 +125,9 @@ test.describe( 'Table of Contents', () => {
 			await admin.createNewPost();
 		} );
 
-		test( 'updates in the editor as headings are added, removed, or reordered', async ( {
+		// A newly created post must be saved before its table of contents can be
+		// shown. The before-save experience is covered separately below.
+		test( 'shows heading changes after saving the post', async ( {
 			editor,
 		} ) => {
 			await editor.setContent(
@@ -133,6 +135,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'First section', anchor: 'first-section' },
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			await expect(
@@ -147,6 +150,10 @@ test.describe( 'Table of Contents', () => {
 			);
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
 				'First section',
+			] );
+			await editor.saveDraft();
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'First section',
 				'Second section',
 			] );
 
@@ -155,6 +162,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'Second section', anchor: 'second-section' },
 				] )
 			);
+			await editor.saveDraft();
 			await expect(
 				tableOfContents.getByRole( 'link', { name: 'Second section' } )
 			).toBeVisible();
@@ -168,13 +176,33 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'First section', anchor: 'first-section' },
 				] )
 			);
+			await editor.saveDraft();
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
 				'Second section',
 				'First section',
 			] );
 		} );
 
-		test( 'shows the same nested heading list in the editor and after publish', async ( {
+		test( 'does not show a table of contents until a new post is saved', async ( {
+			editor,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{
+						content: 'Unsaved first section',
+						anchor: 'unsaved-first-section',
+					},
+				] )
+			);
+
+			await expect(
+				editor.canvas.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} )
+			).toHaveCount( 0 );
+		} );
+
+		test( 'shows the same server-rendered nested heading list in the editor and after publish', async ( {
 			editor,
 			page,
 		} ) => {
@@ -188,6 +216,7 @@ test.describe( 'Table of Contents', () => {
 					},
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
@@ -308,6 +337,7 @@ test.describe( 'Table of Contents', () => {
 					},
 				] )
 			);
+			await editor.saveDraft();
 
 			await getTableOfContentsEditorBlock( editor ).click();
 			await editor.openDocumentSettingsSidebar();
@@ -353,6 +383,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'List style section', anchor: 'list-style' },
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			const list = tableOfContents.getByRole( 'list' ).first();
@@ -380,19 +411,17 @@ test.describe( 'Table of Contents', () => {
 			).toHaveCSS( 'list-style-type', 'disc' );
 		} );
 
-		test( 'shows an editor notice and does not render on the front of site when no headings exist', async ( {
+		test( 'does not render a table of contents when no headings exist', async ( {
 			editor,
 			page,
 		} ) => {
 			await editor.insertBlock( { name: 'core/table-of-contents' } );
 
-			const tableOfContents = getTableOfContentsEditorBlock( editor );
-			await expect( tableOfContents ).toContainText(
-				'Start adding Heading blocks to create a table of contents.'
-			);
-			await expect( tableOfContents ).toContainText(
-				'Headings with HTML anchors will be linked here.'
-			);
+			await expect(
+				editor.canvas.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} )
+			).toHaveCount( 0 );
 
 			const postId = await editor.publishPost();
 			await openPostOnFrontend( page, postId );

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -104,7 +104,9 @@ test.describe( 'Table of Contents', () => {
 			await admin.createNewPost();
 		} );
 
-		test( 'updates in the editor as headings are added, removed, or reordered', async ( {
+		// A newly created post must be saved before its table of contents can be
+		// shown. The before-save experience is covered separately below.
+		test( 'shows heading changes after saving the post', async ( {
 			editor,
 		} ) => {
 			await editor.setContent(
@@ -112,6 +114,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'First section', anchor: 'first-section' },
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			await expect(
@@ -126,6 +129,10 @@ test.describe( 'Table of Contents', () => {
 			);
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
 				'First section',
+			] );
+			await editor.saveDraft();
+			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
+				'First section',
 				'Second section',
 			] );
 
@@ -134,6 +141,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'Second section', anchor: 'second-section' },
 				] )
 			);
+			await editor.saveDraft();
 			await expect(
 				tableOfContents.getByRole( 'link', { name: 'Second section' } )
 			).toBeVisible();
@@ -147,13 +155,33 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'First section', anchor: 'first-section' },
 				] )
 			);
+			await editor.saveDraft();
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
 				'Second section',
 				'First section',
 			] );
 		} );
 
-		test( 'shows the same nested heading list in the editor and after publish', async ( {
+		test( 'does not show a table of contents until a new post is saved', async ( {
+			editor,
+		} ) => {
+			await editor.setContent(
+				postContentWithTocAndHeadings( [
+					{
+						content: 'Unsaved first section',
+						anchor: 'unsaved-first-section',
+					},
+				] )
+			);
+
+			await expect(
+				editor.canvas.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} )
+			).toHaveCount( 0 );
+		} );
+
+		test( 'shows the same server-rendered nested heading list in the editor and after publish', async ( {
 			editor,
 			page,
 			requestUtils,
@@ -168,6 +196,7 @@ test.describe( 'Table of Contents', () => {
 					},
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			await expect( tableOfContents.getByRole( 'link' ) ).toHaveText( [
@@ -300,6 +329,7 @@ test.describe( 'Table of Contents', () => {
 					},
 				] )
 			);
+			await editor.saveDraft();
 
 			await getTableOfContentsEditorBlock( editor ).click();
 			await editor.openDocumentSettingsSidebar();
@@ -345,6 +375,7 @@ test.describe( 'Table of Contents', () => {
 					{ content: 'List style section', anchor: 'list-style' },
 				] )
 			);
+			await editor.saveDraft();
 
 			const tableOfContents = getTableOfContentsEditorBlock( editor );
 			const list = tableOfContents.getByRole( 'list' ).first();
@@ -372,19 +403,17 @@ test.describe( 'Table of Contents', () => {
 			).toHaveCSS( 'list-style-type', 'disc' );
 		} );
 
-		test( 'shows an editor notice and does not render on the front of site when no headings exist', async ( {
+		test( 'does not render a table of contents when no headings exist', async ( {
 			editor,
 			page,
 		} ) => {
 			await editor.insertBlock( { name: 'core/table-of-contents' } );
 
-			const tableOfContents = getTableOfContentsEditorBlock( editor );
-			await expect( tableOfContents ).toContainText(
-				'Start adding Heading blocks to create a table of contents.'
-			);
-			await expect( tableOfContents ).toContainText(
-				'Headings with HTML anchors will be linked here.'
-			);
+			await expect(
+				editor.canvas.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} )
+			).toHaveCount( 0 );
 
 			const postId = await editor.publishPost();
 			await openPostOnFrontend( page, postId );


### PR DESCRIPTION
## What

Related to #80794.

Convert the Table of Contents editor preview to reuse the existing server-side block renderer. When post context is available, the editor renders the heading list produced by the same rendering path that readers receive on the front of the site.

## Why

The editor previously built a client-side approximation of the heading list, while the front end resolves headings from rendered post content. This evaluates whether server-side rendering can avoid a dedicated REST endpoint while giving authors a preview based on the reader-facing rendering path.

## Key reviewer question: persisted preview versus live editing

This approach does not produce a live Table of Contents preview from unsaved editor state. It shows the most recently persisted heading list.

- **New, unsaved post:** No post ID exists, so the server cannot load post content. No Table of Contents preview is shown until the first save.
- **Saved draft:** After an author changes headings, the preview initially remains stale. A WordPress autosave may persist a draft as a regular save, in which case the preview refreshes after that autosave. Saving the draft refreshes it reliably.
- **Published post:** Autosaves are normally revisions, while this preview reads the canonical post. The preview can therefore remain stale until the author explicitly clicks **Update**.

Are we comfortable with that author experience? If not, SSR alone is insufficient and we should consider a client-side fallback, a hybrid, or the dedicated endpoint proposed in #80786.

## How

- Request the preview through `useServerSideRender`, passing the edited post ID when available.
- Allow the existing dynamic renderer to resolve headings for REST previews as well as front-end content rendering.
- Render the returned HTML safely in the editor while preserving editor controls.
- Refresh after persisted post changes and cover the saved and no-post-ID states with user-focused e2e tests.

## Testing Instructions

These scenarios help assess whether a persisted preview is acceptable while an author edits.

### First save of a new post

1. Create a new post.
2. Insert a Table of Contents block and a Heading block.
3. Before saving, observe that no Table of Contents preview is shown.
4. Save a draft and confirm that the preview appears with the heading.

### Saved draft: changes before and after autosave

1. Add a second Heading block to the saved draft without manually saving.
2. Confirm that the preview still shows the last saved heading list.
3. Wait for WordPress to autosave, then observe whether the preview refreshes.
4. Save the draft manually and confirm that the preview reflects the new heading.

### Published post: changes before and after autosave

1. Publish the post and confirm its preview contains the saved headings.
2. Add or rename a heading without clicking **Update**.
3. Wait for WordPress to autosave and confirm that the preview can still show the previous heading list.
4. Click **Update** and confirm that the preview reflects the changed headings.

### Automated coverage

```sh
npm run test:e2e -- test/e2e/specs/editor/blocks/table-of-contents.spec.js --project=chromium
```
