### PR TITLE
Table of Contents: Replace "Convert to static list" with confirmed "Detach" action

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -123,20 +123,6 @@ function TableOfContentsToolbar( {
 	);
 }
 
-/**
- * Table of Contents block edit component.
- *
- * @param {Object}                       props                                   The props.
- * @param {Object}                       props.attributes                        The block attributes.
- * @param {HeadingData[]}                props.attributes.headings               The list of data for each heading in the post.
- * @param {boolean}                      props.attributes.onlyIncludeCurrentPage Whether to only include headings from the current page (if the post is paginated).
- * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or null to include all levels.
- * @param {boolean}                      props.attributes.ordered                Whether to display as an ordered list (true) or unordered list (false).
- * @param {string}                       props.clientId                          The client id.
- * @param {(attributes: Object) => void} props.setAttributes                     The set attributes function.
- *
- * @return {Component} The component.
- */
 export default function TableOfContentsEdit( {
 	attributes: {
 		headings = [],

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -41,6 +41,70 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 /** @typedef {import('./utils').HeadingData} HeadingData */
 
+function TableOfContentsToolbar( {
+	clientId,
+	headingTree,
+	ordered,
+	setAttributes,
+} ) {
+	const canInsertList = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, canInsertBlockType } =
+				select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+
+			return canInsertBlockType( 'core/list', rootClientId );
+		},
+		[ clientId ]
+	);
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	return (
+		<>
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ isRTL() ? formatListBulletsRTL : formatListBullets }
+					title={ __( 'Unordered' ) }
+					description={ __( 'Convert to unordered list' ) }
+					onClick={ () => setAttributes( { ordered: false } ) }
+					isActive={ ordered === false }
+				/>
+				<ToolbarButton
+					icon={
+						isRTL() ? formatListNumberedRTL : formatListNumbered
+					}
+					title={ __( 'Ordered' ) }
+					description={ __( 'Convert to ordered list' ) }
+					onClick={ () => setAttributes( { ordered: true } ) }
+					isActive={ ordered === true }
+				/>
+			</ToolbarGroup>
+			{ canInsertList && (
+				<ToolbarGroup>
+					<ToolbarButton
+						onClick={ () =>
+							replaceBlocks(
+								clientId,
+								createBlock( 'core/list', {
+									ordered,
+									values: renderToString(
+										<TableOfContentsList
+											nestedHeadingList={ headingTree }
+											ordered={ ordered }
+										/>
+									),
+								} )
+							)
+						}
+					>
+						{ __( 'Convert to static list' ) }
+					</ToolbarButton>
+				</ToolbarGroup>
+			) }
+		</>
+	);
+}
+
 /**
  * Table of Contents block edit component.
  *
@@ -83,63 +147,17 @@ export default function TableOfContentsEdit( {
 		} );
 	};
 
-	const canInsertList = useSelect(
-		( select ) => {
-			const { getBlockRootClientId, canInsertBlockType } =
-				select( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
-
-			return canInsertBlockType( 'core/list', rootClientId );
-		},
-		[ clientId ]
-	);
-
-	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const headingTree = linearToNestedHeadingList( headings );
 
 	const toolbarControls = (
 		<BlockControls>
-			<ToolbarGroup>
-				<ToolbarButton
-					icon={ isRTL() ? formatListBulletsRTL : formatListBullets }
-					title={ __( 'Unordered' ) }
-					description={ __( 'Convert to unordered list' ) }
-					onClick={ () => setAttributes( { ordered: false } ) }
-					isActive={ ordered === false }
-				/>
-				<ToolbarButton
-					icon={
-						isRTL() ? formatListNumberedRTL : formatListNumbered
-					}
-					title={ __( 'Ordered' ) }
-					description={ __( 'Convert to ordered list' ) }
-					onClick={ () => setAttributes( { ordered: true } ) }
-					isActive={ ordered === true }
-				/>
-			</ToolbarGroup>
-			{ canInsertList && (
-				<ToolbarGroup>
-					<ToolbarButton
-						onClick={ () =>
-							replaceBlocks(
-								clientId,
-								createBlock( 'core/list', {
-									ordered,
-									values: renderToString(
-										<TableOfContentsList
-											nestedHeadingList={ headingTree }
-											ordered={ ordered }
-										/>
-									),
-								} )
-							)
-						}
-					>
-						{ __( 'Convert to static list' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			) }
+			<TableOfContentsToolbar
+				clientId={ clientId }
+				headingTree={ headingTree }
+				ordered={ ordered }
+				setAttributes={ setAttributes }
+			/>
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -20,7 +20,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { renderToString, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { store as noticeStore } from '@wordpress/notices';
@@ -36,7 +36,7 @@ import {
  * Internal dependencies
  */
 import TableOfContentsList from './list';
