### PR TITLE
Boot: Adjust specificity of the image reset styles so components can size their own images

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Adjust the specificity of the responsive image default in the layout container so components can size their own images ([#80845](https://github.com/WordPress/gutenberg/pull/80845)).
+
 ## 0.18.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -21,11 +21,12 @@
 			min-height: 100vh;
 		}
 	}
+}
 
-	img {
-		max-width: 100%;
-		height: auto;
-	}
+// `:where()` so components can still size their own images.
+:where(.boot-layout) img {
+	max-width: 100%;
+	height: auto;
 }
 
 .boot-layout .boot-notices__snackbar {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Wraps the `img` reset in `:where()` so it stops overriding components that set their own image sizes.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Found this in the font library. On "Appearance > Fonts" the cards come out at different heights creating some sort of jump when the font list is loaded, while the exact same list in the font library modal is consistent. 

While trying to find why, I've found that the the reset is nested, so it compiles to `.boot-layout-container .boot-layout img`, one tag selector more specific than the font library's `.font-library__font-card .font-library__font-variant_demo-image`. `height: auto` wins, the previews render at their natural ratio instead of the 24px they're given (I measured images from 22 to 28px), and each row ends up as tall as its image.

The rule itself is right, an image of unknown size shouldn't blow out the layout. But the problem is that it's beating the components trying to set sizes for their images. 

I can imagine this can become more evident when we start seeing more of these pages, with Dataviews  (found a few places where it would happen the same).

I asked about this in the PR where the reset was added, in case the specificity was serving a specific purpose. No reply yet, so opening this in the meantime, happy to close it if it turns out to be intentional.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`:where()` matches exactly the same images but contributes no specificity, so the reset still catches anything without a more specific rule and loses to anything with one. Removed the `.boot-layout-container` part since it was only there due to nesting.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open Appearance > Fonts.
2. Go to "Install fonts" (authorize google if necessary)
3. Navigate the different pages, and confirm the images on `.font-library__font-card .font-library__font-variant_demo-image` have a computed height of `24px`.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
**After the fix**

https://github.com/user-attachments/assets/421fc605-f617-4ffc-930e-be01f938be71

**Before the fix** (see the jump while navigating)

https://github.com/user-attachments/assets/11867641-f2fc-49ed-99f1-2388ca23fb21





