### PR TITLE
Enforce canonical Vitest test conventions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,6 +48,7 @@ jobs:
 
             - name: Build package TypeScript declarations
               run: |
+                  npx lerna run build
                   npm run --workspace @wordpress/build-scripts generate-worker-placeholders
                   npx tsc --build
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,9 @@ jobs:
             - name: Validate JavaScript test routing
               run: npm run test:unit:routing
 
+            - name: Validate Vitest conventions and TypeScript test graph
+              run: npm run test:unit:conventions
+
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -47,7 +47,9 @@ jobs:
               run: npm run test:unit:routing
 
             - name: Build package TypeScript declarations
-              run: npx tsc --build
+              run: |
+                  npm run --workspace @wordpress/build-scripts generate-worker-placeholders
+                  npx tsc --build
 
             - name: Validate Vitest conventions and TypeScript test graph
               run: npm run test:unit:conventions

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,9 @@ jobs:
             - name: Validate JavaScript test routing
               run: npm run test:unit:routing
 
+            - name: Build package TypeScript declarations
+              run: npx tsc --build
+
             - name: Validate Vitest conventions and TypeScript test graph
               run: npm run test:unit:conventions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54234,6 +54234,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.29.7",
+				"@babel/traverse": "^7.25.7",
 				"@emotion/jest": "^11.14.2",
 				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
 		"test:php": "npm-run-all lint:php test:unit:php",
 		"test:php:watch": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script test:watch",
 		"test:unit": "npm run --workspace @wordpress/unit-tests test:unit --",
+		"test:unit:conventions": "npm run --workspace @wordpress/unit-tests test:unit:conventions",
 		"test:unit:vitest": "npm run --workspace @wordpress/unit-tests test:unit:vitest --",
 		"test:unit:routing": "npm run --workspace @wordpress/unit-tests test:unit:routing",
 		"test:unit:date": "bash ./bin/unit-test-date.sh",

--- a/packages/abilities/src/store/tests/reducer.test.ts
+++ b/packages/abilities/src/store/tests/reducer.test.ts
@@ -28,16 +28,20 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'Test Ability',
 					description: 'Test ability',
+					category: 'test-category',
 					callback: () => Promise.resolve( {} ),
 				};
 
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -54,6 +58,7 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'Test Ability',
 					description: 'Test ability',
+					category: 'test-category',
 					callback: () => Promise.resolve( {} ),
 					// Extra properties that should be filtered out
 					_links: { self: { href: '/test' } },
@@ -63,10 +68,13 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 				const registeredAbility =
@@ -89,6 +97,7 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability',
 						label: 'Old Label',
 						description: 'Old description',
+						category: 'test-category',
 					},
 				};
 
@@ -96,16 +105,20 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'New Label',
 					description: 'New description',
+					category: 'test-category',
 					input_schema: { type: 'string' },
 				};
 
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -128,21 +141,26 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability1',
 						label: 'Test Ability 1',
 						description: 'First test ability',
