### PR TITLE
Migrate block-directory tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49457,7 +49457,8 @@
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -68,7 +68,8 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19",

--- a/packages/block-directory/src/components/downloadable-block-icon/test/__snapshots__/index.js.snap
+++ b/packages/block-directory/src/components/downloadable-block-icon/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Downloadable Block Icon icon rendering should render a <BlockIcon /> component 1`] = `
+exports[`Downloadable Block Icon > icon rendering > should render a <BlockIcon /> component 1`] = `
 <div>
   <span
     class="block-editor-block-icon block-directory-downloadable-block-icon has-colors"
@@ -12,7 +12,7 @@ exports[`Downloadable Block Icon icon rendering should render a <BlockIcon /> co
 </div>
 `;
 
-exports[`Downloadable Block Icon icon rendering should render an <img> tag 1`] = `
+exports[`Downloadable Block Icon > icon rendering > should render an <img> tag 1`] = `
 <div>
   <img
     alt=""
@@ -22,7 +22,7 @@ exports[`Downloadable Block Icon icon rendering should render an <img> tag 1`] =
 </div>
 `;
 
-exports[`Downloadable Block Icon icon rendering should render an <img> tag if icon URL has query string 1`] = `
+exports[`Downloadable Block Icon > icon rendering > should render an <img> tag if icon URL has query string 1`] = `
 <div>
   <img
     alt=""

--- a/packages/block-directory/src/components/downloadable-block-icon/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-icon/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -15,11 +16,11 @@ import { useSelect } from '@wordpress/data';
 import DownloadableBlockListItem from '../';
 import { plugin } from '../../test/fixtures';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'DownloadableBlockListItem', () => {
 	it( 'should render a block item', () => {
@@ -29,7 +30,7 @@ describe( 'DownloadableBlockListItem', () => {
 		} ) );
 
 		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
+			<DownloadableBlockListItem onClick={ vi.fn() } item={ plugin } />
 		);
 		const author = screen.queryByText( `by ${ plugin.author }` );
 		const description = screen.queryByText( plugin.description );
@@ -44,7 +45,7 @@ describe( 'DownloadableBlockListItem', () => {
 		} ) );
 
 		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
+			<DownloadableBlockListItem onClick={ vi.fn() } item={ plugin } />
 		);
 		const statusLabel = screen.queryByText( 'Installing…' );
 		expect( statusLabel ).toBeInTheDocument();
@@ -57,7 +58,7 @@ describe( 'DownloadableBlockListItem', () => {
 		} ) );
 
 		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
+			<DownloadableBlockListItem onClick={ vi.fn() } item={ plugin } />
 		);
 		const button = screen.getByRole( 'option' );
 		// Keeping it false to avoid focus loss and disable it using aria-disabled.
@@ -72,7 +73,7 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstalling: false,
 			isInstallable: true,
 		} ) );
-		const onClick = jest.fn();
+		const onClick = vi.fn();
 		render(
 			<DownloadableBlockListItem onClick={ onClick } item={ plugin } />
 		);

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -14,14 +15,11 @@ import { useSelect } from '@wordpress/data';
 import DownloadableBlocksList from '../';
 import { items } from '../../test/fixtures';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
