### PR TITLE
Port the shared Vitest test environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47234,6 +47234,57 @@
 				}
 			}
 		},
+		"node_modules/vite-plugin-commonjs": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/vite-plugin-commonjs/-/vite-plugin-commonjs-0.10.4.tgz",
+			"integrity": "sha512-eWQuvQKCcx0QYB5e5xfxBNjQKyrjEWZIR9UOkOV6JAgxVhtbZvCOF+FNC2ZijBJ3U3Px04ZMMyyMyFBVWIJ5+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.12.1",
+				"magic-string": "^0.30.11",
+				"vite-plugin-dynamic-import": "^1.6.0"
+			}
+		},
+		"node_modules/vite-plugin-commonjs/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/vite-plugin-dynamic-import": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.6.0.tgz",
+			"integrity": "sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.12.1",
+				"es-module-lexer": "^1.5.4",
+				"fast-glob": "^3.3.2",
+				"magic-string": "^0.30.11"
+			}
+		},
+		"node_modules/vite-plugin-dynamic-import/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/vite/node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -54136,6 +54187,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@babel/core": "^7.29.7",
 				"@emotion/jest": "^11.14.2",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.0",
@@ -54143,8 +54195,11 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 				"@wordpress/scripts": "file:../../packages/scripts",
+				"@wordpress/video-conversion": "file:../../packages/video-conversion",
+				"@wordpress/vips": "file:../../packages/vips",
 				"babel-jest": "^30.4.1",
 				"babel-plugin-transform-import-meta": "^2.3.3",
 				"client-zip": "^2.4.5",
@@ -54159,7 +54214,9 @@
 				"resize-observer-polyfill": "^1.5.1",
 				"snapshot-diff": "^0.10.0",
 				"timezone-mock": "^1.3.6",
