### PR TITLE
Report Flaky Tests: Declare @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51769,7 +51769,8 @@
 				"jest-message-util": "^30.4.1"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0"
+				"@types/jest": "^30.0.0",
+				"@types/node": "^20.19.39"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -42,7 +42,8 @@
 		"jest-message-util": "^30.4.1"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0"
+		"@types/jest": "^30.0.0",
+		"@types/node": "^20.19.39"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?

Follow up to #80767.

Declares `@types/node` as a devDependency of `@wordpress/report-flaky-tests`.

## Why?

The package imports Node built-ins (`path`, `fs/promises`) and uses `process`, but never declared `@types/node`. It type checked only because a hoisted copy was present in the root `node_modules`.

Under an isolated/linked install strategy there is no root copy, and the build fails with `TS2591: Cannot find name 'path'. Do you need to install type definitions for node?` plus knock-on `TS7006` implicit-any errors — see the [failing run](https://github.com/WordPress/gutenberg/actions/runs/30432218170/job/90511799322?pr=75814) on #75814.

## How?

Adds `@types/node` to `devDependencies`, matching the version other workspaces already use.

No `tsconfig.json` change is needed. The package sets `"types": [ "jest" ]`, which restricts automatic global type inclusion, but `import`s of Node built-ins resolve through the package's own `node_modules/@types/node` once it is declared. Verified by building types with the `types` array left untouched.

## Testing Instructions

1. `npm run clean:package-types && npm run build` completes without TypeScript errors.
2. The eight `TS2591` / `TS7006` errors in `packages/report-flaky-tests/src/markdown.ts` and `src/run.ts` are gone.

## Use of AI Tools

Investigated and drafted with Claude Code (Opus). Please adjust this disclosure to match your own review.
