### PR TITLE
Fix view config properties that don't work as expected (type, perPage, fields, search, page, unlocked filters)

### DIFF
--- a/packages/views/src/filter-utils.ts
+++ b/packages/views/src/filter-utils.ts
@@ -9,6 +9,9 @@ import type { View, Filter } from '@wordpress/dataviews';
 import type { ActiveViewOverrides } from './types';
 
 const SCALAR_VALUES = [
+	'type',
+	'perPage',
+	'fields',
 	'titleField',
 	'mediaField',
 	'descriptionField',
@@ -47,20 +50,32 @@ export function mergeActiveViewOverrides(
 		}
 	}
 
-	// Merge filters
+	// Merge filters.
+	// Locked filters (`isLocked: true`) always win over whatever the user has
+	// set for that field. Unlocked filters only seed a default value for
+	// fields the view doesn't already have a filter for — once a filter
+	// exists for that field (e.g. because the user added/edited it), the
+	// unlocked override no longer clobbers it.
 	if (
 		activeViewOverrides.filters &&
 		activeViewOverrides.filters.length > 0
 	) {
-		const activeFields = new Set(
-			activeViewOverrides.filters.map( ( f ) => f.field )
+		const lockedOverrides = activeViewOverrides.filters.filter(
+			( f: Filter ) => !! f.isLocked
 		);
+		const lockedFields = new Set( lockedOverrides.map( ( f ) => f.field ) );
 		const preserved = ( view.filters ?? [] ).filter(
-			( f: Filter ) => ! activeFields.has( f.field )
+			( f: Filter ) => ! lockedFields.has( f.field )
+		);
+		const existingFields = new Set(
+			preserved.map( ( f: Filter ) => f.field )
+		);
+		const unlockedDefaults = activeViewOverrides.filters.filter(
+			( f: Filter ) => ! f.isLocked && ! existingFields.has( f.field )
 		);
 		result = {
 			...result,
-			filters: [ ...preserved, ...activeViewOverrides.filters ],
+			filters: [ ...preserved, ...lockedOverrides, ...unlockedDefaults ],
 		};
 	}
 
@@ -130,18 +145,23 @@ export function stripActiveViewOverrides(
 		}
 	}
 
