### PR TITLE
Jest Preset Default: Support self-referencing via exports

### DIFF
--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   Require Jest v30 or newer and expose the Jest preset from the package root ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
+-   Add an `exports` field. Only the package root and `jest-preset` are exposed; deep imports of other files are no longer resolvable ([#80837](https://github.com/WordPress/gutenberg/pull/80837)).
 
 ## 12.51.0 (2026-07-14)
 

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -30,6 +30,11 @@
 		"jest-preset.js"
 	],
 	"main": "jest-preset.js",
+	"exports": {
+		".": "./jest-preset.js",
+		"./jest-preset": "./jest-preset.js",
+		"./package.json": "./package.json"
+	},
 	"dependencies": {
 		"@wordpress/jest-console": "file:../jest-console",
 		"babel-jest": "^30.4.1",

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -4,15 +4,6 @@
 const path = require( 'path' );
 const glob = require( 'glob' ).sync;
 
-/*
- * Resolve the directory of `@wordpress/jest-preset-default` from this
- * workspace's `node_modules`. Jest's `preset` option expects a directory
- * containing a `jest-preset.js` or `jest-preset.json` file.
- */
-const jestPresetDefaultDir = path.dirname(
-	require.resolve( '@wordpress/jest-preset-default/jest-preset.js' )
-);
-
 /**
  * Path to root project directory.
  */
@@ -59,7 +50,7 @@ module.exports = {
 			'<rootDir>/packages/block-library/src/$1.js',
 		'.+\\.wasm$': '<rootDir>/test/unit/config/wasm-stub.js',
 	},
-	preset: jestPresetDefaultDir,
+	preset: require.resolve( '@wordpress/jest-preset-default' ),
 	setupFiles: [
 		'<rootDir>/test/unit/config/global-mocks.js',
 		'<rootDir>/test/unit/config/gutenberg-env.js',


### PR DESCRIPTION
## What?

Follow up to #80767.

Adds an `exports` field to `@wordpress/jest-preset-default` so the package can be resolved by its own name from within itself, and simplifies how `test/unit/jest.config.js` points at the preset.

## Why?

The test added in #80767 does `require( '@wordpress/jest-preset-default' )` from inside the package. That only resolves because npm hoists every workspace into the root `node_modules`. Under an isolated/linked install strategy there is no root link, and the test fails with `Cannot find module '@wordpress/jest-preset-default'` — see the [failing run](https://github.com/WordPress/gutenberg/actions/runs/30432218135/job/90511799230?pr=75814) on #75814.

[Node's self-referencing](https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name) is the supported way to import a package from within itself, and it requires an `exports` field.

## How?

Adds a minimal `exports` map exposing only the package root, `jest-preset`, and `package.json`.

The `./jest-preset` entry is load-bearing. `jest-config` resolves a preset given as a bare package name by looking up the **extensionless** `<pkg>/jest-preset` subpath, and extensions are not appended to `exports` subpaths. A map without that entry breaks every consumer using `preset: "@wordpress/jest-preset-default"`, and `./jest-preset.js` does not work as a substitute.

Since the package root resolves to `jest-preset.js` (`main`, as of #80767), `test/unit/jest.config.js` can now pass the resolved path straight to `preset` instead of deriving the containing directory from a subpath import.

This narrows the published surface: `scripts/` and `index.js` still ship via `files` but are no longer resolvable as deep imports. Nothing in the repo relies on them — `jest-preset.js` reaches `scripts/` through relative `require.resolve` — but it is a breaking change for anyone deep-importing them, so it is noted in the changelog.

## Testing Instructions

1. `npm run test:unit -- packages/jest-preset-default/test/index.js` passes.
2. `npm run test:unit` passes.
3. Confirm downstream preset usage still works — in a scratch package with `@wordpress/jest-preset-default` linked and a config of `{ preset: "@wordpress/jest-preset-default" }`, Jest resolves the preset and runs. Use a fresh `--cacheDirectory`; a warm Jest cache will mask preset resolution changes.

## Use of AI Tools

Investigated and drafted with Claude Code (Opus). The `exports` shapes were verified empirically against `jest-resolve` and Node, and end to end with a standalone consumer package. Please adjust this disclosure to match your own review.
