### PR TITLE
DataViews: Allow React elements in form descriptions

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   DataForm: Allow form field descriptions to contain React elements.
+-   DataForm: Allow form field descriptions to contain React elements. [#80807](https://github.com/WordPress/gutenberg/pull/80807)
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   DataForm: Allow form field descriptions to contain React elements.
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import normalizeForm from '../normalize-form';
@@ -53,12 +58,18 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'handles mixed string and object field specifications', () => {
+			const description = createElement(
+				'a',
+				{ href: '/docs' },
+				'Documentation'
+			);
 			const form: Form = {
 				fields: [
 					'field1',
 					{
 						id: 'field2',
 						label: 'Field 2',
+						description,
 					},
 				],
 			};
@@ -76,6 +87,7 @@ describe( 'normalizeFormFields', () => {
 					{
 						id: 'field2',
 						label: 'Field 2',
+						description,
 						layout: {
 							type: 'regular',
 							labelPosition: 'top',

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -44,6 +44,12 @@ export const LayoutCard = {
 		withSummary: true,
 		isCollapsible: true,
 	},
+	parameters: {
+		docs: {
+			// Dynamic source generation cannot serialize React elements nested in the form configuration.
+			source: { type: 'code' },
+		},
+	},
 };
 
 export const LayoutDetails = {

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -3,6 +3,7 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { privateApis } from '@wordpress/components';
+import { Link } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -185,8 +186,13 @@ const LayoutCardComponent = ( {
 						isOpened,
 					} ),
 					label: 'Customer',
-					description:
-						'Enter your contact details, plan type, and addresses to complete your customer information.',
+					description: (
+						<>
+							Enter your contact details, plan type, and addresses
+							to complete your customer information. See the{ ' ' }
+							<Link href="#">customer information guide</Link>.
+						</>
+					),
 					children: [
 						{
 							id: 'customerContact',

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ReactElement } from 'react';
+
+/**
  * Internal dependencies
  */
 import type { Field, FieldValidity } from './field-api';
@@ -143,7 +148,7 @@ export type NormalizedSummaryField =
 export type FormField = {
 	id: string;
 	label?: string;
-	description?: string;
+	description?: string | ReactElement;
 	layout?: Layout;
 	children?: Array< FormField | string >;
 };
@@ -151,7 +156,7 @@ export type NormalizedFormField = {
 	id: string;
 	layout: NormalizedLayout;
 	label?: string;
-	description?: string;
+	description?: string | ReactElement;
 	children?: NormalizedFormField[];
 };
 


### PR DESCRIPTION
## What?

Allows DataForm field descriptions to contain React elements, matching the existing `Field.description` API.

## Why?

Form card descriptions were limited to strings, preventing them from including links or other rich content.

## How?

Updates the form field types, verifies React elements survive normalization, and demonstrates a linked description in Storybook. The story uses static source generation to avoid a Storybook-only serialization limitation.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **DataViews → DataForm → Layout Card**.
3. Confirm the Customer card displays the “customer information guide” link.
4. Run:
   `npm run test:unit -- packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts --runInBand`

### Testing Instructions for Keyboard

Tab to the “customer information guide” link and confirm it receives focus and can be activated with Enter.

## Screenshots or screencast

Not included; the behavior is demonstrated in Storybook.

## Use of AI Tools

OpenAI Codex was used to investigate and implement the change, update tests and Storybook, and draft this description.