-	// Strip managed filters
+	// Strip managed filters.
+	// Only locked filters are force-managed and excluded from persistence;
+	// unlocked ones are just a seeded default, so any value the user set for
+	// that field (including edits to the seeded filter) persists normally.
 	if (
 		activeViewOverrides.filters &&
 		activeViewOverrides.filters.length > 0
 	) {
-		const activeFields = new Set(
-			activeViewOverrides.filters.map( ( f ) => f.field )
+		const lockedFields = new Set(
+			activeViewOverrides.filters
+				.filter( ( f: Filter ) => !! f.isLocked )
+				.map( ( f ) => f.field )
 		);
 		result = {
 			...result,
 			filters: ( view.filters ?? [] ).filter(
-				( f: Filter ) => ! activeFields.has( f.field )
+				( f: Filter ) => ! lockedFields.has( f.field )
 			),
 		};
 	}

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -35,12 +35,28 @@ export async function loadView( config: ViewConfig ) {
 	) as View | undefined;
 
 	const baseView = persistedView ?? defaultView;
-	const page = queryParams?.page ?? 1;
-	const search = queryParams?.search ?? '';
+	// Same precedence as useView(): URL state, then the tab-specific
+	// override, then the base view, then the entity-wide defaultView.
+	const page =
+		queryParams?.page ??
+		activeViewOverrides?.page ??
+		baseView?.page ??
+		defaultView?.page ??
+		1;
+	const search =
+		queryParams?.search ??
+		activeViewOverrides?.search ??
+		baseView?.search ??
+		defaultView?.search ??
+		'';
 
+	// Use the type the override will resolve to (if any) rather than the
+	// pre-override baseView type, so type-specific layout defaults match the
+	// view type that's actually about to be rendered.
+	const resolvedType = activeViewOverrides?.type ?? baseView?.type;
 	const rawDefaults =
 		config.defaultLayouts?.[
-			baseView?.type as keyof typeof config.defaultLayouts
+			resolvedType as keyof typeof config.defaultLayouts
 		];
 	const layoutTypeDefaults =
 		! rawDefaults || rawDefaults === true ? {} : rawDefaults;

--- a/packages/views/src/test/filter-utils.ts
+++ b/packages/views/src/test/filter-utils.ts
@@ -33,6 +33,27 @@ describe( 'mergeActiveViewOverrides', () => {
 	} );
 
 	describe( 'scalar overrides', () => {
+		it( 'should merge type override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				type: 'grid',
+			} );
+			expect( result.type ).toBe( 'grid' );
+		} );
+
+		it( 'should merge perPage override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				perPage: 10,
+			} );
+			expect( result.perPage ).toBe( 10 );
+		} );
+
+		it( 'should merge fields override', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				fields: [ 'date' ],
+			} );
+			expect( result.fields ).toEqual( [ 'date' ] );
+		} );
+
 		it( 'should merge titleField override', () => {
 			const result = mergeActiveViewOverrides( baseView, {
 				titleField: 'name',
@@ -113,7 +134,7 @@ describe( 'mergeActiveViewOverrides', () => {
 	} );
 
 	describe( 'filter overrides', () => {
-		it( 'should add override filters', () => {
+		it( 'should add an unlocked override filter as a default when the field is not already present', () => {
 			const result = mergeActiveViewOverrides( baseView, {
 				filters: [
 					{ field: 'status', operator: 'isAny', value: 'publish' },
@@ -132,7 +153,7 @@ describe( 'mergeActiveViewOverrides', () => {
 			);
 		} );
 
-		it( 'should replace same-field filters', () => {
+		it( 'should not clobber an existing filter on the same field with an unlocked override', () => {
 			const result = mergeActiveViewOverrides( baseView, {
 				filters: [
 					{
@@ -142,11 +163,33 @@ describe( 'mergeActiveViewOverrides', () => {
 					},
 				],
 			} );
+			// Unlocked overrides only seed a default; since `author` already
+			// has a filter, the existing (user) value is preserved.
+			expect( result.filters ).toHaveLength( 1 );
+			expect( result.filters![ 0 ] ).toEqual( {
+				field: 'author',
+				operator: 'isAny',
+				value: [ 'admin' ],
+			} );
+		} );
+
+		it( 'should always replace same-field filters when the override is locked', () => {
+			const result = mergeActiveViewOverrides( baseView, {
+				filters: [
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ 'editor' ],
+						isLocked: true,
+					},
+				],
+			} );
 			expect( result.filters ).toHaveLength( 1 );
 			expect( result.filters![ 0 ] ).toEqual( {
 				field: 'author',
 				operator: 'isAny',
 				value: [ 'editor' ],
+				isLocked: true,
 			} );
 		} );
 
@@ -291,6 +334,23 @@ describe( 'stripActiveViewOverrides', () => {
 	} );
 
 	describe( 'scalar stripping', () => {
+		it( 'should strip type/perPage/fields keys managed by overrides', () => {
+			const view: View = {
+				...baseView,
+				type: 'grid',
+				perPage: 10,
+				fields: [ 'date' ],
+			};
+			const result = stripActiveViewOverrides( view, {
+				type: 'grid',
+				perPage: 10,
+				fields: [ 'date' ],
+			} );
+			expect( result ).not.toHaveProperty( 'type' );
+			expect( result ).not.toHaveProperty( 'perPage' );
+			expect( result ).not.toHaveProperty( 'fields' );
+		} );
+
 		it( 'should strip a scalar key managed by overrides', () => {
 			const view: View = { ...baseView, titleField: 'name' };
 			const result = stripActiveViewOverrides( view, {
@@ -331,7 +391,7 @@ describe( 'stripActiveViewOverrides', () => {
 	} );
 
 	describe( 'filter stripping', () => {
-		it( 'should remove filters on managed fields', () => {
+		it( 'should remove filters on locked managed fields', () => {
 			const view: View = {
 				...baseView,
 				filters: [
@@ -353,11 +413,54 @@ describe( 'stripActiveViewOverrides', () => {
 						field: 'status',
 						operator: 'isAny',
 						value: 'publish',
+						isLocked: true,
 					},
 				],
 			} );
 			expect( result.filters ).toHaveLength( 1 );
 			expect( result.filters?.[ 0 ].field ).toBe( 'author' );
+		} );
+
+		it( 'should keep filters on unlocked managed fields so user edits persist', () => {
+			const view: View = {
+				...baseView,
+				filters: [
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'draft', // user-edited value, different from the override default.
+					},
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ 'admin' ],
+					},
+				],
+			};
+			const result = stripActiveViewOverrides( view, {
+				filters: [
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'publish',
+					},
+				],
+			} );
+			expect( result.filters ).toHaveLength( 2 );
+			expect( result.filters ).toEqual(
+				expect.arrayContaining( [
+					{
+						field: 'status',
+						operator: 'isAny',
+						value: 'draft',
+					},
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ 'admin' ],
+					},
+				] )
+			);
 		} );
 
 		it( 'should handle empty override filters', () => {
@@ -502,7 +605,27 @@ describe( 'merge + strip round-trip', () => {
 		expect( stripped.layout ).toEqual( { density: 'compact' } );
 	} );
 
-	it( 'should strip what merge added for filter overrides', () => {
+	it( 'should strip what merge added for locked filter overrides', () => {
+		const overrides = {
+			filters: [
+				{
+					field: 'status' as const,
+					operator: 'isAny' as const,
+					value: 'publish',
+					isLocked: true as const,
+				},
+			],
+		};
+		const merged = mergeActiveViewOverrides( baseView, overrides );
+		const stripped = stripActiveViewOverrides( merged, overrides );
+		// Only the original author filter should remain; the locked
+		// override is never persisted.
+		expect( stripped.filters ).toEqual( [
+			{ field: 'author', operator: 'isAny', value: [ 'admin' ] },
+		] );
+	} );
+
+	it( 'should keep an unlocked filter override once seeded, so later edits persist', () => {
 		const overrides = {
 			filters: [
 				{
@@ -513,10 +636,20 @@ describe( 'merge + strip round-trip', () => {
 			],
 		};
 		const merged = mergeActiveViewOverrides( baseView, overrides );
-		const stripped = stripActiveViewOverrides( merged, overrides );
-		// Only the original author filter should remain.
-		expect( stripped.filters ).toEqual( [
-			{ field: 'author', operator: 'isAny', value: [ 'admin' ] },
-		] );
+		// Simulate the user editing the seeded filter's value.
+		const userEdited: View = {
+			...merged,
+			filters: merged.filters?.map( ( f ) =>
+				f.field === 'status' ? { ...f, value: 'draft' } : f
+			),
+		};
+		const stripped = stripActiveViewOverrides( userEdited, overrides );
+		// The user's edited value is persisted, not discarded.
+		expect( stripped.filters ).toEqual(
+			expect.arrayContaining( [
+				{ field: 'author', operator: 'isAny', value: [ 'admin' ] },
+				{ field: 'status', operator: 'isAny', value: 'draft' },
+			] )
+		);
 	} );
 } );

--- a/packages/views/src/types.ts
+++ b/packages/views/src/types.ts
@@ -5,6 +5,9 @@ import type { View, SupportedLayouts } from '@wordpress/dataviews';
 
 export type ActiveViewOverrides = {
 	// scalar values
+	type?: View[ 'type' ];
+	perPage?: View[ 'perPage' ];
+	fields?: View[ 'fields' ];
 	titleField?: View[ 'titleField' ];
 	showTitle?: View[ 'showTitle' ];
 	mediaField?: View[ 'mediaField' ];
@@ -13,6 +16,10 @@ export type ActiveViewOverrides = {
 	showDescription?: View[ 'showDescription' ];
 	showLevels?: View[ 'showLevels' ];
 	infiniteScrollEnabled?: View[ 'infiniteScrollEnabled' ];
+	// URL-derived values (page, search); used as a tab-specific fallback,
+	// lower priority than the current URL query params.
+	page?: View[ 'page' ];
+	search?: View[ 'search' ];
 	// array & object values
 	filters?: View[ 'filters' ];
 	sort?: View[ 'sort' ];

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -74,13 +74,35 @@ export function useView( config: ViewConfig ): UseViewReturn {
 		() => persistedView ?? defaultView ?? {},
 		[ persistedView, defaultView ]
 	);
-	const page = Number( queryParams?.page ?? baseView.page ?? 1 );
-	const search = queryParams?.search ?? baseView.search ?? '';
+	// Precedence: explicit URL state wins, then a tab-specific default
+	// (activeViewOverrides, e.g. from a `view_list` entry), then the base
+	// view's own value, then the entity-wide defaultView. baseView.page/search
+	// are only ever populated from defaultView (persisted views never carry
+	// page/search — see updateView below), but the extra fallbacks keep page
+	// and search from resetting once a persisted view exists and no longer
+	// mirrors defaultView.
+	const page = Number(
+		queryParams?.page ??
+			activeViewOverrides?.page ??
+			baseView.page ??
+			defaultView?.page ??
+			1
+	);
+	const search =
+		queryParams?.search ??
+		activeViewOverrides?.search ??
+		baseView.search ??
+		defaultView?.search ??
+		'';
 
 	const combinedOverrides = useMemo( () => {
+		// Use the type the override will resolve to (if any) rather than the
+		// pre-override baseView type, so type-specific layout defaults match
+		// the view type that's actually about to be rendered.
+		const resolvedType = activeViewOverrides?.type ?? baseView.type;
 		const rawDefaults =
 			config.defaultLayouts?.[
-				baseView.type as keyof typeof config.defaultLayouts
+				resolvedType as keyof typeof config.defaultLayouts
 			];
 		const layoutTypeDefaults =
 			! rawDefaults || rawDefaults === true ? {} : rawDefaults;


### PR DESCRIPTION
## What?

Fixes #80778. Several properties of the server-side view configuration (`get_entity_view_config_{$kind}_{$name}`) were silently ignored or misbehaving on the client:

- `view_list[].view.type`, `perPage`, and `fields` were never applied.
- `default_view.search`/`page` worked on initial load but were reset to `1`/`''` after any user interaction that didn't touch search/page itself.
- `view_list[].view.search`/`page` didn't work at all.
- Filters provided via `view_list[].view.filters` without `isLocked: true` were visible but any user edit to them was discarded — they behaved as if locked.

## Why?

The client-side merge logic in `packages/views/src/filter-utils.ts` (`mergeActiveViewOverrides`/`stripActiveViewOverrides`), shared by the `useView` and `loadView` hooks, only recognized a fixed allowlist of scalar properties (`titleField`, `showTitle`, `mediaField`, etc.) and had no concept of per-filter `isLocked`. Anything outside that list — `type`, `perPage`, `fields` — was dropped when overrides were merged into the view. Separately, `search`/`page` were computed from `queryParams ?? baseView.page/search ?? 1/''`, but once a user made any change, the persisted preference (which never stores `page`/`search`) became `baseView`, so the fallback collapsed to the hardcoded default instead of the configured one. Filters were merged/stripped unconditionally for any override field, regardless of the documented `isLocked` semantics (`isLocked`: "whether the filter can be edited by the user").

## How?

In `packages/views/src/`:

- `filter-utils.ts`: added `type`, `perPage`, `fields` to the scalar override list. Reworked filter merge/strip so only `isLocked: true` filters are force-applied and excluded from persistence; unlocked filters seed a default only for fields the view doesn't already have one for, and any user edit to them persists normally.
- `use-view.ts` / `load-view.ts`: extended the `page`/`search` fallback chain to `queryParams ?? activeViewOverrides?.page/search ?? baseView.page/search ?? defaultView?.page/search ?? default`, so the configured value survives once a persisted preference exists. Also fixed the layout-defaults lookup to key off the view's resolved (post-override) type instead of its pre-override type.
- `types.ts`: extended `ActiveViewOverrides` with `type`, `perPage`, `fields`, `page`, `search`.
- Updated/added unit tests in `packages/views/src/test/filter-utils.ts`, including two that previously asserted the buggy "always strip unlocked filters" behavior.

## Testing Instructions

Use the repro from #80778 (filter callbacks on `get_entity_view_config_postType_page`):

1. Confirm `default_view.search`/`page` (e.g. `search=level`, `page=2`) persist after changing sort, filters, or layout — they should no longer reset to empty/page 1.
2. Confirm the Trash view for Pages renders as a `table` layout, not `list`.
3. Confirm a `view_list` entry's `perPage`, `fields`, `search`, and `page` are applied when that tab is active.
4. Confirm an unlocked filter from `view_list` is editable/removable by the user and the change sticks; confirm a locked (`isLocked: true`) filter remains fixed and cannot be changed.