### PR TITLE
Tabs block: Place the cursor at the end of a new tab title

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
+-   Tabs: Place the caret at the end of a newly added tab's default title.
 
 ### Internal
 

--- a/packages/block-library/src/tab-list/edit.js
+++ b/packages/block-library/src/tab-list/edit.js
@@ -22,6 +22,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { useEffect, useMemo, useRef } from '@wordpress/element';
 
 /**
@@ -113,7 +114,8 @@ function Edit( {
 	const menuRef = useRef();
 	const prevTabCountRef = useRef( tabsList.length );
 
-	// When tabs are added or removed, focus the appropriate button.
+	// When a tab is added, focus the end of its title. When a tab is removed,
+	// focus the appropriate remaining button.
 	useEffect( () => {
 		const prevCount = prevTabCountRef.current;
 		prevTabCountRef.current = tabsList.length;
@@ -134,9 +136,14 @@ function Edit( {
 			window.requestAnimationFrame( () => {
 				const button =
 					menuRef.current?.querySelectorAll( 'button' )?.[ index ];
-				(
-					button?.querySelector( '[contenteditable]' ) ?? button
-				)?.focus();
+				const target =
+					button?.querySelector( '[contenteditable]' ) ?? button;
+
+				if ( tabsList.length > prevCount ) {
+					placeCaretAtHorizontalEdge( target, true );
+				} else {
+					target?.focus();
+				}
 			} );
 		};
 

--- a/test/e2e/specs/editor/blocks/tabs.spec.js
+++ b/test/e2e/specs/editor/blocks/tabs.spec.js
@@ -180,6 +180,48 @@ test.describe( 'Tabs', () => {
 			await expect( tabs ).toHaveCount( 2 );
 		} );
 
+		test( 'should place the caret at the end of a newly added tab title', async ( {
+			editor,
+			page,
+		} ) => {
+			const tab2 = editor.canvas.getByRole( 'tab', { name: 'Tab 2' } );
+			await tab2.click();
+			await page.keyboard.press( 'End' );
+			await page.keyboard.press( 'Enter' );
+
+			const editable = editor.canvas
+				.getByRole( 'tab', { name: 'Tab', exact: true } )
+				.locator( '[contenteditable="true"]' );
+			await expect( editable ).toBeFocused();
+			await expect
+				.poll( () =>
+					editable.evaluate( ( element ) => {
+						const selection =
+							element.ownerDocument.defaultView.getSelection();
+						if (
+							! selection?.isCollapsed ||
+							! selection.focusNode ||
+							! element.contains( selection.focusNode )
+						) {
+							return null;
+						}
+
+						const range = element.ownerDocument.createRange();
+						range.selectNodeContents( element );
+						range.setEnd(
+							selection.focusNode,
+							selection.focusOffset
+						);
+
+						return [
+							range.toString().length,
+							element.textContent.length,
+						];
+					} )
+				)
+				.toEqual( [ 3, 3 ] );
+		} );
+
 		test( 'removes the tab and activates the previous one when pressing Delete on an empty tab label', async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?

Updates the Tabs block so the text cursor is placed at the end of a newly added tab’s default title.

Closes #80833

## Why?

Previously, the cursor was placed before the default “Tab” title. Placing it at the end makes the title easier to delete or edit using Backspace.

## How?

Uses `placeCaretAtHorizontalEdge` when a new tab is added. The existing focus behavior for removing tabs remains unchanged.

## Testing Instructions

1. Open a post or page.
2. Insert a Tabs block.
3. Place the cursor at the end of an existing tab title.
4. Press Enter to add a new tab.
5. Confirm that the new “Tab” title receives focus.
6. Press Backspace.
7. Confirm caret is at the end and the title changes from “Tab” to “Ta”.

Run the e2e tests:

```bash
npm run test:e2e -- test/e2e/specs/editor/blocks/tabs.spec.js
```

### Testing Instructions for Keyboard

1. In an empty paragraph, type `/tabs` and press Enter.
2. Move focus to a tab title.
3. Press End to move the cursor to the end of the title.
4. Press Enter to add a new tab.
5. Confirm that the new tab receives focus and its cursor is after “Tab”.
6. Press Backspace and confirm that the title changes to “Ta”.

## Screenshots or screencast

Not included because this change affects cursor placement and is best verified through the testing steps above.

## Use of AI Tools

Codex was used to help diagnose the issue, implement the fix, add regression coverage, and draft the PR description. The changes were human-reviewed, manually tested, and verified with formatting, linting, build, end-to-end tests.