### PR TITLE
Global Styles: Put the inheritance UI behind a Gutenberg experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -15,6 +15,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-grid-interactivity' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGridInteractivity = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-global-styles-inheritance-ui' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalGlobalStylesInheritanceUI = true', 'before' );
+	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dataviews-media-modal' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDataViewsMediaModal = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -30,6 +30,11 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Enables new blocks to allow building forms. You are likely to experience UX issues that are being addressed.', 'gutenberg' ),
 				),
 				array(
+					'id'          => 'gutenberg-global-styles-inheritance-ui',
+					'label'       => __( 'Global Styles inheritance in the block inspector', 'gutenberg' ),
+					'description' => __( 'Shows the value a block inherits from Global Styles in the block inspector when nothing is set on the block itself, and adds a control to clear a value you set back to the inherited one.', 'gutenberg' ),
+				),
+				array(
 					'id'          => 'gutenberg-grid-interactivity',
 					'label'       => __( 'Grid interactivity', 'gutenberg' ),
 					'description' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Internal
 
--   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#TODO](https://github.com/WordPress/gutenberg/pull/TODO)).
+-   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#80815](https://github.com/WordPress/gutenberg/pull/80815)).
 -   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 
 ### Bug Fixes

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Internal
 
--   Gate the inherited Global Styles treatment in the block inspector on `IS_GUTENBERG_PLUGIN`, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances in WordPress Core builds ([#80555](https://github.com/WordPress/gutenberg/pull/80555)).
+-   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#TODO](https://github.com/WordPress/gutenberg/pull/TODO)).
 -   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 
 ### Bug Fixes

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -665,7 +665,7 @@ export default function BackgroundImagePanel( {
 	inheritedValue = value,
 	settings,
 	defaultValues = {},
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	/*
 	 * Resolve inherited `ref` pointers for background controls.

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -39,7 +39,10 @@ import { getResolvedValue } from '@wordpress/global-styles-engine';
  * Internal dependencies
  */
 import { hasBackgroundImageValue } from '../global-styles/background-panel';
-import { InheritanceResetButton } from '../global-styles/inheritance';
+import {
+	InheritanceResetButton,
+	isGlobalStylesInheritanceEnabled,
+} from '../global-styles/inheritance';
 import { setImmutably } from '../../utils/object';
 import MediaReplaceFlow from '../media-replace-flow';
 import { store as blockEditorStore } from '../../store';
@@ -665,7 +668,7 @@ export default function BackgroundImagePanel( {
 	inheritedValue = value,
 	settings,
 	defaultValues = {},
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	/*
 	 * Resolve inherited `ref` pointers for background controls.

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -18,11 +18,7 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import {
-	getInheritanceProps,
-	InheritanceToolsPanelItem,
-	ENABLE_GLOBAL_STYLES_INHERITANCE,
-} from './inheritance';
+import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -170,7 +166,7 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Background' ),
 	contrastWarning,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -18,7 +18,11 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	isGlobalStylesInheritanceEnabled,
+} from './inheritance';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -166,7 +170,7 @@ export default function BackgroundImagePanel( {
 	defaultValues = {},
 	headerLabel = __( 'Background' ),
 	contrastWarning,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -21,11 +21,7 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
-import {
-	getInheritanceProps,
-	InheritanceToolsPanelItem,
-	ENABLE_GLOBAL_STYLES_INHERITANCE,
-} from './inheritance';
+import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -107,7 +103,7 @@ export default function BorderPanel( {
 	panelId,
 	name,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const colors = useColorsPerOrigin( settings );
 	const areCustomSolidsEnabled = settings?.color?.custom;

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -21,7 +21,11 @@ import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	isGlobalStylesInheritanceEnabled,
+} from './inheritance';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -103,7 +107,7 @@ export default function BorderPanel( {
 	panelId,
 	name,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const colors = useColorsPerOrigin( settings );
 	const areCustomSolidsEnabled = settings?.color?.custom;

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -30,6 +30,7 @@ import {
 	getInheritanceProps,
 	InheritanceResetButton,
 	InheritanceToolsPanelItem,
+	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
 
 const { Tabs } = unlock( componentsPrivateApis );
@@ -213,7 +214,7 @@ export default function ColorGradientDropdownItem( {
 	className = 'block-editor-tools-panel-color-gradient-settings__item',
 	isPlaceholder = false,
 	hasInheritedValue = false,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const colorGradientDropdownButtonRef = useRef( undefined );
 	const itemClassName = clsx( 'block-editor-color-gradient-item', className );

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -213,7 +213,7 @@ export default function ColorGradientDropdownItem( {
 	className = 'block-editor-tools-panel-color-gradient-settings__item',
 	isPlaceholder = false,
 	hasInheritedValue = false,
-	showInheritanceLabelIndicators = true,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const colorGradientDropdownButtonRef = useRef( undefined );
 	const itemClassName = clsx( 'block-editor-color-gradient-item', className );

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -21,6 +21,7 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
+import { isGlobalStylesInheritanceEnabled } from './inheritance';
 
 // Despite the "ColorPanel" name, this gates only the element-level color
 // controls (link, heading, button, caption, h1–h6) — surfaced as the
@@ -148,7 +149,7 @@ export default function ColorPanel( {
 	label,
 	children,
 	contrastWarning,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -21,7 +21,6 @@ import {
 	extractPresetSlug,
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
-import { ENABLE_GLOBAL_STYLES_INHERITANCE } from './inheritance';
 
 // Despite the "ColorPanel" name, this gates only the element-level color
 // controls (link, heading, button, caption, h1–h6) — surfaced as the
@@ -149,7 +148,7 @@ export default function ColorPanel( {
 	label,
 	children,
 	contrastWarning,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const {
 		colors,

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,11 +33,7 @@ import {
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
-import {
-	getInheritanceProps,
-	InheritanceToolsPanelItem,
-	ENABLE_GLOBAL_STYLES_INHERITANCE,
-} from './inheritance';
+import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -359,7 +355,7 @@ export default function DimensionsPanel( {
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
 	styleState = DEFAULT_BLOCK_STYLE_STATE,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const { dimensions, spacing } = settings;
 

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -33,7 +33,11 @@ import {
 	hasPseudoBlockStyleState,
 	hasViewportBlockStyleState,
 } from '../../hooks/block-style-state';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	isGlobalStylesInheritanceEnabled,
+} from './inheritance';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -355,7 +359,7 @@ export default function DimensionsPanel( {
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
 	styleState = DEFAULT_BLOCK_STYLE_STATE,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const { dimensions, spacing } = settings;
 

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -34,7 +34,6 @@ import {
 	getInheritanceProps,
 	InheritanceToolsPanelItem,
 	InheritanceResetButton,
-	ENABLE_GLOBAL_STYLES_INHERITANCE,
 } from './inheritance';
 
 const EMPTY_ARRAY = [];
@@ -187,7 +186,7 @@ export default function FiltersPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -34,6 +34,7 @@ import {
 	getInheritanceProps,
 	InheritanceToolsPanelItem,
 	InheritanceResetButton,
+	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
 
 const EMPTY_ARRAY = [];
@@ -186,7 +187,7 @@ export default function FiltersPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -16,13 +16,15 @@ import { __ } from '@wordpress/i18n';
 
 /**
  * Whether the inspector surfaces inherited Global Styles values.
- * Plugin-only, so Core builds show locally-set values alone.
+ *
+ * Set by the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment,
+ * so the treatment is off unless someone opts in on the Experiments screen.
+ * With it off, the panels show locally-set values alone.
  *
  * @type {boolean}
  */
-export const ENABLE_GLOBAL_STYLES_INHERITANCE = globalThis.IS_GUTENBERG_PLUGIN
-	? true
-	: false;
+export const ENABLE_GLOBAL_STYLES_INHERITANCE =
+	!! window.__experimentalGlobalStylesInheritanceUI;
 
 /**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -15,6 +15,24 @@ import { reset as resetIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Whether the inspector surfaces inherited Global Styles values.
+ *
+ * Behind the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment,
+ * so the treatment is off unless someone opts in on the Experiments screen.
+ * With it off, the panels show locally-set values alone.
+ *
+ * Evaluated per call rather than once at module scope, so tests can toggle
+ * the experiment and so a later move to a store-backed setting only has to
+ * change this one place. Always returns a boolean: callers pass the result
+ * down as a prop, and `undefined` would trigger a receiving component's own
+ * default parameter.
+ *
+ * @return {boolean} Whether the inherited-value treatment is enabled.
+ */
+export const isGlobalStylesInheritanceEnabled = () =>
+	!! window.__experimentalGlobalStylesInheritanceUI;
+
+/**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
  * so its descendant label picks up the inherited-from-Global-Styles
  * visual treatment.

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -15,18 +15,6 @@ import { reset as resetIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Whether the inspector surfaces inherited Global Styles values.
- *
- * Set by the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment,
- * so the treatment is off unless someone opts in on the Experiments screen.
- * With it off, the panels show locally-set values alone.
- *
- * @type {boolean}
- */
-export const ENABLE_GLOBAL_STYLES_INHERITANCE =
-	!! window.__experimentalGlobalStylesInheritanceUI;
-
-/**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
  * so its descendant label picks up the inherited-from-Global-Styles
  * visual treatment.

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -18,6 +18,7 @@ import { getVariationNameFromClass } from '../../hooks/block-style-variation';
 import { useBlockEditContext } from '../block-edit/context';
 import BlockContext from '../block-context';
 import { unlock } from '../../lock-unlock';
+import { isGlobalStylesInheritanceEnabled } from './inheritance';
 
 const { resolveStyle } = unlock( globalStylesEnginePrivateApis );
 
@@ -247,7 +248,7 @@ export function useResolvedStyle( blockName, className, selectedState = null ) {
 
 	return useMemo( () => {
 		// Skip the cascade merge entirely when the experiment is off.
-		if ( ! window.__experimentalGlobalStylesInheritanceUI ) {
+		if ( ! isGlobalStylesInheritanceEnabled() ) {
 			return NO_RESOLVED_STYLE;
 		}
 		if ( ! blockName ) {

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -18,7 +18,6 @@ import { getVariationNameFromClass } from '../../hooks/block-style-variation';
 import { useBlockEditContext } from '../block-edit/context';
 import BlockContext from '../block-context';
 import { unlock } from '../../lock-unlock';
-import { ENABLE_GLOBAL_STYLES_INHERITANCE } from './inheritance';
 
 const { resolveStyle } = unlock( globalStylesEnginePrivateApis );
 
@@ -247,8 +246,8 @@ export function useResolvedStyle( blockName, className, selectedState = null ) {
 	const globalStyles = useRawGlobalStyles();
 
 	return useMemo( () => {
-		// Skip the cascade merge entirely when the feature is off.
-		if ( ! ENABLE_GLOBAL_STYLES_INHERITANCE ) {
+		// Skip the cascade merge entirely when the experiment is off.
+		if ( ! window.__experimentalGlobalStylesInheritanceUI ) {
 			return NO_RESOLVED_STYLE;
 		}
 		if ( ! blockName ) {

--- a/packages/block-editor/src/components/global-styles/test/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.js
@@ -15,6 +15,13 @@ import BackgroundPanel, {
 	hasLegacyColorGradientValue,
 } from '../background-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 describe( 'hasBackgroundImageValue', () => {
 	it( 'should return `true` when id and url exist', () => {
 		expect(

--- a/packages/block-editor/src/components/global-styles/test/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.js
@@ -22,6 +22,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 describe( 'hasBackgroundImageValue', () => {
 	it( 'should return `true` when id and url exist', () => {
 		expect(

--- a/packages/block-editor/src/components/global-styles/test/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.js
@@ -9,6 +9,13 @@ import userEvent from '@testing-library/user-event';
  */
 import BorderPanel from '../border-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 /**
  * Tests for the inherited Global Styles label treatment in `BorderPanel`.
  * The visual treatment lands on the parent `ToolsPanelItem` via the

--- a/packages/block-editor/src/components/global-styles/test/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.js
@@ -16,6 +16,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 /**
  * Tests for the inherited Global Styles label treatment in `BorderPanel`.
  * The visual treatment lands on the parent `ToolsPanelItem` via the

--- a/packages/block-editor/src/components/global-styles/test/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/color-panel.js
@@ -24,6 +24,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 const settingsWithColors = ( overrides = {} ) => ( {
 	color: {
 		palette: {

--- a/packages/block-editor/src/components/global-styles/test/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/color-panel.js
@@ -17,6 +17,13 @@ import ColorPanel, {
 	useHasCaptionPanel,
 } from '../color-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 const settingsWithColors = ( overrides = {} ) => ( {
 	color: {
 		palette: {

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -10,6 +10,13 @@ import userEvent from '@testing-library/user-event';
  */
 import DimensionsPanel from '../dimensions-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 // `AspectRatioTool` reads its option list from the block-editor data
 // store via `useSettings`. Mock that hook so the tests can render the
 // full set of inherited and selectable ratios without spinning up a

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -17,6 +17,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 // `AspectRatioTool` reads its option list from the block-editor data
 // store via `useSettings`. Mock that hook so the tests can render the
 // full set of inherited and selectable ratios without spinning up a

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.js
@@ -9,6 +9,13 @@ import userEvent from '@testing-library/user-event';
  */
 import FiltersPanel from '../filters-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 /**
  * Tests for the inherited Global Styles label treatment in `FiltersPanel`.
  * The panel hosts a single duotone slot rendered as a `Dropdown` whose toggle

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.js
@@ -16,6 +16,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 /**
  * Tests for the inherited Global Styles label treatment in `FiltersPanel`.
  * The panel hosts a single duotone slot rendered as a `Dropdown` whose toggle

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -14,9 +14,10 @@ import { useSelect } from '@wordpress/data';
 import { useResolvedStyle } from '../inherited-value-context';
 import { globalStylesDataKey } from '../../../store/private-keys';
 
-// Core-build coverage for `useResolvedStyle`. Tests run with
-// `IS_GUTENBERG_PLUGIN` true, so the core path needs a mock. `jest.mock` is
-// file-scoped, so these tests live apart from `inherited-value-context.js`.
+// Coverage for `useResolvedStyle` with the Global Styles inheritance
+// experiment off, which is what WordPress Core gets. Tests run with the
+// experiment on, so the off path needs a mock. `jest.mock` is file-scoped, so
+// these tests live apart from `inherited-value-context.js`.
 jest.mock( '../inheritance', () => ( {
 	...jest.requireActual( '../inheritance' ),
 	ENABLE_GLOBAL_STYLES_INHERITANCE: false,

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -14,14 +14,12 @@ import { useSelect } from '@wordpress/data';
 import { useResolvedStyle } from '../inherited-value-context';
 import { globalStylesDataKey } from '../../../store/private-keys';
 
-// Coverage for `useResolvedStyle` with the Global Styles inheritance
-// experiment off, which is what WordPress Core gets. Tests run with the
-// experiment on, so the off path needs a mock. `jest.mock` is file-scoped, so
-// these tests live apart from `inherited-value-context.js`.
-jest.mock( '../inheritance', () => ( {
-	...jest.requireActual( '../inheritance' ),
-	ENABLE_GLOBAL_STYLES_INHERITANCE: false,
-} ) );
+// Coverage for `useResolvedStyle` with the `gutenberg-global-styles-inheritance-ui`
+// experiment off, which is what WordPress Core gets. Set explicitly rather than
+// left unset, so the tests below state which path they are exercising.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = false;
+} );
 
 // Only `useSelect` is called by the hook. The other four are needed at import
 // time by the store modules this file pulls in transitively.
@@ -53,7 +51,7 @@ jest.mock( '../../../hooks/block-style-variation', () => ( {
 	},
 } ) );
 
-describe( 'useResolvedStyle — core build', () => {
+describe( 'useResolvedStyle — experiment off', () => {
 	beforeEach( () => {
 		useSelect.mockReset();
 		useSelect.mockImplementation( ( mapSelect ) =>

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -15,10 +15,13 @@ import { useResolvedStyle } from '../inherited-value-context';
 import { globalStylesDataKey } from '../../../store/private-keys';
 
 // Coverage for `useResolvedStyle` with the `gutenberg-global-styles-inheritance-ui`
-// experiment off, which is what WordPress Core gets. Set explicitly rather than
-// left unset, so the tests below state which path they are exercising.
+// experiment off, which is what WordPress Core gets. Deleted rather than set to
+// `false`, because an experiment that was never turned on leaves the global
+// unset, and `undefined` is the value that fires a receiving component's own
+// default parameter. Setting `false` here would test a state that does not
+// occur.
 beforeEach( () => {
-	window.__experimentalGlobalStylesInheritanceUI = false;
+	delete window.__experimentalGlobalStylesInheritanceUI;
 } );
 
 afterEach( () => {

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -21,6 +21,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = false;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 // Only `useSelect` is called by the hook. The other four are needed at import
 // time by the store modules this file pulls in transitively.
 jest.mock( '@wordpress/data', () => ( {

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
@@ -16,6 +16,14 @@ import { BlockContextProvider } from '../../block-context';
 
 import { globalStylesDataKey } from '../../../store/private-keys';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the resolving path. The off path lives in
+// `inherited-value-context-core.js`.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 	useDispatch: jest.fn( () => ( {} ) ),

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
@@ -24,6 +24,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 	useDispatch: jest.fn( () => ( {} ) ),

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -16,6 +16,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = false;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 const baseSettings = {
 	typography: {
 		lineHeight: true,

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -9,14 +9,12 @@ import { click, render as renderAriakit } from '@ariakit/test/react';
  */
 import TypographyPanel from '../typography-panel';
 
-// Coverage for `TypographyPanel` with the Global Styles inheritance experiment
-// off, which is what WordPress Core gets. Tests run with the experiment on, so
-// the off path needs a mock. `jest.mock` is file-scoped, so these tests live
-// apart from `typography-panel.js`.
-jest.mock( '../inheritance', () => ( {
-	...jest.requireActual( '../inheritance' ),
-	ENABLE_GLOBAL_STYLES_INHERITANCE: false,
-} ) );
+// Coverage for `TypographyPanel` with the `gutenberg-global-styles-inheritance-ui`
+// experiment off, which is what WordPress Core gets. Set explicitly rather than
+// left unset, so the tests below state which path they are exercising.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = false;
+} );
 
 const baseSettings = {
 	typography: {
@@ -61,10 +59,10 @@ const getItem = ( name ) => {
 	return control.closest( '.components-tools-panel-item' );
 };
 
-describe( 'TypographyPanel — core build defaults', () => {
-	// `showInheritanceLabelIndicators` defaults to the build constant, so a
-	// caller that passes no prop gets no inheritance treatment in core. The
-	// layout className must still come through.
+describe( 'TypographyPanel — experiment off', () => {
+	// `showInheritanceLabelIndicators` defaults to the experiment flag, so a
+	// caller that passes no prop gets no inheritance treatment. The layout
+	// className must still come through.
 	it( 'applies no inherited treatment by default, even when an inherited value is present', () => {
 		renderPanel( {
 			value: {},
@@ -95,7 +93,7 @@ describe( 'TypographyPanel — core build defaults', () => {
 	} );
 } );
 
-describe( 'TypographyPanel — core build setTextColor link sync', () => {
+describe( 'TypographyPanel — experiment off, setTextColor link sync', () => {
 	async function pickRed( value, inheritedValue ) {
 		const onChange = jest.fn();
 		await renderAriakit(
@@ -118,10 +116,10 @@ describe( 'TypographyPanel — core build setTextColor link sync', () => {
 	}
 
 	it( 'leaves an unset link color alone when a text color is already set', async () => {
-		// The plugin falls back to the inherited link color here and syncs.
-		// Core compares the inherited text and link colors directly, which on
-		// this path is the block's own pair, so a link color that was never
-		// set does not start tracking.
+		// With the experiment on this falls back to the inherited link color
+		// and syncs. Off, it compares the inherited text and link colors
+		// directly, which on this path is the block's own pair, so a link
+		// color that was never set does not start tracking.
 		const result = await pickRed( {
 			color: { text: 'var:preset|color|blue' },
 		} );

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -91,6 +91,27 @@ describe( 'TypographyPanel — experiment off', () => {
 			} )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'renders the default color reset button by default when a local color shadows an inherited one', async () => {
+		await renderAriakit(
+			<TypographyPanel
+				value={ { color: { text: 'var:preset|color|blue' } } }
+				inheritedValue={ { color: { text: 'var:preset|color|red' } } }
+				settings={ PALETTE_SETTINGS }
+				panelId="test"
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'button', {
+				name: /reset to inherited value/i,
+			} )
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: /^reset$/i } )
+		).toBeInTheDocument();
+	} );
 } );
 
 describe( 'TypographyPanel — experiment off, setTextColor link sync', () => {

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -9,9 +9,10 @@ import { click, render as renderAriakit } from '@ariakit/test/react';
  */
 import TypographyPanel from '../typography-panel';
 
-// Core-build coverage for `TypographyPanel`. Tests run with
-// `IS_GUTENBERG_PLUGIN` true, so the core path needs a mock. `jest.mock` is
-// file-scoped, so these tests live apart from `typography-panel.js`.
+// Coverage for `TypographyPanel` with the Global Styles inheritance experiment
+// off, which is what WordPress Core gets. Tests run with the experiment on, so
+// the off path needs a mock. `jest.mock` is file-scoped, so these tests live
+// apart from `typography-panel.js`.
 jest.mock( '../inheritance', () => ( {
 	...jest.requireActual( '../inheritance' ),
 	ENABLE_GLOBAL_STYLES_INHERITANCE: false,

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.js
@@ -10,10 +10,13 @@ import { click, render as renderAriakit } from '@ariakit/test/react';
 import TypographyPanel from '../typography-panel';
 
 // Coverage for `TypographyPanel` with the `gutenberg-global-styles-inheritance-ui`
-// experiment off, which is what WordPress Core gets. Set explicitly rather than
-// left unset, so the tests below state which path they are exercising.
+// experiment off, which is what WordPress Core gets. Deleted rather than set to
+// `false`, because an experiment that was never turned on leaves the global
+// unset, and `undefined` is the value that fires a receiving component's own
+// default parameter. Setting `false` here would test a state that does not
+// occur.
 beforeEach( () => {
-	window.__experimentalGlobalStylesInheritanceUI = false;
+	delete window.__experimentalGlobalStylesInheritanceUI;
 } );
 
 afterEach( () => {

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.js
@@ -18,6 +18,10 @@ beforeEach( () => {
 	window.__experimentalGlobalStylesInheritanceUI = true;
 } );
 
+afterEach( () => {
+	delete window.__experimentalGlobalStylesInheritanceUI;
+} );
+
 /**
  * Render helper that flushes async state effects from Ariakit-based
  * controls (CustomSelectControl, FontAppearanceControl, FontFamily) so

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.js
@@ -10,6 +10,14 @@ import { click, render as renderAriakit } from '@ariakit/test/react';
  */
 import TypographyPanel, { useHasTypographyPanel } from '../typography-panel';
 
+// The inheritance treatment sits behind the
+// `gutenberg-global-styles-inheritance-ui` experiment. Turn it on so these
+// tests exercise the inheriting path. The off path lives in
+// `typography-panel-core.js`.
+beforeEach( () => {
+	window.__experimentalGlobalStylesInheritanceUI = true;
+} );
+
 /**
  * Render helper that flushes async state effects from Ariakit-based
  * controls (CustomSelectControl, FontAppearanceControl, FontFamily) so

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -38,11 +38,7 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-import {
-	getInheritanceProps,
-	InheritanceToolsPanelItem,
-	ENABLE_GLOBAL_STYLES_INHERITANCE,
-} from './inheritance';
+import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -255,7 +251,7 @@ export default function TypographyPanel( {
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
 	isGlobalStyles = false,
-	showInheritanceLabelIndicators = ENABLE_GLOBAL_STYLES_INHERITANCE,
+	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
 	contrastWarning,
 } ) {
 	const { colors, allColors, areCustomSolidsEnabled, decodeValue } =
@@ -283,8 +279,9 @@ export default function TypographyPanel( {
 			newSlug
 		);
 		let changedObject = setImmutably( value, [ 'color', 'text' ], encoded );
-		// Core keeps the pre-inheritance comparison on `inheritedValue`.
-		const syncLinkColor = ENABLE_GLOBAL_STYLES_INHERITANCE
+		// With the experiment off, keep the pre-inheritance comparison on
+		// `inheritedValue`.
+		const syncLinkColor = window.__experimentalGlobalStylesInheritanceUI
 			? shouldSyncLinkColor( value, inheritedValue )
 			: inheritedValue?.color?.text ===
 			  inheritedValue?.elements?.link?.color?.text;

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -38,7 +38,11 @@ import {
 	findNearestStyleAndWeight,
 } from './typography-utils';
 import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights';
-import { getInheritanceProps, InheritanceToolsPanelItem } from './inheritance';
+import {
+	getInheritanceProps,
+	InheritanceToolsPanelItem,
+	isGlobalStylesInheritanceEnabled,
+} from './inheritance';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -251,7 +255,7 @@ export default function TypographyPanel( {
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
 	isGlobalStyles = false,
-	showInheritanceLabelIndicators = window.__experimentalGlobalStylesInheritanceUI,
+	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 	contrastWarning,
 } ) {
 	const { colors, allColors, areCustomSolidsEnabled, decodeValue } =
@@ -281,7 +285,7 @@ export default function TypographyPanel( {
 		let changedObject = setImmutably( value, [ 'color', 'text' ], encoded );
 		// With the experiment off, keep the pre-inheritance comparison on
 		// `inheritedValue`.
-		const syncLinkColor = window.__experimentalGlobalStylesInheritanceUI
+		const syncLinkColor = isGlobalStylesInheritanceEnabled()
 			? shouldSyncLinkColor( value, inheritedValue )
 			: inheritedValue?.color?.text ===
 			  inheritedValue?.elements?.link?.color?.text;

--- a/test/unit/config/gutenberg-env.js
+++ b/test/unit/config/gutenberg-env.js
@@ -10,3 +10,10 @@ globalThis.IS_WORDPRESS_CORE = true;
 // Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 // eslint-disable-next-line @wordpress/wp-global-usage
 globalThis.IS_GUTENBERG_PLUGIN = true;
+
+/*
+ * Turn on the `gutenberg-global-styles-inheritance-ui` experiment, which the
+ * plugin sets from `lib/experimental/editor-settings.php`. Tests that need the
+ * experiment-off behaviour mock `ENABLE_GLOBAL_STYLES_INHERITANCE` instead.
+ */
+globalThis.__experimentalGlobalStylesInheritanceUI = true;

--- a/test/unit/config/gutenberg-env.js
+++ b/test/unit/config/gutenberg-env.js
@@ -10,10 +10,3 @@ globalThis.IS_WORDPRESS_CORE = true;
 // Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 // eslint-disable-next-line @wordpress/wp-global-usage
 globalThis.IS_GUTENBERG_PLUGIN = true;
-
-/*
- * Turn on the `gutenberg-global-styles-inheritance-ui` experiment, which the
- * plugin sets from `lib/experimental/editor-settings.php`. Tests that need the
- * experiment-off behaviour mock `ENABLE_GLOBAL_STYLES_INHERITANCE` instead.
- */
-globalThis.__experimentalGlobalStylesInheritanceUI = true;


### PR DESCRIPTION
## What?

Follow up to #80555. See #80649.

Replaces the `IS_GUTENBERG_PLUGIN` gate on the Global Styles inheritance UI with a Gutenberg experiment, `gutenberg-global-styles-inheritance-ui`, under Blocks on Settings > Experiments.

## Why?

See: https://github.com/WordPress/gutenberg/pull/80649#issuecomment-5108834987 We're punting it to 7.2.

The treatment was on for every Gutenberg plugin user. Behind an experiment it is opt-in.

## How?

- `lib/experimental/experiments/load.php` registers the experiment.
- `lib/experimental/editor-settings.php` sets `window.__experimentalGlobalStylesInheritanceUI` when it is on.
- The six block-supports panels, `ColorGradientDropdownItem` and `BackgroundImagePanel` all read that flag.


No server-side gating was added. The Global Styles payload the resolver reads is already sent to the editor for other features.

## Testing Instructions

<img width="664" height="92" alt="Screenshot 2026-07-29 at 11 50 41 am" src="https://github.com/user-attachments/assets/c682448b-ebce-4abe-a602-9696f73a7dae" />

1. Go to Settings > Experiments. Confirm "Global Styles inheritance in the block inspector" appears under Blocks and is unchecked.
2. Open a post, add a Heading and select it. Set a text colour on the block.
3. Confirm no control label has a dotted underline and no blue reset dot appears next to any control.
4. Tick the experiment and save. Reload the post.
5. Confirm labels for inherited controls now have a dotted underline, and the blue reset dot appears next to the text colour.
6. Untick the experiment, reload, and confirm step 3 again.