-import { linearToNestedHeadingList } from './utils';
+import { createListItemBlocks, linearToNestedHeadingList } from './utils';
 import { useObserveHeadings } from './hooks';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
@@ -104,15 +104,11 @@ function TableOfContentsToolbar( {
 						setIsConfirmingDetach( false );
 						replaceBlocks(
 							clientId,
-							createBlock( 'core/list', {
-								ordered,
-								values: renderToString(
-									<TableOfContentsList
-										nestedHeadingList={ headingTree }
-										ordered={ ordered }
-									/>
-								),
-							} )
+							createBlock(
+								'core/list',
+								{ ordered },
+								createListItemBlocks( headingTree, ordered )
+							)
 						);
 					} }
 					onCancel={ () => setIsConfirmingDetach( false ) }
@@ -261,7 +257,7 @@ export default function TableOfContentsEdit( {
 
 	// If there are no headings or the only heading is empty.
 	// Note that the toolbar controls are intentionally omitted since the
-	// "Convert to static list" option is useless to the placeholder state.
+	// "Detach" option is useless to the placeholder state.
 	if ( headings.length === 0 ) {
 		return (
 			<>

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -115,7 +115,7 @@ function TableOfContentsToolbar( {
 					size="medium"
 				>
 					{ __(
-						'The table of contents lists the headings in the post. Detaching will enable you to edit, reorder, or remove entries. However, new headings will no longer be added automatically.'
+						'The Table of Contents block lists the headings in the post. Detaching will enable you to edit, reorder, or remove entries. However, new headings will no longer be added automatically.'
 					) }
 				</ConfirmDialog>
 			) }

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -15,11 +15,12 @@ import {
 	SelectControl,
 	ToolbarButton,
 	ToolbarGroup,
+	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { renderToString } from '@wordpress/element';
+import { renderToString, useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { store as noticeStore } from '@wordpress/notices';
@@ -58,48 +59,69 @@ function TableOfContentsToolbar( {
 		[ clientId ]
 	);
 	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const [ isConfirmingDetach, setIsConfirmingDetach ] = useState( false );
 
 	return (
 		<>
-			<ToolbarGroup>
-				<ToolbarButton
-					icon={ isRTL() ? formatListBulletsRTL : formatListBullets }
-					title={ __( 'Unordered' ) }
-					description={ __( 'Convert to unordered list' ) }
-					onClick={ () => setAttributes( { ordered: false } ) }
-					isActive={ ordered === false }
-				/>
-				<ToolbarButton
-					icon={
-						isRTL() ? formatListNumberedRTL : formatListNumbered
-					}
-					title={ __( 'Ordered' ) }
-					description={ __( 'Convert to ordered list' ) }
-					onClick={ () => setAttributes( { ordered: true } ) }
-					isActive={ ordered === true }
-				/>
-			</ToolbarGroup>
-			{ canInsertList && (
+			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						onClick={ () =>
-							replaceBlocks(
-								clientId,
-								createBlock( 'core/list', {
-									ordered,
-									values: renderToString(
-										<TableOfContentsList
-											nestedHeadingList={ headingTree }
-											ordered={ ordered }
-										/>
-									),
-								} )
-							)
+						icon={
+							isRTL() ? formatListBulletsRTL : formatListBullets
 						}
-					>
-						{ __( 'Convert to static list' ) }
-					</ToolbarButton>
+						title={ __( 'Unordered' ) }
+						description={ __( 'Convert to unordered list' ) }
+						onClick={ () => setAttributes( { ordered: false } ) }
+						isActive={ ordered === false }
+					/>
+					<ToolbarButton
+						icon={
+							isRTL() ? formatListNumberedRTL : formatListNumbered
+						}
+						title={ __( 'Ordered' ) }
+						description={ __( 'Convert to ordered list' ) }
+						onClick={ () => setAttributes( { ordered: true } ) }
+						isActive={ ordered === true }
+					/>
 				</ToolbarGroup>
+				{ canInsertList && (
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ () => setIsConfirmingDetach( true ) }
+						>
+							{ __( 'Detach' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				) }
+			</BlockControls>
+			{ isConfirmingDetach && (
+				<ConfirmDialog
+					isOpen
+					title={ __( 'Detach Table of Contents' ) }
+					__experimentalHideHeader={ false }
+					confirmButtonText={ __( 'Detach' ) }
+					onConfirm={ () => {
+						setIsConfirmingDetach( false );
+						replaceBlocks(
+							clientId,
+							createBlock( 'core/list', {
+								ordered,
+								values: renderToString(
+									<TableOfContentsList
+										nestedHeadingList={ headingTree }
+										ordered={ ordered }
+									/>
+								),
+							} )
+						);
+					} }
+					onCancel={ () => setIsConfirmingDetach( false ) }
+					size="medium"
+				>
+					{ __(
+						'The table of contents lists the headings in the post. Detaching will enable you to edit, reorder, or remove entries. However, new headings will no longer be added automatically.'
+					) }
+				</ConfirmDialog>
 			) }
 		</>
 	);
@@ -151,14 +173,12 @@ export default function TableOfContentsEdit( {
 	const headingTree = linearToNestedHeadingList( headings );
 
 	const toolbarControls = (
-		<BlockControls>
-			<TableOfContentsToolbar
-				clientId={ clientId }
-				headingTree={ headingTree }
-				ordered={ ordered }
-				setAttributes={ setAttributes }
-			/>
-		</BlockControls>
+		<TableOfContentsToolbar
+			clientId={ clientId }
+			headingTree={ headingTree }
+			ordered={ ordered }
+			setAttributes={ setAttributes }
+		/>
 	);
 
 	const inspectorControls = (

--- a/packages/block-library/src/table-of-contents/utils.ts
+++ b/packages/block-library/src/table-of-contents/utils.ts
@@ -1,3 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import type { Block } from '@wordpress/blocks';
+import { escapeAttribute, escapeHTML } from '@wordpress/escape-html';
+
 export interface HeadingData {
 	/** The plain text content of the heading. */
 	content: string;
@@ -68,4 +75,43 @@ export function linearToNestedHeadingList(
 	} );
 
 	return nestedHeadingList;
+}
+
+/**
+ * Converts a nested heading list into `core/list-item` blocks, with
+ * sub-headings nested in a `core/list` block inside their parent item.
+ *
+ * @param nestedHeadingList The nested list of headings.
+ * @param ordered           Whether nested lists are ordered.
+ *
+ * @return The list item blocks.
+ */
+export function createListItemBlocks(
+	nestedHeadingList: NestedHeadingData[],
+	ordered: boolean
+): Block[] {
+	return nestedHeadingList.map(
+		( { heading: { content, link }, children } ) =>
+			createBlock(
+				'core/list-item',
+				{
+					// Headings are plain text, and links can carry query args on
+					// paginated posts, so both need escaping to become markup.
+					content: link
+						? `<a href="${ escapeAttribute( link ) }">${ escapeHTML(
+								content
+						  ) }</a>`
+						: escapeHTML( content ),
+				},
+				children
+					? [
+							createBlock(
+								'core/list',
+								{ ordered },
+								createListItemBlocks( children, ordered )
+							),
+					  ]
+					: []
+			)
+	);
 }

--- a/packages/block-library/src/table-of-contents/utils.ts
+++ b/packages/block-library/src/table-of-contents/utils.ts
@@ -3,7 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import type { Block } from '@wordpress/blocks';
-import { escapeAttribute, escapeHTML } from '@wordpress/escape-html';
+import { escapeAttribute, escapeEditableHTML } from '@wordpress/escape-html';
 
 export interface HeadingData {
 	/** The plain text content of the heading. */
@@ -98,12 +98,12 @@ export function createListItemBlocks(
 					// Headings are plain text, and links can carry query args on
 					// paginated posts, so both need escaping to become markup.
 					content: link
-						? `<a href="${ escapeAttribute( link ) }">${ escapeHTML(
-								content
-						  ) }</a>`
-						: escapeHTML( content ),
+						? `<a href="${ escapeAttribute(
+								link
+						  ) }">${ escapeEditableHTML( content ) }</a>`
+						: escapeEditableHTML( content ),
 				},
-				children
+				children?.length
 					? [
 							createBlock(
 								'core/list',


### PR DESCRIPTION
## What?
See related discussion in #80613.

Renames the Table of Contents block's "Convert to static list" toolbar button to "Detach", behind a confirmation dialog, and builds the resulting list with the v2 list block schema, fixing the undo trap.

## Why?

- "Detach" matches the convention introduced by the Gallery block for breaking a block's link to its dynamic source, so both blocks explain the change the same way.
- The conversion created a `core/list` block using the deprecated v1 `values` attribute, forcing a v1 → v2 migration on every converted block.

## Testing Instructions

1. Add a few Heading blocks with HTML anchors, including sub-levels.
2. Insert a Table of Contents block and select it.
3. Click "Detach" in the toolbar and confirm the dialog.
4. The block becomes a list with linked entries, sub-headings nested as inner lists.
5. Check the code editor: the list serializes as `core/list` + `core/list-item` blocks, no `values` attribute.
6. Cancel path: dialog dismisses, block unchanged.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/58a31e7b-a194-4747-883f-952a928f50ab

**After**

https://github.com/user-attachments/assets/8bbdd44f-1c02-4e04-b292-760880975332


## Use of AI Tools

Assisted by Claude
