### PR TITLE
DataViews: Add time field support

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   DataViews: Add a `time` field type and DataForm control.
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   DataViews: Add a `time` field type and DataForm control.
+-   DataViews: Add a `time` field type and DataForm control. [#80831](https://github.com/WordPress/gutenberg/pull/80831)
 -   DataViews: Add Shift+Click range selection through a shared `useSelectionProps` hook that layouts can adopt, wired up in the table and grid layouts.[#80046](https://github.com/WordPress/gutenberg/pull/80046)
 -   DataViewsPicker: Add Shift+Click range selection to the `picker-table`, `picker-grid`, and `picker-activity` layouts. [#80413](https://github.com/WordPress/gutenberg/pull/80413)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1256,7 +1256,7 @@ Example:
 
 ### `type`
 
-Field type. One of `text`, `integer`, `number`, `datetime`, `date`, `media`, `boolean`, `email`, `password`, `telephone`, `color`, `url`, `array`.
+Field type. One of `text`, `integer`, `number`, `datetime`, `date`, `time`, `media`, `boolean`, `email`, `password`, `telephone`, `color`, `url`, `array`.
 
 -   Type: `string`.
 -   Optional.
@@ -1547,7 +1547,7 @@ Fields that provide a `type` will have a default Edit control:
 }
 ```
 
-Field authors can override the default Edit control by providing a string that maps to one of the bundled UI controls: `array`, `checkbox`, `color`, `date`, `datetime`, `email`, `integer`, `number`, `password`, `radio`, `select`, `telephone`, `text`, `textarea`, `toggle`, `toggleGroup`, or `url`.
+Field authors can override the default Edit control by providing a string that maps to one of the bundled UI controls: `array`, `checkbox`, `color`, `date`, `datetime`, `email`, `integer`, `number`, `password`, `radio`, `select`, `telephone`, `text`, `textarea`, `time`, `toggle`, `toggleGroup`, or `url`.
 
 ```js
 {
@@ -2031,6 +2031,7 @@ Valid operators per field type:
 -   password: none.
 -   email: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
 -   text: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
+-   time: `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`.
 -   url: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
 -   fields with no type: any operator.
 

--- a/packages/dataviews/src/components/dataform-controls/index.tsx
+++ b/packages/dataviews/src/components/dataform-controls/index.tsx
@@ -27,6 +27,7 @@ import toggleGroup from './toggle-group';
 import array from './array';
 import color from './color';
 import password from './password';
+import time from './time';
 import hasElements from '../../field-types/utils/has-elements';
 
 interface FormControls {
@@ -50,6 +51,7 @@ const FORM_CONTROLS: FormControls = {
 	radio,
 	select,
 	text,
+	time,
 	toggle,
 	textarea,
 	richtext,

--- a/packages/dataviews/src/components/dataform-controls/time.tsx
+++ b/packages/dataviews/src/components/dataform-controls/time.tsx
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../../types';
+import ValidatedText from './utils/validated-input';
+
+export default function Time< Item >( props: DataFormControlProps< Item > ) {
+	return <ValidatedText { ...props } type="time" />;
+}

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -18,7 +18,7 @@ export type DataFormValidatedTextControlProps< Item > =
 		/**
 		 * The input type of the control.
 		 */
-		type?: 'text' | 'email' | 'tel' | 'url' | 'password';
+		type?: 'text' | 'email' | 'tel' | 'url' | 'password' | 'time';
 		/**
 		 * Optional prefix element to display before the input.
 		 */

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -189,6 +189,38 @@ describe( 'DataForm component', () => {
 			expect( priceInput ).toHaveValue( 3.75 );
 		} );
 
+		it( 'should edit time fields with a time input', async () => {
+			const onChange = jest.fn();
+			const timeFields = [
+				{
+					id: 'startTime',
+					label: 'Start time',
+					type: 'time' as const,
+				},
+			];
+
+			render(
+				<Dataform
+					onChange={ onChange }
+					fields={ timeFields }
+					form={ { fields: [ 'startTime' ] } }
+					data={ { startTime: '14:30' } }
+				/>
+			);
+
+			const timeInput = screen.getByLabelText( 'Start time' );
+			expect( timeInput ).toHaveAttribute( 'type', 'time' );
+			expect( timeInput ).toHaveValue( '14:30' );
+
+			const user = userEvent.setup();
+			await user.clear( timeInput );
+			await user.type( timeInput, '18:45' );
+
+			expect( onChange ).toHaveBeenLastCalledWith( {
+				startTime: '18:45',
+			} );
+		} );
+
 		it( 'should render combined fields correctly', async () => {
 			const formWithCombinedFields = {
 				fields: [

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -26,6 +26,7 @@ import { default as password } from './password';
 import { default as telephone } from './telephone';
 import { default as color } from './color';
 import { default as url } from './url';
+import { default as time } from './time';
 import { default as noType } from './no-type';
 import getIsValid from './utils/get-is-valid';
 import getFilter from './utils/get-filter';
@@ -52,6 +53,7 @@ function getFieldTypeByName< Item >( type?: FieldTypeName ): FieldType< Item > {
 		telephone,
 		color,
 		url,
+		time,
 	].find( ( fieldType ) => fieldType?.type === type );
 
 	if ( !! found ) {

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -50,6 +50,7 @@ const meta = {
 				'telephone',
 				'url',
 				'text',
+				'time',
 				'toggle',
 				'toggleGroup',
 			],
@@ -119,6 +120,7 @@ type DataType = {
 	datetimeWithElements: string;
 	date: string;
 	dateWithElements: string;
+	time: string;
 	email: string;
 	emailWithElements: string;
 	telephone: string;
@@ -160,6 +162,7 @@ const data: DataType[] = [
 		datetimeWithElements: '1982-05-10T20:30:00Z',
 		date: '2021-01-01',
 		dateWithElements: '2021-01-01',
+		time: '14:30',
 		email: 'hi@example.com',
 		emailWithElements: 'bob@example.com',
 		telephone: '+1-555-123-4567',
@@ -356,6 +359,12 @@ const fields: Field< DataType >[] = [
 			{ value: '2021-02-01', label: 'February 1st, 2021' },
 			{ value: '2021-03-01', label: 'March 1st, 2021' },
 		],
+	},
+	{
+		id: 'time',
+		type: 'time',
+		label: 'Time',
+		description: 'Help for time.',
 	},
 	{
 		id: 'email',
@@ -586,6 +595,7 @@ type ControlTypes =
 	| 'telephone'
 	| 'url'
 	| 'text'
+	| 'time'
 	| 'toggle'
 	| 'toggleGroup';
 
@@ -1162,6 +1172,37 @@ DateComponent.argTypes = {
 			'Day that the week starts on. Leave as Default to use WordPress default.',
 	},
 };
+
+export const TimeComponent = ( {
+	type,
+	Edit,
+	asyncElements,
+	manyElements,
+	disabled,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+	asyncElements: boolean;
+	manyElements: boolean;
+	disabled: boolean;
+} ) => {
+	const timeFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'time' ),
+		[]
+	);
+
+	return (
+		<FieldTypeStory
+			fields={ timeFields }
+			type={ type }
+			Edit={ Edit }
+			asyncElements={ asyncElements }
+			manyElements={ manyElements }
+			disabled={ disabled }
+		/>
+	);
+};
+TimeComponent.storyName = 'time';
 
 export const EmailComponent = ( {
 	type,

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -339,6 +339,44 @@ describe( 'normalizeFields: default getValue', () => {
 		} );
 	} );
 
+	describe( 'time fields', () => {
+		it( 'normalizes time fields using the time field definition', () => {
+			const item = { startTime: '14:30' };
+			const fields: Field< typeof item >[] = [
+				{
+					id: 'startTime',
+					type: 'time',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const field = normalizedFields[ 0 ];
+
+			expect( field.type ).toBe( 'time' );
+			expect( field.Edit ).not.toBeNull();
+			expect( field.getValueFormatted( { item, field } ) ).toBe(
+				'14:30'
+			);
+			expect( field.filterBy ).toStrictEqual( {
+				isPrimary: false,
+				operators: [
+					'is',
+					'isNot',
+					'lessThan',
+					'greaterThan',
+					'lessThanOrEqual',
+					'greaterThanOrEqual',
+				],
+			} );
+			expect(
+				field.sort(
+					{ startTime: '09:30' },
+					{ startTime: '14:30' },
+					'asc'
+				)
+			).toBeLessThan( 0 );
+		} );
+	} );
+
 	describe( 'validation normalization', () => {
 		it( 'ignores string min/max rules on numeric fields', () => {
 			const fields: Field< {} >[] = [

--- a/packages/dataviews/src/field-types/time.tsx
+++ b/packages/dataviews/src/field-types/time.tsx
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import type { FieldType } from '../types/private';
+import {
+	OPERATOR_GREATER_THAN,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_IS,
+	OPERATOR_IS_NOT,
+	OPERATOR_LESS_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+} from '../constants';
+import render from './utils/render-default';
+import sort from './utils/sort-text';
+import isValidRequired from './utils/is-valid-required';
+import isValidElements from './utils/is-valid-elements';
+import getValueFormatted from './utils/get-value-formatted-default';
+
+export default {
+	type: 'time',
+	render,
+	Edit: 'time',
+	sort,
+	enableSorting: true,
+	enableGlobalSearch: false,
+	defaultOperators: [
+		OPERATOR_IS,
+		OPERATOR_IS_NOT,
+		OPERATOR_LESS_THAN,
+		OPERATOR_GREATER_THAN,
+		OPERATOR_LESS_THAN_OR_EQUAL,
+		OPERATOR_GREATER_THAN_OR_EQUAL,
+	],
+	validOperators: [
+		// Single-selection
+		OPERATOR_IS,
+		OPERATOR_IS_NOT,
+		OPERATOR_LESS_THAN,
+		OPERATOR_GREATER_THAN,
+		OPERATOR_LESS_THAN_OR_EQUAL,
+		OPERATOR_GREATER_THAN_OR_EQUAL,
+	],
+	format: {},
+	getValueFormatted,
+	validate: {
+		required: isValidRequired,
+		elements: isValidElements,
+	},
+} satisfies FieldType< any >;

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -72,6 +72,7 @@ export type FieldTypeName =
 	| 'email'
 	| 'password'
 	| 'telephone'
+	| 'time'
 	| 'color'
 	| 'url'
 	| 'array';


### PR DESCRIPTION
## What?

Adds first-class support for time-only fields to DataViews and DataForm.

Field authors can now use `type: 'time'` to display and edit normalized time values such as `14:30`, without attaching an artificial date or timezone.

## Why?

DataViews currently supports `date` and `datetime`, but neither correctly represents a value that contains only a time. Otherwise, consumers have to use a generic text field or introduce date and time zone semantics that do not belong to the value.

## How?

The new field type composes the existing DataViews field infrastructure:

- Uses a native HTML time input through the shared validated-input control.
- Preserves values as time-only strings without timezone conversion.
- Supports equality and chronological comparison operators.
- Sorts normalized time strings chronologically.
- Reuses the existing required and element validation behavior.
- Documents the public field type, control, and supported operators.
- Adds a dedicated `DataViews/FieldTypes/time` Storybook story.

Multi-selection operators are intentionally excluded because the native time control represents a single scalar value.

## Testing Instructions

Open Storybook locally and visit FieldTypes > All / time

https://github.com/user-attachments/assets/cdcfe506-75c3-46cc-8435-016df613de8a


## Use of AI Tools

Codex was used to investigate the existing DataViews field architecture, implement the change, add tests and documentation, and review the resulting diff. I reviewed the generated changes and take responsibility for the final implementation.