### PR TITLE
Make editableRoot a private block setting rather than a public support

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -616,7 +616,7 @@ Start with the basic building block of all narrative.
 
 -	**Name:** [core/paragraph](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-paragraph/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), editableRoot, interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign, textColumns, textIndent), ~~className~~
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fitText, fontSize, lineHeight, textAlign, textColumns, textIndent), ~~className~~
 -	**Attributes:** content, direction, dropCap, placeholder
 
 ## Pattern Placeholder

--- a/packages/block-editor/src/components/writing-flow/use-editable-root.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root.js
@@ -3,7 +3,10 @@
  */
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
-import { hasBlockSupport } from '@wordpress/blocks';
+import {
+	getBlockType,
+	privateApis as blocksPrivateApis,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,6 +15,8 @@ import { store as blockEditorStore } from '../../store';
 import { setContentEditableWrapper } from './utils';
 import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
+
+const { editableRootKey } = unlock( blocksPrivateApis );
 
 /**
  * Returns true when the writing flow wrapper can host editing for the given
@@ -40,7 +45,7 @@ export function canHostEditableRoot( select, clientId ) {
 		// host then, only a textarea, which the editing host would
 		// interfere with.
 		getBlockMode( clientId ) !== 'visual' ||
-		! hasBlockSupport( getBlockName( clientId ), 'editableRoot', false )
+		! getBlockType( getBlockName( clientId ) )?.[ editableRootKey ]
 	) {
 		return false;
 	}

--- a/packages/block-library/src/paragraph/README.md
+++ b/packages/block-library/src/paragraph/README.md
@@ -26,7 +26,6 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 
 - [`align`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#align): `"wide"`, `"full"`
 - [`splitting`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#splitting): `true`
-- [`editableRoot`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#editableroot): `true`
 - [`anchor`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#anchor): `true`
 - [`className`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#classname): `false`
 - [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -29,7 +29,6 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"splitting": true,
-		"editableRoot": true,
 		"anchor": true,
 		"className": false,
 		"__experimentalBorder": {

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -16,7 +16,7 @@ import save from './save';
 import transforms from './transforms';
 import { unlock } from '../lock-unlock';
 
-const { fieldsKey, formKey } = unlock( blocksPrivateApis );
+const { fieldsKey, formKey, editableRootKey } = unlock( blocksPrivateApis );
 
 const { name } = metadata;
 
@@ -24,6 +24,9 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	// Opt into the editing host behaviour privately. It's a Symbol setting
+	// rather than a public `supports` key so it stays an internal detail.
+	[ editableRootKey ]: true,
 	example: {
 		attributes: {
 			content: __(

--- a/packages/blocks/src/api/index.ts
+++ b/packages/blocks/src/api/index.ts
@@ -183,6 +183,13 @@ export {
 const fieldsKey = Symbol( 'fields' );
 const formKey = Symbol( 'form' );
 
+// A private block setting, opted into by core text blocks, that makes the
+// editor canvas the contentEditable editing host (see `useEditableRoot`). It's
+// a Symbol rather than a `supports` key so it stays private for now: it can't
+// be set from `block.json` and third-party blocks can't opt in yet. It may
+// become a public support once the feature has settled.
+const editableRootKey = Symbol( 'editableRoot' );
+
 import { parseRawBlock as _parseRawBlock } from './parser';
 
 export const privateApis = {};
@@ -190,5 +197,6 @@ lock( privateApis, {
 	isContentBlock,
 	fieldsKey,
 	formKey,
+	editableRootKey,
 	parseRawBlock: _parseRawBlock,
 } );

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -712,11 +712,6 @@
 					"description": "This property indicates whether the block can split when the Enter key is pressed or when blocks are pasted.",
 					"type": "boolean",
 					"default": false
-				},
-				"editableRoot": {
-					"description": "This property indicates that the block works when an ancestor element (the editor canvas) is the contenteditable editing host, with focus and native selection residing there instead of on the block's own elements. It enables native partial selection across blocks.",
-					"type": "boolean",
-					"default": false
 				}
 			},
 			"additionalProperties": true

--- a/test/e2e/specs/editor/various/editable-root.spec.js
+++ b/test/e2e/specs/editor/various/editable-root.spec.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'editableRoot host mode', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'wrapper becomes the editing host for a paragraph with siblings', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'b' },
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Host mode: the selected block has a contentEditable ancestor above it
+		// (the canvas wrapper), which does not happen when the block is edited
+		// on its own element.
+		await expect
+			.poll( () =>
+				editor.canvas
+					.locator( ':root' )
+					.evaluate(
+						( root ) =>
+							!! root.ownerDocument.querySelector(
+								'[contenteditable="true"] [data-block]'
+							)
+					)
+			)
+			.toBe( true );
+	} );
+
+	test( 'a heading (no support) is not hosted', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'b' },
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+
+		await expect
+			.poll( () =>
+				editor.canvas
+					.locator( ':root' )
+					.evaluate(
+						( root ) =>
+							!! root.ownerDocument.querySelector(
+								'[contenteditable="true"] [data-block]'
+							)
+					)
+			)
+			.toBe( false );
+	} );
+} );


### PR DESCRIPTION
## What?

Moves the paragraph `editableRoot` opt-in off the public block `supports` surface (the `block.json` key and its schema entry) onto a private Symbol block setting.

## Why?

`editableRoot` (#79105) is still settling, and only the Paragraph block uses it. As a public `supports` key it reads as stable, documented API that any block can adopt. A private Symbol keeps it internal **for now**: a Symbol can't be expressed in `block.json`, so third-party blocks can't opt in, it isn't documented as a support, and we keep the freedom to reshape it. It may become a public support once the feature settles — this doesn't have to stay internal forever.

## How?

- Define `editableRootKey = Symbol( 'editableRoot' )` in the blocks private APIs, next to `fieldsKey`/`formKey`.
- Paragraph opts in through its JS settings: `settings[ editableRootKey ] = true`.
- `canHostEditableRoot` reads it off the block type: `getBlockType( name )?.[ editableRootKey ]` (instead of `hasBlockSupport( name, 'editableRoot' )`).
- Remove the `editableRoot` key from `paragraph/block.json` and the block support schema (regenerated block docs).

Behaviour is unchanged: `getBlockType( 'core/paragraph' )` still carries the setting, so the wrapper still becomes the editing host.

## Testing Instructions

1. Editing a paragraph with sibling blocks still makes the canvas the editing host (native cross-block selection works).
2. New `editable-root.spec.js` asserts this directly: the paragraph wrapper hosts, a heading (no support) does not.
3. `editable-root-compat.spec.js` still passes.

## Use of AI Tools

Written with the help of Claude Code.