-				"vitest": "^4.1.10"
+				"vite-plugin-commonjs": "^0.10.4",
+				"vitest": "^4.1.10",
+				"yargs": "^17.7.2"
 			}
 		},
 		"test/unit/node_modules/@jest/schemas": {

--- a/test/unit/config/fixtures/module.wasm
+++ b/test/unit/config/fixtures/module.wasm
@@ -1,0 +1,1 @@
+This fixture must be replaced by the Vitest WASM alias before it is loaded.

--- a/test/unit/config/fixtures/setup.module.scss
+++ b/test/unit/config/fixtures/setup.module.scss
@@ -1,0 +1,1 @@
+// The Vitest CSS proxy replaces this module during tests.

--- a/test/unit/config/global-mocks.vitest.js
+++ b/test/unit/config/global-mocks.vitest.js
@@ -1,0 +1,162 @@
+/**
+ * Node dependencies
+ */
+import { Blob as BlobPolyfill, File as FilePolyfill } from 'node:buffer';
+import { TextDecoder, TextEncoder } from 'node:util';
+
+/**
+ * External dependencies
+ */
+import ResizeObserver from 'resize-observer-polyfill';
+import timezoneMock from 'timezone-mock';
+import { vi } from 'vitest';
+
+const OriginalDate = globalThis.Date;
+timezoneMock.options( {
+	fallbackFn: ( parameter ) => {
+		if ( parameter instanceof OriginalDate ) {
+			return new timezoneMock._Date( parameter.valueOf() );
+		}
+
+		throw new Error(
+			`Unhandled type passed to MockDate constructor: ${ typeof parameter }`
+		);
+	},
+} );
+
+if ( typeof globalThis.structuredClone === 'undefined' ) {
+	globalThis.structuredClone = ( value ) =>
+		JSON.parse( JSON.stringify( value ) );
+}
+
+vi.mock( '@wordpress/compose', async () => ( {
+	...( await vi.importActual( '@wordpress/compose' ) ),
+	useViewportMatch: vi.fn(),
+} ) );
+
+vi.mock( '@wordpress/block-editor/src/hooks/list-view', () => ( {
+	LIST_VIEW_SUPPORT_KEY: 'listView',
+	hasListViewSupport: vi.fn( () => false ),
+	ListViewPanel: vi.fn( () => null ),
+	default: {
+		edit: vi.fn( () => null ),
+		hasSupport: vi.fn( () => false ),
+		attributeKeys: [],
+	},
+} ) );
+
+vi.mock( 'client-zip', () => ( {
+	downloadZip: vi.fn(),
+} ) );
+
+globalThis.ResizeObserver = ResizeObserver;
+
+class FakeDOMRectList extends Array {
+	item( index ) {
+		return this[ index ] ?? null;
+	}
+}
+
+function hasAssociatedLayoutBox( element ) {
+	if ( ! element.isConnected ) {
+		return false;
+	}
+
+	let current = element;
+	while ( current ) {
+		if ( current.hidden || current.style?.display === 'none' ) {
+			return false;
+		}
+
+		if ( current === element && current.style?.display === 'contents' ) {
+			return false;
+		}
+
+		current = current.parentElement;
+	}
+
+	return true;
+}
+
+if ( typeof window !== 'undefined' ) {
+	window.wp = window.wp || {};
+	window.wp.oldEditor = {};
+
+	if ( ! globalThis.HTMLElement.prototype.getAnimations ) {
+		globalThis.HTMLElement.prototype.getAnimations = () => [];
+	}
+
+	if ( ! globalThis.CSS ) {
+		globalThis.CSS = {};
+	}
+	if ( ! globalThis.CSS.supports ) {
+		globalThis.CSS.supports = vi.fn( () => false );
+	}
+
+	if ( ! window.DOMRect ) {
+		window.DOMRect = class DOMRect {};
+	}
+
+	globalThis.Element.prototype.scrollIntoView = vi.fn();
+	globalThis.Element.prototype.getClientRects = function () {
+		const rects = [];
+		if ( hasAssociatedLayoutBox( this ) ) {
+			rects.push( {
+				bottom: 1,
+				height: 1,
+				left: 0,
+				right: 1,
+				top: 0,
+				width: 1,
+				x: 0,
+				y: 0,
+			} );
+		}
+
+		return new FakeDOMRectList( ...rects );
+	};
+}
+
+if ( ! globalThis.TextDecoder ) {
+	globalThis.TextDecoder = TextDecoder;
+}
+if ( ! globalThis.TextEncoder ) {
+	globalThis.TextEncoder = TextEncoder;
+}
+
+globalThis.Blob = BlobPolyfill;
+globalThis.File = FilePolyfill;
+
+vi.mock( '@testing-library/user-event', async () => {
+	if ( typeof globalThis.window === 'undefined' ) {
+		return {};
+	}
+
+	const actual = await vi.importActual( '@testing-library/user-event' );
+	const patchedUserEvent = {
+		...actual.userEvent,
+		setup( ...args ) {
+			const user = actual.userEvent.setup( ...args );
+			const { focus, blur } = globalThis.HTMLElement.prototype;
+			Object.defineProperties( globalThis.HTMLElement.prototype, {
+				focus: {
+					configurable: true,
+					value: focus,
+					writable: true,
+				},
+				blur: {
+					configurable: true,
+					value: blur,
+					writable: true,
+				},
+			} );
+			return user;
+		},
+	};
+
+	return {
+		...actual,
+		userEvent: patchedUserEvent,
+		default: patchedUserEvent,
+	};
+} );

--- a/test/unit/config/setup-globals.vitest.js
+++ b/test/unit/config/setup-globals.vitest.js
@@ -1,0 +1,45 @@
+// Run all tests with development tools enabled.
+// eslint-disable-next-line @wordpress/wp-global-usage
+globalThis.SCRIPT_DEBUG = true;
+
+if ( typeof globalThis.window !== 'undefined' ) {
+	globalThis.window.tinyMCEPreInit = {
+		baseURL: 'about:blank',
+	};
+
+	globalThis.window.setImmediate = function ( callback ) {
+		return setTimeout( callback, 0 );
+	};
+
+	globalThis.window.requestIdleCallback = function requestIdleCallback(
+		callback
+	) {
+		const start = Date.now();
+
+		return setTimeout(
+			() =>
+				callback( {
+					didTimeout: false,
+					timeRemaining: () =>
+						Math.max( 0, 50 - ( Date.now() - start ) ),
+				} ),
+			0
+		);
+	};
+
+	globalThis.window.cancelIdleCallback = function cancelIdleCallback(
+		handle
+	) {
+		return clearTimeout( handle );
+	};
+
+	globalThis.window.matchMedia = () => ( {
+		matches: false,
+		addListener: () => {},
+		addEventListener: () => {},
+		removeListener: () => {},
+		removeEventListener: () => {},
+	} );
+
+	globalThis.window.userSettings = { uid: 1 };
+}

--- a/test/unit/config/setup.vitest.test.jsx
+++ b/test/unit/config/setup.vitest.test.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { decodeEntities } from '@wordpress/html-entities';
+import { convertGifToVideo } from '@wordpress/video-conversion/worker';
+import { vipsResizeImage } from '@wordpress/vips/worker';
+
+/**
+ * Internal dependencies
+ */
+import styles from './fixtures/setup.module.scss';
+import * as wasmModule from './fixtures/module.wasm';
+
+describe( 'Vitest repository setup', () => {
+	it( 'preserves aliases, DOM globals, CSS modules, and worker stubs', () => {
+		render( <div className={ styles.primaryAction }>Setup content</div> );
+
+		expect( screen.getByText( 'Setup content' ) ).toHaveClass(
+			'style-primary-action'
+		);
+		expect( decodeEntities( '&amp;' ) ).toBe( '&' );
+		// eslint-disable-next-line @wordpress/wp-global-usage -- This compatibility test verifies the test-only global.
+		expect( globalThis.SCRIPT_DEBUG ).toBe( true );
+		expect( window.tinyMCEPreInit.baseURL ).toBe( 'about:blank' );
+		expect( globalThis.CSS.supports( 'selector(:focus-visible)' ) ).toBe(
+			false
+		);
+		expect(
+			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches
+		).toBe( true );
+		expect( vi.isMockFunction( convertGifToVideo ) ).toBe( true );
+		expect( vi.isMockFunction( vipsResizeImage ) ).toBe( true );
+		expect( Object.keys( wasmModule ) ).toEqual( [] );
+	} );
+
+	it( 'cleans up Testing Library renders between tests', () => {
+		expect( screen.queryByText( 'Setup content' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/test/unit/config/style-mock.vitest.js
+++ b/test/unit/config/style-mock.vitest.js
@@ -1,0 +1,23 @@
+function toKebabCase( value ) {
+	return value
+		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
+		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
+		.replace( /[^a-zA-Z0-9]+/g, '-' )
+		.replace( /^-|-$/g, '' )
+		.toLowerCase();
+}
+
+const styles = new Proxy(
+	{},
+	{
+		get( target, property ) {
+			if ( typeof property === 'string' && property !== '__esModule' ) {
+				return `style-${ toKebabCase( property ) }`;
+			}
+
+			return Reflect.get( target, property );
+		},
+	}
+);
+
+export default styles;

--- a/test/unit/config/testing-library.vitest.js
+++ b/test/unit/config/testing-library.vitest.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/vitest';
+// eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach( cleanup );

--- a/test/unit/config/video-conversion-worker-code-stub.vitest.js
+++ b/test/unit/config/video-conversion-worker-code-stub.vitest.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { vi } from 'vitest';
+
+export const convertGifToVideo = vi.fn();
+export const cancelGifToVideoOperations = vi.fn();
+export const terminateVideoConversionWorker = vi.fn();

--- a/test/unit/config/vips-worker-code-stub.vitest.js
+++ b/test/unit/config/vips-worker-code-stub.vitest.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { vi } from 'vitest';
+
+export const vipsConvertImageFormat = vi.fn();
+export const vipsCompressImage = vi.fn();
+export const vipsHasTransparency = vi.fn();
+export const vipsResizeImage = vi.fn();
+export const vipsRotateImage = vi.fn();
+export const vipsCancelOperations = vi.fn();
+export const terminateVipsWorker = vi.fn();

--- a/test/unit/config/yargs.vitest.js
+++ b/test/unit/config/yargs.vitest.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+
+// Match the CommonJS `yargs` entry point, which is initialized with argv.
+export default yargs( hideBin( process.argv ) );

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -22,7 +22,7 @@ const testMigration = require( './test-migration.json' );
 const escapeRegExp = ( value ) =>
 	value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 const vitestTestPathIgnorePatterns = [
-	...testMigration.vitest.files.map(
+	...[ ...testMigration.vitest.files, ...testMigration.added.vitest ].map(
 		( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$`
 	),
 	...testMigration.vitest.directories.map(

--- a/test/unit/mocks/match-media.vitest.js
+++ b/test/unit/mocks/match-media.vitest.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { afterAll, beforeAll, vi } from 'vitest';
+
+if ( typeof window !== 'undefined' ) {
+	const originalMatchMedia = window.matchMedia;
+	const mockedMatchMedia = vi.fn( ( query ) => {
+		if ( /prefers-reduced-motion/.test( query ) ) {
+			return {
+				...originalMatchMedia( query ),
+				matches: true,
+			};
+		}
+
+		return originalMatchMedia( query );
+	} );
+
+	beforeAll( () => {
+		window.matchMedia = vi.fn( mockedMatchMedia );
+	} );
+
+	afterAll( () => {
+		window.matchMedia = originalMatchMedia;
+	} );
+}

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -20,6 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.29.7",
 		"@emotion/jest": "^11.14.2",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.0",
@@ -27,8 +28,11 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 		"@wordpress/scripts": "file:../../packages/scripts",
+		"@wordpress/video-conversion": "file:../../packages/video-conversion",
+		"@wordpress/vips": "file:../../packages/vips",
 		"babel-jest": "^30.4.1",
 		"babel-plugin-transform-import-meta": "^2.3.3",
 		"client-zip": "^2.4.5",
@@ -43,7 +47,9 @@
 		"resize-observer-polyfill": "^1.5.1",
 		"snapshot-diff": "^0.10.0",
 		"timezone-mock": "^1.3.6",
-		"vitest": "^4.1.10"
+		"vite-plugin-commonjs": "^0.10.4",
+		"vitest": "^4.1.10",
+		"yargs": "^17.7.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,6 +10,6 @@
 	"retired": [],
 	"added": {
 		"jest": [],
-		"vitest": []
+		"vitest": [ "test/unit/config/setup.vitest.test.jsx" ]
 	}
 }

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url';
 /**
  * External dependencies
  */
+import { transformAsync } from '@babel/core';
+import globPackage from 'glob';
+import commonjs from 'vite-plugin-commonjs';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -26,13 +29,144 @@ const testMigration = JSON.parse(
 	)
 );
 const vitestTests = getVitestTests( ROOT_DIR, testMigration );
+const { sync: glob } = globPackage;
 
 // Preserve Jest's repository-root configuration discovery and default timezone.
 process.chdir( ROOT_DIR );
 process.env.TZ = 'UTC';
 
+const transpiledPackageNames = glob(
+	path.join( ROOT_DIR, 'packages/*/src/index.{js,ts,tsx}' )
+).map( ( fileName ) => {
+	const relative = path.relative( ROOT_DIR, fileName );
+	return relative.split( path.sep )[ 1 ];
+} );
+
+function wordpressBabelTransform() {
+	return {
+		name: 'wordpress-babel-transform',
+		enforce: 'pre',
+		async transform( source, id ) {
+			const filename = id.split( '?', 1 )[ 0 ];
+
+			if (
+				! filename.startsWith( `${ ROOT_DIR }${ path.sep }` ) ||
+				filename.includes( `${ path.sep }node_modules${ path.sep }` ) ||
+				! /\.m?[jt]sx?$/.test( filename )
+			) {
+				return;
+			}
+
+			const result = await transformAsync( source, {
+				caller: {
+					name: 'vite',
+					supportsDynamicImport: true,
+					supportsExportNamespaceFrom: true,
+					supportsStaticESM: true,
+					supportsTopLevelAwait: true,
+				},
+				envName: 'test',
+				filename,
+				root: ROOT_DIR,
+				sourceMaps: true,
+			} );
+
+			if ( ! result?.code ) {
+				return;
+			}
+
+			return {
+				code: result.code,
+				map: result.map,
+			};
+		},
+	};
+}
+
 export default defineConfig( {
 	root: ROOT_DIR,
+	plugins: [
+		wordpressBabelTransform(),
+		commonjs( {
+			filter: ( id ) =>
+				[
+					`${ ROOT_DIR }/packages/block-serialization-spec-parser/parser.js`,
+					`${ ROOT_DIR }/packages/env/lib/`,
+					`${ ROOT_DIR }/packages/project-management-automation/lib/`,
+					`${ ROOT_DIR }/packages/scripts/utils/`,
+					`${ ROOT_DIR }/tools/release/commands/changelog.js`,
+				].some( ( directory ) => id.startsWith( directory ) ) &&
+				! id.endsWith( '/packages/scripts/utils/license.js' ),
+		} ),
+	],
+	resolve: {
+		alias: [
+			{
+				find: /^.*\.(?:css|scss)$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/style-mock.vitest.js'
+				),
+			},
+			{
+				find: /^yargs$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/yargs.vitest.js'
+				),
+			},
+			{
+				find: '@wordpress/vips/worker',
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/vips-worker-code-stub.vitest.js'
+				),
+			},
+			{
+				find: '@wordpress/video-conversion/worker',
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/video-conversion-worker-code-stub.vitest.js'
+				),
+			},
+			{
+				find: /^@wordpress\/([^/]+)\/src\/(.+)$/,
+				replacement: path.join( ROOT_DIR, 'packages/$1/src/$2' ),
+			},
+			{
+				find: new RegExp(
+					`^@wordpress/(${ transpiledPackageNames.join( '|' ) })$`
+				),
+				replacement: path.join( ROOT_DIR, 'packages/$1/src' ),
+			},
+			{
+				find: '@wordpress/theme/design-tokens.js',
+				replacement: path.join(
+					ROOT_DIR,
+					'packages/theme/prebuilt/js/design-tokens.mjs'
+				),
+			},
+			{
+				find: /^@wordpress\/block-library\/build-module\/(.*)\.mjs$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'packages/block-library/src/$1.js'
+				),
+			},
+			{
+				find: /.+\.wasm$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/wasm-stub.js'
+				),
+			},
+		],
+	},
+	server: {
+		deps: {
+			external: [ /^@babel\// ],
+		},
+	},
 	test: {
 		environment: 'jsdom',
 		environmentOptions: {
@@ -63,6 +197,13 @@ export default defineConfig( {
 			hooks: 'list',
 			setupFiles: 'list',
 		},
+		setupFiles: [
+			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/gutenberg-env.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/mocks/match-media.vitest.js' ),
+		],
 		snapshotFormat: {
 			escapeString: false,
 			printBasicPrototype: false,


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80861; review only the third commit in this PR.

**TL;DR — shared environment parity:** Ports the repository's shared globals, package-source aliases, Babel transform, explicit CommonJS exceptions, CSS proxy, worker/WASM stubs, DOM shims, reduced-motion mock, and Testing Library cleanup to Vitest.

## Why?

Package migrations need one tested compatibility layer before broader groups move. Without it, individual PRs would each rediscover differences in module resolution, generated workers, CSS modules, DOM visibility, or cleanup behavior.

## How?

- Resolves Gutenberg-owned packages to source and preserves the theme, block-library, worker, WASM, CSS, and yargs mappings.
- Applies the repository Babel configuration and keeps the remaining CommonJS source exceptions in an explicit allowlist.
- Ports browser globals, polyfills, user-event prototype repair, and reduced-motion behavior with explicit Vitest imports.
- Registers `@testing-library/jest-dom/vitest` and manual `cleanup` because Vitest globals remain disabled.
- Adds a Vitest-only compatibility test covering source aliases, jsdom globals, CSS class names, worker mocks, WASM replacement, and cross-test DOM cleanup.
- Declares every package imported by the private test workspace directly.

No baseline test changes runner in this PR, and no snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 995 Jest baseline files, 1 Vitest baseline file, and 1 added Vitest compatibility file.
2. Run `npm run test:unit:vitest`; expect 2 files and 6 tests to pass.
3. Run all four Vitest CI shards with `--passWithNoTests` and confirm the two populated shards pass.
4. Run a remaining Jest test, for example `npm run test:unit -- --runInBand packages/api-fetch/src/test/exports.test.ts`.

Locally verified routing, the full migrated Vitest partition, all four Vitest shards, a remaining Jest test, strict ESLint, package/lockfile lint, CSS lint, formatting, and pre-commit checks. The complete remaining Jest partition is covered by the stacked CI workflow.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the Jest behavior, implement the compatibility layer, and run the reported verification. The resulting changes and claims were reviewed against the repository configuration.