### PR TITLE
Port console checks and CI reporting to Vitest

### DIFF
--- a/test/unit/config/console.vitest.js
+++ b/test/unit/config/console.vitest.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { afterEach, beforeAll, beforeEach, expect, vi } from 'vitest';
+
+const supportedMatchers = {
+	error: 'toHaveErrored',
+	info: 'toHaveInformed',
+	log: 'toHaveLogged',
+	warn: 'toHaveWarned',
+};
+
+function createErrorMessage( state, spyInfo ) {
+	const { spy, pass, calls, matcherName, methodName, expected } = spyInfo;
+	const hint = pass ? `.not${ matcherName }` : matcherName;
+	const message = pass
+		? `Expected mock function not to be called but it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`
+		: `Expected mock function to be called${
+				expected
+					? ` with:\n${ state.utils.printExpected( expected ) }\n`
+					: '.'
+		  }\nbut it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`;
+
+	return () =>
+		`${ state.utils.matcherHint( hint, spy.getMockName() ) }` +
+		'\n\n' +
+		message +
+		'\n\n' +
+		`console.${ methodName }() should not be used unless explicitly expected\n` +
+		'See https://www.npmjs.com/package/@wordpress/vitest-console for details.';
+}
+
+function createSpyInfo( state, spy, matcherName, methodName, expected ) {
+	const calls = spy.mock.calls;
+	const pass = expected
+		? JSON.stringify( calls ).includes( JSON.stringify( expected ) )
+		: calls.length > 0;
+
+	return {
+		pass,
+		message: createErrorMessage( state, {
+			spy,
+			pass,
+			calls,
+			matcherName,
+			methodName,
+			expected,
+		} ),
+	};
+}
+
+expect.extend(
+	Object.entries( supportedMatchers ).reduce(
+		( result, [ methodName, matcherName ] ) => {
+			const matcherNameWith = `${ matcherName }With`;
+
+			return {
+				...result,
+				[ matcherName ]( received ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherName }`,
+						methodName
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+				[ matcherNameWith ]( received, ...expected ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherNameWith }`,
+						methodName,
+						expected
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+			};
+		},
+		{}
+	)
+);
+
+vi.spyOn( console, 'groupCollapsed' ).mockImplementation( () => undefined );
+vi.spyOn( console, 'groupEnd' ).mockImplementation( () => undefined );
+
+function setConsoleMethodSpy( [ methodName, matcherName ] ) {
+	const spy = vi
+		.spyOn( console, methodName )
+		.mockName( `console.${ methodName }` );
+
+	function resetSpy() {
+		spy.mockReset();
+		spy.mockImplementation( () => undefined );
+		spy.assertionsNumber = 0;
+	}
+
+	function assertExpectedCalls() {
+		if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
+			expect( console ).not[ matcherName ]();
+		}
+	}
+
+	beforeAll( resetSpy );
+	beforeEach( () => {
+		assertExpectedCalls();
+		resetSpy();
+	} );
+	afterEach( assertExpectedCalls );
+}
+
+Object.entries( supportedMatchers ).forEach( setConsoleMethodSpy );

--- a/test/unit/config/console.vitest.test.js
+++ b/test/unit/config/console.vitest.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+describe( 'Vitest console matchers', () => {
+	describe.each( [
+		[ 'error', 'toHaveErrored' ],
+		[ 'info', 'toHaveInformed' ],
+		[ 'log', 'toHaveLogged' ],
+		[ 'warn', 'toHaveWarned' ],
+	] )( 'console.%s', ( methodName, matcherName ) => {
+		const matcherNameWith = `${ matcherName }With`;
+		const message = `This is ${ methodName }!`;
+
+		test( `${ matcherName } accepts an expected console call`, () => {
+			console[ methodName ]( message );
+			expect( console )[ matcherName ]();
+		} );
+
+		test( `${ matcherName } rejects a missing console call`, () => {
+			expect( console ).not[ matcherName ]();
+			expect( () => expect( console )[ matcherName ]() ).toThrow(
+				'Expected mock function to be called.'
+			);
+		} );
+
+		test( `${ matcherNameWith } accepts matching arguments`, () => {
+			console[ methodName ]( message );
+			expect( console )[ matcherNameWith ]( message );
+		} );
+
+		test( `${ matcherNameWith } rejects non-matching arguments`, () => {
+			console[ methodName ]( 'Unknown message.' );
+			console[ methodName ]( message, 'Unknown param.' );
+
+			expect( console ).not[ matcherNameWith ]( message );
+			expect( () =>
+				expect( console )[ matcherNameWith ]( message )
+			).toThrow(
+				/Expected mock function to be called with:.*but it was called with:.*Unknown param./s
+			);
+		} );
+
+		test( 'tracks matcher assertions for lifecycle validation', () => {
+			const spy = console[ methodName ];
+
+			expect( spy.assertionsNumber ).toBe( 0 );
+			console[ methodName ]( message );
+			expect( console )[ matcherName ]();
+			expect( spy.assertionsNumber ).toBe( 1 );
+			expect( console )[ matcherNameWith ]( message );
+			expect( spy.assertionsNumber ).toBe( 2 );
+		} );
+	} );
+
+	it( 'does not treat collapsed console groups as log calls', () => {
+		console.groupCollapsed( 'Details' );
+		console.groupEnd();
+
+		expect( console ).not.toHaveLogged();
+	} );
+} );
+
+/* eslint-enable no-console */

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,6 +10,9 @@
 	"retired": [],
 	"added": {
 		"jest": [],
-		"vitest": [ "test/unit/config/setup.vitest.test.jsx" ]
+		"vitest": [
+			"test/unit/config/console.vitest.test.js",
+			"test/unit/config/setup.vitest.test.jsx"
+		]
 	}
 }

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -30,6 +30,23 @@ const testMigration = JSON.parse(
 );
 const vitestTests = getVitestTests( ROOT_DIR, testMigration );
 const { sync: glob } = globPackage;
