### PR TITLE
Writing flow: forward delete an empty paragraph without breaking apart the next block

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -464,7 +464,23 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					return;
 				}
 
-				if ( getBlockOrder( nextBlockClientId ).length ) {
+				// Forward deleting an unmodified default block should
+				// remove it and move into the next block, not pull the
+				// next block's first item out of it.
+				if ( isUnmodifiedDefaultBlock( getBlock( clientId ) ) ) {
+					// Select the first leaf block, so the caret starts at
+					// the beginning of the block's content rather than on
+					// a container's shell.
+					let firstLeafClientId = nextBlockClientId;
+					while ( getBlockOrder( firstLeafClientId ).length ) {
+						firstLeafClientId =
+							getBlockOrder( firstLeafClientId )[ 0 ];
+					}
+					registry.batch( () => {
+						removeBlock( clientId );
+						selectBlock( firstLeafClientId );
+					} );
+				} else if ( getBlockOrder( nextBlockClientId ).length ) {
 					moveFirstItemUp( nextBlockClientId, false );
 				} else {
 					mergeBlocks( clientId, nextBlockClientId );

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -277,6 +277,44 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should forward delete an empty paragraph without breaking apart the next block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{ name: 'core/list-item', attributes: { content: 'one' } },
+				{ name: 'core/list-item', attributes: { content: 'two' } },
+			],
+		} );
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.click();
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.type( '|' );
+
+		// The empty paragraph is removed and the list is left intact, with
+		// the caret at the start of its first item.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: '|one' },
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'two' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should remove empty paragraph block on backspace', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -293,6 +293,24 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		await editor.canvas
 			.getByRole( 'document', { name: 'Empty block' } )
 			.click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: '' } },
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one' },
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'two' },
+					},
+				],
+			},
+		] );
+
 		await page.keyboard.press( 'Delete' );
 		await page.keyboard.type( '|' );
 


### PR DESCRIPTION
## What?
Fixes #21558. Forward deleting an empty paragraph before a list removes the paragraph and leaves the list intact, caret at the start of the first item. Previously the empty paragraph survived and the list's first item was pulled out and demoted to a paragraph.

## Why?
Matches other editors: forward delete joins across the boundary, and an empty line dissolves. Backspace already behaves conventionally in both spots (removes the empty paragraph; strips the bullet at the first item's start) and is unchanged.

## How?
The forward branch of `onMerge` went straight to `moveFirstItemUp` when the next block has children. Now an unmodified default block is removed instead, and the next block's first leaf is selected, mirroring the existing rule in `mergeBlocks` and `switchToDefaultOrRemove`.

## Testing Instructions
1. Add an empty paragraph followed by a list.
2. Focus the empty paragraph and press Fn+Backspace (Delete).
3. The paragraph is removed, the list is whole, caret at the start of the first item.

Covered by a regression test; fails on trunk.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.
