### PR TITLE
Add a responsiveEditingEnabled editor setting to hide the Responsive styles option

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
+++ b/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
@@ -96,12 +96,12 @@ This JavaScript should be enqueued much like the block variation example above. 
 The Code Editor allows you to view the underlying block markup for a page or post. While this view is handy for experienced users, you can inadvertently break block markup by editing content. Add the following to your `functions.php` file to restrict access.
 
 ```php
-function example_restrict_code_editor_access( $settings, $context ) {
-    $settings[ 'codeEditingEnabled' ] = false;
+function example_restrict_code_editor_access( $settings ) {
+	$settings[ 'codeEditingEnabled' ] = false;
 
 	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'example_restrict_code_editor_access', 10, 2 );
+add_filter( 'block_editor_settings_all', 'example_restrict_code_editor_access' );
 ```
 
 This code prevents all users from accessing the Code Editor. You could also add [capability](https://wordpress.org/documentation/article/roles-and-capabilities/) checks to disable access for specific users.
@@ -111,12 +111,12 @@ This code prevents all users from accessing the Code Editor. You could also add 
 The "Responsive styles" option in the View menu lets users apply style changes to a single viewport only. If you want style edits to always apply to every viewport, add the following to your `functions.php` file.
 
 ```php
-function example_disable_responsive_editing( $settings, $context ) {
-    $settings[ 'responsiveEditingEnabled' ] = false;
+function example_disable_responsive_editing( $settings ) {
+	$settings[ 'responsiveEditingEnabled' ] = false;
 
 	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'example_disable_responsive_editing', 10, 2 );
+add_filter( 'block_editor_settings_all', 'example_disable_responsive_editing' );
 ```
 
 Responsive styles already defined in `theme.json` or in Global Styles continue to be applied on the front end.

--- a/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
+++ b/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
@@ -106,6 +106,21 @@ add_filter( 'block_editor_settings_all', 'example_restrict_code_editor_access', 
 
 This code prevents all users from accessing the Code Editor. You could also add [capability](https://wordpress.org/documentation/article/roles-and-capabilities/) checks to disable access for specific users.
 
+## Disable responsive editing
+
+The "Responsive styles" option in the View menu lets users apply style changes to a single viewport only. If you want style edits to always apply to every viewport, add the following to your `functions.php` file.
+
+```php
+function example_disable_responsive_editing( $settings, $context ) {
+    $settings[ 'responsiveEditingEnabled' ] = false;
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'example_disable_responsive_editing', 10, 2 );
+```
+
+Responsive styles already defined in `theme.json` or in Global Styles continue to be applied on the front end.
+
 ## Disable formatting options for RichText blocks
 
 Blocks that support [RichText](https://developer.wordpress.org/block-editor/reference-guides/richtext/) come with the default formatting options provided by WordPress.

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -33,6 +33,7 @@ For more examples, check out the [Editor Hooks](https://developer.wordpress.org/
 -   [Set a default image size](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#set-a-default-image-size)
 -   [Disable Openverse](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-openverse)
 -   [Disable the Font Library](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-the-font-library)
+-   [Restrict responsive editing](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#restrict-responsive-editing)
 -   [Disable block inspector tabs](https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#disable-block-inspector-tabs)
 
 ## Server-side theme.json filters

--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -61,6 +61,19 @@ Similar to the `codeEditingEnabled` setting, `richEditingEnabled` allows you to 
 
 The setting defaults to the returned value of the [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/) function. It checks whether the user can access the visual editor and whether the user's browser supports it.
 
+### Restrict responsive editing
+
+The `responsiveEditingEnabled` setting, which defaults to `true`, controls whether the "Responsive styles" option is available in the Editor's View menu. When it is `false`, the option is not rendered and users cannot target style changes at a single viewport. Responsive styles already defined in the theme or in Global Styles are unaffected.
+
+```php
+add_filter( 'block_editor_settings_all', 'example_disable_responsive_editing' );
+
+function example_disable_responsive_editing( $settings ) {
+	$settings['responsiveEditingEnabled'] = false;
+	return $settings;
+}
+```
+
 ### Set a default image size
 
 Images are set to the `large` image size by default in the Editor. You can modify this using the `imageDefaultSize` setting, which is especially useful if you have configured your own custom image sizes. The following example changes the default image size to `medium`.

--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -63,7 +63,7 @@ The setting defaults to the returned value of the [`user_can_richedit`](https://
 
 ### Restrict responsive editing
 
-The `responsiveEditingEnabled` setting, which defaults to `true`, controls whether the "Responsive styles" option is available in the Editor's View menu. When it is `false`, the option is not rendered and users cannot target style changes at a single viewport. Responsive styles already defined in the theme or in Global Styles are unaffected.
+The `responsiveEditingEnabled` setting, which defaults to `true`, controls whether the "Responsive styles" option is available in the Editor's View menu. When it is `false`, the option is not rendered, and the viewport state control in Global Styles is hidden as well, so users cannot target style changes at a single viewport. Pseudo states such as hover remain available. Responsive styles already defined in the theme or in Global Styles are unaffected.
 
 ```php
 add_filter( 'block_editor_settings_all', 'example_disable_responsive_editing' );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### New Features
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
--   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu when set to `false`.
+-   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu when set to `false` ([#80814](https://github.com/WordPress/gutenberg/pull/80814)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### New Features
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
--   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu when set to `false` ([#80814](https://github.com/WordPress/gutenberg/pull/80814)).
+-   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu and the viewport state control in Global Styles when set to `false` ([#80814](https://github.com/WordPress/gutenberg/pull/80814)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New Features
 
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
+-   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu when set to `false`.
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/global-styles/index.js
+++ b/packages/editor/src/components/global-styles/index.js
@@ -26,6 +26,7 @@ function useServerData( settings ) {
 	const __experimentalDiscussionSettings =
 		settings?.__experimentalDiscussionSettings;
 	const fontLibraryEnabled = settings?.fontLibraryEnabled ?? true;
+	const responsiveEditingEnabled = settings?.responsiveEditingEnabled ?? true;
 
 	const mediaUploadHandler = useSelect( ( select ) => {
 		const { canUser } = select( coreStore );
@@ -72,7 +73,12 @@ function useServerData( settings ) {
 		mediaUploadHandler,
 	] );
 
-	return { serverCSS, serverSettings, fontLibraryEnabled };
+	return {
+		serverCSS,
+		serverSettings,
+		fontLibraryEnabled,
+		responsiveEditingEnabled,
+	};
 }
 
 export default function GlobalStylesUIWrapper( {
@@ -80,7 +86,7 @@ export default function GlobalStylesUIWrapper( {
 	onPathChange,
 	settings,
 	selectedViewport,
-	showResponsiveStateControls,
+	showResponsiveStateControls = true,
 } ) {
 	const {
 		user: userConfig,
@@ -88,8 +94,12 @@ export default function GlobalStylesUIWrapper( {
 		setUser: setUserConfig,
 		isReady,
 	} = useGlobalStyles();
-	const { serverCSS, serverSettings, fontLibraryEnabled } =
-		useServerData( settings );
+	const {
+		serverCSS,
+		serverSettings,
+		fontLibraryEnabled,
+		responsiveEditingEnabled,
+	} = useServerData( settings );
 
 	// Show loading state while data is being fetched
 	if ( ! isReady ) {
@@ -108,7 +118,9 @@ export default function GlobalStylesUIWrapper( {
 				serverCSS={ serverCSS }
 				serverSettings={ serverSettings }
 				selectedViewport={ selectedViewport }
-				showResponsiveStateControls={ showResponsiveStateControls }
+				showResponsiveStateControls={
+					showResponsiveStateControls && responsiveEditingEnabled
+				}
 			/>
 			<GlobalStylesBlockLink
 				path={ path }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -46,6 +46,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		isTemplateHidden,
 		templateId,
 		isResponsiveEditing,
+		isResponsiveEditingEnabled,
 		hasBlockSelection,
 		activeComplementaryArea,
 	} = useSelect( ( select ) => {
@@ -54,6 +55,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			getCurrentTemplateId,
 			getRenderingMode,
 			getDeviceType,
+			getEditorSettings,
 		} = unlock( select( editorStore ) );
 		const {
 			isResponsiveEditing: _isResponsiveEditing,
@@ -77,6 +79,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			isTemplateHidden: getRenderingMode() === 'post-only',
 			templateId: getCurrentTemplateId(),
 			isResponsiveEditing: _isResponsiveEditing(),
+			isResponsiveEditingEnabled:
+				getEditorSettings().responsiveEditingEnabled,
 			hasBlockSelection: !! getBlockSelectionStart(),
 			activeComplementaryArea:
 				select( interfaceStore ).getActiveComplementaryArea( 'core' ),
@@ -204,19 +208,21 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							onSelect={ handleDevicePreviewChange }
 						/>
 					</MenuGroup>
-					<MenuGroup>
-						<MenuItem
-							icon={ isResponsiveEditing ? check : undefined }
-							isSelected={ isResponsiveEditing }
-							role="menuitemcheckbox"
-							onClick={ handleResponsiveEditingChange }
-							info={ __(
-								'Style changes apply only to the selected viewport.'
-							) }
-						>
-							{ __( 'Responsive styles' ) }
-						</MenuItem>
-					</MenuGroup>
+					{ isResponsiveEditingEnabled && (
+						<MenuGroup>
+							<MenuItem
+								icon={ isResponsiveEditing ? check : undefined }
+								isSelected={ isResponsiveEditing }
+								role="menuitemcheckbox"
+								onClick={ handleResponsiveEditingChange }
+								info={ __(
+									'Style changes apply only to the selected viewport.'
+								) }
+							>
+								{ __( 'Responsive styles' ) }
+							</MenuItem>
+						</MenuGroup>
+					) }
 					{ isTemplate && (
 						<MenuGroup>
 							<MenuItem

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -6,21 +6,22 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
 /**
  * The default post editor settings.
  *
- * @property {boolean|Array} allowedBlockTypes     Allowed block types
- * @property {boolean}       richEditingEnabled    Whether rich editing is enabled or not
- * @property {boolean}       codeEditingEnabled    Whether code editing is enabled or not
- * @property {boolean}       fontLibraryEnabled    Whether the font library is enabled or not.
- * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
- *                                                 true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
- *                                                 false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
- *                                                 undefined = the current environment does not support Custom Fields, so the option toggle in Preferences -> Panels to enable the Custom Fields panel is not displayed.
- * @property {number}        autosaveInterval      How often in seconds the post will be auto-saved via the REST API.
- * @property {number}        localAutosaveInterval How often in seconds the post will be backed up to sessionStorage.
- * @property {Array?}        availableTemplates    The available post templates
- * @property {boolean}       disablePostFormats    Whether or not the post formats are disabled
- * @property {Array?}        allowedMimeTypes      List of allowed mime types and file extensions
- * @property {number}        maxUploadFileSize     Maximum upload file size
- * @property {boolean}       supportsLayout        Whether the editor supports layouts.
+ * @property {boolean|Array} allowedBlockTypes        Allowed block types
+ * @property {boolean}       richEditingEnabled       Whether rich editing is enabled or not
+ * @property {boolean}       codeEditingEnabled       Whether code editing is enabled or not
+ * @property {boolean}       responsiveEditingEnabled Whether editing styles per viewport is enabled or not
+ * @property {boolean}       fontLibraryEnabled       Whether the font library is enabled or not.
+ * @property {boolean}       enableCustomFields       Whether the WordPress custom fields are enabled or not.
+ *                                                    true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
+ *                                                    false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
+ *                                                    undefined = the current environment does not support Custom Fields, so the option toggle in Preferences -> Panels to enable the Custom Fields panel is not displayed.
+ * @property {number}        autosaveInterval         How often in seconds the post will be auto-saved via the REST API.
+ * @property {number}        localAutosaveInterval    How often in seconds the post will be backed up to sessionStorage.
+ * @property {Array?}        availableTemplates       The available post templates
+ * @property {boolean}       disablePostFormats       Whether or not the post formats are disabled
+ * @property {Array?}        allowedMimeTypes         List of allowed mime types and file extensions
+ * @property {number}        maxUploadFileSize        Maximum upload file size
+ * @property {boolean}       supportsLayout           Whether the editor supports layouts.
  */
 export const EDITOR_SETTINGS_DEFAULTS = {
 	...SETTINGS_DEFAULTS,
@@ -28,6 +29,7 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
 	fontLibraryEnabled: true,
+	responsiveEditingEnabled: true,
 	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
 };

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -28,8 +28,8 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
-	fontLibraryEnabled: true,
 	responsiveEditingEnabled: true,
+	fontLibraryEnabled: true,
 	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
 };

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -9,7 +9,7 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
  * @property {boolean|Array} allowedBlockTypes        Allowed block types
  * @property {boolean}       richEditingEnabled       Whether rich editing is enabled or not
  * @property {boolean}       codeEditingEnabled       Whether code editing is enabled or not
- * @property {boolean}       responsiveEditingEnabled Whether editing styles per viewport is enabled or not
+ * @property {boolean}       responsiveEditingEnabled Whether responsive (per-viewport) style editing is enabled or not
  * @property {boolean}       fontLibraryEnabled       Whether the font library is enabled or not.
  * @property {boolean}       enableCustomFields       Whether the WordPress custom fields are enabled or not.
  *                                                    true  = the user has opted to show the Custom Fields panel at the bottom of the editor.


### PR DESCRIPTION
## What?

- See https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/#comment-3708
- As discussed on Slack: https://wordpress.slack.com/archives/C0B4Q0RJVAT/p1785254573145719

Adds a `responsiveEditingEnabled` editor setting so that sites can hide the "Responsive styles" option from the device preview dropdown.

## Why?

Feedback on the Call for Testing for responsive styling asked for a way to opt out of the feature.

## How?

Adds a `responsiveEditingEnabled` editor setting, which can be set through the `block_editor_settings_all` filter. It follows the existing `richEditingEnabled` / `codeEditingEnabled` pattern.

The setting only hides the toggle. Responsive styles already stored in content, and the styles they output on the front end, are unaffected.

## Testing Instructions

1. On `trunk`, add a block and apply a style to the Mobile viewport only and save the post.
2. Add the filter from [the documentation](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/filters/editor-filters.md) to a plugin or your theme's `functions.php`:

    ```php
    add_filter( 'block_editor_settings_all', function ( $settings ) {
    	$settings['responsiveEditingEnabled'] = false;
    	return $settings;
    } );
    ```

3. Reload the editor and open the device preview dropdown. Confirm that "Responsive styles" is no longer listed and that the viewport options still work.
4. Confirm the style applied in step 1 is still rendered in the editor and on the front end.

Repeat steps 3 and 4 in the Site Editor.

## Use of AI Tools

Claude Code was used to write the implementation and documentation following my direction. I have reviewed and tested all of the changes.

> [!NOTE]
> If this PR is merged, I plan to add code examples to the dev note to disable responsive editing.
> https://make.wordpress.org/core/?p=124535&preview=1&_ppp=bb56023b02
