### PR TITLE
ToggleControl: Add "With Visual" Storybook story

### DIFF
--- a/packages/components/src/toggle-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-control/stories/index.story.tsx
@@ -63,8 +63,8 @@ export const WithHelpText: Story = {
 };
 
 /**
- * When adding a visual aid, prefer placing it on the opposite end of the toggle,
- * rather than directly preceding the label.
+ * When adding a visual aid, prefer placing it at the trailing end of the row,
+ * rather than placing it directly before the label, or moving the toggle to the trailing end.
  */
 export const WithVisual: Story = {
 	...Default,

--- a/packages/components/src/toggle-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-control/stories/index.story.tsx
@@ -1,16 +1,7 @@
-/**
- * External dependencies
- */
-import type { Meta, StoryFn } from '@storybook/react-vite';
-
-/**
- * WordPress dependencies
- */
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { wordpress } from '@wordpress/icons';
+import { Icon, Stack } from '@wordpress/ui';
 import ToggleControl from '..';
 
 const meta: Meta< typeof ToggleControl > = {
@@ -36,10 +27,12 @@ const meta: Meta< typeof ToggleControl > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof ToggleControl > = ( {
+type Story = StoryObj< typeof ToggleControl >;
+
+function ControlledToggleControl( {
 	onChange,
 	...props
-} ) => {
+}: React.ComponentProps< typeof ToggleControl > ) {
 	const [ checked, setChecked ] = useState( true );
 	return (
 		<ToggleControl
@@ -51,15 +44,53 @@ const Template: StoryFn< typeof ToggleControl > = ( {
 			} }
 		/>
 	);
+}
+ControlledToggleControl.displayName = 'ToggleControl';
+
+export const Default: Story = {
+	render: ( args ) => <ControlledToggleControl { ...args } />,
+	args: {
+		label: 'Enable something',
+	},
 };
 
-export const Default = Template.bind( {} );
-Default.args = {
-	label: 'Enable something',
+export const WithHelpText: Story = {
+	...Default,
+	args: {
+		...Default.args,
+		help: 'This is some help text.',
+	},
 };
 
-export const WithHelpText = Template.bind( {} );
-WithHelpText.args = {
-	...Default.args,
-	help: 'This is some help text.',
+/**
+ * When adding a visual aid, prefer placing it on the opposite end of the toggle,
+ * rather than directly preceding the label.
+ */
+export const WithVisual: Story = {
+	...Default,
+	render: ( args ) => (
+		<Stack gap="md" align="flex-start" justify="space-between">
+			<Stack>
+				<ControlledToggleControl { ...args } />
+			</Stack>
+			<Stack
+				align="center"
+				justify="center"
+				style={ {
+					backgroundColor:
+						'var(--wpds-color-background-surface-neutral-weak)',
+					borderRadius: 'var(--wpds-border-radius-md)',
+					flexShrink: 0,
+					height: 'var(--wpds-dimension-size-lg)',
+					width: 'var(--wpds-dimension-size-lg)',
+				} }
+			>
+				<Icon icon={ wordpress } />
+			</Stack>
+		</Stack>
+	),
+	args: {
+		...Default.args,
+		help: 'Additional context that helps users understand what this setting does and when they might want to turn it on or off.',
+	},
 };


### PR DESCRIPTION
## What?

Adds a `WithVisual` Storybook story to `ToggleControl`, demonstrating a pattern for placing a visual aid at the trailing end of the control row.

Also converts the existing stories to the object story format.

## Why?

We want consistent guidance for composing toggle-like controls with visuals. A common pattern we see in the wild is the visual being inserted _between_ the toggle and label, or the visual being placed at the starting end of the row and the toggle being moved to the trailing end. There are several downsides to this:

1. It requires custom composition of the control component, instead of just using the `ToggleControl` out of the box.
2. It makes the click target unclear. Usually, clicking the label would toggle the control, but it's unclear when the toggle isn't directly adjacent to the label. And probably sometimes the custom implementation would forget to set an appropriate click target.
3. The placement of the toggle shouldn't shift around. It should stay on the same side for all instances.

The same pattern and guidance will be added to `CheckboxControl` in a follow-up.

## Testing Instructions

1. Run Storybook and open **Components / Selection & Input / Common / ToggleControl**.
4. Open the **With Visual** story.
5. Confirm the toggle, label, help text, and trailing icon layout look correct.
6. Toggle the control and confirm it still updates as expected.

## Screenshots

<img width="559" height="254" alt="With visual story" src="https://github.com/user-attachments/assets/25f95e56-8902-4e50-99e0-9e52605d69d5" />

---

Discovered in a pairing session with @elizaan36.