### PR TITLE
Migrate edit-post tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50639,7 +50639,8 @@
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@testing-library/user-event": "^14.6.1"
+				"@testing-library/user-event": "^14.6.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -84,7 +84,8 @@
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@testing-library/user-event": "^14.6.1"
+		"@testing-library/user-event": "^14.6.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19",

--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -2,6 +2,15 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * WordPress dependencies
@@ -13,7 +22,10 @@ import { useSelect } from '@wordpress/data';
  */
 import { default as BrowserURL, getPostEditURL } from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( { postId, postStatus } ) {
 	useSelect.mockImplementation( () => {
@@ -36,7 +48,7 @@ describe( 'BrowserURL', () => {
 	let replaceStateSpy;
 
 	beforeAll( () => {
-		replaceStateSpy = jest.spyOn( window.history, 'replaceState' );
+		replaceStateSpy = vi.spyOn( window.history, 'replaceState' );
 	} );
 
 	beforeEach( () => {

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -17,7 +18,7 @@ import { STORE_NAME } from '../../../store/constants';
 describe( 'listener hook tests', () => {
 	const storeConfig = {
 		actions: {
-			forceUpdate: jest.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
+			forceUpdate: vi.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
 		},
 		reducer: ( state = {}, action ) =>
 			action.type === 'FORCE_UPDATE' ? { ...state } : state,
@@ -26,49 +27,49 @@ describe( 'listener hook tests', () => {
 		'core/block-editor': {
 			...storeConfig,
 			selectors: {
-				getBlockSelectionStart: jest.fn(),
+				getBlockSelectionStart: vi.fn(),
 			},
 		},
 		'core/editor': {
 			...storeConfig,
 			selectors: {
-				getCurrentPost: jest.fn(),
-				getCurrentPostType: jest.fn(),
-				getEditedPostAttribute: jest.fn(),
+				getCurrentPost: vi.fn(),
+				getCurrentPostType: vi.fn(),
+				getEditedPostAttribute: vi.fn(),
 			},
 		},
 		core: {
 			...storeConfig,
 			selectors: {
-				getPostType: jest.fn(),
+				getPostType: vi.fn(),
 			},
 		},
 		'core/viewport': {
 			...storeConfig,
 			selectors: {
-				isViewportMatch: jest.fn(),
+				isViewportMatch: vi.fn(),
 			},
 		},
 		'core/preferences': {
 			...storeConfig,
 			selectors: {
-				get: jest.fn(),
+				get: vi.fn(),
 			},
 		},
 		[ STORE_NAME ]: {
 			...storeConfig,
 			actions: {
 				...storeConfig.actions,
-				openGeneralSidebar: jest.fn( () => ( {
+				openGeneralSidebar: vi.fn( () => ( {
 					type: 'OPEN_GENERAL_SIDEBAR',
 				} ) ),
-				closeGeneralSidebar: jest.fn( () => ( {
+				closeGeneralSidebar: vi.fn( () => ( {
 					type: 'CLOSE_GENERAL_SIDEBAR',
 				} ) ),
 			},
 			selectors: {
-				isEditorSidebarOpened: jest.fn(),
-				getActiveGeneralSidebarName: jest.fn(),
+				isEditorSidebarOpened: vi.fn(),
+				getActiveGeneralSidebarName: vi.fn(),
 			},
 		},
 	};
@@ -109,12 +110,12 @@ describe( 'listener hook tests', () => {
 			);
 		};
 
-		const setAttribute = jest.fn();
+		const setAttribute = vi.fn();
 		const mockElement = {
 			setAttribute,
 			style: { display: '' },
 		};
-		const mockSelector = jest.fn();
+		const mockSelector = vi.fn();
 		beforeEach( () => {
 			// Reset the mock element style
 			mockElement.style.display = '';

--- a/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/test/use-meta-box-initialization.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -15,27 +16,28 @@ import { useMetaBoxInitialization } from '../use-meta-box-initialization';
 import { STORE_NAME } from '../../../store/constants';
 
 // Mock unlock to be an identity function so private actions are directly accessible.
-jest.mock( '../../../lock-unlock', () => ( {
+vi.mock( import( '../../../lock-unlock' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	unlock: ( value ) => value,
 } ) );
 
 const storeConfig = {
 	actions: {
-		forceUpdate: jest.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
+		forceUpdate: vi.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
 	},
 	reducer: ( state = {}, action ) =>
 		action.type === 'FORCE_UPDATE' ? { ...state } : state,
 };
 
-const setCollaborationSupported = jest.fn( () => ( {
+const setCollaborationSupported = vi.fn( () => ( {
 	type: 'SET_COLLABORATION_SUPPORTED',
 } ) );
 
-const initializeMetaBoxes = jest.fn( () => ( {
+const initializeMetaBoxes = vi.fn( () => ( {
 	type: 'META_BOXES_INITIALIZED',
 } ) );
 
-const updateEditorSettings = jest.fn( () => ( {
+const updateEditorSettings = vi.fn( () => ( {
 	type: 'UPDATE_EDITOR_SETTINGS',
 } ) );
 
@@ -52,8 +54,8 @@ function createMockStores( {
 				updateEditorSettings,
 			},
 			selectors: {
-				__unstableIsEditorReady: jest.fn( () => isEditorReady ),
-				isCollaborationEnabledForCurrentPost: jest.fn(
+				__unstableIsEditorReady: vi.fn( () => isEditorReady ),
+				isCollaborationEnabledForCurrentPost: vi.fn(
 					() => isCollaborationEnabled
 				),
 			},
@@ -72,9 +74,9 @@ function createMockStores( {
 				initializeMetaBoxes,
 			},
 			selectors: {
-				getAllMetaBoxes: jest.fn( () => metaBoxes ),
-				hasMetaBoxes: jest.fn( () => metaBoxes.length > 0 ),
-				getActiveMetaBoxLocations: jest.fn( () =>
+				getAllMetaBoxes: vi.fn( () => metaBoxes ),
+				hasMetaBoxes: vi.fn( () => metaBoxes.length > 0 ),
+				getActiveMetaBoxLocations: vi.fn( () =>
 					metaBoxes.length > 0 ? [ 'normal' ] : []
 				),
 			},

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation message when toggled on 1`] = `
+exports[`EnableCustomFieldsOption > renders a checked checkbox and a confirmation message when toggled on 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -73,7 +73,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
 </div>
 `;
 
-exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields are enabled 1`] = `
+exports[`EnableCustomFieldsOption > renders a checked checkbox when custom fields are enabled 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -136,7 +136,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
 </div>
 `;
 
-exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmation message when toggled off 1`] = `
+exports[`EnableCustomFieldsOption > renders an unchecked checkbox and a confirmation message when toggled off 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -210,7 +210,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
 </div>
 `;
 
-exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fields are disabled 1`] = `
+exports[`EnableCustomFieldsOption > renders an unchecked checkbox when custom fields are disabled 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
+exports[`MetaBoxesSection > renders a Custom Fields option 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -79,7 +79,7 @@ exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
 </fieldset>
 `;
 
-exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`] = `
+exports[`MetaBoxesSection > renders a Custom Fields option and meta box options 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -246,7 +246,7 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
 </fieldset>
 `;
 
-exports[`MetaBoxesSection renders meta box options 1`] = `
+exports[`MetaBoxesSection > renders meta box options 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;

--- a/packages/edit-post/src/components/preferences-modal/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/test/enable-custom-fields.js
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -17,7 +18,10 @@ import {
 	CustomFieldsConfirmation,
 } from '../enable-custom-fields';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( areCustomFieldsEnabled ) {
 	useSelect.mockImplementation( () => {
@@ -66,9 +70,9 @@ describe( 'EnableCustomFieldsOption', () => {
 describe( 'CustomFieldsConfirmation', () => {
 	it( 'submits the toggle-custom-fields-form', async () => {
 		const user = userEvent.setup();
-		const submit = jest.fn();
-		const setAttribute = jest.fn();
-		const getElementById = jest
+		const submit = vi.fn();
+		const setAttribute = vi.fn();
+		const getElementById = vi
 			.spyOn( document, 'getElementById' )
 			.mockImplementation( () => ( {
 				submit,

--- a/packages/edit-post/src/components/preferences-modal/test/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/test/meta-boxes-section.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,10 @@ import { store as editorStore } from '@wordpress/editor';
 import { MetaBoxesSection } from '../meta-boxes-section';
 import { store as editPostStore } from '../../../store';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 // Override only the selectors the section reads, while delegating the rest
 // (used by the rendered child options) to the real registry.

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { isSavingMetaBoxes, metaBoxLocations } from '../reducer';

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -13,6 +13,7 @@
 			"packages/core-commands",
 			"packages/date",
 			"packages/dom-ready",
+			"packages/edit-post",
 			"packages/edit-site",
 			"packages/escape-html",
 			"packages/fields",


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80875; review commit `eb9922ce463`.

**TL;DR — snapshot format and UI mocking parity:** migrates all eight `@wordpress/edit-post` unit suites to Vitest, keeps Testing Library and user-event, replaces private-path Jest mocks with public-module Vitest partial mocks, and preserves all 47 tests and seven snapshots.

## Why?

This is the first bounded product-package slice that validates the shared Vitest environment against existing Emotion/DOM snapshots and mixed UI/store coverage. It also removes an old private `@wordpress/data/src/...` mock path while preserving the behavior under test.

## How?

- Routes the complete `packages/edit-post` baseline partition to Vitest.
- Uses explicit imports from `vitest` with globals disabled.
- Keeps React Testing Library, `@testing-library/user-event`, jest-dom matchers, and centralized cleanup.
- Uses dynamic-import partial mocks of public modules and `vi` spies.
- Adds Vitest as a package-owned development dependency.
- Leaves production code unchanged.

Snapshot changes were reviewed individually:

- `enable-custom-fields.js.snap`: four keys gain Vitest's `Suite > test` separator and the file gains the Vitest header; serialized DOM and Emotion output is byte-for-byte unchanged.
- `meta-boxes-section.js.snap`: three keys gain the same separator and the file gains the Vitest header; serialized DOM and Emotion output is byte-for-byte unchanged.

## Testing Instructions

1. `volta run --node 20.20.2 node test/unit/scripts/validate-test-routing.mjs`
   - Expected: 940 Jest, 60 Vitest, no overlap, no missing baseline tests.
2. `volta run --node 20.20.2 npm run test:unit:vitest -- packages/edit-post`
   - Expected: 8 files, 47 tests, 7 snapshots.
3. `volta run --node 20.20.2 npm run test:unit:vitest`
   - Expected: 60 files, 861 tests.
4. Run each shard with `volta run --node 20.20.2 npm run test:unit:vitest -- --shard=N/4`.
5. Run the focused JS lint, `npm run lint:pkg-json`, and `npm run lint:lockfile`.

`npm run lint:deps` continues to report only the repository's pre-existing `@babel/core` and `yargs` version drift.

### Testing Instructions for Keyboard

Not applicable; production behavior is unchanged.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

AI tools helped inventory the existing suites, convert runner APIs, compare snapshot bodies, and run the verification matrix. The changes and generated snapshots were reviewed against the Jest baseline.