### PR TITLE
Migrate low-risk utility tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50928,6 +50928,9 @@
 			"name": "@wordpress/escape-html",
 			"version": "3.51.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -51470,7 +51473,8 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/lazy-import": "file:../lazy-import",
-				"benchmark": "^2.1.4"
+				"benchmark": "^2.1.4",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -53009,6 +53013,9 @@
 			"dependencies": {
 				"memize": "^2.1.1"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -53210,6 +53217,9 @@
 			"name": "@wordpress/token-list",
 			"version": "3.51.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -53516,6 +53526,9 @@
 			"name": "@wordpress/wordcount",
 			"version": "4.51.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -42,6 +42,9 @@
 	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": false,
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/escape-html/src/test/index.ts
+++ b/packages/escape-html/src/test/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -46,7 +46,8 @@
 	"sideEffects": false,
 	"devDependencies": {
 		"@wordpress/lazy-import": "file:../lazy-import",
-		"benchmark": "^2.1.4"
+		"benchmark": "^2.1.4",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/is-shallow-equal/test/index.ts
+++ b/packages/is-shallow-equal/test/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -45,6 +45,9 @@
 	"dependencies": {
 		"memize": "^2.1.1"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/shortcode/src/test/index.ts
+++ b/packages/shortcode/src/test/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { next, replace, attrs, string } from '../';

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -42,6 +42,9 @@
 	"wpScript": true,
 	"wpScriptDefaultExport": true,
 	"types": "build-types",
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/token-list/src/test/index.ts
+++ b/packages/token-list/src/test/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import TokenList from '../';

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -42,6 +42,9 @@
 	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": false,
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/wordcount/src/test/index.test.ts
+++ b/packages/wordcount/src/test/index.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -5,7 +5,13 @@
 	},
 	"vitest": {
 		"files": [ "packages/html-entities/src/test/entities.ts" ],
-		"directories": []
+		"directories": [
+			"packages/escape-html",
+			"packages/is-shallow-equal",
+			"packages/shortcode",
+			"packages/token-list",
+			"packages/wordcount"
+		]
 	},
 	"retired": [],
 	"added": {


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80867; review only the sixth commit in this PR.

**TL;DR — low-risk utility migration:** Moves five assertion-only TypeScript utility suites to Vitest with explicit runner imports and package-owned Vitest development dependencies.

## Why?

These suites exercise deterministic string and collection logic without snapshots, timers, DOM interaction, console behavior, or module mocks. They are a bounded first package-migration slice after the shared compatibility infrastructure was proven.

## How?

- Routes the complete test suites for `@wordpress/escape-html`, `@wordpress/is-shallow-equal`, `@wordpress/shortcode`, `@wordpress/token-list`, and `@wordpress/wordcount` to Vitest.
- Imports each used runner API directly from `vitest`; globals remain disabled.
- Declares the shared Vitest version in each importing workspace and updates the lockfile.
- Leaves test cases and production code unchanged.

No snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 990 Jest baseline files, 10 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- --reporter=dot`; expect 10 files and 166 tests to pass.
3. Run the Vitest suite as each of the four `--shard=N/4` partitions and confirm every shard passes.
4. Type-check each migrated package with `tsc --noEmit -p packages/<package>/tsconfig.json`.
5. Run `npm run lint:pkg-json`, `npm run lint:lockfile`, and the targeted strict JavaScript lint.

Locally, all migrated Vitest tests and all four shards passed; all five package TypeScript projects passed. The remaining Jest partition completed with 987 suites passing and 2 skipped; only `packages/env/lib/config/test/config-integration.js` failed because this sandbox has neither the cached current WordPress version nor network access. That unrelated network-dependent suite remains on Jest and is covered by CI.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to classify low-risk suites, apply the explicit-import and dependency-ownership migration, and run the reported routing, Vitest, Jest, type, lint, and lockfile checks. The resulting changes and claims were reviewed against the repository configuration.