### PR TITLE
UI: Add Combobox.InputGroup primitive

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Add `Combobox.InputGroup` primitive.
 -   `Input`: Hide native browser spin controls for `type="number"` inputs by default ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).
 -   Add `Autocomplete.Row` primitive ([#80490](https://github.com/WordPress/gutenberg/pull/80490)).
 -   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Add `Combobox.InputGroup` primitive.
+-   Add `Combobox.InputGroup` primitive ([#80869](https://github.com/WordPress/gutenberg/pull/80869)).
 -   `Input`: Hide native browser spin controls for `type="number"` inputs by default ([#80646](https://github.com/WordPress/gutenberg/pull/80646)).
 -   Add `Autocomplete.Row` primitive ([#80490](https://github.com/WordPress/gutenberg/pull/80490)).
 -   `Combobox`, `Select`, `SelectControl`: Add `Group` and `GroupLabel` subcomponents ([#80574](https://github.com/WordPress/gutenberg/pull/80574)).

--- a/packages/ui/src/form/primitives/combobox/index.ts
+++ b/packages/ui/src/form/primitives/combobox/index.ts
@@ -5,6 +5,7 @@ export { Collection } from './collection';
 export { Empty } from './empty';
 export { Group } from './group';
 export { GroupLabel } from './group-label';
+export { InputGroup } from './input-group';
 export { Input } from './input';
 export { Item } from './item';
 export { List } from './list';

--- a/packages/ui/src/form/primitives/combobox/input-group.tsx
+++ b/packages/ui/src/form/primitives/combobox/input-group.tsx
@@ -1,0 +1,15 @@
+import { Combobox as _Combobox } from '@base-ui/react/combobox';
+import { forwardRef } from '@wordpress/element';
+import type { ComboboxInputGroupProps } from './types';
+
+/**
+ * Wrapper around `Combobox.Input` that defines the visual control
+ * boundary when the input is composed with prefix/suffix slots or other
+ * elements. Without this wrapper, the popup anchors to the bare `<input>`
+ * instead of the full control. Also adds `role="group"`.
+ */
+export const InputGroup = forwardRef< HTMLDivElement, ComboboxInputGroupProps >(
+	function InputGroup( props, ref ) {
+		return <_Combobox.InputGroup ref={ ref } { ...props } />;
+	}
+);

--- a/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/combobox/stories/index.story.tsx
@@ -16,6 +16,7 @@ const meta: Meta< typeof Combobox.Root > = {
 		'Combobox.Portal': Combobox.Portal,
 		'Combobox.Positioner': Combobox.Positioner,
 		'Combobox.Popup': Combobox.Popup,
+		'Combobox.InputGroup': Combobox.InputGroup,
 		'Combobox.Input': Combobox.Input,
 		'Combobox.List': Combobox.List,
 		'Combobox.ListBody': Combobox.ListBody,

--- a/packages/ui/src/form/primitives/combobox/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/combobox/test/index.test.tsx
@@ -58,6 +58,7 @@ describe( 'Combobox', () => {
 		const triggerRef = createRef< HTMLButtonElement >();
 		const popupRef = createRef< HTMLDivElement >();
 		const positionerRef = createRef< HTMLDivElement >();
+		const inputGroupRef = createRef< HTMLDivElement >();
 		const inputRef = createRef< HTMLInputElement >();
 		const listRef = createRef< HTMLDivElement >();
 		const listBodyRef = createRef< HTMLDivElement >();
@@ -75,7 +76,9 @@ describe( 'Combobox', () => {
 					ref={ popupRef }
 					positioner={ <Combobox.Positioner ref={ positionerRef } /> }
 				>
-					<Combobox.Input ref={ inputRef } placeholder="Search" />
+					<Combobox.InputGroup ref={ inputGroupRef }>
+						<Combobox.Input ref={ inputRef } placeholder="Search" />
+					</Combobox.InputGroup>
 					<Combobox.Value>
 						<Combobox.Chips ref={ chipsRef }>
 							<Combobox.ChipWithRemove
@@ -122,6 +125,7 @@ describe( 'Combobox', () => {
 			expect( popupRef.current ).toBeInstanceOf( HTMLDivElement );
 		} );
 		expect( positionerRef.current ).toBeInstanceOf( HTMLDivElement );
+		expect( inputGroupRef.current ).toBeInstanceOf( HTMLDivElement );
 		expect( inputRef.current ).toBeInstanceOf( HTMLInputElement );
 		expect( listRef.current ).toBeInstanceOf( HTMLDivElement );
 		expect( listBodyRef.current ).toBeInstanceOf( HTMLDivElement );

--- a/packages/ui/src/form/primitives/combobox/types.ts
+++ b/packages/ui/src/form/primitives/combobox/types.ts
@@ -53,6 +53,12 @@ export type ComboboxInputProps = Omit<
 	'size'
 >;
 
+export type ComboboxInputGroupProps = ComponentProps<
+	typeof _Combobox.InputGroup
+> & {
+	children?: React.ReactNode;
+};
+
 export type ComboboxItemProps = ComponentProps< typeof _Combobox.Item > & {
 	children?: React.ReactNode;
 	/**


### PR DESCRIPTION
## What?

Adds the missing `Combobox.InputGroup` primitive to `@wordpress/ui`.

## Why?

Base UI's Combobox supports an `InputGroup` wrapper for composing the input with prefix/suffix slots or other elements. Without it, the popup anchors to the bare `<input>` instead of the full control. The Autocomplete family already exposes this subcomponent.

Specifically, we'll need this component to solve the [popover positioning problem](https://github.com/WordPress/gutenberg/pull/80779#pullrequestreview-4808818018) raised in review for `SearchableChipSelect`.

## How?

Add a thin `InputGroup` wrapper around Base UI's `Combobox.InputGroup`, matching the existing `Autocomplete.InputGroup` implementation.

## Testing Instructions

1. Run Storybook for `@wordpress/ui`.
2. Open **Design System / Components / Form / Primitives / Combobox**.
3. Confirm `Combobox.InputGroup` appears in the subcomponents list.