### PR TITLE
Components: Opt-in ConfirmDialog for auto-documentation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,6 +35,10 @@
 -   `ToggleGroupControl`: Type the `disabled` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `DropdownContentWrapper`: Type the `children` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 
+### Documentation
+
+-   `ConfirmDialog`: Opt into auto-generated README documentation from types and JSDoc ([#80866](https://github.com/WordPress/gutenberg/pull/80866)).
+
 ### Internal
 
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -1,33 +1,38 @@
-# `ConfirmDialog`
+# ConfirmDialog
 
-<div class="callout callout-alert">
-This feature is still experimental. "Experimental" means this is an early implementation subject to drastic and breaking changes.
-</div>
+<!-- This file is generated automatically and cannot be edited directly. Make edits via TypeScript types and TSDocs. -->
 
-`ConfirmDialog` is built on top of [`Modal`](/packages/components/src/modal/README.md) and displays a confirmation dialog, with _confirm_ and _cancel_ buttons.
+<p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-confirmdialog--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
 
-The dialog is confirmed by clicking the _confirm_ button or by pressing the `Enter` key. It is cancelled (closed) by clicking the _cancel_ button, by pressing the `ESC` key, or by clicking outside the dialog focus (i.e, the overlay).
+`ConfirmDialog` is built on top of [`Modal`](/packages/components/src/modal/README.md)
+and displays a confirmation dialog, with _confirm_ and _cancel_ buttons.
 
-## Usage
+The dialog is confirmed by clicking the _confirm_ button or by pressing the `Enter` key.
+It is cancelled (closed) by clicking the _cancel_ button, by pressing the `ESC` key, or by
+clicking outside the dialog focus (i.e. the overlay).
 
-`ConfirmDialog` has two main implicit modes: controlled and uncontrolled.
+`ConfirmDialog` has two main modes: controlled and uncontrolled.
 
 ### Uncontrolled mode
 
-Allows the component to be used standalone, just by declaring it as part of another React's component render method:
+Allows the component to be used standalone, just by declaring it as part of another React
+component's render method:
 
--   It will be automatically open (displayed) upon mounting;
--   It will be automatically closed when clicking the _cancel_ button, by pressing the `ESC` key, or by clicking outside the dialog focus (i.e, the overlay);
--   `onCancel` is not mandatory but can be passed. Even if passed, the dialog will still be able to close itself.
+- It will be automatically open (displayed) upon mounting.
+- It will be automatically closed when clicking the _cancel_ button, by pressing the `ESC`
+  key, or by clicking outside the dialog focus (i.e. the overlay).
+- `onCancel` is not mandatory but can be passed. Even if passed, the dialog will still be
+  able to close itself.
 
-Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop, in this case, is the `onConfirm` callback. The message is passed as the `children`. You can pass any JSX you'd like, which allows to further format the message or include sub-component if you'd like:
+Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop
+in this case is the `onConfirm` callback. The message is passed as the `children`.
 
 ```jsx
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 
 function Example() {
 	return (
-		<ConfirmDialog onConfirm={ () => console.debug( ' Confirmed! ' ) }>
+		<ConfirmDialog onConfirm={ () => console.debug( 'Confirmed!' ) }>
 			Are you sure? <strong>This action cannot be undone!</strong>
 		</ConfirmDialog>
 	);
@@ -36,14 +41,17 @@ function Example() {
 
 ### Controlled mode
 
-Let the parent component control when the dialog is open/closed. It's activated when a boolean value is passed to `isOpen`:
+Let the parent component control when the dialog is open/closed. It's activated when a
+boolean value is passed to `isOpen`:
 
--   It will not be automatically closed. You need to let it know when to open/close by updating the value of the `isOpen` prop;
--   Both `onConfirm` and the `onCancel` callbacks are mandatory props in this mode;
--   You'll want to update the state that controls `isOpen` by updating it from the `onCancel` and `onConfirm` callbacks.
+- It will not be automatically closed. You need to let it know when to open/close by
+  updating the value of the `isOpen` prop.
+- Both `onConfirm` and the `onCancel` callbacks are mandatory props in this mode.
+- You'll want to update the state that controls `isOpen` from the `onCancel` and
+  `onConfirm` callbacks.
 
 ```jsx
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 
 function Example() {
@@ -71,83 +79,74 @@ function Example() {
 }
 ```
 
-### Unsupported: Multiple instances
-
-Multiple `ConfirmDialog`s is an edge case that's currently not officially supported by this component. At the moment, new instances will end up closing the last instance due to the way the `Modal` is implemented.
-
-## Custom Types
-
-```ts
-type DialogInputEvent =
-	| KeyboardEvent< HTMLDivElement >
-	| MouseEvent< HTMLButtonElement >;
-```
-
 ## Props
 
-### `title`: `string`
+### `children`
 
--   Required: No
+ - Type: `ReactNode`
+ - Required: Yes
 
-An optional `title` for the dialog. Setting a title will render it in a title bar at the top of the dialog, making it a bit taller. The bar will also include an `x` close button at the top-right corner.
+The actual message for the dialog. It's passed as children and any valid `ReactNode` is accepted.
 
-### `size`: `'small' | 'medium' | 'large' | 'fill'`
+### `confirmButtonText`
 
--   Required: No
+ - Type: `string`
+ - Required: No
 
-Size of the underlying [`Modal`](/packages/components/src/modal/README.md). See `Modal`'s `size` prop for details.
+The optional custom text to display as the confirmation button's label.
 
-### `children`: `React.ReactNode`
+### `cancelButtonText`
 
--   Required: Yes
+ - Type: `string`
+ - Required: No
 
-The actual message for the dialog. It's passed as children and any valid `ReactNode` is accepted:
+The optional custom text to display as the cancellation button's label.
 
-```jsx
-<ConfirmDialog>
-	Are you sure? <strong>This action cannot be undone!</strong>
-</ConfirmDialog>
-```
+### `isOpen`
 
-### `isOpen`: `boolean`
+ - Type: `boolean`
+ - Required: No
 
--   Required: No
+Defines if the dialog is open (displayed) or closed (not rendered/displayed).
+It also implicitly toggles the controlled mode if set or the uncontrolled mode if it's not set.
 
-Defines if the dialog is open (displayed) or closed (not rendered/displayed). It also implicitly toggles the controlled mode if set or the uncontrolled mode if it's not set.
+### `isBusy`
 
-### `onConfirm`: `( event: DialogInputEvent ) => void`
+ - Type: `boolean`
+ - Required: No
 
--   Required: Yes
+Indicates activity while an action is being performed.
+When `true`, the confirm button will show a busy state.
+Both buttons will be disabled.
 
-The callback that's called when the user confirms. A confirmation can happen when the `OK` button is clicked or when `Enter` is pressed.
+### `onConfirm`
 
-### `onCancel`: `( event: DialogInputEvent ) => void`
+ - Type: `(event: DialogInputEvent) => void`
+ - Required: Yes
 
--   Required: Only if `isOpen` is not set
+The callback that's called when the user confirms.
+A confirmation can happen when the `OK` button is clicked or when `Enter` is pressed.
 
-The callback that's called when the user cancels. A cancellation can happen when the `Cancel` button is clicked, when the `ESC` key is pressed, or when a click outside of the dialog focus is detected (i.e. in the overlay).
+### `onCancel`
 
-It's not required if `isOpen` is not set (uncontrolled mode), as the component will take care of closing itself, but you can still pass a callback if something must be done upon cancelling (the component will still close itself in this case).
+ - Type: `((event: DialogInputEvent) => void)`
+ - Required: No
 
-If `isOpen` is set (controlled mode), then it's required, and you need to set the state that defines `isOpen` to `false` as part of this callback if you want the dialog to close when the user cancels.
+The callback that's called when the user cancels. A cancellation can happen
+when the `Cancel` button is clicked, when the `ESC` key is pressed, or when
+a click outside of the dialog focus is detected (i.e. in the overlay).
 
-### `confirmButtonText`: `string`
+It's not required if `isOpen` is not set (uncontrolled mode), as the component
+will take care of closing itself, but you can still pass a callback if something
+must be done upon cancelling (the component will still close itself in this case).
 
--   Required: No
--   Default: "OK"
+If `isOpen` is set (controlled mode), then it's required, and you need to set
+the state that defines `isOpen` to `false` as part of this callback if you want the
+dialog to close when the user cancels.
 
-The optional custom text to display as the confirmation button's label
+### `size`
 
-### `cancelButtonText`: `string`
+ - Type: `"small" | "fill" | "medium" | "large"`
+ - Required: No
 
--   Required: No
--   Default: "Cancel"
-
-The optional custom text to display as the cancellation button's label
-
-## Best practices
-
-The ConfirmDialog component should:
-
--   Be used only for short confirmation messages where a cancel and confirm actions are provided.
--   Use a descriptive text for the _confirm_ button. Default is "OK".
+Size of the underlying Modal. See `Modal`'s `size` prop.

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -124,46 +124,55 @@ const UnconnectedConfirmDialog = (
 };
 
 /**
- * `ConfirmDialog` is built of top of [`Modal`](/packages/components/src/modal/README.md)
+ * `ConfirmDialog` is built on top of [`Modal`](/packages/components/src/modal/README.md)
  * and displays a confirmation dialog, with _confirm_ and _cancel_ buttons.
+ *
  * The dialog is confirmed by clicking the _confirm_ button or by pressing the `Enter` key.
  * It is cancelled (closed) by clicking the _cancel_ button, by pressing the `ESC` key, or by
- * clicking outside the dialog focus (i.e, the overlay).
+ * clicking outside the dialog focus (i.e. the overlay).
  *
- * `ConfirmDialog` has two main implicit modes: controlled and uncontrolled.
+ * `ConfirmDialog` has two main modes: controlled and uncontrolled.
  *
- * UnControlled:
+ * ### Uncontrolled mode
  *
- * Allows the component to be used standalone, just by declaring it as part of another React's component render method:
- * -   It will be automatically open (displayed) upon mounting;
- * -   It will be automatically closed when clicking the _cancel_ button, by pressing the `ESC` key, or by clicking outside the dialog focus (i.e, the overlay);
- * -   `onCancel` is not mandatory but can be passed. Even if passed, the dialog will still be able to close itself.
+ * Allows the component to be used standalone, just by declaring it as part of another React
+ * component's render method:
  *
- * Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop, in this case, is the `onConfirm` callback. The message is passed as the `children`. You can pass any JSX you'd like, which allows to further format the message or include sub-component if you'd like:
+ * - It will be automatically open (displayed) upon mounting.
+ * - It will be automatically closed when clicking the _cancel_ button, by pressing the `ESC`
+ *   key, or by clicking outside the dialog focus (i.e. the overlay).
+ * - `onCancel` is not mandatory but can be passed. Even if passed, the dialog will still be
+ *   able to close itself.
+ *
+ * Activating this mode is as simple as omitting the `isOpen` prop. The only mandatory prop
+ * in this case is the `onConfirm` callback. The message is passed as the `children`.
  *
  * ```jsx
  * import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
  *
  * function Example() {
  * 	return (
- * 		<ConfirmDialog onConfirm={ () => console.debug( ' Confirmed! ' ) }>
+ * 		<ConfirmDialog onConfirm={ () => console.debug( 'Confirmed!' ) }>
  * 			Are you sure? <strong>This action cannot be undone!</strong>
  * 		</ConfirmDialog>
  * 	);
  * }
  * ```
  *
+ * ### Controlled mode
  *
- * Controlled mode:
- *  Let the parent component control when the dialog is open/closed. It's activated when a
+ * Let the parent component control when the dialog is open/closed. It's activated when a
  * boolean value is passed to `isOpen`:
- * -   It will not be automatically closed. You need to let it know when to open/close by updating the value of the `isOpen` prop;
- * -   Both `onConfirm` and the `onCancel` callbacks are mandatory props in this mode;
- * -   You'll want to update the state that controls `isOpen` by updating it from the `onCancel` and `onConfirm` callbacks.
  *
- *```jsx
- * import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+ * - It will not be automatically closed. You need to let it know when to open/close by
+ *   updating the value of the `isOpen` prop.
+ * - Both `onConfirm` and the `onCancel` callbacks are mandatory props in this mode.
+ * - You'll want to update the state that controls `isOpen` from the `onCancel` and
+ *   `onConfirm` callbacks.
+ *
+ * ```jsx
  * import { useState } from '@wordpress/element';
+ * import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
  *
  * function Example() {
  * 	const [ isOpen, setIsOpen ] = useState( true );

--- a/packages/components/src/confirm-dialog/docs-manifest.json
+++ b/packages/components/src/confirm-dialog/docs-manifest.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "../../schemas/docs-manifest.json",
+	"displayName": "ConfirmDialog",
+	"filePath": "./component.tsx"
+}


### PR DESCRIPTION
## What?

- Updates `@wordprss/components` `ConfirmDialog`'s `README.md` to use auto-generated documentation via the `docs-manifest.json` setup.
- Syncs some of the content polish that had existed already in `README.md` back to the original source code so that they're retained in the newly-generated documentation.

## Why?

- Improves accuracy as the props are an identical reflection of the code (this adds props like `isBusy` which were previously missing from documentation)
- Improves readability of the content in the source code
- Avoids future maintenance toil when new or updated props are noted as being out of sync with the README ([example](https://github.com/WordPress/gutenberg/pull/80705#discussion_r3663044840))

## How?

- Added `packages/components/src/confirm-dialog/docs-manifest.json`
- Updated source implementation code comments to minimize difference in produced documentation
- Regenerated via `npm run docs:build` 

## Testing Instructions

Review updated `README.md` for accuracy.

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to generate the `docs-manifest.json` following other components and backport content improvements to the implementation comments.