### PR TITLE
Migrate low-risk state and utility suites to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49265,7 +49265,8 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
-				"@types/react": "^18.3.27"
+				"@types/react": "^18.3.27",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -50000,6 +50001,9 @@
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/private-apis": "file:../private-apis"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"peerDependencies": {
 				"@types/react": "^18 || ^19",
 				"react": "^18 || ^19"
@@ -50075,6 +50079,9 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/router": "file:../router",
 				"@wordpress/url": "file:../url"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -50689,6 +50696,9 @@
 				"fast-deep-equal": "^3.1.3",
 				"react-autosize-textarea": "^7.1.0"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": "^20.19.0 || >=22.13.0",
 				"npm": ">=10.2.3"
@@ -51149,6 +51159,9 @@
 				"clsx": "^2.1.1",
 				"remove-accents": "^0.5.0"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -51343,7 +51356,8 @@
 				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"devDependencies": {
-				"benchmark": "^2.1.4"
+				"benchmark": "^2.1.4",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -52989,7 +53003,7 @@
 				"@wordpress/url": "file:../url"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0"
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -53027,6 +53041,9 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -53279,7 +53296,8 @@
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -49,7 +49,8 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
-		"@types/react": "^18.3.27"
+		"@types/react": "^18.3.27",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19"

--- a/packages/annotations/src/store/test/reducer.ts
+++ b/packages/annotations/src/store/test/reducer.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { annotations } from '../reducer';

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -37,6 +37,9 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/private-apis": "file:../private-apis"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",
 		"react": "^18 || ^19"

--- a/packages/connectors/src/test/store.ts
+++ b/packages/connectors/src/test/store.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -55,6 +55,9 @@
 		"@wordpress/router": "file:../router",
 		"@wordpress/url": "file:../url"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"react": "^18 || ^19",
 		"react-dom": "^18 || ^19"

--- a/packages/core-commands/src/utils/test/order-entity-records-by-search.js
+++ b/packages/core-commands/src/utils/test/order-entity-records-by-search.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { orderEntityRecordsBySearch } from '../order-entity-records-by-search';

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -99,6 +99,9 @@
 		"fast-deep-equal": "^3.1.3",
 		"react-autosize-textarea": "^7.1.0"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"react": "^18 || ^19",
 		"react-dom": "^18 || ^19"

--- a/packages/edit-site/src/utils/test/get-filtered-template-parts.js
+++ b/packages/edit-site/src/utils/test/get-filtered-template-parts.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import getFilteredTemplatePartBlocks from '../get-filtered-template-parts';

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -78,6 +78,9 @@
 		"clsx": "^2.1.1",
 		"remove-accents": "^0.5.0"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",
 		"react": "^18 || ^19"

--- a/packages/fields/src/components/create-template-part-modal/test/utils.js
+++ b/packages/fields/src/components/create-template-part-modal/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from '../utils';

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -51,7 +51,8 @@
 		"tannin": "^1.2.0"
 	},
 	"devDependencies": {
-		"benchmark": "^2.1.4"
+		"benchmark": "^2.1.4",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/src/test/create-i18n.ts
+++ b/packages/i18n/src/test/create-i18n.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @wordpress/i18n-text-domain, @wordpress/i18n-translator-comments */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createHooks } from '@wordpress/hooks';

--- a/packages/i18n/src/test/default-i18n.ts
+++ b/packages/i18n/src/test/default-i18n.ts
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * WordPress dependencies
  */
