### PR TITLE
Only use Flakiness.io in canonical Gutenberg repo

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -28,10 +28,18 @@ const config = defineConfig( {
 				[ 'github' ],
 				[ './config/flaky-tests-reporter.ts' ],
 				[ 'blob' ],
-				[
-					'@flakiness/playwright',
-					{ flakinessProject: 'WordPress/gutenberg' },
-				],
+				/*
+				 * Only interact with flakiness.io for the official WordPress/Gutenberg
+				 * repository. Forks and private mirrors are not configured on the service.
+				 */
+				...( process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
+					? ( [
+							[
+								'@flakiness/playwright',
+								{ flakinessProject: 'WordPress/gutenberg' },
+							],
+					  ] as const )
+					: [] ),
 		  ]
 		: 'list',
 	workers: 1,

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -98,7 +98,13 @@ module.exports = {
 	reporters: [
 		'default',
 		'<rootDir>packages/scripts/config/jest-github-actions-reporter/index.js',
-		process.env.CI
+		/*
+		 * Only interact with flakiness.io for the official WordPress/Gutenberg
+		 * repository. Forks and private mirrors should behave the same as
+		 * running the tests outside a CI environment.
+		 */
+		process.env.CI &&
+		process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
 			? [
 					require.resolve( '@flakiness/jest' ),
 					{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adjusts Playwright and Jest reporter-related configurations so that Flakiness.io is only configured when the current repository is `WordPress/gutenberg`.


## Why?
When a fork or private mirror runs the tests, vthe following error is encountered:

```
Failed to upload: 403 https://flakiness.io/api/upload/start OIDC token repository "desrosj/gutenberg" does not match flakiness project repository "WordPress/gutenberg"
```

## How?
The reporter is conditionally excluded when the [pre-configured `GITHUB_REPOSITORY` environment variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables) does not contain the expected value. 

## Use of AI Tools

Initial draft of this PR was created using Claude.