### PR TITLE
Port snapshot utilities and serializers to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54189,6 +54189,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.29.7",
 				"@emotion/jest": "^11.14.2",
+				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.0",
 				"@testing-library/jest-dom": "^6.9.1",

--- a/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
+++ b/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Emotion snapshot serializer > preserves stable labels for empty styled components 1`] = `
+<div
+  class="css-19mgf5f-EmptyBox emotion-0"
+>
+  Content
+</div>
+`;

--- a/test/unit/config/emotion-serializer.vitest.js
+++ b/test/unit/config/emotion-serializer.vitest.js
@@ -1,0 +1,42 @@
+function isEmptyEmotionClass( className ) {
+	const matchingRules = [];
+	const classSelector = `.${ className }`;
+
+	const collectMatchingRules = ( rules ) => {
+		Array.from( rules ).forEach( ( rule ) => {
+			if ( rule.cssRules ) {
+				collectMatchingRules( rule.cssRules );
+			}
+
+			if ( rule.selectorText?.includes( classSelector ) ) {
+				matchingRules.push( rule );
+			}
+		} );
+	};
+
+	Array.from( document.querySelectorAll( 'style[data-emotion]' ) ).forEach(
+		( element ) => collectMatchingRules( element.sheet?.cssRules ?? [] )
+	);
+
+	return (
+		matchingRules.length > 0 &&
+		matchingRules.every( ( rule ) => rule.style?.length === 0 )
+	);
+}
+
+export function createClassNameReplacer() {
+	let preservedClassNames = 0;
+
+	return ( className, index ) => {
+		if ( index === 0 ) {
+			preservedClassNames = 0;
+		}
+
+		if ( isEmptyEmotionClass( className ) ) {
+			preservedClassNames++;
+			return className;
+		}
+
+		return `emotion-${ index - preservedClassNames }`;
+	};
+}

--- a/test/unit/config/emotion-serializer.vitest.test.jsx
+++ b/test/unit/config/emotion-serializer.vitest.test.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe( 'Emotion snapshot serializer', () => {
+	it( 'preserves the established class and CSS snapshot format', () => {
+		const Box = styled.div`
+			color: red;
+		`;
+		const { container } = render( <Box>Content</Box> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- The serializer input is the rendered root node.
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			.emotion-0 {
+			  color: red;
+			}
+
+			<div
+			  class="emotion-0 emotion-1"
+			>
+			  Content
+			</div>
+		` );
+	} );
+
+	it( 'preserves stable labels for empty styled components', () => {
+		const EmptyBox = styled.div``;
+		const { container } = render( <EmptyBox>Content</EmptyBox> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- The serializer input is the rendered root node.
+		expect( container.firstChild ).toMatchSnapshot();
+	} );
+} );

--- a/test/unit/config/matchers/test/__snapshots__/to-match-diff-snapshot.vitest.test.js.snap
+++ b/test/unit/config/matchers/test/__snapshots__/to-match-diff-snapshot.vitest.test.js.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`snapshotDiff > captures matching stylesheet declarations > style colors 1`] = `
+Snapshot Diff:
+- Received styles
++ Base styles
+
+  Array [
+    Object {
+-     "color": "red",
++     "color": "blue",
+    },
+  ]
+`;
+
+exports[`snapshotDiff > formats the established uncolored object diff > object visibility 1`] = `
+Snapshot Diff:
+- First value
++ Second value
+
+  Object {
+-   "visible": false,
++   "visible": true,
+  }
+`;
+
+exports[`snapshotDiff > supports custom annotations > custom annotations 1`] = `
+Snapshot Diff:
+- Received styles
++ Base styles
+
+  Array [
+-   "old",
++   "new",
+  ]
+`;

