### PR TITLE
Migrate date and timezone variants to Vitest

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -79,8 +79,8 @@ jobs:
                   node-version: ${{ matrix.node }}
 
             - name: Run build scripts
-              # It's not necessary to run the full build, since Jest can interpret
-              # source files with `babel-jest`. Some packages have their own custom
+              # It's not necessary to run the full build, since both test runners
+              # transform source files through Babel. Some packages have custom
               # build tasks, however. These must be run.
               run: npx lerna run build
 
@@ -141,8 +141,8 @@ jobs:
                   node-version: ${{ matrix.node }}
 
             - name: Run build scripts
-              # It's not necessary to run the full build, since Jest can interpret
-              # source files with `babel-jest`. Some packages have their own custom
+              # It's not necessary to run the full build, since Vitest transforms
+              # source files through Babel. Some packages have their own custom
               # build tasks, however. These must be run.
               run: npx lerna run build
 
@@ -152,7 +152,7 @@ jobs:
                   # dimension so flakiness.io keeps a separate history per Node
                   # version in the matrix.
                   FK_ENV_NODEJS: ${{ matrix.node }}
-              run: npm run test:unit:date -- --ci --maxWorkers="$(nproc)" --cacheDirectory="$HOME/.jest-cache"
+              run: npm run test:unit:date -- --maxWorkers="$(nproc)"
 
     compute-previous-wordpress-version:
         name: Compute previous WordPress version

--- a/bin/unit-test-date.sh
+++ b/bin/unit-test-date.sh
@@ -17,7 +17,7 @@ for timezone in "${timezones[@]}"; do
         TZ=$timezone LANG=$locale \
             FK_ENV_TZ=$timezone FK_ENV_LANG=$locale \
             FLAKINESS_OUTPUT_DIR="flakiness-report-$timezone-$locale" \
-            npm run test:unit -- packages/date "$@" &
+            npm run test:unit:vitest -- packages/date "$@" &
         pids+=($!)
         pidsTimezones+=($timezone)
         pidsLocales+=($locale)

--- a/package-lock.json
+++ b/package-lock.json
@@ -50423,6 +50423,9 @@
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -46,6 +46,9 @@
 		"moment": "^2.29.4",
 		"moment-timezone": "^0.5.40"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import momentLib from 'moment';
+import { describe, expect, it, test } from 'vitest';
 
 /**
  * Internal dependencies

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -11,6 +11,7 @@
 			"packages/blob",
 			"packages/connectors",
 			"packages/core-commands",
+			"packages/date",
 			"packages/dom-ready",
 			"packages/edit-site",
 			"packages/escape-html",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -48,9 +48,10 @@ if (
 	] );
 }
 
-// Preserve Jest's repository-root configuration discovery and default timezone.
+// Preserve repository-root configuration discovery and default to UTC while
+// allowing the date-test matrix to supply another timezone.
 process.chdir( ROOT_DIR );
-process.env.TZ = 'UTC';
+process.env.TZ ||= 'UTC';
 
 const transpiledPackageNames = glob(
 	path.join( ROOT_DIR, 'packages/*/src/index.{js,ts,tsx}' )


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80872; review the date/timezone commit in this PR.

**TL;DR — date and timezone parity:** Migrates the date package and its six timezone/locale matrix runs to Vitest while preserving Node-version coverage and Flakiness.io environment identity.

## Why?

The ordinary Vitest config defaults to UTC, but the dedicated date job intentionally runs EST, GMT, and CET under two locales. An unconditional UTC assignment or forwarded Jest-only flags would silently erase that coverage.

## How?

- Routes the complete `@wordpress/date` suite to Vitest with explicit runner imports and a package-owned Vitest dependency.
- Changes the Vitest config to default to UTC only when the caller did not supply `TZ`.
- Routes `test:unit:date` through the Vitest command while retaining the existing `TZ`, `LANG`, `FK_ENV_TZ`, `FK_ENV_LANG`, and per-variant Flakiness.io output directories.
- Removes the Jest-only `--ci` and `--cacheDirectory` flags from the date CI job; keeps its Node 20/22/24 matrix and worker limit.
- Updates build-step comments to describe the mixed-runner transition accurately.

No snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 968 Jest baseline files, 32 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:date -- --maxWorkers=2 --reporter=dot`; expect all six EST/GMT/CET × en_US/ja_JP runs to pass 110 tests each.
3. Run `npm run test:unit:vitest -- --reporter=dot`; expect 32 files and 527 tests to pass.
4. Run all four `--shard=N/4` Vitest partitions.
5. Build the date TypeScript project, run strict lint, validate package metadata and the lockfile, and run `bash -n bin/unit-test-date.sh`.

Locally verified all of the above plus formatting and pre-commit checks. The remaining Jest partition is unchanged and covered by stacked CI.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to trace the existing date matrix and timezone initialization, identify the unconditional-UTC and Jest-flag hazards, implement the Vitest routing, and run all six variants plus the complete reported verification. The resulting changes and claims were reviewed against the workflow and passing tests.