-
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: () => ( { installBlockType: jest.fn() } ),
+	useSelect: vi.fn(),
+	useDispatch: () => ( { installBlockType: vi.fn() } ),
 } ) );
 
 describe( 'DownloadableBlocksList', () => {
@@ -35,8 +33,8 @@ describe( 'DownloadableBlocksList', () => {
 			const { container } = render(
 				<DownloadableBlocksList
 					items={ [] }
-					onSelect={ jest.fn() }
-					onHover={ jest.fn() }
+					onSelect={ vi.fn() }
+					onHover={ vi.fn() }
 				/>
 			);
 
@@ -47,8 +45,8 @@ describe( 'DownloadableBlocksList', () => {
 			render(
 				<DownloadableBlocksList
 					items={ items }
-					onSelect={ jest.fn() }
-					onHover={ jest.fn() }
+					onSelect={ vi.fn() }
+					onHover={ vi.fn() }
 				/>
 			);
 			const downloadableBlocks = screen.getAllByRole( 'option' );

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
@@ -12,13 +17,14 @@ import apiFetch from '@wordpress/api-fetch';
 import { loadAssets } from '../load-assets';
 import { store as blockDirectoryStore } from '..';
 
-jest.mock( '@wordpress/api-fetch', () => ( {
-	__esModule: true,
-	default: jest.fn(),
+vi.mock( import( '@wordpress/api-fetch' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	default: vi.fn(),
 } ) );
 
-jest.mock( '../load-assets', () => ( {
-	loadAssets: jest.fn(),
+vi.mock( import( '../load-assets' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	loadAssets: vi.fn(),
 } ) );
 
 function createRegistryWithStores() {

--- a/packages/block-directory/src/store/test/load-assets.js
+++ b/packages/block-directory/src/store/test/load-assets.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { loadAsset } from '../load-assets';

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -91,7 +96,7 @@ describe( 'selectors', () => {
 	describe( 'getNewBlockTypes', () => {
 		it( 'should retrieve the block types that are installed and in the post content', () => {
 			getNewBlockTypes.registry = {
-				select: jest.fn( () => ( {
+				select: vi.fn( () => ( {
 					getBlockName: ( clientId ) => blockListNameMap[ clientId ],
 					getClientIdsWithDescendants: () => blockListIds,
 				} ) ),
@@ -111,7 +116,7 @@ describe( 'selectors', () => {
 
 		it( 'should return an empty array if no blocks are used', () => {
 			getNewBlockTypes.registry = {
-				select: jest.fn( () => ( {
+				select: vi.fn( () => ( {
 					getBlockName: ( clientId ) => blockListNameMap[ clientId ],
 					getClientIdsWithDescendants: () => [],
 				} ) ),
@@ -132,7 +137,7 @@ describe( 'selectors', () => {
 	describe( 'getUnusedBlockTypes', () => {
 		it( 'should retrieve the block types that are installed but not used', () => {
 			getUnusedBlockTypes.registry = {
-				select: jest.fn( () => ( {
+				select: vi.fn( () => ( {
 					getBlockName: ( clientId ) => blockListNameMap[ clientId ],
 					getClientIdsWithDescendants: () => blockListIds,
 				} ) ),
@@ -152,7 +157,7 @@ describe( 'selectors', () => {
 
 		it( 'should return all block types if no blocks are used', () => {
 			getUnusedBlockTypes.registry = {
-				select: jest.fn( () => ( {
+				select: vi.fn( () => ( {
 					getBlockName: ( clientId ) => blockListNameMap[ clientId ],
 					getClientIdsWithDescendants: () => [],
 				} ) ),

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -9,6 +9,7 @@
 			"packages/abilities",
 			"packages/annotations",
 			"packages/blob",
+			"packages/block-directory",
 			"packages/connectors",
 			"packages/core-commands",
 			"packages/date",


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80876; review commit `3ee422c46de`.

**TL;DR — public-module mocks and nested snapshot keys:** migrates all seven `@wordpress/block-directory` unit suites to Vitest, keeps Testing Library and user-event, replaces private data-hook Jest mocks with a public `@wordpress/data` partial mock, and preserves all 41 tests and three snapshots.

## Why?

This bounded UI/store slice expands snapshot coverage while exercising module mocks for API fetch, asset loading, data selection, and dispatch. It removes private source-path mocks without changing the behavior under test.

## How?

- Routes the complete `packages/block-directory` baseline partition to Vitest.
- Uses explicit imports from `vitest` with globals disabled.
- Keeps React Testing Library, `@testing-library/user-event`, jest-dom matchers, and centralized cleanup.
- Uses dynamic-import partial mocks for `@wordpress/api-fetch`, `@wordpress/data`, and the local asset module.
- Adds Vitest as a package-owned development dependency.
- Leaves production code unchanged.

Snapshot changes were reviewed individually:

- `downloadable-block-icon/test/__snapshots__/index.js.snap`: three keys gain Vitest's nested `Suite > suite > test` separators and the file gains the Vitest header; all serialized DOM output is byte-for-byte unchanged.

## Testing Instructions

1. `volta run --node 20.20.2 node test/unit/scripts/validate-test-routing.mjs`
   - Expected: 933 Jest, 67 Vitest, no overlap, no missing baseline tests.
2. `volta run --node 20.20.2 npm run test:unit:vitest -- packages/block-directory`
   - Expected: 7 files, 41 tests, 3 snapshots.
3. `volta run --node 20.20.2 npm run test:unit:vitest`
   - Expected: 67 files, 902 tests.
4. Run each shard with `volta run --node 20.20.2 npm run test:unit:vitest -- --shard=N/4`.
5. Run focused JS lint, `npm run lint:pkg-json`, and `npm run lint:lockfile`.

`npm run lint:deps` continues to report only the repository's pre-existing `@babel/core` and `yargs` version drift.

### Testing Instructions for Keyboard

Not applicable; production behavior is unchanged.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

AI tools helped inventory the existing suites, convert runner APIs and module mocks, compare snapshot bodies, and run the verification matrix. The changes and snapshot metadata were reviewed against the Jest baseline.