### PR TITLE
URLInput: Add an opt-in `closeSuggestionsOnNavigateOutside` prop

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   `URLInput`: Add an opt-in `closeSuggestionsOnNavigateOutside` prop that closes the suggestions list when focus moves outside the field, dismisses it on Escape without also closing an enclosing popover, and only opens the list while the field has focus ([#80879](https://github.com/WordPress/gutenberg/pull/80879)).
+
 ### Enhancements
 
 -   Inspector controls in the standard block-supports panels (Typography, Dimensions, Border, Color, Background, Filters) now reflect the value a block inherits from Global Styles when no local override is set. Inherited controls show that value at rest (as a placeholder, preselected option, or resolved value) and mark the label with a dotted underline; setting a local override reveals a reset affordance that clears the override back to the inherited value ([#77894](https://github.com/WordPress/gutenberg/pull/77894)).

--- a/packages/block-editor/src/components/url-input/README.md
+++ b/packages/block-editor/src/components/url-input/README.md
@@ -130,6 +130,12 @@ When hiding the URLInput using CSS (as is sometimes done for accessibility purpo
 
 This prop allows the suggestions list to be programmatically not rendered by passing a boolean—it can be `true` to make sure suggestions aren't rendered, or `false`/`undefined` to fall back to the default behaviour of showing suggestions when matching autocompletion items are found.
 
+### `closeSuggestionsOnNavigateOutside: Boolean`
+
+_Optional._ Closes the suggestions list when the user navigates away from the field: when focus moves outside the input and its suggestions — for example into another field — or when Escape is pressed. The Escape key event does not propagate any further in that case, so a popover the component is rendered within stays open. While this prop is set, the list also only opens when the input has focus, so a field that mounts with a value doesn't show its suggestions until it's interacted with.
+
+Defaults to `false`, which preserves the historical behavior: the list stays open regardless of focus, and Escape is left to enclosing components — such as the popovers that core UIs usually render `URLInput` within.
+
 ## Example
 
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { speak } from '@wordpress/a11y';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
+import { UP, DOWN, ENTER, TAB, ESCAPE } from '@wordpress/keycodes';
 import {
 	BaseControl,
 	Button,
@@ -18,7 +18,12 @@ import {
 	Popover,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useDebounce, useEvent, useInstanceId } from '@wordpress/compose';
+import {
+	__experimentalUseFocusOutside as useFocusOutside,
+	useDebounce,
+	useEvent,
+	useInstanceId,
+} from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 
@@ -59,6 +64,7 @@ export default function URLInput( props ) {
 		__experimentalShowInitialSuggestions: showInitialSuggestions = false,
 		autocompleteRef,
 		className,
+		closeSuggestionsOnNavigateOutside = false,
 		customValidity,
 		disableSuggestions,
 		disabled = false,
@@ -162,6 +168,20 @@ export default function URLInput( props ) {
 				setSuggestions( nextSuggestions );
 				setSuggestionsValue( search );
 				setIsLoading( false );
+
+				// When the list may only show while the user is engaged with
+				// the field, don't open it (or announce results) if focus is
+				// known to be elsewhere by the time the results arrive.
+				const inputNode = controlInputRef.current;
+				if (
+					closeSuggestionsOnNavigateOutside &&
+					!! inputNode &&
+					inputNode.ownerDocument.activeElement !== inputNode
+				) {
+					setIsSuggestionsListOpen( false );
+					return;
+				}
+
 				setIsSuggestionsListOpen( !! nextSuggestions.length );
 
 				if ( nextSuggestions.length ) {
@@ -244,6 +264,20 @@ export default function URLInput( props ) {
 		setIsSuggestionsListOpen( false );
 	}
 
+	function closeSuggestionsList() {
+		// Cancel any pending request, so that its response can't reopen the
+		// list after it was dismissed.
+		suggestionsRequestRef.current?.cancel?.();
+		suggestionsRequestRef.current = null;
+		setIsLoading( false );
+		setIsSuggestionsListOpen( false );
+		setSelectedSuggestion( null );
+	}
+
+	function handleFocusOutside() {
+		closeSuggestionsList();
+	}
+
 	function handleSuggestionClick( suggestion ) {
 		selectLink( suggestion );
 		// Move focus to the input field when a link suggestion is clicked.
@@ -256,7 +290,10 @@ export default function URLInput( props ) {
 		onChange( newValue );
 	}
 
-	function handleFocus() {
+	function handleFocus( event ) {
+		// Focus (re)entering the field cancels a pending focus-outside check.
+		focusOutsideProps.onFocus( event );
+
 		// When opening the link editor, if there's a value present, we want to load the suggestions pane with the results for this input search value
 		// Don't re-run the suggestions on focus if there are already suggestions present (prevents searching again when tabbing between the input and buttons)
 		// or there is already a request in progress.
@@ -272,6 +309,21 @@ export default function URLInput( props ) {
 
 	function handleKeyDown( event ) {
 		onKeyDown?.( event );
+
+		// When closing on navigate-outside is enabled, Escape dismisses a
+		// visible suggestions list. The event mustn't propagate any further,
+		// so that a popover the component is rendered within stays open.
+		if (
+			closeSuggestionsOnNavigateOutside &&
+			event.keyCode === ESCAPE &&
+			showSuggestions &&
+			suggestions.length > 0
+		) {
+			event.preventDefault();
+			event.stopPropagation();
+			closeSuggestionsList();
+			return;
+		}
 
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation.
@@ -368,6 +420,15 @@ export default function URLInput( props ) {
 		}
 	}
 
+	// The handlers detect focus moving outside of the component. They are
+	// bound to both the input and the suggestions list, which share the
+	// hook's state, so that focus moving between the two is not treated as
+	// navigating outside.
+	const focusOutsideProps = useFocusOutside( handleFocusOutside );
+	const navigateOutsideProps = closeSuggestionsOnNavigateOutside
+		? focusOutsideProps
+		: undefined;
+
 	const controlProps = {
 		id: inputId, // Passes attribute to label for the for attribute
 		label,
@@ -378,6 +439,9 @@ export default function URLInput( props ) {
 	};
 
 	const inputProps = {
+		// Spread first: the `onFocus` key below overrides the hook's handler,
+		// which `handleFocus` chains instead.
+		...navigateOutsideProps,
 		id: inputId,
 		value,
 		required,
@@ -419,6 +483,7 @@ export default function URLInput( props ) {
 					className={ className }
 					handleSuggestionClick={ handleSuggestionClick }
 					isLoading={ isLoading }
+					navigateOutsideProps={ navigateOutsideProps }
 					renderSuggestions={ renderSuggestions }
 					selectedSuggestion={ selectedSuggestion }
 					suggestionNodesRef={ suggestionNodesRef }
@@ -482,6 +547,7 @@ function Suggestions( {
 	className,
 	handleSuggestionClick,
 	isLoading,
+	navigateOutsideProps,
 	renderSuggestions,
 	selectedSuggestion,
 	suggestionNodesRef,
@@ -491,6 +557,7 @@ function Suggestions( {
 	suggestionsValue,
 } ) {
 	const suggestionsListProps = {
+		...navigateOutsideProps,
 		id: suggestionsListboxId,
 		ref: autocompleteRef,
 		role: 'listbox',

--- a/packages/block-editor/src/components/url-input/test/index.js
+++ b/packages/block-editor/src/components/url-input/test/index.js
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { speak } from '@wordpress/a11y';
 import { useState } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
-import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
+import { UP, DOWN, ENTER, TAB, ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -41,6 +41,7 @@ const KEY_EVENTS = {
 	down: { key: 'ArrowDown', keyCode: DOWN },
 	enter: { key: 'Enter', keyCode: ENTER },
 	tab: { key: 'Tab', keyCode: TAB },
+	esc: { key: 'Escape', keyCode: ESCAPE },
 };
 
 /**
@@ -558,6 +559,158 @@ describe( 'URLInput', () => {
 					currentInputValue: 'hello',
 				} )
 			);
+		} );
+	} );
+
+	describe( 'closeSuggestionsOnNavigateOutside', () => {
+		let hasFocusSpy;
+
+		beforeEach( () => {
+			// `useFocusOutside` treats a document without focus as the window
+			// losing focus and bails, and jsdom's `document.hasFocus()`
+			// returns false.
+			hasFocusSpy = jest
+				.spyOn( document, 'hasFocus' )
+				.mockReturnValue( true );
+		} );
+
+		afterEach( () => {
+			hasFocusSpy.mockRestore();
+		} );
+
+		// With the prop set, the list only opens while the input has focus,
+		// so unlike `renderWithSuggestions` the field is typed in.
+		async function renderFocusedWithSuggestions( props = {} ) {
+			const utils = renderURLInput( {
+				closeSuggestionsOnNavigateOutside: true,
+				...props,
+			} );
+			await utils.user.click( utils.input );
+			await utils.user.keyboard( 'hello' );
+			await screen.findByRole( 'listbox' );
+			return utils;
+		}
+
+		it( 'should close the suggestions when focus moves outside the component', async () => {
+			const { user, input } = await renderFocusedWithSuggestions();
+
+			await user.tab();
+
+			await waitFor( () =>
+				expect(
+					screen.queryByRole( 'listbox' )
+				).not.toBeInTheDocument()
+			);
+			expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
+		} );
+
+		it( 'should keep the suggestions open when focus moves outside without the prop', async () => {
+			const { user, input } = await renderWithSuggestions();
+
+			await user.click( input );
+			await user.tab();
+			await flushDebounce();
+
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+		} );
+
+		it( 'should close the suggestions when pressing Escape, without the event propagating', async () => {
+			const onParentKeyDown = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				// A stand-in for an ancestor listening for keydown, the way
+				// a popover implementation would.
+				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+				<div onKeyDown={ onParentKeyDown }>
+					<ControlledURLInput
+						onChange={ () => {} }
+						__experimentalFetchLinkSuggestions={
+							fetchLinkSuggestions
+						}
+						closeSuggestionsOnNavigateOutside
+					/>
+				</div>
+			);
+			const input = screen.getByRole( 'combobox' );
+			await user.click( input );
+			await user.keyboard( 'hello' );
+			await screen.findByRole( 'listbox' );
+			// The parent saw the typing; only the Escape presses matter below.
+			onParentKeyDown.mockClear();
+
+			fireEvent.keyDown( input, KEY_EVENTS.esc );
+
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+			expect( input ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( input ).toHaveFocus();
+			expect( onParentKeyDown ).not.toHaveBeenCalled();
+
+			// Once the list is closed, Escape propagates again.
+			fireEvent.keyDown( input, KEY_EVENTS.esc );
+			expect( onParentKeyDown ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should leave Escape to the parent without the prop', async () => {
+			const onParentKeyDown = jest.fn();
+
+			render(
+				// A stand-in for an ancestor listening for keydown, the way
+				// a popover implementation would.
+				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+				<div onKeyDown={ onParentKeyDown }>
+					<ControlledURLInput
+						value="hello"
+						onChange={ () => {} }
+						__experimentalFetchLinkSuggestions={
+							fetchLinkSuggestions
+						}
+					/>
+				</div>
+			);
+			const input = screen.getByRole( 'combobox' );
+			await screen.findByRole( 'listbox' );
+
+			fireEvent.keyDown( input, KEY_EVENTS.esc );
+
+			expect( onParentKeyDown ).toHaveBeenCalledTimes( 1 );
+			expect( screen.getByRole( 'listbox' ) ).toBeVisible();
+		} );
+
+		it( 'should not open the suggestions while the field is not focused', async () => {
+			const { user, input } = renderURLInput( {
+				value: 'hello',
+				closeSuggestionsOnNavigateOutside: true,
+			} );
+
+			await waitFor( () =>
+				expect( fetchLinkSuggestions ).toHaveBeenCalledTimes( 1 )
+			);
+			await flushDebounce();
+
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+
+			// Typing in the field opens the list again.
+			await user.click( input );
+			await user.keyboard( ' world' );
+
+			expect( await screen.findByRole( 'listbox' ) ).toBeVisible();
+		} );
+
+		it( 'should still select a suggestion on click', async () => {
+			const { user, input, onChange } =
+				await renderFocusedWithSuggestions();
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Sample page' } )
+			);
+
+			expect( onChange ).toHaveBeenLastCalledWith(
+				SUGGESTIONS[ 1 ].url,
+				SUGGESTIONS[ 1 ]
+			);
+			expect( input ).toHaveFocus();
+			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/27704

`URLInput` has no way to dismiss its suggestions popover short of selecting a suggestion: moving focus to another field leaves the popover hanging open, and Escape does nothing. Core UIs don't notice because they always render the component inside a popover that Escape closes as a whole, but for a bare `URLInput` — the custom block scenario reported in the issue — the lists pile up over the surrounding UI with no way to get rid of them.

This adds the opt-in prop suggested in the issue, `closeSuggestionsOnNavigateOutside`. When it is set:

-   The suggestions list closes when focus moves outside the input and its suggestions. The `useFocusOutside` handlers are bound to both the input and the list, so focus moving between the two doesn't count as leaving, and clicking a suggestion still selects it in browsers that don't focus clicked buttons.
-   Escape dismisses a visible list, without the key event propagating any further. When the component does sit inside a popover, the first Escape now closes the suggestions and the second closes the popover.
-   The list only opens while the field has focus, so a field mounted with a value no longer pops its suggestions open on editor load (the follow-up report in the issue thread).
-   A pending suggestions request is cancelled when the list is dismissed, so a late response can't reopen it.

The prop defaults to `false`, and nothing changes for existing consumers: `LinkControl` and the other core usages don't opt in and keep their current behavior, per the API direction outlined in the issue.

## Testing Instructions

The behavior needs a bare `URLInput`, so a scratch block is the quickest route:

1. Register a test block rendering a `URLInput` with the prop next to a `TextControl`:

    ```js
    wp.blocks.registerBlockType( 'repro/url-input', {
    	title: 'URLInput repro',
    	category: 'widgets',
    	attributes: {
    		url: { type: 'string', default: '' },
    		text: { type: 'string', default: '' },
    	},
    	edit: ( { attributes, setAttributes } ) =>
    		wp.element.createElement(
    			'div',
    			{},
    			wp.element.createElement( wp.blockEditor.URLInput, {
    				label: 'Link',
    				value: attributes.url,
    				closeSuggestionsOnNavigateOutside: true,
    				onChange: ( url ) => setAttributes( { url } ),
    			} ),
    			wp.element.createElement( wp.components.TextControl, {
    				__next40pxDefaultSize: true,
    				__nextHasNoMarginBottom: true,
    				label: 'Text',
    				value: attributes.text,
    				onChange: ( text ) => setAttributes( { text } ),
    			} )
    		),
    	save: () => null,
    } );
    ```

2. In the editor, type e.g. "sample" in the Link field and wait for the suggestions to show.
3. Click into the Text field: the suggestions close.
4. Type in the Link field again so the list reopens, then press <kbd>Escape</kbd>: the suggestions close and focus stays in the field.
5. Reload the editor with a value saved in the Link field: the suggestions don't open until the field is typed in.
6. Remove the `closeSuggestionsOnNavigateOutside` prop and confirm the historical behavior is back: the list stays open when focus moves away, and Escape is left to enclosing components.
7. Confirm no change in the core link UIs (which don't opt in) — inline link popover, Button block link: searching and Escape behave as on trunk.

Unit tests: `npm run test:unit packages/block-editor/src/components/url-input/test/index.js`

The change was developed with the assistance of AI tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting for URL suggestions to close when focus moves outside the field or suggestions list.
  * Pressing Escape now dismisses suggestions without closing an enclosing popover.
  * Suggestions no longer reopen or announce after focus leaves the field.

* **Documentation**
  * Documented the new setting, including its focus, navigation, and Escape-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->