### PR TITLE
Add Gutenberg PR review skill

### DIFF
--- a/.skills/gutenberg-pr-review/SKILL.md
+++ b/.skills/gutenberg-pr-review/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: gutenberg-pr-review
+description: Review WordPress/Gutenberg pull requests, branches, or diffs for project-specific correctness, compatibility, accessibility, data-lifecycle, block, PHP/REST, testing, tooling, documentation, and release risks. Use for pre-submit reviews, PR review comments, or checking a proposed Gutenberg change against recurring maintainer concerns.
+---
+
+# Gutenberg PR Review
+
+Review the change, not a generic checklist. Load only the references relevant to
+the touched areas, verify each suspected problem against the actual diff and
+current repository, and report only actionable findings.
+
+## Establish scope
+
+1. Read the PR description, linked issue, testing instructions, diff, and
+   changed-file list. If only a branch is supplied, compare it with the
+   repository's configured base.
+2. Identify the stated behavior and affected contracts: runtime, public API,
+   serialized content, accessibility, package output, REST schema, generated
+   files, documentation, or release state.
+3. Inspect surrounding implementation, tests, package metadata, and governing
+   contributor documentation before declaring a convention.
+4. Treat repository `AGENTS.md` instructions as authoritative. Do not replace
+   them with historical review patterns.
+
+For a GitHub PR:
+
+```bash
+gh pr view <number> --repo WordPress/gutenberg
+gh pr diff <number> --repo WordPress/gutenberg
+```
+
+For a local branch:
+
+```bash
+git diff <base>...<branch>
+git log <base>..<branch> --oneline
+```
+
+## Load focused guidance
+
+Read the directly relevant files; combine them for cross-cutting changes.
+
+- UI components, interaction, keyboard, focus, styles, responsive behavior,
+  localization: [references/ui-accessibility.md](references/ui-accessibility.md)
+- React hooks, `@wordpress/data`, async work, entities, preferences,
+  performance: [references/react-data-lifecycle.md](references/react-data-lifecycle.md)
+- Package layering, exports, public APIs, blocks, saved markup, compatibility:
+  [references/packages-apis-compatibility.md](references/packages-apis-compatibility.md)
+- PHP, REST routes and schemas, permissions, sanitization, escaping:
+  [references/php-rest-schema.md](references/php-rest-schema.md)
+- Workspaces, dependencies, builds, CI, generated artifacts, releases:
+  [references/tooling-ci-release.md](references/tooling-ci-release.md)
+- Tests, changelogs, documentation, fixtures, snapshots, delivery evidence:
+  [references/testing-docs-delivery.md](references/testing-docs-delivery.md)
+
+## Review method
+
+Follow changed values and state across their complete lifecycle:
+
+```text
+input → validation → state/store → serialization or request
+      → async completion/error → rendered output → cleanup/recovery
+```
+
+At each affected boundary, check:
+
+- whether absent, empty, `false`, `null`, and `undefined` retain their intended
+  meanings;
+- whether authorization and validation occur before side effects;
+- whether loading, empty, success, failure, cancellation, and retry states are
+  distinguishable;
+- whether old public consumers or stored content remain valid;
+- whether keyboard, pointer, screen-reader, RTL, narrow-viewport, and reduced
+  motion behavior remains equivalent where relevant;
+- whether tests exercise observable behavior and would fail without the fix;
+- whether metadata, types, docs, changelogs, generated output, and published
+  artifacts agree with runtime behavior.
+
+Search for existing helpers, analogous implementations, public consumers, and
+fixtures before suggesting a new abstraction or claiming a break. Check both
+editor and frontend behavior for block/style changes.
+
+## Finding threshold
+
+Report a finding only when the diff introduces or exposes a concrete defect,
+compatibility risk, missing consequential verification, unsafe workflow, or
+material maintainability problem.
+
+- Cite the changed file and line.
+- Explain the failure scenario and affected user or consumer.
+- State the smallest credible remedy or the verification needed.
+- Distinguish a must-fix issue from a non-blocking improvement.
+- Phrase uncertain issues as a focused question and say what evidence is
+  missing.
+- Do not report personal style preferences, speculative generalities,
+  pre-existing problems outside the change, or requirements contradicted by
+  current repository evidence.
+- Avoid duplicate findings when one root cause explains several symptoms.
+
+## Output
+
+Lead with findings ordered by severity. Use:
+
+```markdown
+### Must fix
+
+- `path/file.js:42` — Concise defect title. Explain the failing path, impact,
+  and required correction.
+
+### Should fix
+
+- `path/file.js:87` — Concrete non-blocking risk and proportionate remedy.
+```
+
+Omit empty severity sections. After findings, optionally include a short
+summary and residual testing risks. If there are no findings, say so directly
+and name any meaningful verification gap.
+
+## Evidence provenance
+
+This guidance was distilled from a frozen audit of every Gutenberg PR and its
+review/discussion artifacts through PR #80540: 47,037 PRs (35,935 merged,
+8,654 closed without merge, and 2,448 open), 561,837 artifacts collected, and
+233,370 substantive human-authored artifacts individually audited. The audit
+produced 133,803 candidate findings; multi-pass consolidation and editorial
+triage produced 127 candidate rules.
+
+Those candidates were validated against `origin/trunk` commit
+`49120c3204955ba1f83c7224793f52813689e7e1` on 2026-07-28, then delta-checked
+and updated through commit `03a6675a25ede7f8e31e5232742615f95358bcb6`.
+Historical review evidence establishes recurrence, not present-day truth;
+current code and repository instructions always win.