--- a/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
+++ b/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+describe( 'snapshotDiff', () => {
+	it( 'formats the established uncolored object diff', () => {
+		expect( { visible: false } ).toMatchDiffSnapshot(
+			{ visible: true },
+			{},
+			'object visibility'
+		);
+	} );
+
+	it( 'supports custom annotations', () => {
+		expect( [ 'old' ] ).toMatchDiffSnapshot(
+			[ 'new' ],
+			{
+				aAnnotation: 'Received styles',
+				bAnnotation: 'Base styles',
+			},
+			'custom annotations'
+		);
+	} );
+
+	it( 'captures matching stylesheet declarations', () => {
+		const style = document.createElement( 'style' );
+		style.textContent = '.received { color: red; } .base { color: blue; }';
+		const received = document.createElement( 'div' );
+		const base = document.createElement( 'div' );
+		received.className = 'received';
+		base.className = 'base';
+		document.head.append( style );
+		document.body.append( received, base );
+
+		expect( received ).toMatchStyleDiffSnapshot( base, 'style colors' );
+
+		style.remove();
+		received.remove();
+		base.remove();
+	} );
+
+	it( 'recognizes positioned popovers', () => {
+		const popover = document.createElement( 'div' );
+		const child = document.createElement( 'span' );
+		popover.className = 'components-popover is-positioned';
+		popover.append( child );
+
+		expect( child ).toBePositionedPopover();
+	} );
+} );

--- a/test/unit/config/matchers/to-be-positioned-popover.vitest.js
+++ b/test/unit/config/matchers/to-be-positioned-popover.vitest.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'vitest';
+
+function toBePositionedPopover( element ) {
+	const popover = element?.closest( '.components-popover' );
+	const isPopoverPositioned = popover?.classList.contains( 'is-positioned' );
+	const pass = !! isPopoverPositioned;
+
+	return {
+		pass,
+		message: () => {
+			const is = pass ? 'is' : 'is not';
+			return ! popover
+				? `Received element ${ is } a popover element or its descendant.`
+				: `Received element ${ is } positioned`;
+		},
+	};
+}
+
+expect.extend( { toBePositionedPopover } );

--- a/test/unit/config/matchers/to-match-diff-snapshot.vitest.js
+++ b/test/unit/config/matchers/to-match-diff-snapshot.vitest.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { expect, Snapshots } from 'vitest';
+
+const identity = ( value ) => value;
+
+export function snapshotDiff( valueA, valueB, options = {}, utils ) {
+	const difference = utils.diff( valueA, valueB, {
+		aAnnotation: 'First value',
+		aColor: identity,
+		bAnnotation: 'Second value',
+		bColor: identity,
+		changeColor: identity,
+		commonColor: identity,
+		contextLines: -1,
+		expand: false,
+		patchColor: identity,
+		printBasicPrototype: true,
+		...options,
+	} );
+
+	return `Snapshot Diff:\n${
+		difference ?? 'Compared values have no visual difference.'
+	}`;
+}
+
+function toMatchDiffSnapshot(
+	received,
+	expected,
+	options = {},
+	testName = ''
+) {
+	return Snapshots.toMatchSnapshot.call(
+		this,
+		snapshotDiff( received, expected, options, this.utils ),
+		testName
+	);
+}
+
+expect.extend( { toMatchDiffSnapshot } );

--- a/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
+++ b/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { expect, Snapshots } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import { snapshotDiff } from './to-match-diff-snapshot.vitest';
+
+const getStyleSheets = () =>
+	Array.from( document.getElementsByTagName( 'style' ) );
+
+const getStyleRulesForElement = ( element, styleSheets ) => {
+	return styleSheets.reduce( ( matchingRules, styleSheet ) => {
+		const found = [];
+
+		try {
+			Array.from( styleSheet.sheet.cssRules ).forEach( ( rule ) => {
+				if ( element?.matches( rule.selectorText ) ) {
+					found.push( rule.style );
+				}
+			} );
+		} catch {}
+
+		return [ ...matchingRules, ...found ];
+	}, [] );
+};
+
+const cleanStyleRule = ( rule ) => {
+	const size = Array.from( Array( rule.length ).keys() );
+	return size.reduce( ( result, index ) => {
+		const key = rule[ index ];
+		return { ...result, [ key ]: rule[ key ] };
+	}, {} );
+};
+
+function toMatchStyleDiffSnapshot( received, expected, testName = '' ) {
+	const styleSheets = getStyleSheets();
+	const receivedStyles = getStyleRulesForElement( received, styleSheets ).map(
+		cleanStyleRule
+	);
+	const expectedStyles = getStyleRulesForElement( expected, styleSheets ).map(
+		cleanStyleRule
+	);
+	const difference = snapshotDiff(
+		receivedStyles,
+		expectedStyles,
+		{
+			aAnnotation: 'Received styles',
+			bAnnotation: 'Base styles',
+		},
+		this.utils
+	);
+
+	return Snapshots.toMatchSnapshot.call( this, difference, testName );
+}
+
+expect.extend( { toMatchStyleDiffSnapshot } );

