### PR TITLE
Add evals and audit artifacts for Gutenberg PR review skill

### DIFF
--- a/.skills/gutenberg-pr-review/SKILL.md
+++ b/.skills/gutenberg-pr-review/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: gutenberg-pr-review
+description: Review WordPress/Gutenberg pull requests, branches, or diffs for project-specific correctness, compatibility, accessibility, data-lifecycle, block, PHP/REST, testing, tooling, documentation, and release risks. Use for pre-submit reviews, PR review comments, or checking a proposed Gutenberg change against recurring maintainer concerns.
+---
+
+# Gutenberg PR Review
+
+Review the change, not a generic checklist. Load only the references relevant to
+the touched areas, verify each suspected problem against the actual diff and
+current repository, and report only actionable findings.
+
+## Establish scope
+
+1. Read the PR description, linked issue, testing instructions, diff, and
+   changed-file list. If only a branch is supplied, compare it with the
+   repository's configured base.
+2. Identify the stated behavior and affected contracts: runtime, public API,
+   serialized content, accessibility, package output, REST schema, generated
+   files, documentation, or release state.
+3. Inspect surrounding implementation, tests, package metadata, and governing
+   contributor documentation before declaring a convention.
+4. Treat repository `AGENTS.md` instructions as authoritative. Do not replace
+   them with historical review patterns.
+
+For a GitHub PR:
+
+```bash
+gh pr view <number> --repo WordPress/gutenberg
+gh pr diff <number> --repo WordPress/gutenberg
+```
+
+For a local branch:
+
+```bash
+git diff <base>...<branch>
+git log <base>..<branch> --oneline
+```
+
+## Load focused guidance
+
+Read the directly relevant files; combine them for cross-cutting changes.
+
+- UI components, interaction, keyboard, focus, styles, responsive behavior,
+  localization: [references/ui-accessibility.md](references/ui-accessibility.md)
+- React hooks, `@wordpress/data`, async work, entities, preferences,
+  performance: [references/react-data-lifecycle.md](references/react-data-lifecycle.md)
+- Package layering, exports, public APIs, blocks, saved markup, compatibility:
+  [references/packages-apis-compatibility.md](references/packages-apis-compatibility.md)
+- PHP, REST routes and schemas, permissions, sanitization, escaping:
+  [references/php-rest-schema.md](references/php-rest-schema.md)
+- Workspaces, dependencies, builds, CI, generated artifacts, releases:
+  [references/tooling-ci-release.md](references/tooling-ci-release.md)
+- Tests, changelogs, documentation, fixtures, snapshots, delivery evidence:
+  [references/testing-docs-delivery.md](references/testing-docs-delivery.md)
+
+## Review method
+
+Follow changed values and state across their complete lifecycle:
+
+```text
+input → validation → state/store → serialization or request
+      → async completion/error → rendered output → cleanup/recovery
+```
+
+At each affected boundary, check:
+
+- whether absent, empty, `false`, `null`, and `undefined` retain their intended
+  meanings;
+- whether authorization and validation occur before side effects;
+- whether loading, empty, success, failure, cancellation, and retry states are
+  distinguishable;
+- whether old public consumers or stored content remain valid;
+- whether keyboard, pointer, screen-reader, RTL, narrow-viewport, and reduced
+  motion behavior remains equivalent where relevant;
+- whether tests exercise observable behavior and would fail without the fix;
+- whether metadata, types, docs, changelogs, generated output, and published
+  artifacts agree with runtime behavior.
+
+Search for existing helpers, analogous implementations, public consumers, and
+fixtures before suggesting a new abstraction or claiming a break. Check both
+editor and frontend behavior for block/style changes.
+
+## Finding threshold
+
+Report a finding only when the diff introduces or exposes a concrete defect,
+compatibility risk, missing consequential verification, unsafe workflow, or
+material maintainability problem.
+
+- Cite the changed file and line.
+- Explain the failure scenario and affected user or consumer.
+- State the smallest credible remedy or the verification needed.
+- Distinguish a must-fix issue from a non-blocking improvement.
+- Phrase uncertain issues as a focused question and say what evidence is
+  missing.
+- Do not report personal style preferences, speculative generalities,
+  pre-existing problems outside the change, or requirements contradicted by
+  current repository evidence.
+- Avoid duplicate findings when one root cause explains several symptoms.
+
+## Output
+
+Lead with findings ordered by severity. Use:
+
+```markdown
+### Must fix
+
+- `path/file.js:42` — Concise defect title. Explain the failing path, impact,
+  and required correction.
+
+### Should fix
+
+- `path/file.js:87` — Concrete non-blocking risk and proportionate remedy.
+```
+
+Omit empty severity sections. After findings, optionally include a short
+summary and residual testing risks. If there are no findings, say so directly
+and name any meaningful verification gap.
+
+## Evidence provenance
+
+This guidance was distilled from a frozen audit of every Gutenberg PR and its
+review/discussion artifacts through PR #80540: 47,037 PRs (35,935 merged,
+8,654 closed without merge, and 2,448 open), 561,837 artifacts collected, and
+233,370 substantive human-authored artifacts individually audited. The audit
+produced 133,803 candidate findings; multi-pass consolidation and editorial
+triage produced 127 candidate rules.
+
+Those candidates were validated against `origin/trunk` commit
+`49120c3204955ba1f83c7224793f52813689e7e1` on 2026-07-28, then delta-checked
+and updated through commit `03a6675a25ede7f8e31e5232742615f95358bcb6`.
+Historical review evidence establishes recurrence, not present-day truth;
+current code and repository instructions always win.

--- a/.skills/gutenberg-pr-review/evals/.gitignore
+++ b/.skills/gutenberg-pr-review/evals/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.workspaces/
+results/raw/
+.DS_Store

--- a/.skills/gutenberg-pr-review/evals/assertions/grade-gutenberg-review.cjs
+++ b/.skills/gutenberg-pr-review/evals/assertions/grade-gutenberg-review.cjs
@@ -1,0 +1,161 @@
+function check(label, passed, detail) {
+  return {
+    pass: Boolean(passed),
+    score: passed ? 1 : 0,
+    reason: `${label}: ${detail}`,
+    namedScores: { [label]: passed ? 1 : 0 },
+  };
+}
+
+const cases = {
+  'block-serialized-markup': [
+    {
+      label: 'Changed contract',
+      test: (text) => /save\.js/.test(text) && /(serializ|saved markup|save output|class name)/.test(text),
+      pass: 'identifies the changed serialized output',
+      fail: 'does not connect save.js to the serialized markup contract',
+    },
+    {
+      label: 'Existing-content impact',
+      test: (text) => /(existing|previously saved|old|previously serialized).{0,50}(posts?|content|blocks?|markup).{0,180}(invalid|validation|unexpected|recovery|fail)/s.test(text)
+        || /(invalid|invalidates|validation|unexpected|recovery|fail).{0,140}(existing|previously saved|old|previously serialized).{0,50}(posts?|content|blocks?|markup)/s.test(text),
+      pass: 'explains the validation failure for existing content',
+      fail: 'does not explain what happens when existing content is reopened',
+    },
+    {
+      label: 'Compatibility remedy',
+      test: (text) => /deprecat|migration|preserve.{0,60}(old|existing).{0,40}(markup|class)|keep.{0,60}(old|existing).{0,40}(markup|class)/s.test(text),
+      pass: 'requests a compatible serialization or deprecation path',
+      fail: 'does not request a compatibility or deprecation path',
+    },
+    {
+      label: 'Regression coverage',
+      test: (text) => /(test|fixture).{0,120}(old|existing|previous|deprecated).{0,80}(markup|content|block|serialization)/s.test(text)
+        || /(old|existing|previous|deprecated).{0,100}(markup|content|block|serialization).{0,80}(test|fixture)/s.test(text),
+      pass: 'requests old-content or deprecated-version coverage',
+      fail: 'does not request coverage using previously saved content',
+    },
+    {
+      label: 'File reference',
+      test: (text) => /packages\/block-library\/src\/call-to-action\/save\.js/.test(text),
+      pass: 'cites the changed save.js file',
+      fail: 'does not cite the relevant save.js file',
+    },
+    {
+      label: 'No API-version decoy',
+      test: (text) => !/(bump|increment|change).{0,50}(block )?api version|(block )?api version.{0,50}(must|needs?|required).{0,30}(bump|increment|change)/s.test(text),
+      pass: 'does not demand an unrelated Block API version bump',
+      fail: 'incorrectly demands a Block API version bump',
+    },
+  ],
+  'async-stale-response': [
+    {
+      label: 'Race identified',
+      test: (text) => /(stale|older|earlier|out[- ]of[- ]order).{0,160}(response|request|result).{0,160}(overwrite|replace|win|preview|newer|latest)/s.test(text)
+        || /(response|request|result).{0,120}(resolve|complete|finish).{0,80}(out of order|later|last).{0,120}(overwrite|preview|newer|latest)/s.test(text)
+        || /(slower|old|older|earlier|previous).{0,100}request.{0,180}(overwrite|replace).{0,100}(current|selected|newer|latest|preview)/s.test(text),
+      pass: 'identifies the stale-response race',
+      fail: 'does not identify the out-of-order response race',
+    },
+    {
+      label: 'User sequence',
+      test: (text) => /(switch|select|change|navigate).{0,100}(template|templateid).{0,180}(old|earlier|previous|first|stale).{0,100}(response|request|result)/s.test(text)
+        || /(old|older|earlier|previous|first|stale).{0,80}(response|request|result).{0,120}(resolve|complete|finish).{0,100}(last|later|after|current|newer|selected)/s.test(text)
+        || /(response|request|result).{0,100}(out of order|resolve last).{0,100}(current|newer|selected|template)/s.test(text)
+        || /(previous|older|slower).{0,100}templateid.{0,180}(current|selected|latest|newer)/s.test(text)
+        || /(a.{0,30}(followed by|to).{0,30}b|switching.{0,30}a.{0,30}b).{0,140}(a|first|earlier).{0,80}(resolve|overwrite)/s.test(text),
+      pass: 'explains the rapid-template-change failure sequence',
+      fail: 'does not explain the user-visible sequence that triggers the race',
+    },
+    {
+      label: 'Lifecycle remedy',
+      test: (text) => /abortcontroller|abort signal|cancel|request (id|identity|token)|sequence (id|number)|ignore.{0,80}(stale|old|previous)|cleanup.{0,80}(stale|request)/s.test(text),
+      pass: 'suggests cancellation or an equivalent stale-result guard',
+      fail: 'does not suggest a credible stale-result guard',
+    },
+    {
+      label: 'Race coverage',
+      test: (text) => /(test|coverage).{0,200}(out[- ]of[- ]order|resolve.{0,50}(later|last|after)|rapid.{0,40}(switch|change|select)|stale|changes?.{0,40}templateid.{0,60}(pending|before))/s.test(text)
+        || /(out[- ]of[- ]order|deferred[- ]promise|both requests pending).{0,100}(test|coverage|race)/s.test(text),
+      pass: 'requests a test that controls completion order',
+      fail: 'does not request meaningful race-condition coverage',
+    },
+    {
+      label: 'File reference',
+      test: (text) => /packages\/editor\/src\/hooks\/use-template-preview\.js/.test(text),
+      pass: 'cites the changed hook',
+      fail: 'does not cite the relevant hook',
+    },
+    {
+      label: 'No dependency decoy',
+      test: (text) => !/(missing|add|include).{0,70}templateid.{0,70}dependenc|dependenc.{0,70}(missing|omit).{0,70}templateid/s.test(text),
+      pass: 'does not claim templateId is absent from the dependency array',
+      fail: 'incorrectly claims templateId is missing from the dependency array',
+    },
+  ],
+  'rest-false-update': [
+    {
+      label: 'False-value defect',
+      test: (text) => /(false|turn.{0,20}off|disable).{0,180}(skip|ignore|not|never|remain|stay|unchanged|true)/s.test(text)
+        || /(skip|ignore|not update|never update|remain|stay).{0,140}(false|turn.{0,20}off|disable)/s.test(text),
+      pass: 'explains why an explicit false value is not saved',
+      fail: 'does not explain the true-to-false update failure',
+    },
+    {
+      label: 'Truthiness cause',
+      test: (text) => /truthiness|truthy|falsy|presence.{0,80}(value|truth)|has_param|array_key_exists|if \(.{0,50}allow_comments/s.test(text),
+      pass: 'connects the failure to the truthiness guard',
+      fail: 'does not identify the truthiness-versus-presence mistake',
+    },
+    {
+      label: 'Presence-aware remedy',
+      test: (text) => /has_param|array_key_exists|parameter (is )?present|check.{0,50}presence|update.{0,80}(unconditionally|regardless)|distinguish.{0,80}(presence|provided).{0,80}(truth|value)/s.test(text),
+      pass: 'suggests a presence-aware or unconditional update',
+      fail: 'does not suggest a fix that preserves explicit false',
+    },
+    {
+      label: 'Regression coverage',
+      test: (text) => /(test|coverage).{0,300}(true.{0,30}(to|→).{0,30}false|turn.{0,30}off|disable|explicit false|send.{0,40}false|submit.{0,40}false|open.{0,80}false.{0,80}closed)/s.test(text),
+      pass: 'requests a true-to-false regression test',
+      fail: 'does not request coverage for an explicit false update',
+    },
+    {
+      label: 'File reference',
+      test: (text) => /lib\/experimental\/class-site-settings-controller\.php/.test(text),
+      pass: 'cites the changed REST controller',
+      fail: 'does not cite the relevant controller',
+    },
+    {
+      label: 'No security decoy',
+      test: (text) => !/(missing|lacks?|add|needs?|must have).{0,60}(permission_callback|permission callback|sanitiz)|(?:permission_callback|permission callback|sanitiz).{0,60}(missing|absent|required)/s.test(text),
+      pass: 'does not invent missing permission or sanitization checks',
+      fail: 'incorrectly reports missing permissions or sanitization',
+    },
+  ],
+};
+
+module.exports = (output, context) => {
+  const caseName = context?.vars?.case;
+  const definition = cases[caseName];
+  if (!definition) {
+    return {
+      pass: false,
+      score: 0,
+      reason: `Unknown Gutenberg review case: ${caseName || '(missing)'}`,
+    };
+  }
+
+  const text = String(output || '').toLowerCase();
+  const components = definition.map((item) => {
+    const passed = item.test(text);
+    return check(item.label, passed, passed ? item.pass : item.fail);
+  });
+  const score = components.reduce((sum, item) => sum + item.score, 0) / components.length;
+
+  return {
+    pass: score === 1,
+    score,
+    reason: `${Math.round(score * 100)}% of seeded review checks passed`,
+    componentResults: components,
+  };
+};

--- a/.skills/gutenberg-pr-review/evals/audit/AUDITOR_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/AUDITOR_PROMPT.md
@@ -1,0 +1,40 @@
+# Gutenberg review-artifact audit instructions
+
+Audit every artifact in the supplied batch independently. The objective is to
+identify credible, generalizable lessons that could improve an operational
+Gutenberg PR-review skill. This is a coverage pass, not the later reduction or
+current-trunk validation pass.
+
+For each artifact:
+
+1. Preserve its artifact ID and all supplied metadata exactly.
+2. Use `finding` only when the review text expresses a concrete lesson that
+   could help reviewers catch a defect, missing verification, architectural
+   violation, compatibility risk, or recurring maintainability problem.
+3. Use `no_finding` for acknowledgements, questions that contain no discernible
+   lesson, one-off project coordination, purely subjective preference, or text
+   whose meaning cannot be established from the artifact itself.
+4. Do not discount evidence because its PR is open or closed-unmerged. Treat
+   OPEN, CLOSED, and MERGED evidence equally.
+5. Do not deduplicate similar findings. Reduction happens only after exhaustive
+   per-artifact coverage has been validated.
+6. Do not claim that a historical observation still applies. Set
+   `current_validation_needed` to true for any finding whose continued validity
+   depends on current code, documentation, tests, tooling, or policy.
+7. Phrase `proposed_rule` as a concise reviewer instruction, not as a summary of
+   the particular PR.
+
+Severity describes the risk if the lesson is ignored:
+
+- `critical`: likely security compromise, irreversible data loss, or similarly
+  exceptional harm.
+- `high`: user-visible breakage, serious accessibility failure, release/CI
+  corruption, or broad compatibility failure.
+- `medium`: meaningful correctness, lifecycle, test-coverage, API, or
+  maintainability risk.
+- `low`: narrow robustness or clarity issue with limited impact.
+- `info`: useful review practice without a concrete defect impact.
+
+Return only one JSON object matching the supplied output schema. Its `results`
+array must contain exactly one result for every artifact in the batch, in the
+same order as the batch.

--- a/.skills/gutenberg-pr-review/evals/audit/CURRENT_VALIDATION_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/CURRENT_VALIDATION_PROMPT.md
@@ -1,0 +1,35 @@
+# Gutenberg current-trunk rule validation
+
+Validate every supplied historical review rule against the exact pinned
+`origin/trunk` commit. Work only in the Gutenberg repository supplied as the
+working directory.
+
+Repository rules:
+
+- Inspect the pinned tree with `git grep <pattern> <sha> -- <paths>` and
+  `git show <sha>:<path>`. Do not treat the checked-out working tree as current.
+- Cite exact paths and line numbers from the pinned blob. Obtain line numbers
+  with commands such as `git show <sha>:<path> | nl -ba`.
+- Repository code, documentation, package metadata, schemas, tests, and
+  workflows are valid evidence. Historical review frequency is not proof of
+  current validity.
+- Do not edit files, fetch, or use network resources.
+
+Choose one disposition:
+
+- `supported`: the rule is accurate as written.
+- `revised`: the underlying check is current but its wording, scope, or
+  mechanism must change. Put the current imperative wording in
+  `validated_rule`.
+- `obsolete`: current repository evidence contradicts or supersedes the rule.
+  Leave `validated_rule` empty.
+- `insufficient-context`: the repository cannot establish a reliable
+  project-wide rule. Leave `validated_rule` empty.
+
+For `supported` and `revised`, provide at least one direct repository citation.
+Prefer two when a rule combines a convention with an implementation contract.
+Do not infer a project-wide mandate from one incidental example. For
+`obsolete`, cite the superseding evidence when available.
+
+Return decisions in the exact supplied order and return only the JSON object
+required by the schema.

--- a/.skills/gutenberg-pr-review/evals/audit/EDITORIAL_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/EDITORIAL_PROMPT.md
@@ -1,0 +1,40 @@
+# Gutenberg review-rule editorial triage instructions
+
+Evaluate every supplied evidence-backed cluster for inclusion in a compact,
+operational Gutenberg PR-review skill. This is an editorial selection and
+within-batch collision pass. Current-`trunk` validation happens afterward, so
+do not claim a historical convention is still current.
+
+Advance a cluster when it expresses a concrete, generalizable reviewer check
+that can catch a defect, compatibility break, accessibility failure, unsafe
+workflow, missing behavioral verification, or consequential maintainability
+risk. Prefer independent support across PRs and reviewers, but retain a
+credible high-impact singleton. Raw comment count alone is not strong support.
+
+Reject with exactly one terminal reason when appropriate:
+
+- `reject-too-specific`: tied to one obsolete-looking implementation detail or
+  incident and not generalizable.
+- `reject-preference`: subjective style or optional refactoring without a
+  demonstrated defect risk.
+- `reject-unsupported`: the summarized evidence does not justify the rule.
+- `reject-obsolete`: clearly superseded by information already present in the
+  supplied rule summary; uncertain currency should advance for later
+  validation instead.
+- `reject-not-operational`: true in the abstract but not a check a PR reviewer
+  can apply.
+
+Merge advanced inputs only when they express the same operational check.
+Preserve distinct preconditions, failure modes, and validation techniques.
+Create at most 25 candidates, prioritizing the most useful guidance rather than
+filling the limit.
+
+For every input cluster, emit one decision in the supplied order:
+
+- `advance` must name a declared candidate key such as `C01`.
+- A rejection must use an empty `candidate` string.
+- Explain the decision concretely and briefly.
+
+Every advanced cluster ID must appear exactly once in its candidate's
+`member_ids`; rejected IDs must not appear in candidates. Do not invent, omit,
+reorder, or duplicate IDs. Return only the JSON object required by the schema.

--- a/.skills/gutenberg-pr-review/evals/audit/FINAL_AUDIT_SUMMARY.md
+++ b/.skills/gutenberg-pr-review/evals/audit/FINAL_AUDIT_SUMMARY.md
@@ -1,0 +1,84 @@
+# Gutenberg PR review skill: final audit summary
+
+Completed 2026-07-28.
+
+## Frozen corpus
+
+- Last collected PR: #80540
+- PRs: 47,037
+    - merged: 35,935
+    - closed without merge: 8,654
+    - open: 2,448
+- Review/discussion artifacts collected: 561,837
+- Deterministic exclusions:
+    - PR-author follow-ups: 199,832
+    - empty artifacts: 69,728
+    - bot artifacts: 56,331
+    - exact low-signal artifacts: 2,576
+- Substantive human-authored artifacts individually audited: 233,370
+- Candidate findings: 133,803
+- No-finding decisions: 99,567
+
+## Reduction
+
+- Initial semantic microclusters: 93,622
+- Recursive merge 1: 74,971
+- Recursive merge 2: 66,731
+- Recursive prepass: 61,299
+- Editorial candidates: 20,180
+- Final cross-batch candidates: 127
+- Historical evidence supporting the final candidates: 55,875 artifacts
+
+All merge, advance, and rejection passes preserved explicit evidence closure.
+
+## Current-tree validation
+
+All 127 final candidates were checked against `origin/trunk`
+`49120c3204955ba1f83c7224793f52813689e7e1`:
+
+- revised for current wording: 111
+- supported unchanged: 1
+- insufficient repository evidence: 14
+- obsolete: 1
+- failed or invalid validation batches: 0
+
+A later six-commit delta was checked through
+`03a6675a25ede7f8e31e5232742615f95358bcb6`. It required three narrow guidance
+updates and invalidated no other rule.
+
+## Skill output
+
+- Core skill: `../../SKILL.md`
+- References:
+    - `references/ui-accessibility.md`
+    - `references/react-data-lifecycle.md`
+    - `references/packages-apis-compatibility.md`
+    - `references/php-rest-schema.md`
+    - `references/tooling-ci-release.md`
+    - `references/testing-docs-delivery.md`
+- Total: 501 lines; core skill: 132 lines
+- Skill structural validator: passed
+- Final core skill SHA-256:
+  `9cec9e33db818c24dbe8ba2c84ab342f3012b662f2a08a5a391ed02a1853fc94`
+
+## Forward tests
+
+Eight blind reviews covered component APIs, SCSS migration, RichText,
+keyboard selection, theme CSS, forked-PR workflows, toolchain pinning, and a
+documentation-only change.
+
+- execution failures: 0
+- independent adjudication:
+    - pass: 6
+    - pass with minor output notes: 2
+    - fail: 0
+- required skill changes from adjudication: none
+- missed high-signal defects found by adjudication: none
+
+## Cleanup
+
+After the checks above passed, the raw full/pilot SQLite corpora, artifact and
+finding ledgers, worker responses/attempt logs, intermediate reduction plans
+and results, and pilot analysis were deleted as authorized. Generalized
+collection/audit/reduction scripts and prompts, the test plan, this summary,
+and compact forward-test verdicts were retained.

--- a/.skills/gutenberg-pr-review/evals/audit/FINAL_EDITORIAL_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/FINAL_EDITORIAL_PROMPT.md
@@ -1,0 +1,27 @@
+# Gutenberg review-rule final consolidation instructions
+
+Select and merge the strongest operational Gutenberg PR-review rules in this
+cross-batch shortlist. Historical evidence supports each input, but current
+`trunk` validation happens afterward.
+
+Advance only checks that are concrete, broadly reusable, and likely to catch a
+meaningful defect, compatibility break, accessibility failure, unsafe workflow,
+or missing behavioral verification. Prefer support from multiple PRs and
+reviewers. Retain a singleton only for a credible high-impact failure mode.
+
+Apply exactly one terminal rejection to every input that does not advance:
+
+- `reject-too-specific`: incident- or implementation-specific.
+- `reject-preference`: optional style or refactoring preference.
+- `reject-unsupported`: evidence does not justify the generalized rule.
+- `reject-obsolete`: clearly superseded in the supplied information.
+- `reject-not-operational`: not an actionable PR-review check.
+
+Merge advanced inputs only when they express the same operational check. Keep
+distinct preconditions, failure modes, and verification techniques separate.
+Create at most eight candidates. Do not fill the limit: choose only guidance
+strong enough to justify scarce skill context.
+
+For every input, emit one decision in the supplied order. Every advanced ID
+must appear exactly once in its declared candidate; rejected IDs must not
+appear. Return only the schema-conforming JSON object.

--- a/.skills/gutenberg-pr-review/evals/audit/FORWARD_TEST_EVALUATOR_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/FORWARD_TEST_EVALUATOR_PROMPT.md
@@ -1,0 +1,31 @@
+# Independent Gutenberg review-skill forward-test evaluation
+
+Evaluate the eight blind review outputs in
+`.skills/gutenberg-pr-review/evals/audit/forward-test-results/`.
+
+The corresponding commits are listed in
+`.skills/gutenberg-pr-review/evals/audit/forward-test-summary.json`. The reviewed skill is
+at `../../SKILL.md`.
+
+For every case:
+
+1. Inspect the raw commit diff and enough surrounding code at that exact commit.
+2. Verify each reported finding's factual premise, changed-line relevance,
+   failure path, severity, and proposed remedy.
+3. Look for a clear high-signal defect the review missed, without inventing
+   stylistic or speculative requirements.
+4. Check whether a "No findings" result is credible.
+5. Judge adherence to the skill's evidence threshold and output contract.
+
+Classify each case as:
+
+- `pass`: no material false positive or missed high-signal defect;
+- `pass-with-notes`: useful and materially correct, but wording, severity, or
+  evidence needs a minor adjustment;
+- `fail`: material false positive, unsupported mandate, or clear missed defect.
+
+Do not edit files or use network access. Do not assume that merged commits are
+correct. Produce a concise Markdown report with one section per case, quoting
+only enough of a finding title to identify it, followed by a final tally and
+specific skill edits required before acceptance. If no skill edit is required,
+say so explicitly.

--- a/.skills/gutenberg-pr-review/evals/audit/FULL_AUDIT_TEST_PLAN.md
+++ b/.skills/gutenberg-pr-review/evals/audit/FULL_AUDIT_TEST_PLAN.md
@@ -1,0 +1,266 @@
+# Full Gutenberg PR audit verification plan
+
+This is the release gate for the full, single-pass audit. The audit is not complete until every mandatory check below passes. Run destructive cleanup only after copying the final counts into `FULL_AUDIT_SUMMARY.md`, updating the skill, and rerunning the non-raw-data checks.
+
+## Snapshot contract
+
+The repository-wide GitHub API does not provide an atomic historical snapshot. Define the audit precisely instead of implying that it does:
+
+- At initialization, record `audit_started_at`, the union connection's `totalCount`, state totals, and the last edge's PR number and `createdAt` as the population high-water mark.
+- Crawl one `pullRequests(states: [OPEN, CLOSED, MERGED], orderBy: { field: CREATED_AT, direction: ASC })` connection. All connection arguments must have `first` or `last` in the range 1–100.
+- Admit only PRs at or before the recorded high-water mark. PRs created later must not enter the database even if they appear before the crawl ends.
+- Record `observed_at` for every PR. Metadata, reviews, and comments are the values observed during that PR's one collection pass; they are not an atomic repository-wide view. Overflow pagination is part of that same pass, not a later refresh.
+- A state transition cannot remove a PR from this union connection. A deletion or an unstable cursor that prevents reaching the high-water mark is a hard failure requiring investigation, not a reason to adjust the expected count silently.
+- The final provenance reports the observed state counts. They may differ from the initialization counts if a PR transitions while the crawl is running, but their sum must equal the frozen population total.
+
+Observed preflight on 2026-07-21 (diagnostic only, not a hard-coded target): 47,037 total PRs = 35,914 merged + 8,651 closed-unmerged + 2,472 open. A small GraphQL probe also confirmed the expected timestamp shapes: merged has `mergedAt` and `closedAt`, closed-unmerged has only `closedAt`, and open has neither.
+
+## API correctness gates
+
+Before a long crawl, inspect the rendered GraphQL query and make these checks mechanically:
+
+- The population query contains all three states and ascending creation order. It stores `state`, `isDraft`, `createdAt`, `updatedAt`, nullable `closedAt`, nullable `mergedAt`, and the per-connection `totalCount` values.
+- Every nested connection exposes `totalCount`; every GraphQL connection explicitly requests `pageInfo { hasNextPage endCursor }` when it can be backfilled with GraphQL.
+- Collection is single-threaded. Model analysis may be parallel, but GitHub requests must not be. Respect `Retry-After` and rate-limit reset headers, and checkpoint before a clean low-budget exit. GitHub applies secondary limits across REST and GraphQL even though the primary budgets differ.
+- `gh api --paginate --slurp` returns an array of pages. Flatten exactly one level and reject a non-list page instead of treating it as records.
+- Do not rely on the REST pull-files endpoint above 3,000 files: GitHub documents a hard 3,000-file response ceiling. Use per-PR GraphQL pagination for files, or stop with an explicit unsupported-overflow error. The REST review, review-comment, and issue-comment endpoints must follow pagination links through exhaustion.
+- Store REST `node_id` as the canonical artifact ID and retain numeric IDs separately. For review comments, preserve and validate the parent review mapping (`pull_request_review_id`/review database ID).
+- Use an UPSERT that updates in place. Avoid `INSERT OR REPLACE` on `pull_requests`: SQLite implements replacement as delete-plus-insert and can cascade-delete children before an interrupted refill.
+- Treat null/deleted authors and empty bodies as valid collected records. Classification belongs in the ledger phase, not collection.
+- Never infer completion from a short page alone when the API supplies `pageInfo` or `Link`; follow the server's pagination signal.
+
+References: [GitHub GraphQL rate and node limits](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api), [REST pagination](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api), and [pull-request files endpoint and its 3,000-file cap](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files).
+
+## 1. Deterministic smoke test
+
+Run the collector against an injectable fake transport and a temporary directory, never the pilot or production database. The fixture should contain at least these PRs:
+
+| PR | State | Draft | `closedAt` | `mergedAt` | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| 101 | `OPEN` | true | null | null | Open/draft/null timestamps |
+| 102 | `CLOSED` | false | non-null | null | Closed-unmerged |
+| 103 | `MERGED` | false | non-null | non-null | Merged |
+
+Across the fixture, include a human review body, an empty review body, an issue comment, a review comment, a reply, a bot, a deleted/null author, a PR-author follow-up, and an exact low-signal approval. Use non-ASCII Markdown in one body. Assert:
+
+- Exactly three PRs are stored with the expected timestamp nullability and state.
+- Every review, review comment, and issue comment is stored before classification, including empty and excluded artifacts.
+- Text round-trips as UTF-8, IDs retain their type/source mapping, and review-comment parents resolve.
+- The manifest is atomically written, parses as JSON, names the union scope, and records the cutoff/high-water metadata.
+- A run against an invalid fixture (missing node ID, count mismatch, or unknown state) exits nonzero without setting `completed_at`.
+
+The test transport should count requests and return named pages so resume and pagination behavior can be asserted without spending API budget.
+
+## 2. Interrupt, resume, and idempotence
+
+Use a fixture with at least three top-level pages and two overflow pages.
+
+1. Start a fresh temporary database and interrupt with `SIGINT` immediately after the first committed page.
+2. Save the committed cursor, PR/artifact/file counts, and a deterministic logical checksum (sorted primary keys plus stored fields; do not hash the mutable SQLite/WAL bytes).
+3. Resume with the same arguments. Assert that the first request starts at the saved cursor, the interrupted page is not skipped, and collection reaches the frozen high-water PR.
+4. Compare the resumed database to an uninterrupted fixture run with `EXCEPT` queries in both directions for every table other than timestamp/rate metadata.
+5. Run the completed collector again. It must make zero fixture API requests, preserve all logical checksums, and not create duplicate rows.
+6. Interrupt once during an overflow backfill. Resume must either continue from its persisted child cursor or safely replace that one connection from page one; it must not combine partial and complete child sets.
+
+Also simulate a crash after an API response but before the transaction commits. Replaying the page must produce the same database as the uninterrupted run.
+
+## 3. Overflow and backfill coverage
+
+Create deterministic fixture cases for every first-page boundary:
+
+- 101 files on one PR.
+- 101 reviews on one PR, including empty review bodies.
+- 101 issue comments on one PR.
+- One review with 205 review comments (three pages at `per_page=100`).
+- Two overflowing child connections on the same PR to catch cursor cross-wiring.
+- Duplicate IDs on adjacent API pages to verify idempotent insertion while still detecting an API/count inconsistency.
+
+For every case, assert stored count equals declared `totalCount`, IDs are unique, no page is skipped, and the manifest's truncation count is zero. A response that exhausts pagination below `totalCount`, exceeds the observed expected count, or repeats a cursor must fail with PR number, connection kind, expected count, actual count, and cursor in the error.
+
+Use PR #79816 as a non-destructive live sentinel for file pagination: the pilot observed `files_total = 239`. A targeted temporary run should collect 239 unique paths. This validates the real transport but does not replace the synthetic cases for reviews and comments. If any live PR reports more than 3,000 files, verify GraphQL pagination is used rather than the capped REST files endpoint.
+
+## 4. SQLite integrity and corpus completeness
+
+Run these checks on the frozen full database while its raw data still exists:
+
+```sql
+PRAGMA wal_checkpoint(TRUNCATE);
+PRAGMA integrity_check;
+PRAGMA foreign_key_check;
+
+SELECT COUNT(*) AS pr_count,
+       COUNT(DISTINCT number) AS distinct_pr_count
+FROM pull_requests;
+
+SELECT state, COUNT(*)
+FROM pull_requests
+GROUP BY state
+ORDER BY state;
+
+SELECT number, state, closed_at, merged_at
+FROM pull_requests
+WHERE state NOT IN ('OPEN', 'CLOSED', 'MERGED')
+   OR (state = 'OPEN' AND (closed_at IS NOT NULL OR merged_at IS NOT NULL))
+   OR (state = 'CLOSED' AND (closed_at IS NULL OR merged_at IS NOT NULL))
+   OR (state = 'MERGED' AND (closed_at IS NULL OR merged_at IS NULL));
+
+SELECT number
+FROM pull_requests
+WHERE observed_at IS NULL
+   OR created_at > (SELECT value FROM meta WHERE key = 'snapshot_high_water_created_at');
+
+SELECT a.id
+FROM artifacts a
+LEFT JOIN pull_requests p ON p.number = a.pr_number
+WHERE p.number IS NULL;
+
+SELECT parent_review_id, COUNT(*)
+FROM artifacts
+WHERE kind = 'review_comment'
+GROUP BY parent_review_id
+HAVING parent_review_id IS NULL
+    OR NOT EXISTS (
+        SELECT 1 FROM artifacts r
+        WHERE r.id = artifacts.parent_review_id AND r.kind = 'review'
+    );
+```
+
+Expected results:
+
+- `integrity_check` returns exactly `ok`; `foreign_key_check` and every violation query return no rows.
+- PR count equals distinct PR count, the frozen initialization total, and the sum of the three observed state counts.
+- The recorded high-water PR is present, no later-created PR exists, and the oldest PR is #2 unless GitHub reports a repository-history change that is documented in the summary.
+- `completed_at` is absent until population collection, every overflow backfill, and all integrity checks succeed.
+
+For each connection, compare declared versus stored counts. Adapt column/table names to the finalized schema, but preserve these invariants:
+
+```sql
+SELECT p.number, 'files' AS kind, p.files_total AS expected, COUNT(f.path) AS actual
+FROM pull_requests p LEFT JOIN files f ON f.pr_number = p.number
+GROUP BY p.number HAVING actual != expected;
+
+SELECT p.number, 'reviews' AS kind, p.reviews_total AS expected, COUNT(a.id) AS actual
+FROM pull_requests p LEFT JOIN artifacts a
+  ON a.pr_number = p.number AND a.kind = 'review'
+GROUP BY p.number HAVING actual != expected;
+
+SELECT p.number, 'issue_comments' AS kind,
+       p.issue_comments_total AS expected, COUNT(a.id) AS actual
+FROM pull_requests p LEFT JOIN artifacts a
+  ON a.pr_number = p.number AND a.kind = 'issue_comment'
+GROUP BY p.number HAVING actual != expected;
+
+SELECT r.pr_number, r.id, r.comments_total AS expected, COUNT(c.id) AS actual
+FROM artifacts r LEFT JOIN artifacts c
+  ON c.parent_review_id = r.id AND c.kind = 'review_comment'
+WHERE r.kind = 'review'
+GROUP BY r.id HAVING actual != expected;
+```
+
+All four queries must return no rows. Also require the manifest's four truncation counters (`files`, `reviews`, `issue_comments`, and `review_comments`) to be exactly zero. Counts alone do not prove identity, so preserve unique canonical IDs and reject duplicate/cross-PR IDs during insertion.
+
+## 5. Ledger coverage and exclusions
+
+The ledger is the proof that every collected artifact received exactly one disposition. It must include excluded artifacts, not only actionable ones. Require a unique `artifact_id` and one of these outcomes:
+
+- `actionable`, with exactly one analysis batch assignment.
+- `excluded_bot`.
+- `excluded_pr_author`.
+- `excluded_empty`.
+- `excluded_low_signal`, restricted to the explicit deterministic phrase/pattern allowlist.
+
+Do not exclude by PR state, age, author association, path, or review state. Apply exclusion precedence deterministically and record the reason so a bot who is also the PR author is assigned once.
+
+Mandatory assertions:
+
+```sql
+SELECT
+  (SELECT COUNT(*) FROM artifacts) AS artifacts,
+  (SELECT COUNT(*) FROM audit_ledger) AS ledger_rows,
+  (SELECT COUNT(DISTINCT artifact_id) FROM audit_ledger) AS ledger_ids;
+
+SELECT l.artifact_id
+FROM audit_ledger l LEFT JOIN artifacts a ON a.id = l.artifact_id
+WHERE a.id IS NULL
+UNION ALL
+SELECT a.id
+FROM artifacts a LEFT JOIN audit_ledger l ON l.artifact_id = a.id
+WHERE l.artifact_id IS NULL;
+
+SELECT artifact_id, COUNT(*)
+FROM batch_assignments
+GROUP BY artifact_id
+HAVING COUNT(*) != 1;
+```
+
+The three scalar counts must match, the missing/extra query must return no rows, and the assignment query must return no rows when restricted to actionable ledger rows. Separately assert that excluded rows have no batch assignment and actionable rows have no exclusion reason. Group ledger outcomes and actionable assignments by PR state; the state totals must reconcile to the artifact table, demonstrating that open, merged, and closed-unmerged evidence was handled by the same rules.
+
+Batch generation must be deterministic: running it twice against the same frozen DB produces identical ordered artifact-ID lists and file checksums. No batch may exceed the configured character/token safety bound, except a documented single-artifact oversize batch that is split deterministically without losing its ID.
+
+## 6. Worker result schema and reduction
+
+Validate every worker JSONL line before reduction. A result should contain at least:
+
+- `schema_version`, `artifact_id`, `batch_id`, `pr_number`, `pr_state`, `artifact_kind`, `reviewer`, and `url`.
+- `assessment`: an enum such as `credible_finding`, `no_general_rule`, or `needs_context`.
+- `categories` and `severity`.
+- `proposed_rule` (required only for a credible finding).
+- `current_validation_needed` plus a short rationale.
+- Optional representative diff/code references added during validation, never invented by the worker.
+
+Reject unknown fields if a strict schema is used, malformed JSON, missing IDs, duplicate artifact results, worker results for unassigned IDs, metadata that disagrees with the ledger, or a result count different from the actionable assignment count. A `needs_context` result is incomplete until the reducer resolves it with the comment's PR metadata or a targeted representative diff.
+
+Reduction may deduplicate candidate rules, but never worker coverage. For every retained skill rule, the final evidence table should record supporting artifact IDs, PRs, reviewers, all represented PR states, current `origin/trunk` validation references, and the keep/merge/reject decision. Equal state weight means a credible finding is not discounted merely because its source PR was open or closed-unmerged.
+
+Before writing the skill, assert:
+
+- Every actionable artifact has exactly one valid worker result.
+- Every `needs_context` item has a terminal reducer decision.
+- Every retained rule has current-code/docs/tests validation, or is explicitly rejected as obsolete/era-specific.
+- Links and artifact IDs in the concise summary resolve back to the frozen corpus.
+
+## 7. Skill and summary acceptance
+
+Save the pre-audit skill SHA-256. After the edit:
+
+- The file is readable, nonempty, valid Markdown, and still contains its required skill front matter/name.
+- Provenance gives exact frozen PR and artifact totals, state counts, exclusion/actionable counts, audit start/completion dates, and explicitly describes the non-atomic single-pass observation model.
+- New or changed guidance is supported by the reducer evidence and current `origin/trunk`; obsolete or redundant advice is removed rather than archived by era.
+- The skill remains concise enough to load as operational instructions. Raw comments, long evidence excerpts, and per-era history belong neither in the skill nor the retained summary.
+- `FULL_AUDIT_SUMMARY.md` contains all counts needed to verify the audit after raw deletion, the final skill SHA-256, the exact `origin/trunk` commit used for current validation, and a note that all raw corpora were deleted after verification.
+
+## 8. Destructive cleanup gate
+
+Cleanup is permanently destructive and runs only after sections 1–7 pass and the skill and summary have been reread from disk. Record an allowlist of retained files before deletion. The intended retained set is the updated skill outside the workspace plus generalized collection/ledger scripts, `README.md`, `FULL_AUDIT_SUMMARY.md`, and this reusable test plan if desired.
+
+Delete both the full-audit raw corpus and the old 500-PR pilot corpus, including:
+
+- SQLite databases and `-wal`/`-shm` companions.
+- Raw GraphQL/REST payloads and manifests that contain corpus data.
+- Corpus and ledger JSONL, generated batches, worker outputs, candidate evidence, and temporary diff backfills.
+- Pilot `reviews.sqlite*`, `analysis/`, `manifest.json`, and pilot-only evidence/report files once their needed provenance has been incorporated into the final summary.
+- Temporary smoke databases, fixtures containing copied comments, and test output.
+
+After deletion, run an allowlist-based check rather than only checking a few known names:
+
+```bash
+find .skills/gutenberg-pr-review/evals/audit -type f -print | sort
+find .skills/gutenberg-pr-review/evals/audit -type f \
+  \( -name '*.sqlite*' -o -name '*.jsonl' -o -name 'manifest.json' \) -print
+git status --short
+```
+
+The first command must contain only the explicit retained allowlist; the second must print nothing. `git status --short` must show no tracked Gutenberg changes caused by the audit. Finally, reread and hash the skill and `FULL_AUDIT_SUMMARY.md`; their values must match the summary's recorded hashes. Raw-data-dependent checks cannot be rerun after this point, which is why their exact results and counts must already be in the retained summary.
+
+## Final go/no-go checklist
+
+- [ ] Deterministic all-state smoke test passes, including null timestamps and deleted authors.
+- [ ] Interrupt/resume and completed-run idempotence pass.
+- [ ] All four overflow paths pass synthetic pagination tests; PR #79816 returns 239 files live.
+- [ ] Frozen population count equals the initialization total and reaches the recorded high-water PR.
+- [ ] SQLite integrity/FK checks pass and all declared/stored connection counts match.
+- [ ] Every artifact has one ledger disposition; every actionable artifact has one worker result.
+- [ ] Every context-needed result is resolved and every retained rule is current-validated.
+- [ ] Updated skill and concise summary pass content/hash checks.
+- [ ] Raw full and pilot corpora are deleted; only the retained allowlist remains.
+- [ ] Gutenberg's tracked worktree is clean with respect to this audit.

--- a/.skills/gutenberg-pr-review/evals/audit/MERGER_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/MERGER_PROMPT.md
@@ -1,0 +1,35 @@
+# Gutenberg review-rule cluster merge instructions
+
+Merge the supplied microclusters into a smaller set of semantically equivalent,
+evidence-backed PR-review rules. This is a recursive consolidation pass, not
+the later current-`trunk` validation or editorial-selection pass.
+
+Merge clusters only when they express the same operational reviewer check.
+Wording similarity alone is insufficient. Keep separate:
+
+- a defect check from a test or validation technique for that defect;
+- public contract design from backward-compatibility handling;
+- a precondition from cleanup or recovery after failure;
+- accessibility semantics from merely visual behavior;
+- broad principles from concrete checks unless the concrete checks are truly
+  interchangeable in review.
+
+Do not reject or discard any input cluster. Preserve an unmatched cluster as a
+singleton. For each output cluster:
+
+1. Use a unique batch-local key `C01`, `C02`, and so on.
+2. Select the best canonical domain; the routed domain and lexical bucket are
+   hints, not constraints.
+3. Choose a stable, concrete kebab-case topic slug.
+4. Phrase the canonical rule as a concise imperative reviewer instruction.
+5. Preserve the greatest credible severity of its members.
+6. Require current validation if any merged rule depends on current repository
+   code, documentation, tooling, policy, or conventions.
+7. List every direct input cluster ID exactly once in `member_ids`.
+8. Explain the semantic equivalence—not merely shared words—in `merge_basis`.
+
+Use `unresolved` only when the supplied cluster summaries cannot establish
+whether two meanings are compatible. Do not use it for unique inputs. Every
+input cluster ID must appear exactly once across output member lists and
+unresolved entries. Preserve input order within each member list. Return only
+the JSON object required by the supplied schema.

--- a/.skills/gutenberg-pr-review/evals/audit/README.md
+++ b/.skills/gutenberg-pr-review/evals/audit/README.md
@@ -1,0 +1,78 @@
+# Gutenberg PR review audit
+
+This gitignored workspace contains the resumable tooling used to audit every
+`WordPress/gutenberg` pull request and update
+`.skills/gutenberg-pr-review/SKILL.md` from review evidence.
+
+## Scope and snapshot
+
+`full_collect.py` freezes the union of open, merged, and closed-unmerged PRs at
+startup using the total and last edge from one oldest-first GraphQL connection.
+It then records each PR as observed during a single serial pass. This is an
+exact population snapshot, but review content and state are per-PR observations
+rather than an atomic repository-wide point-in-time view.
+
+Nested connections are reconciled to their declared counts. Reviews, inline
+review comments, and issue comments use fully paginated REST fallbacks when
+their first 100 entries overflow. File overflow uses cursor-paginated GraphQL so
+it is not subject to the REST endpoint's 3,000-file cap. The SQLite cursor and
+manifest are checkpointed after every top-level page.
+
+```bash
+python3 .skills/gutenberg-pr-review/evals/audit/full_collect.py \
+  --db .skills/gutenberg-pr-review/evals/audit/full_reviews.sqlite \
+  --batch-size 20
+```
+
+Exit status 75 means the collector stopped cleanly near a rate-limit boundary;
+rerun the same command after the recorded reset. A completed rerun is
+idempotent. For the full multi-reset crawl, the scheduler performs only that
+resume loop and stops on any non-rate-limit failure:
+
+```bash
+python3 .skills/gutenberg-pr-review/evals/audit/run_full_collection.py
+```
+
+## Exhaustive comment ledger
+
+The analysis stage streams the database, gives every collected artifact one
+ledger disposition, and creates bounded batches. Exclusions are deterministic
+and applied in this order: bot, PR-author follow-up, empty body, exact
+low-signal approval/thanks. Every other artifact is assigned exactly once,
+without filtering by PR state, age, author association, path, or review state.
+
+```bash
+python3 .skills/gutenberg-pr-review/evals/audit/full_analyze.py build \
+  --db .skills/gutenberg-pr-review/evals/audit/full_reviews.sqlite \
+  --output .skills/gutenberg-pr-review/evals/audit/full-analysis
+
+python3 .skills/gutenberg-pr-review/evals/audit/full_analyze.py validate \
+  --db .skills/gutenberg-pr-review/evals/audit/full_reviews.sqlite \
+  --output .skills/gutenberg-pr-review/evals/audit/full-analysis
+```
+
+`run_audit_workers.py` runs one isolated Codex context per batch, with three
+workers by default. It validates exact ordered IDs and ledger metadata before
+atomically accepting an output and is safe to resume.
+
+```bash
+python3 .skills/gutenberg-pr-review/evals/audit/run_audit_workers.py \
+  --analysis .skills/gutenberg-pr-review/evals/audit/full-analysis \
+  --output .skills/gutenberg-pr-review/evals/audit/full-worker-results \
+  --concurrency 3
+
+python3 .skills/gutenberg-pr-review/evals/audit/full_analyze.py validate-workers \
+  --analysis .skills/gutenberg-pr-review/evals/audit/full-analysis \
+  --workers .skills/gutenberg-pr-review/evals/audit/full-worker-results
+```
+
+The accepted result is reduced into candidate guidance only after exhaustive
+worker coverage passes. Candidate rules are then checked against the current
+`origin/trunk` code, tests, and documentation before the skill is edited.
+
+## Retention
+
+`FULL_AUDIT_TEST_PLAN.md` is the release and cleanup gate. After the skill and
+`FULL_AUDIT_SUMMARY.md` are verified, raw full-audit and old 500-PR pilot data
+are permanently removed. The generalized scripts, shared prompt, README, test
+plan, concise summary, and updated skill are retained.

--- a/.skills/gutenberg-pr-review/evals/audit/REDUCER_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/REDUCER_PROMPT.md
@@ -1,0 +1,30 @@
+# Gutenberg review-finding reduction instructions
+
+Reduce every supplied finding into a smaller set of evidence-backed,
+generalizable PR-review rules. This is a semantic consolidation pass, not the
+later current-`trunk` validation pass.
+
+Cluster findings that express the same underlying reviewer check even when
+their wording and source categories differ. Preserve meaningful distinctions
+between preconditions, failure modes, and validation techniques. Do not reject
+or discard findings in this stage: a finding with no credible semantic peer
+must remain as a singleton cluster.
+
+For each cluster:
+
+1. Use a unique batch-local key `C01`, `C02`, and so on.
+2. Select the best matching canonical domain from the schema; the batch's
+   routed domain is only a hint.
+3. Use a stable kebab-case `topic_slug` describing the concrete check.
+4. Phrase `canonical_rule` as a concise imperative reviewer instruction.
+5. Set severity to the greatest credible impact represented by the members.
+6. Set `needs_current_validation` when the rule depends on current repository
+   code, documentation, tooling, policy, or conventions.
+7. List every supporting finding ID exactly once in `member_ids`.
+8. Explain why the members express the same operational check in `merge_basis`.
+
+Use `unresolved` only when the supplied fields cannot establish meaning without
+the original comment body or PR diff. Do not use it merely because a finding is
+unique. Every supplied finding ID must appear exactly once across all cluster
+member lists and unresolved entries. Do not invent, omit, or duplicate IDs.
+Return only the JSON object required by the supplied schema.

--- a/.skills/gutenberg-pr-review/evals/audit/TRUNK_DELTA_VALIDATION_PROMPT.md
+++ b/.skills/gutenberg-pr-review/evals/audit/TRUNK_DELTA_VALIDATION_PROMPT.md
@@ -1,0 +1,18 @@
+# Gutenberg skill trunk-delta validation
+
+The review guidance in `.skills/gutenberg-pr-review/` was
+validated against commit `49120c3204955ba1f83c7224793f52813689e7e1`.
+`origin/trunk` is now `03a6675a25ede7f8e31e5232742615f95358bcb6`.
+
+Inspect the exact six-commit delta and determine whether any statement in the
+skill or its six references is contradicted, superseded, or needs narrower
+wording. Pay particular attention to the removal of the private Components
+Theme API, the URLInput refactor, UI Dialog/Drawer guidance, dependency
+updates, and changelog/build conventions.
+
+Do not edit files or use network access. Return a concise Markdown report:
+
+- exact commits and relevant files inspected;
+- each affected skill statement, if any, with the required replacement;
+- otherwise an explicit conclusion that no rule is invalidated;
+- the newer commit that can safely be recorded as the delta-checked head.

--- a/.skills/gutenberg-pr-review/evals/audit/analyze.py
+++ b/.skills/gutenberg-pr-review/evals/audit/analyze.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Create bounded, evidence-linked analysis inputs from the pilot database."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import re
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ACTION_MARKERS = re.compile(
+    r"\b(should|could|would|please|need(?:s|ed)?|must|consider|prefer|instead|"
+    r"missing|incorrect|break|broken|fail|lost|race|regress|bug|issue|error|"
+    r"why|what about|how about|can we|do we|is this|nit(?:pick)?|suggest|"
+    r"non[- ]?block|blocker|follow[- ]?up|not sure|wonder|avoid|remove|add|"
+    r"update|rename|test|document|a11y|accessib|focus|aria|type|token|cache|"
+    r"permission|security|validate|sanitize|escape|deprecated|compatib)\b",
+    re.IGNORECASE,
+)
+
+LOW_SIGNAL = re.compile(
+    r"^(?:lgtm|looks good(?: to me)?|approved|ship it|nice|great|thanks!?|"
+    r"thank you!?|tested and works|works for me|✅|👍)[.!\s🎉:+-]*$",
+    re.IGNORECASE,
+)
+
+CATEGORY_PATTERNS: dict[str, tuple[str, ...]] = {
+    "scope_simplicity": (
+        r"\bscope\b", r"unrelated", r"separate pr", r"follow[- ]?up",
+        r"overkill", r"simplif", r"inline this", r"single call",
+        r"duplica", r"redundan", r"dead code",
+    ),
+    "changelog_documentation": (
+        r"changelog", r"readme", r"document(?:ation|ed)?", r"docblock",
+        r"phpdoc", r"jsdoc", r"pr link", r"comment (?:is|says)",
+        r"description", r"example", r"wording", r"typo",
+    ),
+    "css_design_system": (
+        r"\.s?css\b", r"stylesheet", r"class(?:name)?", r"selector",
+        r"design token", r"--wpds-", r"base-styles", r"mixin", r"outline",
+        r"focus ring", r"hardcoded", r"spacing", r"color", r"module\.scss",
+    ),
+    "state_lifecycle": (
+        r"useeffect", r"usememo", r"usecallback", r"dependency array",
+        r"stale", r"race", r"unmount", r"cleanup", r"deboun", r"pending",
+        r"derived state", r"controlled", r"uncontrolled", r"onopenchange",
+        r"callback ref", r"resizeobserver", r"lost", r"silently",
+    ),
+    "typescript_types": (
+        r"typescript", r"\btype(?:s|d)?\b", r"interface", r"\bany\b",
+        r"as const", r"literal", r"return type", r"type guard", r"is_string",
+        r"is_array", r"instanceof", r"undefined", r"nullable?",
+    ),
+    "tests": (
+        r"\btests?\b", r"coverage", r"regression", r"storybook", r"e2e",
+        r"assert", r"expect\(", r"mock", r"fixture", r"timeout", r"flaky",
+        r"implementation detail", r"happy path", r"edge case",
+    ),
+    "existing_utility_api": (
+        r"existing", r"already (?:have|exists)", r"reuse", r"utility",
+        r"helper", r"primitive", r"extend .*props", r"public api", r"private api",
+        r"export", r"prop name", r"selector", r"action", r"component",
+    ),
+    "dependencies_build": (
+        r"dependenc", r"package\.json", r"node_modules", r"isolated",
+        r"hoist", r"resolve .*explicit", r"transitive", r"workspace",
+        r"pnpm", r"npm", r"node\.js", r"webpack", r"storybook.*alias",
+        r"import", r"require\(", r"build",
+    ),
+    "ci_release_tooling": (
+        r"workflow", r"github action", r"release", r"permission", r"token",
+        r"secret", r"cache key", r"cache hit", r"artifact", r"publish",
+        r"cherry-pick", r"rollback", r"restore", r"fail fast", r"side effect",
+    ),
+    "accessibility": (
+        r"accessib", r"\ba11y\b", r"screen reader", r"voiceover", r"nvda",
+        r"\baria[-_]", r"focus", r"keyboard", r"tooltip", r"visuallyhidden",
+        r"announcement", r"speak\(", r"semantic", r"role=", r"assistive",
+        r"rtl", r"dir=", r"shortcut",
+    ),
+    "php_rest_security": (
+        r"\bphp\b", r"rest api", r"validate_callback", r"sanitize",
+        r"escape", r"nonce", r"capabilit", r"permission_callback",
+        r"wp_html_tag_processor", r"wpdb", r"phpcs",
+    ),
+    "data_validation_errors": (
+        r"validat", r"schema", r"data shape", r"malformed", r"corrupt",
+        r"error handling", r"throw new error", r"console\.error", r"fallback",
+        r"partial", r"atomic", r"rollback", r"unexpected", r"guard",
+    ),
+    "performance": (
+        r"performance", r"expensive", r"memoiz", r"re-render", r"render cycle",
+        r"layout thrash", r"query count", r"cache", r"batch", r"worker",
+    ),
+    "i18n": (
+        r"i18n", r"translat", r"localiz", r"__\(", r"_n\(", r"_x\(",
+        r"translator comment", r"locale",
+    ),
+    "compatibility_deprecation": (
+        r"back(?:ward|wards)? compat", r"back compat", r"deprecated",
+        r"deprecat", r"legacy", r"migration", r"backport", r"wordpress-\d",
+        r"minimum required", r"consumer", r"third[- ]party",
+    ),
+    "icons": (
+        r"\bicon\b", r"\bsvg\b", r"viewbox", r"currentcolor", r"path d=",
+    ),
+}
+
+COMPILED_CATEGORIES = {
+    name: [re.compile(pattern, re.IGNORECASE) for pattern in patterns]
+    for name, patterns in CATEGORY_PATTERNS.items()
+}
+
+STOPWORDS = {
+    "about", "after", "again", "also", "because", "been", "before", "being",
+    "between", "both", "could", "does", "doing", "from", "have", "here",
+    "into", "just", "like", "looks", "maybe", "more", "most", "need", "only",
+    "other", "should", "some", "still", "than", "that", "their", "there",
+    "these", "they", "think", "this", "those", "through", "using", "very",
+    "want", "when", "where", "which", "while", "with", "would", "your",
+    "suggested", "change", "diff", "gutenberg", "packages", "wordpress",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db", type=Path, default=Path(__file__).with_name("reviews.sqlite")
+    )
+    parser.add_argument(
+        "--output", type=Path, default=Path(__file__).with_name("analysis")
+    )
+    parser.add_argument("--batch-chars", type=int, default=40000)
+    return parser.parse_args()
+
+
+def actionable(row: sqlite3.Row) -> bool:
+    body = row["body"].strip()
+    if not body or row["is_bot"] or row["author"] == row["pr_author"]:
+        return False
+    compact = re.sub(r"\s+", " ", body)
+    if LOW_SIGNAL.fullmatch(compact):
+        return False
+    if row["kind"] == "review_comment":
+        return len(compact) >= 12
+    if row["kind"] == "review" and row["state"] == "CHANGES_REQUESTED":
+        return True
+    return bool(ACTION_MARKERS.search(compact))
+
+
+def categories(body: str) -> list[str]:
+    found = [
+        name
+        for name, patterns in COMPILED_CATEGORIES.items()
+        if any(pattern.search(body) for pattern in patterns)
+    ]
+    return found or ["unclassified"]
+
+
+def tokens(body: str) -> list[str]:
+    body = re.sub(r"https?://\S+|```.*?```", " ", body, flags=re.DOTALL)
+    return [
+        token
+        for token in re.findall(r"[a-z][a-z0-9_-]{2,}", body.lower())
+        if token not in STOPWORDS and not token.isdigit()
+    ]
+
+
+def ngrams(items: list[str], size: int) -> Iterable[tuple[str, ...]]:
+    for index in range(len(items) - size + 1):
+        gram = tuple(items[index : index + size])
+        if len(set(gram)) > 1:
+            yield gram
+
+
+def compact_body(body: str, limit: int = 1200) -> str:
+    compact = re.sub(r"\s+", " ", body).strip()
+    return compact if len(compact) <= limit else compact[: limit - 1] + "…"
+
+
+def diverse_samples(records: list[dict[str, Any]], limit: int = 12) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    authors: collections.Counter[str] = collections.Counter()
+    prs: set[int] = set()
+    ranked = sorted(
+        records,
+        key=lambda record: (
+            record["state"] == "CHANGES_REQUESTED",
+            record["kind"] == "review_comment",
+            min(len(record["body"]), 3000),
+        ),
+        reverse=True,
+    )
+    for record in ranked:
+        if authors[record["author"] or ""] >= 2 or record["pr_number"] in prs:
+            continue
+        selected.append(record)
+        authors[record["author"] or ""] += 1
+        prs.add(record["pr_number"])
+        if len(selected) == limit:
+            break
+    return selected
+
+
+def write_batches(records: list[dict[str, Any]], output: Path, limit: int) -> int:
+    batches_dir = output / "batches"
+    if batches_dir.exists():
+        shutil.rmtree(batches_dir)
+    batches_dir.mkdir(parents=True)
+    batch: list[str] = []
+    batch_size = 0
+    batch_number = 1
+    for record in records:
+        text = (
+            f"## PR #{record['pr_number']} — {record['title']}\n"
+            f"- Artifact: {record['kind']} / {record['state'] or 'N/A'}\n"
+            f"- Reviewer: {record['author']}\n"
+            f"- Path: {record['path'] or 'general discussion'}\n"
+            f"- URL: {record['url']}\n"
+            f"- Seed categories: {', '.join(record['categories'])}\n\n"
+            f"{record['body'].strip()}\n\n"
+        )
+        if batch and batch_size + len(text) > limit:
+            (batches_dir / f"batch-{batch_number:03d}.md").write_text(
+                "".join(batch), encoding="utf-8"
+            )
+            batch_number += 1
+            batch = []
+            batch_size = 0
+        batch.append(text)
+        batch_size += len(text)
+    if batch:
+        (batches_dir / f"batch-{batch_number:03d}.md").write_text(
+            "".join(batch), encoding="utf-8"
+        )
+    return batch_number
+
+
+def main() -> int:
+    args = parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(args.db)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT a.*, p.title, p.author AS pr_author, p.created_at AS pr_created_at,
+               p.merged_at, p.labels_json
+        FROM artifacts a
+        JOIN pull_requests p ON p.number = a.pr_number
+        WHERE TRIM(a.body) != ''
+        ORDER BY p.number DESC, a.created_at, a.id
+        """
+    ).fetchall()
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        if not actionable(row):
+            continue
+        body = row["body"].strip()
+        record = {
+            "id": row["id"],
+            "fingerprint": hashlib.sha256(body.encode()).hexdigest()[:16],
+            "pr_number": row["pr_number"],
+            "title": row["title"],
+            "kind": row["kind"],
+            "state": row["state"],
+            "author": row["author"],
+            "author_association": row["author_association"],
+            "url": row["url"],
+            "path": row["path"],
+            "created_at": row["created_at"],
+            "merged_at": row["merged_at"],
+            "labels": json.loads(row["labels_json"]),
+            "categories": categories(body),
+            "body": body,
+        }
+        records.append(record)
+
+    with (args.output / "corpus.jsonl").open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    category_records: dict[str, list[dict[str, Any]]] = collections.defaultdict(list)
+    author_counts: collections.Counter[str] = collections.Counter()
+    bigrams: collections.Counter[tuple[str, ...]] = collections.Counter()
+    trigrams: collections.Counter[tuple[str, ...]] = collections.Counter()
+    code_terms: collections.Counter[str] = collections.Counter()
+    kinds: collections.Counter[str] = collections.Counter()
+    prs: set[int] = set()
+    for record in records:
+        prs.add(record["pr_number"])
+        kinds[record["kind"]] += 1
+        author_counts[record["author"] or "unknown"] += 1
+        for category in record["categories"]:
+            category_records[category].append(record)
+        words = tokens(record["body"])
+        bigrams.update(ngrams(words, 2))
+        trigrams.update(ngrams(words, 3))
+        code_terms.update(re.findall(r"`([^`\n]{2,80})`", record["body"]))
+
+    batch_count = write_batches(records, args.output, args.batch_chars)
+    summary: list[str] = [
+        "# Pilot analysis summary\n\n",
+        f"- Actionable artifacts retained: {len(records)} across {len(prs)} PRs.\n",
+        f"- Kinds: {dict(kinds)}.\n",
+        f"- Bounded analysis batches: {batch_count} (target {args.batch_chars:,} characters each).\n\n",
+        "## Category counts\n\n",
+    ]
+    for category, items in sorted(
+        category_records.items(), key=lambda item: len(item[1]), reverse=True
+    ):
+        summary.append(f"- `{category}`: {len(items)}\n")
+    summary.extend(["\n## Top reviewers\n\n"])
+    for author, count in author_counts.most_common(25):
+        summary.append(f"- {author}: {count}\n")
+    summary.extend(["\n## Recurring phrases\n\n", "### Bigrams\n\n"])
+    for gram, count in bigrams.most_common(40):
+        summary.append(f"- `{ ' '.join(gram) }`: {count}\n")
+    summary.extend(["\n### Trigrams\n\n"])
+    for gram, count in trigrams.most_common(30):
+        summary.append(f"- `{ ' '.join(gram) }`: {count}\n")
+    summary.extend(["\n### Backticked terms\n\n"])
+    for term, count in code_terms.most_common(50):
+        summary.append(f"- `{term}`: {count}\n")
+    summary.extend(["\n## Diverse evidence samples by category\n\n"])
+    for category, items in sorted(category_records.items()):
+        summary.append(f"### {category} ({len(items)})\n\n")
+        for record in diverse_samples(items):
+            summary.append(
+                f"- [#{record['pr_number']}]({record['url']}) "
+                f"{record['author']} — {record['path'] or 'general'}: "
+                f"{compact_body(record['body'])}\n"
+            )
+        summary.append("\n")
+    (args.output / "summary.md").write_text("".join(summary), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "actionable_artifacts": len(records),
+                "prs": len(prs),
+                "batches": batch_count,
+                "categories": {
+                    key: len(value)
+                    for key, value in sorted(category_records.items())
+                },
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/build_current_validation.py
+++ b/.skills/gutenberg-pr-review/evals/audit/build_current_validation.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Build current-origin/trunk validation batches for the final rule shortlist."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import reduce_clusters
+
+
+def schema(origin_sha: str) -> dict:
+    evidence = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["path", "line_start", "line_end", "explanation"],
+        "properties": {
+            "path": {"type": "string", "minLength": 1, "maxLength": 300},
+            "line_start": {"type": "integer", "minimum": 1},
+            "line_end": {"type": "integer", "minimum": 1},
+            "explanation": {"type": "string", "minLength": 1, "maxLength": 500},
+        },
+    }
+    decision = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "cluster_id",
+            "disposition",
+            "validated_rule",
+            "evidence",
+            "rationale",
+        ],
+        "properties": {
+            "cluster_id": {"type": "string", "pattern": "^K[0-9a-f]{16}$"},
+            "disposition": {
+                "type": "string",
+                "enum": ["supported", "revised", "obsolete", "insufficient-context"],
+            },
+            "validated_rule": {"type": "string", "maxLength": 500},
+            "evidence": {"type": "array", "maxItems": 6, "items": evidence},
+            "rationale": {"type": "string", "minLength": 1, "maxLength": 1000},
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["origin_sha", "decisions"],
+        "properties": {
+            "origin_sha": {"type": "string", "const": origin_sha},
+            "decisions": {"type": "array", "items": decision},
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shortlist", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--origin-sha", required=True)
+    args = parser.parse_args()
+    shortlist = args.shortlist.resolve()
+    output = args.output.resolve()
+    nodes = list(reduce_clusters.jsonl(shortlist / "cluster-ledger.jsonl"))
+    ids = [node["cluster_id"] for node in nodes]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate shortlist cluster IDs")
+    by_domain: dict[str, list[dict]] = defaultdict(list)
+    for node in nodes:
+        by_domain[node["domain"]].append(node)
+
+    output.mkdir(parents=True, exist_ok=True)
+    batches = output / "batches"
+    batches.mkdir(exist_ok=True)
+    reduce_clusters.write_json(output / "validation-output.schema.json", schema(args.origin_sha))
+    index = []
+    for number, (domain, domain_nodes) in enumerate(sorted(by_domain.items()), 1):
+        name = f"validate-{number:02d}-{domain}.md"
+        path = batches / name
+        lines = [
+            f"# Current-trunk validation: {domain}",
+            "",
+            f"Pinned origin/trunk commit: `{args.origin_sha}`",
+            f"Candidate count: {len(domain_nodes)}",
+            "",
+            "Candidates follow as JSON Lines:",
+            "",
+        ]
+        for node in domain_nodes:
+            lines.append(
+                json.dumps(
+                    {
+                        "cluster_id": node["cluster_id"],
+                        "canonical_rule": node["canonical_rule"],
+                        "topic_slug": node["topic_slug"],
+                        "severity": node["severity"],
+                        "support_count": node["support_count"],
+                        "distinct_prs": node["distinct_prs"],
+                        "distinct_reviewers": node["distinct_reviewers"],
+                        "state_counts": node["state_counts"],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+        lines.append("")
+        path.write_text("\n".join(lines), encoding="utf-8")
+        index.append(
+            {
+                "batch": name,
+                "domain": domain,
+                "candidate_count": len(domain_nodes),
+                "candidate_ids": [node["cluster_id"] for node in domain_nodes],
+                "sha256": reduce_clusters.sha256(path),
+            }
+        )
+    reduce_clusters.write_jsonl(output / "validation-index.jsonl", index)
+    manifest = {
+        "origin_sha": args.origin_sha,
+        "candidate_count": len(nodes),
+        "batch_count": len(index),
+        "domain_counts": dict(Counter(node["domain"] for node in nodes)),
+        "shortlist_ledger_sha256": reduce_clusters.sha256(
+            shortlist / "cluster-ledger.jsonl"
+        ),
+        "index_sha256": reduce_clusters.sha256(output / "validation-index.jsonl"),
+        "schema_sha256": reduce_clusters.sha256(
+            output / "validation-output.schema.json"
+        ),
+    }
+    reduce_clusters.write_json(output / "manifest.json", manifest)
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/build_editorial.py
+++ b/.skills/gutenberg-pr-review/evals/audit/build_editorial.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Prepare strict editorial-triage schema and validate its source plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import reduce_findings
+from reduce_clusters import jsonl, sha256, write_json
+
+
+def schema() -> dict:
+    decision = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["cluster_id", "action", "candidate", "reason"],
+        "properties": {
+            "cluster_id": {"type": "string", "pattern": "^K[0-9a-f]{16}$"},
+            "action": {
+                "type": "string",
+                "enum": [
+                    "advance",
+                    "reject-too-specific",
+                    "reject-preference",
+                    "reject-unsupported",
+                    "reject-obsolete",
+                    "reject-not-operational",
+                ],
+            },
+            "candidate": {"type": "string", "pattern": "^(?:C[0-9]{2}|)$"},
+            "reason": {"type": "string", "minLength": 1, "maxLength": 500},
+        },
+    }
+    cluster = reduce_findings.worker_schema()["properties"]["clusters"]["items"]
+    cluster = json.loads(json.dumps(cluster))
+    cluster["required"] = [
+        "local_id",
+        "domain",
+        "topic_slug",
+        "canonical_rule",
+        "severity",
+        "needs_current_validation",
+        "member_ids",
+        "merge_basis",
+    ]
+    cluster["properties"]["member_ids"]["items"]["pattern"] = "^K[0-9a-f]{16}$"
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["decisions", "candidates"],
+        "properties": {
+            "decisions": {"type": "array", "items": decision},
+            "candidates": {
+                "type": "array",
+                "maxItems": 25,
+                "items": cluster,
+            },
+        },
+    }
+
+
+def prepare(source: Path) -> dict:
+    ledger = list(jsonl(source / "cluster-ledger.jsonl"))
+    index = list(jsonl(source / "merge-index.jsonl"))
+    ids = {row["cluster_id"] for row in ledger}
+    indexed = [value for batch in index for value in batch["finding_ids"]]
+    if len(ids) != len(ledger) or len(indexed) != len(set(indexed)):
+        raise ValueError("duplicate editorial-source IDs")
+    if set(indexed) != ids:
+        raise ValueError("editorial index does not partition source clusters")
+    for batch in index:
+        path = source / "batches" / batch["batch"]
+        if sha256(path) != batch["sha256"]:
+            raise ValueError(f"{path}: checksum mismatch")
+    output = source / "editorial-output.schema.json"
+    write_json(output, schema())
+    result = {
+        "source_cluster_count": len(ledger),
+        "batch_count": len(index),
+        "schema": str(output),
+        "schema_sha256": sha256(output),
+    }
+    write_json(source / "editorial-manifest.json", result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    args = parser.parse_args()
+    print(json.dumps(prepare(args.source.resolve()), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/collect.py
+++ b/.skills/gutenberg-pr-review/evals/audit/collect.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Collect a resumable pilot corpus of merged Gutenberg PR reviews."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+QUERY = r"""
+query CollectPullRequests($first: Int!, $after: String) {
+  repository(owner: "WordPress", name: "gutenberg") {
+    pullRequests(
+      first: $first
+      after: $after
+      states: MERGED
+      orderBy: { field: CREATED_AT, direction: DESC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        url
+        title
+        bodyText
+        createdAt
+        updatedAt
+        mergedAt
+        authorAssociation
+        author { login __typename }
+        labels(first: 50) { nodes { name } }
+        files(first: 100) {
+          totalCount
+          nodes { path }
+        }
+        reviews(first: 100) {
+          totalCount
+          nodes {
+            id
+            databaseId
+            url
+            state
+            bodyText
+            submittedAt
+            authorAssociation
+            author { login __typename }
+            comments(first: 100) {
+              totalCount
+              nodes {
+                id
+                databaseId
+                url
+                bodyText
+                createdAt
+                updatedAt
+                path
+                line
+                originalLine
+                outdated
+                authorAssociation
+                author { login __typename }
+              }
+            }
+          }
+        }
+        comments(first: 100) {
+          totalCount
+          nodes {
+            id
+            databaseId
+            url
+            bodyText
+            createdAt
+            updatedAt
+            authorAssociation
+            author { login __typename }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+
+SCHEMA = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pull_requests (
+    number INTEGER PRIMARY KEY,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author TEXT,
+    author_association TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    merged_at TEXT NOT NULL,
+    labels_json TEXT NOT NULL,
+    files_total INTEGER NOT NULL,
+    reviews_total INTEGER NOT NULL,
+    issue_comments_total INTEGER NOT NULL,
+    raw_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS files (
+    pr_number INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    PRIMARY KEY (pr_number, path),
+    FOREIGN KEY (pr_number) REFERENCES pull_requests(number) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS artifacts (
+    id TEXT PRIMARY KEY,
+    database_id INTEGER,
+    pr_number INTEGER NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('review', 'review_comment', 'issue_comment')),
+    parent_review_id TEXT,
+    url TEXT,
+    body TEXT NOT NULL,
+    state TEXT,
+    path TEXT,
+    line INTEGER,
+    original_line INTEGER,
+    outdated INTEGER,
+    author TEXT,
+    author_association TEXT,
+    is_bot INTEGER NOT NULL,
+    created_at TEXT,
+    updated_at TEXT,
+    comments_total INTEGER,
+    FOREIGN KEY (pr_number) REFERENCES pull_requests(number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS artifacts_pr_number ON artifacts(pr_number);
+CREATE INDEX IF NOT EXISTS artifacts_kind ON artifacts(kind);
+CREATE INDEX IF NOT EXISTS artifacts_author ON artifacts(author);
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--batch-size", type=int, default=10)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path(__file__).with_name("reviews.sqlite"),
+    )
+    return parser.parse_args()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def author_fields(author: dict[str, Any] | None) -> tuple[str | None, int]:
+    if not author:
+        return None, 0
+    login = author.get("login")
+    typename = author.get("__typename")
+    is_bot = typename == "Bot" or bool(login and login.lower().endswith("[bot]"))
+    return login, int(is_bot)
+
+
+def gh_graphql(first: int, after: str | None) -> dict[str, Any]:
+    command = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={QUERY}",
+        "-F",
+        f"first={first}",
+    ]
+    if after:
+        command.extend(["-F", f"after={after}"])
+    result = subprocess.run(command, text=True, capture_output=True)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "gh api graphql failed")
+    payload = json.loads(result.stdout)
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2))
+    return payload
+
+
+def gh_rest_pages(endpoint: str) -> list[dict[str, Any]]:
+    result = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", endpoint],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or f"gh api failed for {endpoint}")
+    pages = json.loads(result.stdout)
+    return [item for page in pages for item in page]
+
+
+def gh_rate_limit() -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            "query=query { rateLimit { cost remaining resetAt } }",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "failed to query GraphQL rate limit")
+    return json.loads(result.stdout)["data"]["rateLimit"]
+
+
+def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def set_meta(conn: sqlite3.Connection, key: str, value: Any) -> None:
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, str(value)),
+    )
+
+
+def insert_artifact(
+    conn: sqlite3.Connection,
+    *,
+    artifact: dict[str, Any],
+    pr_number: int,
+    kind: str,
+    parent_review_id: str | None = None,
+    state: str | None = None,
+    comments_total: int | None = None,
+) -> None:
+    author, is_bot = author_fields(artifact.get("author"))
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO artifacts(
+            id, database_id, pr_number, kind, parent_review_id, url, body, state,
+            path, line, original_line, outdated, author, author_association,
+            is_bot, created_at, updated_at, comments_total
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            artifact["id"],
+            artifact.get("databaseId"),
+            pr_number,
+            kind,
+            parent_review_id,
+            artifact.get("url"),
+            artifact.get("bodyText") or "",
+            state,
+            artifact.get("path"),
+            artifact.get("line"),
+            artifact.get("originalLine"),
+            int(artifact["outdated"]) if artifact.get("outdated") is not None else None,
+            author,
+            artifact.get("authorAssociation"),
+            is_bot,
+            artifact.get("submittedAt") or artifact.get("createdAt"),
+            artifact.get("updatedAt"),
+            comments_total,
+        ),
+    )
+
+
+def insert_pr(conn: sqlite3.Connection, pr: dict[str, Any]) -> None:
+    number = pr["number"]
+    author, _ = author_fields(pr.get("author"))
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO pull_requests(
+            number, url, title, body, author, author_association, created_at,
+            updated_at, merged_at, labels_json, files_total, reviews_total,
+            issue_comments_total, raw_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            number,
+            pr["url"],
+            pr["title"],
+            pr.get("bodyText") or "",
+            author,
+            pr.get("authorAssociation"),
+            pr["createdAt"],
+            pr["updatedAt"],
+            pr["mergedAt"],
+            json.dumps([node["name"] for node in pr["labels"]["nodes"]]),
+            pr["files"]["totalCount"],
+            pr["reviews"]["totalCount"],
+            pr["comments"]["totalCount"],
+            json.dumps(pr, separators=(",", ":")),
+        ),
+    )
+    conn.execute("DELETE FROM files WHERE pr_number = ?", (number,))
+    conn.executemany(
+        "INSERT OR IGNORE INTO files(pr_number, path) VALUES (?, ?)",
+        [(number, node["path"]) for node in pr["files"]["nodes"]],
+    )
+    conn.execute("DELETE FROM artifacts WHERE pr_number = ?", (number,))
+    for review in pr["reviews"]["nodes"]:
+        insert_artifact(
+            conn,
+            artifact=review,
+            pr_number=number,
+            kind="review",
+            state=review["state"],
+            comments_total=review["comments"]["totalCount"],
+        )
+        for comment in review["comments"]["nodes"]:
+            insert_artifact(
+                conn,
+                artifact=comment,
+                pr_number=number,
+                kind="review_comment",
+                parent_review_id=review["id"],
+                state=review["state"],
+            )
+    for comment in pr["comments"]["nodes"]:
+        insert_artifact(
+            conn,
+            artifact=comment,
+            pr_number=number,
+            kind="issue_comment",
+        )
+
+
+def backfill_files(conn: sqlite3.Connection) -> int:
+    rows = conn.execute(
+        """
+        SELECT p.number, p.files_total, COUNT(f.path) AS files_collected
+        FROM pull_requests p
+        LEFT JOIN files f ON f.pr_number = p.number
+        GROUP BY p.number
+        HAVING files_collected < p.files_total
+        ORDER BY p.number DESC
+        """
+    ).fetchall()
+    for number, expected, _ in rows:
+        files = gh_rest_pages(
+            f"repos/WordPress/gutenberg/pulls/{number}/files?per_page=100"
+        )
+        with conn:
+            conn.execute("DELETE FROM files WHERE pr_number = ?", (number,))
+            conn.executemany(
+                "INSERT INTO files(pr_number, path) VALUES (?, ?)",
+                [(number, item["filename"]) for item in files],
+            )
+        if len(files) != expected:
+            raise RuntimeError(
+                f"PR #{number}: expected {expected} files but collected {len(files)}"
+            )
+        print(f"backfilled files for PR #{number}: {len(files)}", flush=True)
+    return len(rows)
+
+
+def write_manifest(db_path: Path, conn: sqlite3.Connection, rate: dict[str, Any]) -> None:
+    if not rate:
+        stored_rate = get_meta(conn, "last_rate_limit")
+        rate = json.loads(stored_rate) if stored_rate else {}
+    counts = conn.execute(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM pull_requests),
+          (SELECT COUNT(*) FROM artifacts),
+          (SELECT COUNT(*) FROM artifacts WHERE kind = 'review'),
+          (SELECT COUNT(*) FROM artifacts WHERE kind = 'review_comment'),
+          (SELECT COUNT(*) FROM artifacts WHERE kind = 'issue_comment'),
+          (SELECT COUNT(*) FROM artifacts WHERE is_bot = 0 AND TRIM(body) != '')
+        """
+    ).fetchone()
+    truncation = conn.execute(
+        """
+        SELECT
+          COALESCE(SUM(
+            (SELECT COUNT(*) FROM files f WHERE f.pr_number = p.number) < p.files_total
+          ), 0),
+          COALESCE(SUM(
+            (SELECT COUNT(*) FROM artifacts a
+             WHERE a.pr_number = p.number AND a.kind = 'review') < p.reviews_total
+          ), 0),
+          COALESCE(SUM(
+            (SELECT COUNT(*) FROM artifacts a
+             WHERE a.pr_number = p.number AND a.kind = 'issue_comment') < p.issue_comments_total
+          ), 0),
+          COALESCE((
+            SELECT SUM(
+              (SELECT COUNT(*) FROM artifacts child
+               WHERE child.parent_review_id = review.id
+                 AND child.kind = 'review_comment') < review.comments_total
+            )
+            FROM artifacts review
+            WHERE review.kind = 'review'
+          ), 0)
+        FROM pull_requests p
+        """
+    ).fetchone()
+    manifest = {
+        "updated_at": utc_now(),
+        "scope": "merged PRs ordered by creation time descending",
+        "target_limit": int(get_meta(conn, "target_limit") or 0),
+        "pull_requests": counts[0],
+        "artifacts": {
+            "total": counts[1],
+            "reviews": counts[2],
+            "review_comments": counts[3],
+            "issue_comments": counts[4],
+            "nonempty_human": counts[5],
+        },
+        "possibly_truncated_connections": {
+            "files": truncation[0],
+            "reviews": truncation[1],
+            "issue_comments": truncation[2],
+            "review_comments": truncation[3],
+        },
+        "rate_limit": rate,
+        "cursor": get_meta(conn, "cursor"),
+        "has_next_page": get_meta(conn, "has_next_page") == "True",
+    }
+    destination = db_path.with_name("manifest.json")
+    with tempfile.NamedTemporaryFile(
+        "w", dir=destination.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, destination)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.limit <= 0 or not 1 <= args.batch_size <= 20:
+        raise SystemExit("limit must be positive; batch size must be between 1 and 20")
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(args.db)
+    conn.executescript(SCHEMA)
+    existing_target = get_meta(conn, "target_limit")
+    if existing_target and int(existing_target) != args.limit:
+        raise SystemExit(
+            f"database target is {existing_target}; use a fresh database for {args.limit}"
+        )
+    set_meta(conn, "target_limit", args.limit)
+    if not get_meta(conn, "started_at"):
+        set_meta(conn, "started_at", utc_now())
+        set_meta(conn, "ordering", "CREATED_AT_DESC")
+    conn.commit()
+
+    count = conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]
+    cursor = get_meta(conn, "cursor")
+    last_rate: dict[str, Any] = {}
+    while count < args.limit:
+        first = min(args.batch_size, args.limit - count)
+        payload = gh_graphql(first, cursor)
+        connection = payload["data"]["repository"]["pullRequests"]
+        nodes = connection["nodes"]
+        if not nodes:
+            raise RuntimeError("GitHub returned no PRs before the target was reached")
+        with conn:
+            for pr in nodes:
+                insert_pr(conn, pr)
+            cursor = connection["pageInfo"]["endCursor"]
+            set_meta(conn, "cursor", cursor)
+            set_meta(conn, "has_next_page", connection["pageInfo"]["hasNextPage"])
+            set_meta(conn, "updated_at", utc_now())
+        count = conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]
+        last_rate = payload["data"]["rateLimit"]
+        with conn:
+            set_meta(conn, "last_rate_limit", json.dumps(last_rate))
+        write_manifest(args.db, conn, last_rate)
+        print(
+            f"collected={count}/{args.limit} cost={last_rate['cost']} "
+            f"remaining={last_rate['remaining']}",
+            flush=True,
+        )
+        if not connection["pageInfo"]["hasNextPage"] and count < args.limit:
+            raise RuntimeError("connection ended before the target was reached")
+
+    backfill_files(conn)
+    if not last_rate:
+        stored_rate = get_meta(conn, "last_rate_limit")
+        last_rate = json.loads(stored_rate) if stored_rate else gh_rate_limit()
+        with conn:
+            set_meta(conn, "last_rate_limit", json.dumps(last_rate))
+    with conn:
+        set_meta(conn, "completed_at", utc_now())
+    write_manifest(args.db, conn, last_rate)
+    print(f"complete: {args.db}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("interrupted; progress has been checkpointed", file=sys.stderr)
+        sys.exit(130)

--- a/.skills/gutenberg-pr-review/evals/audit/consolidate_editorial.py
+++ b/.skills/gutenberg-pr-review/evals/audit/consolidate_editorial.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Materialize editorial candidates and build evidence-preserving cross-batch plans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import build_editorial
+import reduce_clusters
+
+
+def load_unique(path: Path, key: str) -> dict[str, dict[str, Any]]:
+    rows = list(reduce_clusters.jsonl(path))
+    result = {row[key]: row for row in rows}
+    if len(result) != len(rows):
+        raise ValueError(f"{path}: duplicate {key}")
+    return result
+
+
+def materialize(
+    source: Path,
+    results: Path,
+    findings_path: Path,
+    output: Path,
+    generation: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    children = load_unique(source / "cluster-ledger.jsonl", "cluster_id")
+    findings = load_unique(findings_path, "finding_id")
+    index = list(reduce_clusters.jsonl(source / "merge-index.jsonl"))
+    expected_by_result = {
+        Path(row["batch"]).with_suffix(".json").name: row["finding_ids"]
+        for row in index
+    }
+    result_paths = sorted(results.glob("merge-s*-*.json"))
+    if {path.name for path in result_paths} != set(expected_by_result):
+        missing = sorted(set(expected_by_result) - {path.name for path in result_paths})
+        extra = sorted({path.name for path in result_paths} - set(expected_by_result))
+        raise ValueError(f"result partition mismatch; missing={missing[:5]}, extra={extra[:5]}")
+
+    candidates: list[dict[str, Any]] = []
+    rejections: list[dict[str, Any]] = []
+    covered_children: set[str] = set()
+    generated_ids: set[str] = set()
+    for path in result_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        decisions = payload["decisions"]
+        expected = expected_by_result[path.name]
+        decision_ids = [row["cluster_id"] for row in decisions]
+        if decision_ids != expected:
+            raise ValueError(f"{path}: decisions differ from indexed order")
+        if covered_children.intersection(decision_ids):
+            raise ValueError(f"{path}: duplicate source decisions")
+        covered_children.update(decision_ids)
+        decisions_by_id = {row["cluster_id"]: row for row in decisions}
+
+        advanced: list[str] = []
+        for decision in decisions:
+            child = children.get(decision["cluster_id"])
+            if child is None:
+                raise ValueError(f"{path}: foreign child {decision['cluster_id']}")
+            if decision["action"] == "advance":
+                advanced.append(decision["cluster_id"])
+            else:
+                rejections.append(
+                    {
+                        "generation": generation,
+                        "source": path.name,
+                        "cluster_id": decision["cluster_id"],
+                        "action": decision["action"],
+                        "reason": decision["reason"],
+                        "canonical_rule": child["canonical_rule"],
+                        "domain": child["domain"],
+                        "evidence_ids": child["evidence_ids"],
+                        "support_count": child["support_count"],
+                        "distinct_prs": child["distinct_prs"],
+                        "distinct_reviewers": child["distinct_reviewers"],
+                        "state_counts": child["state_counts"],
+                    }
+                )
+
+        declared = [
+            member
+            for candidate in payload["candidates"]
+            for member in candidate["member_ids"]
+        ]
+        if len(declared) != len(set(declared)) or set(declared) != set(advanced):
+            raise ValueError(f"{path}: candidates do not partition advances")
+        for candidate in payload["candidates"]:
+            direct_ids = candidate["member_ids"]
+            for member in direct_ids:
+                decision = decisions_by_id[member]
+                if decision["candidate"] != candidate["local_id"]:
+                    raise ValueError(f"{path}: decision/candidate mismatch for {member}")
+            evidence_ids = [
+                evidence_id
+                for member in direct_ids
+                for evidence_id in children[member]["evidence_ids"]
+            ]
+            if len(evidence_ids) != len(set(evidence_ids)):
+                raise ValueError(f"{path}: overlapping evidence in candidate")
+            cluster_id = reduce_clusters.stable_id(
+                generation, path.name, candidate["local_id"], direct_ids
+            )
+            if cluster_id in generated_ids:
+                raise ValueError(f"stable ID collision {cluster_id}")
+            generated_ids.add(cluster_id)
+            prs = {findings[value]["pr_number"] for value in evidence_ids}
+            reviewers = {findings[value]["reviewer"] for value in evidence_ids}
+            states = Counter(findings[value]["pr_state"] for value in evidence_ids)
+            candidates.append(
+                {
+                    "cluster_id": cluster_id,
+                    "stage": generation,
+                    "source": path.name,
+                    "local_id": candidate["local_id"],
+                    "domain": candidate["domain"],
+                    "topic_slug": candidate["topic_slug"],
+                    "canonical_rule": candidate["canonical_rule"],
+                    "severity": candidate["severity"],
+                    "needs_current_validation": candidate["needs_current_validation"],
+                    "merge_basis": candidate["merge_basis"],
+                    "direct_member_ids": direct_ids,
+                    "evidence_ids": evidence_ids,
+                    "support_count": len(evidence_ids),
+                    "distinct_prs": len(prs),
+                    "distinct_reviewers": len(reviewers),
+                    "state_counts": dict(states),
+                }
+            )
+
+    if covered_children != set(children):
+        raise ValueError(
+            f"editorial results do not partition source: "
+            f"{len(covered_children)} != {len(children)}"
+        )
+    selected_evidence = [
+        evidence for candidate in candidates for evidence in candidate["evidence_ids"]
+    ]
+    rejected_evidence = [
+        evidence for rejection in rejections for evidence in rejection["evidence_ids"]
+    ]
+    if set(selected_evidence).intersection(rejected_evidence):
+        raise ValueError("selected and rejected evidence overlap")
+    if len(selected_evidence) != len(set(selected_evidence)):
+        raise ValueError("selected candidate evidence overlaps")
+    if len(rejected_evidence) != len(set(rejected_evidence)):
+        raise ValueError("rejected candidate evidence overlaps")
+    source_evidence = [
+        evidence for child in children.values() for evidence in child["evidence_ids"]
+    ]
+    if set(source_evidence) != set(selected_evidence).union(rejected_evidence):
+        raise ValueError("editorial disposition does not preserve evidence closure")
+
+    output.mkdir(parents=True, exist_ok=True)
+    reduce_clusters.write_jsonl(output / "cluster-ledger.jsonl", candidates)
+    reduce_clusters.write_jsonl(output / "rejection-ledger.jsonl", rejections)
+    summary = {
+        "generation": generation,
+        "source": str(source.resolve()),
+        "results": str(results.resolve()),
+        "source_cluster_count": len(children),
+        "candidate_count": len(candidates),
+        "rejection_count": len(rejections),
+        "selected_evidence_count": len(selected_evidence),
+        "rejected_evidence_count": len(rejected_evidence),
+        "rejection_actions": dict(Counter(row["action"] for row in rejections)),
+        "candidate_ledger_sha256": reduce_clusters.sha256(
+            output / "cluster-ledger.jsonl"
+        ),
+        "rejection_ledger_sha256": reduce_clusters.sha256(
+            output / "rejection-ledger.jsonl"
+        ),
+    }
+    return candidates, rejections, summary
+
+
+def build_plan(
+    nodes: list[dict[str, Any]],
+    output: Path,
+    batch_stage: int,
+    max_clusters: int,
+    max_chars: int,
+    max_candidates: int,
+) -> dict[str, Any]:
+    keys = reduce_clusters.grouping_keys(nodes)
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for node in nodes:
+        buckets[(node["domain"], keys[node["cluster_id"]])].append(node)
+    by_domain: dict[str, list[tuple[str, list[dict[str, Any]]]]] = defaultdict(list)
+    for (domain, bucket), bucket_nodes in buckets.items():
+        by_domain[domain].append((bucket, bucket_nodes))
+
+    batches_dir = output / "batches"
+    batches_dir.mkdir(exist_ok=True)
+    schema = build_editorial.schema()
+    schema["properties"]["candidates"]["maxItems"] = max_candidates
+    reduce_clusters.write_json(output / "editorial-output.schema.json", schema)
+    index: list[dict[str, Any]] = []
+    domain_numbers: Counter[str] = Counter()
+
+    def flush(domain: str, pending: list[dict[str, Any]], labels: list[str]) -> None:
+        domain_numbers[domain] += 1
+        name = f"merge-s{batch_stage}-{domain}-{domain_numbers[domain]:04d}.md"
+        label = (
+            labels[0]
+            if len(set(labels)) == 1
+            else f"mixed:{labels[0]}..{labels[-1]}"
+        )
+        path = batches_dir / name
+        path.write_text(
+            reduce_clusters.render_batch(name, domain, label, pending),
+            encoding="utf-8",
+        )
+        index.append(
+            {
+                "batch": name,
+                "stage": batch_stage,
+                "domain": domain,
+                "bucket": label,
+                "finding_count": len(pending),
+                "finding_ids": [node["cluster_id"] for node in pending],
+                "sha256": reduce_clusters.sha256(path),
+            }
+        )
+
+    for domain, domain_buckets in sorted(by_domain.items()):
+        pending: list[dict[str, Any]] = []
+        labels: list[str] = []
+        pending_chars = 0
+        for bucket, bucket_nodes in sorted(domain_buckets):
+            for node in bucket_nodes:
+                prompt_row = {
+                    key: node[key]
+                    for key in (
+                        "cluster_id",
+                        "topic_slug",
+                        "canonical_rule",
+                        "severity",
+                        "needs_current_validation",
+                        "support_count",
+                        "distinct_prs",
+                        "distinct_reviewers",
+                        "state_counts",
+                    )
+                }
+                row_chars = len(json.dumps(prompt_row, ensure_ascii=False))
+                if pending and (
+                    len(pending) >= max_clusters
+                    or pending_chars + row_chars > max_chars
+                ):
+                    flush(domain, pending, labels)
+                    pending, labels, pending_chars = [], [], 0
+                pending.append(node)
+                labels.append(bucket)
+                pending_chars += row_chars
+        if pending:
+            flush(domain, pending, labels)
+
+    reduce_clusters.write_jsonl(output / "merge-index.jsonl", index)
+    return {
+        "batch_stage": batch_stage,
+        "batch_count": len(index),
+        "bucket_count": len(buckets),
+        "max_clusters": max_clusters,
+        "max_chars": max_chars,
+        "max_candidates": max_candidates,
+        "index_sha256": reduce_clusters.sha256(output / "merge-index.jsonl"),
+        "schema_sha256": reduce_clusters.sha256(
+            output / "editorial-output.schema.json"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--finding-ledger", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--generation", type=int, required=True)
+    parser.add_argument("--batch-stage", type=int, required=True)
+    parser.add_argument("--max-clusters", type=int, default=75)
+    parser.add_argument("--max-chars", type=int, default=28_000)
+    parser.add_argument("--max-candidates", type=int, default=8)
+    args = parser.parse_args()
+    output = args.output.resolve()
+    candidates, _, summary = materialize(
+        args.source.resolve(),
+        args.results.resolve(),
+        args.finding_ledger.resolve(),
+        output,
+        args.generation,
+    )
+    summary.update(
+        build_plan(
+            candidates,
+            output,
+            args.batch_stage,
+            args.max_clusters,
+            args.max_chars,
+            args.max_candidates,
+        )
+    )
+    reduce_clusters.write_json(output / "manifest.json", summary)
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-evaluation.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-evaluation.md
@@ -1,0 +1,50 @@
+# Forward-Test Evaluation
+
+## component-api — `pass`
+
+The “Changing `allowPopups` after mount…” finding is correct. Both iframe implementations update only the `sandbox` attribute; neither forces the navigation required to apply the new sandbox flags to the active document. The cited lines are changed and the remount/navigation remedy is proportionate. No additional high-signal defect found.
+
+## scss-migration — `pass`
+
+“No findings” is credible. The module preserves the prior positioning and pointer-blocking rules, retains the public `components-disabled` class, removes the obsolete suppression, and documents the Emotion cascade compatibility consequence. Tests cover the generated and compatibility classes. Contract followed.
+
+## richtext-regression — `pass`
+
+“Only advance selection after successful removal” is correct. `privateRemoveBlocks` returns when `canRemoveBlocks` is false, but the new batch still selects the following block. Template locking supplies a concrete failure path, and checking removal permission before changing selection is the smallest credible remedy. No clear missed defect.
+
+## keyboard-selection — `pass-with-notes`
+
+“Preserve Shift+Arrow behavior inside native inputs” is correct. The new block-selection branch at lines 297–314 executes before `isNavigationCandidate`, allowing a selected block’s native text input to be mistaken for a block-level selection. The proposed guard and regression test are appropriate.
+
+The changelog finding is also supported by the package guidance, but its citation points to the hook declaration at line 175 rather than the changed behavior or the missing changelog. This is a minor output-contract defect, not a factual error.
+
+## theme-css — `pass`
+
+“No findings” is credible. PHP and TypeScript generate equivalent `:where(<block selector>).has-*` rules, including selector lists, while root presets remain unchanged. Tests and documentation were updated consistently. No clear compatibility or cascade regression found.
+
+## workflow-forks — `pass`
+
+“No findings” is credible. A fork checkout’s `origin` points to the fork, so fetching through the base repository URL is necessary. The fetch makes the event’s base SHA available for the subsequent three-dot diffs and preserves same-repository behavior. The stated hosted-execution verification gap is appropriate.
+
+## toolchain-pinning — `pass-with-notes`
+
+Both findings are materially correct:
+
+- “Unconditionally installing `npm@10`…” correctly identifies that accepted historical refs select Node 14 or 16, while npm 10 declares Node `^18.17.0 || >=20.5.0`.
+- “The declared npm range includes versions…” is correct: the locally available npm 10.8.2 lacks `devEngines` enforcement, while npm 10.9.2 contains it. Thus `>=10.2.3` does not deliver the stated failure behavior.
+
+The first finding’s word “documented” was not substantiated by local documentation. The command clearly accepts arbitrary refs and the cited tags exist, so the defect remains valid; “accepted historical refs” would be tighter wording. No additional high-signal defect found.
+
+## documentation-only — `pass`
+
+“The persistence description is incorrect for synced-pattern overrides” is correct. `core/pattern-overrides.setValues` writes per-instance values into the containing `core/block` instance’s `content` attribute. Those overrides persist with the containing post or template, while editing the original pattern updates its own entity. The documentation’s blanket statement conflates those paths, and correcting both source and generated documentation is appropriate.
+
+## Tally
+
+- `pass`: 6
+- `pass-with-notes`: 2
+- `fail`: 0
+
+## Skill edits required before acceptance
+
+No skill edit is required. The existing skill already requires exact changed-line citations and repository-backed evidence. The two notes are execution-level corrections: cite the actual changed branch for the changelog finding, and avoid unsupported qualifiers such as “documented.”

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/component-api.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/component-api.md
@@ -1,0 +1,5 @@
+# Component API
+
+## Must fix
+
+- `packages/components/src/sandbox/index.tsx:364` — Changing `allowPopups` after mount only updates the iframe attribute; browsers apply sandbox flags when the iframe navigates, so the active document retains its original popup permission. This also affects the same-origin path at line 533: enabling the prop does not enable popups until a later navigation, while disabling it does not reliably revoke permission. Remount or navigate the iframe whenever the sandbox policy changes, and add browser-level coverage for both enabling and revoking the permission.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/documentation-only.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/documentation-only.md
@@ -1,0 +1,7 @@
+# Documentation Only
+
+## Must fix
+
+- `packages/block-editor/src/store/selectors.js:165` — The persistence description is incorrect for synced-pattern overrides. Editing an overridable child updates the containing `core/block` instance’s `content` attribute via `core/pattern-overrides`, so the override is saved with the post or template containing that instance—not to the source pattern. Rephrase this around ownership of the base block structure and explicitly distinguish editing the original pattern from editing per-instance overrides. Apply the same correction to the generated documentation at `docs/reference-guides/data/data-core-block-editor.md:178`.
+
+No files were modified and no network access was used.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/keyboard-selection.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/keyboard-selection.md
@@ -1,0 +1,11 @@
+# Keyboard Selection
+
+## Must fix
+
+- `packages/block-editor/src/components/writing-flow/use-arrow-nav.js:300` — Preserve Shift+Arrow behavior inside native inputs. This branch runs before `isNavigationCandidate`, so focusing a selected Search block’s placeholder input and pressing Shift+ArrowLeft/Right can multi-select an adjacent block instead of extending the input’s text selection. Require a block-wrapper target or apply the existing native-input guard before handling block selection; add coverage for an input inside a selected block.
+
+## Should fix
+
+- `packages/block-editor/src/components/writing-flow/use-arrow-nav.js:175` — Add this production behavior change to `packages/block-editor/CHANGELOG.md` under “Unreleased,” as required by the package contribution guidance.
+
+Review was static; tests were not run.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/richtext-regression.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/richtext-regression.md
@@ -1,0 +1,5 @@
+# RichText Regression
+
+## Must fix
+
+- `packages/block-editor/src/store/actions.js:1261` — Only advance selection after successful removal. `removeBlock()` can no-op when `canRemoveBlocks()` is false, such as for an empty paragraph inside a `templateLock: 'all'` or `'insert'` container. The batch still selects block B, so the locked empty paragraph remains while focus unexpectedly jumps to the next block; a repeated Delete can then erase that block’s first character. Gate the selection on removal permission/success and add a locked-template regression case.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/scss-migration.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/scss-migration.md
@@ -1,0 +1,7 @@
+# SCSS Migration
+
+No findings.
+
+The SCSS module preserves the existing styles and public `components-disabled` class, removes the obsolete lint suppression, and includes proportionate class coverage and changelog entries.
+
+Residual verification gap: tests and production build were not executed because the workspace is read-only and not checked out at the target commit.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/theme-css.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/theme-css.md
@@ -1,0 +1,5 @@
+# Theme CSS
+
+No findings.
+
+Residual verification gap: review was static because the workspace was not checked out at the target commit. I inspected the PHP and TypeScript regression expectations but did not execute them.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/toolchain-pinning.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/toolchain-pinning.md
@@ -1,0 +1,9 @@
+# Toolchain Pinning
+
+## Must fix
+
+- `tools/release/commands/performance.js:363` — Unconditionally installing `npm@10` breaks comparisons against older refs. The command runs `nvm install` from each checked-out ref, and documented/supported refs such as Gutenberg v14–v17 select Node 14 or 16, while npm 10 requires Node 18.17 or newer. Dependency installation then fails before benchmarks run. Select an npm version compatible with each ref’s Node version, or avoid overriding npm in these historical checkouts. The same issue occurs at line 406.
+
+## Should fix
+
+- `package.json:28` — The declared npm range includes versions that do not implement `devEngines`. npm 10.2.3 predates `devEngines`, so developers using an explicitly supported version receive only the existing `engines` warning instead of the intended install failure. Raise the minimum npm version to one that supports `devEngines`—npm 10.9.0 or newer—or retain a separate enforcement mechanism.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-results/workflow-forks.md
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-results/workflow-forks.md
@@ -1,0 +1,5 @@
+# Workflow Forks
+
+No findings.
+
+The explicit base-repository fetch correctly supports forked PRs while preserving same-repository behavior. Residual gap: GitHub-hosted fork execution was not reproduced locally; review was static as requested.

--- a/.skills/gutenberg-pr-review/evals/audit/forward-test-summary.json
+++ b/.skills/gutenberg-pr-review/evals/audit/forward-test-summary.json
@@ -1,0 +1,56 @@
+{
+	"skill": "../../SKILL.md",
+	"cases": 8,
+	"completed": 8,
+	"failed": 0,
+	"statuses": [
+		{
+			"case": "component-api",
+			"commit": "839f5c67e0d2a869611c6f5d3f1a9201ffc34ab1",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "scss-migration",
+			"commit": "94db96e4ffbbf522efa7daf8269b2b20267abd80",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "richtext-regression",
+			"commit": "1cfca19c6b1c763892a7511c3a16219e0be4bc7a",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "keyboard-selection",
+			"commit": "c6c8e71cfef82fe01b189ad58b00af4ea921f743",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "theme-css",
+			"commit": "02cfe19f92e4fcdb085d1525f24bc4f9b2a2874e",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "workflow-forks",
+			"commit": "7546d82f37427d2ca3b4204c9d76641d2012fdb7",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "toolchain-pinning",
+			"commit": "658cb29d541b946538231697017b450755a2c209",
+			"status": "completed",
+			"returncode": 0
+		},
+		{
+			"case": "documentation-only",
+			"commit": "4fa4b6c05ea8c8f5d6009c5f74191dee6fcef3ac",
+			"status": "completed",
+			"returncode": 0
+		}
+	]
+}

--- a/.skills/gutenberg-pr-review/evals/audit/forward_test_run.log
+++ b/.skills/gutenberg-pr-review/evals/audit/forward_test_run.log
@@ -1,0 +1,56 @@
+{
+  "skill": "../../SKILL.md",
+  "cases": 8,
+  "completed": 8,
+  "failed": 0,
+  "statuses": [
+    {
+      "case": "component-api",
+      "commit": "839f5c67e0d2a869611c6f5d3f1a9201ffc34ab1",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "scss-migration",
+      "commit": "94db96e4ffbbf522efa7daf8269b2b20267abd80",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "richtext-regression",
+      "commit": "1cfca19c6b1c763892a7511c3a16219e0be4bc7a",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "keyboard-selection",
+      "commit": "c6c8e71cfef82fe01b189ad58b00af4ea921f743",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "theme-css",
+      "commit": "02cfe19f92e4fcdb085d1525f24bc4f9b2a2874e",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "workflow-forks",
+      "commit": "7546d82f37427d2ca3b4204c9d76641d2012fdb7",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "toolchain-pinning",
+      "commit": "658cb29d541b946538231697017b450755a2c209",
+      "status": "completed",
+      "returncode": 0
+    },
+    {
+      "case": "documentation-only",
+      "commit": "4fa4b6c05ea8c8f5d6009c5f74191dee6fcef3ac",
+      "status": "completed",
+      "returncode": 0
+    }
+  ]
+}

--- a/.skills/gutenberg-pr-review/evals/audit/full_analyze.py
+++ b/.skills/gutenberg-pr-review/evals/audit/full_analyze.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""Build and validate bounded, exhaustive Gutenberg review-audit batches.
+
+The pipeline uses four ordered exclusions: bot-authored artifacts, PR-author
+follow-ups, empty bodies, and exact low-signal approval/thanks messages. Every
+other artifact is assigned to exactly one analysis batch. The ledger records
+every collected artifact so coverage can be reconciled exactly with the DB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, TextIO
+
+
+LOW_SIGNAL = re.compile(
+    r"^(?:lgtm|looks good(?: to me)?|approved|ship it|nice|great|thanks!?|"
+    r"thank you!?|tested and works|works for me|\+1|✅|👍)[.!\s🎉:+-]*$",
+    re.IGNORECASE,
+)
+
+EXCLUSION_PRECEDENCE = ("bot", "pr_author_followup", "empty", "exact_low_signal")
+EXCLUSION_REASONS = set(EXCLUSION_PRECEDENCE)
+ASSESSMENTS = {"finding", "no_finding"}
+SEVERITIES = {"info", "low", "medium", "high", "critical"}
+
+WORKER_RECORD_SCHEMA: dict[str, Any] = {
+    "title": "Gutenberg PR review audit result",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "artifact_id",
+        "batch",
+        "pr_number",
+        "pr_state",
+        "reviewer",
+        "url",
+        "kind",
+        "assessment",
+        "category",
+        "severity",
+        "proposed_rule",
+        "current_validation_needed",
+        "rationale",
+    ],
+    "properties": {
+        "artifact_id": {"type": "string", "minLength": 1},
+        "batch": {"type": "string", "pattern": r"^batch-\d{5}\.md$"},
+        "pr_number": {"type": "integer", "minimum": 1},
+        "pr_state": {"enum": ["MERGED", "OPEN", "CLOSED"]},
+        "reviewer": {"type": ["string", "null"]},
+        "url": {"type": ["string", "null"]},
+        "kind": {"enum": ["review", "review_comment", "issue_comment"]},
+        "assessment": {"enum": sorted(ASSESSMENTS)},
+        "category": {"type": ["string", "null"]},
+        "severity": {"enum": [None, *sorted(SEVERITIES)]},
+        "proposed_rule": {"type": ["string", "null"]},
+        "current_validation_needed": {"type": "boolean"},
+        "rationale": {"type": "string", "minLength": 1},
+    },
+}
+
+BATCH_WORKER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Gutenberg PR review audit batch results",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["results"],
+    "properties": {
+        "results": {
+            "type": "array",
+            "minItems": 1,
+            "items": WORKER_RECORD_SCHEMA,
+        }
+    },
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(value, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def source_query(conn: sqlite3.Connection) -> str:
+    """Return a query compatible with both the pilot and full-audit schemas."""
+    pr_columns = table_columns(conn, "pull_requests")
+    if "state" in pr_columns:
+        pr_state = "p.state"
+    elif "closed_at" in pr_columns:
+        pr_state = (
+            "CASE WHEN p.merged_at IS NOT NULL THEN 'MERGED' "
+            "WHEN p.closed_at IS NOT NULL THEN 'CLOSED' ELSE 'OPEN' END"
+        )
+    else:
+        pr_state = "CASE WHEN p.merged_at IS NOT NULL THEN 'MERGED' ELSE 'OPEN' END"
+    observed_at = "p.observed_at" if "observed_at" in pr_columns else "NULL"
+    return f"""
+        SELECT a.id, a.pr_number, a.kind, a.url, a.body,
+               a.state AS review_state, a.path, a.line, a.original_line,
+               a.author, a.author_association, a.is_bot, a.created_at,
+               p.title, p.author AS pr_author, {pr_state} AS pr_state,
+               p.created_at AS pr_created_at, p.merged_at,
+               {observed_at} AS observed_at
+        FROM artifacts a
+        JOIN pull_requests p ON p.number = a.pr_number
+        ORDER BY p.number, COALESCE(a.created_at, ''), a.id
+    """
+
+
+def source_rows(conn: sqlite3.Connection) -> Iterator[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    yield from conn.execute(source_query(conn))
+
+
+def compact_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def decision(row: sqlite3.Row) -> tuple[str, str | None]:
+    if row["is_bot"]:
+        return "excluded", "bot"
+    author = row["author"]
+    pr_author = row["pr_author"]
+    if author and pr_author and author.casefold() == pr_author.casefold():
+        return "excluded", "pr_author_followup"
+    if not row["body"].strip():
+        return "excluded", "empty"
+    if LOW_SIGNAL.fullmatch(compact_whitespace(row["body"])):
+        return "excluded", "exact_low_signal"
+    return "assigned", None
+
+
+def record_text(row: sqlite3.Row) -> str:
+    metadata = {
+        "artifact_id": row["id"],
+        "pr_number": row["pr_number"],
+        "pr_state": row["pr_state"],
+        "title": row["title"],
+        "kind": row["kind"],
+        "review_state": row["review_state"],
+        "reviewer": row["author"],
+        "author_association": row["author_association"],
+        "url": row["url"],
+        "path": row["path"],
+        "line": row["line"],
+        "original_line": row["original_line"],
+        "created_at": row["created_at"],
+    }
+    return (
+        f"## Artifact `{row['id']}`\n\n"
+        f"Metadata: `{json.dumps(metadata, ensure_ascii=False, separators=(',', ':'))}`\n\n"
+        "### Review text\n\n"
+        f"{row['body'].strip()}\n\n"
+    )
+
+
+def ledger_record(
+    row: sqlite3.Row,
+    status: str,
+    reason: str | None,
+    batch: str | None,
+) -> dict[str, Any]:
+    body = row["body"].strip()
+    return {
+        "artifact_id": row["id"],
+        "fingerprint": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "pr_number": row["pr_number"],
+        "pr_state": row["pr_state"],
+        "kind": row["kind"],
+        "review_state": row["review_state"],
+        "reviewer": row["author"],
+        "url": row["url"],
+        "status": status,
+        "exclusion_reason": reason,
+        "batch": batch,
+    }
+
+
+class BatchWriter:
+    def __init__(self, batches_dir: Path, index: TextIO, char_limit: int) -> None:
+        self.batches_dir = batches_dir
+        self.index = index
+        self.char_limit = char_limit
+        self.number = 1
+        self.parts: list[str] = []
+        self.ids: list[str] = []
+        self.size = 0
+        self.written = 0
+        self.oversized = 0
+
+    @property
+    def filename(self) -> str:
+        return f"batch-{self.number:05d}.md"
+
+    def _header(self) -> str:
+        return (
+            f"# Gutenberg PR review audit — batch {self.number:05d}\n\n"
+            "Assess every artifact individually. Return one JSON object whose `results` "
+            "array contains exactly one schema-valid record per artifact; do not "
+            "deduplicate findings within this pass. `finding` means the review text "
+            "contains a credible, generalizable review lesson. Current-trunk validation "
+            "happens later.\n\n"
+        )
+
+    def add(self, artifact_id: str, text: str) -> str:
+        header_size = len(self._header())
+        if self.parts and header_size + self.size + len(text) > self.char_limit:
+            self.flush()
+        filename = self.filename
+        self.parts.append(text)
+        self.ids.append(artifact_id)
+        self.size += len(text)
+        return filename
+
+    def flush(self) -> None:
+        if not self.parts:
+            return
+        content = self._header() + "".join(self.parts)
+        path = self.batches_dir / self.filename
+        path.write_text(content, encoding="utf-8")
+        encoded = content.encode("utf-8")
+        oversized = len(content) > self.char_limit
+        if oversized:
+            self.oversized += 1
+        entry = {
+            "batch": self.filename,
+            "sha256": hashlib.sha256(encoded).hexdigest(),
+            "characters": len(content),
+            "bytes": len(encoded),
+            "artifact_count": len(self.ids),
+            "artifact_ids": self.ids,
+            "oversized_single_artifact": oversized and len(self.ids) == 1,
+        }
+        self.index.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        self.written += 1
+        self.number += 1
+        self.parts = []
+        self.ids = []
+        self.size = 0
+
+
+def prepare_output(output: Path) -> tuple[Path, Path, Path]:
+    output.mkdir(parents=True, exist_ok=True)
+    batches = output / "batches"
+    if batches.exists():
+        shutil.rmtree(batches)
+    batches.mkdir()
+    ledger = output / "ledger.jsonl"
+    index = output / "batch-index.jsonl"
+    for path in (
+        ledger,
+        index,
+        output / "manifest.json",
+        output / "batch-worker-output.schema.json",
+        output / "worker-output.schema.json",
+    ):
+        if path.exists():
+            path.unlink()
+    return batches, ledger.with_suffix(".jsonl.tmp"), index.with_suffix(".jsonl.tmp")
+
+
+def build(db_path: Path, output: Path, batch_chars: int) -> dict[str, Any]:
+    if batch_chars < 1000:
+        raise ValueError("--batch-chars must be at least 1000")
+    conn = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    batches_dir, ledger_tmp, index_tmp = prepare_output(output)
+    counts: Counter[str] = Counter()
+    states: Counter[str] = Counter()
+    kinds: Counter[str] = Counter()
+    prs: set[int] = set()
+    try:
+        with ledger_tmp.open("w", encoding="utf-8") as ledger_handle, index_tmp.open(
+            "w", encoding="utf-8"
+        ) as index_handle:
+            writer = BatchWriter(batches_dir, index_handle, batch_chars)
+            for row in source_rows(conn):
+                counts["artifacts"] += 1
+                status, reason = decision(row)
+                batch = None
+                if status == "assigned":
+                    batch = writer.add(row["id"], record_text(row))
+                    counts["assigned"] += 1
+                    states[row["pr_state"]] += 1
+                    kinds[row["kind"]] += 1
+                    prs.add(row["pr_number"])
+                else:
+                    counts[f"excluded_{reason}"] += 1
+                ledger_handle.write(
+                    json.dumps(
+                        ledger_record(row, status, reason, batch), ensure_ascii=False
+                    )
+                    + "\n"
+                )
+            writer.flush()
+        ledger = output / "ledger.jsonl"
+        index = output / "batch-index.jsonl"
+        os.replace(ledger_tmp, ledger)
+        os.replace(index_tmp, index)
+        atomic_json(output / "batch-worker-output.schema.json", BATCH_WORKER_SCHEMA)
+        manifest = {
+            "format_version": 1,
+            "created_at": utc_now(),
+            "source_db": str(db_path.resolve()),
+            "policy": {
+                "scope": "every collected review, review comment, and issue comment",
+                "assigned": "all artifacts except the deterministic exclusions",
+                "exclusion_precedence": list(EXCLUSION_PRECEDENCE),
+            },
+            "batch_target_characters": batch_chars,
+            "counts": {
+                **dict(counts),
+                "assigned_prs": len(prs),
+                "batches": writer.written,
+                "oversized_single_artifact_batches": writer.oversized,
+            },
+            "assigned_by_pr_state": dict(sorted(states.items())),
+            "assigned_by_kind": dict(sorted(kinds.items())),
+            "files": {
+                "ledger.jsonl": sha256_path(ledger),
+                "batch-index.jsonl": sha256_path(index),
+                "batch-worker-output.schema.json": sha256_path(
+                    output / "batch-worker-output.schema.json"
+                ),
+            },
+        }
+        atomic_json(output / "manifest.json", manifest)
+        return manifest
+    except BaseException:
+        for path in (ledger_tmp, index_tmp):
+            if path.exists():
+                path.unlink()
+        raise
+    finally:
+        conn.close()
+
+
+def jsonl(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: expected a JSON object")
+            yield line_number, value
+
+
+def require_keys(record: dict[str, Any], required: set[str], context: str) -> None:
+    missing = sorted(required - record.keys())
+    if missing:
+        raise ValueError(f"{context}: missing keys: {', '.join(missing)}")
+
+
+def validate_analysis(output: Path, db_path: Path | None = None) -> dict[str, int]:
+    manifest_path = output / "manifest.json"
+    ledger_path = output / "ledger.jsonl"
+    index_path = output / "batch-index.jsonl"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for name, expected in manifest["files"].items():
+        actual = sha256_path(output / name)
+        if actual != expected:
+            raise ValueError(f"{name}: checksum mismatch")
+
+    audit = sqlite3.connect(":memory:")
+    audit.executescript(
+        """
+        CREATE TABLE ledger (
+            id TEXT PRIMARY KEY, status TEXT NOT NULL, reason TEXT, batch TEXT,
+            pr_number INTEGER NOT NULL, pr_state TEXT NOT NULL, kind TEXT NOT NULL,
+            reviewer TEXT, url TEXT, fingerprint TEXT NOT NULL
+        );
+        CREATE TABLE batched (
+            id TEXT PRIMARY KEY, batch TEXT NOT NULL
+        );
+        """
+    )
+    ledger_counts: Counter[str] = Counter()
+    required_ledger = {
+        "artifact_id", "pr_number", "pr_state", "kind", "reviewer", "url",
+        "status", "exclusion_reason", "batch", "fingerprint",
+    }
+    for line, record in jsonl(ledger_path):
+        require_keys(record, required_ledger, f"{ledger_path}:{line}")
+        status = record["status"]
+        reason = record["exclusion_reason"]
+        batch = record["batch"]
+        if status == "assigned":
+            if reason is not None or not isinstance(batch, str):
+                raise ValueError(f"{ledger_path}:{line}: invalid assigned decision")
+            ledger_counts["assigned"] += 1
+        elif status == "excluded":
+            if reason not in EXCLUSION_REASONS or batch is not None:
+                raise ValueError(f"{ledger_path}:{line}: invalid exclusion decision")
+            ledger_counts[f"excluded_{reason}"] += 1
+        else:
+            raise ValueError(f"{ledger_path}:{line}: invalid status {status!r}")
+        try:
+            audit.execute(
+                "INSERT INTO ledger VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    record["artifact_id"], status, reason, batch,
+                    record["pr_number"], record["pr_state"], record["kind"],
+                    record["reviewer"], record["url"], record["fingerprint"],
+                ),
+            )
+        except sqlite3.IntegrityError as error:
+            raise ValueError(f"{ledger_path}:{line}: duplicate artifact ID") from error
+        ledger_counts["artifacts"] += 1
+
+    batches = 0
+    indexed_artifacts = 0
+    for line, entry in jsonl(index_path):
+        require_keys(
+            entry,
+            {"batch", "sha256", "characters", "bytes", "artifact_count", "artifact_ids"},
+            f"{index_path}:{line}",
+        )
+        batch_path = output / "batches" / entry["batch"]
+        # Hash the exact bytes written by BatchWriter. Text-mode reads perform
+        # universal-newline conversion, which changes CRLF sequences preserved
+        # inside historical review bodies and produces a false checksum failure.
+        encoded = batch_path.read_bytes()
+        content = encoded.decode("utf-8")
+        if hashlib.sha256(encoded).hexdigest() != entry["sha256"]:
+            raise ValueError(f"{batch_path}: checksum mismatch")
+        if len(content) != entry["characters"] or len(encoded) != entry["bytes"]:
+            raise ValueError(f"{batch_path}: size mismatch")
+        ids = entry["artifact_ids"]
+        if not isinstance(ids, list) or len(ids) != entry["artifact_count"]:
+            raise ValueError(f"{index_path}:{line}: artifact count mismatch")
+        for artifact_id in ids:
+            try:
+                audit.execute(
+                    "INSERT INTO batched VALUES (?, ?)", (artifact_id, entry["batch"])
+                )
+            except sqlite3.IntegrityError as error:
+                raise ValueError(f"artifact {artifact_id}: assigned to multiple batches") from error
+        indexed_artifacts += len(ids)
+        batches += 1
+
+    missing = audit.execute(
+        "SELECT id FROM ledger WHERE status = 'assigned' "
+        "EXCEPT SELECT id FROM batched LIMIT 1"
+    ).fetchone()
+    extra = audit.execute(
+        "SELECT id FROM batched EXCEPT "
+        "SELECT id FROM ledger WHERE status = 'assigned' LIMIT 1"
+    ).fetchone()
+    mismatch = audit.execute(
+        "SELECT l.id FROM ledger l JOIN batched b ON b.id = l.id "
+        "WHERE l.batch != b.batch LIMIT 1"
+    ).fetchone()
+    if missing or extra or mismatch:
+        raise ValueError(
+            f"batch coverage mismatch: missing={missing}, extra={extra}, mismatch={mismatch}"
+        )
+    actual_batch_files = {path.name for path in (output / "batches").glob("batch-*.md")}
+    indexed_batch_files = {
+        row[0] for row in audit.execute("SELECT DISTINCT batch FROM batched")
+    }
+    if actual_batch_files != indexed_batch_files:
+        raise ValueError("batch-index.jsonl does not exactly match the batch files")
+
+    expected_counts = manifest["counts"]
+    for key, actual in ledger_counts.items():
+        if expected_counts.get(key, 0) != actual:
+            raise ValueError(f"manifest count mismatch for {key}: {expected_counts.get(key)} != {actual}")
+    if expected_counts["batches"] != batches or expected_counts["assigned"] != indexed_artifacts:
+        raise ValueError("manifest batch totals do not match the index")
+
+    if db_path is not None:
+        source = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True)
+        source.row_factory = sqlite3.Row
+        source_count = 0
+        try:
+            for row in source_rows(source):
+                source_count += 1
+                expected_status, expected_reason = decision(row)
+                found = audit.execute(
+                    "SELECT status, reason, pr_number, pr_state, kind, reviewer, url, fingerprint "
+                    "FROM ledger WHERE id = ?",
+                    (row["id"],),
+                ).fetchone()
+                body_fingerprint = hashlib.sha256(
+                    row["body"].strip().encode("utf-8")
+                ).hexdigest()
+                expected = (
+                    expected_status, expected_reason, row["pr_number"], row["pr_state"],
+                    row["kind"], row["author"], row["url"], body_fingerprint,
+                )
+                if found is None or tuple(found) != expected:
+                    raise ValueError(f"source reconciliation failed for artifact {row['id']}")
+        finally:
+            source.close()
+        if source_count != ledger_counts["artifacts"]:
+            raise ValueError("source DB has artifacts missing from the ledger")
+
+    audit.close()
+    return {
+        "artifacts": ledger_counts["artifacts"],
+        "assigned": ledger_counts["assigned"],
+        "excluded": ledger_counts["artifacts"] - ledger_counts["assigned"],
+        "batches": batches,
+    }
+
+
+def worker_files(path: Path) -> Iterable[Path]:
+    if path.is_file():
+        yield path
+    else:
+        yield from sorted(
+            [*path.rglob("batch-*.json"), *path.rglob("batch-*.jsonl")]
+        )
+
+
+def worker_records(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Read one structured batch object, with legacy JSONL compatibility."""
+    if path.suffix == ".jsonl":
+        for line, record in jsonl(path):
+            yield f"{path}:{line}", record
+        return
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{path}: invalid JSON: {error}") from error
+    if not isinstance(payload, dict) or set(payload) != {"results"}:
+        raise ValueError(f"{path}: expected one object containing only `results`")
+    results = payload["results"]
+    if not isinstance(results, list) or not results:
+        raise ValueError(f"{path}: results must be a nonempty array")
+    for index, record in enumerate(results):
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:results[{index}]: expected an object")
+        yield f"{path}:results[{index}]", record
+
+
+def validate_worker_record(record: dict[str, Any], context: str) -> None:
+    required = set(WORKER_RECORD_SCHEMA["required"])
+    require_keys(record, required, context)
+    extra = sorted(record.keys() - required)
+    if extra:
+        raise ValueError(f"{context}: unexpected keys: {', '.join(extra)}")
+    if record["assessment"] not in ASSESSMENTS:
+        raise ValueError(f"{context}: invalid assessment")
+    if not isinstance(record["artifact_id"], str) or not record["artifact_id"]:
+        raise ValueError(f"{context}: artifact_id must be a nonempty string")
+    if not isinstance(record["batch"], str) or not re.fullmatch(
+        r"batch-\d{5}\.md", record["batch"]
+    ):
+        raise ValueError(f"{context}: invalid batch name")
+    if type(record["pr_number"]) is not int or record["pr_number"] < 1:
+        raise ValueError(f"{context}: pr_number must be a positive integer")
+    if record["pr_state"] not in {"MERGED", "OPEN", "CLOSED"}:
+        raise ValueError(f"{context}: invalid PR state")
+    if record["kind"] not in {"review", "review_comment", "issue_comment"}:
+        raise ValueError(f"{context}: invalid artifact kind")
+    for field in ("reviewer", "url"):
+        if record[field] is not None and not isinstance(record[field], str):
+            raise ValueError(f"{context}: {field} must be a string or null")
+    if record["severity"] not in SEVERITIES | {None}:
+        raise ValueError(f"{context}: invalid severity")
+    if type(record["current_validation_needed"]) is not bool:
+        raise ValueError(f"{context}: current_validation_needed must be boolean")
+    if not isinstance(record["rationale"], str) or not record["rationale"].strip():
+        raise ValueError(f"{context}: rationale must be nonempty")
+    if record["assessment"] == "finding":
+        for field in ("category", "severity", "proposed_rule"):
+            if not isinstance(record[field], str) or not record[field].strip():
+                raise ValueError(f"{context}: finding requires nonempty {field}")
+    elif any(record[field] not in (None, "") for field in ("category", "severity", "proposed_rule")):
+        raise ValueError(f"{context}: no_finding must not supply finding fields")
+
+
+def validate_workers(analysis: Path, workers: Path) -> dict[str, int]:
+    audit = sqlite3.connect(":memory:")
+    audit.executescript(
+        """
+        CREATE TABLE expected (
+            id TEXT PRIMARY KEY, batch TEXT NOT NULL, pr_number INTEGER NOT NULL,
+            pr_state TEXT NOT NULL, reviewer TEXT, url TEXT, kind TEXT NOT NULL
+        );
+        CREATE TABLE seen (id TEXT PRIMARY KEY, assessment TEXT NOT NULL);
+        """
+    )
+    for _, record in jsonl(analysis / "ledger.jsonl"):
+        if record["status"] == "assigned":
+            audit.execute(
+                "INSERT INTO expected VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    record["artifact_id"], record["batch"], record["pr_number"],
+                    record["pr_state"], record["reviewer"], record["url"],
+                    record["kind"],
+                ),
+            )
+    files = list(worker_files(workers))
+    if not files:
+        raise ValueError(f"no batch worker JSON files found at {workers}")
+    counts: Counter[str] = Counter()
+    processed_batches: set[str] = set()
+    for path in files:
+        filename_match = re.fullmatch(r"(batch-\d{5})\.(?:json|jsonl)", path.name)
+        if not filename_match:
+            raise ValueError(f"{path}: expected a batch-NNNNN.json filename")
+        expected_batch = f"{filename_match.group(1)}.md"
+        if expected_batch in processed_batches:
+            raise ValueError(f"{path}: duplicate output file for {expected_batch}")
+        processed_batches.add(expected_batch)
+        expected_ids = {
+            row[0]
+            for row in audit.execute(
+                "SELECT id FROM expected WHERE batch = ?", (expected_batch,)
+            )
+        }
+        if not expected_ids:
+            raise ValueError(f"{path}: no ledger batch named {expected_batch}")
+        file_ids: set[str] = set()
+        for context, record in worker_records(path):
+            validate_worker_record(record, context)
+            if record["batch"] != expected_batch:
+                raise ValueError(
+                    f"{context}: record batch does not match output filename"
+                )
+            expected = audit.execute(
+                "SELECT batch, pr_number, pr_state, reviewer, url, kind "
+                "FROM expected WHERE id = ?",
+                (record["artifact_id"],),
+            ).fetchone()
+            actual = tuple(
+                record[field]
+                for field in ("batch", "pr_number", "pr_state", "reviewer", "url", "kind")
+            )
+            if expected is None:
+                raise ValueError(f"{context}: unknown or excluded artifact")
+            if tuple(expected) != actual:
+                raise ValueError(f"{context}: metadata does not match the ledger")
+            try:
+                audit.execute(
+                    "INSERT INTO seen VALUES (?, ?)",
+                    (record["artifact_id"], record["assessment"]),
+                )
+            except sqlite3.IntegrityError as error:
+                raise ValueError(f"{context}: duplicate worker result") from error
+            file_ids.add(record["artifact_id"])
+            counts[record["assessment"]] += 1
+        if file_ids != expected_ids:
+            missing_ids = sorted(expected_ids - file_ids)
+            extra_ids = sorted(file_ids - expected_ids)
+            raise ValueError(
+                f"{path}: expected artifact set mismatch; "
+                f"missing={missing_ids[:3]}, extra={extra_ids[:3]}"
+            )
+    missing = audit.execute(
+        "SELECT id FROM expected EXCEPT SELECT id FROM seen LIMIT 1"
+    ).fetchone()
+    if missing:
+        total = audit.execute(
+            "SELECT COUNT(*) FROM expected WHERE id NOT IN (SELECT id FROM seen)"
+        ).fetchone()[0]
+        raise ValueError(f"worker results missing {total} artifacts; first is {missing[0]}")
+    counts["total"] = audit.execute("SELECT COUNT(*) FROM seen").fetchone()[0]
+    audit.close()
+    return dict(counts)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser("build", help="build ledger and batches")
+    build_parser.add_argument("--db", type=Path, required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+    build_parser.add_argument("--batch-chars", type=int, default=40000)
+
+    validate_parser = subparsers.add_parser("validate", help="validate analysis coverage")
+    validate_parser.add_argument("--output", type=Path, required=True)
+    validate_parser.add_argument("--db", type=Path)
+
+    workers_parser = subparsers.add_parser(
+        "validate-workers", help="validate exhaustive per-batch worker JSON results"
+    )
+    workers_parser.add_argument("--analysis", type=Path, required=True)
+    workers_parser.add_argument("--workers", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "build":
+        result = build(args.db, args.output, args.batch_chars)
+    elif args.command == "validate":
+        result = validate_analysis(args.output, args.db)
+    else:
+        result = validate_workers(args.analysis, args.workers)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/full_collect.py
+++ b/.skills/gutenberg-pr-review/evals/audit/full_collect.py
@@ -1,0 +1,1281 @@
+#!/usr/bin/env python3
+"""Collect a resumable, all-state Gutenberg pull-request review corpus.
+
+The primary PR connection is deliberately ordered oldest-first and includes every
+state.  A fixed ``audit_started_at`` timestamp makes the moving tail deterministic:
+PRs created after that timestamp are never inserted.  Connections nested under a
+PR are fetched inline up to GitHub's maximum page size and are repaired through
+paginated REST endpoints whenever they overflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+
+
+OWNER = "WordPress"
+REPOSITORY = "gutenberg"
+SCHEMA_VERSION = "1"
+MAX_GITHUB_ATTEMPTS = 6
+MAX_RETRY_DELAY_SECONDS = 60.0
+
+TRANSIENT_GITHUB_FAILURES = (
+    re.compile(r"\bHTTP\s+(?:429|502|503|504)\b", re.IGNORECASE),
+    re.compile(r"\bconnection (?:reset|refused|aborted)\b", re.IGNORECASE),
+    re.compile(r"\b(?:request |i/o |read |write )?timed? ?out\b", re.IGNORECASE),
+    re.compile(r"\bTLS handshake timeout\b", re.IGNORECASE),
+    re.compile(r"\bdeadline exceeded\b", re.IGNORECASE),
+    re.compile(r"\btemporary failure\b", re.IGNORECASE),
+    re.compile(r"\bserver closed (?:the )?(?:idle )?connection\b", re.IGNORECASE),
+    re.compile(r"\bstream error\b", re.IGNORECASE),
+    re.compile(r"\bunexpected EOF\b", re.IGNORECASE),
+    re.compile(r"\bunexpected end of JSON input\b", re.IGNORECASE),
+    re.compile(r"\binvalid JSON response\b", re.IGNORECASE),
+    re.compile(r"\berror connecting to\b", re.IGNORECASE),
+    re.compile(r"\bcheck your internet connection\b", re.IGNORECASE),
+    re.compile(r"\bcould not resolve host\b", re.IGNORECASE),
+    re.compile(r"\bnetwork is unreachable\b", re.IGNORECASE),
+    re.compile(r"\bno route to host\b", re.IGNORECASE),
+)
+
+QUERY = r"""
+query CollectPullRequests($first: Int!, $after: String) {
+  repository(owner: "WordPress", name: "gutenberg") {
+    pullRequests(
+      first: $first
+      after: $after
+      states: [OPEN, MERGED, CLOSED]
+      orderBy: { field: CREATED_AT, direction: ASC }
+    ) {
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        url
+        title
+        bodyText
+        state
+        isDraft
+        createdAt
+        updatedAt
+        mergedAt
+        closedAt
+        authorAssociation
+        author { login __typename }
+        labels(first: 100) { totalCount nodes { name } }
+        files(first: 100) {
+          totalCount
+          nodes { path }
+        }
+        reviews(first: 100) {
+          totalCount
+          nodes {
+            id
+            databaseId
+            url
+            state
+            bodyText
+            submittedAt
+            authorAssociation
+            author { login __typename }
+            comments(first: 100) {
+              totalCount
+              nodes {
+                id
+                databaseId
+                url
+                bodyText
+                createdAt
+                updatedAt
+                path
+                line
+                originalLine
+                outdated
+                authorAssociation
+                author { login __typename }
+              }
+            }
+          }
+        }
+        comments(first: 100) {
+          totalCount
+          nodes {
+            id
+            databaseId
+            url
+            bodyText
+            createdAt
+            updatedAt
+            authorAssociation
+            author { login __typename }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+BOOTSTRAP_QUERY = r"""
+query BootstrapPullRequestSnapshot {
+  repository(owner: "WordPress", name: "gutenberg") {
+    population: pullRequests(states: [OPEN, MERGED, CLOSED]) {
+      totalCount
+    }
+    newest: pullRequests(
+      last: 1
+      states: [OPEN, MERGED, CLOSED]
+      orderBy: { field: CREATED_AT, direction: ASC }
+    ) {
+      nodes { number createdAt }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+FILES_QUERY = r"""
+query CollectPullRequestFiles($number: Int!, $after: String) {
+  repository(owner: "WordPress", name: "gutenberg") {
+    pullRequest(number: $number) {
+      files(first: 100, after: $after) {
+        totalCount
+        nodes { path }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+SCHEMA = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pull_requests (
+    number INTEGER PRIMARY KEY,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('OPEN', 'MERGED', 'CLOSED')),
+    is_draft INTEGER NOT NULL,
+    author TEXT,
+    author_association TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    merged_at TEXT,
+    closed_at TEXT,
+    observed_at TEXT NOT NULL,
+    labels_json TEXT NOT NULL,
+    labels_total INTEGER NOT NULL,
+    files_total INTEGER NOT NULL,
+    reviews_total INTEGER NOT NULL,
+    issue_comments_total INTEGER NOT NULL,
+    review_comments_total INTEGER NOT NULL,
+    raw_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS files (
+    pr_number INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    PRIMARY KEY (pr_number, path),
+    FOREIGN KEY (pr_number) REFERENCES pull_requests(number) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS artifacts (
+    id TEXT PRIMARY KEY,
+    database_id INTEGER,
+    pr_number INTEGER NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('review', 'review_comment', 'issue_comment')),
+    parent_review_id TEXT,
+    url TEXT,
+    body TEXT NOT NULL,
+    state TEXT,
+    path TEXT,
+    line INTEGER,
+    original_line INTEGER,
+    outdated INTEGER,
+    author TEXT,
+    author_association TEXT,
+    is_bot INTEGER NOT NULL,
+    created_at TEXT,
+    updated_at TEXT,
+    observed_at TEXT NOT NULL,
+    comments_total INTEGER,
+    FOREIGN KEY (pr_number) REFERENCES pull_requests(number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS pull_requests_state ON pull_requests(state);
+CREATE INDEX IF NOT EXISTS artifacts_pr_number ON artifacts(pr_number);
+CREATE INDEX IF NOT EXISTS artifacts_kind ON artifacts(kind);
+CREATE INDEX IF NOT EXISTS artifacts_author ON artifacts(author);
+"""
+
+
+class RateLimitPause(RuntimeError):
+    """A recoverable stop requested before consuming the remaining API budget."""
+
+    def __init__(self, resource: str, remaining: int, reset_at: str) -> None:
+        super().__init__(
+            f"{resource} rate limit has {remaining} remaining; resets at {reset_at}"
+        )
+        self.resource = resource
+        self.remaining = remaining
+        self.reset_at = reset_at
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path(__file__).with_name("full_reviews.sqlite"),
+        help="SQLite checkpoint database (default: full_reviews.sqlite)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=10,
+        help="PR nodes per GraphQL page, 1-20 (default: 10)",
+    )
+    parser.add_argument(
+        "--audit-started-at",
+        help="fixed ISO-8601 cutoff for a new database (default: now, UTC)",
+    )
+    parser.add_argument(
+        "--graphql-threshold",
+        type=int,
+        default=100,
+        help="pause before a request at or below this remaining budget",
+    )
+    parser.add_argument(
+        "--rest-threshold",
+        type=int,
+        default=100,
+        help="pause before an overflow backfill at or below this core budget",
+    )
+    parser.add_argument(
+        "--stop-after-pages",
+        type=int,
+        help="checkpoint and stop after N pages (for smoke/resume tests)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="exercise schema and idempotent inserts without network access",
+    )
+    return parser.parse_args()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError(f"timestamp must include a timezone: {value}")
+    return parsed.astimezone(timezone.utc)
+
+
+def is_transient_github_failure(message: str) -> bool:
+    return any(pattern.search(message) for pattern in TRANSIENT_GITHUB_FAILURES)
+
+
+def retry_after_seconds(message: str, now: datetime | None = None) -> float | None:
+    """Extract Retry-After seconds or an HTTP date when gh exposes the header."""
+
+    match = re.search(
+        r"(?:^|[\r\n])\s*retry-after\s*:\s*([^\r\n]+)",
+        message,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    value = match.group(1).strip()
+    if value.isdigit():
+        return float(value)
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    return max(0.0, (retry_at.astimezone(timezone.utc) - current).total_seconds())
+
+
+def retry_delay(attempt: int, message: str) -> float:
+    requested = retry_after_seconds(message)
+    if requested is not None:
+        return min(requested, MAX_RETRY_DELAY_SECONDS)
+    return min(float(2 ** (attempt - 1)), MAX_RETRY_DELAY_SECONDS)
+
+
+def run_gh(arguments: list[str], failure: str) -> Any:
+    for attempt in range(1, MAX_GITHUB_ATTEMPTS + 1):
+        result = subprocess.run(
+            ["gh", "api", *arguments], text=True, capture_output=True
+        )
+        if not result.returncode:
+            try:
+                return json.loads(result.stdout)
+            except json.JSONDecodeError as error:
+                message = f"invalid JSON response from GitHub: {error}"
+        else:
+            message = result.stderr.strip() or failure
+        if (
+            not is_transient_github_failure(message)
+            or attempt == MAX_GITHUB_ATTEMPTS
+        ):
+            raise RuntimeError(message)
+
+        delay = retry_delay(attempt, message)
+        summary = message.splitlines()[-1][:240]
+        print(
+            f"transient GitHub API failure ({summary}); retrying in "
+            f"{delay:g}s ({attempt + 1}/{MAX_GITHUB_ATTEMPTS})",
+            file=sys.stderr,
+            flush=True,
+        )
+        time.sleep(delay)
+
+    raise AssertionError("unreachable")
+
+
+def api_limits() -> dict[str, dict[str, Any]]:
+    return run_gh(["rate_limit"], "failed to query API rate limits")["resources"]
+
+
+def ensure_budget(resource: str, threshold: int) -> dict[str, Any]:
+    rate = api_limits()[resource]
+    if int(rate["remaining"]) <= threshold:
+        reset_at = datetime.fromtimestamp(
+            int(rate["reset"]), timezone.utc
+        ).isoformat()
+        raise RateLimitPause(resource, int(rate["remaining"]), reset_at)
+    return rate
+
+
+def gh_graphql(first: int, after: str | None) -> dict[str, Any]:
+    arguments = ["graphql", "-f", f"query={QUERY}", "-F", f"first={first}"]
+    if after:
+        arguments.extend(["-F", f"after={after}"])
+    payload = run_gh(arguments, "gh api graphql failed")
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2))
+    return payload
+
+
+def gh_bootstrap() -> dict[str, Any]:
+    payload = run_gh(
+        ["graphql", "-f", f"query={BOOTSTRAP_QUERY}"],
+        "failed to establish the initial PR snapshot",
+    )
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2))
+    return payload
+
+
+def gh_file_page(number: int, after: str | None) -> dict[str, Any]:
+    arguments = [
+        "graphql",
+        "-f",
+        f"query={FILES_QUERY}",
+        "-F",
+        f"number={number}",
+    ]
+    if after:
+        arguments.extend(["-F", f"after={after}"])
+    payload = run_gh(arguments, f"failed to paginate files for PR #{number}")
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2))
+    return payload
+
+
+def gh_all_file_paths(
+    number: int, expected: int, graphql_threshold: int
+) -> list[str]:
+    """Read a PR's complete file connection without REST's 3,000-file cap."""
+
+    paths: list[str] = []
+    after: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        ensure_budget("graphql", graphql_threshold)
+        payload = gh_file_page(number, after)
+        pull_request = payload["data"]["repository"]["pullRequest"]
+        if pull_request is None:
+            raise RuntimeError(f"PR #{number} disappeared while paginating files")
+        connection = pull_request["files"]
+        current_total = int(connection["totalCount"])
+        if current_total != expected:
+            raise RuntimeError(
+                f"PR #{number}: file connection changed during collection "
+                f"(snapshot expected {expected}, now {current_total}); restart with "
+                "a fresh audit snapshot"
+            )
+        paths.extend(node["path"] for node in connection["nodes"])
+        page_info = connection["pageInfo"]
+        if not page_info["hasNextPage"]:
+            break
+        next_cursor = page_info["endCursor"]
+        if not next_cursor or next_cursor == after or next_cursor in seen_cursors:
+            raise RuntimeError(
+                f"PR #{number}: repeated or missing cursor while paginating files"
+            )
+        seen_cursors.add(next_cursor)
+        after = next_cursor
+
+    if len(paths) != expected or len(set(paths)) != expected:
+        raise RuntimeError(
+            f"PR #{number}: expected {expected} distinct file paths, collected "
+            f"{len(paths)} rows ({len(set(paths))} distinct)"
+        )
+    return paths
+
+
+def gh_rest_pages(endpoint: str) -> list[dict[str, Any]]:
+    pages = run_gh(
+        ["--paginate", "--slurp", endpoint], f"gh api failed for {endpoint}"
+    )
+    return [item for page in pages for item in page]
+
+
+def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def set_meta(conn: sqlite3.Connection, key: str, value: Any) -> None:
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, str(value)),
+    )
+
+
+def author_fields(author: dict[str, Any] | None) -> tuple[str | None, int]:
+    if not author:
+        return None, 0
+    login = author.get("login")
+    typename = author.get("__typename") or author.get("type")
+    is_bot = typename == "Bot" or bool(login and login.lower().endswith("[bot]"))
+    return login, int(is_bot)
+
+
+def artifact_id(artifact: dict[str, Any], kind: str) -> str:
+    # REST's numeric ``id`` values are only unique within an artifact type;
+    # ``node_id`` shares GraphQL's globally unique namespace.
+    value = artifact.get("node_id") or artifact.get("id")
+    if value is not None:
+        return str(value)
+    database_id = artifact.get("databaseId") or artifact.get("database_id")
+    if database_id is None:
+        raise RuntimeError(f"{kind} has neither a node ID nor database ID")
+    return f"{kind}:{database_id}"
+
+
+def insert_artifact(
+    conn: sqlite3.Connection,
+    *,
+    artifact: dict[str, Any],
+    pr_number: int,
+    kind: str,
+    observed_at: str,
+    parent_review_id: str | None = None,
+    state: str | None = None,
+    comments_total: int | None = None,
+    rest: bool = False,
+) -> None:
+    author, is_bot = author_fields(artifact.get("user") if rest else artifact.get("author"))
+    database_id = artifact.get("id") if rest else artifact.get("databaseId")
+    body = artifact.get("body") if rest else artifact.get("bodyText")
+    url = artifact.get("html_url") if rest else artifact.get("url")
+    author_association = (
+        artifact.get("author_association") if rest else artifact.get("authorAssociation")
+    )
+    created_at = (
+        artifact.get("submitted_at") or artifact.get("created_at")
+        if rest
+        else artifact.get("submittedAt") or artifact.get("createdAt")
+    )
+    updated_at = artifact.get("updated_at") if rest else artifact.get("updatedAt")
+    outdated = artifact.get("outdated")
+    if rest and kind == "review_comment":
+        outdated = artifact.get("position") is None
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO artifacts(
+            id, database_id, pr_number, kind, parent_review_id, url, body, state,
+            path, line, original_line, outdated, author, author_association,
+            is_bot, created_at, updated_at, observed_at, comments_total
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            artifact_id(artifact, kind),
+            database_id,
+            pr_number,
+            kind,
+            parent_review_id,
+            url,
+            body or "",
+            state,
+            artifact.get("path"),
+            artifact.get("line"),
+            artifact.get("original_line") if rest else artifact.get("originalLine"),
+            int(outdated) if outdated is not None else None,
+            author,
+            author_association,
+            is_bot,
+            created_at,
+            updated_at,
+            observed_at,
+            comments_total,
+        ),
+    )
+
+
+def insert_pr(
+    conn: sqlite3.Connection, pr: dict[str, Any], observed_at: str
+) -> None:
+    number = int(pr["number"])
+    author, _ = author_fields(pr.get("author"))
+    review_comments_total = sum(
+        int(review["comments"]["totalCount"]) for review in pr["reviews"]["nodes"]
+    )
+    conn.execute(
+        """
+        INSERT INTO pull_requests(
+            number, url, title, body, state, is_draft, author,
+            author_association, created_at, updated_at, merged_at, closed_at,
+            observed_at, labels_json, labels_total, files_total, reviews_total,
+            issue_comments_total, review_comments_total, raw_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(number) DO UPDATE SET
+            url = excluded.url,
+            title = excluded.title,
+            body = excluded.body,
+            state = excluded.state,
+            is_draft = excluded.is_draft,
+            author = excluded.author,
+            author_association = excluded.author_association,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            merged_at = excluded.merged_at,
+            closed_at = excluded.closed_at,
+            observed_at = excluded.observed_at,
+            labels_json = excluded.labels_json,
+            labels_total = excluded.labels_total,
+            files_total = excluded.files_total,
+            reviews_total = excluded.reviews_total,
+            issue_comments_total = excluded.issue_comments_total,
+            review_comments_total = excluded.review_comments_total,
+            raw_json = excluded.raw_json
+        """,
+        (
+            number,
+            pr["url"],
+            pr["title"],
+            pr.get("bodyText") or "",
+            pr["state"],
+            int(pr["isDraft"]),
+            author,
+            pr.get("authorAssociation"),
+            pr["createdAt"],
+            pr["updatedAt"],
+            pr.get("mergedAt"),
+            pr.get("closedAt"),
+            observed_at,
+            json.dumps([node["name"] for node in pr["labels"]["nodes"]]),
+            int(pr["labels"]["totalCount"]),
+            int(pr["files"]["totalCount"]),
+            int(pr["reviews"]["totalCount"]),
+            int(pr["comments"]["totalCount"]),
+            review_comments_total,
+            json.dumps(pr, separators=(",", ":")),
+        ),
+    )
+    conn.execute("DELETE FROM files WHERE pr_number = ?", (number,))
+    conn.executemany(
+        "INSERT OR IGNORE INTO files(pr_number, path) VALUES (?, ?)",
+        [(number, node["path"]) for node in pr["files"]["nodes"]],
+    )
+    conn.execute("DELETE FROM artifacts WHERE pr_number = ?", (number,))
+    for review in pr["reviews"]["nodes"]:
+        insert_artifact(
+            conn,
+            artifact=review,
+            pr_number=number,
+            kind="review",
+            observed_at=observed_at,
+            state=review["state"],
+            comments_total=int(review["comments"]["totalCount"]),
+        )
+        for comment in review["comments"]["nodes"]:
+            insert_artifact(
+                conn,
+                artifact=comment,
+                pr_number=number,
+                kind="review_comment",
+                observed_at=observed_at,
+                parent_review_id=review["id"],
+                state=review["state"],
+            )
+    for comment in pr["comments"]["nodes"]:
+        insert_artifact(
+            conn,
+            artifact=comment,
+            pr_number=number,
+            kind="issue_comment",
+            observed_at=observed_at,
+        )
+
+
+def collected_counts(conn: sqlite3.Connection, number: int) -> dict[str, int]:
+    row = conn.execute(
+        """
+        SELECT
+          (SELECT COUNT(*) FROM files WHERE pr_number = ?),
+          (SELECT COUNT(*) FROM artifacts WHERE pr_number = ? AND kind = 'review'),
+          (SELECT COUNT(*) FROM artifacts WHERE pr_number = ? AND kind = 'issue_comment'),
+          (SELECT COUNT(*) FROM artifacts WHERE pr_number = ? AND kind = 'review_comment')
+        """,
+        (number, number, number, number),
+    ).fetchone()
+    return dict(zip(("files", "reviews", "issue_comments", "review_comments"), row))
+
+
+def expected_counts(conn: sqlite3.Connection, number: int) -> dict[str, int]:
+    row = conn.execute(
+        """
+        SELECT files_total, reviews_total, issue_comments_total,
+               review_comments_total
+        FROM pull_requests WHERE number = ?
+        """,
+        (number,),
+    ).fetchone()
+    if not row:
+        raise RuntimeError(f"missing pull request #{number}")
+    return dict(zip(("files", "reviews", "issue_comments", "review_comments"), row))
+
+
+def verify_count(number: int, kind: str, actual: int, expected: int) -> None:
+    if actual != expected:
+        raise RuntimeError(
+            f"PR #{number}: {kind} connection changed during collection "
+            f"(snapshot expected {expected}, paginated API returned {actual}); "
+            "this can happen when an OPEN PR is edited during collection—restart "
+            "with a fresh audit snapshot"
+        )
+
+
+def replace_review_comments(
+    conn: sqlite3.Connection,
+    number: int,
+    comments: list[dict[str, Any]],
+    observed_at: str,
+) -> None:
+    reviews = {
+        row[0]: (row[1], row[2])
+        for row in conn.execute(
+            "SELECT database_id, id, state FROM artifacts "
+            "WHERE pr_number = ? AND kind = 'review'",
+            (number,),
+        )
+    }
+    conn.execute(
+        "DELETE FROM artifacts WHERE pr_number = ? AND kind = 'review_comment'",
+        (number,),
+    )
+    for comment in comments:
+        review_database_id = comment.get("pull_request_review_id")
+        parent_id, state = reviews.get(review_database_id, (None, None))
+        insert_artifact(
+            conn,
+            artifact=comment,
+            pr_number=number,
+            kind="review_comment",
+            observed_at=observed_at,
+            parent_review_id=parent_id,
+            state=state,
+            rest=True,
+        )
+
+
+def repair_pr_connections(
+    conn: sqlite3.Connection,
+    number: int,
+    observed_at: str,
+    graphql_threshold: int,
+    rest_threshold: int,
+) -> list[str]:
+    """Fully paginate overflowed connections for one PR, returning repaired kinds."""
+
+    expected = expected_counts(conn, number)
+    actual = collected_counts(conn, number)
+    repaired: list[str] = []
+
+    if actual["files"] < expected["files"]:
+        paths = gh_all_file_paths(
+            number, expected["files"], graphql_threshold
+        )
+        conn.execute("DELETE FROM files WHERE pr_number = ?", (number,))
+        conn.executemany(
+            "INSERT INTO files(pr_number, path) VALUES (?, ?)",
+            [(number, path) for path in paths],
+        )
+        repaired.append("files")
+
+    reviews_replaced = actual["reviews"] < expected["reviews"]
+    if reviews_replaced:
+        ensure_budget("core", rest_threshold)
+        reviews = gh_rest_pages(
+            f"repos/{OWNER}/{REPOSITORY}/pulls/{number}/reviews?per_page=100"
+        )
+        reviews_observed_at = utc_now()
+        verify_count(number, "reviews", len(reviews), expected["reviews"])
+        conn.execute(
+            "DELETE FROM artifacts WHERE pr_number = ? "
+            "AND kind IN ('review', 'review_comment')",
+            (number,),
+        )
+        for review in reviews:
+            insert_artifact(
+                conn,
+                artifact=review,
+                pr_number=number,
+                kind="review",
+                observed_at=reviews_observed_at,
+                state=(review.get("state") or "").upper() or None,
+                rest=True,
+            )
+        repaired.append("reviews")
+
+    if reviews_replaced or actual["review_comments"] < expected["review_comments"]:
+        ensure_budget("core", rest_threshold)
+        backfill_observed_at = utc_now()
+        comments = gh_rest_pages(
+            f"repos/{OWNER}/{REPOSITORY}/pulls/{number}/comments?per_page=100"
+        )
+        if not reviews_replaced:
+            verify_count(
+                number, "review comments", len(comments), expected["review_comments"]
+            )
+        else:
+            conn.execute(
+                "UPDATE pull_requests SET review_comments_total = ? WHERE number = ?",
+                (len(comments), number),
+            )
+        replace_review_comments(conn, number, comments, backfill_observed_at)
+        repaired.append("review_comments")
+
+    if actual["issue_comments"] < expected["issue_comments"]:
+        ensure_budget("core", rest_threshold)
+        backfill_observed_at = utc_now()
+        comments = gh_rest_pages(
+            f"repos/{OWNER}/{REPOSITORY}/issues/{number}/comments?per_page=100"
+        )
+        verify_count(number, "issue comments", len(comments), expected["issue_comments"])
+        conn.execute(
+            "DELETE FROM artifacts WHERE pr_number = ? AND kind = 'issue_comment'",
+            (number,),
+        )
+        for comment in comments:
+            insert_artifact(
+                conn,
+                artifact=comment,
+                pr_number=number,
+                kind="issue_comment",
+                observed_at=backfill_observed_at,
+                rest=True,
+            )
+        repaired.append("issue_comments")
+
+    return repaired
+
+
+def truncation_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    rows = conn.execute(
+        """
+        SELECT p.number, p.files_total, p.reviews_total,
+               p.issue_comments_total, p.review_comments_total,
+               (SELECT COUNT(*) FROM files f WHERE f.pr_number = p.number),
+               (SELECT COUNT(*) FROM artifacts a
+                WHERE a.pr_number = p.number AND a.kind = 'review'),
+               (SELECT COUNT(*) FROM artifacts a
+                WHERE a.pr_number = p.number AND a.kind = 'issue_comment'),
+               (SELECT COUNT(*) FROM artifacts a
+                WHERE a.pr_number = p.number AND a.kind = 'review_comment')
+        FROM pull_requests p
+        """
+    ).fetchall()
+    totals = dict.fromkeys(("files", "reviews", "issue_comments", "review_comments"), 0)
+    for row in rows:
+        expected = row[1:5]
+        actual = row[5:9]
+        for index, kind in enumerate(totals):
+            totals[kind] += int(actual[index] != expected[index])
+    return totals
+
+
+def write_manifest(db_path: Path, conn: sqlite3.Connection) -> None:
+    state_counts = {
+        state: count
+        for state, count in conn.execute(
+            "SELECT state, COUNT(*) FROM pull_requests GROUP BY state"
+        )
+    }
+    artifact_counts = {
+        kind: count
+        for kind, count in conn.execute(
+            "SELECT kind, COUNT(*) FROM artifacts GROUP BY kind"
+        )
+    }
+    manifest = {
+        "updated_at": utc_now(),
+        "repository": f"{OWNER}/{REPOSITORY}",
+        "scope": "OPEN, MERGED, and CLOSED PRs ordered by CREATED_AT ascending",
+        "audit_started_at": get_meta(conn, "audit_started_at"),
+        "status": get_meta(conn, "status") or "collecting",
+        "pull_requests": {
+            "total": conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0],
+            "by_state": state_counts,
+            "snapshot_total": int(get_meta(conn, "snapshot_total") or 0),
+            "high_water": {
+                "number": int(get_meta(conn, "high_water_number") or 0),
+                "created_at": get_meta(conn, "high_water_created_at"),
+            },
+        },
+        "artifacts": {
+            "total": conn.execute("SELECT COUNT(*) FROM artifacts").fetchone()[0],
+            "by_kind": artifact_counts,
+            "nonempty_human": conn.execute(
+                "SELECT COUNT(*) FROM artifacts WHERE is_bot = 0 AND TRIM(body) != ''"
+            ).fetchone()[0],
+        },
+        "possibly_truncated_connections": truncation_counts(conn),
+        "cursor": get_meta(conn, "cursor"),
+        "has_next_page": get_meta(conn, "has_next_page") == "True",
+        "snapshot_complete": get_meta(conn, "snapshot_complete") == "True",
+        "last_rate_limit": json.loads(get_meta(conn, "last_rate_limit") or "{}"),
+    }
+    destination = db_path.with_name(f"{db_path.stem}.manifest.json")
+    with tempfile.NamedTemporaryFile(
+        "w", dir=destination.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, destination)
+
+
+def initialize_database(
+    conn: sqlite3.Connection, requested_cutoff: str | None
+) -> datetime:
+    conn.executescript(SCHEMA)
+    existing_version = get_meta(conn, "schema_version")
+    if existing_version and existing_version != SCHEMA_VERSION:
+        raise SystemExit(
+            f"database schema is {existing_version}; expected {SCHEMA_VERSION}"
+        )
+    existing_cutoff = get_meta(conn, "audit_started_at")
+    if existing_cutoff:
+        if requested_cutoff and parse_timestamp(requested_cutoff) != parse_timestamp(
+            existing_cutoff
+        ):
+            raise SystemExit(
+                f"database cutoff is {existing_cutoff}; requested {requested_cutoff}"
+            )
+        return parse_timestamp(existing_cutoff)
+
+    cutoff = requested_cutoff or utc_now()
+    parsed_cutoff = parse_timestamp(cutoff)
+    with conn:
+        set_meta(conn, "schema_version", SCHEMA_VERSION)
+        set_meta(conn, "repository", f"{OWNER}/{REPOSITORY}")
+        set_meta(conn, "states", "OPEN,MERGED,CLOSED")
+        set_meta(conn, "ordering", "CREATED_AT_ASC")
+        set_meta(conn, "audit_started_at", parsed_cutoff.isoformat())
+        set_meta(
+            conn,
+            "audit_cutoff_source",
+            "explicit" if requested_cutoff else "automatic",
+        )
+        set_meta(conn, "started_at", utc_now())
+        set_meta(conn, "status", "collecting")
+    return parsed_cutoff
+
+
+def establish_snapshot(
+    conn: sqlite3.Connection, cutoff: datetime, graphql_threshold: int
+) -> datetime:
+    """Freeze the population count and newest edge before the oldest-first crawl."""
+
+    stored_total = get_meta(conn, "snapshot_total")
+    if stored_total is not None:
+        if not get_meta(conn, "high_water_number"):
+            raise RuntimeError("snapshot metadata is incomplete; use a fresh database")
+        return cutoff
+    if conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]:
+        raise RuntimeError(
+            "database has PR rows but no initial high-water snapshot; use a fresh database"
+        )
+
+    ensure_budget("graphql", graphql_threshold)
+    payload = gh_bootstrap()
+    repository = payload["data"]["repository"]
+    total = int(repository["population"]["totalCount"])
+    newest_nodes = repository["newest"]["nodes"]
+    if total <= 0 or len(newest_nodes) != 1:
+        raise RuntimeError(
+            f"cannot establish snapshot: total={total}, newest_edges={len(newest_nodes)}"
+        )
+    high_water = newest_nodes[0]
+    high_water_created = parse_timestamp(high_water["createdAt"])
+
+    # For the normal automatic snapshot, the high-water query is authoritative;
+    # move the secondary wall-clock cutoff just after that atomic query.  An
+    # explicitly requested cutoff must already include the high-water edge.
+    if get_meta(conn, "audit_cutoff_source") == "automatic":
+        cutoff = parse_timestamp(utc_now())
+    elif high_water_created > cutoff:
+        raise RuntimeError(
+            "the explicit audit cutoff predates the current newest PR; historical "
+            "population snapshots are unsupported"
+        )
+
+    with conn:
+        set_meta(conn, "audit_started_at", cutoff.isoformat())
+        set_meta(conn, "snapshot_total", total)
+        set_meta(conn, "high_water_number", int(high_water["number"]))
+        set_meta(conn, "high_water_created_at", high_water_created.isoformat())
+        set_meta(conn, "snapshot_established_at", utc_now())
+        set_meta(conn, "last_rate_limit", json.dumps(payload["data"]["rateLimit"]))
+    return cutoff
+
+
+def repair_all(
+    conn: sqlite3.Connection, graphql_threshold: int, rest_threshold: int
+) -> None:
+    rows = conn.execute(
+        "SELECT number, observed_at FROM pull_requests ORDER BY number"
+    ).fetchall()
+    for number, observed_at in rows:
+        if expected_counts(conn, number) != collected_counts(conn, number):
+            with conn:
+                repaired = repair_pr_connections(
+                    conn,
+                    number,
+                    observed_at,
+                    graphql_threshold,
+                    rest_threshold,
+                )
+            if repaired:
+                print(f"repaired PR #{number}: {', '.join(repaired)}", flush=True)
+
+
+def run_self_test() -> int:
+    from unittest import mock
+
+    assert is_transient_github_failure("gh: HTTP 502: Bad Gateway")
+    assert is_transient_github_failure("read: connection reset by peer")
+    assert is_transient_github_failure("net/http: TLS handshake timeout")
+    assert is_transient_github_failure("unexpected end of JSON input")
+    assert is_transient_github_failure("invalid JSON response from GitHub")
+    assert is_transient_github_failure("error connecting to api.github.com")
+    assert is_transient_github_failure("check your internet connection")
+    assert is_transient_github_failure("could not resolve host: api.github.com")
+    assert not is_transient_github_failure("gh: HTTP 422: GraphQL schema error")
+    assert retry_after_seconds("gh: HTTP 429\nRetry-After: 17") == 17.0
+    assert retry_delay(6, "gh: HTTP 503\nRetry-After: 120") == 60.0
+    assert retry_delay(3, "gh: HTTP 503") == 4.0
+
+    transient = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="gh: HTTP 502: Bad Gateway"
+    )
+    success = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout='{"ok":true}', stderr=""
+    )
+    with mock.patch.object(subprocess, "run", side_effect=[transient, success]) as run:
+        with mock.patch.object(time, "sleep") as sleep:
+            assert run_gh(["example"], "failure") == {"ok": True}
+            assert run.call_count == 2
+            sleep.assert_called_once_with(1.0)
+
+    truncated = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout='{"partial":', stderr=""
+    )
+    with mock.patch.object(subprocess, "run", side_effect=[truncated, success]) as run:
+        with mock.patch.object(time, "sleep") as sleep:
+            assert run_gh(["example"], "failure") == {"ok": True}
+            assert run.call_count == 2
+            sleep.assert_called_once_with(1.0)
+
+    fatal = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="gh: HTTP 422: schema error"
+    )
+    with mock.patch.object(subprocess, "run", return_value=fatal) as run:
+        with mock.patch.object(time, "sleep") as sleep:
+            try:
+                run_gh(["example"], "failure")
+            except RuntimeError as error:
+                assert "HTTP 422" in str(error)
+            else:
+                raise AssertionError("deterministic GitHub failure was retried")
+            assert run.call_count == 1
+            sleep.assert_not_called()
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "test.sqlite"
+        conn = sqlite3.connect(path)
+        initialize_database(conn, "2026-01-01T00:00:00Z")
+        observed = "2026-01-01T00:00:01+00:00"
+        for number, state in enumerate(("OPEN", "MERGED", "CLOSED"), start=1):
+            pr = {
+                "number": number,
+                "url": f"https://example.invalid/{number}",
+                "title": state,
+                "bodyText": "",
+                "state": state,
+                "isDraft": state == "OPEN",
+                "createdAt": f"2025-01-0{number}T00:00:00Z",
+                "updatedAt": f"2025-01-0{number}T01:00:00Z",
+                "mergedAt": "2025-01-02T00:00:00Z" if state == "MERGED" else None,
+                "closedAt": "2025-01-03T00:00:00Z" if state != "OPEN" else None,
+                "authorAssociation": "CONTRIBUTOR",
+                "author": {"login": "contributor", "__typename": "User"},
+                "labels": {"totalCount": 0, "nodes": []},
+                "files": {"totalCount": 1, "nodes": [{"path": "file.txt"}]},
+                "reviews": {"totalCount": 0, "nodes": []},
+                "comments": {"totalCount": 0, "nodes": []},
+            }
+            with conn:
+                insert_pr(conn, pr, observed)
+                insert_pr(conn, pr, observed)
+        assert conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0] == 3
+        assert conn.execute("SELECT COUNT(*) FROM files").fetchone()[0] == 3
+        assert dict(
+            conn.execute("SELECT state, COUNT(*) FROM pull_requests GROUP BY state")
+        ) == {"OPEN": 1, "MERGED": 1, "CLOSED": 1}
+        assert truncation_counts(conn) == {
+            "files": 0,
+            "reviews": 0,
+            "issue_comments": 0,
+            "review_comments": 0,
+        }
+        assert conn.execute(
+            "SELECT merged_at IS NULL, closed_at IS NULL FROM pull_requests "
+            "WHERE state = 'OPEN'"
+        ).fetchone() == (1, 1)
+        conn.close()
+    print("self-test passed")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        return run_self_test()
+    if not 1 <= args.batch_size <= 20:
+        raise SystemExit("batch size must be between 1 and 20")
+    if args.graphql_threshold < 0 or args.rest_threshold < 0:
+        raise SystemExit("rate-limit thresholds must be nonnegative")
+    if args.stop_after_pages is not None and args.stop_after_pages <= 0:
+        raise SystemExit("stop-after-pages must be positive")
+
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(args.db)
+    cutoff = initialize_database(conn, args.audit_started_at)
+    try:
+        cutoff = establish_snapshot(conn, cutoff, args.graphql_threshold)
+    except RateLimitPause as pause:
+        with conn:
+            set_meta(conn, "status", "rate_limited")
+            set_meta(conn, "rate_limit_resource", pause.resource)
+            set_meta(conn, "rate_limit_reset_at", pause.reset_at)
+        write_manifest(args.db, conn)
+        conn.close()
+        print(f"checkpointed: {pause}", file=sys.stderr)
+        return 75
+    with conn:
+        set_meta(conn, "status", "collecting")
+    cursor = get_meta(conn, "cursor")
+    snapshot_total = int(get_meta(conn, "snapshot_total") or 0)
+    high_water_number = int(get_meta(conn, "high_water_number") or 0)
+    high_water_created = parse_timestamp(
+        get_meta(conn, "high_water_created_at") or ""
+    )
+    pages = 0
+
+    try:
+        while get_meta(conn, "snapshot_complete") != "True":
+            ensure_budget("graphql", args.graphql_threshold)
+            payload = gh_graphql(args.batch_size, cursor)
+            connection = payload["data"]["repository"]["pullRequests"]
+            rate = payload["data"]["rateLimit"]
+            observed_at = utc_now()
+            count_before = conn.execute(
+                "SELECT COUNT(*) FROM pull_requests"
+            ).fetchone()[0]
+            if int(connection["totalCount"]) < snapshot_total:
+                raise RuntimeError(
+                    "the all-state PR population shrank after the initial snapshot; "
+                    "an edge may have been deleted, so a fresh audit snapshot is required"
+                )
+            eligible: list[dict[str, Any]] = []
+            reached_high_water = False
+            for pr in connection["nodes"]:
+                position = count_before + len(eligible) + 1
+                created_at = parse_timestamp(pr["createdAt"])
+                if position > snapshot_total:
+                    break
+                if conn.execute(
+                    "SELECT 1 FROM pull_requests WHERE number = ?", (pr["number"],)
+                ).fetchone():
+                    raise RuntimeError(
+                        f"PR #{pr['number']} appeared twice in the cursor traversal"
+                    )
+                if created_at > cutoff or created_at > high_water_created:
+                    raise RuntimeError(
+                        f"encountered PR #{pr['number']} beyond the initial high-water "
+                        "before collecting the frozen population"
+                    )
+                if int(pr["number"]) == high_water_number and position != snapshot_total:
+                    raise RuntimeError(
+                        "the initial high-water edge appeared before the frozen population "
+                        "count was reached; CREATED_AT tie ordering changed"
+                    )
+                if position == snapshot_total:
+                    if (
+                        int(pr["number"]) != high_water_number
+                        or created_at != high_water_created
+                    ):
+                        raise RuntimeError(
+                            "the final frozen-population edge does not match the initial "
+                            "high-water identity; restart with a fresh audit snapshot"
+                        )
+                    reached_high_water = True
+                eligible.append(pr)
+                if reached_high_water:
+                    break
+
+            if not reached_high_water and not connection["pageInfo"]["hasNextPage"]:
+                raise RuntimeError(
+                    "the PR connection ended before the initial high-water edge was reached"
+                )
+
+            with conn:
+                for pr in eligible:
+                    insert_pr(conn, pr, observed_at)
+                    repaired = repair_pr_connections(
+                        conn,
+                        int(pr["number"]),
+                        observed_at,
+                        args.graphql_threshold,
+                        args.rest_threshold,
+                    )
+                    if repaired:
+                        print(
+                            f"repaired PR #{pr['number']}: {', '.join(repaired)}",
+                            flush=True,
+                        )
+                cursor = connection["pageInfo"]["endCursor"]
+                set_meta(conn, "cursor", cursor or "")
+                set_meta(
+                    conn,
+                    "has_next_page",
+                    connection["pageInfo"]["hasNextPage"],
+                )
+                set_meta(conn, "last_rate_limit", json.dumps(rate))
+                set_meta(conn, "updated_at", observed_at)
+                if reached_high_water:
+                    final_count = conn.execute(
+                        "SELECT COUNT(*) FROM pull_requests"
+                    ).fetchone()[0]
+                    if final_count != snapshot_total:
+                        raise RuntimeError(
+                            f"frozen population expected {snapshot_total} PRs, inserted "
+                            f"{final_count}"
+                        )
+                    set_meta(conn, "snapshot_complete", True)
+                    set_meta(conn, "snapshot_pr_count", final_count)
+            pages += 1
+            count = conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]
+            write_manifest(args.db, conn)
+            print(
+                f"pages={pages} collected={count} page_cost={rate['cost']} "
+                f"graphql_remaining={rate['remaining']}",
+                flush=True,
+            )
+            if args.stop_after_pages is not None and pages >= args.stop_after_pages:
+                with conn:
+                    set_meta(conn, "status", "checkpointed")
+                write_manifest(args.db, conn)
+                print(f"checkpointed after {pages} page(s): {args.db}")
+                return 0
+
+        final_count = conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]
+        if final_count != snapshot_total:
+            raise RuntimeError(
+                f"snapshot marked complete with {final_count} PRs; expected {snapshot_total}"
+            )
+        high_water_row = conn.execute(
+            "SELECT created_at FROM pull_requests WHERE number = ?",
+            (high_water_number,),
+        ).fetchone()
+        if not high_water_row or parse_timestamp(high_water_row[0]) != high_water_created:
+            raise RuntimeError("stored high-water PR does not match the initial snapshot")
+
+        repair_all(conn, args.graphql_threshold, args.rest_threshold)
+        truncated = truncation_counts(conn)
+        if any(truncated.values()):
+            raise RuntimeError(f"collection still has truncated connections: {truncated}")
+        with conn:
+            set_meta(conn, "status", "complete")
+            set_meta(conn, "completed_at", utc_now())
+        write_manifest(args.db, conn)
+        print(
+            "complete: "
+            f"{conn.execute('SELECT COUNT(*) FROM pull_requests').fetchone()[0]} PRs "
+            f"in {args.db}",
+            flush=True,
+        )
+        return 0
+    except RateLimitPause as pause:
+        with conn:
+            set_meta(conn, "status", "rate_limited")
+            set_meta(conn, "rate_limit_resource", pause.resource)
+            set_meta(conn, "rate_limit_reset_at", pause.reset_at)
+        write_manifest(args.db, conn)
+        print(f"checkpointed: {pause}", file=sys.stderr)
+        return 75
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("interrupted; the last completed page remains checkpointed", file=sys.stderr)
+        sys.exit(130)

--- a/.skills/gutenberg-pr-review/evals/audit/mine_candidates.py
+++ b/.skills/gutenberg-pr-review/evals/audit/mine_candidates.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Measure focused rule hypotheses against every actionable pilot artifact."""
+
+from __future__ import annotations
+
+import collections
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).with_name("analysis")
+
+HYPOTHESES: dict[str, dict[str, Any]] = {
+    "lifecycle_exit_paths": {
+        "rule": "Test pending/debounced/async work across unmount, navigation, close, and cleanup paths.",
+        "patterns": [
+            r"\bunmount", r"\bcleanup\b", r"debounc", r"pending (?:timer|edit|work|callback)",
+            r"navigate away", r"silently lost", r"lost.*edit", r"queued callback",
+        ],
+    },
+    "atomic_shared_state": {
+        "rule": "Shared staging layers should commit only the intended change atomically, not unrelated drafts.",
+        "patterns": [
+            r"shared stag", r"whole staged", r"atomic (?:write|update|commit)",
+            r"unrelated.*(?:draft|edit|state)", r"stale closure",
+        ],
+    },
+    "regression_tests_fail_before_fix": {
+        "rule": "For regression tests, verify the test fails on trunk and passes with the fix.",
+        "patterns": [
+            r"fail(?:s|ed|ing)? (?:on|against|with) trunk", r"trunk.*(?:hang|fail)",
+            r"regression test", r"before (?:the|this) fix", r"without (?:the|this) (?:change|fix)",
+        ],
+    },
+    "behavior_not_implementation_tests": {
+        "rule": "Prefer assertions on observable behavior over implementation details.",
+        "patterns": [
+            r"implementation detail", r"assert.*(?:computed|visible|output|behavior)",
+            r"test.*(?:computed|visible|output|behavior)", r"more robust way to test",
+        ],
+    },
+    "before_after_manual_validation": {
+        "rule": "For bug fixes, reproduce on trunk and repeat the same steps on the branch.",
+        "patterns": [
+            r"tested (?:this )?on (?:both )?trunk and", r"on trunk.*(?:on|fix) branch",
+            r"on trunk.*this branch", r"trunk.*before.*after", r"compare the two",
+        ],
+    },
+    "visual_state_evidence": {
+        "rule": "Visual changes should include before/after evidence and exercise empty, long, overflow, and narrow states.",
+        "patterns": [
+            r"screenshot for this visual change", r"before\s*/?\s*after screenshots?",
+            r"long string", r"small viewport", r"narrow viewport", r"empty state",
+            r"more than ten options", r"(?:title|text|content).*(?:overflow|wrap)",
+        ],
+    },
+    "workflow_preflight": {
+        "rule": "Validate permissions and prerequisites before irreversible workflow mutations.",
+        "patterns": [
+            r"\bpreflight\b", r"before any .*mutation", r"permission.*(?:too|so) late",
+            r"fail.*late", r"before .*version[- ]bump", r"before .*push",
+        ],
+    },
+    "workflow_recovery": {
+        "rule": "Design release/build workflows for concurrency, partial completion, and idempotent recovery.",
+        "patterns": [
+            r"half[- ]completed", r"partial(?:ly)? (?:complete|publish)", r"resume from",
+            r"recovery", r"concurren", r"cancel-in-progress", r"idempoten",
+        ],
+    },
+    "cache_tool_versions": {
+        "rule": "Cache keys must include tool versions that affect generated dependency/build state.",
+        "patterns": [
+            r"cache key", r"cache hit", r"restore.*(?:npm|node|tool).*version",
+            r"tree produced by", r"floating npm",
+        ],
+    },
+    "isolated_resolution": {
+        "rule": "Exercise isolated dependency layouts and resolve modules from the package/config that owns them.",
+        "patterns": [
+            r"isolated (?:dependenc|layout|build)", r"transitive dep", r"hoist",
+            r"resolve .* explicitly", r"resolve from this file", r"bare .* fails",
+        ],
+    },
+    "tooltip_equivalent": {
+        "rule": "Information available only in a tooltip needs an equivalent for screen-reader and keyboard users.",
+        "patterns": [
+            r"tooltip.*(?:screen reader|assistive|keyboard|focus)",
+            r"screen reader.*tooltip", r"visuallyhidden", r"make .* focusable",
+            r"information equivalent to the tooltip",
+        ],
+    },
+    "shortcut_semantics": {
+        "rule": "Keyboard shortcuts need aria-keyshortcuts; hide visual hints from AT and preserve LTR key order in RTL.",
+        "patterns": [
+            r"aria-keyshortcuts", r"visual(?:ly)? .*shortcut", r"shortcut.*assistive",
+            r"shortcut.*rtl", r"dir=[\"']ltr", r"displayed shortcut",
+        ],
+    },
+    "avoid_duplicate_announcements": {
+        "rule": "Verify native accessibility announcements before adding wp.a11y.speak(), to avoid duplicate output.",
+        "patterns": [
+            r"screen reader.*(?:twice|duplicate)", r"duplicat.*screen reader",
+            r"native api.*(?:communicat|announce)", r"speak.*present in the page twice",
+        ],
+    },
+    "all_input_methods": {
+        "rule": "Exercise equivalent pointer, keyboard, clear, and focus/blur paths for interactive controls.",
+        "patterns": [
+            r"pointer.*keyboard|keyboard.*pointer", r"backspac", r"select-all.*delete",
+            r"clear (?:button|press|case)", r"arrow (?:up|down|left|right)",
+            r"focus.*blur|blur.*focus", r"keyboard.*(?:case|path|change)",
+        ],
+    },
+    "scss_module_compatibility": {
+        "rule": "During SCSS-module migrations, preserve established public class names used by consumers.",
+        "patterns": [
+            r"preserve.*(?:public|legacy).*class", r"public .*class names",
+            r"consumer.*class", r"module\.scss.*(?:legacy|compat)",
+        ],
+    },
+    "runtime_type_boundaries": {
+        "rule": "Narrow and validate external/runtime data before accessing union-specific fields.",
+        "patterns": [
+            r"typeof .*string", r"\bis_string\(", r"\bis_array\(",
+            r"instanceof error", r"unexpected (?:shape|type)", r"type guard",
+        ],
+    },
+    "user_facing_errors": {
+        "rule": "Error messages should state the actual failure and recovery expectation in user-facing language.",
+        "patterns": [
+            r"error message.*(?:explicit|clear|human|accurate|actual)",
+            r"human[- ]focused", r"notice string", r"recovery command",
+            r"expected .*aligns.*automated tests",
+        ],
+    },
+    "docs_match_latest_behavior": {
+        "rule": "Keep PR descriptions, comments, and docs synchronized with the final behavior.",
+        "patterns": [
+            r"update the pr description", r"description to match the latest",
+            r"comment.*not accurate", r"no longer accurate", r"docs?.*misleading",
+            r"this says .* but", r"documentation.*actual",
+        ],
+    },
+    "options_object_for_many_parameters": {
+        "rule": "Prefer an options object once a function accumulates several optional parameters.",
+        "patterns": [
+            r"optional params?.*options object", r"options or config object",
+            r"function signatures?.*hard to read", r"params?.*config object",
+        ],
+    },
+    "icon_viewbox_exceptions": {
+        "rule": "Treat 24×24 icon viewBox as the default, not an exceptionless invariant.",
+        "patterns": [
+            r"non-0 0 24 24", r"view[- ]?box.*intentional", r"viewbox.*exception",
+        ],
+    },
+}
+
+
+def main() -> int:
+    records = [json.loads(line) for line in (ROOT / "corpus.jsonl").read_text().splitlines()]
+    output = [
+        "# Candidate rule evidence\n\n",
+        "Counts are measured across every actionable pilot artifact. They indicate recurrence, not automatic validity.\n\n",
+    ]
+    machine: dict[str, Any] = {}
+    for name, hypothesis in HYPOTHESES.items():
+        patterns = [re.compile(item, re.IGNORECASE | re.DOTALL) for item in hypothesis["patterns"]]
+        matches = [
+            record for record in records if any(pattern.search(record["body"]) for pattern in patterns)
+        ]
+        prs = {record["pr_number"] for record in matches}
+        authors = {record["author"] for record in matches}
+        machine[name] = {
+            "rule": hypothesis["rule"],
+            "artifacts": len(matches),
+            "prs": len(prs),
+            "authors": len(authors),
+            "evidence_ids": [record["id"] for record in matches],
+        }
+        output.extend(
+            [
+                f"## {name}\n\n",
+                f"**Hypothesis:** {hypothesis['rule']}\n\n",
+                f"Support: {len(matches)} artifacts, {len(prs)} PRs, {len(authors)} reviewers.\n\n",
+            ]
+        )
+        selected: list[dict[str, Any]] = []
+        seen_prs: set[int] = set()
+        reviewer_counts: collections.Counter[str] = collections.Counter()
+        for record in sorted(matches, key=lambda item: len(item["body"]), reverse=True):
+            if record["pr_number"] in seen_prs or reviewer_counts[record["author"]] >= 2:
+                continue
+            selected.append(record)
+            seen_prs.add(record["pr_number"])
+            reviewer_counts[record["author"]] += 1
+            if len(selected) == 10:
+                break
+        for record in selected:
+            body = re.sub(r"\s+", " ", record["body"]).strip()
+            if len(body) > 1000:
+                body = body[:999] + "…"
+            output.append(
+                f"- [#{record['pr_number']}]({record['url']}) {record['author']}: {body}\n"
+            )
+        output.append("\n")
+    (ROOT / "candidate-evidence.md").write_text("".join(output), encoding="utf-8")
+    (ROOT / "candidate-counts.json").write_text(
+        json.dumps(machine, indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(machine, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/reduce_clusters.py
+++ b/.skills/gutenberg-pr-review/evals/audit/reduce_clusters.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Build and validate evidence-preserving recursive cluster-merge batches."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import math
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+import reduce_findings
+
+
+CLUSTER_ID = re.compile(r"^K[0-9a-f]{16}$")
+TOKEN = re.compile(r"[a-z0-9]+")
+STOPWORDS = {
+    "a",
+    "all",
+    "an",
+    "and",
+    "any",
+    "are",
+    "as",
+    "at",
+    "avoid",
+    "be",
+    "before",
+    "by",
+    "check",
+    "correct",
+    "do",
+    "each",
+    "ensure",
+    "every",
+    "for",
+    "from",
+    "has",
+    "have",
+    "in",
+    "instead",
+    "into",
+    "is",
+    "it",
+    "keep",
+    "make",
+    "new",
+    "no",
+    "not",
+    "of",
+    "on",
+    "only",
+    "or",
+    "preserve",
+    "prefer",
+    "provide",
+    "require",
+    "review",
+    "should",
+    "that",
+    "the",
+    "their",
+    "through",
+    "to",
+    "use",
+    "used",
+    "using",
+    "verify",
+    "when",
+    "where",
+    "with",
+    "without",
+}
+ALIASES = {
+    "accessible": "accessibility",
+    "a11y": "accessibility",
+    "apis": "api",
+    "backwards": "backward",
+    "compat": "compatibility",
+    "compatible": "compatibility",
+    "components": "component",
+    "dependencies": "dependency",
+    "docs": "documentation",
+    "effects": "effect",
+    "hooks": "hook",
+    "internationalisation": "internationalization",
+    "localisation": "localization",
+    "props": "prop",
+    "selectors": "selector",
+    "styles": "style",
+    "tests": "test",
+    "workflows": "workflow",
+}
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def stable_id(stage: int, source: str, local_id: str, members: list[str]) -> str:
+    value = {
+        "stage": stage,
+        "source": source,
+        "local_id": local_id,
+        "members": members,
+    }
+    return "K" + hashlib.sha256(canonical_json(value)).hexdigest()[:16]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: expected object")
+            yield value
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def stem(token: str) -> str:
+    token = ALIASES.get(token, token)
+    if len(token) > 6 and token.endswith("ies"):
+        token = token[:-3] + "y"
+    elif len(token) > 6 and token.endswith("ing"):
+        token = token[:-3]
+    elif len(token) > 5 and token.endswith("ed"):
+        token = token[:-2]
+    elif len(token) > 5 and token.endswith("s") and not token.endswith("ss"):
+        token = token[:-1]
+    return ALIASES.get(token, token)
+
+
+def tokens(node: dict[str, Any]) -> tuple[str, ...]:
+    text = f"{node['topic_slug']} {node['canonical_rule']}".lower()
+    values = {
+        stem(value)
+        for value in TOKEN.findall(text)
+        if value not in STOPWORDS and len(value) > 1
+    }
+    return tuple(sorted(value for value in values if value not in STOPWORDS))
+
+
+def finding_authority(path: Path) -> dict[str, dict[str, Any]]:
+    authority: dict[str, dict[str, Any]] = {}
+    for row in jsonl(path):
+        finding_id = row["finding_id"]
+        if finding_id in authority:
+            raise ValueError(f"duplicate finding {finding_id}")
+        authority[finding_id] = row
+    return authority
+
+
+def load_stage1(
+    results: Path, findings_path: Path
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    findings = finding_authority(findings_path)
+    nodes: list[dict[str, Any]] = []
+    ids: set[str] = set()
+    covered: set[str] = set()
+    for path in sorted(results.glob("reduce-*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("unresolved"):
+            raise ValueError(f"{path}: unresolved stage-one members remain")
+        for cluster in payload["clusters"]:
+            evidence_ids = cluster["member_ids"]
+            if any(value not in findings for value in evidence_ids):
+                raise ValueError(f"{path}: foreign evidence ID")
+            if covered.intersection(evidence_ids):
+                raise ValueError(f"{path}: duplicate evidence coverage")
+            covered.update(evidence_ids)
+            cluster_id = stable_id(
+                1, path.name, cluster["local_id"], evidence_ids
+            )
+            if cluster_id in ids:
+                raise ValueError(f"stable ID collision {cluster_id}")
+            ids.add(cluster_id)
+            prs = {findings[value]["pr_number"] for value in evidence_ids}
+            reviewers = {findings[value]["reviewer"] for value in evidence_ids}
+            states = Counter(findings[value]["pr_state"] for value in evidence_ids)
+            nodes.append(
+                {
+                    "cluster_id": cluster_id,
+                    "stage": 1,
+                    "source": path.name,
+                    "local_id": cluster["local_id"],
+                    "domain": cluster["domain"],
+                    "topic_slug": cluster["topic_slug"],
+                    "canonical_rule": cluster["canonical_rule"],
+                    "severity": cluster["severity"],
+                    "needs_current_validation": cluster[
+                        "needs_current_validation"
+                    ],
+                    "merge_basis": cluster["merge_basis"],
+                    "direct_member_ids": evidence_ids,
+                    "evidence_ids": evidence_ids,
+                    "support_count": len(evidence_ids),
+                    "distinct_prs": len(prs),
+                    "distinct_reviewers": len(reviewers),
+                    "state_counts": dict(states),
+                }
+            )
+    if covered != set(findings):
+        raise ValueError(
+            f"stage-one coverage mismatch: {len(covered)} != {len(findings)}"
+        )
+    return nodes, findings
+
+
+def grouping_keys(nodes: list[dict[str, Any]]) -> dict[str, str]:
+    """Choose a reproducible association-based lexical bucket per node."""
+    by_domain: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for node in nodes:
+        by_domain[node["domain"]].append(node)
+    result: dict[str, str] = {}
+    for domain, domain_nodes in by_domain.items():
+        token_map = {node["cluster_id"]: tokens(node) for node in domain_nodes}
+        document_frequency: Counter[str] = Counter()
+        pair_frequency: Counter[tuple[str, str]] = Counter()
+        for values in token_map.values():
+            document_frequency.update(values)
+            pair_frequency.update(itertools.combinations(values, 2))
+        for node in domain_nodes:
+            values = token_map[node["cluster_id"]]
+            candidates = [
+                pair
+                for pair in itertools.combinations(values, 2)
+                if pair_frequency[pair] >= 2
+            ]
+            if candidates:
+                pair = max(
+                    candidates,
+                    key=lambda value: (
+                        pair_frequency[value]
+                        / math.sqrt(
+                            document_frequency[value[0]]
+                            * document_frequency[value[1]]
+                        ),
+                        pair_frequency[value],
+                        value,
+                    ),
+                )
+                key = "+".join(pair)
+            else:
+                repeated = [
+                    value for value in values if document_frequency[value] >= 2
+                ]
+                if repeated:
+                    value = min(
+                        repeated,
+                        key=lambda item: (document_frequency[item], item),
+                    )
+                    key = value
+                else:
+                    key = "long-tail"
+            result[node["cluster_id"]] = f"{domain}:{key}"
+    return result
+
+
+def merge_schema() -> dict[str, Any]:
+    schema = reduce_findings.worker_schema()
+    cluster = schema["properties"]["clusters"]
+    cluster["maxItems"] = 80
+    cluster["items"]["properties"]["member_ids"]["items"]["pattern"] = (
+        "^K[0-9a-f]{16}$"
+    )
+    schema["properties"]["unresolved"]["items"]["properties"]["member_id"][
+        "pattern"
+    ] = "^K[0-9a-f]{16}$"
+    return schema
+
+
+def render_batch(
+    name: str, domain: str, bucket: str, nodes: list[dict[str, Any]]
+) -> str:
+    rows = [
+        {
+            "cluster_id": node["cluster_id"],
+            "topic_slug": node["topic_slug"],
+            "canonical_rule": node["canonical_rule"],
+            "severity": node["severity"],
+            "needs_current_validation": node["needs_current_validation"],
+            "support_count": node["support_count"],
+            "distinct_prs": node["distinct_prs"],
+            "distinct_reviewers": node["distinct_reviewers"],
+            "state_counts": node["state_counts"],
+        }
+        for node in nodes
+    ]
+    lines = [
+        f"# Cluster merge batch {name}",
+        "",
+        f"Primary domain: `{domain}`",
+        f"Lexical bucket: `{bucket}`",
+        f"Input cluster count: {len(nodes)}",
+        "",
+        "The input microclusters follow as JSON Lines:",
+        "",
+    ]
+    lines.extend(json.dumps(row, ensure_ascii=False) for row in rows)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_stage2(
+    results: Path,
+    findings: Path,
+    output: Path,
+    max_clusters: int,
+    max_chars: int,
+) -> dict[str, Any]:
+    nodes, finding_rows = load_stage1(results, findings)
+    keys = grouping_keys(nodes)
+    output.mkdir(parents=True, exist_ok=True)
+    batches_dir = output / "batches"
+    batches_dir.mkdir(exist_ok=True)
+    write_jsonl(output / "cluster-ledger.jsonl", nodes)
+    write_json(output / "merge-output.schema.json", merge_schema())
+
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for node in nodes:
+        buckets[(node["domain"], keys[node["cluster_id"]])].append(node)
+
+    index: list[dict[str, Any]] = []
+    domain_numbers: Counter[str] = Counter()
+    domain_buckets: dict[str, list[tuple[str, list[dict[str, Any]]]]] = (
+        defaultdict(list)
+    )
+    for (domain, bucket), bucket_nodes in buckets.items():
+        domain_buckets[domain].append((bucket, bucket_nodes))
+
+    def flush(
+        domain: str,
+        pending: list[dict[str, Any]],
+        labels: list[str],
+    ) -> None:
+        domain_numbers[domain] += 1
+        name = f"merge-s2-{domain}-{domain_numbers[domain]:04d}.md"
+        label = labels[0] if len(set(labels)) == 1 else (
+            f"mixed:{labels[0]}..{labels[-1]}"
+        )
+        path = batches_dir / name
+        path.write_text(
+            render_batch(name, domain, label, pending), encoding="utf-8"
+        )
+        index.append(
+            {
+                "batch": name,
+                "stage": 2,
+                "domain": domain,
+                "bucket": label,
+                "finding_count": len(pending),
+                "finding_ids": [item["cluster_id"] for item in pending],
+                "sha256": sha256(path),
+            }
+        )
+
+    for domain, ordered_buckets in sorted(domain_buckets.items()):
+        pending: list[dict[str, Any]] = []
+        pending_labels: list[str] = []
+        pending_chars = 0
+        for bucket, bucket_nodes in sorted(ordered_buckets):
+            for node in bucket_nodes:
+                prompt_row = {
+                    key: node[key]
+                    for key in (
+                        "cluster_id",
+                        "topic_slug",
+                        "canonical_rule",
+                        "severity",
+                        "needs_current_validation",
+                        "support_count",
+                        "distinct_prs",
+                        "distinct_reviewers",
+                        "state_counts",
+                    )
+                }
+                row_chars = len(json.dumps(prompt_row, ensure_ascii=False))
+                if pending and (
+                    len(pending) >= max_clusters
+                    or pending_chars + row_chars > max_chars
+                ):
+                    flush(domain, pending, pending_labels)
+                    pending = []
+                    pending_labels = []
+                    pending_chars = 0
+                pending.append(node)
+                pending_labels.append(bucket)
+                pending_chars += row_chars
+        if pending:
+            flush(domain, pending, pending_labels)
+
+    write_jsonl(output / "merge-index.jsonl", index)
+    manifest = {
+        "stage": 2,
+        "source_results": str(results.resolve()),
+        "source_findings": str(findings.resolve()),
+        "source_cluster_count": len(nodes),
+        "source_evidence_count": len(finding_rows),
+        "batch_count": len(index),
+        "bucket_count": len(buckets),
+        "domain_counts": dict(Counter(node["domain"] for node in nodes)),
+        "max_clusters": max_clusters,
+        "max_chars": max_chars,
+        "ledger_sha256": sha256(output / "cluster-ledger.jsonl"),
+        "index_sha256": sha256(output / "merge-index.jsonl"),
+        "schema_sha256": sha256(output / "merge-output.schema.json"),
+    }
+    write_json(output / "manifest.json", manifest)
+    return manifest
+
+
+def load_previous_stage(
+    previous_plan: Path,
+    previous_results: Path,
+    findings_path: Path,
+    source_stage: int,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    findings = finding_authority(findings_path)
+    children = {
+        row["cluster_id"]: row
+        for row in jsonl(previous_plan / "cluster-ledger.jsonl")
+    }
+    if len(children) != sum(
+        1 for _ in jsonl(previous_plan / "cluster-ledger.jsonl")
+    ):
+        raise ValueError("duplicate previous-stage cluster IDs")
+    nodes: list[dict[str, Any]] = []
+    covered_children: set[str] = set()
+    generated_ids: set[str] = set()
+    for path in sorted(previous_results.glob(f"merge-s{source_stage}-*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("unresolved"):
+            raise ValueError(f"{path}: unresolved previous-stage members remain")
+        for cluster in payload["clusters"]:
+            direct_ids = cluster["member_ids"]
+            if any(value not in children for value in direct_ids):
+                raise ValueError(f"{path}: foreign child cluster ID")
+            if covered_children.intersection(direct_ids):
+                raise ValueError(f"{path}: duplicate child coverage")
+            covered_children.update(direct_ids)
+            evidence_ids: list[str] = []
+            for child_id in direct_ids:
+                evidence_ids.extend(children[child_id]["evidence_ids"])
+            if len(evidence_ids) != len(set(evidence_ids)):
+                raise ValueError(f"{path}: child evidence closures overlap")
+            cluster_id = stable_id(
+                source_stage, path.name, cluster["local_id"], direct_ids
+            )
+            if cluster_id in generated_ids:
+                raise ValueError(f"stable ID collision {cluster_id}")
+            generated_ids.add(cluster_id)
+            prs = {findings[value]["pr_number"] for value in evidence_ids}
+            reviewers = {findings[value]["reviewer"] for value in evidence_ids}
+            states = Counter(findings[value]["pr_state"] for value in evidence_ids)
+            nodes.append(
+                {
+                    "cluster_id": cluster_id,
+                    "stage": source_stage,
+                    "source": path.name,
+                    "local_id": cluster["local_id"],
+                    "domain": cluster["domain"],
+                    "topic_slug": cluster["topic_slug"],
+                    "canonical_rule": cluster["canonical_rule"],
+                    "severity": cluster["severity"],
+                    "needs_current_validation": cluster[
+                        "needs_current_validation"
+                    ],
+                    "merge_basis": cluster["merge_basis"],
+                    "direct_member_ids": direct_ids,
+                    "evidence_ids": evidence_ids,
+                    "support_count": len(evidence_ids),
+                    "distinct_prs": len(prs),
+                    "distinct_reviewers": len(reviewers),
+                    "state_counts": dict(states),
+                }
+            )
+    if covered_children != set(children):
+        raise ValueError(
+            "previous results do not partition previous cluster ledger: "
+            f"{len(covered_children)} != {len(children)}"
+        )
+    return nodes, findings
+
+
+def build_recursive(
+    previous_plan: Path,
+    previous_results: Path,
+    findings: Path,
+    output: Path,
+    stage: int,
+    max_clusters: int,
+    max_chars: int,
+) -> dict[str, Any]:
+    if stage < 3:
+        raise ValueError("recursive stage must be at least 3")
+    nodes, finding_rows = load_previous_stage(
+        previous_plan, previous_results, findings, stage - 1
+    )
+    keys = grouping_keys(nodes)
+    output.mkdir(parents=True, exist_ok=True)
+    batches_dir = output / "batches"
+    batches_dir.mkdir(exist_ok=True)
+    write_jsonl(output / "cluster-ledger.jsonl", nodes)
+    write_json(output / "merge-output.schema.json", merge_schema())
+
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for node in nodes:
+        buckets[(node["domain"], keys[node["cluster_id"]])].append(node)
+    domain_buckets: dict[str, list[tuple[str, list[dict[str, Any]]]]] = (
+        defaultdict(list)
+    )
+    for (domain, bucket), bucket_nodes in buckets.items():
+        domain_buckets[domain].append((bucket, bucket_nodes))
+
+    index: list[dict[str, Any]] = []
+    domain_numbers: Counter[str] = Counter()
+
+    def flush(
+        domain: str,
+        pending: list[dict[str, Any]],
+        labels: list[str],
+    ) -> None:
+        domain_numbers[domain] += 1
+        name = f"merge-s{stage}-{domain}-{domain_numbers[domain]:04d}.md"
+        label = labels[0] if len(set(labels)) == 1 else (
+            f"mixed:{labels[0]}..{labels[-1]}"
+        )
+        path = batches_dir / name
+        path.write_text(
+            render_batch(name, domain, label, pending), encoding="utf-8"
+        )
+        index.append(
+            {
+                "batch": name,
+                "stage": stage,
+                "domain": domain,
+                "bucket": label,
+                "finding_count": len(pending),
+                "finding_ids": [item["cluster_id"] for item in pending],
+                "sha256": sha256(path),
+            }
+        )
+
+    for domain, ordered_buckets in sorted(domain_buckets.items()):
+        pending: list[dict[str, Any]] = []
+        labels: list[str] = []
+        pending_chars = 0
+        for bucket, bucket_nodes in sorted(ordered_buckets):
+            for node in bucket_nodes:
+                prompt_row = {
+                    key: node[key]
+                    for key in (
+                        "cluster_id",
+                        "topic_slug",
+                        "canonical_rule",
+                        "severity",
+                        "needs_current_validation",
+                        "support_count",
+                        "distinct_prs",
+                        "distinct_reviewers",
+                        "state_counts",
+                    )
+                }
+                row_chars = len(json.dumps(prompt_row, ensure_ascii=False))
+                if pending and (
+                    len(pending) >= max_clusters
+                    or pending_chars + row_chars > max_chars
+                ):
+                    flush(domain, pending, labels)
+                    pending = []
+                    labels = []
+                    pending_chars = 0
+                pending.append(node)
+                labels.append(bucket)
+                pending_chars += row_chars
+        if pending:
+            flush(domain, pending, labels)
+
+    write_jsonl(output / "merge-index.jsonl", index)
+    evidence = [value for node in nodes for value in node["evidence_ids"]]
+    if len(evidence) != len(finding_rows) or len(set(evidence)) != len(finding_rows):
+        raise ValueError("recursive source clusters do not partition evidence")
+    manifest = {
+        "stage": stage,
+        "source_stage": stage - 1,
+        "source_plan": str(previous_plan.resolve()),
+        "source_results": str(previous_results.resolve()),
+        "source_findings": str(findings.resolve()),
+        "source_cluster_count": len(nodes),
+        "source_evidence_count": len(finding_rows),
+        "batch_count": len(index),
+        "bucket_count": len(buckets),
+        "domain_counts": dict(Counter(node["domain"] for node in nodes)),
+        "max_clusters": max_clusters,
+        "max_chars": max_chars,
+        "ledger_sha256": sha256(output / "cluster-ledger.jsonl"),
+        "index_sha256": sha256(output / "merge-index.jsonl"),
+        "schema_sha256": sha256(output / "merge-output.schema.json"),
+    }
+    write_json(output / "manifest.json", manifest)
+    return manifest
+
+
+def validate(output: Path) -> dict[str, Any]:
+    nodes = list(jsonl(output / "cluster-ledger.jsonl"))
+    index = list(jsonl(output / "merge-index.jsonl"))
+    node_ids = [node["cluster_id"] for node in nodes]
+    if len(node_ids) != len(set(node_ids)):
+        raise ValueError("duplicate cluster IDs")
+    if not all(CLUSTER_ID.fullmatch(value) for value in node_ids):
+        raise ValueError("invalid cluster ID")
+    indexed = [value for batch in index for value in batch["finding_ids"]]
+    if len(indexed) != len(set(indexed)) or set(indexed) != set(node_ids):
+        raise ValueError("merge index does not partition the cluster ledger")
+    evidence = [value for node in nodes for value in node["evidence_ids"]]
+    if len(evidence) != 133_803 or len(set(evidence)) != 133_803:
+        raise ValueError("cluster ledger does not partition source evidence")
+    for batch in index:
+        path = output / "batches" / batch["batch"]
+        if sha256(path) != batch["sha256"]:
+            raise ValueError(f"{path}: checksum mismatch")
+        if batch["finding_count"] != len(batch["finding_ids"]):
+            raise ValueError(f"{path}: member count mismatch")
+    return {
+        "cluster_count": len(nodes),
+        "evidence_count": len(evidence),
+        "batch_count": len(index),
+        "bucket_count": len({batch["bucket"] for batch in index}),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    build = sub.add_parser("build-stage2")
+    build.add_argument("--stage1-results", type=Path, required=True)
+    build.add_argument("--finding-ledger", type=Path, required=True)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--max-clusters", type=int, default=80)
+    build.add_argument("--max-chars", type=int, default=28_000)
+    recursive = sub.add_parser("build-recursive")
+    recursive.add_argument("--previous-plan", type=Path, required=True)
+    recursive.add_argument("--previous-results", type=Path, required=True)
+    recursive.add_argument("--finding-ledger", type=Path, required=True)
+    recursive.add_argument("--output", type=Path, required=True)
+    recursive.add_argument("--stage", type=int, required=True)
+    recursive.add_argument("--max-clusters", type=int, default=80)
+    recursive.add_argument("--max-chars", type=int, default=28_000)
+    validate_parser = sub.add_parser("validate")
+    validate_parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "build-stage2":
+        result = build_stage2(
+            args.stage1_results.resolve(),
+            args.finding_ledger.resolve(),
+            args.output.resolve(),
+            args.max_clusters,
+            args.max_chars,
+        )
+    elif args.command == "build-recursive":
+        result = build_recursive(
+            args.previous_plan.resolve(),
+            args.previous_results.resolve(),
+            args.finding_ledger.resolve(),
+            args.output.resolve(),
+            args.stage,
+            args.max_clusters,
+            args.max_chars,
+        )
+    else:
+        result = validate(args.output.resolve())
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/reduce_findings.py
+++ b/.skills/gutenberg-pr-review/evals/audit/reduce_findings.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Build and validate evidence-preserving first-stage finding-reduction batches."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DOMAINS = (
+    "accessibility",
+    "internationalization",
+    "security-privacy",
+    "performance",
+    "testing-tooling",
+    "documentation-release",
+    "api-compatibility",
+    "blocks-content",
+    "state-data-runtime",
+    "interaction-ux",
+    "visual-styles-theme",
+    "architecture-code-quality",
+)
+
+DOMAIN_TERMS = {
+    "accessibility": (
+        "accessibility",
+        "a11y",
+        "aria",
+        "screen reader",
+        "accessible name",
+        "keyboard",
+        "focus management",
+        "live region",
+        "announcement",
+        "semantic html",
+        "target size",
+        "contrast",
+    ),
+    "internationalization": (
+        "internationalization",
+        "localization",
+        "i18n",
+        "l10n",
+        "translatable",
+        "translator",
+        "translation",
+        "locale",
+        "rtl",
+        "plural",
+        "date format",
+        "number format",
+    ),
+    "security-privacy": (
+        "security",
+        "privacy",
+        "authorization",
+        "nonce",
+        "capability",
+        "csrf",
+        "xss",
+        "injection",
+        "secret",
+        "permission callback",
+        "sanitize",
+        "untrusted input",
+        "output escaping",
+    ),
+    "performance": (
+        "performance",
+        "cache",
+        "memoization",
+        "latency",
+        "memory",
+        "bundle size",
+        "scalability",
+        "benchmark",
+        "query count",
+        "render performance",
+    ),
+    "testing-tooling": (
+        "test",
+        "testing",
+        "coverage",
+        "regression",
+        "e2e",
+        "integration",
+        "fixture",
+        "snapshot",
+        "mock",
+        "jest",
+        "playwright",
+        "puppeteer",
+        "phpunit",
+        "storybook",
+        "ci verification",
+        "test reliability",
+        "test isolation",
+        "lint",
+        "build tooling",
+        "toolchain",
+        "workflow",
+        "github action",
+        "continuous integration",
+    ),
+    "documentation-release": (
+        "documentation",
+        "docs",
+        "changelog",
+        "readme",
+        "since annotation",
+        "@since",
+        "release note",
+        "migration note",
+        "backport",
+        "example",
+        "code comment",
+        "terminology",
+    ),
+    "api-compatibility": (
+        "api",
+        "compatibility",
+        "backward compatibility",
+        "public api",
+        "private api",
+        "experimental",
+        "extensibility",
+        "deprecation",
+        "contract",
+        "browser compatibility",
+        "plugin compatibility",
+        "rest api",
+        "component api",
+        "api naming",
+    ),
+    "blocks-content": (
+        "block",
+        "block attribute",
+        "block support",
+        "block context",
+        "block transform",
+        "serialization",
+        "serialized",
+        "saved markup",
+        "content preservation",
+        "editor frontend",
+        "editor-frontend",
+        "theme json",
+        "theme.json",
+        "pattern",
+        "template",
+        "parser",
+    ),
+    "state-data-runtime": (
+        "state management",
+        "state synchronization",
+        "state lifecycle",
+        "data model",
+        "selector",
+        "action",
+        "dispatch",
+        "store",
+        "core data",
+        "core-data",
+        "entity",
+        "persistence",
+        "save",
+        "undo",
+        "async",
+        "race",
+        "lifecycle",
+        "effect",
+        "event handling",
+        "error handling",
+        "runtime correctness",
+        "input validation",
+    ),
+    "interaction-ux": (
+        "interaction",
+        "usability",
+        "user experience",
+        "workflow",
+        "navigation",
+        "feedback",
+        "discoverability",
+        "affordance",
+        "empty state",
+        "loading state",
+        "control",
+        "modal",
+        "popover",
+        "tooltip",
+    ),
+    "visual-styles-theme": (
+        "css",
+        "scss",
+        "visual",
+        "layout",
+        "responsive",
+        "design token",
+        "theme compatibility",
+        "specificity",
+        "cascade",
+        "style",
+        "color",
+        "spacing",
+    ),
+    "architecture-code-quality": (
+        "architecture",
+        "maintainability",
+        "package layering",
+        "package architecture",
+        "dependency management",
+        "component architecture",
+        "component responsibility",
+        "component reuse",
+        "code clarity",
+        "type safety",
+        "typescript",
+        "dead code",
+        "duplication",
+        "change scope",
+        "naming",
+        "separation of concerns",
+    ),
+}
+
+
+def json_files(path: Path) -> list[Path]:
+    files = sorted(path.glob("batch-*.json"))
+    if not files:
+        raise ValueError(f"no audit result files in {path}")
+    return files
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compact(value: str) -> str:
+    return " ".join(value.split())
+
+
+def route(record: dict[str, Any]) -> str:
+    fields = (
+        (str(record.get("category", "")).lower(), 8),
+        (str(record.get("proposed_rule", "")).lower(), 3),
+        (str(record.get("rationale", "")).lower(), 1),
+    )
+    scores = {}
+    for domain, terms in DOMAIN_TERMS.items():
+        scores[domain] = sum(
+            weight * sum(term in text for term in terms) for text, weight in fields
+        )
+    best = max(scores, key=lambda domain: scores[domain])
+    return best if scores[best] else "architecture-code-quality"
+
+
+def iter_findings(results: Path) -> Iterable[dict[str, Any]]:
+    sequence = 0
+    seen: set[str] = set()
+    for path in json_files(results):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rows = payload.get("results")
+        if not isinstance(rows, list):
+            raise ValueError(f"{path}: invalid results")
+        for record in rows:
+            if record.get("assessment") != "finding":
+                continue
+            artifact_id = record.get("artifact_id")
+            if not isinstance(artifact_id, str) or artifact_id in seen:
+                raise ValueError(f"{path}: invalid or duplicate finding artifact ID")
+            seen.add(artifact_id)
+            sequence += 1
+            yield {
+                "finding_id": f"F{sequence:06d}",
+                "artifact_id": artifact_id,
+                "source_batch": path.name,
+                "pr_number": record["pr_number"],
+                "pr_state": record["pr_state"],
+                "reviewer": record["reviewer"],
+                "url": record["url"],
+                "kind": record["kind"],
+                "source_category": compact(record["category"]),
+                "severity": record["severity"],
+                "proposed_rule": compact(record["proposed_rule"]),
+                "rationale": compact(record["rationale"]),
+                "current_validation_needed": record["current_validation_needed"],
+                "routed_domain": route(record),
+            }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def worker_schema() -> dict[str, Any]:
+    cluster = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "local_id",
+            "domain",
+            "topic_slug",
+            "canonical_rule",
+            "severity",
+            "needs_current_validation",
+            "member_ids",
+            "merge_basis",
+        ],
+        "properties": {
+            "local_id": {"type": "string", "pattern": "^C[0-9]{2}$"},
+            "domain": {"type": "string", "enum": list(DOMAINS)},
+            "topic_slug": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                "maxLength": 80,
+            },
+            "canonical_rule": {"type": "string", "minLength": 1, "maxLength": 360},
+            "severity": {
+                "type": "string",
+                "enum": ["critical", "high", "medium", "low", "info"],
+            },
+            "needs_current_validation": {"type": "boolean"},
+            "member_ids": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "pattern": "^F[0-9]{6}$"},
+            },
+            "merge_basis": {"type": "string", "minLength": 1, "maxLength": 600},
+        },
+    }
+    unresolved = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["member_id", "reason"],
+        "properties": {
+            "member_id": {"type": "string", "pattern": "^F[0-9]{6}$"},
+            "reason": {
+                "type": "string",
+                "enum": ["needs-raw-body", "needs-pr-diff", "ambiguous-meaning"],
+            },
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["clusters", "unresolved"],
+        "properties": {
+            "clusters": {"type": "array", "maxItems": 60, "items": cluster},
+            "unresolved": {"type": "array", "items": unresolved},
+        },
+    }
+
+
+def render_batch(name: str, domain: str, rows: list[dict[str, Any]]) -> str:
+    prompt_rows = [
+        {
+            "finding_id": row["finding_id"],
+            "pr_number": row["pr_number"],
+            "pr_state": row["pr_state"],
+            "reviewer": row["reviewer"],
+            "source_category": row["source_category"],
+            "severity": row["severity"],
+            "proposed_rule": row["proposed_rule"],
+            "rationale": row["rationale"],
+        }
+        for row in rows
+    ]
+    lines = [
+        f"# Reduction batch {name}",
+        "",
+        f"Primary routed domain: `{domain}`",
+        f"Finding count: {len(rows)}",
+        "",
+        "The findings follow as JSON Lines:",
+        "",
+    ]
+    lines.extend(json.dumps(row, ensure_ascii=False) for row in prompt_rows)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build(
+    results: Path, output: Path, max_findings: int, max_chars: int
+) -> dict[str, Any]:
+    rows = list(iter_findings(results))
+    if len(rows) != 133_803:
+        raise ValueError(f"expected 133803 findings, found {len(rows)}")
+    output.mkdir(parents=True, exist_ok=True)
+    batches_dir = output / "batches"
+    batches_dir.mkdir(exist_ok=True)
+    write_jsonl(output / "finding-ledger.jsonl", rows)
+    write_json(output / "stage1-output.schema.json", worker_schema())
+
+    grouped: dict[str, list[dict[str, Any]]] = {domain: [] for domain in DOMAINS}
+    for row in rows:
+        grouped[row["routed_domain"]].append(row)
+
+    index: list[dict[str, Any]] = []
+    for domain in DOMAINS:
+        pending: list[dict[str, Any]] = []
+        pending_chars = 0
+        number = 0
+        for row in grouped[domain]:
+            row_chars = len(
+                json.dumps(
+                    {
+                        key: row[key]
+                        for key in (
+                            "finding_id",
+                            "pr_number",
+                            "pr_state",
+                            "reviewer",
+                            "source_category",
+                            "severity",
+                            "proposed_rule",
+                            "rationale",
+                        )
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            if pending and (
+                len(pending) >= max_findings or pending_chars + row_chars > max_chars
+            ):
+                number += 1
+                name = f"reduce-{domain}-{number:04d}.md"
+                path = batches_dir / name
+                path.write_text(render_batch(name, domain, pending), encoding="utf-8")
+                index.append(
+                    {
+                        "batch": name,
+                        "domain": domain,
+                        "finding_count": len(pending),
+                        "finding_ids": [item["finding_id"] for item in pending],
+                        "sha256": sha256(path),
+                    }
+                )
+                pending = []
+                pending_chars = 0
+            pending.append(row)
+            pending_chars += row_chars
+        if pending:
+            number += 1
+            name = f"reduce-{domain}-{number:04d}.md"
+            path = batches_dir / name
+            path.write_text(render_batch(name, domain, pending), encoding="utf-8")
+            index.append(
+                {
+                    "batch": name,
+                    "domain": domain,
+                    "finding_count": len(pending),
+                    "finding_ids": [item["finding_id"] for item in pending],
+                    "sha256": sha256(path),
+                }
+            )
+
+    write_jsonl(output / "stage1-index.jsonl", index)
+    manifest = {
+        "source": str(results.resolve()),
+        "source_file_count": len(json_files(results)),
+        "finding_count": len(rows),
+        "domain_counts": dict(Counter(row["routed_domain"] for row in rows)),
+        "batch_count": len(index),
+        "max_findings": max_findings,
+        "max_chars": max_chars,
+        "schema_sha256": sha256(output / "stage1-output.schema.json"),
+    }
+    write_json(output / "manifest.json", manifest)
+    return manifest
+
+
+def jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: expected object")
+            yield value
+
+
+def validate(output: Path) -> dict[str, Any]:
+    ledger = list(jsonl(output / "finding-ledger.jsonl"))
+    index = list(jsonl(output / "stage1-index.jsonl"))
+    ids = [row["finding_id"] for row in ledger]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate finding IDs")
+    indexed = [finding_id for batch in index for finding_id in batch["finding_ids"]]
+    if set(indexed) != set(ids) or len(indexed) != len(ids):
+        raise ValueError("batch index coverage differs from finding ledger")
+    for batch in index:
+        path = output / "batches" / batch["batch"]
+        if sha256(path) != batch["sha256"]:
+            raise ValueError(f"{path}: checksum mismatch")
+        if batch["finding_count"] != len(batch["finding_ids"]):
+            raise ValueError(f"{path}: finding count mismatch")
+    return {
+        "finding_count": len(ledger),
+        "batch_count": len(index),
+        "domains": dict(Counter(row["routed_domain"] for row in ledger)),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    build_parser = sub.add_parser("build")
+    build_parser.add_argument("--results", type=Path, required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+    build_parser.add_argument("--max-findings", type=int, default=60)
+    build_parser.add_argument("--max-chars", type=int, default=28_000)
+    validate_parser = sub.add_parser("validate")
+    validate_parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "build":
+        result = build(
+            args.results.resolve(),
+            args.output.resolve(),
+            args.max_findings,
+            args.max_chars,
+        )
+    else:
+        result = validate(args.output.resolve())
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_audit_workers.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_audit_workers.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Run one validated, resumable Codex audit worker per Markdown batch.
+
+The runner never trusts a model response merely because `codex exec` exited
+successfully.  Each batch result is checked against the analyzer ledger for
+exact artifact order and metadata before it is atomically installed as a final
+`batch-NNNNN.json` file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+import full_analyze  # noqa: E402  (the sibling module is the schema authority)
+
+
+RESULT_METADATA = ("batch", "pr_number", "pr_state", "reviewer", "url", "kind")
+BATCH_NAME = re.compile(r"^batch-\d{5}\.md$")
+
+
+@dataclass(frozen=True)
+class BatchPlan:
+    name: str
+    path: Path
+    sha256: str
+    expected: tuple[dict[str, Any], ...]
+    output: Path
+
+    @property
+    def stem(self) -> str:
+        return self.name.removesuffix(".md")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(value, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def atomic_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(value)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: expected an object")
+            yield value
+
+
+def selected_name(value: str) -> str:
+    name = Path(value).name
+    if name.endswith(".json"):
+        name = name.removesuffix(".json") + ".md"
+    elif not name.endswith(".md"):
+        name += ".md"
+    if not BATCH_NAME.fullmatch(name):
+        raise argparse.ArgumentTypeError("batch must look like batch-00001 or batch-00001.md")
+    return name
+
+
+def load_plans(
+    analysis: Path,
+    output: Path,
+    selected: set[str] | None = None,
+    limit: int | None = None,
+) -> list[BatchPlan]:
+    """Load a reconciled index and immutable expected metadata for each batch."""
+    full_analyze.validate_analysis(analysis)
+    ledger: dict[str, dict[str, Any]] = {}
+    for record in jsonl(analysis / "ledger.jsonl"):
+        if record.get("status") == "assigned":
+            artifact_id = record["artifact_id"]
+            if artifact_id in ledger:
+                raise ValueError(f"duplicate assigned ledger ID {artifact_id}")
+            ledger[artifact_id] = record
+
+    plans: list[BatchPlan] = []
+    indexed_names: set[str] = set()
+    for entry in jsonl(analysis / "batch-index.jsonl"):
+        name = entry.get("batch")
+        if not isinstance(name, str) or not BATCH_NAME.fullmatch(name):
+            raise ValueError(f"invalid batch-index name: {name!r}")
+        if name in indexed_names:
+            raise ValueError(f"duplicate batch-index entry {name}")
+        indexed_names.add(name)
+        if selected is not None and name not in selected:
+            continue
+        batch_path = analysis / "batches" / name
+        expected_hash = entry.get("sha256")
+        actual_hash = sha256_path(batch_path)
+        if actual_hash != expected_hash:
+            raise ValueError(f"{batch_path}: checksum mismatch")
+        ids = entry.get("artifact_ids")
+        if not isinstance(ids, list) or len(ids) != entry.get("artifact_count"):
+            raise ValueError(f"{name}: invalid artifact index")
+        expected: list[dict[str, Any]] = []
+        for artifact_id in ids:
+            record = ledger.get(artifact_id)
+            if record is None:
+                raise ValueError(f"{name}: ID {artifact_id} is absent or excluded in ledger")
+            if record.get("batch") != name:
+                raise ValueError(f"{name}: ledger batch mismatch for {artifact_id}")
+            expected.append(record)
+        plans.append(
+            BatchPlan(
+                name=name,
+                path=batch_path,
+                sha256=actual_hash,
+                expected=tuple(expected),
+                output=output / f"{name.removesuffix('.md')}.json",
+            )
+        )
+
+    if selected is not None:
+        missing = sorted(selected - indexed_names)
+        if missing:
+            raise ValueError(f"unknown selected batches: {', '.join(missing)}")
+    plans.sort(key=lambda plan: plan.name)
+    if limit is not None:
+        plans = plans[:limit]
+    if not plans:
+        raise ValueError("no batches selected")
+    return plans
+
+
+def validate_payload(payload: Any, plan: BatchPlan, context: str) -> dict[str, int]:
+    """Require exact ordered coverage and ledger metadata for one batch."""
+    if not isinstance(payload, dict) or set(payload) != {"results"}:
+        raise ValueError(f"{context}: expected an object containing only `results`")
+    results = payload["results"]
+    if not isinstance(results, list):
+        raise ValueError(f"{context}: results must be an array")
+    if len(results) != len(plan.expected):
+        raise ValueError(
+            f"{context}: expected {len(plan.expected)} results, received {len(results)}"
+        )
+
+    counts = {"finding": 0, "no_finding": 0}
+    seen: set[str] = set()
+    for index, (record, expected) in enumerate(zip(results, plan.expected, strict=True)):
+        item_context = f"{context}:results[{index}]"
+        if not isinstance(record, dict):
+            raise ValueError(f"{item_context}: expected an object")
+        full_analyze.validate_worker_record(record, item_context)
+        artifact_id = record["artifact_id"]
+        if artifact_id in seen:
+            raise ValueError(f"{item_context}: duplicate artifact ID {artifact_id}")
+        seen.add(artifact_id)
+        if artifact_id != expected["artifact_id"]:
+            raise ValueError(
+                f"{item_context}: expected ordered ID {expected['artifact_id']}, got {artifact_id}"
+            )
+        for field in RESULT_METADATA:
+            if record[field] != expected[field]:
+                raise ValueError(
+                    f"{item_context}: {field} disagrees with ledger "
+                    f"({record[field]!r} != {expected[field]!r})"
+                )
+        counts[record["assessment"]] += 1
+    counts["total"] = len(results)
+    return counts
+
+
+def read_valid_output(plan: BatchPlan) -> dict[str, int]:
+    try:
+        payload = json.loads(plan.output.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{plan.output}: invalid JSON: {error}") from error
+    return validate_payload(payload, plan, str(plan.output))
+
+
+def next_attempt(log_dir: Path, plan: BatchPlan) -> int:
+    highest = 0
+    pattern = re.compile(rf"^attempt-{re.escape(plan.stem)}-(\d{{3}})\.json$")
+    for path in log_dir.glob(f"attempt-{plan.stem}-*.json"):
+        match = pattern.fullmatch(path.name)
+        if match:
+            highest = max(highest, int(match.group(1)))
+    return highest + 1
+
+
+def prompt_for(prompt_path: Path, plan: BatchPlan) -> str:
+    shared = prompt_path.read_text(encoding="utf-8").strip()
+    batch = plan.path.read_text(encoding="utf-8")
+    ids = [record["artifact_id"] for record in plan.expected]
+    return (
+        f"{shared}\n\n"
+        "Operational constraints for this invocation:\n\n"
+        "- Do not edit files and do not perform repository or network research.\n"
+        "- Return the structured JSON object directly; do not use Markdown fences.\n"
+        f"- Set every result's `batch` to `{plan.name}`.\n"
+        "- Preserve the supplied artifact order exactly. The expected ordered IDs are:\n"
+        f"  {json.dumps(ids, ensure_ascii=False)}\n\n"
+        "The batch follows. Return the one JSON object required by the supplied "
+        "batch schema.\n\n"
+        f"{batch}"
+    )
+
+
+def codex_command(args: argparse.Namespace, schema: Path, response: Path) -> list[str]:
+    command = [
+        args.codex_bin,
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--output-schema",
+        str(schema),
+        "--output-last-message",
+        str(response),
+        "--json",
+        "--color",
+        "never",
+        "--cd",
+        str(args.analysis),
+    ]
+    if args.model:
+        command.extend(["--model", args.model])
+    command.append("-")
+    return command
+
+
+def preserve_response(response: Path, destination: Path) -> None:
+    if not response.exists():
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(response, destination)
+
+
+def run_attempt(
+    args: argparse.Namespace,
+    plan: BatchPlan,
+    schema: Path,
+    log_dir: Path,
+    attempt: int,
+) -> tuple[bool, str | None, dict[str, int] | None]:
+    if sha256_path(plan.path) != plan.sha256:
+        return False, "batch changed after planning", None
+
+    prefix = f"{plan.stem}-{attempt:03d}"
+    events_path = log_dir / f"events-{prefix}.jsonl"
+    stderr_path = log_dir / f"stderr-{prefix}.log"
+    metadata_path = log_dir / f"attempt-{prefix}.json"
+    with tempfile.NamedTemporaryFile(
+        "w", dir=log_dir, delete=False, suffix=".response.json", encoding="utf-8"
+    ) as handle:
+        response_path = Path(handle.name)
+    response_path.unlink()
+    command = codex_command(args, schema, response_path)
+    started = utc_now()
+    started_monotonic = time.monotonic()
+    returncode: int | None = None
+    error: str | None = None
+    stderr = ""
+    timed_out = False
+    counts: dict[str, int] | None = None
+    try:
+        with events_path.open("w", encoding="utf-8") as events:
+            completed = subprocess.run(
+                command,
+                input=prompt_for(args.prompt, plan),
+                text=True,
+                stdout=events,
+                stderr=subprocess.PIPE,
+                timeout=args.timeout,
+                check=False,
+            )
+        returncode = completed.returncode
+        stderr = completed.stderr or ""
+        if returncode:
+            error = f"codex exec exited {returncode}"
+        elif not response_path.exists():
+            error = "codex exec did not write --output-last-message"
+        else:
+            try:
+                payload = json.loads(response_path.read_text(encoding="utf-8"))
+                counts = validate_payload(payload, plan, str(response_path))
+            except (OSError, ValueError, json.JSONDecodeError) as validation_error:
+                error = str(validation_error)
+            else:
+                atomic_json(plan.output, payload)
+    except subprocess.TimeoutExpired as timeout_error:
+        timed_out = True
+        error = f"codex exec timed out after {args.timeout} seconds"
+        if isinstance(timeout_error.stderr, str):
+            stderr = timeout_error.stderr
+    except OSError as process_error:
+        error = f"could not run codex exec: {process_error}"
+    finally:
+        atomic_text(stderr_path, stderr)
+        if response_path.exists():
+            preserve_response(response_path, log_dir / f"response-{prefix}.json")
+        atomic_json(
+            metadata_path,
+            {
+                "batch": plan.name,
+                "attempt": attempt,
+                "started_at": started,
+                "finished_at": utc_now(),
+                "duration_seconds": round(time.monotonic() - started_monotonic, 3),
+                "returncode": returncode,
+                "timed_out": timed_out,
+                "success": error is None,
+                "error": error,
+                "counts": counts,
+                "batch_sha256": plan.sha256,
+                "schema_sha256": sha256_path(schema),
+                "command": command,
+            },
+        )
+    return error is None, error, counts
+
+
+def run_plan(
+    args: argparse.Namespace, plan: BatchPlan, schema: Path, log_dir: Path
+) -> dict[str, Any]:
+    first_attempt = next_attempt(log_dir, plan)
+    errors: list[str] = []
+    for offset in range(args.max_attempts):
+        attempt = first_attempt + offset
+        success, error, counts = run_attempt(args, plan, schema, log_dir, attempt)
+        if success:
+            return {
+                "batch": plan.name,
+                "status": "completed",
+                "attempt": attempt,
+                "counts": counts,
+            }
+        errors.append(error or "unknown worker failure")
+        if offset + 1 < args.max_attempts and args.retry_delay:
+            time.sleep(min(args.retry_delay * (2**offset), 60))
+    return {
+        "batch": plan.name,
+        "status": "failed",
+        "attempts": args.max_attempts,
+        "errors": errors,
+    }
+
+
+def self_test() -> dict[str, Any]:
+    """Exercise validation and atomic output without invoking Codex."""
+    expected = {
+        "artifact_id": "artifact-1",
+        "batch": "batch-00001.md",
+        "pr_number": 42,
+        "pr_state": "CLOSED",
+        "reviewer": "reviewer",
+        "url": "https://example.invalid/comment/1",
+        "kind": "review_comment",
+    }
+    record = {
+        **expected,
+        "assessment": "finding",
+        "category": "testing",
+        "severity": "medium",
+        "proposed_rule": "Exercise the failure path.",
+        "current_validation_needed": True,
+        "rationale": "The comment identifies a missing failure-path test.",
+    }
+    with tempfile.TemporaryDirectory(prefix="gutenberg-worker-self-test-") as directory:
+        root = Path(directory)
+        batch = root / "batch-00001.md"
+        batch.write_text("fixture\n", encoding="utf-8")
+        plan = BatchPlan(
+            name="batch-00001.md",
+            path=batch,
+            sha256=sha256_path(batch),
+            expected=(expected,),
+            output=root / "batch-00001.json",
+        )
+        payload = {"results": [record]}
+        counts = validate_payload(payload, plan, "self-test")
+        atomic_json(plan.output, payload)
+        resumed = read_valid_output(plan)
+        broken = json.loads(json.dumps(payload))
+        broken["results"][0]["pr_number"] = 43
+        try:
+            validate_payload(broken, plan, "self-test-broken")
+        except ValueError:
+            mismatch_rejected = True
+        else:
+            mismatch_rejected = False
+        if not mismatch_rejected or counts != resumed:
+            raise AssertionError("self-test validation failed")
+    return {
+        "self_test": "passed",
+        "codex_calls": 0,
+        "validated_records": counts["total"],
+        "metadata_mismatch_rejected": mismatch_rejected,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test", action="store_true", help="run local tests; never invoke Codex"
+    )
+    parser.add_argument("--analysis", type=Path, help="full_analyze output directory")
+    parser.add_argument("--output", type=Path, help="directory for final batch JSON files")
+    parser.add_argument(
+        "--logs",
+        type=Path,
+        help="attempt log directory (default: a sibling of --output)",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=Path,
+        default=SCRIPT_DIR / "AUDITOR_PROMPT.md",
+        help="common audit prompt prepended to each batch",
+    )
+    parser.add_argument("--codex-bin", default="codex")
+    parser.add_argument("--model", help="optional Codex model override")
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--retry-delay", type=float, default=2.0)
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument(
+        "--batch",
+        action="append",
+        type=selected_name,
+        help="run only this batch (repeatable; accepts batch-00001 or .md)",
+    )
+    parser.add_argument("--limit", type=int, help="cap selected batches for a bounded smoke run")
+    parser.add_argument("--force", action="store_true", help="rerun already-valid final outputs")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="validate and print the execution plan only"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        print(json.dumps(self_test(), indent=2))
+        return 0
+    if args.analysis is None or args.output is None:
+        raise SystemExit("--analysis and --output are required unless --self-test is used")
+    if not 1 <= args.concurrency <= 32:
+        raise SystemExit("--concurrency must be between 1 and 32")
+    if args.max_attempts < 1:
+        raise SystemExit("--max-attempts must be positive")
+    if args.retry_delay < 0 or args.timeout <= 0:
+        raise SystemExit("--retry-delay must be nonnegative and --timeout must be positive")
+    if args.limit is not None and args.limit < 1:
+        raise SystemExit("--limit must be positive")
+
+    args.analysis = args.analysis.resolve()
+    args.output = args.output.resolve()
+    args.prompt = args.prompt.resolve()
+    if not args.prompt.is_file():
+        raise SystemExit(f"prompt does not exist: {args.prompt}")
+    schema = args.analysis / "batch-worker-output.schema.json"
+    if not schema.is_file():
+        raise SystemExit(f"worker schema does not exist: {schema}")
+    args.output.mkdir(parents=True, exist_ok=True)
+    log_dir = (
+        args.logs.resolve()
+        if args.logs
+        else args.output.parent / f"{args.output.name}-attempts"
+    )
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    selected = set(args.batch) if args.batch else None
+    plans = load_plans(args.analysis, args.output, selected, args.limit)
+    pending: list[BatchPlan] = []
+    statuses: list[dict[str, Any]] = []
+    for plan in plans:
+        if plan.output.exists() and not args.force:
+            try:
+                counts = read_valid_output(plan)
+            except (OSError, ValueError) as error:
+                statuses.append(
+                    {
+                        "batch": plan.name,
+                        "status": "invalid_existing_output",
+                        "error": str(error),
+                    }
+                )
+                pending.append(plan)
+            else:
+                statuses.append(
+                    {"batch": plan.name, "status": "skipped_valid", "counts": counts}
+                )
+        else:
+            pending.append(plan)
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "dry_run": True,
+                    "selected": len(plans),
+                    "pending": len(pending),
+                    "already_valid": sum(
+                        item["status"] == "skipped_valid" for item in statuses
+                    ),
+                    "concurrency": args.concurrency,
+                    "schema": str(schema),
+                    "prompt": str(args.prompt),
+                    "batches": [plan.name for plan in pending],
+                    "existing": statuses,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    if pending:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.concurrency, thread_name_prefix="audit-worker"
+        ) as executor:
+            futures = {
+                executor.submit(run_plan, args, plan, schema, log_dir): plan
+                for plan in pending
+            }
+            for future in concurrent.futures.as_completed(futures):
+                plan = futures[future]
+                try:
+                    status = future.result()
+                except BaseException as error:
+                    status = {
+                        "batch": plan.name,
+                        "status": "failed",
+                        "errors": [f"runner exception: {error}"],
+                    }
+                statuses.append(status)
+                print(json.dumps(status, ensure_ascii=False), flush=True)
+
+    statuses.sort(key=lambda item: item["batch"])
+    failed = [item for item in statuses if item["status"] in {"failed", "invalid_existing_output"}]
+    # An invalid old output is healed when a later status for the same batch completed.
+    completed_names = {
+        item["batch"] for item in statuses if item["status"] == "completed"
+    }
+    failed = [item for item in failed if item["batch"] not in completed_names]
+    summary = {
+        "finished_at": utc_now(),
+        "selected": len(plans),
+        "completed": len(completed_names),
+        "skipped_valid": sum(item["status"] == "skipped_valid" for item in statuses),
+        "failed": len(failed),
+        "concurrency": args.concurrency,
+        "statuses": statuses,
+    }
+    atomic_json(log_dir / "run-summary.json", summary)
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_current_validation_workers.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_current_validation_workers.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Run resumable current-trunk validation workers."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import reduce_clusters
+import run_reduction_workers as base
+
+
+@dataclass(frozen=True)
+class Plan:
+    name: str
+    path: Path
+    sha256: str
+    ids: tuple[str, ...]
+    output: Path
+
+
+def validate(payload: Any, plan: Plan, origin_sha: str) -> dict[str, int]:
+    if not isinstance(payload, dict) or set(payload) != {"origin_sha", "decisions"}:
+        raise ValueError("expected origin_sha and decisions")
+    if payload["origin_sha"] != origin_sha:
+        raise ValueError("origin SHA mismatch")
+    decisions = payload["decisions"]
+    if not isinstance(decisions, list) or len(decisions) != len(plan.ids):
+        raise ValueError("decision count mismatch")
+    counts: dict[str, int] = {}
+    for expected, decision in zip(plan.ids, decisions, strict=True):
+        if not isinstance(decision, dict) or set(decision) != {
+            "cluster_id", "disposition", "validated_rule", "evidence", "rationale"
+        }:
+            raise ValueError("invalid decision fields")
+        decision["cluster_id"] = expected
+        disposition = decision["disposition"]
+        if disposition not in {
+            "supported", "revised", "obsolete", "insufficient-context"
+        }:
+            raise ValueError("invalid disposition")
+        counts[disposition] = counts.get(disposition, 0) + 1
+        rule = decision["validated_rule"]
+        evidence = decision["evidence"]
+        if not isinstance(rule, str) or not isinstance(evidence, list):
+            raise ValueError("invalid rule or evidence")
+        if disposition in {"supported", "revised"} and (not rule or not evidence):
+            raise ValueError("supported/revised decision lacks rule or evidence")
+        if disposition in {"obsolete", "insufficient-context"} and rule:
+            raise ValueError("rejected decision must have empty rule")
+        if not isinstance(decision["rationale"], str) or not decision["rationale"]:
+            raise ValueError("missing rationale")
+        for citation in evidence:
+            if not isinstance(citation, dict) or set(citation) != {
+                "path", "line_start", "line_end", "explanation"
+            }:
+                raise ValueError("invalid citation")
+            if (
+                not isinstance(citation["path"], str)
+                or not citation["path"]
+                or not isinstance(citation["line_start"], int)
+                or not isinstance(citation["line_end"], int)
+                or citation["line_start"] < 1
+                or citation["line_end"] < citation["line_start"]
+                or not isinstance(citation["explanation"], str)
+                or not citation["explanation"]
+            ):
+                raise ValueError("invalid citation values")
+    return counts
+
+
+def run_one(args: argparse.Namespace, plan: Plan, origin_sha: str, schema: Path) -> dict:
+    if plan.output.exists():
+        try:
+            payload = json.loads(plan.output.read_text(encoding="utf-8"))
+            return {"batch": plan.name, "status": "skipped", "counts": validate(payload, plan, origin_sha)}
+        except Exception:
+            pass
+    prompt = (
+        args.prompt.read_text(encoding="utf-8")
+        + "\n\nExact candidate order:\n"
+        + json.dumps(list(plan.ids))
+        + "\n\n"
+        + plan.path.read_text(encoding="utf-8")
+    )
+    errors = []
+    logs = args.output.parent / f"{args.output.name}-attempts"
+    logs.mkdir(parents=True, exist_ok=True)
+    for attempt in range(1, args.max_attempts + 1):
+        with tempfile.NamedTemporaryFile(dir=logs, delete=False, suffix=".json") as handle:
+            response = Path(handle.name)
+        response.unlink()
+        command = [
+            args.codex_bin, "exec", "--sandbox", "read-only", "--ephemeral",
+            "--output-schema", str(schema), "--output-last-message", str(response),
+            "--json", "--color", "never", "--cd", str(args.repo), "-"
+        ]
+        events = logs / f"events-{plan.path.stem}-{attempt:03d}.jsonl"
+        completed = subprocess.run(
+            command, input=prompt, text=True, stdout=events.open("w"),
+            stderr=subprocess.PIPE, timeout=args.timeout, check=False
+        )
+        (logs / f"stderr-{plan.path.stem}-{attempt:03d}.log").write_text(
+            completed.stderr or "", encoding="utf-8"
+        )
+        try:
+            if completed.returncode:
+                raise ValueError(f"codex exec exited {completed.returncode}")
+            payload = json.loads(response.read_text(encoding="utf-8"))
+            counts = validate(payload, plan, origin_sha)
+            base.atomic_json(plan.output, payload)
+            response.replace(logs / f"response-{plan.path.stem}-{attempt:03d}.json")
+            return {"batch": plan.name, "status": "completed", "counts": counts}
+        except Exception as error:
+            errors.append(str(error))
+            if response.exists():
+                response.replace(logs / f"response-{plan.path.stem}-{attempt:03d}.json")
+    return {"batch": plan.name, "status": "failed", "errors": errors}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prompt", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--codex-bin", default="codex")
+    args = parser.parse_args()
+    args.plan, args.output, args.prompt, args.repo = (
+        args.plan.resolve(), args.output.resolve(), args.prompt.resolve(), args.repo.resolve()
+    )
+    args.output.mkdir(parents=True, exist_ok=True)
+    manifest = json.loads((args.plan / "manifest.json").read_text(encoding="utf-8"))
+    origin_sha = manifest["origin_sha"]
+    schema = args.plan / "validation-output.schema.json"
+    plans = []
+    for row in reduce_clusters.jsonl(args.plan / "validation-index.jsonl"):
+        path = args.plan / "batches" / row["batch"]
+        if reduce_clusters.sha256(path) != row["sha256"]:
+            raise ValueError(f"{path}: checksum mismatch")
+        plans.append(Plan(row["batch"], path, row["sha256"], tuple(row["candidate_ids"]),
+                          args.output / f"{path.stem}.json"))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        statuses = list(pool.map(lambda plan: run_one(args, plan, origin_sha, schema), plans))
+    failed = [row for row in statuses if row["status"] == "failed"]
+    summary = {
+        "origin_sha": origin_sha,
+        "selected": len(plans),
+        "completed": sum(row["status"] == "completed" for row in statuses),
+        "skipped": sum(row["status"] == "skipped" for row in statuses),
+        "failed": len(failed),
+        "statuses": statuses,
+    }
+    base.atomic_json(args.output.parent / f"{args.output.name}-attempts" / "run-summary.json", summary)
+    print(json.dumps(summary, indent=2))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_editorial_workers.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_editorial_workers.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Run validated, resumable editorial triage workers."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import run_reduction_workers as base
+
+
+ACTIONS = {
+    "advance",
+    "reject-too-specific",
+    "reject-preference",
+    "reject-unsupported",
+    "reject-obsolete",
+    "reject-not-operational",
+}
+
+
+def validate(payload: Any, plan: base.Plan, context: str) -> dict[str, int]:
+    if not isinstance(payload, dict) or set(payload) != {"decisions", "candidates"}:
+        raise ValueError(f"{context}: expected decisions and candidates")
+    decisions = payload["decisions"]
+    candidates = payload["candidates"]
+    if not isinstance(decisions, list) or len(decisions) != len(plan.expected_ids):
+        raise ValueError(f"{context}: decision count mismatch")
+    if not isinstance(candidates, list) or len(candidates) > 25:
+        raise ValueError(f"{context}: invalid candidate array")
+    candidate_ids: set[str] = set()
+    candidate_members: dict[str, list[str]] = {}
+    for index, candidate in enumerate(candidates):
+        where = f"{context}:candidates[{index}]"
+        if not isinstance(candidate, dict) or set(candidate) != {
+            "local_id",
+            "domain",
+            "topic_slug",
+            "canonical_rule",
+            "severity",
+            "needs_current_validation",
+            "member_ids",
+            "merge_basis",
+        }:
+            raise ValueError(f"{where}: invalid fields")
+        local_id = candidate["local_id"]
+        if (
+            not isinstance(local_id, str)
+            or not base.LOCAL_ID.fullmatch(local_id)
+            or local_id in candidate_ids
+        ):
+            raise ValueError(f"{where}: invalid local_id")
+        candidate_ids.add(local_id)
+        members = candidate["member_ids"]
+        if not isinstance(members, list) or not members or len(members) != len(set(members)):
+            raise ValueError(f"{where}: invalid member_ids")
+        candidate_members[local_id] = members
+        if candidate["domain"] not in base.DOMAINS:
+            raise ValueError(f"{where}: invalid domain")
+        if candidate["severity"] not in base.SEVERITIES:
+            raise ValueError(f"{where}: invalid severity")
+        if not isinstance(candidate["needs_current_validation"], bool):
+            raise ValueError(f"{where}: invalid validation flag")
+        base.require_string(candidate, "topic_slug", where, maximum=80)
+        base.require_string(candidate, "canonical_rule", where, maximum=360)
+        base.require_string(candidate, "merge_basis", where, maximum=600)
+
+    advanced: list[str] = []
+    rejected = 0
+    for index, (decision, expected_id) in enumerate(
+        zip(decisions, plan.expected_ids, strict=True)
+    ):
+        where = f"{context}:decisions[{index}]"
+        if not isinstance(decision, dict) or set(decision) != {
+            "cluster_id",
+            "action",
+            "candidate",
+            "reason",
+        }:
+            raise ValueError(f"{where}: invalid fields")
+        if decision["cluster_id"] != expected_id:
+            raise ValueError(f"{where}: expected {expected_id}")
+        if decision["action"] not in ACTIONS:
+            raise ValueError(f"{where}: invalid action")
+        base.require_string(decision, "reason", where, maximum=500)
+        if decision["action"] == "advance":
+            if decision["candidate"] not in candidate_ids:
+                raise ValueError(f"{where}: missing candidate")
+            advanced.append(expected_id)
+        else:
+            if decision["candidate"] != "":
+                raise ValueError(f"{where}: rejection must have empty candidate")
+            rejected += 1
+    declared = [
+        member for members in candidate_members.values() for member in members
+    ]
+    if len(declared) != len(set(declared)) or set(declared) != set(advanced):
+        raise ValueError(f"{context}: candidate membership differs from advances")
+    decision_candidate = {
+        decision["cluster_id"]: decision["candidate"]
+        for decision in decisions
+        if decision["action"] == "advance"
+    }
+    for candidate_id, members in candidate_members.items():
+        if any(decision_candidate.get(member) != candidate_id for member in members):
+            raise ValueError(f"{context}: decision/candidate mismatch")
+    return {
+        "inputs": len(decisions),
+        "advanced": len(advanced),
+        "rejected": rejected,
+        "candidates": len(candidates),
+    }
+
+
+def normalize(payload: Any, plan: base.Plan) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+    decisions = payload.get("decisions")
+    if isinstance(decisions, list) and len(decisions) == len(plan.expected_ids):
+        for decision, expected_id in zip(
+            decisions, plan.expected_ids, strict=True
+        ):
+            if isinstance(decision, dict):
+                decision["cluster_id"] = expected_id
+    assigned: dict[str, list[str]] = {}
+    if isinstance(decisions, list):
+        for decision in decisions:
+            if (
+                isinstance(decision, dict)
+                and decision.get("action") == "advance"
+                and isinstance(decision.get("candidate"), str)
+            ):
+                assigned.setdefault(decision["candidate"], []).append(
+                    decision.get("cluster_id")
+                )
+    for candidate in payload.get("candidates", []):
+        if isinstance(candidate, dict) and isinstance(candidate.get("member_ids"), list):
+            candidate["member_ids"] = assigned.get(candidate.get("local_id"), [])
+    return payload
+
+
+def prompt_for(prompt: Path, plan: base.Plan) -> str:
+    return (
+        prompt.read_text(encoding="utf-8").strip()
+        + "\n\nOperational constraints:\n\n"
+        + "- Do not edit files or perform repository/network research.\n"
+        + "- Return JSON only.\n"
+        + "- Preserve the exact decision order. Input IDs:\n  "
+        + json.dumps(list(plan.expected_ids))
+        + "\n\n"
+        + plan.path.read_text(encoding="utf-8")
+    )
+
+
+def run_one(
+    args: argparse.Namespace,
+    plan: base.Plan,
+    schema: Path,
+    logs: Path,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    first = base.next_attempt(logs, plan)
+    for offset in range(args.max_attempts):
+        attempt = first + offset
+        prefix = f"{plan.stem}-{attempt:03d}"
+        response = Path(tempfile.mktemp(dir=logs, suffix=".response.json"))
+        command = base.codex_command(args, schema, response)
+        started = base.utc_now()
+        clock = time.monotonic()
+        error = None
+        counts = None
+        stderr = ""
+        returncode = None
+        try:
+            with (logs / f"events-{prefix}.jsonl").open("w", encoding="utf-8") as events:
+                result = subprocess.run(
+                    command,
+                    input=prompt_for(args.prompt, plan),
+                    text=True,
+                    stdout=events,
+                    stderr=subprocess.PIPE,
+                    timeout=args.timeout,
+                    check=False,
+                )
+            returncode = result.returncode
+            stderr = result.stderr or ""
+            if returncode:
+                error = f"codex exec exited {returncode}"
+            elif not response.exists():
+                error = "codex exec did not write a response"
+            else:
+                payload = normalize(
+                    json.loads(response.read_text(encoding="utf-8")), plan
+                )
+                counts = validate(payload, plan, str(response))
+                base.atomic_json(plan.output, payload)
+        except (OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as exc:
+            error = str(exc)
+        base.atomic_text(logs / f"stderr-{prefix}.log", stderr)
+        if response.exists():
+            os.replace(response, logs / f"response-{prefix}.json")
+        base.atomic_json(
+            logs / f"attempt-{prefix}.json",
+            {
+                "batch": plan.name,
+                "attempt": attempt,
+                "started_at": started,
+                "finished_at": base.utc_now(),
+                "duration_seconds": round(time.monotonic() - clock, 3),
+                "returncode": returncode,
+                "success": error is None,
+                "error": error,
+                "counts": counts,
+            },
+        )
+        if error is None:
+            return {
+                "batch": plan.name,
+                "status": "completed",
+                "attempt": attempt,
+                "counts": counts,
+            }
+        errors.append(error)
+    return {
+        "batch": plan.name,
+        "status": "failed",
+        "attempts": args.max_attempts,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reduction", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prompt", type=Path, required=True)
+    parser.add_argument("--concurrency", type=int, default=6)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=1800)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--codex-bin", default="codex")
+    parser.add_argument("--model")
+    args = parser.parse_args()
+    args.reduction = args.reduction.resolve()
+    args.output = args.output.resolve()
+    args.prompt = args.prompt.resolve()
+    args.output.mkdir(parents=True, exist_ok=True)
+    logs = args.output.parent / f"{args.output.name}-attempts"
+    logs.mkdir(parents=True, exist_ok=True)
+    schema = args.reduction / "editorial-output.schema.json"
+    plans = base.load_plans(
+        args.reduction, args.output, "merge-index.jsonl", None, args.limit
+    )
+    pending = []
+    for plan in plans:
+        if plan.output.exists():
+            try:
+                validate(
+                    json.loads(plan.output.read_text(encoding="utf-8")),
+                    plan,
+                    str(plan.output),
+                )
+                continue
+            except (OSError, ValueError, json.JSONDecodeError):
+                pass
+        pending.append(plan)
+    statuses = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = {
+            pool.submit(run_one, args, plan, schema, logs): plan for plan in pending
+        }
+        for future in concurrent.futures.as_completed(futures):
+            status = future.result()
+            statuses.append(status)
+            print(json.dumps(status, ensure_ascii=False), flush=True)
+    failed = [item for item in statuses if item["status"] == "failed"]
+    summary = {
+        "finished_at": base.utc_now(),
+        "selected": len(plans),
+        "completed": sum(item["status"] == "completed" for item in statuses),
+        "skipped_valid": len(plans) - len(pending),
+        "failed": len(failed),
+        "statuses": sorted(statuses, key=lambda item: item["batch"]),
+    }
+    base.atomic_json(logs / "run-summary.json", summary)
+    print(json.dumps(summary, indent=2))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_final_consolidation.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_final_consolidation.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Continue the final editorial consolidation through three bounded passes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+FINDINGS = ROOT / "reduction" / "finding-ledger.jsonl"
+PROMPT = ROOT / "FINAL_EDITORIAL_PROMPT.md"
+STATUS = ROOT / "final-consolidation-status.json"
+
+
+def atomic_status(value: dict) -> None:
+    temporary = STATUS.with_suffix(".tmp")
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(STATUS)
+
+
+def expected_batches(source: Path) -> int:
+    with (source / "merge-index.jsonl").open(encoding="utf-8") as handle:
+        return sum(1 for line in handle if line.strip())
+
+
+def accepted_results(results: Path) -> int:
+    count = 0
+    for path in results.glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if set(payload) == {"decisions", "candidates"}:
+                count += 1
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+    return count
+
+
+def wait_for_pass(source: Path, results: Path, label: str) -> None:
+    expected = expected_batches(source)
+    while True:
+        accepted = accepted_results(results)
+        summary_path = results.parent / f"{results.name}-attempts" / "run-summary.json"
+        summary = None
+        if summary_path.exists():
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        atomic_status(
+            {
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "phase": label,
+                "state": "running",
+                "accepted_batches": accepted,
+                "expected_batches": expected,
+            }
+        )
+        if (
+            summary
+            and summary.get("failed") == 0
+            and summary.get("selected") == expected
+            and accepted == expected
+        ):
+            return
+        if summary and summary.get("failed"):
+            raise RuntimeError(f"{label} failed: {summary['failed']} batches")
+        time.sleep(30)
+
+
+def build_source(
+    prior_source: Path,
+    prior_results: Path,
+    output: Path,
+    generation: int,
+    batch_stage: int,
+) -> None:
+    command = [
+        "python3",
+        str(ROOT / "consolidate_editorial.py"),
+        "--source",
+        str(prior_source),
+        "--results",
+        str(prior_results),
+        "--finding-ledger",
+        str(FINDINGS),
+        "--output",
+        str(output),
+        "--generation",
+        str(generation),
+        "--batch-stage",
+        str(batch_stage),
+        "--max-clusters",
+        "75",
+        "--max-candidates",
+        "8",
+    ]
+    subprocess.run(command, check=True)
+
+
+def run_workers(source: Path, results: Path, log: Path) -> None:
+    command = [
+        "python3",
+        str(ROOT / "run_editorial_workers.py"),
+        "--reduction",
+        str(source),
+        "--output",
+        str(results),
+        "--prompt",
+        str(PROMPT),
+        "--concurrency",
+        "8",
+        "--max-attempts",
+        "4",
+        "--timeout",
+        "1800",
+    ]
+    with log.open("a", encoding="utf-8") as handle:
+        subprocess.run(command, stdout=handle, stderr=subprocess.STDOUT, check=True)
+
+
+def main() -> int:
+    source1 = ROOT / "final-editorial-1-source"
+    results1 = ROOT / "final-editorial-1-results"
+    wait_for_pass(source1, results1, "cross-batch pass 1 of 3")
+
+    source2 = ROOT / "final-editorial-2-source"
+    results2 = ROOT / "final-editorial-2-results"
+    build_source(source1, results1, source2, 7, 7)
+    run_workers(source2, results2, ROOT / "final_editorial_2_run.log")
+    wait_for_pass(source2, results2, "cross-batch pass 2 of 3")
+
+    source3 = ROOT / "final-editorial-3-source"
+    results3 = ROOT / "final-editorial-3-results"
+    build_source(source2, results2, source3, 8, 8)
+    run_workers(source3, results3, ROOT / "final_editorial_3_run.log")
+    wait_for_pass(source3, results3, "cross-batch pass 3 of 3")
+
+    final_source = ROOT / "final-shortlist"
+    build_source(source3, results3, final_source, 9, 9)
+    manifest = json.loads((final_source / "manifest.json").read_text(encoding="utf-8"))
+    atomic_status(
+        {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "phase": "cross-batch consolidation",
+            "state": "complete",
+            "final_candidate_count": manifest["candidate_count"],
+            "selected_evidence_count": manifest["selected_evidence_count"],
+            "rejection_count_last_pass": manifest["rejection_count"],
+            "next_phase": "current-trunk validation",
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_forward_tests.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_forward_tests.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Forward-test the updated skill on fresh representative Gutenberg commits."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+REPO = ROOT.parents[3]
+SKILL = ROOT.parents[1] / "SKILL.md"
+OUTPUT = ROOT / "forward-test-results"
+ATTEMPTS = ROOT / "forward-test-attempts"
+
+CASES = [
+    ("component-api", "839f5c67e0d2a869611c6f5d3f1a9201ffc34ab1"),
+    ("scss-migration", "94db96e4ffbbf522efa7daf8269b2b20267abd80"),
+    ("richtext-regression", "1cfca19c6b1c763892a7511c3a16219e0be4bc7a"),
+    ("keyboard-selection", "c6c8e71cfef82fe01b189ad58b00af4ea921f743"),
+    ("theme-css", "02cfe19f92e4fcdb085d1525f24bc4f9b2a2874e"),
+    ("workflow-forks", "7546d82f37427d2ca3b4204c9d76641d2012fdb7"),
+    ("toolchain-pinning", "658cb29d541b946538231697017b450755a2c209"),
+    ("documentation-only", "4fa4b6c05ea8c8f5d6009c5f74191dee6fcef3ac"),
+]
+
+
+def run_case(case: tuple[str, str]) -> dict:
+    name, commit = case
+    result = OUTPUT / f"{name}.md"
+    events = ATTEMPTS / f"{name}.jsonl"
+    if result.exists() and result.stat().st_size:
+        return {"case": name, "commit": commit, "status": "skipped"}
+    prompt = f"""
+Use the Gutenberg PR review skill at {SKILL} to independently review the
+single commit {commit}, comparing {commit}^..{commit}.
+
+This is a blind forward test. Inspect the raw diff and necessary surrounding
+repository context yourself. Do not assume the commit is defective or clean,
+and do not infer an intended answer from the test name. Follow the skill's
+finding threshold and output format. Do not edit files or use network access.
+"""
+    command = [
+        "codex", "exec", "--sandbox", "read-only", "--ephemeral",
+        "--output-last-message", str(result), "--json", "--color", "never",
+        "--cd", str(REPO), "-"
+    ]
+    with events.open("w", encoding="utf-8") as handle:
+        completed = subprocess.run(
+            command, input=prompt, text=True, stdout=handle,
+            stderr=subprocess.PIPE, timeout=1800, check=False
+        )
+    (ATTEMPTS / f"{name}.stderr.log").write_text(
+        completed.stderr or "", encoding="utf-8"
+    )
+    return {
+        "case": name,
+        "commit": commit,
+        "status": "completed" if completed.returncode == 0 and result.exists() else "failed",
+        "returncode": completed.returncode,
+    }
+
+
+def main() -> int:
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    ATTEMPTS.mkdir(parents=True, exist_ok=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        statuses = list(pool.map(run_case, CASES))
+    summary = {
+        "skill": str(SKILL),
+        "cases": len(CASES),
+        "completed": sum(row["status"] in {"completed", "skipped"} for row in statuses),
+        "failed": sum(row["status"] == "failed" for row in statuses),
+        "statuses": statuses,
+    }
+    (ROOT / "forward-test-summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(summary, indent=2))
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/run_full_collection.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_full_collection.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Resume the full collector across clean GitHub rate-limit checkpoints."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--collector", type=Path, default=SCRIPT_DIR / "full_collect.py"
+    )
+    parser.add_argument(
+        "--db", type=Path, default=SCRIPT_DIR / "full_reviews.sqlite"
+    )
+    parser.add_argument("--batch-size", type=int, default=20)
+    parser.add_argument("--graphql-threshold", type=int, default=150)
+    parser.add_argument("--rest-threshold", type=int, default=150)
+    parser.add_argument(
+        "--reset-grace-seconds",
+        type=float,
+        default=5.0,
+        help="extra delay after GitHub's recorded reset",
+    )
+    parser.add_argument(
+        "--max-cycles",
+        type=int,
+        help="optional cap for a bounded scheduler smoke test",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def meta(db: Path, key: str) -> str | None:
+    if not db.exists():
+        return None
+    connection = sqlite3.connect(f"file:{db.resolve()}?mode=ro", uri=True)
+    try:
+        row = connection.execute(
+            "SELECT value FROM meta WHERE key = ?", (key,)
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        connection.close()
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError(f"reset timestamp lacks a timezone: {value}")
+    return parsed.astimezone(timezone.utc)
+
+
+def command(args: argparse.Namespace) -> list[str]:
+    return [
+        sys.executable,
+        str(args.collector.resolve()),
+        "--db",
+        str(args.db.resolve()),
+        "--batch-size",
+        str(args.batch_size),
+        "--graphql-threshold",
+        str(args.graphql_threshold),
+        "--rest-threshold",
+        str(args.rest_threshold),
+    ]
+
+
+def wait_for_reset(db: Path, grace: float) -> None:
+    reset_value = meta(db, "rate_limit_reset_at")
+    if not reset_value:
+        raise RuntimeError("collector exited 75 without recording rate_limit_reset_at")
+    target = parse_timestamp(reset_value).timestamp() + grace
+    while True:
+        remaining = target - time.time()
+        if remaining <= 0:
+            return
+        delay = min(remaining, 60.0)
+        print(
+            f"rate-limit checkpoint; resuming in {remaining:.0f}s "
+            f"(reset {reset_value})",
+            flush=True,
+        )
+        time.sleep(delay)
+
+
+def main() -> int:
+    args = parse_args()
+    if not 1 <= args.batch_size <= 20:
+        raise SystemExit("--batch-size must be between 1 and 20")
+    if args.graphql_threshold < 0 or args.rest_threshold < 0:
+        raise SystemExit("rate-limit thresholds must be nonnegative")
+    if args.reset_grace_seconds < 0:
+        raise SystemExit("--reset-grace-seconds must be nonnegative")
+    if args.max_cycles is not None and args.max_cycles < 1:
+        raise SystemExit("--max-cycles must be positive")
+
+    collector_command = command(args)
+    if args.dry_run:
+        print(" ".join(collector_command))
+        return 0
+
+    cycle = 0
+    while args.max_cycles is None or cycle < args.max_cycles:
+        cycle += 1
+        print(f"starting collection cycle {cycle}", flush=True)
+        result = subprocess.run(collector_command, check=False)
+        if result.returncode == 0:
+            print("full collection completed", flush=True)
+            return 0
+        if result.returncode != 75:
+            print(
+                f"collector failed with exit status {result.returncode}; not retrying",
+                file=sys.stderr,
+            )
+            return result.returncode
+        if args.max_cycles is not None and cycle >= args.max_cycles:
+            print("cycle limit reached at a clean checkpoint", flush=True)
+            return 75
+        wait_for_reset(args.db, args.reset_grace_seconds)
+
+    return 75
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print("scheduler interrupted; collector checkpoints remain resumable", file=sys.stderr)
+        raise SystemExit(130)

--- a/.skills/gutenberg-pr-review/evals/audit/run_reduction_workers.py
+++ b/.skills/gutenberg-pr-review/evals/audit/run_reduction_workers.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Run validated, resumable first-stage semantic reduction workers."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DOMAINS = {
+    "accessibility",
+    "internationalization",
+    "security-privacy",
+    "performance",
+    "testing-tooling",
+    "documentation-release",
+    "api-compatibility",
+    "blocks-content",
+    "state-data-runtime",
+    "interaction-ux",
+    "visual-styles-theme",
+    "architecture-code-quality",
+}
+SEVERITIES = {"critical", "high", "medium", "low", "info"}
+UNRESOLVED_REASONS = {"needs-raw-body", "needs-pr-diff", "ambiguous-meaning"}
+BATCH_NAME = re.compile(r"^(?:reduce-[a-z0-9-]+|merge-s\d+-[a-z0-9-]+)-\d{4}\.md$")
+MEMBER_ID = re.compile(r"^(?:F\d{6}|K[0-9a-f]{16})$")
+LOCAL_ID = re.compile(r"^C\d{2}$")
+TOPIC = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class Plan:
+    name: str
+    path: Path
+    sha256: str
+    expected_ids: tuple[str, ...]
+    output: Path
+
+    @property
+    def stem(self) -> str:
+        return self.name.removesuffix(".md")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        json.dump(value, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def atomic_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(value)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: expected object")
+            yield value
+
+
+def selected_name(value: str) -> str:
+    name = Path(value).name
+    if name.endswith(".json"):
+        name = name.removesuffix(".json") + ".md"
+    elif not name.endswith(".md"):
+        name += ".md"
+    if not BATCH_NAME.fullmatch(name):
+        raise argparse.ArgumentTypeError("invalid reduction batch name")
+    return name
+
+
+def load_plans(
+    reduction: Path,
+    output: Path,
+    index_name: str,
+    selected: set[str] | None,
+    limit: int | None,
+) -> list[Plan]:
+    plans: list[Plan] = []
+    indexed: set[str] = set()
+    for entry in jsonl(reduction / index_name):
+        name = entry.get("batch")
+        if not isinstance(name, str) or not BATCH_NAME.fullmatch(name):
+            raise ValueError(f"invalid indexed batch {name!r}")
+        if name in indexed:
+            raise ValueError(f"duplicate indexed batch {name}")
+        indexed.add(name)
+        if selected is not None and name not in selected:
+            continue
+        path = reduction / "batches" / name
+        actual_hash = sha256_path(path)
+        if actual_hash != entry.get("sha256"):
+            raise ValueError(f"{path}: checksum mismatch")
+        ids = entry.get("finding_ids")
+        if (
+            not isinstance(ids, list)
+            or len(ids) != entry.get("finding_count")
+            or len(ids) != len(set(ids))
+            or not all(isinstance(value, str) and MEMBER_ID.fullmatch(value) for value in ids)
+        ):
+            raise ValueError(f"{name}: invalid finding index")
+        plans.append(
+            Plan(
+                name=name,
+                path=path,
+                sha256=actual_hash,
+                expected_ids=tuple(ids),
+                output=output / f"{name.removesuffix('.md')}.json",
+            )
+        )
+    if selected is not None:
+        missing = sorted(selected - indexed)
+        if missing:
+            raise ValueError(f"unknown selected batches: {', '.join(missing)}")
+    plans.sort(key=lambda plan: plan.name)
+    if limit is not None:
+        plans = plans[:limit]
+    if not plans:
+        raise ValueError("no batches selected")
+    return plans
+
+
+def require_string(
+    record: dict[str, Any],
+    field: str,
+    context: str,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or len(value) < minimum:
+        raise ValueError(f"{context}: invalid {field}")
+    if maximum is not None and len(value) > maximum:
+        raise ValueError(f"{context}: {field} exceeds {maximum} characters")
+    return value
+
+
+def validate_payload(payload: Any, plan: Plan, context: str) -> dict[str, int]:
+    if not isinstance(payload, dict) or set(payload) != {"clusters", "unresolved"}:
+        raise ValueError(f"{context}: expected only clusters and unresolved")
+    clusters = payload["clusters"]
+    unresolved = payload["unresolved"]
+    if not isinstance(clusters, list) or len(clusters) > 80:
+        raise ValueError(f"{context}: clusters must be an array of at most 80")
+    if not isinstance(unresolved, list):
+        raise ValueError(f"{context}: unresolved must be an array")
+
+    expected = set(plan.expected_ids)
+    ordinal = {finding_id: index for index, finding_id in enumerate(plan.expected_ids)}
+    covered: list[str] = []
+    local_ids: set[str] = set()
+    singleton_count = 0
+    for index, cluster in enumerate(clusters):
+        item_context = f"{context}:clusters[{index}]"
+        if not isinstance(cluster, dict) or set(cluster) != {
+            "local_id",
+            "domain",
+            "topic_slug",
+            "canonical_rule",
+            "severity",
+            "needs_current_validation",
+            "member_ids",
+            "merge_basis",
+        }:
+            raise ValueError(f"{item_context}: invalid fields")
+        local_id = require_string(cluster, "local_id", item_context)
+        if not LOCAL_ID.fullmatch(local_id) or local_id in local_ids:
+            raise ValueError(f"{item_context}: invalid or duplicate local_id")
+        local_ids.add(local_id)
+        if cluster["domain"] not in DOMAINS:
+            raise ValueError(f"{item_context}: invalid domain")
+        topic = require_string(cluster, "topic_slug", item_context, maximum=80)
+        if not TOPIC.fullmatch(topic):
+            raise ValueError(f"{item_context}: invalid topic_slug")
+        require_string(cluster, "canonical_rule", item_context, maximum=360)
+        if cluster["severity"] not in SEVERITIES:
+            raise ValueError(f"{item_context}: invalid severity")
+        if not isinstance(cluster["needs_current_validation"], bool):
+            raise ValueError(f"{item_context}: invalid needs_current_validation")
+        require_string(cluster, "merge_basis", item_context, maximum=600)
+        members = cluster["member_ids"]
+        if (
+            not isinstance(members, list)
+            or not members
+            or len(members) != len(set(members))
+            or not all(isinstance(value, str) and MEMBER_ID.fullmatch(value) for value in members)
+        ):
+            raise ValueError(f"{item_context}: invalid member_ids")
+        covered.extend(members)
+        singleton_count += len(members) == 1
+
+    for index, item in enumerate(unresolved):
+        item_context = f"{context}:unresolved[{index}]"
+        if not isinstance(item, dict) or set(item) != {"member_id", "reason"}:
+            raise ValueError(f"{item_context}: invalid fields")
+        member_id = item["member_id"]
+        if not isinstance(member_id, str) or not MEMBER_ID.fullmatch(member_id):
+            raise ValueError(f"{item_context}: invalid member_id")
+        if item["reason"] not in UNRESOLVED_REASONS:
+            raise ValueError(f"{item_context}: invalid reason")
+        covered.append(member_id)
+
+    if len(covered) != len(set(covered)):
+        raise ValueError(f"{context}: duplicate finding membership")
+    foreign = sorted(set(covered) - expected)
+    missing = sorted(expected - set(covered))
+    if foreign or missing or len(covered) != len(plan.expected_ids):
+        raise ValueError(
+            f"{context}: coverage mismatch; missing={missing[:5]}, foreign={foreign[:5]}"
+        )
+    return {
+        "inputs": len(plan.expected_ids),
+        "clusters": len(clusters),
+        "singletons": singleton_count,
+        "unresolved": len(unresolved),
+    }
+
+
+def normalize_member_order(payload: Any, plan: Plan) -> Any:
+    """Repair unambiguous copied IDs and canonicalize member ordering."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("clusters"), list):
+        return payload
+    ordinal = {
+        member_id: index for index, member_id in enumerate(plan.expected_ids)
+    }
+    supplied = [
+        member_id
+        for cluster in payload["clusters"]
+        if isinstance(cluster, dict)
+        and isinstance(cluster.get("member_ids"), list)
+        for member_id in cluster["member_ids"]
+        if isinstance(member_id, str)
+    ]
+    if isinstance(payload.get("unresolved"), list):
+        supplied.extend(
+            item["member_id"]
+            for item in payload["unresolved"]
+            if isinstance(item, dict) and isinstance(item.get("member_id"), str)
+        )
+    expected = set(plan.expected_ids)
+    missing = expected - set(supplied)
+    foreign = set(supplied) - expected
+    corrections: dict[str, str] = {}
+    if len(missing) == len(foreign):
+        if len(missing) == 1:
+            corrections[next(iter(foreign))] = next(iter(missing))
+        candidates: list[tuple[int, str, str]] = []
+        for wrong in foreign - set(corrections):
+            distances = sorted(
+                (
+                    sum(left != right for left, right in zip(wrong, right_id))
+                    if len(wrong) == len(right_id)
+                    else 10**9,
+                    right_id,
+                )
+                for right_id in missing
+            )
+            if (
+                distances
+                and distances[0][0] <= 8
+                and (len(distances) == 1 or distances[0][0] < distances[1][0])
+            ):
+                candidates.append((distances[0][0], wrong, distances[0][1]))
+        used_targets: set[str] = set()
+        for _, wrong, right_id in sorted(candidates):
+            if right_id not in used_targets:
+                corrections[wrong] = right_id
+                used_targets.add(right_id)
+    for cluster in payload["clusters"]:
+        if not isinstance(cluster, dict) or not isinstance(
+            cluster.get("member_ids"), list
+        ):
+            continue
+        cluster["member_ids"] = [
+            corrections.get(value, value) for value in cluster["member_ids"]
+        ]
+        cluster["member_ids"].sort(
+            key=lambda value: ordinal.get(value, len(ordinal))
+        )
+    if isinstance(payload.get("unresolved"), list):
+        for item in payload["unresolved"]:
+            if isinstance(item, dict) and isinstance(item.get("member_id"), str):
+                item["member_id"] = corrections.get(
+                    item["member_id"], item["member_id"]
+                )
+    return payload
+
+
+def read_valid_output(plan: Plan) -> dict[str, int]:
+    payload = json.loads(plan.output.read_text(encoding="utf-8"))
+    return validate_payload(payload, plan, str(plan.output))
+
+
+def next_attempt(log_dir: Path, plan: Plan) -> int:
+    highest = 0
+    pattern = re.compile(rf"^attempt-{re.escape(plan.stem)}-(\d{{3}})\.json$")
+    for path in log_dir.glob(f"attempt-{plan.stem}-*.json"):
+        match = pattern.fullmatch(path.name)
+        if match:
+            highest = max(highest, int(match.group(1)))
+    return highest + 1
+
+
+def prompt_for(prompt_path: Path, plan: Plan) -> str:
+    shared = prompt_path.read_text(encoding="utf-8").strip()
+    batch = plan.path.read_text(encoding="utf-8")
+    return (
+        f"{shared}\n\n"
+        "Operational constraints for this invocation:\n\n"
+        "- Do not edit files and do not perform repository or network research.\n"
+        "- Return the structured JSON object directly; do not use Markdown fences.\n"
+        "- Preserve member ordering within each cluster.\n"
+        "- The exact input finding IDs are:\n"
+        f"  {json.dumps(list(plan.expected_ids))}\n\n"
+        f"{batch}"
+    )
+
+
+def codex_command(args: argparse.Namespace, schema: Path, response: Path) -> list[str]:
+    command = [
+        args.codex_bin,
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--output-schema",
+        str(schema),
+        "--output-last-message",
+        str(response),
+        "--json",
+        "--color",
+        "never",
+        "--cd",
+        str(args.reduction),
+    ]
+    if args.model:
+        command.extend(["--model", args.model])
+    command.append("-")
+    return command
+
+
+def run_attempt(
+    args: argparse.Namespace,
+    plan: Plan,
+    schema: Path,
+    logs: Path,
+    attempt: int,
+) -> tuple[bool, str | None, dict[str, int] | None]:
+    prefix = f"{plan.stem}-{attempt:03d}"
+    events_path = logs / f"events-{prefix}.jsonl"
+    stderr_path = logs / f"stderr-{prefix}.log"
+    metadata_path = logs / f"attempt-{prefix}.json"
+    with tempfile.NamedTemporaryFile(
+        "w", dir=logs, delete=False, suffix=".response.json", encoding="utf-8"
+    ) as handle:
+        response_path = Path(handle.name)
+    response_path.unlink()
+    command = codex_command(args, schema, response_path)
+    started = utc_now()
+    start_clock = time.monotonic()
+    returncode: int | None = None
+    stderr = ""
+    error: str | None = None
+    timed_out = False
+    counts: dict[str, int] | None = None
+    try:
+        if sha256_path(plan.path) != plan.sha256:
+            raise ValueError("batch changed after planning")
+        with events_path.open("w", encoding="utf-8") as events:
+            completed = subprocess.run(
+                command,
+                input=prompt_for(args.prompt, plan),
+                text=True,
+                stdout=events,
+                stderr=subprocess.PIPE,
+                timeout=args.timeout,
+                check=False,
+            )
+        returncode = completed.returncode
+        stderr = completed.stderr or ""
+        if returncode:
+            error = f"codex exec exited {returncode}"
+        elif not response_path.exists():
+            error = "codex exec did not write a response"
+        else:
+            payload = normalize_member_order(
+                json.loads(response_path.read_text(encoding="utf-8")), plan
+            )
+            counts = validate_payload(payload, plan, str(response_path))
+            atomic_json(plan.output, payload)
+    except subprocess.TimeoutExpired as timeout_error:
+        timed_out = True
+        error = f"codex exec timed out after {args.timeout} seconds"
+        if isinstance(timeout_error.stderr, str):
+            stderr = timeout_error.stderr
+    except (OSError, ValueError, json.JSONDecodeError) as run_error:
+        error = str(run_error)
+    finally:
+        atomic_text(stderr_path, stderr)
+        if response_path.exists():
+            os.replace(response_path, logs / f"response-{prefix}.json")
+        atomic_json(
+            metadata_path,
+            {
+                "batch": plan.name,
+                "attempt": attempt,
+                "started_at": started,
+                "finished_at": utc_now(),
+                "duration_seconds": round(time.monotonic() - start_clock, 3),
+                "returncode": returncode,
+                "timed_out": timed_out,
+                "success": error is None,
+                "error": error,
+                "counts": counts,
+                "batch_sha256": plan.sha256,
+                "prompt_sha256": sha256_path(args.prompt),
+                "schema_sha256": sha256_path(schema),
+                "command": command,
+            },
+        )
+    return error is None, error, counts
+
+
+def run_plan(
+    args: argparse.Namespace, plan: Plan, schema: Path, logs: Path
+) -> dict[str, Any]:
+    errors: list[str] = []
+    first_attempt = next_attempt(logs, plan)
+    for offset in range(args.max_attempts):
+        attempt = first_attempt + offset
+        success, error, counts = run_attempt(args, plan, schema, logs, attempt)
+        if success:
+            return {
+                "batch": plan.name,
+                "status": "completed",
+                "attempt": attempt,
+                "counts": counts,
+            }
+        errors.append(error or "unknown worker failure")
+        if offset + 1 < args.max_attempts and args.retry_delay:
+            time.sleep(min(args.retry_delay * (2**offset), 60))
+    return {
+        "batch": plan.name,
+        "status": "failed",
+        "attempts": args.max_attempts,
+        "errors": errors,
+    }
+
+
+def self_test() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="gutenberg-reducer-test-") as directory:
+        root = Path(directory)
+        batch = root / "reduce-testing-tooling-0001.md"
+        batch.write_text("fixture\n", encoding="utf-8")
+        plan = Plan(
+            name=batch.name,
+            path=batch,
+            sha256=sha256_path(batch),
+            expected_ids=("F000001", "F000002"),
+            output=root / "output.json",
+        )
+        payload = {
+            "clusters": [
+                {
+                    "local_id": "C01",
+                    "domain": "testing-tooling",
+                    "topic_slug": "behavioral-regression-tests",
+                    "canonical_rule": "Add a behavioral regression test for each bug fix.",
+                    "severity": "medium",
+                    "needs_current_validation": True,
+                    "member_ids": ["F000001", "F000002"],
+                    "merge_basis": "Both findings require behavior-level regression coverage.",
+                }
+            ],
+            "unresolved": [],
+        }
+        counts = validate_payload(payload, plan, "self-test")
+        broken = json.loads(json.dumps(payload))
+        broken["clusters"][0]["member_ids"].append("F000002")
+        try:
+            validate_payload(broken, plan, "self-test-broken")
+        except ValueError:
+            duplicate_rejected = True
+        else:
+            duplicate_rejected = False
+        if not duplicate_rejected:
+            raise AssertionError("duplicate membership was accepted")
+        return {
+            "self_test": "passed",
+            "validated_inputs": counts["inputs"],
+            "duplicate_membership_rejected": True,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--reduction", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--logs", type=Path)
+    parser.add_argument("--prompt", type=Path, default=SCRIPT_DIR / "REDUCER_PROMPT.md")
+    parser.add_argument("--index-name", default="stage1-index.jsonl")
+    parser.add_argument("--schema-name", default="stage1-output.schema.json")
+    parser.add_argument("--codex-bin", default="codex")
+    parser.add_argument("--model")
+    parser.add_argument("--concurrency", type=int, default=6)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--retry-delay", type=float, default=2.0)
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument("--batch", action="append", type=selected_name)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        print(json.dumps(self_test(), indent=2))
+        return 0
+    if args.reduction is None or args.output is None:
+        raise SystemExit("--reduction and --output are required")
+    if not 1 <= args.concurrency <= 32 or args.max_attempts < 1:
+        raise SystemExit("invalid concurrency or max-attempts")
+    if args.limit is not None and args.limit < 1:
+        raise SystemExit("--limit must be positive")
+    args.reduction = args.reduction.resolve()
+    args.output = args.output.resolve()
+    args.prompt = args.prompt.resolve()
+    schema = args.reduction / args.schema_name
+    if not schema.is_file() or not args.prompt.is_file():
+        raise SystemExit("schema or prompt is missing")
+    args.output.mkdir(parents=True, exist_ok=True)
+    logs = (
+        args.logs.resolve()
+        if args.logs
+        else args.output.parent / f"{args.output.name}-attempts"
+    )
+    logs.mkdir(parents=True, exist_ok=True)
+    selected = set(args.batch) if args.batch else None
+    plans = load_plans(
+        args.reduction, args.output, args.index_name, selected, args.limit
+    )
+    statuses: list[dict[str, Any]] = []
+    pending: list[Plan] = []
+    for plan in plans:
+        if plan.output.exists() and not args.force:
+            try:
+                counts = read_valid_output(plan)
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                statuses.append(
+                    {
+                        "batch": plan.name,
+                        "status": "invalid-existing-output",
+                        "error": str(error),
+                    }
+                )
+                pending.append(plan)
+            else:
+                statuses.append(
+                    {"batch": plan.name, "status": "skipped-valid", "counts": counts}
+                )
+        else:
+            pending.append(plan)
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "selected": len(plans),
+                    "pending": len(pending),
+                    "already_valid": len(plans) - len(pending),
+                    "concurrency": args.concurrency,
+                    "batches": [plan.name for plan in pending],
+                },
+                indent=2,
+            )
+        )
+        return 0
+    if pending:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.concurrency, thread_name_prefix="reducer"
+        ) as executor:
+            futures = {
+                executor.submit(run_plan, args, plan, schema, logs): plan
+                for plan in pending
+            }
+            for future in concurrent.futures.as_completed(futures):
+                plan = futures[future]
+                try:
+                    status = future.result()
+                except BaseException as error:
+                    status = {
+                        "batch": plan.name,
+                        "status": "failed",
+                        "errors": [f"runner exception: {error}"],
+                    }
+                statuses.append(status)
+                print(json.dumps(status, ensure_ascii=False), flush=True)
+    statuses.sort(key=lambda item: item["batch"])
+    completed = {item["batch"] for item in statuses if item["status"] == "completed"}
+    failed = [
+        item
+        for item in statuses
+        if item["status"] in {"failed", "invalid-existing-output"}
+        and item["batch"] not in completed
+    ]
+    summary = {
+        "finished_at": utc_now(),
+        "selected": len(plans),
+        "completed": len(completed),
+        "skipped_valid": sum(item["status"] == "skipped-valid" for item in statuses),
+        "failed": len(failed),
+        "concurrency": args.concurrency,
+        "statuses": statuses,
+    }
+    atomic_json(logs / "run-summary.json", summary)
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.skills/gutenberg-pr-review/evals/audit/trunk-delta-validation.md
+++ b/.skills/gutenberg-pr-review/evals/audit/trunk-delta-validation.md
@@ -1,0 +1,69 @@
+# Trunk-delta validation
+
+Inspected the exact six-commit, 31-file range `49120c3..03a6675`; `49120c3` is the merge base.
+
+## Commits and relevant files
+
+1. `65951ddf6afd2d41ae679f2c440e05d6ac156f90` — `createInterpolateElement` unmatched closing tags
+   `packages/element/{CHANGELOG.md,src/create-interpolate-element.ts,src/test/create-interpolate-element.tsx}`
+
+2. `b2ab2ccba568a4031493cb7d087b2a2d07e0dc70` — remove private Components `Theme`
+   `docs/private-apis.md`, `tools/eslint/config.mjs`, `packages/components/{CHANGELOG.md,src/private-apis.ts}`, and all eight deleted files under `packages/components/src/theme/`.
+
+3. `c61142588be492a045fbe4b6b6660078907afb19` — refactor `URLInput`
+   `packages/block-editor/{CHANGELOG.md,README.md,src/components/url-input/index.js,src/components/url-input/test/index.js}`
+
+4. `fe47e1c427d05f10aecaa1f50026dffd0b562be3` — Dialog/Drawer guidance
+   `packages/ui/{CHANGELOG.md,src/dialog/stories/usage-guidelines.mdx,src/dialog/stories/usage-guidelines.story.tsx,src/drawer/root.tsx}`
+
+5. `f290c8b117c2b3333fba37474bebd5a26fa32202` — `date-fns` 4.4.0
+   `package-lock.json`; `packages/{components,dataviews,editor}/{package.json,CHANGELOG.md}`
+
+6. `03a6675a25ede7f8e31e5232742615f95358bcb6` — Color.js 0.7.1
+   `package-lock.json`; `packages/theme/{package.json,CHANGELOG.md}`
+
+Also checked `packages/README.md`, `.github/workflows/check-package-changelogs.yml`, and `docs/contributors/code/workspace-development.md` for governing conventions.
+
+## Required guidance changes
+
+1. `packages-apis-compatibility.md` — narrow the compatibility-remediation rule to public/durable contracts. Private APIs are intentionally removable.
+
+   Replace:
+
+   > When compatibility cannot be preserved directly, provide a supported alternative, deprecation metadata, migration path, correctly classified changelog entry, and a Dev Note when third-party developers are affected.
+
+   With:
+
+   > When a documented public API or durable stored contract cannot be preserved directly, provide a supported alternative, deprecation metadata, migration path, correctly classified changelog entry, and a Dev Note when third-party developers are affected. Private APIs do not promise external compatibility; before removing one, inventory and update in-repository consumers, private-API documentation, and the package changelog.
+
+2. `ui-accessibility.md` — supersede the Modal-only overlay wording with current component-selection guidance.
+
+   Replace the “For Modal and Popover changes…” bullet with:
+
+   > For overlay changes, verify both component choice and behavior. Use `Dialog` for short, focused, context-light tasks with one primary action; use `AlertDialog` for destructive or irreversible decisions; use `Drawer` for contextual editing, multiple sections, or drill-down flows; and do not nest dialogs. Test initial focus, dismissal, required containment, focus restoration, viewport behavior, and mobile expansion. For Popovers, also test anchoring and collision behavior.
+
+   Narrow the destructive-action bullet to add:
+
+   > In a Drawer requiring explicit choice, omit the close icon and provide explicit Cancel/Confirm actions.
+
+3. `testing-docs-delivery.md` — the changelog rule is too narrow. Current repository guidance covers relevant package changes, including dependency and material documentation changes.
+
+   Replace:
+
+   > For package production-code changes, add the relevant entry under `Unreleased` and classify it with the repository's release subsection.
+
+   With:
+
+   > For each relevant package change—including production code, shipped dependencies, public or private API changes, and material package documentation—add an entry under `Unreleased`, link the PR, and classify it under the appropriate release subsection. Omission is acceptable only when the package’s optional changelog check and repository evidence establish that the change is too small to warrant an entry.
+
+4. `SKILL.md` provenance — replace the validated head `49120c3204955ba1f83c7224793f52813689e7e1` with `03a6675a25ede7f8e31e5232742615f95358bcb6`.
+
+## Conclusion
+
+No other rule is invalidated. The `URLInput` refactor reinforces the existing hook, event-time selector, stale-request, accessibility, and behavioral-testing guidance. Both dependency updates follow the workspace/package-lock convention; no build or generated-artifact rule changed.
+
+The safely recordable delta-checked head is:
+
+`03a6675a25ede7f8e31e5232742615f95358bcb6`
+
+No files were edited and no network access was used.

--- a/.skills/gutenberg-pr-review/evals/fixtures/async-stale-response/PR_CONTEXT.md
+++ b/.skills/gutenberg-pr-review/evals/fixtures/async-stale-response/PR_CONTEXT.md
@@ -1,0 +1,56 @@
+# Overview
+
+**Title:** Fetch template previews when the selected template changes
+
+**Description:**
+
+This replaces preview data selected from a large preloaded response with a
+focused REST request. It reduces editor boot payload and keeps the preview in
+sync with the selected template.
+
+## Testing instructions
+
+1. Open the editor.
+2. Select several templates and confirm each preview loads.
+3. Confirm the spinner disappears after each request.
+
+## Changed files
+
+- `packages/editor/src/hooks/use-template-preview.js`
+- `packages/editor/src/hooks/test/use-template-preview.js`
+
+## Diff
+
+```diff
+diff --git a/packages/editor/src/hooks/use-template-preview.js b/packages/editor/src/hooks/use-template-preview.js
+@@ -8,14 +8,22 @@ import { useSelect } from '@wordpress/data';
+ export function useTemplatePreview( templateId ) {
+-    const template = useSelect(
+-        ( select ) => select( coreStore ).getEntityRecord( 'postType', 'wp_template', templateId ),
+-        [ templateId ]
+-    );
++    const [ template, setTemplate ] = useState();
++    const [ isLoading, setIsLoading ] = useState( false );
++
++    useEffect( () => {
++        setIsLoading( true );
++        apiFetch( { path: `/wp/v2/templates/${ templateId }` } )
++            .then( ( result ) => setTemplate( result ) )
++            .finally( () => setIsLoading( false ) );
++    }, [ templateId ] );
+
+-    return template;
++    return { template, isLoading };
+ }
+diff --git a/packages/editor/src/hooks/test/use-template-preview.js b/packages/editor/src/hooks/test/use-template-preview.js
+@@ -18,6 +18,13 @@ describe( 'useTemplatePreview', () => {
++    it( 'loads the selected template', async () => {
++        apiFetch.mockResolvedValue( { id: 'theme//home' } );
++        const { result } = renderHook( () => useTemplatePreview( 'theme//home' ) );
++        await waitFor( () => expect( result.current.template.id ).toBe( 'theme//home' ) );
++    } );
+ } );
+```
+
+The request mock resolves immediately. There is no test that changes
+`templateId` while a previous request is pending.

--- a/.skills/gutenberg-pr-review/evals/fixtures/block-serialized-markup/PR_CONTEXT.md
+++ b/.skills/gutenberg-pr-review/evals/fixtures/block-serialized-markup/PR_CONTEXT.md
@@ -1,0 +1,56 @@
+# Overview
+
+**Title:** Normalize Call to Action alignment classes
+
+**Description:**
+
+This makes the Call to Action block use the component naming convention already
+used by its editor styles. The visual result is unchanged. Existing content is
+not expected to be affected because the attribute and rendered alignment value
+are unchanged.
+
+## Discussion
+
+**Reviewer:** Does changing the class emitted by `save` require a Block API
+version bump?
+
+**Author:** I do not think so. The block already uses API version 3 and this is
+only a CSS naming cleanup.
+
+## Changed files
+
+- `packages/block-library/src/call-to-action/save.js`
+- `packages/block-library/src/call-to-action/style.scss`
+- `packages/block-library/src/call-to-action/test/save.js`
+
+## Diff
+
+```diff
+diff --git a/packages/block-library/src/call-to-action/save.js b/packages/block-library/src/call-to-action/save.js
+@@ -18,7 +18,7 @@ export default function save( { attributes } ) {
+     const { textAlign, url, text } = attributes;
+     const blockProps = useBlockProps.save( {
+-        className: `has-text-align-${ textAlign }`,
++        className: `is-aligned-${ textAlign }`,
+     } );
+
+     return (
+diff --git a/packages/block-library/src/call-to-action/style.scss b/packages/block-library/src/call-to-action/style.scss
+@@ -7,7 +7,7 @@
+ .wp-block-call-to-action {
+-    &.has-text-align-center {
++    &.is-aligned-center {
+         justify-content: center;
+     }
+ }
+diff --git a/packages/block-library/src/call-to-action/test/save.js b/packages/block-library/src/call-to-action/test/save.js
+@@ -22,7 +22,7 @@ describe( 'save', () => {
+     expect( render( attributes ) ).toEqual(
+-        '<div class="wp-block-call-to-action has-text-align-center">...</div>'
++        '<div class="wp-block-call-to-action is-aligned-center">...</div>'
+     );
+ } );
+```
+
+There is no `deprecated.js` entry or fixture containing markup produced by the
+previous implementation.

--- a/.skills/gutenberg-pr-review/evals/fixtures/rest-false-update/PR_CONTEXT.md
+++ b/.skills/gutenberg-pr-review/evals/fixtures/rest-false-update/PR_CONTEXT.md
@@ -1,0 +1,60 @@
+# Overview
+
+**Title:** Expose the allow-comments site setting to the editor
+
+**Description:**
+
+This adds a boolean REST setting used by the editor's Discussion panel. The
+route uses the existing site-settings permission model and sanitizes the value
+as a boolean.
+
+## Changed files
+
+- `lib/experimental/class-site-settings-controller.php`
+- `lib/experimental/test/class-site-settings-controller-test.php`
+
+## Diff
+
+```diff
+diff --git a/lib/experimental/class-site-settings-controller.php b/lib/experimental/class-site-settings-controller.php
+@@ -32,6 +32,13 @@ public function register_routes() {
+             'methods'             => WP_REST_Server::EDITABLE,
+             'callback'            => array( $this, 'update_item' ),
+             'permission_callback' => array( $this, 'can_edit_site_settings' ),
++            'args'                => array(
++                'allow_comments' => array(
++                    'type'              => 'boolean',
++                    'sanitize_callback' => 'rest_sanitize_boolean',
++                ),
++            ),
+         )
+     );
+ }
+@@ -61,6 +68,10 @@ public function can_edit_site_settings() {
+     return current_user_can( 'edit_theme_options' );
+ }
+
+ public function update_item( WP_REST_Request $request ) {
++    if ( $request['allow_comments'] ) {
++        update_option(
++            'default_comment_status',
++            $request['allow_comments'] ? 'open' : 'closed'
++        );
++    }
++
+     return $this->prepare_item();
+ }
+diff --git a/lib/experimental/test/class-site-settings-controller-test.php b/lib/experimental/test/class-site-settings-controller-test.php
+@@ -90,6 +90,15 @@ class Site_Settings_Controller_Test extends WP_UnitTestCase {
++    public function test_updates_allow_comments() {
++        $request = new WP_REST_Request( 'POST', '/gutenberg/v1/site-settings' );
++        $request->set_param( 'allow_comments', true );
++        $response = rest_get_server()->dispatch( $request );
++
++        $this->assertSame( 200, $response->get_status() );
++        $this->assertSame( 'open', get_option( 'default_comment_status' ) );
++    }
+ }
+```
+
+The test suite does not send `false` after the option has been set to `open`.

--- a/.skills/gutenberg-pr-review/evals/package-lock.json
+++ b/.skills/gutenberg-pr-review/evals/package-lock.json
@@ -1,0 +1,12490 @@
+{
+	"name": "gutenberg-pr-review-evals",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "gutenberg-pr-review-evals",
+			"devDependencies": {
+				"@anthropic-ai/claude-agent-sdk": "^0.3.211",
+				"@openai/codex-sdk": "^0.144.5",
+				"promptfoo": "^0.121.19"
+			},
+			"engines": {
+				"node": "^20.20.0 || >=22.22.0"
+			}
+		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "3.0.159",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.159.tgz",
+			"integrity": "sha512-BJ1SMVpD2Qie/OVmQho1b1wb8rcGYC38p2D20MyP0+zUGBlXJOMfq1zP97+tl1oyT1u/A84R+oaYrUT18dIdWg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.14",
+				"@ai-sdk/provider-utils": "4.0.40",
+				"@vercel/oidc": "3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+			"integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.40",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+			"integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.14",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.8"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+			"integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+			"dev": true,
+			"license": "SEE LICENSE IN README.md",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+			},
+			"peerDependencies": {
+				"@anthropic-ai/sdk": ">=0.93.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+			"integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+			"integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+			"integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+			"integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+			"integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+			"integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+			"integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.3.220",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+			"integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+			"integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "15.5.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.5.0.tgz",
+			"integrity": "sha512-Ps4w0FwrDoeVK6hfYxWkVbkmxm+zN+6xoXF2ZfEhfiox0ZNbcSAiUWO6iAIvP5bc3DB270r+EaKcoT1IUyzfxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-yaml": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@types/json-schema": "^7.0.15"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@aws-sdk/checksums": {
+			"version": "3.1000.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.22.tgz",
+			"integrity": "sha512-YsSac72lcCOSjk5X4fMc20SjltkGUDjckB2vYZcEd/RpgB+huzeQwVZrOWxUvLVo+5D7X9sURgmAAPmErgCQ7w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-agent-runtime": {
+			"version": "3.1097.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1097.0.tgz",
+			"integrity": "sha512-4hz6FWSWsdlF44xKvwkNUUG6+w+19MuY3IYpaJcOaTiu/MY5P0GYc9ChVRR67s77U1dJcBr3yYuWCnNaP3cY5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/credential-provider-node": "^3.972.74",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1097.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1097.0.tgz",
+			"integrity": "sha512-8hiLecjH22uKhtkco9AinQ2/Qc0s9AvoSVPjT1tj6pHwVXaDLmBasAxLw3TzFs68J8gkgIYdJp5pslA2GY4h5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/credential-provider-node": "^3.972.74",
+				"@aws-sdk/eventstream-handler-node": "^3.972.30",
+				"@aws-sdk/middleware-eventstream": "^3.972.25",
+				"@aws-sdk/middleware-websocket": "^3.972.45",
+				"@aws-sdk/token-providers": "3.1097.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3": {
+			"version": "3.1097.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1097.0.tgz",
+			"integrity": "sha512-iCBD95hrynpxiOzD301pUW9H3mxKcEfMErLqdg58WcIZnEqJuOd7JwcARsV3/y6OWj1t6j2tpS9lGt6X4OnPFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/checksums": "^3.1000.22",
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/credential-provider-node": "^3.972.74",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.68",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.42",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sagemaker-runtime": {
+			"version": "3.1097.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker-runtime/-/client-sagemaker-runtime-3.1097.0.tgz",
+			"integrity": "sha512-ZdMoAXQPzITcnf1ac6pRwxB/mp+ACCNbgSfDT764IkTanWxT4mGX6qh3r/UgfkmRpbqMYwAqvKTHifLGd9Z7HQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/credential-provider-node": "^3.972.74",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.977.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+			"integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.37",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.29.8",
+				"@smithy/signature-v4": "^5.6.9",
+				"@smithy/types": "^4.16.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.63",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+			"integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.65",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+			"integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+			"integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/credential-provider-env": "^3.972.63",
+				"@aws-sdk/credential-provider-http": "^3.972.65",
+				"@aws-sdk/credential-provider-login": "^3.972.70",
+				"@aws-sdk/credential-provider-process": "^3.972.63",
+				"@aws-sdk/credential-provider-sso": "^3.973.7",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.69",
+				"@aws-sdk/nested-clients": "^3.997.37",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/credential-provider-imds": "^4.4.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.70",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+			"integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/nested-clients": "^3.997.37",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.74",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+			"integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.63",
+				"@aws-sdk/credential-provider-http": "^3.972.65",
+				"@aws-sdk/credential-provider-ini": "^3.973.8",
+				"@aws-sdk/credential-provider-process": "^3.972.63",
+				"@aws-sdk/credential-provider-sso": "^3.973.7",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.69",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/credential-provider-imds": "^4.4.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.63",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+			"integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.7",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+			"integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/nested-clients": "^3.997.37",
+				"@aws-sdk/token-providers": "3.1097.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.69",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+			"integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/nested-clients": "^3.997.37",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.30",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.30.tgz",
+			"integrity": "sha512-hJboPgIpq5+ADc++/B9TBqn65CXV21cZLGB8V5RBQbxkZ/rQ6qMfcxTnW/SvQlasX4jhaSG8B1wsVjhQyDrsnQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.25.tgz",
+			"integrity": "sha512-9SFbPzJDHHR5k6Q6KvXVas/veUm/TzNcNTFM2UhdXHZHpyIvI2lS+s4cxljw1BihGpVhsAkQDo/2nW7dHxpf4Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.68.tgz",
+			"integrity": "sha512-JA/LRxCSXQAsFHyIZzgncYdcTQTOL3ZS8R7EAeDwoSoWcNG8yxDAacrwFTZIyVSMvkogvlKHRvmrMU68UyQbkw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.42",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.45",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.45.tgz",
+			"integrity": "sha512-z8Mrk85epmaESLPt2sKHoGv3VYJiw+2VOL3CTdvl8BfMANVb637g4RDwPQtZWDHSHugPbDKtXjSjwOE0nZK0jw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/signature-v4": "^5.6.9",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+			"integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.42",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+			"integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.9",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1097.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+			"integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.2",
+				"@aws-sdk/nested-clients": "^3.997.37",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure-rest/core-client": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.8.0.tgz",
+			"integrity": "sha512-F1ybHeN+++QhyFCF/ehLUEvrOB6fehPdFBFtGdj0C3B2lpQ9zkPiO5JDgsqc6IfjuUe6b3dAbXK0a7+VgSGfhw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.10.0",
+				"@azure/core-rest-pipeline": "^1.24.0",
+				"@azure/core-tracing": "^1.3.0",
+				"@typespec/ts-http-runtime": "^0.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/abort-controller": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+			"integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/ai-projects": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@azure/ai-projects/-/ai-projects-2.3.1.tgz",
+			"integrity": "sha512-xrBy4UQqx5nhV4xx2dFdEMWFPSiwDHHDYKBkKXNTMn5SXyBujvjxBDU3w9c4sH9KDeMxSaGUP1dbNfMcgL04fQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure-rest/core-client": "^2.1.0",
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.6.0",
+				"@azure/core-lro": "^3.1.0",
+				"@azure/core-paging": "^1.5.0",
+				"@azure/core-rest-pipeline": "^1.5.0",
+				"@azure/core-sse": "^2.1.3",
+				"@azure/core-util": "^1.9.0",
+				"@azure/identity": "^4.13.0",
+				"@azure/logger": "^1.1.4",
+				"@azure/storage-blob": "^12.26.0",
+				"@opentelemetry/api": "^1.9.0",
+				"openai": "^6.16.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-auth": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+			"integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-util": "^1.13.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-client": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
+			"integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.10.0",
+				"@azure/core-rest-pipeline": "^1.22.0",
+				"@azure/core-tracing": "^1.3.0",
+				"@azure/core-util": "^1.13.0",
+				"@azure/logger": "^1.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-http-compat": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.5.0.tgz",
+			"integrity": "sha512-BoSmXPx2er1Ai+wKlDvj29jIQespCNBwEmKyZVHO2kEFsWbGjAjwMCGzug3DJM5/QYIV3vej0S1zcU5bq9fa8w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"peerDependencies": {
+				"@azure/core-client": "^1.10.0",
+				"@azure/core-rest-pipeline": "^1.22.0"
+			}
+		},
+		"node_modules/@azure/core-lro": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-3.4.0.tgz",
+			"integrity": "sha512-y0uqcVFp5NHd7tkZcn8Nes6yIhVR05m4dd+L8foWiH1IsS75Z2BodJxwdErEF3bV+NSh6nkNnwPyXaLp0ma1Nw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-util": "^1.13.0",
+				"@azure/logger": "^1.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-paging": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.7.0.tgz",
+			"integrity": "sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-rest-pipeline": {
+			"version": "1.25.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+			"integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.10.0",
+				"@azure/core-tracing": "^1.3.0",
+				"@azure/core-util": "^1.13.0",
+				"@azure/logger": "^1.3.0",
+				"@typespec/ts-http-runtime": "^0.3.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-sse": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-sse/-/core-sse-2.4.0.tgz",
+			"integrity": "sha512-BFNVsoYE843I/q5/OFNHpaYN8TK8W99OwU9ipToYXdwB14o92A16ZjD6JW/BZ8kO7fWSM4jK2EoojAQmXAOExw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-tracing": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+			"integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-util": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+			"integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@typespec/ts-http-runtime": "^0.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/core-xml": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.6.0.tgz",
+			"integrity": "sha512-e7lX/dk//F6Qf7BB6PTY4+p2yuOQtyOeHGyapYHNwqSp2OnYpwQt49A/Nin2XmKBQ69pwagR4k/lQBq8lbHQkA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"fast-xml-parser": "^5.5.9",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/identity": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+			"integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.9.0",
+				"@azure/core-client": "^1.9.2",
+				"@azure/core-rest-pipeline": "^1.17.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.11.0",
+				"@azure/logger": "^1.0.0",
+				"@azure/msal-browser": "^5.5.0",
+				"@azure/msal-node": "^5.1.0",
+				"open": "^10.1.0",
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@azure/logger": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+			"integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@typespec/ts-http-runtime": "^0.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/msal-browser": {
+			"version": "5.17.3",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.3.tgz",
+			"integrity": "sha512-qMabD7Xrm/UgRhs+/IVyCTZRjUl8Qb+uGsRrCkaKNWsiTwRaeyStJbChE7/ySNTNYtiWo7khfF7vUDd0wGMnLw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/msal-common": "16.11.3"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-common": {
+			"version": "16.11.3",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
+			"integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@azure/msal-node": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.3.tgz",
+			"integrity": "sha512-tumCMmzrRhKmTbYQg/7OlfbrIKcKaf8Ed0Fw3suUpRT3owFYljznVgxcfHe8RycQXY9uyROGiLD1GjhpF45AwA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/msal-common": "16.11.3",
+				"jsonwebtoken": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@azure/openai-assistants": {
+			"version": "1.0.0-beta.6",
+			"resolved": "https://registry.npmjs.org/@azure/openai-assistants/-/openai-assistants-1.0.0-beta.6.tgz",
+			"integrity": "sha512-gINKKcqTpR0neF+36Owe0Q1u1JO3IK6clBzWTfZ+9V/TkQq+LoUgp5F8dKvSv/YChfwEpZA2r1DWCwNE07eYIQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure-rest/core-client": "^1.1.4",
+				"@azure/core-auth": "^1.5.0",
+				"@azure/core-client": "^1.7.3",
+				"@azure/core-rest-pipeline": "^1.13.0",
+				"@azure/core-util": "^1.6.1",
+				"@azure/logger": "^1.0.4",
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/openai-assistants/node_modules/@azure-rest/core-client": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.4.0.tgz",
+			"integrity": "sha512-ozTDPBVUDR5eOnMIwhggbnVmOrka4fXCs8n8mvUo4WLLc38kki6bAOByDoVZZPz/pZy2jMt2kwfpvy/UjALj6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-auth": "^1.3.0",
+				"@azure/core-rest-pipeline": "^1.5.0",
+				"@azure/core-tracing": "^1.0.1",
+				"@azure/core-util": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/storage-blob": {
+			"version": "12.33.0",
+			"resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+			"integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.9.0",
+				"@azure/core-client": "^1.9.3",
+				"@azure/core-http-compat": "^2.2.0",
+				"@azure/core-lro": "^2.2.0",
+				"@azure/core-paging": "^1.6.2",
+				"@azure/core-rest-pipeline": "^1.19.1",
+				"@azure/core-tracing": "^1.2.0",
+				"@azure/core-util": "^1.11.0",
+				"@azure/core-xml": "^1.4.5",
+				"@azure/logger": "^1.1.4",
+				"@azure/storage-common": "^12.4.1",
+				"events": "^3.0.0",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@azure/storage-blob/node_modules/@azure/core-lro": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+			"integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.0.0",
+				"@azure/core-util": "^1.2.0",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@azure/storage-common": {
+			"version": "12.4.1",
+			"resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+			"integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@azure/abort-controller": "^2.1.2",
+				"@azure/core-auth": "^1.9.0",
+				"@azure/core-http-compat": "^2.2.0",
+				"@azure/core-rest-pipeline": "^1.24.0",
+				"@azure/core-tracing": "^1.2.0",
+				"@azure/core-util": "^1.11.0",
+				"@azure/logger": "^1.1.4",
+				"events": "^3.3.0",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@cacheable/utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+			"integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hashery": "^1.5.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@so-ric/colorspace": "^1.1.6",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@fal-ai/client": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@fal-ai/client/-/client-1.10.1.tgz",
+			"integrity": "sha512-c3AVeH31OioiI2J1BfW8Cryi1DhUYldnY3X35nv6xLMq3fU2NQOo+eYaR5mL2O8MoHHh+HzXdQuIyanIyeq+ug==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@msgpack/msgpack": "^3.0.0-beta2",
+				"eventsource-parser": "^1.1.2",
+				"robot3": "^0.4.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@fal-ai/client/node_modules/eventsource-parser": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+			"integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14.18"
+			}
+		},
+		"node_modules/@googleapis/sheets": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/@googleapis/sheets/-/sheets-13.0.2.tgz",
+			"integrity": "sha512-b1tBlMcfvNEziM4DZCikLOc9iqSlgCK1e5bMKtNQIADRXr1CQmbkHV3ZBVvTsFsjLErgihqO58Itn/kzCnSZ0A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"googleapis-common": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+			"integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@huggingface/jinja": {
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+			"integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@huggingface/tokenizers": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+			"integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true
+		},
+		"node_modules/@huggingface/transformers": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+			"integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@huggingface/jinja": "^0.5.6",
+				"@huggingface/tokenizers": "^0.1.3",
+				"onnxruntime-node": "1.24.3",
+				"onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+				"sharp": "^0.34.5"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-s390x": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-wasm32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.7.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-ia32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/sharp": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/colour": "^1.0.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.34.5",
+				"@img/sharp-darwin-x64": "0.34.5",
+				"@img/sharp-libvips-darwin-arm64": "1.2.4",
+				"@img/sharp-libvips-darwin-x64": "1.2.4",
+				"@img/sharp-libvips-linux-arm": "1.2.4",
+				"@img/sharp-libvips-linux-arm64": "1.2.4",
+				"@img/sharp-libvips-linux-ppc64": "1.2.4",
+				"@img/sharp-libvips-linux-riscv64": "1.2.4",
+				"@img/sharp-libvips-linux-s390x": "1.2.4",
+				"@img/sharp-libvips-linux-x64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+				"@img/sharp-linux-arm": "0.34.5",
+				"@img/sharp-linux-arm64": "0.34.5",
+				"@img/sharp-linux-ppc64": "0.34.5",
+				"@img/sharp-linux-riscv64": "0.34.5",
+				"@img/sharp-linux-s390x": "0.34.5",
+				"@img/sharp-linux-x64": "0.34.5",
+				"@img/sharp-linuxmusl-arm64": "0.34.5",
+				"@img/sharp-linuxmusl-x64": "0.34.5",
+				"@img/sharp-wasm32": "0.34.5",
+				"@img/sharp-win32-arm64": "0.34.5",
+				"@img/sharp-win32-ia32": "0.34.5",
+				"@img/sharp-win32-x64": "0.34.5"
+			}
+		},
+		"node_modules/@ibm-cloud/watsonx-ai": {
+			"version": "1.7.15",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.15.tgz",
+			"integrity": "sha512-JUxFuACcKhDC+shavgyLEFjWiSsBjI+tjIBvLrzcHywh0HqTT0m+whe2kL3isPheBzrduSMfovwypbSuKwCp+g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"form-data": "^4.0.4",
+				"ibm-cloud-sdk-core": "^5.4.20"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+			"integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+			"integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+			"integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+			"integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+			"integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+			"integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+			"integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+			"integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+			"integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+			"integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+			"integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+			"integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+			"integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+			"integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+			"integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+			"integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+			"integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+			"integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+			"integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+			"integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+			"integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+			"integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.11.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+			"integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+			"integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+			"integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+			"integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@inquirer/ansi": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+			"integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+			"integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+			"integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7",
+				"cli-width": "^4.1.0",
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+			"integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/external-editor": "^3.0.3",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+			"integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+			"integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+			"integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+			"integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@keyv/serialize": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@libsql/client": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
+			"integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@libsql/core": "^0.17.4",
+				"@libsql/hrana-client": "^0.10.0",
+				"js-base64": "^3.7.5",
+				"libsql": "^0.5.28",
+				"promise-limit": "^2.7.0"
+			}
+		},
+		"node_modules/@libsql/core": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.4.tgz",
+			"integrity": "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-base64": "^3.7.5"
+			}
+		},
+		"node_modules/@libsql/darwin-arm64": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+			"integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@libsql/darwin-x64": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+			"integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@libsql/hrana-client": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+			"integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@libsql/isomorphic-ws": "^0.1.5",
+				"js-base64": "^3.7.5"
+			}
+		},
+		"node_modules/@libsql/isomorphic-ws": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+			"integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ws": "^8.5.4",
+				"ws": "^8.13.0"
+			}
+		},
+		"node_modules/@libsql/linux-arm-gnueabihf": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+			"integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/linux-arm-musleabihf": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+			"integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/linux-arm64-gnu": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+			"integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/linux-arm64-musl": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+			"integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/linux-x64-gnu": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+			"integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/linux-x64-musl": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+			"integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@libsql/win32-x64-msvc": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+			"integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@mongodb-js/saslprep": {
+			"version": "1.4.13",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.13.tgz",
+			"integrity": "sha512-E3Sv4eCYAlKYUTx8S3ioQcDUscOif+8zZ5OnW1IzJ+Tt+EO+ke8mn+Y3FX6N1H79picwbdOavVOb1jPi2EOyrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
+		"node_modules/@msgpack/msgpack": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+			"integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+			"integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-x64": "0.1.80",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.80",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+			"integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+			"integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+			"integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+			"integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+			"integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+			"integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+			"integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+			"integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+			"integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+			"integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@neon-rs/load": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+			"integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@nodable/entities": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+			"integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@openai/agents": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.11.8.tgz",
+			"integrity": "sha512-D4XHF2g+Ub/L9fRJT/xpuiCqHyxiKzZbi0BqQxnso42t+J049O/OSvVzFBcRskF4uPFAvs0TOOB7KBbanCwaYQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@openai/agents-core": "0.11.8",
+				"@openai/agents-openai": "0.11.8",
+				"@openai/agents-realtime": "0.11.8",
+				"debug": "^4.4.0",
+				"openai": "^6.35.0"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@openai/agents-core": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.11.8.tgz",
+			"integrity": "sha512-TrE34RXXPoWYv2PjXf5hq3Eq+uvRJMNiY+Q5WBgEPjAg60yt2hya8cS2I8qkO6i25MjNJl37a25X0vL/gs5Wdg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.4.0",
+				"openai": "^6.35.0"
+			},
+			"optionalDependencies": {
+				"@modelcontextprotocol/sdk": "^1.26.0"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@openai/agents-openai": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.11.8.tgz",
+			"integrity": "sha512-XjHCnJPGapgZBlh8y5oxU7zV0hrAQTF5im6HpUwaPcH5CeRFLtc06VXLso0vJ5G3g9e/J5gIh3S1iAxiJqEAVQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@openai/agents-core": "0.11.8",
+				"debug": "^4.4.0",
+				"openai": "^6.35.0"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@openai/agents-realtime": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.11.8.tgz",
+			"integrity": "sha512-i1qEGUE8GTW0neWgAc1aj/3wZFtstz8bVG2BvVbU/BzQbyhZV8j3CvndkMJGFfgeobvVmn2qGTV5Ry6ibfuxeQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@openai/agents-core": "0.11.8",
+				"@types/ws": "^8.18.1",
+				"debug": "^4.4.0",
+				"ws": "^8.18.1"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@openai/codex": {
+			"version": "0.144.6",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6.tgz",
+			"integrity": "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"codex": "bin/codex.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64",
+				"@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64",
+				"@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64",
+				"@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64",
+				"@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64",
+				"@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64"
+			}
+		},
+		"node_modules/@openai/codex-darwin-arm64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-darwin-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
+			"integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-darwin-x64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-darwin-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-x64.tgz",
+			"integrity": "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-linux-arm64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-linux-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+			"integrity": "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-linux-x64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-linux-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+			"integrity": "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-sdk": {
+			"version": "0.144.6",
+			"resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.6.tgz",
+			"integrity": "sha512-jFgXHjFq2//PTfJa8CySqhUilRBPVmCLuQoH5F+iJ2x4owZwPlnqmIbCkWIJJ6IxDuQdjf3ewg0LaDtc3i6h9Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@openai/codex": "0.144.6"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@openai/codex-win32-arm64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-win32-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-arm64.tgz",
+			"integrity": "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-win32-x64": {
+			"name": "@openai/codex",
+			"version": "0.144.6-win32-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+			"integrity": "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@opencode-ai/sdk": {
+			"version": "1.18.9",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.9.tgz",
+			"integrity": "sha512-oDJSmsmiGW+3lNLmZYj3EpUkpiT3ITZBKffH3mrmu2KMJXlkxQ/Nvv7jqPffSM7o8lCdBZS/aCE+2GkA3/92gQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"cross-spawn": "7.0.6"
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api-logs": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+			"integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/context-async-hooks": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+			"integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+			"integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
+			"integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/otlp-exporter-base": "0.220.0",
+				"@opentelemetry/otlp-transformer": "0.220.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/sdk-trace": "2.9.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-exporter-base": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+			"integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/otlp-transformer": "0.220.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+			"integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.220.0",
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/sdk-logs": "0.220.0",
+				"@opentelemetry/sdk-metrics": "2.9.0",
+				"@opentelemetry/sdk-trace": "2.9.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+			"integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.10.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+			"integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+			"integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.220.0",
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.4.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+			"integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.9.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+			"integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/resources": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+			"integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.10.0",
+				"@opentelemetry/resources": "2.10.0",
+				"@opentelemetry/sdk-trace": "2.10.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+			"integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/sdk-trace": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+			"integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.10.0",
+				"@opentelemetry/resources": "2.10.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+			"integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": "2.10.0",
+				"@opentelemetry/core": "2.10.0",
+				"@opentelemetry/sdk-trace-base": "2.10.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+			"integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+			"integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@playwright/browser-chromium": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.62.0.tgz",
+			"integrity": "sha512-ei50lLPtDlIK+LCBQHurcO3MAh4e2XhAKQwH/qVWVHUrVIRQzloOeYKeatRArFNzC4i3K5+d+2POSUveDU2Q5g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"playwright-core": "1.62.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@posthog/core": {
+			"version": "1.23.1",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.23.1.tgz",
+			"integrity": "sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.6"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/@redis/bloom": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+			"integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 18.19.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^5.12.1"
+			}
+		},
+		"node_modules/@redis/client": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+			"integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"cluster-key-slot": "1.1.2"
+			},
+			"engines": {
+				"node": ">= 18.19.0"
+			},
+			"peerDependencies": {
+				"@node-rs/xxhash": "^1.1.0",
+				"@opentelemetry/api": ">=1 <2"
+			},
+			"peerDependenciesMeta": {
+				"@node-rs/xxhash": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@redis/json": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+			"integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 18.19.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^5.12.1"
+			}
+		},
+		"node_modules/@redis/search": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+			"integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 18.19.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^5.12.1"
+			}
+		},
+		"node_modules/@redis/time-series": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+			"integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 18.19.0"
+			},
+			"peerDependencies": {
+				"@redis/client": "^5.12.1"
+			}
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+			"integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@simple-git/args-pathspec": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+			"integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@simple-git/argv-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+			"integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-git/args-pathspec": "^1.0.3"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@slack/logger": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+			"integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": ">=18"
+			},
+			"engines": {
+				"node": ">= 18",
+				"npm": ">= 8.6.0"
+			}
+		},
+		"node_modules/@slack/types": {
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/@slack/types/-/types-2.22.0.tgz",
+			"integrity": "sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 12.13.0",
+				"npm": ">= 6.12.0"
+			}
+		},
+		"node_modules/@slack/web-api": {
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.19.0.tgz",
+			"integrity": "sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@slack/logger": "^4.0.1",
+				"@slack/types": "^2.21.0",
+				"@types/node": ">=18",
+				"@types/retry": "0.12.0",
+				"axios": "^1.16.0",
+				"eventemitter3": "^5.0.1",
+				"form-data": "^4.0.4",
+				"is-electron": "2.2.2",
+				"is-stream": "^2",
+				"p-queue": "^6",
+				"p-retry": "^4",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">= 18",
+				"npm": ">= 8.6.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.31.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+			"integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.6.13",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+			"integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.9.13",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.6.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+			"integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@so-ric/colorspace": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color": "^5.0.2",
+				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/@socket.io/component-emitter": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@swc/core": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+			"integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@swc/counter": "^0.1.3",
+				"@swc/types": "^0.1.27"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/swc"
+			},
+			"optionalDependencies": {
+				"@swc/core-darwin-arm64": "1.15.47",
+				"@swc/core-darwin-x64": "1.15.47",
+				"@swc/core-linux-arm-gnueabihf": "1.15.47",
+				"@swc/core-linux-arm64-gnu": "1.15.47",
+				"@swc/core-linux-arm64-musl": "1.15.47",
+				"@swc/core-linux-ppc64-gnu": "1.15.47",
+				"@swc/core-linux-s390x-gnu": "1.15.47",
+				"@swc/core-linux-x64-gnu": "1.15.47",
+				"@swc/core-linux-x64-musl": "1.15.47",
+				"@swc/core-win32-arm64-msvc": "1.15.47",
+				"@swc/core-win32-ia32-msvc": "1.15.47",
+				"@swc/core-win32-x64-msvc": "1.15.47"
+			},
+			"peerDependencies": {
+				"@swc/helpers": ">=0.5.17"
+			},
+			"peerDependenciesMeta": {
+				"@swc/helpers": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@swc/core-darwin-arm64": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+			"integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-x64": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+			"integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm-gnueabihf": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+			"integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+			"integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-musl": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+			"integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-ppc64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+			"integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-s390x-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+			"integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+			"integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-musl": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+			"integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-arm64-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+			"integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-ia32-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+			"integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-x64-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+			"integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/counter": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true
+		},
+		"node_modules/@swc/types": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+			"integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@swc/counter": "^0.1.3"
+			}
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.19",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+			"integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/node": {
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+			"integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/@types/pegjs": {
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
+			"integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/webidl-conversions": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+			"integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/whatwg-url": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+			"integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/webidl-conversions": "*"
+			}
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@typespec/ts-http-runtime": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+			"integrity": "sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@vercel/oidc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+			"integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/a-sync-waterfall": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/adm-zip": {
+			"version": "0.5.18",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+			"integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12.0"
+			}
+		},
+		"node_modules/afinn-165": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
+			"integrity": "sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/afinn-165-financialmarketnews": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-3.0.0.tgz",
+			"integrity": "sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ai": {
+			"version": "6.0.237",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.237.tgz",
+			"integrity": "sha512-TdiKxGoYrKQyaN6fkk1WRxA+XSQ8nO3LZo/QVnJsME54bMuddXqzJ4KrJozF5/czHfJ5BmgHJ4mJmGqRZHX3Hw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "3.0.159",
+				"@ai-sdk/provider": "3.0.14",
+				"@ai-sdk/provider-utils": "4.0.40",
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/apparatus": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+			"integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"sylvester": ">= 0.0.8"
+			},
+			"engines": {
+				"node": ">=0.2.6"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/axios": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/axios/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^4.5.0 || >= 5.9"
+			}
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/big-integer": {
+			"version": "1.6.52",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+			"dev": true,
+			"license": "Unlicense",
+			"optional": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-3.1.0.tgz",
+			"integrity": "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/binaryextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+			"integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^2.0.0",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
+				"on-finished": "^2.4.1",
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/bson": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+			"integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cache-manager": {
+			"version": "7.2.9",
+			"resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.9.tgz",
+			"integrity": "sha512-d4vceEyYe95gPxEyQchlEOH9vJlkNRW8G6gzFzzMTxJK9PahYMhC9chrEqgZN0HulROjgw3IzmWVNk7Q7ytiGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cacheable/utils": "^2.5.0",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chardet": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+			"integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-progress": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+			"integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.3"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+			"integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/color": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.6"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+			"integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/color-string": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/complex.js": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+			"integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
+		"node_modules/compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": ">= 1.43.0 < 2"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/compression": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"compressible": "~2.0.18",
+				"debug": "2.6.9",
+				"negotiator": "~0.6.4",
+				"on-headers": "~1.1.0",
+				"safe-buffer": "5.2.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/compression/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/compression/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/compression/node_modules/negotiator": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/csv-parse": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.1.tgz",
+			"integrity": "sha512-+2z7Ar0APQ7Uu6fX4cn+pitRmxjZ1WPBcGmZFKmA74FCyi7Et/XZx8cjNQ5CjbZ4HCOxXCOpRBYvYH08Qa003A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/csv-stringify": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
+			"integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debounce": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
+			"integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dedent": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
+			"integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^2.2.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/dotenv": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/drizzle-orm": {
+			"version": "0.45.2",
+			"resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+			"integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/client-rds-data": ">=3",
+				"@cloudflare/workers-types": ">=4",
+				"@electric-sql/pglite": ">=0.2.0",
+				"@libsql/client": ">=0.10.0",
+				"@libsql/client-wasm": ">=0.10.0",
+				"@neondatabase/serverless": ">=0.10.0",
+				"@op-engineering/op-sqlite": ">=2",
+				"@opentelemetry/api": "^1.4.1",
+				"@planetscale/database": ">=1.13",
+				"@prisma/client": "*",
+				"@tidbcloud/serverless": "*",
+				"@types/better-sqlite3": "*",
+				"@types/pg": "*",
+				"@types/sql.js": "*",
+				"@upstash/redis": ">=1.34.7",
+				"@vercel/postgres": ">=0.8.0",
+				"@xata.io/client": "*",
+				"better-sqlite3": ">=7",
+				"bun-types": "*",
+				"expo-sqlite": ">=14.0.0",
+				"gel": ">=2",
+				"knex": "*",
+				"kysely": "*",
+				"mysql2": ">=2",
+				"pg": ">=8",
+				"postgres": ">=3",
+				"sql.js": ">=1",
+				"sqlite3": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/client-rds-data": {
+					"optional": true
+				},
+				"@cloudflare/workers-types": {
+					"optional": true
+				},
+				"@electric-sql/pglite": {
+					"optional": true
+				},
+				"@libsql/client": {
+					"optional": true
+				},
+				"@libsql/client-wasm": {
+					"optional": true
+				},
+				"@neondatabase/serverless": {
+					"optional": true
+				},
+				"@op-engineering/op-sqlite": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@planetscale/database": {
+					"optional": true
+				},
+				"@prisma/client": {
+					"optional": true
+				},
+				"@tidbcloud/serverless": {
+					"optional": true
+				},
+				"@types/better-sqlite3": {
+					"optional": true
+				},
+				"@types/pg": {
+					"optional": true
+				},
+				"@types/sql.js": {
+					"optional": true
+				},
+				"@upstash/redis": {
+					"optional": true
+				},
+				"@vercel/postgres": {
+					"optional": true
+				},
+				"@xata.io/client": {
+					"optional": true
+				},
+				"better-sqlite3": {
+					"optional": true
+				},
+				"bun-types": {
+					"optional": true
+				},
+				"expo-sqlite": {
+					"optional": true
+				},
+				"gel": {
+					"optional": true
+				},
+				"knex": {
+					"optional": true
+				},
+				"kysely": {
+					"optional": true
+				},
+				"mysql2": {
+					"optional": true
+				},
+				"pg": {
+					"optional": true
+				},
+				"postgres": {
+					"optional": true
+				},
+				"prisma": {
+					"optional": true
+				},
+				"sql.js": {
+					"optional": true
+				},
+				"sqlite3": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/editions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+			"integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"version-range": "^4.15.0"
+			},
+			"engines": {
+				"ecmascript": ">= es5",
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/engine.io": {
+			"version": "6.6.9",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+			"integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"@types/ws": "^8.5.12",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.7.2",
+				"cors": "~2.8.5",
+				"debug": "~4.4.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.21.0"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/engine.io-client": {
+			"version": "6.6.6",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+			"integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.4.1",
+				"engine.io-parser": "~5.2.1",
+				"ws": "~8.21.0",
+				"xmlhttprequest-ssl": "~2.1.1"
+			}
+		},
+		"node_modules/engine.io-parser": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+			"integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io/node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/engine.io/node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/es6-promisify": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
+			"integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/escape-latex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+			"integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/execa": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+			"integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.6",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^8.0.1",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^6.0.0",
+				"pretty-ms": "^9.2.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.6.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+			"integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/exsolve": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+			"integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+			"integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.6.2",
+				"xml-naming": "^0.3.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+			"integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^3.0.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^2.0.0",
+				"path-expression-matcher": "^1.6.2",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.3.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.2",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+			"integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/flatbuffers": {
+			"version": "25.9.23",
+			"resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+			"integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fraction.js": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2",
+				"rimraf": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.4",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+			"integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "7.1.3",
+				"google-logging-utils": "1.1.3",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-stream/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
+			"integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.3.1",
+				"data-uri-to-buffer": "8.0.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+			"integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/gaxios": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+			"integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/googleapis-common": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.3.tgz",
+			"integrity": "sha512-7g1yzQKx0mmNTjiK0H9dJ8eqKqDBveES9vLHeg5neb3BMQy/d1oQefIMhIpOVT8a+f+LOcixMEdRbFIW/cQUJw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"gaxios": "7.1.3",
+				"google-auth-library": "10.5.0",
+				"google-logging-utils": "1.1.3",
+				"qs": "^6.7.0",
+				"url-template": "^2.0.8"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/googleapis-common/node_modules/google-auth-library": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.0.0",
+				"gcp-metadata": "^8.0.0",
+				"google-logging-utils": "^1.0.0",
+				"gtoken": "^8.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/gtoken": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/guid-typescript": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+			"integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hashery": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+			"integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.32",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+			"integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/hookified": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/http-z": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/http-z/-/http-z-8.1.1.tgz",
+			"integrity": "sha512-4rEIu4SljSAs+lgCzzskyNdYllteGIHdnMBsu9MqafivyPAofSmCsrRjHQgxLs0BoPkUJBa7Ld6rXP32SPI8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+			"integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.6.0.tgz",
+			"integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@types/debug": "4.1.12",
+				"@types/node": "18.19.80",
+				"@types/tough-cookie": "4.0.0",
+				"axios": "1.18.0",
+				"camelcase": "6.3.0",
+				"debug": "4.3.4",
+				"dotenv": "16.4.5",
+				"extend": "3.0.2",
+				"file-type": "21.3.2",
+				"form-data": "4.0.6",
+				"isstream": "0.1.2",
+				"jsonwebtoken": "9.0.3",
+				"load-esm": "1.0.3",
+				"mime-types": "2.1.35",
+				"retry-axios": "2.6.0",
+				"tough-cookie": "4.1.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
+			"version": "18.19.80",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.80.tgz",
+			"integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/axios": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ip-address": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+			"integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-binary-path/node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-electron": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+			"integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-unsafe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+			"integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/istextorbinary": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+			"integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"binaryextensions": "^6.11.0",
+				"editions": "^6.21.0",
+				"textextensions": "^6.11.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/javascript-natural-sort": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+			"integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jks-js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/jks-js/-/jks-js-1.1.7.tgz",
+			"integrity": "sha512-BeiDRKsAi1NwEwgx2JB/9/0tar5BNGIv+foGm1G5GgiyR35s/iUnfd/BWqYd16mLDD8qTaAVBrIcOOuVqXJZNQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-forge": "^1.4.0",
+				"node-int64": "^0.4.0",
+				"node-rsa": "^1.1.1"
+			}
+		},
+		"node_modules/jose": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+			"integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/js-base64": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+			"integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/js-rouge": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/js-rouge/-/js-rouge-3.2.0.tgz",
+			"integrity": "sha512-2dvY28iFq5NcwxPNzc2zMgLVJED843m6CnKrCy0jYnOKd+QQhdkxI1wmdQspbcOAggo3K3gUZfhTSwmM+lWoBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+			"integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.mjs"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"dev": true,
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/kareem": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
+			"integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/keyv-file": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/keyv-file/-/keyv-file-5.3.5.tgz",
+			"integrity": "sha512-0JFTTi55d1HdhIrSOnPngUw0fyHLn3BHqoLJ8TyGKM/fQfuZsz8HkcFxpl6YzU2mj1ZfRF/6BXlSqOpyfXYAmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1",
+				"tslib": "^1.14.1"
+			}
+		},
+		"node_modules/keyv-file/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/langfuse": {
+			"version": "3.38.20",
+			"resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.38.20.tgz",
+			"integrity": "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"langfuse-core": "^3.38.20"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/langfuse-core": {
+			"version": "3.38.20",
+			"resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.38.20.tgz",
+			"integrity": "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"mustache": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/libsql": {
+			"version": "0.5.29",
+			"resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+			"integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+			"cpu": [
+				"x64",
+				"arm64",
+				"wasm32",
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"os": [
+				"darwin",
+				"linux",
+				"win32"
+			],
+			"dependencies": {
+				"@neon-rs/load": "^0.0.4",
+				"detect-libc": "2.0.2"
+			},
+			"optionalDependencies": {
+				"@libsql/darwin-arm64": "0.5.29",
+				"@libsql/darwin-x64": "0.5.29",
+				"@libsql/linux-arm-gnueabihf": "0.5.29",
+				"@libsql/linux-arm-musleabihf": "0.5.29",
+				"@libsql/linux-arm64-gnu": "0.5.29",
+				"@libsql/linux-arm64-musl": "0.5.29",
+				"@libsql/linux-x64-gnu": "0.5.29",
+				"@libsql/linux-x64-musl": "0.5.29",
+				"@libsql/win32-x64-msvc": "0.5.29"
+			}
+		},
+		"node_modules/load-esm": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+			"integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/Borewit"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://buymeacoffee.com/borewit"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=13.2.0"
+			}
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/log-symbols": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/logform": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/logform/node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mathjs": {
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+			"integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@babel/runtime": "^7.26.10",
+				"complex.js": "^2.2.5",
+				"decimal.js": "^10.4.3",
+				"escape-latex": "^1.2.0",
+				"fraction.js": "^5.2.1",
+				"javascript-natural-sort": "^0.7.1",
+				"seedrandom": "^3.0.5",
+				"tiny-emitter": "^2.1.0",
+				"typed-function": "^4.2.1"
+			},
+			"bin": {
+				"mathjs": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+			"integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/memjs": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/memjs/-/memjs-1.3.2.tgz",
+			"integrity": "sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.8"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mongodb-connection-string-url": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+			"integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@types/whatwg-url": "^13.0.0",
+				"whatwg-url": "^14.1.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/mongoose": {
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.8.1.tgz",
+			"integrity": "sha512-1ncioLSBWeFSXIiKw6aR4YYFAhpvS7uSbPpkzq5ELSP9PEScGkbzFg6Q0mNuHighosmgZPYPsY4sSIXqkY3/hw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"kareem": "3.3.0",
+				"mongodb": "~7.5",
+				"mpath": "0.9.0",
+				"mquery": "6.0.0",
+				"ms": "2.1.3",
+				"sift": "17.1.3"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mongoose"
+			}
+		},
+		"node_modules/mongoose/node_modules/gcp-metadata": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+			"integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/mongoose/node_modules/mongodb": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+			"integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@mongodb-js/saslprep": "^1.4.11",
+				"bson": "^7.2.0",
+				"mongodb-connection-string-url": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-providers": "^3.806.0",
+				"@mongodb-js/zstd": "^7.0.0",
+				"gcp-metadata": "^7.0.1",
+				"kerberos": "^7.0.0",
+				"mongodb-client-encryption": "^7.2.0",
+				"snappy": "^7.3.2",
+				"socks": "^2.8.6"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-providers": {
+					"optional": true
+				},
+				"@mongodb-js/zstd": {
+					"optional": true
+				},
+				"gcp-metadata": {
+					"optional": true
+				},
+				"kerberos": {
+					"optional": true
+				},
+				"mongodb-client-encryption": {
+					"optional": true
+				},
+				"snappy": {
+					"optional": true
+				},
+				"socks": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mpath": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/mquery": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+			"integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"mustache": "bin/mustache"
+			}
+		},
+		"node_modules/mute-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/natural": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/natural/-/natural-8.1.1.tgz",
+			"integrity": "sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"afinn-165": "^2.0.2",
+				"afinn-165-financialmarketnews": "^3.0.0",
+				"apparatus": "^0.0.10",
+				"dotenv": "^17.3.1",
+				"memjs": "^1.3.2",
+				"mongoose": "^9.2.1",
+				"pg": "^8.18.0",
+				"redis": "^5.11.0",
+				"safe-stable-stringify": "^2.5.0",
+				"stopwords-iso": "^1.1.0",
+				"sylvester": "^0.0.21",
+				"underscore": "^1.13.0",
+				"uuid": "^13.0.0",
+				"wordnet-db": "^3.1.14"
+			},
+			"engines": {
+				"node": ">=0.4.10"
+			}
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/node-forge": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+			"dev": true,
+			"license": "(BSD-3-Clause OR GPL-2.0)",
+			"optional": true,
+			"engines": {
+				"node": ">= 6.13.0"
+			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-rsa": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+			"integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"asn1": "^0.2.4"
+			}
+		},
+		"node_modules/node-sql-parser": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
+			"integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@types/pegjs": "^0.10.0",
+				"big-integer": "^1.6.48"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0",
+				"unicorn-magic": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/nunjucks": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+			"integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"a-sync-waterfall": "^1.0.0",
+				"asap": "^2.0.3",
+				"commander": "^5.1.0"
+			},
+			"bin": {
+				"nunjucks-precompile": "bin/precompile"
+			},
+			"engines": {
+				"node": ">= 6.9.0"
+			},
+			"peerDependencies": {
+				"chokidar": "^3.3.0"
+			},
+			"peerDependenciesMeta": {
+				"chokidar": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/nunjucks/node_modules/commander": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/on-headers": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fn.name": "1.x.x"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/onnxruntime-common": {
+			"version": "1.24.3",
+			"resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+			"integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/onnxruntime-node": {
+			"version": "1.24.3",
+			"resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+			"integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32",
+				"darwin",
+				"linux"
+			],
+			"dependencies": {
+				"adm-zip": "^0.5.16",
+				"global-agent": "^3.0.0",
+				"onnxruntime-common": "1.24.3"
+			}
+		},
+		"node_modules/onnxruntime-web": {
+			"version": "1.26.0-dev.20260416-b7804b056c",
+			"resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+			"integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"flatbuffers": "^25.1.24",
+				"guid-typescript": "^1.0.9",
+				"long": "^5.2.3",
+				"onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+				"platform": "^1.3.6",
+				"protobufjs": "^7.2.4"
+			}
+		},
+		"node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+			"version": "1.24.0-dev.20251116-b39e144322",
+			"resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+			"integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/onnxruntime-web/node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.49.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+			"integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/opener": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+			"dev": true,
+			"license": "(WTFPL OR MIT)",
+			"bin": {
+				"opener": "bin/opener-bin.js"
+			}
+		},
+		"node_modules/ora": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+			"integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.6.2",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^3.2.0",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.1.0",
+				"log-symbols": "^7.0.1",
+				"stdin-discarder": "^0.3.2",
+				"string-width": "^8.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/p-queue": {
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"eventemitter3": "^4.0.4",
+				"p-timeout": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-queue/node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"p-finally": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"get-uri": "8.0.1",
+				"http-proxy-agent": "9.1.0",
+				"https-proxy-agent": "9.1.0",
+				"pac-resolver": "9.0.1",
+				"quickjs-wasi": "^2.2.0",
+				"socks-proxy-agent": "10.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/agent-base": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+			"integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
+			"integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "7.0.1",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^2.2.0"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+			"integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pdf-parse": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+			"integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/canvas": "0.1.80",
+				"pdfjs-dist": "5.4.296"
+			},
+			"bin": {
+				"pdf-parse": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": ">=20.16.0 <21 || >=22.3.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/mehmet-kozan"
+			}
+		},
+		"node_modules/pdfjs-dist": {
+			"version": "5.4.296",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+			"integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=20.16.0 || >=22.3.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas": "^0.1.80"
+			}
+		},
+		"node_modules/pem": {
+			"version": "1.14.8",
+			"resolved": "https://registry.npmjs.org/pem/-/pem-1.14.8.tgz",
+			"integrity": "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es6-promisify": "^7.0.0",
+				"md5": "^2.3.0",
+				"os-tmpdir": "^1.0.2",
+				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/pg": {
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+			"integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"pg-connection-string": "^2.14.0",
+				"pg-pool": "^3.14.0",
+				"pg-protocol": "^1.15.0",
+				"pg-types": "2.2.0",
+				"pgpass": "1.0.5"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"optionalDependencies": {
+				"pg-cloudflare": "^1.4.0"
+			},
+			"peerDependencies": {
+				"pg-native": ">=3.0.1"
+			},
+			"peerDependenciesMeta": {
+				"pg-native": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/pg-cloudflare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+			"integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/pg-connection-string": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+			"integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/pg-int8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/pg-pool": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+			"integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peerDependencies": {
+				"pg": ">=8.0"
+			}
+		},
+		"node_modules/pg-protocol": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+			"integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/pg-types": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"pg-int8": "1.0.1",
+				"postgres-array": "~2.0.0",
+				"postgres-bytea": "~1.0.0",
+				"postgres-date": "~1.0.4",
+				"postgres-interval": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pgpass": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+			"integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"split2": "^4.1.0"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/platform": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/playwright": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+			"integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"playwright-core": "1.62.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+			"integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/playwright-extra": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
+			"integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"playwright": "*",
+				"playwright-core": "*"
+			},
+			"peerDependenciesMeta": {
+				"playwright": {
+					"optional": true
+				},
+				"playwright-core": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/postgres-array": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postgres-bytea": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-date": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-interval": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/posthog-node": {
+			"version": "5.24.17",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.24.17.tgz",
+			"integrity": "sha512-mdb8TKt+YCRbGQdYar3AKNUPCyEiqcprScF4unYpGALF6HlBaEuO6wPuIqXXpCWkw4VclJYCKbb6lq6pH6bJeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/core": "1.23.1"
+			},
+			"engines": {
+				"node": "^20.20.0 || >=22.22.0"
+			}
+		},
+		"node_modules/pretty-ms": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+			"integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse-ms": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/promise-limit": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+			"integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/promptfoo": {
+			"version": "0.121.19",
+			"resolved": "https://registry.npmjs.org/promptfoo/-/promptfoo-0.121.19.tgz",
+			"integrity": "sha512-5YebsCED/bmR9JktH9YNU62Tr1m3ncFMlM2tKrguI8vFFUfvqxhNzUBa3Z6huG7OvDKbi69UpamU4CLtYLDezQ==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"src/app",
+				"site"
+			],
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.110.0",
+				"@apidevtools/json-schema-ref-parser": "^15.3.1",
+				"@inquirer/checkbox": "^5.1.0",
+				"@inquirer/confirm": "^6.0.8",
+				"@inquirer/core": "^11.1.5",
+				"@inquirer/editor": "^5.0.8",
+				"@inquirer/input": "^5.0.8",
+				"@inquirer/search": "^4.1.8",
+				"@inquirer/select": "^5.1.0",
+				"@libsql/client": "^0.17.3",
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "2.9.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+				"@opentelemetry/resources": "^2.6.0",
+				"@opentelemetry/sdk-trace-base": "^2.6.0",
+				"@opentelemetry/sdk-trace-node": "^2.6.0",
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"@types/ws": "^8.18.1",
+				"ai": "^6.0.190",
+				"ajv": "^8.18.0",
+				"ajv-formats": "^3.0.1",
+				"async": "^3.2.6",
+				"binary-extensions": "^3.1.0",
+				"cache-manager": "^7.2.8",
+				"chalk": "^5.6.2",
+				"chokidar": "5.0.0",
+				"cli-progress": "^3.12.0",
+				"cli-table3": "^0.6.5",
+				"commander": "^14.0.3",
+				"compression": "^1.8.1",
+				"cors": "^2.8.6",
+				"csv-parse": "^7.0.0",
+				"csv-stringify": "^6.7.0",
+				"debounce": "^3.0.0",
+				"dedent": "^1.7.2",
+				"dotenv": "^17.3.1",
+				"drizzle-orm": "^0.45.1",
+				"execa": "^9.6.1",
+				"express": "^5.2.1",
+				"exsolve": "^1.0.8",
+				"fast-deep-equal": "^3.1.3",
+				"fast-safe-stringify": "^2.1.1",
+				"fast-xml-parser": "^5.7.1",
+				"fastest-levenshtein": "^1.0.16",
+				"gcp-metadata": "^8.1.2",
+				"glob": "^13.0.6",
+				"http-z": "^8.1.1",
+				"istextorbinary": "^9.5.0",
+				"js-rouge": "^3.2.0",
+				"js-yaml": "5.2.1",
+				"json5": "^2.2.3",
+				"keyv": "^5.6.0",
+				"keyv-file": "^5.3.3",
+				"lru-cache": "^11.3.0",
+				"mathjs": "^15.1.1",
+				"minimatch": "^10.2.4",
+				"nunjucks": "^3.2.4",
+				"openai": "^6.37.0",
+				"opener": "^1.5.2",
+				"ora": "^9.3.0",
+				"parse5": "^8.0.0",
+				"posthog-node": "~5.24.10",
+				"protobufjs": "^8.0.0",
+				"proxy-agent": "^8.0.0",
+				"proxy-from-env": "^2.1.0",
+				"python-shell": "^5.0.0",
+				"rfdc": "^1.4.1",
+				"rxjs": "^7.8.2",
+				"saxes": "^6.0.0",
+				"semver": "^7.7.4",
+				"simple-git": "^3.33.0",
+				"socket.io": "^4.8.3",
+				"socket.io-client": "^4.8.3",
+				"text-extensions": "^3.1.0",
+				"tsx": "^4.21.0",
+				"undici": ">=7.28.0 <8",
+				"winston": "^3.19.0",
+				"ws": "^8.19.0",
+				"zod": "^4.3.6"
+			},
+			"bin": {
+				"pf": "dist/src/entrypoint.js",
+				"promptfoo": "dist/src/entrypoint.js"
+			},
+			"engines": {
+				"node": "^20.20.0 || >=22.22.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk": "0.3.201",
+				"@aws-sdk/client-bedrock-agent-runtime": "^3.1045.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.1045.0",
+				"@aws-sdk/client-s3": "^3.1003.0",
+				"@aws-sdk/client-sagemaker-runtime": "^3.1045.0",
+				"@aws-sdk/credential-provider-sso": "^3.972.16",
+				"@azure/ai-projects": "^2.1.1",
+				"@azure/identity": "^4.13.0",
+				"@azure/msal-node": "^5.2.0",
+				"@azure/openai-assistants": "^1.0.0-beta.6",
+				"@azure/storage-blob": "^12.31.0",
+				"@fal-ai/client": "~1.10.1",
+				"@googleapis/sheets": "^13.0.1",
+				"@huggingface/transformers": "^4.0.0",
+				"@ibm-cloud/watsonx-ai": "^1.7.14",
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"@openai/agents": "^0.11.3",
+				"@openai/codex-sdk": "^0.144.0",
+				"@opencode-ai/sdk": "^1.14.33",
+				"@playwright/browser-chromium": "^1.60.0",
+				"@rollup/rollup-linux-x64-gnu": "^4.62.0",
+				"@slack/web-api": "^7.15.2",
+				"@smithy/node-http-handler": "^4.4.14",
+				"@swc/core": "^1.15.41",
+				"@swc/core-darwin-arm64": "^1.15.41",
+				"@swc/core-darwin-x64": "^1.15.41",
+				"@swc/core-linux-x64-gnu": "^1.15.41",
+				"@swc/core-linux-x64-musl": "^1.15.41",
+				"@swc/core-win32-x64-msvc": "^1.15.41",
+				"google-auth-library": "^10.9.0",
+				"hono": "^4.12.25",
+				"ibm-cloud-sdk-core": "^5.4.22",
+				"jks-js": "^1.1.5",
+				"langfuse": "^3.38.20",
+				"natural": "^8.1.1",
+				"node-sql-parser": "^5.4.0",
+				"pdf-parse": "^2.4.5",
+				"pem": "~1.14.8",
+				"playwright": "^1.60.0",
+				"playwright-extra": "^4.3.6",
+				"read-excel-file": "^9.0.0",
+				"sharp": "^0.35.3"
+			}
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.201.tgz",
+			"integrity": "sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==",
+			"dev": true,
+			"license": "SEE LICENSE IN README.md",
+			"optional": true,
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.201",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.201"
+			},
+			"peerDependencies": {
+				"@anthropic-ai/sdk": ">=0.93.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.201.tgz",
+			"integrity": "sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.201.tgz",
+			"integrity": "sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.201.tgz",
+			"integrity": "sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.201.tgz",
+			"integrity": "sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.201.tgz",
+			"integrity": "sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.201.tgz",
+			"integrity": "sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.201.tgz",
+			"integrity": "sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.3.201",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.201.tgz",
+			"integrity": "sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/promptfoo/node_modules/@anthropic-ai/sdk": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+			"integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/promptfoo/node_modules/chokidar": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/promptfoo/node_modules/readdirp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+			"integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
+			"integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "9.1.0",
+				"https-proxy-agent": "9.1.0",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "9.1.0",
+				"proxy-from-env": "^2.0.0",
+				"socks-proxy-agent": "10.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/proxy-agent-negotiate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+			"integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"kerberos": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"kerberos": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/proxy-agent/node_modules/agent-base": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+			"integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/http-proxy-agent": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/https-proxy-agent": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/python-shell": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
+			"integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/quickjs-wasi": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
+			"integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/range-parser": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+			"integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/read-excel-file": {
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.5.tgz",
+			"integrity": "sha512-A4EbaJxFrqzBNdU4Lw0g6wzme3m7ywW3MsPLLuBiGPUWJbxETyVDT5vyqsOnl/AW48OGM4MGoOgKFsEZNMMVVw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"fflate": "^0.8.3",
+				"saxen": "^11.1.0",
+				"unzipper-esm": "^0.13.3",
+				"worker-f": "^0.1.12"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/redis": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+			"integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@redis/bloom": "5.12.1",
+				"@redis/client": "5.12.1",
+				"@redis/json": "5.12.1",
+				"@redis/search": "5.12.1",
+				"@redis/time-series": "5.12.1"
+			},
+			"engines": {
+				"node": ">= 18.19.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/retry-axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+			"integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=10.7.0"
+			},
+			"peerDependencies": {
+				"axios": "*"
+			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/robot3": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/robot3/-/robot3-0.4.1.tgz",
+			"integrity": "sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/saxen": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+			"integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 20.12"
+			}
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/seedrandom": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/sharp": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+			"integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/colour": "^1.1.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.8.5"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.35.3",
+				"@img/sharp-darwin-x64": "0.35.3",
+				"@img/sharp-freebsd-wasm32": "0.35.3",
+				"@img/sharp-libvips-darwin-arm64": "1.3.2",
+				"@img/sharp-libvips-darwin-x64": "1.3.2",
+				"@img/sharp-libvips-linux-arm": "1.3.2",
+				"@img/sharp-libvips-linux-arm64": "1.3.2",
+				"@img/sharp-libvips-linux-ppc64": "1.3.2",
+				"@img/sharp-libvips-linux-riscv64": "1.3.2",
+				"@img/sharp-libvips-linux-s390x": "1.3.2",
+				"@img/sharp-libvips-linux-x64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+				"@img/sharp-linux-arm": "0.35.3",
+				"@img/sharp-linux-arm64": "0.35.3",
+				"@img/sharp-linux-ppc64": "0.35.3",
+				"@img/sharp-linux-riscv64": "0.35.3",
+				"@img/sharp-linux-s390x": "0.35.3",
+				"@img/sharp-linux-x64": "0.35.3",
+				"@img/sharp-linuxmusl-arm64": "0.35.3",
+				"@img/sharp-linuxmusl-x64": "0.35.3",
+				"@img/sharp-webcontainers-wasm32": "0.35.3",
+				"@img/sharp-win32-arm64": "0.35.3",
+				"@img/sharp-win32-ia32": "0.35.3",
+				"@img/sharp-win32-x64": "0.35.3"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/sharp/node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/sift": {
+			"version": "17.1.3",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+			"integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/simple-git": {
+			"version": "3.36.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+			"integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"@simple-git/args-pathspec": "^1.0.3",
+				"@simple-git/argv-parser": "^1.1.0",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socket.io": {
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+			"integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.4.1",
+				"engine.io": "~6.6.0",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.2.0"
+			}
+		},
+		"node_modules/socket.io-adapter": {
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "~4.4.1",
+				"ws": "~8.21.0"
+			}
+		},
+		"node_modules/socket.io-client": {
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+			"integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.4.1",
+				"engine.io-client": "~6.6.1",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io-parser": {
+			"version": "4.2.7",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+			"integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.4.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io/node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/socket.io/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/socket.io/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/socket.io/node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+			"integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/socks-proxy-agent/node_modules/agent-base": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+			"integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"memory-pager": "^1.0.2"
+			}
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+			"integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/stopwords-iso": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stopwords-iso/-/stopwords-iso-1.1.0.tgz",
+			"integrity": "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/sylvester": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
+			"integrity": "sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=0.2.6"
+			}
+		},
+		"node_modules/text-extensions": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-3.1.0.tgz",
+			"integrity": "sha512-anOjtXr8OT5w4vc/2mP4AYTCE0GWc/21icGmaHtBHnI7pN7o01a/oqG9m06/rGzoAsDm/WNzggBpqptuCmRlZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/textextensions": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+			"integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"dependencies": {
+				"editions": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/typed-function": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+			"integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/underscore": {
+			"version": "1.13.8",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/undici": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/unzipper-esm": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.3.tgz",
+			"integrity": "sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.2",
+				"node-int64": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+			"dev": true,
+			"license": "BSD",
+			"optional": true
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/version-range": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+			"integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+			"dev": true,
+			"license": "Artistic-2.0",
+			"engines": {
+				"node": ">=4"
+			},
+			"funding": {
+				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.8",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.7.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.9.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston/node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/wordnet-db": {
+			"version": "3.1.14",
+			"resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
+			"integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/worker-f": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/worker-f/-/worker-f-0.1.13.tgz",
+			"integrity": "sha512-wAtKSRQjuaUueG/rZEN19aJEp9nY4fUEM+HoFidN7qpicB/wSf9fbyQ7Q3gAcJqoWvXHMxQ4kATPFxlLiD6rbQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+			"integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/xmlhttprequest-ssl": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+			"integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/.skills/gutenberg-pr-review/evals/package.json
+++ b/.skills/gutenberg-pr-review/evals/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "gutenberg-pr-review-evals",
+	"private": true,
+	"type": "module",
+	"engines": {
+		"node": "^20.20.0 || >=22.22.0"
+	},
+	"scripts": {
+		"eval": "node scripts/run-eval.mjs codex",
+		"eval:codex": "node scripts/run-eval.mjs codex",
+		"eval:claude": "node scripts/run-eval.mjs claude",
+		"reset": "node scripts/reset-workspaces.mjs",
+		"clean": "node scripts/clean-workspaces.mjs",
+		"validate:codex": "promptfoo validate -c promptfooconfig.yaml",
+		"validate:claude": "promptfoo validate -c promptfooconfig.claude.yaml"
+	},
+	"devDependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.3.211",
+		"@openai/codex-sdk": "^0.144.5",
+		"promptfoo": "^0.121.19"
+	}
+}

--- a/.skills/gutenberg-pr-review/evals/promptfooconfig.claude.yaml
+++ b/.skills/gutenberg-pr-review/evals/promptfooconfig.claude.yaml
@@ -1,0 +1,109 @@
+description: Compare Gutenberg PR reviews with and without the gutenberg-pr-review skill
+
+prompts:
+    - label: Review a Gutenberg pull request
+      raw: |
+          Use the `gutenberg-pr-review` skill if it is available in this workspace.
+
+          Read `cases/{{case}}/PR_CONTEXT.md` and review the proposed Gutenberg pull
+          request. Do not modify files or run commands. Report only actionable
+          findings, ordered by severity, with file references and concise remedies.
+
+providers:
+    - id: anthropic:claude-agent-sdk
+      label: Claude Code without gutenberg-pr-review
+      config:
+          working_dir: ./.workspaces/without-skill
+          setting_sources: ['project']
+          permission_mode: dontAsk
+          apiKeyRequired: false
+          persist_session: false
+
+    - id: anthropic:claude-agent-sdk
+      label: Claude Code with gutenberg-pr-review
+      config:
+          working_dir: ./.workspaces/with-skill
+          setting_sources: ['project']
+          skills: ['gutenberg-pr-review']
+          permission_mode: dontAsk
+          apiKeyRequired: false
+          persist_session: false
+
+defaultTest:
+    options:
+        bustCache: true
+    assert:
+        - type: javascript
+          value: file://assertions/grade-gutenberg-review.cjs
+          threshold: 1
+          metric: Seeded review checks
+        - type: llm-rubric
+          value: '{{rubric}}'
+          threshold: 0.8
+          metric: Review usefulness
+          provider:
+              id: anthropic:claude-agent-sdk
+              config:
+                  permission_mode: dontAsk
+                  apiKeyRequired: false
+                  persist_session: false
+
+tests:
+    - description: Preserve serialized block markup
+      vars:
+          case: block-serialized-markup
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded compatibility regression.
+
+              The pull request changes the Call to Action block's serialized class
+              name in save.js. Existing posts still contain the old class, so those
+              blocks fail validation when reopened. There is no deprecated block
+              version or migration, and tests cover only newly serialized markup.
+              The Block API version does not need to be bumped.
+
+              Pass only if the review prioritizes the existing-content validation
+              failure, identifies the missing compatibility/deprecation path, and
+              requests meaningful old-content coverage. Fail reviews that demand an
+              API-version bump or bury the defect in generic checklist advice.
+
+    - description: Ignore stale async responses
+      vars:
+          case: async-stale-response
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded async lifecycle regression.
+
+              When templateId changes quickly, the earlier request can resolve last
+              and overwrite the newer template preview. The effect already lists
+              templateId as a dependency. The implementation needs cancellation,
+              request identity, or an equivalent stale-result guard, plus a
+              regression test with out-of-order completion.
+
+              Pass only if the review explains the concrete stale-response sequence,
+              proposes a proportionate guard, and requests meaningful race coverage.
+              Fail reviews that claim templateId is missing from the dependency array
+              or provide only generic async advice.
+
+    - description: Preserve explicit false REST values
+      vars:
+          case: rest-false-update
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded REST update regression.
+
+              The truthiness guard skips update_option when allow_comments is
+              explicitly false, so a user cannot turn an existing true value off.
+              The route already has an appropriate permission callback, boolean
+              schema, and sanitization. The fix must distinguish parameter presence
+              from truthiness and test a true-to-false update.
+
+              Pass only if the review explains the false-value failure, recommends a
+              presence-aware or unconditional update, and requests the consequential
+              regression test. Fail reviews that invent missing permission or
+              sanitization findings.
+
+evaluateOptions:
+    maxConcurrency: 2
+
+outputPath: results/raw/claude.json

--- a/.skills/gutenberg-pr-review/evals/promptfooconfig.yaml
+++ b/.skills/gutenberg-pr-review/evals/promptfooconfig.yaml
@@ -1,0 +1,111 @@
+description: Compare Gutenberg PR reviews with and without the gutenberg-pr-review skill
+
+prompts:
+    - label: Review a Gutenberg pull request
+      raw: |
+          Use the `gutenberg-pr-review` skill if it is available in this workspace.
+
+          Read `cases/{{case}}/PR_CONTEXT.md` and review the proposed Gutenberg pull
+          request. Do not modify files or run commands. Report only actionable
+          findings, ordered by severity, with file references and concise remedies.
+
+providers:
+    - id: openai:codex-sdk
+      label: Codex without gutenberg-pr-review
+      config:
+          working_dir: ./.workspaces/without-skill
+          skip_git_repo_check: true
+          sandbox_mode: read-only
+          approval_policy: never
+          network_access_enabled: false
+          enable_streaming: true
+
+    - id: openai:codex-sdk
+      label: Codex with gutenberg-pr-review
+      config:
+          working_dir: ./.workspaces/with-skill
+          skip_git_repo_check: true
+          sandbox_mode: read-only
+          approval_policy: never
+          network_access_enabled: false
+          enable_streaming: true
+
+defaultTest:
+    options:
+        bustCache: true
+    assert:
+        - type: javascript
+          value: file://assertions/grade-gutenberg-review.cjs
+          threshold: 1
+          metric: Seeded review checks
+        - type: llm-rubric
+          value: '{{rubric}}'
+          threshold: 0.8
+          metric: Review usefulness
+          provider:
+              id: openai:codex-sdk
+              config:
+                  skip_git_repo_check: true
+                  sandbox_mode: read-only
+                  approval_policy: never
+                  network_access_enabled: false
+
+tests:
+    - description: Preserve serialized block markup
+      vars:
+          case: block-serialized-markup
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded compatibility regression.
+
+              The pull request changes the Call to Action block's serialized class
+              name in save.js. Existing posts still contain the old class, so those
+              blocks fail validation when reopened. There is no deprecated block
+              version or migration, and tests cover only newly serialized markup.
+              The Block API version does not need to be bumped.
+
+              Pass only if the review prioritizes the existing-content validation
+              failure, identifies the missing compatibility/deprecation path, and
+              requests meaningful old-content coverage. Fail reviews that demand an
+              API-version bump or bury the defect in generic checklist advice.
+
+    - description: Ignore stale async responses
+      vars:
+          case: async-stale-response
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded async lifecycle regression.
+
+              When templateId changes quickly, the earlier request can resolve last
+              and overwrite the newer template preview. The effect already lists
+              templateId as a dependency. The implementation needs cancellation,
+              request identity, or an equivalent stale-result guard, plus a
+              regression test with out-of-order completion.
+
+              Pass only if the review explains the concrete stale-response sequence,
+              proposes a proportionate guard, and requests meaningful race coverage.
+              Fail reviews that claim templateId is missing from the dependency array
+              or provide only generic async advice.
+
+    - description: Preserve explicit false REST values
+      vars:
+          case: rest-false-update
+          rubric: |
+              Judge whether this review would help a Gutenberg maintainer catch the
+              seeded REST update regression.
+
+              The truthiness guard skips update_option when allow_comments is
+              explicitly false, so a user cannot turn an existing true value off.
+              The route already has an appropriate permission callback, boolean
+              schema, and sanitization. The fix must distinguish parameter presence
+              from truthiness and test a true-to-false update.
+
+              Pass only if the review explains the false-value failure, recommends a
+              presence-aware or unconditional update, and requests the consequential
+              regression test. Fail reviews that invent missing permission or
+              sanitization findings.
+
+evaluateOptions:
+    maxConcurrency: 2
+
+outputPath: results/raw/codex.json

--- a/.skills/gutenberg-pr-review/evals/scripts/clean-workspaces.mjs
+++ b/.skills/gutenberg-pr-review/evals/scripts/clean-workspaces.mjs
@@ -1,0 +1,10 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const evalsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+fs.rmSync(path.join(evalsDir, '.workspaces'), {
+  recursive: true,
+  force: true,
+});
+console.log('Removed generated Gutenberg review eval workspaces.');

--- a/.skills/gutenberg-pr-review/evals/scripts/reset-workspaces.mjs
+++ b/.skills/gutenberg-pr-review/evals/scripts/reset-workspaces.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const evalsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspacesDir = path.join(evalsDir, '.workspaces');
+const fixturesDir = path.join(evalsDir, 'fixtures');
+const skillSource = path.resolve(evalsDir, '..');
+const skipFinderMetadata = (source) => path.basename(source) !== '.DS_Store';
+const skillEntries = fs.readdirSync(skillSource)
+  .filter((entry) => entry !== 'evals' && entry !== '.DS_Store');
+
+if (!fs.existsSync(path.join(skillSource, 'SKILL.md'))) {
+  console.error(`Gutenberg review skill not found at ${skillSource}`);
+  process.exit(1);
+}
+
+fs.rmSync(workspacesDir, { recursive: true, force: true });
+
+for (const variant of ['without-skill', 'with-skill']) {
+  const target = path.join(workspacesDir, variant);
+  fs.mkdirSync(target, { recursive: true });
+  fs.cpSync(fixturesDir, path.join(target, 'cases'), {
+    recursive: true,
+    filter: skipFinderMetadata,
+  });
+
+  if (variant === 'with-skill') {
+    for (const skillsRoot of [
+      path.join(target, '.agents', 'skills'),
+      path.join(target, '.claude', 'skills'),
+    ]) {
+      const targetSkill = path.join(skillsRoot, 'gutenberg-pr-review');
+      fs.mkdirSync(targetSkill, { recursive: true });
+      for (const entry of skillEntries) {
+        fs.cpSync(
+          path.join(skillSource, entry),
+          path.join(targetSkill, entry),
+          {
+            recursive: true,
+            filter: skipFinderMetadata,
+          },
+        );
+      }
+    }
+  }
+
+  execFileSync('git', ['init', '--quiet'], { cwd: target });
+}
+
+console.log(`Reset Gutenberg review workspaces using ${skillSource}`);

--- a/.skills/gutenberg-pr-review/evals/scripts/run-eval.mjs
+++ b/.skills/gutenberg-pr-review/evals/scripts/run-eval.mjs
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const evalsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const executable = process.platform === 'win32' ? 'promptfoo.cmd' : 'promptfoo';
+const binDir = path.join(evalsDir, 'node_modules', '.bin');
+const agent = process.argv[2] || 'codex';
+const requestedRepeats = Number.parseInt(process.argv[3] || '3', 10);
+const repeats = Number.isFinite(requestedRepeats) && requestedRepeats > 0 ? requestedRepeats : 3;
+const configs = {
+  codex: 'promptfooconfig.yaml',
+  claude: 'promptfooconfig.claude.yaml',
+};
+const outputFile = path.join(evalsDir, 'results', 'raw', `${agent}.json`);
+
+if (!configs[agent]) {
+  console.error(`Choose an agent: codex or claude. Received: ${agent}`);
+  process.exit(1);
+}
+
+function runNode(script) {
+  return spawnSync(process.execPath, [path.join(evalsDir, 'scripts', script)], {
+    cwd: evalsDir,
+    env: process.env,
+    stdio: 'inherit',
+  });
+}
+
+fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+fs.rmSync(outputFile, { force: true });
+
+const reset = runNode('reset-workspaces.mjs');
+if (reset.status !== 0) {
+  process.exit(reset.status ?? 1);
+}
+
+const result = spawnSync(executable, [
+  'eval',
+  '--config',
+  configs[agent],
+  '--no-cache',
+  '--repeat',
+  String(repeats),
+  '--output',
+  outputFile,
+], {
+  cwd: evalsDir,
+  env: {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+  },
+  stdio: 'inherit',
+});
+
+if (!fs.existsSync(outputFile)) {
+  process.exit(result.status ?? 1);
+}
+
+const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+const errors = output.results?.stats?.errors || 0;
+if (errors > 0) {
+  console.error(`The eval completed with ${errors} provider error${errors === 1 ? '' : 's'}.`);
+  process.exit(1);
+}
+
+console.log('The eval completed. Assertion failures in the no-skill baseline are expected.');
+process.exit(0);

--- a/.skills/gutenberg-pr-review/references/packages-apis-compatibility.md
+++ b/.skills/gutenberg-pr-review/references/packages-apis-compatibility.md
@@ -1,0 +1,67 @@
+# Packages, APIs, blocks, and compatibility
+
+Use this reference for public exports, package layering, types, metadata, block
+serialization, transforms, Block Supports, and WordPress compatibility.
+
+## Public contracts
+
+- Before changing a public function, component, selector, block, or package,
+  inventory consumers and preserve names, arguments, return types, props,
+  accepted values, context behavior, and durable stored representations.
+- Expose only deliberate documented APIs. Use private/plugin-only mechanisms
+  for unsettled internals; do not introduce new `__experimental` or
+  `__unstable` APIs. Deprecate legacy experimental APIs that already shipped.
+- External consumers must use documented public APIs. Cross-package private
+  access inside the repository must follow `@wordpress/private-apis`.
+- Preserve distinct sentinel meanings explicitly; do not collapse omission,
+  `undefined`, `null`, `false`, and empty values through truthiness.
+- When a documented public API or durable stored contract cannot be preserved
+  directly, provide a supported alternative, deprecation metadata, migration
+  path, correctly classified changelog entry, and a Dev Note when third-party
+  developers are affected. Private APIs do not promise external compatibility;
+  before removing one, inventory and update in-repository consumers,
+  private-API documentation, and the package changelog.
+- Keep runtime exports, JSDoc/TypeScript declarations, generated API docs,
+  READMEs, examples, changelogs, and migration guidance synchronized.
+
+## Package architecture
+
+- Preserve editor layering: `block-editor` stays standalone and independent of
+  higher WordPress screen layers; post-aware screen-neutral behavior belongs in
+  `editor`; screen-specific behavior belongs in `edit-post` or `edit-site`.
+- Keep declarations faithful to runtime values. Prefer precise object,
+  function, promise, generic, key, and optional-value types; do not broaden
+  types merely to silence strict checks.
+- For public package builds, verify `files`, `main`, `module`, `exports`, types,
+  styles, side effects, dependencies, and WordPress script/script-module
+  exposure against the artifacts actually published.
+- Keep supported Node, npm, browser, PHP, and WordPress targets aligned between
+  metadata and CI.
+- Keep compatibility branches and suppressions narrow, documented, and
+  removable; do not let an exception mask unrelated violations.
+
+## Blocks and durable content
+
+- Use schema-valid `block.json` as canonical metadata and register server-side
+  when REST exposure or metadata-managed assets require it.
+- Treat static saved markup as durable. If a change invalidates old content,
+  provide a self-contained deprecated version and fixtures covering parsing,
+  migration, inner blocks, attributes, and serialization—or introduce a new
+  block when migration is not credible.
+- Keep static `save` pure and dependent on attributes. Persist required values
+  or use dynamic server rendering when output depends on external state.
+- Treat edit rendering, static serialization, and dynamic PHP rendering as
+  separate contracts and verify each affected path.
+- Use Block Supports and the appropriate wrapper API:
+  `useBlockProps`, `useBlockProps.save`, or
+  `get_block_wrapper_attributes()`.
+- Define each transform direction explicitly, return valid block objects,
+  withhold inapplicable transforms with `isMatch`, and preserve inner blocks
+  where the target supports them.
+- Express static nesting with `parent`, `ancestor`, and `allowedBlocks`;
+  provide per-instance restrictions through `useInnerBlocksProps`; honor
+  locking and capability selectors before offering structural operations.
+- Preserve original source markup when an invalid block is serialized. Keep
+  recovery or conversion explicit rather than silently rewriting content.
+- When block or `theme.json` metadata shapes change, update and validate the
+  applicable JSON schema.

--- a/.skills/gutenberg-pr-review/references/php-rest-schema.md
+++ b/.skills/gutenberg-pr-review/references/php-rest-schema.md
@@ -1,0 +1,49 @@
+# PHP, REST, schema, and security
+
+Use this reference for `lib/`, REST controllers and routes, schemas,
+permissions, sanitization, escaping, and compatibility shims.
+
+## Compatibility and loading
+
+- Put new compatibility code in the applicable
+  `lib/compat/wordpress-X.Y/` directory and register required version layers in
+  `lib/load.php`.
+- Guard fallback definitions with direct capability checks when functions or
+  classes may already exist.
+- For Gutenberg-to-Core synchronization, identify all eligible PHP files. Keep
+  direct-sync files byte-identical and port only relevant changes from
+  versioned shims to their Core destinations.
+
+## REST contracts
+
+- Register routes with action-specific `permission_callback`s. Resolve the
+  requested resource before capability checks and recheck immediately before a
+  sensitive side effect.
+- Derive endpoint arguments from the item schema where applicable; prepare
+  responses through the controller contract; honor requested fields and
+  contexts; test schema and dispatched response together.
+- When fields change, keep route arguments, server item schema, prepared
+  responses, `_fields` behavior, contexts, and client consumers aligned.
+- A custom `validate_callback` replaces default argument validation. Explicitly
+  retain the schema's type/format validation when adding custom checks.
+- For structured configuration, define exact types, bounds, patterns, enums,
+  and nested schemas. Set `additionalProperties: false` when unknown keys are
+  unsupported; sanitize the decoded container against the schema before
+  applying field-specific sanitization.
+- Verify an unauthorized representative role is rejected before any protected
+  side effect.
+
+## Input and output safety
+
+- Validate caller-supplied remote media URLs with REST schema validation and
+  `wp_http_validate_url()`. Reject unsupported filenames before download, use
+  WordPress download helpers, and propagate failures without creating partial
+  attachments.
+- Build UI with WordPress Element instead of raw HTML when practical. In PHP,
+  escape text, attributes, and URLs for their final sink; use `wp_kses_post()`
+  only when safe HTML is intentionally allowed.
+- Process dynamic CSS declarations with `safecss_filter_attr()`, narrowly
+  allowlist any extensions, then escape for the final HTML attribute context.
+  Test unsafe properties and markup-bearing values.
+- Authorize REST responses, declare permitted field contexts, honor requested
+  fields, and filter assembled data by request context before returning it.

--- a/.skills/gutenberg-pr-review/references/react-data-lifecycle.md
+++ b/.skills/gutenberg-pr-review/references/react-data-lifecycle.md
@@ -1,0 +1,68 @@
+# React, data, runtime lifecycle, and performance
+
+Use this reference for hooks, `@wordpress/data`, `core-data`, preferences,
+asynchronous requests, controlled components, and performance-sensitive code.
+
+## State and selectors
+
+- Read render-driving store data with registry-aware `useSelect`. Retrieve
+  selector functions without a render subscription only for event-time reads.
+- Include changing callback inputs in React/data hook dependency arrays. Return
+  equal, stable selector values for unchanged state to avoid stale data and
+  needless rendering.
+- Use authoritative resolution metadata for the exact selector arguments.
+  Distinguish unresolved, resolved-empty, populated, and failed states.
+- Base updates on current state with pure updater functions. Use
+  `registry.batch` when synchronous store updates must become observable as one
+  final state.
+- Never mutate Redux-backed state or block attribute objects/arrays directly.
+  Respect explicit exceptions such as the Interactivity API's mutable reactive
+  state contract.
+- Use the owning API's stable unique identity when reconciling independently
+  managed items.
+
+## Boundaries and persistence
+
+- Preserve the receiving contract's distinctions among missing, empty, `false`,
+  `null`, and `undefined`. Normalize runtime input at the boundary rather than
+  relying on truthiness.
+- Edit and save entities through `core-data`; serialize block content through
+  `post_content`; persist cross-package preferences in the preferences store.
+  Avoid competing writable copies.
+- Keep preference defaults separate from stored overrides. An override exists
+  whenever its value is not `undefined`, including explicit `false` or `null`.
+- Mark non-serialized block attributes with `role: 'local'`. Replace or revoke
+  upload-preview blob URLs instead of treating them as durable content.
+- Mount the established unsaved-changes warning in editor surfaces that can
+  lose dirty entity records.
+- New stateful `@wordpress/ui` components should support controlled and
+  uncontrolled use consistently: `x`, `defaultX`, and `onXChange`, with the
+  controlled value taking precedence.
+
+## Async lifecycle
+
+- Prevent a stale request from replacing current data. Key resolutions to the
+  active arguments and use `AbortController` when the request itself must be
+  canceled; handle `AbortError`.
+- Show loading only before resolution and empty UI only after it. On save
+  failure, keep recoverable UI open and show the recorded error.
+- Follow pending, queued, and debounced work through unmount, navigation,
+  closing, retries, and cleanup. Cleanup must neither drop an intended edit nor
+  publish unrelated staged edits.
+- Attach DOM listeners to the owning element's `ownerDocument`/`defaultView`,
+  remove the corresponding listener during cleanup, and use `useRefEffect` when
+  the attachment follows a changing element.
+- Follow the Rules of Hooks: stable unconditional ordering, correct
+  dependencies, and no hook calls from events or conditional branches.
+
+## Performance checks
+
+- For `core-data` fetching, pass limiting query arguments to
+  `getEntityRecords`, reuse cached responses, and check resolution with exactly
+  the same arguments.
+- Initialize Interactivity API derived hydration state on the server so initial
+  HTML matches client state.
+- Evaluate editor performance against the base branch with the same environment
+  and repeated suites; compare stable median metrics rather than one run.
+- For production JS, CSS, metadata, or build changes, inspect compressed-size
+  effects and preserve selective loading of unrelated packages.

--- a/.skills/gutenberg-pr-review/references/testing-docs-delivery.md
+++ b/.skills/gutenberg-pr-review/references/testing-docs-delivery.md
@@ -1,0 +1,51 @@
+# Tests, documentation, changelogs, and delivery evidence
+
+Use this reference when behavior, fixtures, snapshots, generated documentation,
+package changelogs, PR testing instructions, or release notes are affected.
+
+## Behavioral verification
+
+- Add proportionate coverage for changed behavior, likely errors, and
+  materially different empty, null, enabled, disabled, and boundary inputs.
+- Make a bug regression test fail on the base revision and pass with the fix.
+- Assert observable user behavior rather than incidental implementation. Guard
+  explicitly against false positives and false negatives.
+- Prefer `user-event` and accessible `getByRole` queries for UI tests. Scope
+  locators to the intended region and rely on strict lazy locators.
+- In Playwright, use web-first assertions and `expect.poll` for changing state
+  rather than eager element handles or arbitrary waits.
+- Test block UI at the integration layer where possible; reserve E2E tests for
+  behavior that requires a full browser environment.
+- Establish state in setup hooks and restore it in teardown that runs after
+  assertion failures. Use supported API utilities for repeated E2E setup while
+  retaining a user-driven test for the workflow itself.
+- For changed visuals, include useful before/after evidence and exercise
+  overflow, long content, empty states, and narrow viewports where relevant.
+
+## Canonical commands and governed files
+
+- Run the applicable repository lint, build, type-check, and focused test
+  commands against the final change. Do not claim broad coverage from an
+  unrelated green check.
+- Regenerate fixtures, snapshots, schemas, docs, and metadata with their
+  repository-provided commands. Review the generated diff and verify a second
+  generation is clean.
+- For handbook changes, synchronize Markdown with `docs/toc.json`, run
+  `npm run docs:build`, commit `docs/manifest.json`, and use repository-absolute
+  links that work in the handbook, GitHub, and npm contexts.
+
+## Changelogs and release communication
+
+- For each relevant package change—including production code, shipped
+  dependencies, public or private API changes, and material package
+  documentation—add an entry under `Unreleased`, link the PR, and classify it
+  under the appropriate release subsection. Omission is acceptable only when
+  the package's optional changelog check and repository evidence establish
+  that the change is too small to warrant an entry.
+- Update public API docs, examples, types, migration notes, and Dev Notes when
+  third-party behavior changes. Documentation must describe the final shipped
+  behavior, not an earlier review iteration.
+- Keep the PR description and testing instructions synchronized with the final
+  diff. State which environments and interaction paths were actually tested.
+- Curate generated plugin release notes for accurate categories, reverted work,
+  and changes excluded from that distribution.

--- a/.skills/gutenberg-pr-review/references/tooling-ci-release.md
+++ b/.skills/gutenberg-pr-review/references/tooling-ci-release.md
@@ -1,0 +1,51 @@
+# Tooling, dependencies, CI, generated artifacts, and releases
+
+Use this reference for workspace packages, build configuration, scripts,
+workflows, generated output, plugin ZIPs, dependency changes, and publishing.
+
+## Dependencies and workspaces
+
+- Declare each imported or executed dependency in the workspace that consumes
+  it, with the correct dependency role. Do not add workspace-only dependencies
+  to the repository root.
+- Update the root `package-lock.json` through supported npm workspace commands.
+  Run dependency, root-dependency, lockfile, and license validators.
+- Register TypeScript project references for typed workspace dependencies and
+  use supported public package entry points.
+- Do not rely on hoisting, the current working directory, or undeclared root
+  packages. Exercise isolated resolution where a build or subprocess could
+  resolve from the wrong owner.
+- Production dependencies shipped by packages with `wpScript` or
+  `wpScriptModuleExports` must be GPLv2-compatible; manually inspect malformed
+  license metadata rather than silently excluding it.
+
+## Builds and generated output
+
+- Treat documented source files as authoritative. Edit the source, run the
+  repository generator, review its diff, and ensure regeneration leaves no
+  uncommitted governed output.
+- Use repository root/workspace commands rather than `npx` for WordPress's
+  local or forked tooling.
+- For package/build changes, build production artifacts and verify declared
+  files, entry points, exports, types, styles, side effects, and WordPress
+  exposure against the output.
+- Keep centralized lint suppressions and dependency-audit exceptions narrowly
+  scoped; prune entries that no longer correspond to a current violation.
+- Run the applicable supported CI target matrix when runtime compatibility or
+  generated output differs by Node, PHP, WordPress, browser, or environment.
+
+## Workflow and release safety
+
+- Validate credentials, permissions, environment variables, version state, and
+  remote prerequisites before version bumps, pushes, publishes, or other
+  irreversible mutations.
+- Analyze concurrency and cancellation. Prevent two runs from publishing the
+  same version and prevent cancellation from leaving a partially mutated
+  release.
+- Make retries idempotent: inspect remote and registry state, resume safely
+  after partial completion, and print actionable recovery commands.
+- Include tool versions in cache/reproducibility inputs when those versions
+  affect generated or installed state; pin versions where alignment matters.
+- Build plugin ZIPs through `bin/build-plugin-zip.sh` from a clean,
+  commit-traceable worktree. Retain the uploaded artifact for the GitHub release
+  and deploy that release asset to WordPress.org rather than rebuilding.

--- a/.skills/gutenberg-pr-review/references/ui-accessibility.md
+++ b/.skills/gutenberg-pr-review/references/ui-accessibility.md
@@ -1,0 +1,83 @@
+# UI, interaction, accessibility, styles, and localization
+
+Use this reference for component, editor UI, keyboard, focus, CSS, responsive,
+animation, date/time, RTL, or translatable-string changes.
+
+## Semantics and keyboard
+
+- Give changed controls meaningful accessible names. Keep labels, tooltips,
+  advertised shortcuts, and actions consistent; expose pressed, busy, disabled,
+  destructive, and validation states accurately.
+- Exercise affected flows with keyboard input alone. Verify Tab/Shift+Tab,
+  pattern-specific arrows, Enter/Space, Escape, clearing keys, intermediate
+  focus transitions, and the final action.
+- Ignore keyboard events already consumed by a nested widget and IME composition
+  events. Prevent the browser default only when the control performs its
+  replacement action.
+- When arrow-managed items leave the Tab sequence, use the appropriate composite
+  role and one coherent focus model. Define the initial item, boundaries, and
+  disabled-item behavior.
+- For overlay changes, verify component choice and behavior. Use `Dialog` for a
+  short, focused, context-light task with one primary action; `AlertDialog` for
+  destructive or irreversible decisions; and `Drawer` for contextual editing,
+  multiple sections, or drill-down flows. Do not nest dialogs. Test initial
+  focus, dismissal, required containment, focus restoration, viewport behavior,
+  and mobile expansion. For Popovers, also test anchoring and collision behavior.
+- Announce meaningful dynamic updates through `@wordpress/a11y` when native
+  semantics will not announce them. Prefer concise polite announcements and
+  reserve assertive announcements for genuinely interruptive updates.
+
+## Interaction states
+
+- Treat editable-control values as raw input. Validate before committing to a
+  constrained model, preserve required/empty semantics, and associate errors
+  without replacing useful help text.
+- For async mutations, prevent duplicate activation, set busy state before the
+  await, show success only after settlement, surface the real error, and clear
+  busy state in a `finally` path.
+- Do not expose mutation controls until authoritative permissions and feature
+  constraints resolve. Disallowed actions must be inert.
+- For destructive changes, state what will be affected, confirm irreversible
+  actions with explicit labels, and prevent repeated confirmation while pending.
+  In a Drawer requiring explicit choice, omit the close icon and provide
+  explicit Cancel and Confirm actions.
+- Make consequential publication, placement, shared/global, structural, or
+  reusable scope apparent before the edit completes.
+- For RichText changes, cover no selection, ranges, collapsed carets, format
+  boundaries, split/merge, empty values, and the complete resulting selection
+  and format state.
+
+## Visual and responsive behavior
+
+- Verify changed UI with pointer and keyboard interaction and relevant focus,
+  hover, active, disabled, and forced-colors states.
+- Keep overlays fully within the viewport. Test anchor changes, placement,
+  flipping, resizing, shifting, portal slots, narrow screens, overflow, and
+  long content; do not combine incompatible positioning modes.
+- Keep essential block controls available in the edit view or toolbar rather
+  than only in the dismissible Settings Sidebar.
+- Respect reduced-motion preferences; interaction availability must not depend
+  on an animation completing.
+- Scope component classes to their owner and use package/directory prefixes.
+  Apply block wrapper APIs so editor, saved, and dynamic markup receive the
+  intended generated classes.
+- Classify block CSS correctly: `editorStyle` for editor-only, `style` for
+  editor and frontend, and `viewStyle` for frontend-only. Account for iframe
+  loading and verify existing blocks remain styled.
+- For `theme.json` changes, check schema validity, core/theme/user precedence,
+  inheritance, block support gates, generated preset names, and enqueued CSS.
+
+## Internationalization
+
+- Translate application-supplied visible and assistive strings with the owning
+  text domain. Keep machine identifiers separate from localized labels.
+- Keep source strings statically extractable. Use `_n`/`_nx` with the raw
+  numeric count, `sprintf` with matching arguments, contextual `_x`/`_nx` when
+  needed, and adjacent translator comments describing substitutions.
+- Do not translate inside block `save`; render dynamic labels on the server or
+  persist user-authored values.
+- For date/time changes, define input, stored instant, and output timezone.
+  Use `@wordpress/date` and test named site zones, fixed offsets, DST, locale
+  formatting, and relevant calendar boundaries.
+- Test direction-sensitive behavior in LTR and RTL. Derive UI direction from
+  `@wordpress/i18n` and content direction from the relevant semantic element.


### PR DESCRIPTION
## What?

Adds the `evals/` package and retained audit artifacts for the Gutenberg PR review skill introduced in #80862.

The evals include promptfoo configs for Codex and Claude Agent SDK runs, three seeded Gutenberg review fixtures, a deterministic JavaScript grader for expected findings, and scripts to reset/clean local eval workspaces.

The audit artifacts under `.skills/gutenberg-pr-review/evals/audit/` include:

- audit methodology and totals in `FINAL_AUDIT_SUMMARY.md`
- retained collection, audit, reduction, validation, editorial, and forward-test scripts
- retained prompts used by each audit/reduction/validation stage
- forward-test result snippets plus the compact run summary/log
- independent forward-test evaluation
- trunk-delta validation notes

## Why?

This keeps the base skill PR focused on runtime guidance while making the evaluation harness and provenance artifacts available in a stacked PR so reviewers can decide whether they belong in the repository.

## Notes

The copied audit artifacts were normalized for repository use: private machine paths were replaced with checked-in relative paths, generated data/cache/install files were excluded, and markdown formatting was adjusted to pass the repo lint rules without changing the substantive evidence.

## Testing Instructions

- `git diff --check scruffian/add/gutenberg-pr-review-skill...HEAD`
- `./node_modules/.bin/markdownlint .skills/gutenberg-pr-review/evals/fixtures/*/PR_CONTEXT.md`
- `./node_modules/.bin/markdownlint .skills/gutenberg-pr-review/evals/audit/*.md .skills/gutenberg-pr-review/evals/audit/forward-test-results/*.md .skills/gutenberg-pr-review/evals/fixtures/*/PR_CONTEXT.md`
- `node --check .skills/gutenberg-pr-review/evals/scripts/run-eval.mjs`
- `node --check .skills/gutenberg-pr-review/evals/scripts/reset-workspaces.mjs`
- `node --check .skills/gutenberg-pr-review/evals/scripts/clean-workspaces.mjs`
- `node --check .skills/gutenberg-pr-review/evals/assertions/grade-gutenberg-review.cjs`
- `python3 -m py_compile .skills/gutenberg-pr-review/evals/audit/*.py`
- JSON parse check for `.skills/gutenberg-pr-review/evals/audit/forward-test-summary.json` and `.skills/gutenberg-pr-review/evals/audit/forward_test_run.log`
- From `.skills/gutenberg-pr-review/evals`: `npm ci`
- From `.skills/gutenberg-pr-review/evals`: `npm run validate:codex`
- From `.skills/gutenberg-pr-review/evals`: `npm run validate:claude`
- From `.skills/gutenberg-pr-review/evals`: `npm run reset && npm run clean`

I did not run the full model evals. `npm ci` reports 13 high-severity audit findings in the eval tooling dependency tree.