### PR TITLE
Block Editor: Fix overflowing block UI being covered after a block is moved

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -121,8 +121,11 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			return;
 		}
 
-		// Make sure the other blocks move under the selected block(s).
-		const zIndex = isPartOfSelection ? '1' : '';
+		// Make sure the other blocks move under the selected block(s). This has to
+		// clear the in-block UI of the blocks being moved past (z-index 1 and 2),
+		// which a plain `1` ties with and loses to on DOM order. Matches
+		// `.block-editor-block-list__block.is-selected`.
+		const zIndex = isPartOfSelection ? '20' : '';
 
 		const controller = new Controller( {
 			x: 0,
@@ -140,7 +143,10 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 				ref.current.style.transform = finishedMoving
 					? null // Set to `null` to explicitly remove the transform.
 					: `translate3d(${ x }px,${ y }px,0)`;
-				ref.current.style.zIndex = zIndex;
+				// Only needed while moving. Left behind, it makes the block a
+				// stacking context and clamps overflowing UI inside it, e.g. a
+				// Navigation submenu flyout renders behind its siblings.
+				ref.current.style.zIndex = finishedMoving ? null : zIndex;
 				preserveScrollPosition();
 			},
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #80823 

Stops the block reordering animation from leaving an inline `z-index` behind on the block it moved.

## Why?
The animation sets `z-index: 1` on the moved block so the other blocks slide under it, but it never takes it off again. Any block with `position: relative` is then a stacking context for good, which caps the `z-index` of anything overflowing out of it.

The visible symptom is in the Navigation block: move a menu item that has a submenu and its open flyout drops behind the menu items after it, permanently.

`1` is also too low. The menu links inside the neighbouring items are `z-index: 1` too, and the block list appender is `2`. A tie is settled by DOM order, so the later items win and cover the flyout while the animation runs.

## How?
Two lines in `useMovingAnimation`:

- Clear the `z-index` on the animation's last frame, the same way the `transform` on the line above already is. Interrupted animations are covered by the existing `controller.set( { x: 0, y: 0 } )` in the effect cleanup, which pushes a final `onChange`.
- Raise the value from `1` to `20` so it clears the in-block UI of the blocks being moved past. `20` is what `.block-editor-block-list__block.is-selected` already uses to bring the selected block forward, and the moved block is the selected block. It's only safe to go that high because the value no longer outlives the animation.

## Testing Instructions
1. On a block theme, edit a template containing a Navigation block.
2. Add enough menu items to wrap onto two rows and give several of them submenus.
3. Select a menu item with a submenu in the middle of the first row, so its flyout opens over the second row.
4. Click **Move right**, then **Move left**.
5. The flyout should stay above the other menu items throughout the move and after it.
6. Move the same item a few more times in quick succession, interrupting the animation. The flyout should never be covered, and the block should have no leftover inline `z-index` or `transform` in the inspector once it settles.

### Testing Instructions for Keyboard
1. With the submenu item selected, press <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Cmd</kbd>+<kbd>Y</kbd>
   (<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>Y</kbd> on Windows) to move it right,
   and <kbd>…</kbd>+<kbd>T</kbd> to move it left.
2. Same expectation: the flyout stays on top.

## Screenshots or screencast <!-- if applicable -->

### Before:

https://github.com/user-attachments/assets/5025eea4-7c93-4a34-a0cb-dbc9d7d8a2f1

### After:

https://github.com/user-attachments/assets/fd3ccbd6-c6c3-4e7d-88e6-f50375fbb98e
