### PR TITLE
Apply block styles to Page List items when nested in a Submenu

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -123,6 +123,7 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
 
 	return $colors;
 }
+
 /**
  * Outputs Page list markup from an array of pages with nested children.
  *
@@ -136,10 +137,15 @@ function block_core_page_list_build_css_colors( $attributes, $context ) {
  * @param array   $active_page_ancestor_ids An array of ancestor ids for active page.
  * @param array   $colors Color information for overlay styles.
  * @param integer $depth The nesting depth.
+ * @param string  $block_css_classes  Full set of classes that would have been on the omitted
+ *                                    wrapper (from get_block_wrapper_attributes()), applied to the
+ *                                    top-level <li> elements instead when nested inside a Submenu.
+ * @param string  $block_inline_styles Full set of inline styles that would have been on the omitted
+ *                                     wrapper, applied to the top-level <li> elements instead.
  *
  * @return string List markup.
  */
-function block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids = array(), $colors = array(), $depth = 0 ) {
+function block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids = array(), $colors = array(), $depth = 0, $block_css_classes = '', $block_inline_styles = '' ) {
 	if ( empty( $nested_pages ) ) {
 		return;
 	}
@@ -152,9 +158,9 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 	$open_always   = 'always' === $submenu_visibility;
 
 	foreach ( (array) $nested_pages as $page ) {
-		$css_class       = $page['is_active'] ? ' current-menu-item' : '';
-		$aria_current    = $page['is_active'] ? ' aria-current="page"' : '';
-		$style_attribute = '';
+		$css_class          = $page['is_active'] ? ' current-menu-item' : '';
+		$aria_current       = $page['is_active'] ? ' aria-current="page"' : '';
+		$style_declarations = array();
 
 		$css_class .= in_array( $page['page_id'], $active_page_ancestor_ids, true ) ? ' current-menu-ancestor' : '';
 		if ( isset( $page['children'] ) ) {
@@ -181,9 +187,19 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 		if ( ( ( 0 < $depth && ! $is_nested ) || $is_nested ) && isset( $colors['overlay_css_classes'], $colors['overlay_inline_styles'] ) ) {
 			$css_class .= ' ' . trim( implode( ' ', $colors['overlay_css_classes'] ) );
 			if ( '' !== $colors['overlay_inline_styles'] ) {
-				$style_attribute = sprintf( ' style="%s"', esc_attr( $colors['overlay_inline_styles'] ) );
+				$style_declarations[] = trim( $colors['overlay_inline_styles'] );
 			}
 		}
+
+		if ( 0 === $depth && $is_nested ) {
+			if ( '' !== $block_css_classes ) {
+				$css_class .= ' ' . trim( $block_css_classes );
+			}
+			if ( '' !== $block_inline_styles ) {
+				$style_declarations[] = trim( $block_inline_styles );
+			}
+		}
+		$style_attribute = ! empty( $style_declarations ) ? sprintf( ' style="%s"', esc_attr( implode( ' ', $style_declarations ) ) ) : '';
 
 		if ( (int) $page['page_id'] === $front_page_id ) {
 			$css_class .= ' menu-item-home';
@@ -336,13 +352,35 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$wrapper_markup = $is_nested ? '%2$s' : '<ul %1$s>%2$s</ul>';
 
-	$items_markup = block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids, $colors );
-
-	$wrapper_attributes = get_block_wrapper_attributes(
+	$wrapper_attributes  = get_block_wrapper_attributes(
 		array(
 			'class' => $css_classes,
 			'style' => $style_attribute,
 		)
+	);
+	$block_css_classes   = '';
+	$block_inline_styles = '';
+
+	if ( $is_nested ) {
+		if ( preg_match( '/class="([^"]*)"/', $wrapper_attributes, $class_matches ) ) {
+			$block_css_classes = html_entity_decode( $class_matches[1] );
+		}
+		if ( preg_match( '/style="([^"]*)"/', $wrapper_attributes, $style_matches ) ) {
+			$block_inline_styles = html_entity_decode( $style_matches[1] );
+		}
+	}
+
+	$items_markup = block_core_page_list_render_nested_page_list(
+		$submenu_visibility,
+		$show_submenu_icons,
+		$is_navigation_child,
+		$nested_pages,
+		$is_nested,
+		$active_page_ancestor_ids,
+		$colors,
+		0,
+		$block_css_classes,
+		$block_inline_styles
 	);
 
 	return sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #80000 

This PR ensures that custom styles (like text color, background color, font size, etc.) applied to a Page List block are rendered on the frontend when the block is nested inside a Navigation Submenu. 

## Why?
When a Page List is placed inside a Submenu, its outer `<ul>` wrapper is intentionally omitted to prevent invalid HTML nesting (`<ul>` inside `<ul>`). However, because `get_block_wrapper_attributes()` was tied to that wrapper, all block support classes and inline styles were being silently discarded on the frontend, resulting in a mismatch between the editor (where styles worked) and the published site (where they disappeared).

## How?
This fix intercepts the generated wrapper attributes when the block is nested. It extracts the `class` and `style` attributes from the discarded wrapper and manually injects them into the top-level `<li>` elements (`$depth === 0`) generated by `block_core_page_list_render_nested_page_list()`. 

**Note on theme spacing:** Themes that add intentional spacing between submenu items (like Twenty Twenty-Five's `margin-bottom: 3px` for keyboard focus outline clearance) will show a thin unstyled gap between colored Page List items. This PR intentionally leaves that gap alone rather than injecting a hardcoded CSS height/margin hack, preserving the theme's box-model and accessibility choices.

This can be fixed specifically for Twenty Twenty-Five theme using:
```scss
.wp-block-navigation {
    .wp-block-navigation-submenu .wp-block-navigation-item.wp-block-page-list:not(:last-child) {
		position: relative;

		&::after {
			content: "";
			position: absolute;
			inset-inline: 0;
			inset-block-end: -3px;
			block-size: 3px;
			background-color: inherit;
			pointer-events: none;
		}
	}
}
```

## Testing Instructions
1. Go to Appearance → Editor or create a new Post/Page.
2. Insert a **Navigation** block.
3. Add a **Submenu** block inside the Navigation block.
4. Insert a **Page List** block inside the Submenu. (Ensure you have a few published pages on your site so they populate).
5. Select the nested Page List block and use the Styles sidebar to apply a custom **Text** color and **Background** color.
6. Confirm the styles apply correctly in the Editor.
7. Save and view the site on the frontend.
8. Open the submenu and verify that the text and background colors are now correctly applied to the Page List items.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="406" height="464" alt="image" src="https://github.com/user-attachments/assets/fb7e1a17-f38c-4c35-896a-8dea6e19ed7b" />|<img width="408" height="460" alt="image" src="https://github.com/user-attachments/assets/62785c54-5086-4b83-b8a0-63e499ee2ead" />|