--- a/.skills/gutenberg-pr-review/references/packages-apis-compatibility.md
+++ b/.skills/gutenberg-pr-review/references/packages-apis-compatibility.md
@@ -1,0 +1,67 @@
+# Packages, APIs, blocks, and compatibility
+
+Use this reference for public exports, package layering, types, metadata, block
+serialization, transforms, Block Supports, and WordPress compatibility.
+
+## Public contracts
+
+- Before changing a public function, component, selector, block, or package,
+  inventory consumers and preserve names, arguments, return types, props,
+  accepted values, context behavior, and durable stored representations.
+- Expose only deliberate documented APIs. Use private/plugin-only mechanisms
+  for unsettled internals; do not introduce new `__experimental` or
+  `__unstable` APIs. Deprecate legacy experimental APIs that already shipped.
+- External consumers must use documented public APIs. Cross-package private
+  access inside the repository must follow `@wordpress/private-apis`.
+- Preserve distinct sentinel meanings explicitly; do not collapse omission,
+  `undefined`, `null`, `false`, and empty values through truthiness.
+- When a documented public API or durable stored contract cannot be preserved
+  directly, provide a supported alternative, deprecation metadata, migration
+  path, correctly classified changelog entry, and a Dev Note when third-party
+  developers are affected. Private APIs do not promise external compatibility;
+  before removing one, inventory and update in-repository consumers,
+  private-API documentation, and the package changelog.
+- Keep runtime exports, JSDoc/TypeScript declarations, generated API docs,
+  READMEs, examples, changelogs, and migration guidance synchronized.
+
+## Package architecture
+
+- Preserve editor layering: `block-editor` stays standalone and independent of
+  higher WordPress screen layers; post-aware screen-neutral behavior belongs in
+  `editor`; screen-specific behavior belongs in `edit-post` or `edit-site`.
+- Keep declarations faithful to runtime values. Prefer precise object,
+  function, promise, generic, key, and optional-value types; do not broaden
+  types merely to silence strict checks.
+- For public package builds, verify `files`, `main`, `module`, `exports`, types,
+  styles, side effects, dependencies, and WordPress script/script-module
+  exposure against the artifacts actually published.
+- Keep supported Node, npm, browser, PHP, and WordPress targets aligned between
+  metadata and CI.
+- Keep compatibility branches and suppressions narrow, documented, and
+  removable; do not let an exception mask unrelated violations.
+
+## Blocks and durable content
+
+- Use schema-valid `block.json` as canonical metadata and register server-side
+  when REST exposure or metadata-managed assets require it.
+- Treat static saved markup as durable. If a change invalidates old content,
+  provide a self-contained deprecated version and fixtures covering parsing,
+  migration, inner blocks, attributes, and serialization—or introduce a new
+  block when migration is not credible.
+- Keep static `save` pure and dependent on attributes. Persist required values
+  or use dynamic server rendering when output depends on external state.
+- Treat edit rendering, static serialization, and dynamic PHP rendering as
+  separate contracts and verify each affected path.
+- Use Block Supports and the appropriate wrapper API:
+  `useBlockProps`, `useBlockProps.save`, or
+  `get_block_wrapper_attributes()`.
+- Define each transform direction explicitly, return valid block objects,
+  withhold inapplicable transforms with `isMatch`, and preserve inner blocks
+  where the target supports them.
+- Express static nesting with `parent`, `ancestor`, and `allowedBlocks`;
+  provide per-instance restrictions through `useInnerBlocksProps`; honor
+  locking and capability selectors before offering structural operations.
+- Preserve original source markup when an invalid block is serialized. Keep
+  recovery or conversion explicit rather than silently rewriting content.
+- When block or `theme.json` metadata shapes change, update and validate the
+  applicable JSON schema.

