### PR TITLE
[WP7.1] Fix cursor position during forward delete of empty blocks

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1253,10 +1253,16 @@ export const mergeBlocks =
 		}
 
 		if ( isUnmodifiedDefaultBlock( blockA ) ) {
-			dispatch.removeBlock(
-				clientIdA,
-				select.isBlockSelected( clientIdA )
-			);
+			const isASelected = select.isBlockSelected( clientIdA );
+
+			if ( isASelected ) {
+				registry.batch( () => {
+					dispatch.removeBlock( clientIdA, false );
+					dispatch.selectBlock( clientIdB, 0 );
+				} );
+			} else {
+				dispatch.removeBlock( clientIdA, false );
+			}
 			return;
 		}
 

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -242,6 +242,41 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		);
 	} );
 
+	test( 'should place the caret in the next block on forward delete from an empty paragraph', async ( {
+		editor,
+		page,
+	} ) => {
+		for ( const content of [ 'first', '', '', 'last' ] ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content },
+			} );
+		}
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.first()
+			.click();
+
+		// Forward delete removes the empty block; the caret must move to
+		// the start of the next block, not the end of the previous one,
+		// so repeated presses keep deleting forward.
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.type( '|' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'first' },
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: '|last' },
+			},
+		] );
+	} );
+
 	test( 'should remove empty paragraph block on backspace', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Manual backport of #77525 to the `wp/7.1` branch.

## Why?

Label-triggered cherry-picks don't seem to work for PRs from forked repositories, so the backport is done manually.

## Testing Instructions

The cherry-pick applied cleanly, so CI checks should be green.

## Use of AI Tools

None