### PR TITLE
Migrate sync tests and fake timers to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53163,8 +53163,8 @@
 				"yjs": "^13.6.29"
 			},
 			"devDependencies": {
-				"@jest/globals": "^30.4.1",
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -54,8 +54,8 @@
 		"yjs": "^13.6.29"
 	},
 	"devDependencies": {
-		"@jest/globals": "^30.4.1",
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/sync/src/providers/http-polling/test/config.test.ts
+++ b/packages/sync/src/providers/http-polling/test/config.test.ts
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it, vi } from 'vitest';
 
 type SyncConfig = typeof import('../config');
 
 function loadConfigWithFilteredIntervals(
 	filteredIntervals: Record< string, unknown >
-): SyncConfig {
-	jest.resetModules();
-	jest.doMock( '@wordpress/hooks', () => ( {
-		applyFilters: jest.fn( ( hookName: string, defaultValue: unknown ) => {
+): Promise< SyncConfig > {
+	vi.resetModules();
+	vi.doMock( import( '@wordpress/hooks' ), async ( importOriginal ) => ( {
+		...( await importOriginal() ),
+		applyFilters: vi.fn( ( hookName: string, defaultValue: unknown ) => {
 			if (
 				Object.prototype.hasOwnProperty.call(
 					filteredIntervals,
@@ -24,19 +25,19 @@ function loadConfigWithFilteredIntervals(
 		} ),
 	} ) );
 
-	return require( '../config' ) as SyncConfig;
+	return import( '../config' );
 }
 
 describe( 'http-polling config', () => {
-	it( 'uses default polling intervals when filters do not change them', () => {
-		const config = loadConfigWithFilteredIntervals( {} );
+	it( 'uses default polling intervals when filters do not change them', async () => {
+		const config = await loadConfigWithFilteredIntervals( {} );
 
 		expect( config.POLLING_INTERVAL_IN_MS ).toBe( 4000 );
 		expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe( 1000 );
 	} );
 
-	it( 'allows filters to make active polling intervals faster', () => {
-		const config = loadConfigWithFilteredIntervals( {
+	it( 'allows filters to make active polling intervals faster', async () => {
+		const config = await loadConfigWithFilteredIntervals( {
 			'sync.pollingManager.pollingInterval': 1000,
 			'sync.pollingManager.pollingIntervalWithCollaborators': 250,
 		} );
@@ -45,8 +46,8 @@ describe( 'http-polling config', () => {
 		expect( config.POLLING_INTERVAL_WITH_COLLABORATORS_IN_MS ).toBe( 250 );
 	} );
 
-	it( 'caps filters that would make active polling intervals slower', () => {
-		const config = loadConfigWithFilteredIntervals( {
+	it( 'caps filters that would make active polling intervals slower', async () => {
+		const config = await loadConfigWithFilteredIntervals( {
 			'sync.pollingManager.pollingInterval': 10000,
 			'sync.pollingManager.pollingIntervalWithCollaborators': 2500,
 		} );
@@ -62,8 +63,8 @@ describe( 'http-polling config', () => {
 		[ 'non-number', '100' ],
 	] )(
 		'uses default intervals when filters return %s values',
-		( _label, filteredValue ) => {
-			const config = loadConfigWithFilteredIntervals( {
+		async ( _label, filteredValue ) => {
+			const config = await loadConfigWithFilteredIntervals( {
 				'sync.pollingManager.pollingInterval': filteredValue,
 				'sync.pollingManager.pollingIntervalWithCollaborators':
 					filteredValue,

--- a/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
+++ b/packages/sync/src/providers/http-polling/test/polling-manager.test.ts
@@ -7,58 +7,78 @@ import {
 	describe,
 	expect,
 	it,
-	jest,
-} from '@jest/globals';
+	type Mock,
+	vi,
+} from 'vitest';
 import { type SyncPayload, type SyncResponse } from '../types';
 
 // Mock all external dependencies before imports.
-jest.mock( 'yjs', () => ( {
-	mergeUpdatesV2: jest.fn( () => new Uint8Array() ),
-	applyUpdateV2: jest.fn(),
-	encodeStateAsUpdateV2: jest.fn( () => new Uint8Array() ),
+vi.mock( import( 'yjs' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	mergeUpdatesV2: vi.fn( () => new Uint8Array() ),
+	applyUpdateV2: vi.fn(),
+	encodeStateAsUpdateV2: vi.fn( () => new Uint8Array() ),
 } ) );
 
-jest.mock( 'lib0/encoding', () => ( {
-	createEncoder: jest.fn( () => ( {} ) ),
-	toUint8Array: jest.fn( () => new Uint8Array( [ 0 ] ) ),
+vi.mock( import( 'lib0/encoding' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	createEncoder: vi.fn< typeof import('lib0/encoding').createEncoder >(
+		() =>
+			( {} ) as ReturnType< typeof import('lib0/encoding').createEncoder >
+	),
+	toUint8Array: vi.fn< typeof import('lib0/encoding').toUint8Array >(
+		() => new Uint8Array( [ 0 ] )
+	),
 } ) );
 
-jest.mock( 'lib0/decoding', () => ( {
-	createDecoder: jest.fn( () => ( {} ) ),
+vi.mock( import( 'lib0/decoding' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
+	return {
+		...original,
+		createDecoder: vi.fn( () => ( {} ) ),
+	} as unknown as typeof original;
+} );
+
+vi.mock( import( 'y-protocols/sync' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	writeSyncStep1: vi.fn(),
+	readSyncMessage: vi.fn(),
 } ) );
 
-jest.mock( 'y-protocols/sync', () => ( {
-	writeSyncStep1: jest.fn(),
-	readSyncMessage: jest.fn(),
+vi.mock( import( 'y-protocols/awareness' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	removeAwarenessStates: vi.fn(),
 } ) );
 
-jest.mock( 'y-protocols/awareness', () => ( {
-	removeAwarenessStates: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/hooks', () => ( {
-	applyFilters: jest.fn(
+vi.mock( import( '@wordpress/hooks' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	applyFilters: vi.fn(
 		( _hook: string, defaultValue: unknown ) => defaultValue
 	),
 } ) );
 
-jest.mock( '../config', () => ( {
-	...( jest.requireActual( '../config' ) as object ),
-	MAX_UPDATE_SIZE_IN_BYTES: 10,
-	// Shrink the per-request room cap so rotation tests don't need 50+
-	// registered rooms. Existing tests register at most 2 rooms and
-	// stay well under this cap.
-	MAX_ROOMS_PER_REQUEST: 10,
-	MAX_SYNC_REQUEST_BODY_SIZE_IN_BYTES: 1000,
-	// Keep the dynamic-shrink floor below MAX so the halving logic in the
-	// 413 retry path has room to actually halve.
-	MIN_SYNC_REQUEST_BODY_SIZE_IN_BYTES: 100,
-} ) );
+vi.mock( import( '../config' ), async ( importOriginal ) => {
+	const original = await importOriginal();
 
-jest.mock( '../utils', () => ( {
-	...( jest.requireActual( '../utils' ) as object ),
-	postSyncUpdate: jest.fn(),
-	postSyncUpdateNonBlocking: jest.fn(),
+	return {
+		...original,
+		MAX_UPDATE_SIZE_IN_BYTES: 10,
+		// Shrink the per-request room cap so rotation tests don't need 50+
+		// registered rooms. Existing tests register at most 2 rooms and
+		// stay well under this cap.
+		MAX_ROOMS_PER_REQUEST: 10,
+		MAX_SYNC_REQUEST_BODY_SIZE_IN_BYTES: 1000,
+		// Keep the dynamic-shrink floor below MAX so the halving logic in the
+		// 413 retry path has room to actually halve.
+		MIN_SYNC_REQUEST_BODY_SIZE_IN_BYTES: 100,
+	} as unknown as typeof original;
+} );
+
+vi.mock( import( '../utils' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	postSyncUpdate: vi.fn(),
+	postSyncUpdateNonBlocking: vi.fn(),
 } ) );
 
 interface PollingManager {
@@ -85,7 +105,7 @@ function createDeferred< T >() {
 }
 
 function createMockDoc( clientID = 1 ) {
-	return { clientID, on: jest.fn(), off: jest.fn() };
+	return { clientID, on: vi.fn(), off: vi.fn() };
 }
 
 // Helper to extract the onDocUpdate callback registered via doc.on('updateV2', ...).
@@ -102,11 +122,11 @@ function getOnDocUpdate( doc: ReturnType< typeof createMockDoc > ) {
 function createMockAwareness() {
 	return {
 		clientID: 1,
-		getLocalState: jest.fn( () => ( {} ) ),
-		getStates: jest.fn( () => new Map() ),
-		on: jest.fn(),
-		off: jest.fn(),
-		emit: jest.fn(),
+		getLocalState: vi.fn( () => ( {} ) ),
+		getStates: vi.fn( () => new Map() ),
+		on: vi.fn(),
+		off: vi.fn(),
+		emit: vi.fn(),
 	};
 }
 
@@ -116,6 +136,18 @@ function simulateVisibilityChange( state: string ) {
 		get: () => state,
 	} );
 	document.dispatchEvent( new Event( 'visibilitychange' ) );
+}
+
+async function advancePollingTime( duration: number ) {
+	// The polling callback crosses several awaited request and response stages.
+	// Drain that promise chain before and after moving the fake clock.
+	for ( let attempt = 0; attempt < 50; attempt++ ) {
+		await Promise.resolve();
+	}
+	vi.advanceTimersByTime( duration );
+	for ( let attempt = 0; attempt < 50; attempt++ ) {
+		await Promise.resolve();
+	}
 }
 
 const syncResponse = {
@@ -150,31 +182,54 @@ function getServerAwareness(
 
 describe( 'polling-manager', () => {
 	let pollingManager: PollingManager;
-	let mockPostSyncUpdate: jest.Mock<
-		typeof import('../utils').postSyncUpdate
-	>;
-	let mockPostSyncUpdateNonBlocking: jest.Mock<
+	let mockPostSyncUpdate: Mock< typeof import('../utils').postSyncUpdate >;
+	let mockPostSyncUpdateNonBlocking: Mock<
 		typeof import('../utils').postSyncUpdateNonBlocking
 	>;
-	let mockApplyFilters: jest.Mock;
+	let mockApplyFilters: Mock;
+	let registeredRooms: Set< string >;
 
-	beforeEach( () => {
-		jest.useFakeTimers();
-
-		// Use isolateModules so each test gets fresh module-level state
-		// (isPolling, pollingTimeoutId, roomStates, etc.).
-		jest.isolateModules( () => {
-			pollingManager = require( '../polling-manager' ).pollingManager;
-			mockPostSyncUpdate = require( '../utils' ).postSyncUpdate;
-			mockPostSyncUpdateNonBlocking =
-				require( '../utils' ).postSyncUpdateNonBlocking;
-			mockApplyFilters = require( '@wordpress/hooks' ).applyFilters;
+	beforeEach( async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		vi.useFakeTimers( {
+			toFake: [ 'clearTimeout', 'setTimeout' ],
 		} );
+
+		// Reload the module graph so each test gets fresh module-level state
+		// (isPolling, pollingTimeoutId, roomStates, etc.).
+		const manager = ( await import( '../polling-manager' ) ).pollingManager;
+		registeredRooms = new Set();
+		pollingManager = {
+			registerRoom( options ) {
+				registeredRooms.add( options.room );
+				manager.registerRoom(
+					options as Parameters< typeof manager.registerRoom >[ 0 ]
+				);
+			},
+			unregisterRoom( room, options ) {
+				registeredRooms.delete( room );
+				manager.unregisterRoom( room, options );
+			},
+		};
+		const utils = await import( '../utils' );
+		mockPostSyncUpdate = vi.mocked( utils.postSyncUpdate );
+		mockPostSyncUpdateNonBlocking = vi.mocked(
+			utils.postSyncUpdateNonBlocking
+		);
+		mockApplyFilters = vi.mocked(
+			( await import( '@wordpress/hooks' ) ).applyFilters
+		);
 	} );
 
 	afterEach( () => {
-		jest.clearAllTimers();
-		jest.useRealTimers();
+		for ( const room of registeredRooms ) {
+			pollingManager.unregisterRoom( room, {
+				sendDisconnectSignal: false,
+			} );
+		}
+		vi.clearAllTimers();
+		vi.useRealTimers();
 		Object.defineProperty( document, 'visibilityState', {
 			configurable: true,
 			get: () => 'visible',
@@ -185,16 +240,16 @@ describe( 'polling-manager', () => {
 		it( 'emits document-size-limit-exceeded error when an update exceeds the size limit', async () => {
 			mockPostSyncUpdate.mockResolvedValue( syncResponse );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 			const doc = createMockDoc( 1 );
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// Simulate a doc update that exceeds the mocked MAX_UPDATE_SIZE_IN_BYTES (10).
@@ -218,9 +273,9 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			const onDocUpdate = getOnDocUpdate( doc );
@@ -248,20 +303,20 @@ describe( 'polling-manager', () => {
 		it( 'does not trigger for updates within the size limit', async () => {
 			mockPostSyncUpdate.mockResolvedValue( syncResponse );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 			const doc = createMockDoc( 1 );
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// Flush the initial poll so 'connected' status is emitted first.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			onStatusChange.mockClear();
 
 			// Send an update within the limit (10 bytes).
@@ -300,18 +355,18 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( {
 				status: 'disconnected',
@@ -340,18 +395,18 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			expect( onStatusChange ).not.toHaveBeenCalledWith(
 				expect.objectContaining( {
@@ -379,12 +434,12 @@ describe( 'polling-manager', () => {
 				room: 'first-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Now register a second room with many clients — should not disconnect.
 			const awarenessMany = {
@@ -412,18 +467,18 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'second-room',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			expect( onStatusChange ).not.toHaveBeenCalledWith(
 				expect.objectContaining( {
@@ -452,19 +507,19 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// First poll passes.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			onStatusChange.mockClear();
 
 			// Second poll: 5 clients (over limit).
@@ -486,7 +541,7 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			// Should NOT disconnect — limit check only runs on initial sync.
 			expect( onStatusChange ).not.toHaveBeenCalledWith(
@@ -521,12 +576,12 @@ describe( 'polling-manager', () => {
 				room: 'my-custom-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			expect( mockApplyFilters ).toHaveBeenCalledWith(
 				'sync.pollingProvider.maxClientsPerRoom',
@@ -558,18 +613,18 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// 5 clients under a limit of 10 — should not disconnect.
 			expect( onStatusChange ).not.toHaveBeenCalledWith(
@@ -610,22 +665,22 @@ describe( 'polling-manager', () => {
 				room: 'primary-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			pollingManager.registerRoom( {
 				room: 'collection-room',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// First poll: detects collaborators on primary room, resumes all queues.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Second poll: collection room queue should now be unpaused,
 			// so its initial sync_step1 update should be included.
@@ -649,7 +704,7 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			// The second call should include non-empty updates for the collection room.
 			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
@@ -682,25 +737,25 @@ describe( 'polling-manager', () => {
 				room: 'primary-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			pollingManager.registerRoom( {
 				room: 'collection-room',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// First poll: no collaborators.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Second poll: collection room queue should still be paused.
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
 			const collectionRoom = secondCallPayload.rooms.find(
@@ -734,22 +789,22 @@ describe( 'polling-manager', () => {
 				room: 'primary-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			pollingManager.registerRoom( {
 				room: 'collection-room',
 				doc: collectionDoc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// First poll: no collaborators, queues stay paused.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Simulate a local doc update on the collection room (e.g., a note was saved).
 			const onDocUpdate = getOnDocUpdate( collectionDoc );
@@ -772,7 +827,7 @@ describe( 'polling-manager', () => {
 					},
 				],
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			const secondCallPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
 			const collectionRoomPoll2 = secondCallPayload.rooms.find(
@@ -800,7 +855,7 @@ describe( 'polling-manager', () => {
 					},
 				],
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			// Fourth poll: collection room should now send accumulated updates.
 			mockPostSyncUpdate.mockResolvedValue( {
@@ -822,7 +877,7 @@ describe( 'polling-manager', () => {
 					},
 				],
 			} );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			const fourthCallPayload = mockPostSyncUpdate.mock.calls[ 3 ][ 0 ];
 			const collectionRoomPoll4 = fourthCallPayload.rooms.find(
@@ -853,28 +908,28 @@ describe( 'polling-manager', () => {
 				],
 			} );
 
-			const onStatusChangeA = jest.fn();
-			const onStatusChangeB = jest.fn();
+			const onStatusChangeA = vi.fn();
+			const onStatusChangeB = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'room-a',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange: onStatusChangeA,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
 			pollingManager.registerRoom( {
 				room: 'room-b',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange: onStatusChangeB,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			onStatusChangeA.mockClear();
 			onStatusChangeB.mockClear();
 
@@ -884,7 +939,7 @@ describe( 'polling-manager', () => {
 				message: 'Protocol version mismatch',
 			} );
 
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			expect( onStatusChangeA ).toHaveBeenCalledWith( {
 				status: 'disconnected',
@@ -909,12 +964,12 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Second poll: protocol mismatch.
@@ -922,12 +977,12 @@ describe( 'polling-manager', () => {
 				code: 'rest_sync_protocol_mismatch',
 			} );
 
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Wait a long time — no further polls should occur (return stops scheduling).
 			mockPostSyncUpdate.mockResolvedValue( syncResponse );
-			await jest.advanceTimersByTimeAsync( 60000 );
+			await advancePollingTime( 60000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 		} );
 
@@ -938,19 +993,19 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			mockPostSyncUpdateNonBlocking.mockClear();
 
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_sync_protocol_mismatch',
 			} );
 
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			expect( mockPostSyncUpdateNonBlocking ).not.toHaveBeenCalled();
 		} );
@@ -962,18 +1017,18 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_sync_protocol_mismatch',
 			} );
 
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Register a new room. If isPolling weren't reset, this would
@@ -984,12 +1039,12 @@ describe( 'polling-manager', () => {
 				room: 'new-room',
 				doc: createMockDoc( 3 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 			const lastPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ];
@@ -1001,25 +1056,25 @@ describe( 'polling-manager', () => {
 			// First poll succeeds.
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Protocol mismatch — should return early without touching backoff.
 			mockPostSyncUpdate.mockRejectedValueOnce( {
 				code: 'rest_sync_protocol_mismatch',
 			} );
 
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			// The error should be protocol-mismatch, not unknown-error
 			// (which would indicate the generic catch handler ran).
@@ -1054,21 +1109,21 @@ describe( 'polling-manager', () => {
 					room: `room-${ i }`,
 					doc,
 					awareness: createMockAwareness(),
-					log: jest.fn(),
-					onStatusChange: jest.fn(),
-					onSync: jest.fn(),
+					log: vi.fn(),
+					onStatusChange: vi.fn(),
+					onSync: vi.fn(),
 				} );
 			}
 
 			// First poll includes the primary room and detects a collaborator,
 			// which resumes all queues.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			docs.forEach( ( doc ) => {
 				getOnDocUpdate( doc )( new Uint8Array( 8 ), 'user' );
 			} );
 
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			const secondCallPayload = mockPostSyncUpdate.mock
 				.calls[ 1 ][ 0 ] as {
@@ -1082,7 +1137,7 @@ describe( 'polling-manager', () => {
 				0
 			);
 
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			const thirdCallPayload = mockPostSyncUpdate.mock
 				.calls[ 2 ][ 0 ] as {
@@ -1117,12 +1172,12 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			getOnDocUpdate( doc )( new Uint8Array( [ 1, 2, 3 ] ), 'user' );
 
@@ -1131,7 +1186,7 @@ describe( 'polling-manager', () => {
 				message: 'Request body is too large.',
 				data: { status: 413 },
 			} );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			const failedPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ] as {
 				rooms: Array< {
@@ -1145,7 +1200,7 @@ describe( 'polling-manager', () => {
 			mockPostSyncUpdate.mockResolvedValueOnce(
 				responseWithCollaborator
 			);
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 
 			const retryPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ] as {
 				rooms: Array< {
@@ -1184,13 +1239,13 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// Flush the initial poll (queue is paused, so no updates sent).
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Add a document update (queue is now resumed due to collaborators).
@@ -1199,7 +1254,7 @@ describe( 'polling-manager', () => {
 
 			// Second poll: fail with a network error.
 			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'timeout' ) );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Verify the second poll included the queued updates (sync_step1 + doc update).
@@ -1220,7 +1275,7 @@ describe( 'polling-manager', () => {
 			);
 
 			// First failure with collaborators: retry in 1000ms (schedule[0]).
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const thirdCallPayload = mockPostSyncUpdate.mock
@@ -1242,17 +1297,17 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Second poll: fail (no updates were sent because queue is paused).
 			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'timeout' ) );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Verify no updates were sent on the failed poll.
@@ -1267,7 +1322,7 @@ describe( 'polling-manager', () => {
 			// Third poll: succeed — should still have no updates (no compaction queued).
 			// First failure solo: retry in 2000ms (schedule[0]).
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
-			await jest.advanceTimersByTimeAsync( 2000 );
+			await advancePollingTime( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const thirdCallPayload = mockPostSyncUpdate.mock
@@ -1291,9 +1346,9 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc(),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// registerRoom → poll() → start() → postSyncUpdate (pending).
@@ -1314,13 +1369,13 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc(),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
 			// Flush so the first poll completes and schedules a timeout.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Tab hidden → visible while a timeout is pending.
@@ -1328,7 +1383,7 @@ describe( 'polling-manager', () => {
 			simulateVisibilityChange( 'visible' );
 
 			// Should trigger an immediate repoll (not wait for timeout).
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
@@ -1354,26 +1409,26 @@ describe( 'polling-manager', () => {
 			};
 			mockPostSyncUpdate.mockResolvedValueOnce( twoRoomResponse );
 
-			const onStatusChangeA = jest.fn();
-			const onStatusChangeB = jest.fn();
+			const onStatusChangeA = vi.fn();
+			const onStatusChangeB = vi.fn();
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange: onStatusChangeA,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 			pollingManager.registerRoom( {
 				room: 'other-room',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange: onStatusChangeB,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Second poll: 403 listing only test-room.
@@ -1383,7 +1438,7 @@ describe( 'polling-manager', () => {
 					'You do not have permission to sync one or more entities: test-room.',
 				data: { status: 403, rooms: [ 'test-room' ] },
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// No error should be emitted — the room is silently removed.
@@ -1411,7 +1466,7 @@ describe( 'polling-manager', () => {
 					},
 				],
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
@@ -1444,28 +1499,28 @@ describe( 'polling-manager', () => {
 				room: 'keep-room',
 				doc: keepDoc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 			pollingManager.registerRoom( {
 				room: 'forbidden-room-a',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 			pollingManager.registerRoom( {
 				room: 'forbidden-room-b',
 				doc: createMockDoc( 3 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			const onDocUpdate = getOnDocUpdate( keepDoc );
 			onDocUpdate( new Uint8Array( [ 1, 2, 3 ] ), 'local-origin' );
@@ -1479,7 +1534,7 @@ describe( 'polling-manager', () => {
 					rooms: [ 'forbidden-room-a', 'forbidden-room-b' ],
 				},
 			} );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			const failedPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ];
@@ -1498,7 +1553,7 @@ describe( 'polling-manager', () => {
 					},
 				],
 			} );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const retryPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ];
@@ -1527,22 +1582,22 @@ describe( 'polling-manager', () => {
 				room: 'primary',
 				doc: primaryDoc,
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 			for ( let i = 1; i <= 10; i++ ) {
 				pollingManager.registerRoom( {
 					room: `overflow-${ i }`,
 					doc: createMockDoc( i + 1 ),
 					awareness: createMockAwareness(),
-					log: jest.fn(),
-					onStatusChange: jest.fn(),
-					onSync: jest.fn(),
+					log: vi.fn(),
+					onStatusChange: vi.fn(),
+					onSync: vi.fn(),
 				} );
 			}
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			const onPrimaryDocUpdate = getOnDocUpdate( primaryDoc );
@@ -1557,7 +1612,7 @@ describe( 'polling-manager', () => {
 					rooms: [ 'overflow-1', 'overflow-10' ],
 				},
 			} );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			const failedPayload = mockPostSyncUpdate.mock.calls[ 1 ][ 0 ] as {
@@ -1583,7 +1638,7 @@ describe( 'polling-manager', () => {
 			expect( failedPrimaryRoom!.updates.length ).toBeGreaterThan( 0 );
 
 			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
-			await jest.advanceTimersByTimeAsync( 1000 );
+			await advancePollingTime( 1000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const retryPayload = mockPostSyncUpdate.mock.calls[ 2 ][ 0 ] as {
@@ -1602,17 +1657,17 @@ describe( 'polling-manager', () => {
 		it( 'retries normally on a 401 (not treated as forbidden)', async () => {
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
 
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 			pollingManager.registerRoom( {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
+				log: vi.fn(),
 				onStatusChange,
-				onSync: jest.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Fail with a 401 — should go through normal retry path.
 			mockPostSyncUpdate.mockRejectedValueOnce( {
@@ -1620,7 +1675,7 @@ describe( 'polling-manager', () => {
 				message: 'You are not currently logged in.',
 				data: { status: 401 },
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 
 			// Should emit a disconnected status (normal error handling).
 			expect( onStatusChange ).toHaveBeenCalledWith(
@@ -1632,7 +1687,7 @@ describe( 'polling-manager', () => {
 
 			// Should retry after backoff (2000ms for solo first failure).
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
-			await jest.advanceTimersByTimeAsync( 2000 );
+			await advancePollingTime( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
@@ -1643,23 +1698,23 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 
 			// Fail with a generic network error (no data.status).
 			mockPostSyncUpdate.mockRejectedValueOnce(
 				new Error( 'Network error' )
 			);
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Should retry after backoff (2000ms for solo first failure).
 			mockPostSyncUpdate.mockResolvedValueOnce( syncResponse );
-			await jest.advanceTimersByTimeAsync( 2000 );
+			await advancePollingTime( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 
@@ -1670,12 +1725,12 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Next poll: 403 listing the only registered room.
@@ -1685,7 +1740,7 @@ describe( 'polling-manager', () => {
 					'You do not have permission to sync one or more entities: test-room.',
 				data: { status: 403, rooms: [ 'test-room' ] },
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// The server already denied the sync request, so our awareness
@@ -1700,12 +1755,12 @@ describe( 'polling-manager', () => {
 				room: 'test-room',
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 
 			// Next poll: a generic 403 without room details.
@@ -1715,7 +1770,7 @@ describe( 'polling-manager', () => {
 				message: 'You do not have permission to perform this action.',
 				data: { status: 403 },
 			} );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			// Register a brand-new room. This should kick off a fresh poll
@@ -1735,12 +1790,12 @@ describe( 'polling-manager', () => {
 				room: 'new-room',
 				doc: createMockDoc( 2 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 		} );
 	} );
@@ -1761,9 +1816,9 @@ describe( 'polling-manager', () => {
 				room,
 				doc: createMockDoc( 1 ),
 				awareness: createMockAwareness(),
-				log: jest.fn(),
-				onStatusChange: jest.fn(),
-				onSync: jest.fn(),
+				log: vi.fn(),
+				onStatusChange: vi.fn(),
+				onSync: vi.fn(),
 			} );
 		}
 
@@ -1794,8 +1849,8 @@ describe( 'polling-manager', () => {
 			// Primary + 9 overflow = 10 rooms, exactly at the cap.
 			const overflow = registerPrimaryAndOverflow( pollingManager, 9 );
 
-			await jest.advanceTimersByTimeAsync( 0 );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 0 );
+			await advancePollingTime( 4000 );
 
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
@@ -1813,9 +1868,9 @@ describe( 'polling-manager', () => {
 			// Primary + 11 overflow = 12 rooms, over the cap of 10.
 			registerPrimaryAndOverflow( pollingManager, 11 );
 
-			await jest.advanceTimersByTimeAsync( 0 );
-			await jest.advanceTimersByTimeAsync( 4000 );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 0 );
+			await advancePollingTime( 4000 );
+			await advancePollingTime( 4000 );
 
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
@@ -1838,9 +1893,9 @@ describe( 'polling-manager', () => {
 			// enough to cover every overflow room at least once.
 			const overflow = registerPrimaryAndOverflow( pollingManager, 15 );
 
-			await jest.advanceTimersByTimeAsync( 0 );
-			await jest.advanceTimersByTimeAsync( 4000 );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 0 );
+			await advancePollingTime( 4000 );
+			await advancePollingTime( 4000 );
 
 			const overflowSeen = new Set< string >();
 			// Skip poll 0 (primary only); inspect rotation polls.
@@ -1861,9 +1916,9 @@ describe( 'polling-manager', () => {
 			// Primary + 11 overflow rooms, 9 slots per request.
 			registerPrimaryAndOverflow( pollingManager, 11 );
 
-			await jest.advanceTimersByTimeAsync( 0 );
-			await jest.advanceTimersByTimeAsync( 4000 );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 0 );
+			await advancePollingTime( 4000 );
+			await advancePollingTime( 4000 );
 
 			// Compare the two rotation polls (poll 0 is primary-only).
 			const first = getRoomNames( 1 ).slice( 1 );
@@ -1876,19 +1931,20 @@ describe( 'polling-manager', () => {
 		} );
 
 		it( 'advances the rotation window even when a poll fails', async () => {
+			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
+
 			// Primary + 11 overflow rooms, 9 slots per request.
 			registerPrimaryAndOverflow( pollingManager, 11 );
 
 			// Poll 1: primary only (fires synchronously at registration).
-			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 1 );
 			expect( getRoomNames( 0 ) ).toEqual( [ 'primary' ] );
 
 			// Poll 2 fails while sending primary + 9 overflow. The
 			// rotation offset should still advance past this window.
 			mockPostSyncUpdate.mockRejectedValueOnce( new Error( 'network' ) );
-			await jest.advanceTimersByTimeAsync( 4000 );
+			await advancePollingTime( 4000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 2 );
 
 			const failedSent = getRoomNames( 1 );
@@ -1898,7 +1954,7 @@ describe( 'polling-manager', () => {
 			// Poll 3 retries after the failure and should send a different
 			// overflow slice, proving the offset advanced despite the error.
 			mockPostSyncUpdate.mockResolvedValueOnce( { rooms: [] } );
-			await jest.advanceTimersByTimeAsync( 2000 );
+			await advancePollingTime( 2000 );
 			expect( mockPostSyncUpdate ).toHaveBeenCalledTimes( 3 );
 
 			const retrySent = getRoomNames( 2 );
@@ -1915,7 +1971,7 @@ describe( 'polling-manager', () => {
 
 			// Flush the initial poll so the pagehide test observes
 			// postSyncUpdateNonBlocking calls from the page-hide handler only.
-			await jest.advanceTimersByTimeAsync( 0 );
+			await advancePollingTime( 0 );
 			mockPostSyncUpdateNonBlocking.mockClear();
 
 			window.dispatchEvent( new Event( 'pagehide' ) );

--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // Mock @wordpress/api-fetch
-jest.mock( '@wordpress/api-fetch', () => ( {
-	__esModule: true,
-	default: jest.fn(),
-} ) );
+vi.mock( import( '@wordpress/api-fetch' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
+	return {
+		...original,
+		default: vi.fn(),
+	} as unknown as typeof original;
+} );
 
 /**
  * WordPress dependencies
@@ -29,7 +33,7 @@ import {
 	uint8ArrayToBase64,
 } from '../utils';
 
-const mockApiFetch = jest.mocked( apiFetch );
+const mockApiFetch = vi.mocked( apiFetch );
 const SERVER_MAX_UPDATE_DATA_SIZE_IN_BYTES = 1024 * 1024;
 
 describe( 'http-polling utils', () => {
@@ -581,7 +585,7 @@ describe( 'http-polling utils', () => {
 
 	describe( 'postSyncUpdate', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'sends a POST request to the sync endpoint', async () => {

--- a/packages/sync/src/quill-delta/test/Delta.ts
+++ b/packages/sync/src/quill-delta/test/Delta.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -8,10 +8,12 @@ import {
 	describe,
 	expect,
 	it,
-	jest,
+	vi,
 	beforeEach,
 	afterEach,
-} from '@jest/globals';
+	type Mock,
+	type Mocked,
+} from 'vitest';
 
 /**
  * Internal dependencies
@@ -36,21 +38,22 @@ import type {
 import { serializeCrdtDoc } from '../utils';
 
 // Mock dependencies.
-jest.mock( '../providers', () => ( {
-	getProviderCreators: jest.fn(),
+vi.mock( import( '../providers' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getProviderCreators: vi.fn(),
 } ) );
-const mockGetProviderCreators = jest.mocked( getProviderCreators );
+const mockGetProviderCreators = vi.mocked( getProviderCreators );
 
 describe( 'SyncManager', () => {
-	let mockHandlers: jest.MockedObject< RecordHandlers >;
-	let mockProviderCreator: jest.Mock< ProviderCreator >;
+	let mockHandlers: Mocked< RecordHandlers >;
+	let mockProviderCreator: Mock< ProviderCreator >;
 	let mockProviderResult: ProviderCreatorResult;
 	let mockRecord: ObjectData;
-	let mockSyncConfig: jest.MockedObject< SyncConfig >;
+	let mockSyncConfig: Mocked< SyncConfig >;
 
 	beforeEach( () => {
 		// Reset all mocks
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 
 		mockRecord = {
 			id: '123',
@@ -59,17 +62,17 @@ describe( 'SyncManager', () => {
 		};
 
 		mockProviderResult = {
-			destroy: jest.fn(),
-			on: jest.fn(),
+			destroy: vi.fn(),
+			on: vi.fn(),
 		};
-		mockProviderCreator = jest.fn( () =>
+		mockProviderCreator = vi.fn( () =>
 			Promise.resolve( mockProviderResult )
 		);
 		mockGetProviderCreators.mockReturnValue( [ mockProviderCreator ] );
 
 		mockSyncConfig = {
-			applyChangesToCRDTDoc: jest.fn(),
-			getChangesFromCRDTDoc: jest.fn(
+			applyChangesToCRDTDoc: vi.fn(),
+			getChangesFromCRDTDoc: vi.fn(
 				( ydoc: CRDTDoc, editedRecord: ObjectData ) => {
 					const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 
@@ -85,27 +88,26 @@ describe( 'SyncManager', () => {
 					);
 				}
 			),
-			createAwareness: jest.fn(
-				( ydoc: Y.Doc ) => new Awareness( ydoc )
-			),
-			getPersistedCRDTDoc: jest.fn( () => null ),
+			createAwareness: vi.fn( ( ydoc: Y.Doc ) => new Awareness( ydoc ) ),
+			getPersistedCRDTDoc: vi.fn( () => null ),
+			shouldSync: undefined,
+			supportsPersistence: undefined,
 		};
 
 		mockHandlers = {
-			addUndoMeta: jest.fn(),
-			editRecord: jest.fn(),
-			getEditedRecord: jest.fn( async () =>
-				Promise.resolve( mockRecord )
-			),
-			onStatusChange: jest.fn(),
-			persistCRDTDoc: jest.fn(),
-			refetchRecord: jest.fn( async () => Promise.resolve() ),
-			restoreUndoMeta: jest.fn(),
+			addUndoMeta: vi.fn(),
+			editRecord: vi.fn(),
+			getEditedRecord: vi.fn( async () => Promise.resolve( mockRecord ) ),
+			onStatusChange: vi.fn(),
+			onUndoStackChange: undefined,
+			persistCRDTDoc: vi.fn(),
+			refetchRecord: vi.fn( async () => Promise.resolve() ),
+			restoreUndoMeta: vi.fn(),
 		};
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	describe( 'load', () => {
@@ -228,7 +230,7 @@ describe( 'SyncManager', () => {
 		} );
 
 		it( 'only adds undo metadata for the entity that changed', async () => {
-			mockSyncConfig.applyChangesToCRDTDoc = jest.fn(
+			mockSyncConfig.applyChangesToCRDTDoc = vi.fn(
 				( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
 					const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 					Object.entries( changes ).forEach( ( [ key, value ] ) => {
@@ -241,19 +243,19 @@ describe( 'SyncManager', () => {
 			const recordB = { id: '456', title: 'Post B', meta: {} };
 			const handlersA = {
 				...mockHandlers,
-				addUndoMeta: jest.fn(),
-				getEditedRecord: jest.fn( async () =>
+				addUndoMeta: vi.fn(),
+				getEditedRecord: vi.fn( async () =>
 					Promise.resolve( recordA )
 				),
-				restoreUndoMeta: jest.fn(),
+				restoreUndoMeta: vi.fn(),
 			};
 			const handlersB = {
 				...mockHandlers,
-				addUndoMeta: jest.fn(),
-				getEditedRecord: jest.fn( async () =>
+				addUndoMeta: vi.fn(),
+				getEditedRecord: vi.fn( async () =>
 					Promise.resolve( recordB )
 				),
-				restoreUndoMeta: jest.fn(),
+				restoreUndoMeta: vi.fn(),
 			};
 
 			const manager = createSyncManager();
@@ -339,7 +341,7 @@ describe( 'SyncManager', () => {
 			it( 'accepts a valid persisted CRDT doc without applying changes', async () => {
 				mockSyncConfig = {
 					...mockSyncConfig,
-					getPersistedCRDTDoc: jest.fn( () =>
+					getPersistedCRDTDoc: vi.fn( () =>
 						createPersistedCRDTDoc( mockRecord )
 					),
 				};
@@ -375,7 +377,7 @@ describe( 'SyncManager', () => {
 			it( 'applies a persisted CRDT doc with invalidated fields, then applies changes', async () => {
 				mockSyncConfig = {
 					...mockSyncConfig,
-					getPersistedCRDTDoc: jest.fn( () =>
+					getPersistedCRDTDoc: vi.fn( () =>
 						createPersistedCRDTDoc( {
 							...mockRecord,
 							title: 'Invalidated title from persisted CRDT doc',
@@ -459,7 +461,7 @@ describe( 'SyncManager', () => {
 
 			manager.unload( 'post', '123' );
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			await manager.load(
 				mockSyncConfig,
@@ -500,7 +502,7 @@ describe( 'SyncManager', () => {
 			expect( mockProviderResult.destroy ).toHaveBeenCalledTimes( 1 );
 
 			// Should still be able to update the other entity
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 			manager.update( 'post', '456', { title: 'Updated' }, 'local' );
 
 			// Wait a tick for any async follow-up work.
@@ -584,7 +586,7 @@ describe( 'SyncManager', () => {
 			mockProviderCreator.mockImplementation( () =>
 				Promise.resolve( mockProviderResult )
 			);
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			await manager.load(
 				mockSyncConfig,
@@ -620,7 +622,7 @@ describe( 'SyncManager', () => {
 				mockHandlers
 			);
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			const changes = { title: 'Updated Title' };
 			manager.update( 'post', '123', changes, 'local-editor' );
@@ -660,7 +662,7 @@ describe( 'SyncManager', () => {
 			};
 			const syncConfig = {
 				...mockSyncConfig,
-				applyChangesToCRDTDoc: jest.fn(
+				applyChangesToCRDTDoc: vi.fn(
 					( ydoc: CRDTDoc, changes: Partial< ObjectData > ) => {
 						const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 						Object.entries( changes ).forEach(
@@ -673,8 +675,8 @@ describe( 'SyncManager', () => {
 			};
 			const handlers = {
 				...mockHandlers,
-				editRecord: jest.fn(),
-				getEditedRecord: jest.fn( async () =>
+				editRecord: vi.fn(),
+				getEditedRecord: vi.fn( async () =>
 					Promise.resolve( editedRecord )
 				),
 			};
@@ -737,7 +739,7 @@ describe( 'SyncManager', () => {
 				mockHandlers
 			);
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			manager.update(
 				'post',
@@ -793,7 +795,7 @@ describe( 'SyncManager', () => {
 			expect( capturedDoc ).not.toBeNull();
 
 			// Spy on transact to verify origin is passed
-			const transactSpy = jest.spyOn(
+			const transactSpy = vi.spyOn(
 				capturedDoc as unknown as Y.Doc,
 				'transact'
 			);
@@ -830,7 +832,7 @@ describe( 'SyncManager', () => {
 				mockHandlers
 			);
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			const changes = { title: 'Updated Title' };
 			const now = Date.now();
@@ -862,7 +864,7 @@ describe( 'SyncManager', () => {
 		it( 'skips loading entity when shouldSync returns false', async () => {
 			const manager = createSyncManager();
 
-			mockSyncConfig.shouldSync = jest.fn( () => false );
+			mockSyncConfig.shouldSync = vi.fn( () => false );
 
 			await manager.load(
 				mockSyncConfig,
@@ -885,7 +887,7 @@ describe( 'SyncManager', () => {
 		it( 'loads entity when shouldSync returns true', async () => {
 			const manager = createSyncManager();
 
-			mockSyncConfig.shouldSync = jest.fn( () => true );
+			mockSyncConfig.shouldSync = vi.fn( () => true );
 
 			await manager.load(
 				mockSyncConfig,
@@ -927,11 +929,11 @@ describe( 'SyncManager', () => {
 		it( 'skips loading collection when shouldSync returns false', async () => {
 			const manager = createSyncManager();
 
-			mockSyncConfig.shouldSync = jest.fn( () => false );
+			mockSyncConfig.shouldSync = vi.fn( () => false );
 
 			const mockCollectionHandlers = {
-				onStatusChange: jest.fn(),
-				refetchRecords: jest.fn( async () => Promise.resolve() ),
+				onStatusChange: vi.fn(),
+				refetchRecords: vi.fn( async () => Promise.resolve() ),
 			};
 
 			await manager.loadCollection(
@@ -950,11 +952,11 @@ describe( 'SyncManager', () => {
 		it( 'loads collection when shouldSync returns true', async () => {
 			const manager = createSyncManager();
 
-			mockSyncConfig.shouldSync = jest.fn( () => true );
+			mockSyncConfig.shouldSync = vi.fn( () => true );
 
 			const mockCollectionHandlers = {
-				onStatusChange: jest.fn(),
-				refetchRecords: jest.fn( async () => Promise.resolve() ),
+				onStatusChange: vi.fn(),
+				refetchRecords: vi.fn( async () => Promise.resolve() ),
 			};
 
 			await manager.loadCollection(
@@ -976,8 +978,8 @@ describe( 'SyncManager', () => {
 			delete mockSyncConfig.shouldSync;
 
 			const mockCollectionHandlers = {
-				onStatusChange: jest.fn(),
-				refetchRecords: jest.fn( async () => Promise.resolve() ),
+				onStatusChange: vi.fn(),
+				refetchRecords: vi.fn( async () => Promise.resolve() ),
 			};
 
 			await manager.loadCollection(
@@ -1099,7 +1101,7 @@ describe( 'SyncManager', () => {
 			const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 
 			// Clear previous calls
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			// Simulate a local update with sync manager origin
 			ydoc.transact( () => {

--- a/packages/sync/src/test/performance.test.ts
+++ b/packages/sync/src/test/performance.test.ts
@@ -5,10 +5,11 @@ import {
 	describe,
 	expect,
 	it,
-	jest,
+	vi,
 	beforeEach,
 	afterEach,
-} from '@jest/globals';
+	type MockInstance,
+} from 'vitest';
 
 /**
  * Internal dependencies
@@ -21,10 +22,10 @@ import {
 
 describe( 'performance utilities', () => {
 	describe( 'logPerformanceTiming', () => {
-		let consoleSpy: jest.SpiedFunction< typeof console.log >;
+		let consoleSpy: MockInstance< typeof console.log >;
 
 		beforeEach( () => {
-			consoleSpy = jest
+			consoleSpy = vi
 				.spyOn( console, 'log' )
 				.mockImplementation( () => {} );
 		} );
@@ -57,7 +58,7 @@ describe( 'performance utilities', () => {
 		} );
 
 		it( 'passes all arguments to the wrapped function', () => {
-			const fn = jest.fn( ( a: number, b: string, c: boolean ) => {
+			const fn = vi.fn( ( a: number, b: string, c: boolean ) => {
 				return `${ a }-${ b }-${ c }`;
 			} );
 
@@ -116,7 +117,7 @@ describe( 'performance utilities', () => {
 
 	describe( 'passThru', () => {
 		it( 'returns a function that calls the original function', () => {
-			const fn = jest.fn( () => 'result' );
+			const fn = vi.fn( () => 'result' );
 
 			const wrapped = passThru( fn );
 			const result = wrapped();
@@ -126,7 +127,7 @@ describe( 'performance utilities', () => {
 		} );
 
 		it( 'passes all arguments to the original function', () => {
-			const fn = jest.fn( ( a: number, b: string ) => `${ a }-${ b }` );
+			const fn = vi.fn( ( a: number, b: string ) => `${ a }-${ b }` );
 
 			const wrapped = passThru( fn );
 			const result = wrapped( 42, 'test' );
@@ -180,33 +181,33 @@ describe( 'performance utilities', () => {
 
 	describe( 'yieldToEventLoop', () => {
 		beforeEach( () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'delays function execution to the next tick', () => {
-			const fn = jest.fn();
+			const fn = vi.fn();
 
 			const wrapped = yieldToEventLoop( fn );
 			wrapped();
 
 			expect( fn ).not.toHaveBeenCalled();
 
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( fn ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'passes all arguments to the wrapped function', () => {
-			const fn = jest.fn( ( a: number, b: string ) => `${ a }-${ b }` );
+			const fn = vi.fn( ( a: number, b: string ) => `${ a }-${ b }` );
 
 			const wrapped = yieldToEventLoop( fn );
 			wrapped( 42, 'test' );
 
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( fn ).toHaveBeenCalledWith( 42, 'test' );
 		} );
@@ -214,7 +215,7 @@ describe( 'performance utilities', () => {
 		it( 'preserves the this context', () => {
 			const obj = {
 				value: 10,
-				logValue: jest.fn( function ( this: { value: number } ) {
+				logValue: vi.fn( function ( this: { value: number } ) {
 					return this.value;
 				} ),
 			};
@@ -222,14 +223,14 @@ describe( 'performance utilities', () => {
 			const wrapped = yieldToEventLoop( obj.logValue );
 			wrapped.call( obj );
 
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( obj.logValue ).toHaveBeenCalled();
 			expect( obj.logValue.mock.instances[ 0 ] ).toBe( obj );
 		} );
 
 		it( 'handles multiple invocations', () => {
-			const fn = jest.fn();
+			const fn = vi.fn();
 
 			const wrapped = yieldToEventLoop( fn );
 			wrapped();
@@ -238,7 +239,7 @@ describe( 'performance utilities', () => {
 
 			expect( fn ).not.toHaveBeenCalled();
 
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( fn ).toHaveBeenCalledTimes( 3 );
 		} );
@@ -254,14 +255,14 @@ describe( 'performance utilities', () => {
 			wrapped( 2 );
 			wrapped( 3 );
 
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( calls ).toEqual( [ 1, 2, 3 ] );
 		} );
 
 		it( 'uses setTimeout with 0ms delay', () => {
-			const setTimeoutSpy = jest.spyOn( global, 'setTimeout' );
-			const fn = jest.fn();
+			const setTimeoutSpy = vi.spyOn( global, 'setTimeout' );
+			const fn = vi.fn();
 
 			const wrapped = yieldToEventLoop( fn );
 			wrapped();
@@ -275,7 +276,7 @@ describe( 'performance utilities', () => {
 		} );
 
 		it( 'returns void', () => {
-			const fn = jest.fn( () => 'result' );
+			const fn = vi.fn( () => 'result' );
 
 			const wrapped = yieldToEventLoop( fn as () => void );
 			const result = wrapped();

--- a/packages/sync/src/test/undo-manager.test.ts
+++ b/packages/sync/src/test/undo-manager.test.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as Y from 'yjs';
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -24,9 +24,9 @@ describe( 'SyncUndoManager', () => {
 			doc,
 			map: doc.getMap( 'record' ),
 			handlers: {
-				addUndoMeta: jest.fn(),
-				onUndoStackChange: jest.fn(),
-				restoreUndoMeta: jest.fn(),
+				addUndoMeta: vi.fn(),
+				onUndoStackChange: vi.fn(),
+				restoreUndoMeta: vi.fn(),
 			},
 		};
 	}

--- a/packages/sync/src/test/utils.ts
+++ b/packages/sync/src/test/utils.ts
@@ -3,7 +3,7 @@
  */
 import * as Y from 'yjs';
 import * as buffer from 'lib0/buffer';
-import { describe, expect, it, beforeEach } from '@jest/globals';
+import { describe, expect, it, beforeEach } from 'vitest';
 
 /**
  * Internal dependencies

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -22,6 +22,7 @@
 			"packages/server-side-render",
 			"packages/shortcode",
 			"packages/style-engine",
+			"packages/sync",
 			"packages/token-list",
 			"packages/undo-manager",
 			"packages/wordcount"


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80873; review the sync migration commit in this PR.

**TL;DR — async fake-timer and module-mocking parity:** Migrates the complete `@wordpress/sync` test package to Vitest, replacing Jest module isolation and timer APIs with typed ESM mocks, explicit module reloads, deterministic async-clock settlement, and per-test polling cleanup.

## Why?

The sync suites combine module-level polling state, partial protocol mocks, zero-delay scheduling, retry backoff, and asynchronous timer callbacks. A mechanical `jest` to `vi` rename either hangs on `advanceTimersByTimeAsync` or leaks polling state between tests, so this package needs an explicit Vitest lifecycle rather than compatibility globals.

## How?

- Routes all eight sync test files to Vitest with explicit runner imports and a package-owned Vitest dependency.
- Uses typed `vi.mock( import( ... ) )` factories that preserve real exports; narrow casts are limited to generic third-party APIs and overridden literal constants that cannot represent test values in their published types.
- Replaces `isolateModules` and CommonJS `require` with `resetModules` plus dynamic ESM imports.
- Tracks registered rooms and unregisters them after each test so module reloading does not leave active polling state behind.
- Fakes only `setTimeout`/`clearTimeout` in the polling suite and drains its awaited request/response stages before and after advancing the fake clock.
- Makes one initial queued response explicit before room registration, removing reliance on a mock implementation inherited from the preceding test.
- Completes optional mocked interface fields so the migrated test graph type-checks.

No production code or snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 960 Jest baseline files, 40 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- packages/sync`; expect 8 files and 226 tests to pass.
3. Run `npm run test:unit:vitest`; expect 40 files and 753 tests to pass.
4. Run all four `--shard=N/4` Vitest partitions; expect 143, 236, 119, and 255 tests respectively.
5. Build the sync TypeScript project, run JS lint, and validate package metadata and the lockfile.
6. Run the complementary Jest partition with `--maxWorkers=4`.

Locally verified all of the above plus formatting and commit-time strict lint/docs checks. The complementary Jest run passed 957 suites (33,978 tests) with 2 suites skipped and all 376 snapshots passing; only the unchanged `packages/env/lib/config/test/config-integration.js` suite failed because the current WordPress version was unavailable from both the local cache and the restricted network. `lint:deps` still reports only the repository's pre-existing `@babel/core` and `yargs` alignment issues.

### Testing Instructions for Keyboard

Not applicable; this PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to reconcile the Jest baseline, port the sync package with typed ESM mocks and explicit timer settlement, identify and remove one cross-test mock-order dependency, and run the package, full Vitest, four-shard, TypeScript, lint, lockfile, and complementary Jest verification. The resulting diff and reported limitations were reviewed against the migration goal.