--- a/.skills/gutenberg-pr-review/references/php-rest-schema.md
+++ b/.skills/gutenberg-pr-review/references/php-rest-schema.md
@@ -1,0 +1,49 @@
+# PHP, REST, schema, and security
+
+Use this reference for `lib/`, REST controllers and routes, schemas,
+permissions, sanitization, escaping, and compatibility shims.
+
+## Compatibility and loading
+
+- Put new compatibility code in the applicable
+  `lib/compat/wordpress-X.Y/` directory and register required version layers in
+  `lib/load.php`.
+- Guard fallback definitions with direct capability checks when functions or
+  classes may already exist.
+- For Gutenberg-to-Core synchronization, identify all eligible PHP files. Keep
+  direct-sync files byte-identical and port only relevant changes from
+  versioned shims to their Core destinations.
+
+## REST contracts
+
+- Register routes with action-specific `permission_callback`s. Resolve the
+  requested resource before capability checks and recheck immediately before a
+  sensitive side effect.
+- Derive endpoint arguments from the item schema where applicable; prepare
+  responses through the controller contract; honor requested fields and
+  contexts; test schema and dispatched response together.
+- When fields change, keep route arguments, server item schema, prepared
+  responses, `_fields` behavior, contexts, and client consumers aligned.
+- A custom `validate_callback` replaces default argument validation. Explicitly
+  retain the schema's type/format validation when adding custom checks.
+- For structured configuration, define exact types, bounds, patterns, enums,
+  and nested schemas. Set `additionalProperties: false` when unknown keys are
+  unsupported; sanitize the decoded container against the schema before
+  applying field-specific sanitization.
+- Verify an unauthorized representative role is rejected before any protected
+  side effect.
+
+## Input and output safety
+
+- Validate caller-supplied remote media URLs with REST schema validation and
+  `wp_http_validate_url()`. Reject unsupported filenames before download, use
+  WordPress download helpers, and propagate failures without creating partial
+  attachments.
+- Build UI with WordPress Element instead of raw HTML when practical. In PHP,
+  escape text, attributes, and URLs for their final sink; use `wp_kses_post()`
+  only when safe HTML is intentionally allowed.
+- Process dynamic CSS declarations with `safecss_filter_attr()`, narrowly
+  allowlist any extensions, then escape for the final HTML attribute context.
+  Test unsafe properties and markup-bearing values.
+- Authorize REST responses, declare permitted field contexts, honor requested
+  fields, and filter assembled data by request context before returning it.

