### PR TITLE
CheckboxControl: Add "With Visual" Storybook story

### DIFF
--- a/packages/components/src/checkbox-control/stories/index.story.tsx
+++ b/packages/components/src/checkbox-control/stories/index.story.tsx
@@ -1,16 +1,7 @@
-/**
- * External dependencies
- */
-import type { Meta, StoryFn } from '@storybook/react-vite';
-
-/**
- * WordPress dependencies
- */
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { wordpress } from '@wordpress/icons';
+import { Icon, Stack } from '@wordpress/ui';
 import CheckboxControl from '..';
 import { VStack } from '../../v-stack';
 import { HStack } from '../../h-stack';
@@ -44,15 +35,17 @@ const meta: Meta< typeof CheckboxControl > = {
 };
 export default meta;
 
-const DefaultTemplate: StoryFn< typeof CheckboxControl > = ( {
+type Story = StoryObj< typeof CheckboxControl >;
+
+function ControlledCheckboxControl( {
 	onChange,
-	...args
-} ) => {
+	...props
+}: React.ComponentProps< typeof CheckboxControl > ) {
 	const [ isChecked, setChecked ] = useState( true );
 
 	return (
 		<CheckboxControl
-			{ ...args }
+			{ ...props }
 			checked={ isChecked }
 			onChange={ ( v ) => {
 				setChecked( v );
@@ -60,65 +53,68 @@ const DefaultTemplate: StoryFn< typeof CheckboxControl > = ( {
 			} }
 		/>
 	);
+}
+ControlledCheckboxControl.displayName = 'CheckboxControl';
+
+export const Default: Story = {
+	render: ( args ) => <ControlledCheckboxControl { ...args } />,
+	args: {
+		label: 'Is author',
+		help: 'Is the user an author or not?',
+	},
 };
 
-export const Default: StoryFn< typeof CheckboxControl > = DefaultTemplate.bind(
-	{}
-);
-Default.args = {
-	label: 'Is author',
-	help: 'Is the user an author or not?',
-};
+export const Indeterminate: Story = {
+	render: ( { onChange, ...args } ) => {
+		const [ fruits, setFruits ] = useState( {
+			apple: false,
+			orange: false,
+		} );
 
-export const Indeterminate: StoryFn< typeof CheckboxControl > = ( {
-	onChange,
-	...args
-} ) => {
-	const [ fruits, setFruits ] = useState( { apple: false, orange: false } );
+		const isAllChecked = Object.values( fruits ).every( Boolean );
+		const isIndeterminate =
+			Object.values( fruits ).some( Boolean ) && ! isAllChecked;
 
-	const isAllChecked = Object.values( fruits ).every( Boolean );
-	const isIndeterminate =
-		Object.values( fruits ).some( Boolean ) && ! isAllChecked;
-
-	return (
-		<VStack>
-			<CheckboxControl
-				{ ...args }
-				checked={ isAllChecked }
-				indeterminate={ isIndeterminate }
-				onChange={ ( v ) => {
-					setFruits( {
-						apple: v,
-						orange: v,
-					} );
-					onChange( v );
-				} }
-			/>
-			<CheckboxControl
-				label="Apple"
-				checked={ fruits.apple }
-				onChange={ ( apple ) =>
-					setFruits( ( prevState ) => ( {
-						...prevState,
-						apple,
-					} ) )
-				}
-			/>
-			<CheckboxControl
-				label="Orange"
-				checked={ fruits.orange }
-				onChange={ ( orange ) =>
-					setFruits( ( prevState ) => ( {
-						...prevState,
-						orange,
-					} ) )
-				}
-			/>
-		</VStack>
-	);
-};
-Indeterminate.args = {
-	label: 'Select all',
+		return (
+			<VStack>
+				<CheckboxControl
+					{ ...args }
+					checked={ isAllChecked }
+					indeterminate={ isIndeterminate }
+					onChange={ ( v ) => {
+						setFruits( {
+							apple: v,
+							orange: v,
+						} );
+						onChange( v );
+					} }
+				/>
+				<CheckboxControl
+					label="Apple"
+					checked={ fruits.apple }
+					onChange={ ( apple ) =>
+						setFruits( ( prevState ) => ( {
+							...prevState,
+							apple,
+						} ) )
+					}
+				/>
+				<CheckboxControl
+					label="Orange"
+					checked={ fruits.orange }
+					onChange={ ( orange ) =>
+						setFruits( ( prevState ) => ( {
+							...prevState,
+							orange,
+						} ) )
+					}
+				/>
+			</VStack>
+		);
+	},
+	args: {
+		label: 'Select all',
+	},
 };
 
 /**
@@ -131,35 +127,67 @@ Indeterminate.args = {
  * Similarly, a custom description can be added by omitting the `help` prop
  * and using the `aria-describedby` prop instead.
  */
-export const WithCustomLabel: StoryFn< typeof CheckboxControl > = ( {
-	onChange,
-	...args
-} ) => {
-	const [ isChecked, setChecked ] = useState( true );
+export const WithCustomLabel: Story = {
+	render: ( { onChange, ...args } ) => {
+		const [ isChecked, setChecked ] = useState( true );
 
-	return (
-		<HStack justify="flex-start" alignment="top" spacing={ 0 }>
-			<CheckboxControl
-				{ ...args }
-				checked={ isChecked }
-				onChange={ ( v ) => {
-					setChecked( v );
-					onChange( v );
+		return (
+			<HStack justify="flex-start" alignment="top" spacing={ 0 }>
+				<CheckboxControl
+					{ ...args }
+					checked={ isChecked }
+					onChange={ ( v ) => {
+						setChecked( v );
+						onChange( v );
+					} }
+					// Disable reason: For simplicity of the code snippet.
+					// eslint-disable-next-line no-restricted-syntax
+					id="my-checkbox-with-custom-label"
+					aria-describedby="my-custom-description"
+				/>
+				<VStack>
+					<label htmlFor="my-checkbox-with-custom-label">
+						My custom label
+					</label>
+					{ /* eslint-disable-next-line no-restricted-syntax */ }
+					<div id="my-custom-description" style={ { fontSize: 13 } }>
+						A custom description.
+					</div>
+				</VStack>
+			</HStack>
+		);
+	},
+};
+
+/**
+ * When adding a visual aid, prefer placing it at the trailing end of the row,
+ * rather than placing it directly before the label, or moving the checkbox to the trailing end.
+ */
+export const WithVisual: Story = {
+	...Default,
+	render: ( args ) => (
+		<Stack gap="md" align="flex-start" justify="space-between">
+			<Stack>
+				<ControlledCheckboxControl { ...args } />
+			</Stack>
+			<Stack
+				align="center"
+				justify="center"
+				style={ {
+					backgroundColor:
+						'var(--wpds-color-background-surface-neutral-weak)',
+					borderRadius: 'var(--wpds-border-radius-md)',
+					flexShrink: 0,
+					height: 'var(--wpds-dimension-size-lg)',
+					width: 'var(--wpds-dimension-size-lg)',
 				} }
-				// Disable reason: For simplicity of the code snippet.
-				// eslint-disable-next-line no-restricted-syntax
-				id="my-checkbox-with-custom-label"
-				aria-describedby="my-custom-description"
-			/>
-			<VStack>
-				<label htmlFor="my-checkbox-with-custom-label">
-					My custom label
-				</label>
-				{ /* eslint-disable-next-line no-restricted-syntax */ }
-				<div id="my-custom-description" style={ { fontSize: 13 } }>
-					A custom description.
-				</div>
-			</VStack>
-		</HStack>
-	);
+			>
+				<Icon icon={ wordpress } />
+			</Stack>
+		</Stack>
+	),
+	args: {
+		...Default.args,
+		help: 'Additional context that helps users understand what this setting does and when they might want to turn it on or off.',
+	},
 };


### PR DESCRIPTION
Follow-up to #80803

## What?

Adds a `WithVisual` Storybook story to `CheckboxControl`, demonstrating a pattern for placing a visual aid at the trailing end of the control row.

Also converts the existing stories to the object story format.

## Why?

We want consistent guidance for composing checkbox-like controls with visuals. A common pattern we see in the wild is the visual being inserted _between_ the checkbox and label, or the visual being placed at the starting end of the row and the checkbox being moved to the trailing end. There are several downsides to this:

1. It requires custom composition of the control component, instead of just using the `CheckboxControl` out of the box.
2. It makes the click target unclear. Usually, clicking the label would toggle the control, but it's unclear when the checkbox isn't directly adjacent to the label. And probably sometimes the custom implementation would forget to set an appropriate click target.
3. The placement of the checkbox shouldn't shift around. It should stay on the same side for all instances.

## Testing Instructions

1. Run Storybook and open **Components / Selection & Input / Common / CheckboxControl**.
2. Open the **With Visual** story.
3. Confirm the checkbox, label, help text, and trailing icon layout look correct.
4. Toggle the control and confirm it still updates as expected.

## Screenshots

<img width="653" height="241" alt="Checkbox story with trailing visual" src="https://github.com/user-attachments/assets/bf249131-329c-4965-ac91-44419ffee1b5" />
