### PR TITLE
Migrate widget dashboard tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53475,8 +53475,8 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/jest": "^30.0.0",
-				"storybook": "^10.4.3"
+				"storybook": "^10.4.3",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/widget-dashboard/package.json
+++ b/packages/widget-dashboard/package.json
@@ -72,8 +72,8 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/jest": "^30.0.0",
-		"storybook": "^10.4.3"
+		"storybook": "^10.4.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/widget-dashboard/src/test/actions.test.tsx
+++ b/packages/widget-dashboard/src/test/actions.test.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -84,7 +85,7 @@ describe( 'WidgetDashboard.Actions', () => {
 	} );
 
 	it( 'fires onEditChange with true when Customize is clicked', async () => {
-		const onEditChange = jest.fn();
+		const onEditChange = vi.fn();
 		render( <Harness onEditChange={ onEditChange } /> );
 
 		await user.click( screen.getByRole( 'button', { name: 'Customize' } ) );
@@ -101,8 +102,8 @@ describe( 'WidgetDashboard.Actions', () => {
 	} );
 
 	it( 'fires onEditChange with false when Cancel is clicked', async () => {
-		const onEditChange = jest.fn();
-		const onLayoutChange = jest.fn();
+		const onEditChange = vi.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				initialEditMode
@@ -145,14 +146,19 @@ describe( 'WidgetDashboard.Actions', () => {
 	} );
 
 	it( 'throws when used outside a WidgetDashboard subtree', () => {
-		const spy = jest
-			.spyOn( console, 'error' )
-			.mockImplementation( () => {} );
+		const spy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const preventJSDOMError = ( event: ErrorEvent ) => {
+			event.preventDefault();
+		};
+		window.addEventListener( 'error', preventJSDOMError );
 
-		expect( () => render( <WidgetDashboard.Actions /> ) ).toThrow(
-			/Dashboard compound used outside a WidgetDashboard subtree/
-		);
-
-		spy.mockRestore();
+		try {
+			expect( () => render( <WidgetDashboard.Actions /> ) ).toThrow(
+				/Dashboard compound used outside a WidgetDashboard subtree/
+			);
+		} finally {
+			window.removeEventListener( 'error', preventJSDOMError );
+			spy.mockRestore();
+		}
 	} );
 } );

--- a/packages/widget-dashboard/src/test/commands.test.tsx
+++ b/packages/widget-dashboard/src/test/commands.test.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 /**
  * WordPress dependencies

--- a/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
+++ b/packages/widget-dashboard/src/test/create-dashboard-widget.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import type { WidgetType } from '@wordpress/widget-primitives';

--- a/packages/widget-dashboard/src/test/dashboard-context.test.tsx
+++ b/packages/widget-dashboard/src/test/dashboard-context.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ function CaptureWidgetContext( {
 
 describe( 'useWidgetContext', () => {
 	it( 'returns null outside a widget render subtree', () => {
-		const handler = jest.fn();
+		const handler = vi.fn();
 		render( <CaptureWidgetContext onRender={ handler } /> );
 		expect( handler ).toHaveBeenCalledWith( null );
 	} );

--- a/packages/widget-dashboard/src/test/staging.test.tsx
+++ b/packages/widget-dashboard/src/test/staging.test.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -89,7 +90,7 @@ function Harness( {
 
 describe( 'WidgetDashboard staging layer', () => {
 	it( 'keeps mutations in staging without firing onLayoutChange', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -117,7 +118,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'fires onLayoutChange with the staged layout on commit', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -151,7 +152,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'restores staging to the committed layout on cancel', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -178,7 +179,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'reports no uncommitted changes after a swap-and-revert when the visible order is restored', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -206,7 +207,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'commits a canonicalized layout, sorted by order with order stripped', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -265,7 +266,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'forces edit mode when the layout becomes empty', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		const { rerender } = render(
 			<Harness
 				layout={ initialLayout }
@@ -280,7 +281,7 @@ describe( 'WidgetDashboard staging layer', () => {
 	} );
 
 	it( 'stays in edit mode when commit passes exitEditMode: false', () => {
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render(
 			<Harness
 				layout={ initialLayout }
@@ -307,15 +308,15 @@ describe( 'WidgetDashboard staging layer', () => {
 		];
 
 		beforeEach( () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'publishes a scheduled edit once the debounce elapses, staying in normal mode', () => {
-			const onLayoutChange = jest.fn();
+			const onLayoutChange = vi.fn();
 			render(
 				<Harness
 					layout={ initialLayout }
@@ -332,7 +333,7 @@ describe( 'WidgetDashboard staging layer', () => {
 			expect( onLayoutChange ).not.toHaveBeenCalled();
 
 			act( () => {
-				jest.runOnlyPendingTimers();
+				vi.runOnlyPendingTimers();
 			} );
 
 			expect( onLayoutChange ).toHaveBeenCalledTimes( 1 );
@@ -345,7 +346,7 @@ describe( 'WidgetDashboard staging layer', () => {
 		} );
 
 		it( 'publishes a pending edit immediately on flushAutoSave', () => {
-			const onLayoutChange = jest.fn();
+			const onLayoutChange = vi.fn();
 			render(
 				<Harness
 					layout={ initialLayout }
@@ -367,7 +368,7 @@ describe( 'WidgetDashboard staging layer', () => {
 		} );
 
 		it( 'flushes a pending edit on unmount instead of dropping it', () => {
-			const onLayoutChange = jest.fn();
+			const onLayoutChange = vi.fn();
 			const { unmount } = render(
 				<Harness
 					layout={ initialLayout }
@@ -394,7 +395,7 @@ describe( 'WidgetDashboard staging layer', () => {
 		} );
 
 		it( 'does not publish unscheduled staging on unmount', () => {
-			const onLayoutChange = jest.fn();
+			const onLayoutChange = vi.fn();
 			const { unmount } = render(
 				<Harness
 					layout={ initialLayout }

--- a/packages/widget-dashboard/src/test/use-inline-fit.test.tsx
+++ b/packages/widget-dashboard/src/test/use-inline-fit.test.tsx
@@ -3,6 +3,7 @@
  */
 import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -12,8 +13,8 @@ import { WidgetHeaderAvailableSizeProvider } from '../components/widget-header/w
 
 let notifyResize: ( entries: unknown[] ) => void = () => {};
 
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	useResizeObserver: ( callback: ( entries: unknown[] ) => void ) => {
 		notifyResize = callback;
 		return () => {};

--- a/packages/widget-dashboard/src/test/widget-attributes-transitions.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-attributes-transitions.test.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentType } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -29,8 +30,8 @@ import type { DashboardWidget } from '../types';
  */
 const mockObserved = new Map< Element, ( entries: unknown[] ) => void >();
 
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	useResizeObserver: ( callback: ( entries: unknown[] ) => void ) => {
 		return ( element: Element | null ) => {
 			if ( element ) {

--- a/packages/widget-dashboard/src/test/widget-attributes.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-attributes.test.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentType } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -23,11 +24,15 @@ import { useInlineFit } from '../components/widget-attributes/use-inline-fit';
 import { WidgetDashboard } from '../widget-dashboard';
 import type { DashboardWidget } from '../types';
 
-jest.mock( '../components/widget-attributes/use-inline-fit', () => ( {
-	useInlineFit: jest.fn(),
-} ) );
+vi.mock(
+	import( '../components/widget-attributes/use-inline-fit' ),
+	async ( importOriginal ) => ( {
+		...( await importOriginal() ),
+		useInlineFit: vi.fn(),
+	} )
+);
 
-const mockedUseInlineFit = jest.mocked( useInlineFit );
+const mockedUseInlineFit = vi.mocked( useInlineFit );
 
 function TestWidget( {
 	attributes,

--- a/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-dashboard.test.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import type { ComponentType } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -126,7 +127,7 @@ describe( 'WidgetDashboard', () => {
 	} );
 
 	it( 'threads setAttributes into onLayoutChange on commit with merged attributes', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render( <Harness onLayoutChange={ onChange } /> );
 
 		const button = await screen.findByRole( 'button', {

--- a/packages/widget-dashboard/src/test/widget-inserter.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-inserter.test.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentType } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -100,7 +101,7 @@ describe( 'WidgetDashboard.WidgetInserter', () => {
 
 	it( 'inserts the selected widget type into the layout on Done', async () => {
 		const user = userEvent.setup();
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 
 		await user.click(
@@ -141,7 +142,7 @@ describe( 'WidgetDashboard.WidgetInserter', () => {
 
 	it( 'inserts multiple widgets via multi-select in a single layout change', async () => {
 		const user = userEvent.setup();
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 
 		await user.click(
@@ -173,7 +174,7 @@ describe( 'WidgetDashboard.WidgetInserter', () => {
 
 	it( 'preserves existing widgets when appending new ones', async () => {
 		const user = userEvent.setup();
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		const existing: DashboardWidget = {
 			uuid: 'existing-1',
 			type: 'wordpress/welcome',

--- a/packages/widget-dashboard/src/test/widget-settings.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-settings.test.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentType } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -102,7 +103,7 @@ describe( 'WidgetDashboard widget settings', () => {
 
 	it( 'stages attribute edits behind the drawer and publishes them on Save', async () => {
 		const user = userEvent.setup();
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 		await screen.findByTestId( 'greeting' );
 
@@ -146,7 +147,7 @@ describe( 'WidgetDashboard widget settings', () => {
 
 	it( 'discards staged edits when the drawer is dismissed', async () => {
 		const user = userEvent.setup();
-		const onLayoutChange = jest.fn();
+		const onLayoutChange = vi.fn();
 		render( <Harness onLayoutChange={ onLayoutChange } /> );
 		await screen.findByTestId( 'greeting' );
 

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/widget-dashboard/tsconfig.json
+++ b/packages/widget-dashboard/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "style-imports" ],
+		"types": [ "style-imports" ],
 		"checkJs": false
 	},
 	"references": [

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -25,6 +25,7 @@
 			"packages/sync",
 			"packages/token-list",
 			"packages/undo-manager",
+			"packages/widget-dashboard",
 			"packages/wordcount"
 		]
 	},


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80874; review the widget-dashboard migration commit in this PR.

**TL;DR — Testing Library integration:** Migrates the complete `@wordpress/widget-dashboard` suite to Vitest while keeping React Testing Library and user-event, switching jest-dom to its Vitest entry point, using explicit runner imports, and preserving centralized DOM cleanup.

## Why?

Vitest replaces the test runner, not Testing Library. This slice proves the canonical UI-test shape before larger component areas move: semantic Testing Library queries and user interactions remain unchanged, runner globals stay disabled, jest-dom uses its Vitest adapter, and cleanup remains registered once in the shared setup.

## How?

- Routes all 12 widget-dashboard test files to Vitest with explicit `describe`, `it`, `expect`, hook, and `vi` imports.
- Keeps `@testing-library/react`, `@testing-library/user-event`, and `@testing-library/jest-dom`; imports the `/vitest` matcher entry point so test-file TypeScript sees the correct matcher augmentation.
- Uses the shared Vitest setup's explicit `afterEach( cleanup )` because runner globals are disabled.
- Replaces partial Jest mocks with typed `vi.mock( import( ... ) )` factories that preserve real exports.
- Preserves the staging suite's fake-timer behavior with `vi.useFakeTimers` and `vi.runOnlyPendingTimers`.
- Prevents JSDOM from logging an expected render error while retaining the assertion that the compound component throws outside its provider.
- Removes package-local Jest types and adds the package-owned Vitest dependency.

No production code or snapshots changed.

## Testing Instructions

1. Run `npm run test:unit:routing`; expect 948 Jest baseline files, 52 Vitest baseline files, and 4 added Vitest compatibility files.
2. Run `npm run test:unit:vitest -- packages/widget-dashboard`; expect 12 files and 61 tests to pass.
3. Run `npm run test:unit:vitest`; expect 52 files and 814 tests to pass.
4. Run all four `--shard=N/4` Vitest partitions.
5. Build the widget-dashboard TypeScript project, run JS lint, and validate package metadata and the lockfile.

Locally verified all of the above plus formatting and commit-time strict lint, docs, and tsconfig checks. The remaining Jest files are unchanged from #80874; that parent verification passed 957 suites with only the documented offline `@wordpress/env` integration failure, and stacked CI covers the reduced partition here.

### Testing Instructions for Keyboard

Not applicable; this PR changes test infrastructure only. Existing keyboard interaction tests continue to run through Testing Library user-event.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to reconcile the widget-dashboard Jest baseline, port its Testing Library and fake-timer usage to explicit Vitest APIs, remove Jest-only types and mocking patterns, suppress one expected JSDOM error without weakening its assertion, and run the package, full-suite, shard, TypeScript, lint, package, and lockfile verification. The resulting diff and claims were reviewed against the migration goal.