--- a/.skills/gutenberg-pr-review/references/react-data-lifecycle.md
+++ b/.skills/gutenberg-pr-review/references/react-data-lifecycle.md
@@ -1,0 +1,68 @@
+# React, data, runtime lifecycle, and performance
+
+Use this reference for hooks, `@wordpress/data`, `core-data`, preferences,
+asynchronous requests, controlled components, and performance-sensitive code.
+
+## State and selectors
+
+- Read render-driving store data with registry-aware `useSelect`. Retrieve
+  selector functions without a render subscription only for event-time reads.
+- Include changing callback inputs in React/data hook dependency arrays. Return
+  equal, stable selector values for unchanged state to avoid stale data and
+  needless rendering.
+- Use authoritative resolution metadata for the exact selector arguments.
+  Distinguish unresolved, resolved-empty, populated, and failed states.
+- Base updates on current state with pure updater functions. Use
+  `registry.batch` when synchronous store updates must become observable as one
+  final state.
+- Never mutate Redux-backed state or block attribute objects/arrays directly.
+  Respect explicit exceptions such as the Interactivity API's mutable reactive
+  state contract.
+- Use the owning API's stable unique identity when reconciling independently
+  managed items.
+
+## Boundaries and persistence
+
+- Preserve the receiving contract's distinctions among missing, empty, `false`,
+  `null`, and `undefined`. Normalize runtime input at the boundary rather than
+  relying on truthiness.
+- Edit and save entities through `core-data`; serialize block content through
+  `post_content`; persist cross-package preferences in the preferences store.
+  Avoid competing writable copies.
+- Keep preference defaults separate from stored overrides. An override exists
+  whenever its value is not `undefined`, including explicit `false` or `null`.
+- Mark non-serialized block attributes with `role: 'local'`. Replace or revoke
+  upload-preview blob URLs instead of treating them as durable content.
+- Mount the established unsaved-changes warning in editor surfaces that can
+  lose dirty entity records.
+- New stateful `@wordpress/ui` components should support controlled and
+  uncontrolled use consistently: `x`, `defaultX`, and `onXChange`, with the
+  controlled value taking precedence.
+
+## Async lifecycle
+
+- Prevent a stale request from replacing current data. Key resolutions to the
+  active arguments and use `AbortController` when the request itself must be
+  canceled; handle `AbortError`.
+- Show loading only before resolution and empty UI only after it. On save
+  failure, keep recoverable UI open and show the recorded error.
+- Follow pending, queued, and debounced work through unmount, navigation,
+  closing, retries, and cleanup. Cleanup must neither drop an intended edit nor
+  publish unrelated staged edits.
+- Attach DOM listeners to the owning element's `ownerDocument`/`defaultView`,
+  remove the corresponding listener during cleanup, and use `useRefEffect` when
+  the attachment follows a changing element.
+- Follow the Rules of Hooks: stable unconditional ordering, correct
+  dependencies, and no hook calls from events or conditional branches.
+
+## Performance checks
+
+- For `core-data` fetching, pass limiting query arguments to
+  `getEntityRecords`, reuse cached responses, and check resolution with exactly
+  the same arguments.
+- Initialize Interactivity API derived hydration state on the server so initial
+  HTML matches client state.
+- Evaluate editor performance against the base branch with the same environment
+  and repeated suites; compare stable median metrics rather than one run.
+- For production JS, CSS, metadata, or build changes, inspect compressed-size
+  effects and preserve selective loading of unrelated packages.

--- a/.skills/gutenberg-pr-review/references/testing-docs-delivery.md
+++ b/.skills/gutenberg-pr-review/references/testing-docs-delivery.md
@@ -1,0 +1,51 @@
+# Tests, documentation, changelogs, and delivery evidence
+
+Use this reference when behavior, fixtures, snapshots, generated documentation,
+package changelogs, PR testing instructions, or release notes are affected.
+
+## Behavioral verification
+
+- Add proportionate coverage for changed behavior, likely errors, and
+  materially different empty, null, enabled, disabled, and boundary inputs.
+- Make a bug regression test fail on the base revision and pass with the fix.
+- Assert observable user behavior rather than incidental implementation. Guard
+  explicitly against false positives and false negatives.
+- Prefer `user-event` and accessible `getByRole` queries for UI tests. Scope
+  locators to the intended region and rely on strict lazy locators.
+- In Playwright, use web-first assertions and `expect.poll` for changing state
+  rather than eager element handles or arbitrary waits.
+- Test block UI at the integration layer where possible; reserve E2E tests for
+  behavior that requires a full browser environment.
+- Establish state in setup hooks and restore it in teardown that runs after
+  assertion failures. Use supported API utilities for repeated E2E setup while
+  retaining a user-driven test for the workflow itself.
+- For changed visuals, include useful before/after evidence and exercise
+  overflow, long content, empty states, and narrow viewports where relevant.
+
+## Canonical commands and governed files
+
+- Run the applicable repository lint, build, type-check, and focused test
+  commands against the final change. Do not claim broad coverage from an
+  unrelated green check.
+- Regenerate fixtures, snapshots, schemas, docs, and metadata with their
+  repository-provided commands. Review the generated diff and verify a second
+  generation is clean.
+- For handbook changes, synchronize Markdown with `docs/toc.json`, run
+  `npm run docs:build`, commit `docs/manifest.json`, and use repository-absolute
+  links that work in the handbook, GitHub, and npm contexts.
+
+## Changelogs and release communication
+
+- For each relevant package change—including production code, shipped
+  dependencies, public or private API changes, and material package
+  documentation—add an entry under `Unreleased`, link the PR, and classify it
+  under the appropriate release subsection. Omission is acceptable only when
+  the package's optional changelog check and repository evidence establish
+  that the change is too small to warrant an entry.
+- Update public API docs, examples, types, migration notes, and Dev Notes when
+  third-party behavior changes. Documentation must describe the final shipped
+  behavior, not an earlier review iteration.
+- Keep the PR description and testing instructions synchronized with the final
+  diff. State which environments and interaction paths were actually tested.
+- Curate generated plugin release notes for accurate categories, reverted work,
+  and changes excluded from that distribution.