+						category: 'test-category',
 					},
 					'test/ability2': {
 						name: 'test/ability2',
 						label: 'Test Ability 2',
 						description: 'Second test ability',
+						category: 'test-category',
 					},
 				};
 
 				const action = {
 					type: UNREGISTER_ABILITY,
 					name: 'test/ability1',
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -162,16 +180,20 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability',
 						label: 'Test Ability',
 						description: 'Test ability',
+						category: 'test-category',
 					},
 				};
 
 				const action = {
 					type: UNREGISTER_ABILITY,
 					name: 'test/non-existent',
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -185,8 +207,13 @@ describe( 'Store Reducer', () => {
 				};
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
-					action
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.abilitiesByName ).toEqual( defaultState );
@@ -208,7 +235,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -234,7 +261,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -260,7 +287,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -303,7 +330,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -329,7 +356,9 @@ describe( 'Store Reducer', () => {
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
-					action
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.categoriesBySlug ).toEqual( defaultState );
@@ -354,7 +383,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: UNREGISTER_ABILITY_CATEGORY,
 					slug: 'category1',
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -379,7 +408,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: UNREGISTER_ABILITY_CATEGORY,
 					slug: 'non-existent',
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -405,7 +434,9 @@ describe( 'Store Reducer', () => {
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
-					action
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.categoriesBySlug ).toEqual( initialState );

--- a/packages/is-shallow-equal/test/index.ts
+++ b/packages/is-shallow-equal/test/index.ts
@@ -154,7 +154,7 @@ describe( 'isShallowEqual', () => {
 	} );
 
 	it( 'returns true on arrays that are a copy of each other', () => {
-		const a = [];
+		const a: unknown[] = [];
 		const b = a;
 
 		expect( isShallowEqual( a, b ) ).toBe( true );

--- a/packages/widget-dashboard/src/test/commands.test.tsx
+++ b/packages/widget-dashboard/src/test/commands.test.tsx
@@ -26,13 +26,24 @@ const layout: DashboardWidget[] = [
 	{ uuid: 'a', type: 'core/test', placement: { width: 1, height: 1 } },
 ];
 
+interface CommandsSelectors {
+	getContext: () => string;
+	getCommands: ( contextual: boolean ) => Array< { name: string } >;
+}
+
 function CommandsProbe( { names }: { names: string[] } ) {
 	const context = useSelect(
-		( select ) => select( commandsStore ).getContext(),
+		( select ) =>
+			(
+				select( commandsStore ) as unknown as CommandsSelectors
+			 ).getContext(),
 		[]
 	);
 	const contextualCommands = useSelect(
-		( select ) => select( commandsStore ).getCommands( true ),
+		( select ) =>
+			(
+				select( commandsStore ) as unknown as CommandsSelectors
+			 ).getCommands( true ),
 		[]
 	);
 

--- a/packages/widget-dashboard/src/test/use-inline-fit.test.tsx
+++ b/packages/widget-dashboard/src/test/use-inline-fit.test.tsx
@@ -15,10 +15,10 @@ let notifyResize: ( entries: unknown[] ) => void = () => {};
 
 vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
 	...( await importOriginal() ),
-	useResizeObserver: ( callback: ( entries: unknown[] ) => void ) => {
+	useResizeObserver: ( ( callback: ( entries: unknown[] ) => void ) => {
 		notifyResize = callback;
 		return () => {};
-	},
+	} ) as typeof import('@wordpress/compose').useResizeObserver,
 } ) );
 
 let availableSize: number | null = null;

--- a/packages/widget-dashboard/src/test/widget-attributes-transitions.test.tsx
+++ b/packages/widget-dashboard/src/test/widget-attributes-transitions.test.tsx
@@ -32,13 +32,13 @@ const mockObserved = new Map< Element, ( entries: unknown[] ) => void >();
 
 vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
 	...( await importOriginal() ),
-	useResizeObserver: ( callback: ( entries: unknown[] ) => void ) => {
+	useResizeObserver: ( ( callback: ( entries: unknown[] ) => void ) => {
 		return ( element: Element | null ) => {
 			if ( element ) {
 				mockObserved.set( element, callback );
 			}
 		};
-	},
+	} ) as typeof import('@wordpress/compose').useResizeObserver,
 } ) );
 
 /**

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -21,6 +21,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.29.7",
+		"@babel/traverse": "^7.25.7",
 		"@emotion/jest": "^11.14.2",
 		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
@@ -57,6 +58,7 @@
 	},
 	"scripts": {
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
+		"test:unit:conventions": "node scripts/validate-vitest-conventions.mjs",
 		"test:unit:vitest": "vitest run --config vitest.config.mjs",
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -1,0 +1,305 @@
+/**
+ * External dependencies
+ */
+import { parseSync } from '@babel/core';
+import traverseModule from '@babel/traverse';
+import globPackage from 'glob';
+
+/**
+ * Node dependencies
+ */
+import { execFileSync } from 'node:child_process';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
+import { getVitestTests } from './discover-test-files.mjs';
+
+const traverse = traverseModule.default ?? traverseModule;
+const { sync: glob } = globPackage;
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../..'
+);
+const migration = JSON.parse(
+	readFileSync(
+		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
+		'utf8'
+	)
+);
+const vitestTests = getVitestTests( ROOT_DIR, migration );
+const vitestInfrastructure = [
+	'test/unit/vitest.config.mjs',
+	...glob( 'test/unit/config/**/*.vitest.{js,mjs,ts,tsx}', {
+		cwd: ROOT_DIR,
+		nodir: true,
+	} ),
+	...glob( 'test/unit/scripts/*.mjs', {
+		cwd: ROOT_DIR,
+		nodir: true,
+	} ),
+];
+const files = [
+	...new Set( [ ...vitestTests, ...vitestInfrastructure ] ),
+].sort();
+const vitestApiNames = new Set( [
+	'afterAll',
+	'afterEach',
+	'assert',
+	'beforeAll',
+	'beforeEach',
+	'describe',
+	'expect',
+	'it',
+	'onTestFailed',
+	'onTestFinished',
+	'suite',
+	'test',
+	'vi',
+] );
+const violations = [];
+
+function isCommonJsExport( node ) {
+	if ( node?.type !== 'MemberExpression' ) {
+		return false;
+	}
+
+	if (
+		node.object?.type === 'Identifier' &&
+		node.object.name === 'exports'
+	) {
+		return true;
+	}
+
+	return (
+		node.object?.type === 'Identifier' &&
+		node.object.name === 'module' &&
+		node.property?.type === 'Identifier' &&
+		node.property.name === 'exports'
+	);
+}
+
+function isDynamicImport( node ) {
+	return (
+		node?.type === 'ImportExpression' ||
+		( node?.type === 'CallExpression' && node.callee?.type === 'Import' )
+	);
+}
+
+function findWorkspacePackage( file ) {
+	let directory = path.dirname( path.join( ROOT_DIR, file ) );
+
+	while ( directory.startsWith( ROOT_DIR ) ) {
+		const packagePath = path.join( directory, 'package.json' );
+		if ( existsSync( packagePath ) ) {
+			return packagePath;
+		}
+		if ( directory === ROOT_DIR ) {
+			break;
+		}
+		directory = path.dirname( directory );
+	}
+
+	return null;
+}
+
+for ( const file of files ) {
+	const filename = path.join( ROOT_DIR, file );
+	const source = readFileSync( filename, 'utf8' );
+	const plugins = [
+		'decorators-legacy',
+		'importAttributes',
+		'jsx',
+		'topLevelAwait',
+	];
+
+	if ( /\.[cm]?tsx?$/.test( file ) ) {
+		plugins.push( 'typescript' );
+	}
+
+	const ast = parseSync( source, {
+		ast: true,
+		babelrc: false,
+		code: false,
+		configFile: false,
+		filename,
+		parserOpts: {
+			plugins,
+			sourceType: 'module',
+		},
+	} );
+
+	traverse( ast, {
+		AssignmentExpression( astPath ) {
+			if ( isCommonJsExport( astPath.node.left ) ) {
+				violations.push(
+					`${ file }:${ astPath.node.loc.start.line } CommonJS export`
+				);
+			}
+		},
+		CallExpression( astPath ) {
+			const { node } = astPath;
+
+			if (
+				node.callee?.type === 'Identifier' &&
+				node.callee.name === 'require' &&
+				! astPath.scope.hasBinding( 'require' )
+			) {
+				violations.push(
+					`${ file }:${ node.loc.start.line } unbound require()`
+				);
+			}
+
+			if (
+				/\.tsx?$/.test( file ) &&
+				node.callee?.type === 'MemberExpression' &&
+				node.callee.object?.type === 'Identifier' &&
+				node.callee.object.name === 'vi' &&
+				node.callee.property?.type === 'Identifier' &&
+				node.callee.property.name === 'mock' &&
+				! isDynamicImport( node.arguments[ 0 ] )
+			) {
+				violations.push(
+					`${ file }:${ node.loc.start.line } TypeScript vi.mock() must use vi.mock(import(...))`
+				);
+			}
+		},
+		ReferencedIdentifier( astPath ) {
+			const { name } = astPath.node;
+			if (
+				vitestTests.includes( file ) &&
+				vitestApiNames.has( name ) &&
+				! astPath.scope.hasBinding( name )
+			) {
+				violations.push(
+					`${ file }:${ astPath.node.loc.start.line } unbound Vitest API: ${ name }`
+				);
+			}
+		},
+	} );
+
+	if (
+		vitestTests.includes( file ) &&
+		/(?:from\s+|import\s*)[('"]vitest\/globals/.test( source )
+	) {
+		violations.push( `${ file }: vitest/globals is not allowed` );
+	}
+}
+
+const vitestVersions = new Map();
+for ( const file of vitestTests ) {
+	const source = readFileSync( path.join( ROOT_DIR, file ), 'utf8' );
+	if ( ! /(?:from\s+|import\s*)[('"]vitest[)'"]/.test( source ) ) {
+		violations.push( `${ file }: no explicit import from vitest` );
+		continue;
+	}
+
+	const packagePath = findWorkspacePackage( file );
+	if ( ! packagePath ) {
+		violations.push( `${ file }: no owning package.json` );
+		continue;
+	}
+
+	const packageJson = JSON.parse( readFileSync( packagePath, 'utf8' ) );
+	const version = packageJson.devDependencies?.vitest;
+	const relativePackagePath = path.relative( ROOT_DIR, packagePath );
+	if ( ! version ) {
+		violations.push(
+			`${ file }: ${ relativePackagePath } must declare devDependencies.vitest`
+		);
+		continue;
+	}
+
+	vitestVersions.set( relativePackagePath, version );
+}
+
+const distinctVersions = new Set( vitestVersions.values() );
+if ( distinctVersions.size > 1 ) {
+	violations.push(
+		`Vitest dependency versions must match:\n${ [
+			...vitestVersions.entries(),
+		]
+			.map(
+				( [ packagePath, version ] ) => `${ packagePath }: ${ version }`
+			)
+			.join( '\n' ) }`
+	);
+}
+
+if ( violations.length ) {
+	throw new Error(
+		`Vitest convention violations:\n${ violations.join( '\n' ) }`
+	);
+}
+
+const typescriptTests = vitestTests.filter( ( file ) =>
+	/\.tsx?$/.test( file )
+);
+if ( typescriptTests.length ) {
+	const temporaryDirectory = mkdtempSync(
+		path.join( os.tmpdir(), 'gutenberg-vitest-typecheck-' )
+	);
+	const configPath = path.join( temporaryDirectory, 'tsconfig.json' );
+	const compatibilityTypesPath = path.join(
+		temporaryDirectory,
+		'compatibility.d.ts'
+	);
+	const typecheckConfig = {
+		extends: path.join( ROOT_DIR, 'tsconfig.base.json' ),
+		compilerOptions: {
+			allowJs: true,
+			checkJs: false,
+			composite: false,
+			declaration: true,
+			declarationMap: false,
+			emitDeclarationOnly: false,
+			noEmit: true,
+			rootDir: ROOT_DIR,
+			typeRoots: [
+				path.join( ROOT_DIR, 'typings' ),
+				path.join( ROOT_DIR, 'node_modules/@types' ),
+			],
+			types: [ 'gutenberg-env', 'node', 'style-imports' ],
+		},
+		files: [
+			compatibilityTypesPath,
+			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
+			...typescriptTests.map( ( file ) => path.join( ROOT_DIR, file ) ),
+		],
+	};
+
+	try {
+		// @wordpress/commands is a JavaScript package without published types.
+		// Keep this exception explicit until that package gains declarations.
+		writeFileSync(
+			compatibilityTypesPath,
+			"declare module '@wordpress/commands';"
+		);
+		writeFileSync( configPath, JSON.stringify( typecheckConfig ) );
+		execFileSync(
+			path.join(
+				ROOT_DIR,
+				'node_modules/.bin',
+				process.platform === 'win32' ? 'tsc.cmd' : 'tsc'
+			),
+			[ '--project', configPath, '--pretty', 'false' ],
+			{ cwd: ROOT_DIR, stdio: 'inherit' }
+		);
+	} finally {
+		rmSync( temporaryDirectory, { force: true, recursive: true } );
+	}
+}
+
+console.log(
+	`Validated ${ vitestTests.length } Vitest tests, ${ files.length } ESM graph files, ${ vitestVersions.size } workspace dependencies, and ${ typescriptTests.length } TypeScript tests.`
+);


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80878; review commit `1daffed73db`.

**TL;DR — canonical authoring and type-graph guardrails:** adds a CI validator for ESM-only Vitest tests, explicit runner imports, dynamic-import TypeScript mocks, workspace-owned Vitest dependencies, version consistency, and complete migrated TS/TSX test type-checking.

## Why?

Passing tests alone does not prove the intended native-Vitest end state. Normal package builds also exclude some test directories, so migrated TypeScript tests could execute while retaining type errors or untyped mocks. This PR makes the canonical conventions in #80855 executable gates before larger package migrations.

## How?

The validator:

- discovers the active Vitest partition from the migration manifest;
- rejects CommonJS exports and unbound `require()` in the authored Vitest graph;
- rejects unbound Vitest APIs and `vitest/globals`;
- requires TypeScript `vi.mock()` calls to use `vi.mock(import(...))`;
- requires each owning workspace to declare the same `devDependencies.vitest` version;
- generates isolated no-emit TypeScript projects covering every migrated TS/TSX test;
- runs in the existing JavaScript routing CI job.

The clean CI job first runs the repository's standard custom workspace builds (including generated Icons exports), then generates the official Vips/video-conversion worker placeholders and package declarations before validating the test-only TypeScript graph. This preserves real workspace types without pulling unrelated package source into the isolated test project or relying on local build artifacts.

Enabling the type graph exposed and fixed type-only gaps in existing migrated tests: complete Abilities reducer fixtures, explicit invalid-input boundaries, an ambiguous empty array, two `useResizeObserver` mocks, and the narrow selector contract used from untyped `@wordpress/commands`.

`@wordpress/commands` remains an explicit compatibility declaration because that JavaScript package does not publish types. No production code, runner ownership, or snapshots change.

## Testing Instructions

1. From a checkout without generated build outputs, declarations, or worker placeholders, run:
   - `npx lerna run build`
   - `npm run --workspace @wordpress/build-scripts generate-worker-placeholders`
   - `npx tsc --build`
   - `npm run test:unit:conventions`
   - Expected: 67 Vitest tests, 83 ESM graph files, 25 workspaces, and 41 TypeScript tests validated.
2. `npm run test:unit:routing`
   - Expected: 933 Jest, 67 Vitest, no overlap, and no missing baseline tests.
3. `npm run test:unit:vitest`
   - Expected: 67 files and 902 tests.
4. Run all four Vitest shards.
5. Run focused JS lint, `npm run lint:pkg-json`, `npm run lint:lockfile`, and `npm run lint:tsconfig`.

`npm run lint:deps` continues to report only the repository's pre-existing `@babel/core` and `yargs` version drift.

### Testing Instructions for Keyboard

Not applicable; production behavior is unchanged.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

AI tools helped implement and adversarially exercise the validator, reproduce clean-CI failures, add the official generated prerequisites, and run deterministic verification.