### PR TITLE
Migrate abilities tests with typed Vitest mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49197,6 +49197,9 @@
 				"ajv-draft-04": "^1.0.0",
 				"ajv-formats": "^3.0.1"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/abilities/package.json
+++ b/packages/abilities/package.json
@@ -51,6 +51,9 @@
 		"ajv-draft-04": "^1.0.0",
 		"ajv-formats": "^3.0.1"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/abilities/src/store/tests/actions.test.ts
+++ b/packages/abilities/src/store/tests/actions.test.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -26,10 +31,10 @@ import type {
 describe( 'Store Actions', () => {
 	describe( 'registerAbility', () => {
 		let mockSelect: any;
-		let mockDispatch: jest.Mock;
+		let mockDispatch: Mock;
 
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 			const defaultCategories = [
 				{
 					slug: 'test-category',
@@ -44,11 +49,11 @@ describe( 'Store Actions', () => {
 			];
 
 			mockSelect = {
-				getAbility: jest.fn().mockReturnValue( null ),
-				getAbilityCategories: jest
+				getAbility: vi.fn().mockReturnValue( null ),
+				getAbilityCategories: vi
 					.fn()
 					.mockReturnValue( defaultCategories ),
-				getAbilityCategory: jest.fn().mockImplementation( ( slug ) => {
+				getAbilityCategory: vi.fn().mockImplementation( ( slug ) => {
 					const categories: Record< string, any > = {
 						'test-category': {
 							slug: 'test-category',
@@ -64,7 +69,7 @@ describe( 'Store Actions', () => {
 					return categories[ slug ] || null;
 				} ),
 			};
-			mockDispatch = jest.fn();
+			mockDispatch = vi.fn();
 		} );
 
 		it( 'should register a valid client ability', () => {
@@ -85,7 +90,7 @@ describe( 'Store Actions', () => {
 						success: { type: 'boolean' },
 					},
 				},
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -128,7 +133,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: 'test-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -155,7 +160,7 @@ describe( 'Store Actions', () => {
 					label: 'Test Ability',
 					description: 'Test description',
 					category: 'test-category',
-					callback: jest.fn(),
+					callback: vi.fn(),
 				};
 
 				const action = registerAbility( ability );
@@ -184,7 +189,7 @@ describe( 'Store Actions', () => {
 					label: 'Test Ability',
 					description: 'Test description',
 					category: 'test-category',
-					callback: jest.fn(),
+					callback: vi.fn(),
 				};
 
 				mockSelect.getAbility.mockReturnValue( null );
@@ -209,7 +214,7 @@ describe( 'Store Actions', () => {
 				label: '',
 				description: 'Test description',
 				category: 'test-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -226,7 +231,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: '',
 				category: 'test-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -243,7 +248,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: '',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -271,7 +276,7 @@ describe( 'Store Actions', () => {
 					label: 'Test Ability',
 					description: 'Test description',
 					category: invalidCategory,
-					callback: jest.fn(),
+					callback: vi.fn(),
 				};
 
 				const action = registerAbility( ability );
@@ -300,7 +305,7 @@ describe( 'Store Actions', () => {
 					label: 'Test Ability',
 					description: 'Test description',
 					category: validCategory,
-					callback: jest.fn(),
+					callback: vi.fn(),
 				};
 
 				const categoriesForTest = [
@@ -361,7 +366,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: 'non-existent-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -397,7 +402,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: 'data-retrieval',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -437,7 +442,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test ability with custom scope',
 				category: 'test-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 				meta: {
 					scope: 'editor',
 					customProperty: 'customValue',
@@ -475,7 +480,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: 'test-category',
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const action = registerAbility( ability );
@@ -511,15 +516,15 @@ describe( 'Store Actions', () => {
 
 	describe( 'registerAbilityCategory', () => {
 		let mockSelect: any;
-		let mockDispatch: jest.Mock;
+		let mockDispatch: Mock;
 
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 			mockSelect = {
-				getAbilityCategory: jest.fn().mockReturnValue( null ),
-				getAbilityCategories: jest.fn().mockReturnValue( [] ),
+				getAbilityCategory: vi.fn().mockReturnValue( null ),
+				getAbilityCategories: vi.fn().mockReturnValue( [] ),
 			};
-			mockDispatch = jest.fn();
+			mockDispatch = vi.fn();
 		} );
 
 		it( 'should register a valid category', () => {
@@ -812,10 +817,10 @@ describe( 'Store Actions', () => {
 					description: categoryArgs.description,
 				},
 			];
-			mockSelect.getAbilityCategories = jest
+			mockSelect.getAbilityCategories = vi
 				.fn()
 				.mockReturnValue( categoriesWithNew );
-			mockSelect.getAbility = jest.fn().mockReturnValue( null );
+			mockSelect.getAbility = vi.fn().mockReturnValue( null );
 			mockDispatch.mockClear();
 
 			// Register an ability using the new category
@@ -824,7 +829,7 @@ describe( 'Store Actions', () => {
 				label: 'Test Ability',
 				description: 'Test description',
 				category: categorySlug,
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			const abilityAction = registerAbility( ability );

--- a/packages/abilities/src/store/tests/reducer.test.ts
+++ b/packages/abilities/src/store/tests/reducer.test.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/abilities/src/store/tests/selectors.test.ts
+++ b/packages/abilities/src/store/tests/selectors.test.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -33,7 +38,7 @@ describe( 'Store Selectors', () => {
 						category: 'test-category',
 						input_schema: { type: 'object' },
 						output_schema: { type: 'object' },
-						callback: jest.fn(),
+						callback: vi.fn(),
 					},
 				},
 				categoriesBySlug: {},
@@ -210,7 +215,7 @@ describe( 'Store Selectors', () => {
 					category: 'test-category',
 					input_schema: { type: 'object' },
 					output_schema: { type: 'object' },
-					callback: jest.fn(),
+					callback: vi.fn(),
 				},
 			},
 			categoriesBySlug: {},

--- a/packages/abilities/src/tests/api.test.ts
+++ b/packages/abilities/src/tests/api.test.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
@@ -22,18 +27,37 @@ import {
 import { store } from '../store';
 import type { Ability, AbilityCategory } from '../types';
 
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn(),
-	dispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	select: vi.fn(),
+	dispatch: vi.fn(),
 } ) );
 
-jest.mock( '../store', () => ( {
-	store: 'abilities-api/store',
+vi.mock( import( '../store' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	store: 'abilities-api/store' as unknown as typeof store,
 } ) );
+
+type AbilitySelectors = ReturnType< typeof select< typeof store > >;
+type AbilityDispatch = ReturnType< typeof dispatch< typeof store > >;
+const mockedSelect = vi.mocked( select ) as Mock<
+	( storeDescriptor: typeof store ) => AbilitySelectors
+>;
+const mockedDispatch = vi.mocked( dispatch ) as Mock<
+	( storeDescriptor: typeof store ) => AbilityDispatch
+>;
+
+const mockSelect = ( selectors: Partial< AbilitySelectors > ) => {
+	mockedSelect.mockReturnValue( selectors as AbilitySelectors );
+};
+
+const mockDispatch = ( actions: Partial< AbilityDispatch > ) => {
+	mockedDispatch.mockReturnValue( actions as AbilityDispatch );
+};
 
 describe( 'API functions', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'getAbilities', () => {
@@ -57,8 +81,8 @@ describe( 'API functions', () => {
 				},
 			];
 
-			const mockGetAbilities = jest.fn().mockReturnValue( mockAbilities );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbilities = vi.fn().mockReturnValue( mockAbilities );
+			mockSelect( {
 				getAbilities: mockGetAbilities,
 			} );
 
@@ -89,8 +113,8 @@ describe( 'API functions', () => {
 				},
 			];
 
-			const mockGetAbilities = jest.fn().mockReturnValue( mockAbilities );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbilities = vi.fn().mockReturnValue( mockAbilities );
+			mockSelect( {
 				getAbilities: mockGetAbilities,
 			} );
 
@@ -115,8 +139,8 @@ describe( 'API functions', () => {
 				output_schema: { type: 'object' },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -130,14 +154,14 @@ describe( 'API functions', () => {
 
 	describe( 'registerAbility', () => {
 		it( 'should register a client-side ability with a callback', () => {
-			const mockRegisterAbility = jest.fn();
-			( dispatch as jest.Mock ).mockReturnValue( {
+			const mockRegisterAbility = vi.fn();
+			mockDispatch( {
 				registerAbility: mockRegisterAbility,
 			} );
 
 			// Mock select to return no existing ability
-			( select as jest.Mock ).mockReturnValue( {
-				getAbility: jest.fn().mockReturnValue( null ),
+			mockSelect( {
+				getAbility: vi.fn().mockReturnValue( null ),
 			} );
 
 			const ability = {
@@ -147,7 +171,7 @@ describe( 'API functions', () => {
 				category: 'test-category',
 				input_schema: { type: 'object' },
 				output_schema: { type: 'object' },
-				callback: jest.fn(),
+				callback: vi.fn(),
 			};
 
 			registerAbility( ability );
@@ -159,8 +183,8 @@ describe( 'API functions', () => {
 
 	describe( 'unregisterAbility', () => {
 		it( 'should unregister an ability', () => {
-			const mockUnregisterAbility = jest.fn();
-			( dispatch as jest.Mock ).mockReturnValue( {
+			const mockUnregisterAbility = vi.fn();
+			mockDispatch( {
 				unregisterAbility: mockUnregisterAbility,
 			} );
 
@@ -175,7 +199,7 @@ describe( 'API functions', () => {
 
 	describe( 'executeAbility', () => {
 		it( 'should execute a server-side ability via callback', async () => {
-			const mockServerCallback = jest
+			const mockServerCallback = vi
 				.fn()
 				.mockResolvedValue( { success: true, result: 'test' } );
 			const mockAbility: Ability = {
@@ -195,8 +219,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { serverRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -211,9 +235,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should execute a client-side ability locally', async () => {
-			const mockCallback = jest
-				.fn()
-				.mockResolvedValue( { success: true } );
+			const mockCallback = vi.fn().mockResolvedValue( { success: true } );
 			const mockAbility: Ability = {
 				name: 'test/client-ability',
 				label: 'Client Ability',
@@ -225,8 +247,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { clientRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -241,8 +263,8 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should throw error if ability not found', async () => {
-			const mockGetAbility = jest.fn().mockReturnValue( null );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( null );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -252,7 +274,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should validate input for client abilities', async () => {
-			const mockCallback = jest.fn();
+			const mockCallback = vi.fn();
 			const mockAbility: Ability = {
 				name: 'test/client-ability',
 				label: 'Client Ability',
@@ -270,8 +292,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { clientRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -281,7 +303,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should execute a read-only server ability', async () => {
-			const mockServerCallback = jest
+			const mockServerCallback = vi
 				.fn()
 				.mockResolvedValue( { data: 'read-only data' } );
 			const mockAbility: Ability = {
@@ -303,8 +325,8 @@ describe( 'API functions', () => {
 				callback: mockServerCallback,
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -316,7 +338,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should execute a read-only ability with empty input', async () => {
-			const mockServerCallback = jest
+			const mockServerCallback = vi
 				.fn()
 				.mockResolvedValue( { data: 'read-only data' } );
 			const mockAbility: Ability = {
@@ -332,8 +354,8 @@ describe( 'API functions', () => {
 				callback: mockServerCallback,
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -344,7 +366,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should execute a destructive idempotent server ability', async () => {
-			const mockServerCallback = jest
+			const mockServerCallback = vi
 				.fn()
 				.mockResolvedValue( 'Item deleted successfully.' );
 			const mockAbility: Ability = {
@@ -370,8 +392,8 @@ describe( 'API functions', () => {
 				callback: mockServerCallback,
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -383,11 +405,11 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should handle errors in client ability execution', async () => {
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 			const executionError = new Error( 'Execution failed' );
-			const mockCallback = jest.fn().mockRejectedValue( executionError );
+			const mockCallback = vi.fn().mockRejectedValue( executionError );
 
 			const mockAbility: Ability = {
 				name: 'test/client-ability',
@@ -400,8 +422,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { clientRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -418,13 +440,11 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should handle errors in server ability execution', async () => {
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 			const serverError = new Error( 'Server execution failed' );
-			const mockServerCallback = jest
-				.fn()
-				.mockRejectedValue( serverError );
+			const mockServerCallback = vi.fn().mockRejectedValue( serverError );
 
 			const mockAbility: Ability = {
 				name: 'test/server-ability',
@@ -437,8 +457,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { serverRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -455,7 +475,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should execute ability without callback as server ability', async () => {
-			const mockServerCallback = jest
+			const mockServerCallback = vi
 				.fn()
 				.mockResolvedValue( { success: true } );
 			const mockAbility: Ability = {
@@ -470,8 +490,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { serverRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -486,7 +506,7 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should validate output for client abilities', async () => {
-			const mockCallback = jest
+			const mockCallback = vi
 				.fn()
 				.mockResolvedValue( { invalid: 'response' } );
 			const mockAbility: Ability = {
@@ -506,8 +526,8 @@ describe( 'API functions', () => {
 				meta: { annotations: { clientRegistered: true } },
 			};
 
-			const mockGetAbility = jest.fn().mockReturnValue( mockAbility );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbility = vi.fn().mockReturnValue( mockAbility );
+			mockSelect( {
 				getAbility: mockGetAbility,
 			} );
 
@@ -532,10 +552,10 @@ describe( 'API functions', () => {
 				},
 			];
 
-			const mockGetAbilityCategories = jest
+			const mockGetAbilityCategories = vi
 				.fn()
 				.mockReturnValue( mockCategories );
-			( select as jest.Mock ).mockReturnValue( {
+			mockSelect( {
 				getAbilityCategories: mockGetAbilityCategories,
 			} );
 
@@ -547,8 +567,8 @@ describe( 'API functions', () => {
 		} );
 
 		it( 'should return empty array when no categories exist', () => {
-			const mockGetAbilityCategories = jest.fn().mockReturnValue( [] );
-			( select as jest.Mock ).mockReturnValue( {
+			const mockGetAbilityCategories = vi.fn().mockReturnValue( [] );
+			mockSelect( {
 				getAbilityCategories: mockGetAbilityCategories,
 			} );
 
@@ -566,10 +586,10 @@ describe( 'API functions', () => {
 				description: 'Abilities that retrieve data',
 			};
 
-			const mockGetAbilityCategory = jest
+			const mockGetAbilityCategory = vi
 				.fn()
 				.mockReturnValue( mockCategory );
-			( select as jest.Mock ).mockReturnValue( {
+			mockSelect( {
 				getAbilityCategory: mockGetAbilityCategory,
 			} );
 
@@ -592,10 +612,10 @@ describe( 'API functions', () => {
 				},
 			};
 
-			const mockGetAbilityCategory = jest
+			const mockGetAbilityCategory = vi
 				.fn()
 				.mockReturnValue( mockCategory );
-			( select as jest.Mock ).mockReturnValue( {
+			mockSelect( {
 				getAbilityCategory: mockGetAbilityCategory,
 			} );
 

--- a/packages/abilities/src/tests/validation.test.ts
+++ b/packages/abilities/src/tests/validation.test.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateValueFromSchema } from '../validation';
@@ -137,9 +142,9 @@ describe( 'validateValueFromSchema', () => {
 
 	describe( 'edge cases', () => {
 		it( 'should pass validation when empty schema provided', () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'warn' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 
 			expect( validateValueFromSchema( 'anything', {} ) ).toBe( true );
 			expect( consoleSpy ).toHaveBeenCalledWith(
@@ -150,9 +155,9 @@ describe( 'validateValueFromSchema', () => {
 		} );
 
 		it( 'should warn when type is missing but still pass validation', () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'warn' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 			const schema = { properties: { name: { type: 'string' } } };
 			const result = validateValueFromSchema( { name: 'test' }, schema );
 
@@ -165,9 +170,9 @@ describe( 'validateValueFromSchema', () => {
 		} );
 
 		it( 'should include param name in warning when provided', () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'warn' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 			const schema = { format: 'email' }; // Schema without type
 			const result = validateValueFromSchema(
 				'test@example.com',
@@ -453,9 +458,9 @@ describe( 'validateValueFromSchema', () => {
 
 	describe( 'schema edge cases and errors', () => {
 		it( 'should handle empty schema object as valid but warn about missing type', () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'warn' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 
 			// Empty object schema triggers warning about missing type
 			expect( validateValueFromSchema( 'anything', {} ) ).toBe( true );
@@ -467,9 +472,9 @@ describe( 'validateValueFromSchema', () => {
 		} );
 
 		it( 'should warn for invalid schema types but still pass validation', () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'warn' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 
 			// Testing edge cases where schema is not a valid object
 			expect(
@@ -510,9 +515,9 @@ describe( 'validateValueFromSchema', () => {
 		it( 'should handle schema compilation errors', () => {
 			// Pass an invalid schema that will cause compilation error
 			const invalidSchema = { type: 'invalid-type' };
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 
 			const result = validateValueFromSchema( 'test', invalidSchema );
 
@@ -570,9 +575,9 @@ describe( 'validateValueFromSchema', () => {
 						},
 					},
 				};
-				const consoleErrorSpy = jest
+				const consoleErrorSpy = vi
 					.spyOn( console, 'error' )
-					.mockImplementation();
+					.mockImplementation( () => {} );
 
 				expect(
 					validateValueFromSchema( { name: 'hello' }, schema )
@@ -591,9 +596,9 @@ describe( 'validateValueFromSchema', () => {
 				type: 'string',
 				sanitize_callback: 'sanitize_text_field',
 			};
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
-				.mockImplementation();
+				.mockImplementation( () => {} );
 
 			expect( validateValueFromSchema( 'hello', schema ) ).toBe(
 				'Invalid schema provided for validation.'

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -6,6 +6,7 @@
 	"vitest": {
 		"files": [ "packages/html-entities/src/test/entities.ts" ],
 		"directories": [
+			"packages/abilities",
 			"packages/annotations",
 			"packages/blob",
 			"packages/connectors",


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80871; review the abilities-package commit in this PR.

**TL;DR — typed module mocks:** Migrates all five `@wordpress/abilities` suites to Vitest, replacing Jest casts with typed ESM module mocks, `vi.mocked()`, and narrow selector/dispatcher helpers.

## Why?

The abilities tests mock generic `@wordpress/data` APIs and a local store module. A mechanical Jest-to-`vi` rename would preserve untyped casts and string-based mock paths, so this slice establishes the canonical TypeScript pattern before larger data-layer migrations.

## How?

- Uses type-checked `vi.mock(import())` paths and partial async factories that preserve unmocked module exports.
- Uses `vi.mocked()` for the imported generic `select` and `dispatch` functions, with one narrow cast per generic boundary and typed partial-return helpers.
- Replaces Jest mock functions, spies, reset calls, and `jest.Mock` references with explicit Vitest imports and types.
- Makes console-suppression callbacks explicit; Vitest does not preserve Jest's zero-argument `mockImplementation()` no-op behavior on the shared console spies.
- Declares Vitest in the abilities workspace and removes active Jest identifiers from the complete package test tree.

No snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 969 Jest baseline files, 31 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- --reporter=dot`; expect 31 files and 417 tests to pass without unexpected console output.
3. Run all four `--shard=N/4` Vitest partitions.
4. Type-check the mock-bearing actions, selectors, API, and validation tests with a test-inclusive no-emit config, and build the package's production TypeScript project.
5. Run strict lint, package metadata and lockfile validation, and audit the package for Jest identifiers, `@types/jest`, `vitest/globals`, and string-based `vi.mock` paths.

Locally verified all of the above plus formatting and pre-commit checks. The existing reducer test is still excluded by the package's production tsconfig; the dedicated test-graph PR will bring every routed TS/TSX test, including that file, under the enforced CI type check before Jest retirement. The remaining Jest partition is unchanged and covered by stacked CI.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to compare the Jest mocks with Vitest's ESM and generic-function typing, implement the typed factories and helpers, identify the console suppression semantic difference, and run the reported verification. The resulting changes and claims were reviewed against the current repository configuration and passing tests.