--- a/.skills/gutenberg-pr-review/references/tooling-ci-release.md
+++ b/.skills/gutenberg-pr-review/references/tooling-ci-release.md
@@ -1,0 +1,51 @@
+# Tooling, dependencies, CI, generated artifacts, and releases
+
+Use this reference for workspace packages, build configuration, scripts,
+workflows, generated output, plugin ZIPs, dependency changes, and publishing.
+
+## Dependencies and workspaces
+
+- Declare each imported or executed dependency in the workspace that consumes
+  it, with the correct dependency role. Do not add workspace-only dependencies
+  to the repository root.
+- Update the root `package-lock.json` through supported npm workspace commands.
+  Run dependency, root-dependency, lockfile, and license validators.
+- Register TypeScript project references for typed workspace dependencies and
+  use supported public package entry points.
+- Do not rely on hoisting, the current working directory, or undeclared root
+  packages. Exercise isolated resolution where a build or subprocess could
+  resolve from the wrong owner.
+- Production dependencies shipped by packages with `wpScript` or
+  `wpScriptModuleExports` must be GPLv2-compatible; manually inspect malformed
+  license metadata rather than silently excluding it.
+
+## Builds and generated output
+
+- Treat documented source files as authoritative. Edit the source, run the
+  repository generator, review its diff, and ensure regeneration leaves no
+  uncommitted governed output.
+- Use repository root/workspace commands rather than `npx` for WordPress's
+  local or forked tooling.
+- For package/build changes, build production artifacts and verify declared
+  files, entry points, exports, types, styles, side effects, and WordPress
+  exposure against the output.
+- Keep centralized lint suppressions and dependency-audit exceptions narrowly
+  scoped; prune entries that no longer correspond to a current violation.
+- Run the applicable supported CI target matrix when runtime compatibility or
+  generated output differs by Node, PHP, WordPress, browser, or environment.
+
+## Workflow and release safety
+
+- Validate credentials, permissions, environment variables, version state, and
+  remote prerequisites before version bumps, pushes, publishes, or other
+  irreversible mutations.
+- Analyze concurrency and cancellation. Prevent two runs from publishing the
+  same version and prevent cancellation from leaving a partially mutated
+  release.
+- Make retries idempotent: inspect remote and registry state, resume safely
+  after partial completion, and print actionable recovery commands.
+- Include tool versions in cache/reproducibility inputs when those versions
+  affect generated or installed state; pin versions where alignment matters.
+- Build plugin ZIPs through `bin/build-plugin-zip.sh` from a clean,
+  commit-traceable worktree. Retain the uploaded artifact for the GitHub release
+  and deploy that release asset to WordPress.org rather than rebuilding.