-import { __, _x, _n, _nx } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { __, _x, _n, _nx } from '@wordpress/i18n';
 
 describe( 'i18n filters', () => {
 	test( 'Default i18n functions call filters', () => {

--- a/packages/i18n/src/test/sprintf.ts
+++ b/packages/i18n/src/test/sprintf.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { sprintf } from '../sprintf';

--- a/packages/i18n/src/test/subscribe-i18n.ts
+++ b/packages/i18n/src/test/subscribe-i18n.ts
@@ -1,12 +1,17 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { createI18n } from '..';
+import { describe, expect, it } from 'vitest';
 
 /**
  * WordPress dependencies
  */
 import { createHooks } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { createI18n } from '..';
 
 describe( 'i18n updates', () => {
 	it( 'updates on setLocaleData', () => {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -55,7 +55,7 @@
 		"@wordpress/url": "file:../url"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0"
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/server-side-render/src/test/index.ts
+++ b/packages/server-side-render/src/test/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { rendererPath, removeBlockSupportAttributes } from '../hook';

--- a/packages/server-side-render/tsconfig.json
+++ b/packages/server-side-render/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "gutenberg-env", "gutenberg-test-env", "jest" ]
+		"types": [ "gutenberg-env", "gutenberg-test-env" ]
 	},
 	"references": [
 		{ "path": "../api-fetch" },

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -66,6 +66,9 @@
 	"dependencies": {
 		"change-case": "^4.1.2"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19"
 	},

--- a/packages/style-engine/src/styles/test/utils.js
+++ b/packages/style-engine/src/styles/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { camelCaseJoin, getCSSValueFromRawStyle, upperFirst } from '../utils';

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getCSSRules, compileCSS } from '../index';

--- a/packages/undo-manager/package.json
+++ b/packages/undo-manager/package.json
@@ -47,7 +47,8 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/undo-manager/src/test/index.js
+++ b/packages/undo-manager/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createUndoManager } from '../';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -6,10 +6,19 @@
 	"vitest": {
 		"files": [ "packages/html-entities/src/test/entities.ts" ],
 		"directories": [
+			"packages/annotations",
+			"packages/connectors",
+			"packages/core-commands",
+			"packages/edit-site",
 			"packages/escape-html",
+			"packages/fields",
+			"packages/i18n",
 			"packages/is-shallow-equal",
+			"packages/server-side-render",
 			"packages/shortcode",
+			"packages/style-engine",
 			"packages/token-list",
+			"packages/undo-manager",
 			"packages/wordcount"
 		]
 	},


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80868; review only the seventh commit in this PR.

**TL;DR — low-risk state and utility migration:** Moves nine complete package suites with no mocks, timers, snapshots, or Testing Library interaction to Vitest, including removal of one package-local Jest type dependency.

## Why?

These deterministic reducer, formatting, and utility suites can move without Jest-compatibility shims. Migrating complete package boundaries also lets each importer own its Vitest dependency and removes Jest types where the package no longer needs them.

## How?

- Routes all tests in `@wordpress/annotations`, `@wordpress/connectors`, `@wordpress/core-commands`, `@wordpress/edit-site`, `@wordpress/fields`, `@wordpress/i18n`, `@wordpress/server-side-render`, `@wordpress/style-engine`, and `@wordpress/undo-manager` to Vitest.
- Adds explicit imports for every used runner API; Vitest globals remain disabled.
- Declares Vitest in each importing workspace.
- Removes `@types/jest` and the `jest` compiler type from `@wordpress/server-side-render`, whose only test now uses explicit Vitest imports.
- Leaves production code and test assertions unchanged.

No snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 977 Jest baseline files, 23 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- --reporter=dot`; expect 23 files and 267 tests to pass.
3. Run all four `--shard=N/4` Vitest partitions.
4. Build the TypeScript project references for the eight migrated packages that have a `tsconfig.json`.
5. Run targeted strict JavaScript lint, `npm run lint:pkg-json`, `npm run lint:lockfile`, and `npm run lint:tsconfig`.

Locally verified the complete Vitest partition, all four shards, all eight applicable TypeScript project builds, strict lint, package metadata, lockfile, tsconfig validation, formatting, and pre-commit checks. The remaining Jest partition is unchanged by this commit and remains covered by stacked CI.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to classify complete low-risk package suites, add explicit runner imports and dependency ownership, remove the obsolete package-local Jest types, and run the reported verification. The resulting changes and claims were reviewed against the repository configuration.