+const reporters = [ 'default' ];
+
+if ( process.env.GITHUB_ACTIONS === 'true' ) {
+	reporters.push( 'github-actions' );
+}
+if (
+	process.env.CI &&
+	process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
+) {
+	reporters.push( [
+		'@flakiness/vitest',
+		{
+			duplicates: 'rename',
+			flakinessProject: 'WordPress/gutenberg',
+		},
+	] );
+}
 
 // Preserve Jest's repository-root configuration discovery and default timezone.
 process.chdir( ROOT_DIR );
@@ -178,21 +195,7 @@ export default defineConfig( {
 		include: vitestTests,
 		includeTaskLocation: true,
 		passWithNoTests: false,
-		reporters:
-			process.env.CI &&
-			process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
-				? [
-						'default',
-						'github-actions',
-						[
-							'@flakiness/vitest',
-							{
-								duplicates: 'rename',
-								flakinessProject: 'WordPress/gutenberg',
-							},
-						],
-				  ]
-				: [ 'default' ],
+		reporters,
 		sequence: {
 			hooks: 'list',
 			setupFiles: 'list',
@@ -201,6 +204,7 @@ export default defineConfig( {
 			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/gutenberg-env.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/mocks/match-media.vitest.js' ),
 		],


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80864; review only the fourth commit in this PR.

**TL;DR — console and reporting parity:** Adds private Vitest console matchers with lifecycle enforcement and configures GitHub annotations independently from the WordPress-only Flakiness.io reporter.

## Why?

The remaining tests rely on unexpected console calls failing the test and on explicit assertions for intentional logging. CI also needs source-linked GitHub annotations while preserving the existing Flakiness.io project identity.

## How?

- Ports `toHaveErrored`, `toHaveInformed`, `toHaveLogged`, `toHaveWarned`, and their `*With` variants using Vitest's public `expect.extend` and matcher context APIs.
- Resets and validates console spies around each test and suppresses collapsed console groups so they do not become unexpected log calls.
- Adds compatibility coverage for all matcher forms, failure messages, assertion tracking, and collapsed groups.
- Enables the built-in `github-actions` reporter whenever the run is in GitHub Actions.
- Keeps `@flakiness/vitest` limited to official `WordPress/gutenberg` CI with the existing project and duplicate naming.

The Jest console package remains active for the Jest partition. No baseline test changes runner, and no snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 995 Jest baseline files, 1 Vitest baseline file, and 2 added Vitest compatibility files.
2. Run `npm run test:unit:vitest`; expect 3 files and 27 tests to pass.
3. Run all four Vitest CI shards with `--passWithNoTests` and confirm every populated shard passes.
4. Inspect a GitHub Actions run and confirm failures would use the built-in annotation reporter while Flakiness.io remains scoped to the official repository.

Locally verified routing, the complete migrated Vitest partition, all four Vitest shards, strict ESLint, formatting, and pre-commit checks. The remaining Jest partition is unchanged and covered by stacked CI.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the existing Jest console behavior, verify current Vitest matcher/reporter APIs, implement the compatibility layer, and run the reported checks. The resulting changes and claims were reviewed against the repository configuration.