--- a/.skills/gutenberg-pr-review/references/ui-accessibility.md
+++ b/.skills/gutenberg-pr-review/references/ui-accessibility.md
@@ -1,0 +1,83 @@
+# UI, interaction, accessibility, styles, and localization
+
+Use this reference for component, editor UI, keyboard, focus, CSS, responsive,
+animation, date/time, RTL, or translatable-string changes.
+
+## Semantics and keyboard
+
+- Give changed controls meaningful accessible names. Keep labels, tooltips,
+  advertised shortcuts, and actions consistent; expose pressed, busy, disabled,
+  destructive, and validation states accurately.
+- Exercise affected flows with keyboard input alone. Verify Tab/Shift+Tab,
+  pattern-specific arrows, Enter/Space, Escape, clearing keys, intermediate
+  focus transitions, and the final action.
+- Ignore keyboard events already consumed by a nested widget and IME composition
+  events. Prevent the browser default only when the control performs its
+  replacement action.
+- When arrow-managed items leave the Tab sequence, use the appropriate composite
+  role and one coherent focus model. Define the initial item, boundaries, and
+  disabled-item behavior.
+- For overlay changes, verify component choice and behavior. Use `Dialog` for a
+  short, focused, context-light task with one primary action; `AlertDialog` for
+  destructive or irreversible decisions; and `Drawer` for contextual editing,
+  multiple sections, or drill-down flows. Do not nest dialogs. Test initial
+  focus, dismissal, required containment, focus restoration, viewport behavior,
+  and mobile expansion. For Popovers, also test anchoring and collision behavior.
+- Announce meaningful dynamic updates through `@wordpress/a11y` when native
+  semantics will not announce them. Prefer concise polite announcements and
+  reserve assertive announcements for genuinely interruptive updates.
+
+## Interaction states
+
+- Treat editable-control values as raw input. Validate before committing to a
+  constrained model, preserve required/empty semantics, and associate errors
+  without replacing useful help text.
+- For async mutations, prevent duplicate activation, set busy state before the
+  await, show success only after settlement, surface the real error, and clear
+  busy state in a `finally` path.
+- Do not expose mutation controls until authoritative permissions and feature
+  constraints resolve. Disallowed actions must be inert.
+- For destructive changes, state what will be affected, confirm irreversible
+  actions with explicit labels, and prevent repeated confirmation while pending.
+  In a Drawer requiring explicit choice, omit the close icon and provide
+  explicit Cancel and Confirm actions.
+- Make consequential publication, placement, shared/global, structural, or
+  reusable scope apparent before the edit completes.
+- For RichText changes, cover no selection, ranges, collapsed carets, format
+  boundaries, split/merge, empty values, and the complete resulting selection
+  and format state.
+
+## Visual and responsive behavior
+
+- Verify changed UI with pointer and keyboard interaction and relevant focus,
+  hover, active, disabled, and forced-colors states.
+- Keep overlays fully within the viewport. Test anchor changes, placement,
+  flipping, resizing, shifting, portal slots, narrow screens, overflow, and
+  long content; do not combine incompatible positioning modes.
+- Keep essential block controls available in the edit view or toolbar rather
+  than only in the dismissible Settings Sidebar.
+- Respect reduced-motion preferences; interaction availability must not depend
+  on an animation completing.
+- Scope component classes to their owner and use package/directory prefixes.
+  Apply block wrapper APIs so editor, saved, and dynamic markup receive the
+  intended generated classes.
+- Classify block CSS correctly: `editorStyle` for editor-only, `style` for
+  editor and frontend, and `viewStyle` for frontend-only. Account for iframe
+  loading and verify existing blocks remain styled.
+- For `theme.json` changes, check schema validity, core/theme/user precedence,
+  inheritance, block support gates, generated preset names, and enqueued CSS.
+
+## Internationalization
+
+- Translate application-supplied visible and assistive strings with the owning
+  text domain. Keep machine identifiers separate from localized labels.
+- Keep source strings statically extractable. Use `_n`/`_nx` with the raw
+  numeric count, `sprintf` with matching arguments, contextual `_x`/`_nx` when
+  needed, and adjacent translator comments describing substitutions.
+- Do not translate inside block `save`; render dynamic labels on the server or
+  persist user-authored values.
+- For date/time changes, define input, stored instant, and output timezone.
+  Use `@wordpress/date` and test named site zones, fixed offsets, DST, locale
+  formatting, and relevant calendar boundaries.
+- Test direction-sensitive behavior in LTR and RTL. Derive UI direction from
+  `@wordpress/i18n` and content direction from the relevant semantic element.


### PR DESCRIPTION
Superseded by #80862, which uses a branch on `WordPress/gutenberg` instead of the fork branch.

The evals are split into stacked PR #80863.