--- a/test/unit/config/testing-library.vitest.js
+++ b/test/unit/config/testing-library.vitest.js
@@ -1,9 +1,34 @@
 /**
  * External dependencies
  */
+import { createSerializer as createEmotionSerializer } from '@emotion/jest';
 import '@testing-library/jest-dom/vitest';
 // eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, expect } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import './matchers/to-match-diff-snapshot.vitest';
+import './matchers/to-match-style-diff-snapshot.vitest';
+import './matchers/to-be-positioned-popover.vitest';
+import { createClassNameReplacer } from './emotion-serializer.vitest';
 
 afterEach( cleanup );
+
+expect.addSnapshotSerializer(
+	createEmotionSerializer( {
+		classNameReplacer: createClassNameReplacer(),
+	} )
+);
+expect.addSnapshotSerializer( {
+	test( value ) {
+		return (
+			typeof value === 'string' && value.startsWith( 'Snapshot Diff:\n' )
+		);
+	},
+	serialize( value ) {
+		return value;
+	},
+} );

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -22,6 +22,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.29.7",
 		"@emotion/jest": "^11.14.2",
+		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.0",
 		"@testing-library/jest-dom": "^6.9.1",

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -12,6 +12,8 @@
 		"jest": [],
 		"vitest": [
 			"test/unit/config/console.vitest.test.js",
+			"test/unit/config/emotion-serializer.vitest.test.jsx",
+			"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
 			"test/unit/config/setup.vitest.test.jsx"
 		]
 	}


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80865; review only the fifth commit in this PR.

**TL;DR — snapshot parity:** Replaces the private Vitest dependency on `snapshot-diff` with public Vitest snapshot APIs, ports the style-diff and popover matchers, and proves the Emotion serializer format before snapshot-heavy packages move.

## Why?

Snapshot consumers must not migrate until their custom matchers and serializers have a verified Vitest implementation. This isolates snapshot-format changes from later component-test migrations and keeps `snapshot-diff` available only to the remaining Jest partition.

## How?

- Implements `toMatchDiffSnapshot` and `toMatchStyleDiffSnapshot` with Vitest's public `Snapshots` API and matcher-context diff utilities.
- Ports `toBePositionedPopover` with explicit Vitest imports.
- Registers an unquoted snapshot-diff serializer and the existing Emotion serializer behavior in the Vitest Testing Library setup.
- Adds compatibility coverage for object diffs, custom annotations, style diffs, positioned popovers, non-empty Emotion styles, and empty styled-component labels.
- Adds `@emotion/styled` to the test-infrastructure workspace that directly imports it.

No existing baseline snapshot was regenerated or changed. This PR adds two reviewed compatibility snapshot files:
- the diff snapshot records object visibility, custom array annotations, and red-to-blue style declarations;
- the Emotion snapshot records the empty `EmptyBox` label and normalized `emotion-0` class, while the non-empty CSS format is reviewed inline.

The Jest partition retains `snapshot-diff`, its serializer, and existing consumers until those packages migrate.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 995 Jest baseline files, 1 Vitest baseline file, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- --reporter=dot`; expect 5 files and 33 tests to pass.
3. Run the Vitest suite as each of the four `--shard=N/4` partitions and confirm every shard passes.
4. Inspect both new snapshot files and confirm the four formats listed above are intentional.
5. Run `npm run lint:pkg-json`, `npm run lint:lockfile`, and `git diff --check`.

Locally verified routing, the complete Vitest partition, all four shards, targeted strict ESLint, package and lockfile validation, formatting, and pre-commit checks.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the existing Jest snapshot behavior, verify Vitest's public matcher and snapshot APIs, implement the compatibility layer, review each new snapshot, and run the reported checks. The resulting changes and claims were reviewed against the repository configuration.