### PR TITLE
CI: Debounce pushes to wp/** release branches

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -17,9 +17,14 @@ on:
 # Workflow-dispatched release runs must not cancel an in-flight run after it may have
 # pushed version bump commits.
 concurrency:
-    # The concurrency group contains a shared release group for dispatches,
-    # the branch name for pull requests, or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'release' || ( github.event_name == 'pull_request' && github.head_ref || github.sha ) }}
+    # The concurrency group contains a shared release group for dispatches, the branch name for
+    # pull requests, the full ref for pushes to wp/** release branches, so a burst of
+    # cherry-picks cancels its own superseded runs and those commits publish no per-SHA GHCR
+    # artifact, or the commit hash for any other events. Which run survives the burst is not
+    # guaranteed to be the tip: GitHub orders a group by the time each run started waiting, not
+    # by dispatch time. github.ref, not github.ref_name: the refs/heads/ prefix keeps pushes
+    # from sharing a group with a PR opened from a like-named branch.
+    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'release' || ( github.event_name == 'pull_request' && github.head_ref || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/wp/') && github.ref || github.sha ) }}
     cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -7,9 +7,13 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # The concurrency group contains the workflow name and the branch name for pull requests,
+    # the full ref for pushes to wp/** release branches, so a burst of cherry-picks cancels its
+    # own superseded runs, or the commit hash for any other events. Which run survives the burst
+    # is not guaranteed to be the tip: GitHub orders a group by the time each run started
+    # waiting, not by dispatch time. github.ref, not github.ref_name: the refs/heads/ prefix
+    # keeps pushes from sharing a group with a PR opened from a like-named branch.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/wp/') && github.ref || github.sha }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -10,9 +10,13 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # The concurrency group contains the workflow name and the branch name for pull requests,
+    # the full ref for pushes to wp/** release branches, so a burst of cherry-picks cancels its
+    # own superseded runs, or the commit hash for any other events. Which run survives the burst
+    # is not guaranteed to be the tip: GitHub orders a group by the time each run started
+    # waiting, not by dispatch time. github.ref, not github.ref_name: the refs/heads/ prefix
+    # keeps pushes from sharing a group with a PR opened from a like-named branch.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/wp/') && github.ref || github.sha }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -10,9 +10,13 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # The concurrency group contains the workflow name and the branch name for pull requests,
+    # the full ref for pushes to wp/** release branches, so a burst of cherry-picks cancels its
+    # own superseded runs, or the commit hash for any other events. Which run survives the burst
+    # is not guaranteed to be the tip: GitHub orders a group by the time each run started
+    # waiting, not by dispatch time. github.ref, not github.ref_name: the refs/heads/ prefix
+    # keeps pushes from sharing a group with a PR opened from a like-named branch.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/wp/') && github.ref || github.sha }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,9 +14,13 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # The concurrency group contains the workflow name and the branch name for pull requests,
+    # the full ref for pushes to wp/** release branches, so a burst of cherry-picks cancels its
+    # own superseded runs, or the commit hash for any other events. Which run survives the burst
+    # is not guaranteed to be the tip: GitHub orders a group by the time each run started
+    # waiting, not by dispatch time. github.ref, not github.ref_name: the refs/heads/ prefix
+    # keeps pushes from sharing a group with a PR opened from a like-named branch.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'push' && startsWith(github.ref, 'refs/heads/wp/') && github.ref || github.sha }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.


### PR DESCRIPTION
## What?

Pushes to `wp/**` release branches now debounce: a burst of cherry-picks cancels its own superseded runs instead of running full CI on every intermediate commit. Trunk and `release/**` are untouched and keep one run per commit. Affects Build Zip, Create Block, End-to-End Tests, Static Analysis and Unit Tests.

## Why?

[Auto Cherry-Pick](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/cherry-pick-wp-release.yml) lands backports one commit at a time, and each landing is a separate push. All five workflows trigger on `wp/**` pushes and key their concurrency group on `github.sha`, so every intermediate commit gets a full run.

One week on `wp/7.1`: 46 E2E push runs, against 103 on trunk. Across the five workflows that is roughly 17,400 raw / 34,500 weighted minutes a week, or 6.6% of raw CI time. Seven of those 46 runs failed — the same broken branch re-tested 46 times.

Trunk stays per-commit deliberately, so a regression stays attributable to the commit that caused it. A backport branch replays commits already tested on trunk, so per-commit attribution there buys little.

## How?

The group key becomes `github.ref` for `wp/**` pushes. Build Zip keeps its `workflow_dispatch` → `release` clause in front, so a dispatched release still cannot be cancelled after it pushes version bump commits.

Two details are load-bearing. Please keep them if this expression is edited later:

- **`github.ref`, not `github.ref_name`.** Forks routinely carry a branch named `wp/latest`. A pull request from one sets `github.head_ref` to the bare `wp/latest`, which would collide with a push group keyed on `ref_name`.
- **The `github.event_name == 'push'` guard.** Without it, manually dispatching Unit Tests on `wp/7.1` joins that branch's cancel group, and a cherry-pick landing seconds later kills the manual run.

<details>
<summary>How each event resolves</summary>

| Event | Group suffix |
|---|---|
| `pull_request` | `github.head_ref` |
| push to `trunk` | `github.sha` |
| push to `release/**` | `github.sha` |
| push to `wp/**` | `refs/heads/wp/X` |
| `workflow_dispatch` (Build Zip) | `release`, with `cancel-in-progress: false` |
| `workflow_dispatch` (Unit Tests) | `github.sha` |

`&&` binds tighter than `||`, and `||` is left-associative, so the expression reads as `(pr && head_ref) || (push && startsWith && ref) || sha`.

</details>

<details>
<summary>Checks performed</summary>

- **Branch protection.** `wp/6.9` and `wp/latest` carry only `creation`, `deletion`, `non_fast_forward` and `pull_request` rules. No required status checks exist on `wp/**`, so a cancelled run there gates nothing. Pull requests targeting `wp/**` use the `head_ref` group and are unaffected.
- **Release safety in Build Zip.** On a push event, only `build` and `publish-to-container-registry` run. `bump-version`, `revert-version-bump`, `create-release` and `npm-publish` are gated on `workflow_dispatch` or on `needs.bump-version.outputs.*`, which only a dispatch populates. The `release` group never intersects `refs/heads/wp/*`.
- **Coverage.** All 24 workflows were checked. These five are the only ones that trigger on `wp/` pushes.
- **`actionlint` 1.7.12** passes clean on the tree.

</details>

### The surviving run is not guaranteed to be the branch tip

Worth stating plainly, because it is the real cost of this change. Per [GitHub's concurrency documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency):

> Jobs or workflow runs in the same concurrency group are processed in first-in-first-out (FIFO) order according to the time each one started waiting on the concurrency group, not the time each workflow was dispatched. Additionally, since the actual start time of a job or run may vary, ordering is not guaranteed.

So an older commit's run can enter the group second, cancel the newer one, and leave the branch tip unvalidated. Three things bound the damage:

- **It costs signal, never a false pass.** Each run is bound to its own SHA, so a reordered burst leaves the tip commit showing a *cancelled* run. Nobody reads that as green.
- **Bursts are minutes apart, not seconds.** Auto Cherry-Pick serializes on `group: ${{ github.workflow }}` with `cancel-in-progress: false`, and each landing does a full-depth checkout, cherry-pick and push. Reordering needs two runs entering the queue near-simultaneously.
- **The release gate is a human reading a passing build.** `package-release-and-core-updates.md` tells the release manager to wait for the `wp/latest` build to pass before publishing. A cancelled run does not satisfy that.

The same race already applies to every pull request in this repository, since those groups key on `github.head_ref` with `cancel-in-progress: true`. The difference is that required checks make it visible there and no required checks exist on `wp/**`. If that bound feels too loose, the cheap mitigation is to add `workflow_dispatch` to Static Analysis, End-to-End Tests and Create Block, which do not have it, so anyone can re-run against the tip on demand. Happy to add it here or in a follow-up.

### Known consequence

Build Zip publishes `ghcr.io/wordpress/gutenberg/gutenberg-wp-develop-build:<sha>` on every push. A `wp/**` commit whose run is cancelled will not publish its per-SHA artifact. The mutable branch tag (`wp-7.1`, `wp-latest`) still lands on whichever run survives, and nothing in this repository resolves that image by SHA. Please flag if anything in `wordpress-develop` pins intermediate `wp/**` SHAs.

## Testing Instructions

CI configuration only. No runtime or editor behavior changes.

1. Land two backports close together, or push two commits to a `wp/**` branch in quick succession. One run is cancelled, the other completes.
2. Push two commits to trunk in quick succession. Both runs complete.
3. Dispatch Unit Tests manually on a `wp/**` branch, then push to that branch. The manual run survives.

## Use of AI Tools

Written with Claude Code (Opus 5), which drafted the expression and comments and ran five adversarial review passes. Those caught a missed workflow, a wrong claim about `wp/latest`, and a defect where a dispatched Unit Tests run could be cancelled by a push. A separate review caught that an earlier version of this description claimed the branch tip is always the surviving run, which GitHub does not guarantee. I reviewed and verified the result and take responsibility for it.
